### PR TITLE
[JSC] Add fast path for `Array#concat` with multiple arguments

### DIFF
--- a/JSTests/microbenchmarks/concat-multiarg-int32-three.js
+++ b/JSTests/microbenchmarks/concat-multiarg-int32-three.js
@@ -1,0 +1,22 @@
+var as = [];
+for (var a = 0; a < 8; a++) {
+    var h = [];
+    for (var j = 0; j < 8; j++)
+        h.push(a * 100 + j);
+    as.push(h);
+}
+var b = [];
+for (var j = 0; j < 16; j++)
+    b.push(j);
+var c = [];
+for (var j = 0; j < 4; j++)
+    c.push(j);
+
+var result = 0;
+for (var i = 0; i < 2e6; i++) {
+    var r = [].concat(as[i & 7], b, c);
+    result += r.length;
+}
+
+if (result !== 56e6)
+    throw new Error("bad result: " + result);

--- a/JSTests/microbenchmarks/concat-multiarg-receiver.js
+++ b/JSTests/microbenchmarks/concat-multiarg-receiver.js
@@ -1,0 +1,18 @@
+var base = [];
+for (var j = 0; j < 8; j++)
+    base.push({ name: 'base' + j });
+var user = [];
+for (var j = 0; j < 8; j++)
+    user.push({ name: 'user' + j });
+var extra = [];
+for (var j = 0; j < 2; j++)
+    extra.push({ name: 'extra' + j });
+
+var result = 0;
+for (var i = 0; i < 2e6; i++) {
+    var r = base.concat(user, extra);
+    result += r.length;
+}
+
+if (result !== 36e6)
+    throw new Error("bad result: " + result);

--- a/JSTests/microbenchmarks/concat-multiarg-scalar.js
+++ b/JSTests/microbenchmarks/concat-multiarg-scalar.js
@@ -1,0 +1,13 @@
+var a = [1, 2, 3, 4, 5, 6, 7, 8];
+var b = [10, 20, 30, 40];
+
+var result = 0;
+for (var i = 0; i < 2e6; i++) {
+    var r = a.concat(i & 7, 9);
+    result += r.length;
+    r = a.concat(b, i & 7);
+    result += r.length;
+}
+
+if (result !== 46e6)
+    throw new Error("bad result: " + result);

--- a/JSTests/microbenchmarks/concat-multiarg-strings.js
+++ b/JSTests/microbenchmarks/concat-multiarg-strings.js
@@ -1,0 +1,19 @@
+var heads = [];
+for (var a = 0; a < 8; a++) {
+    var h = [];
+    for (var j = 0; j < 8; j++)
+        h.push('h' + a + '_' + j);
+    heads.push(h);
+}
+var mid = [];
+for (var j = 0; j < 8; j++)
+    mid.push('m' + j);
+
+var result = 0;
+for (var i = 0; i < 2e6; i++) {
+    var r = [].concat(heads[i & 7], mid);
+    result += r.length;
+}
+
+if (result !== 32e6)
+    throw new Error("bad result: " + result);

--- a/JSTests/stress/array-concat-multiple-arguments-holes.js
+++ b/JSTests/stress/array-concat-multiple-arguments-holes.js
@@ -1,0 +1,34 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("bad value: " + String(actual) + ", expected " + String(expected));
+}
+
+// Holes in sources must stay holes in the result.
+for (let i = 0; i < testLoopCount; i++) {
+    let holey = [1, , 3];
+    let r = [0].concat(holey, [4], 9);
+    shouldBe(r.length, 6);
+    shouldBe(2 in r, false);
+    shouldBe(r[1], 1);
+    shouldBe(r[3], 3);
+    shouldBe(r[4], 4);
+    shouldBe(r[5], 9);
+}
+
+// Once Array.prototype has indexed properties, holes must forward to the prototype
+// and the resolved values become own properties of the result.
+Array.prototype[1] = "proto";
+for (let i = 0; i < testLoopCount; i++) {
+    let holey = [1, , 3];
+    let r = [].concat(holey, [4]);
+    shouldBe(r.length, 4);
+    shouldBe(r[1], "proto");
+    shouldBe(r.hasOwnProperty(1), true);
+    shouldBe(r[3], 4);
+
+    let r2 = [0].concat([5], holey);
+    shouldBe(r2.length, 5);
+    shouldBe(r2[3], "proto");
+    shouldBe(r2.hasOwnProperty(3), true);
+}
+delete Array.prototype[1];

--- a/JSTests/stress/array-concat-multiple-arguments-is-concat-spreadable.js
+++ b/JSTests/stress/array-concat-multiple-arguments-is-concat-spreadable.js
@@ -1,0 +1,70 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("bad value: " + String(actual) + ", expected " + String(expected));
+}
+
+function shouldThrow(func, errorType) {
+    let error = null;
+    try {
+        func();
+    } catch (e) {
+        error = e;
+    }
+    if (!(error instanceof errorType))
+        throw new Error("expected " + errorType.name + ", got " + String(error));
+}
+
+// An array argument with @@isConcatSpreadable = false is appended whole.
+for (let i = 0; i < testLoopCount; i++) {
+    let ns = [7, 8];
+    ns[Symbol.isConcatSpreadable] = false;
+    let r = [1].concat([2], ns);
+    shouldBe(r.length, 3);
+    shouldBe(r[2], ns);
+}
+
+// A plain object with @@isConcatSpreadable = true is spread.
+for (let i = 0; i < testLoopCount; i++) {
+    let fake = { length: 2, 0: "p", 1: "q" };
+    fake[Symbol.isConcatSpreadable] = true;
+    shouldBe([1].concat(fake, [2]).join(","), "1,p,q,2");
+}
+
+// @@isConcatSpreadable = false on Array.prototype affects the receiver and all array arguments.
+{
+    Array.prototype[Symbol.isConcatSpreadable] = false;
+    let r = [1].concat([2], [3]);
+    shouldBe(r.length, 3);
+    shouldBe(r[0][0], 1);
+    shouldBe(r[1][0], 2);
+    shouldBe(r[2][0], 3);
+    delete Array.prototype[Symbol.isConcatSpreadable];
+}
+
+// A @@isConcatSpreadable getter runs left to right and its side effects on later
+// arguments must be observed.
+for (let i = 0; i < testLoopCount; i++) {
+    let order = [];
+    let later = [1, 2, 3];
+    let tricky = {
+        length: 1,
+        0: "t",
+        get [Symbol.isConcatSpreadable]() {
+            order.push("tricky");
+            later.length = 1;
+            return true;
+        }
+    };
+    let r = [0].concat(tricky, later);
+    shouldBe(order.join(","), "tricky");
+    shouldBe(r.join(","), "0,t,1");
+}
+
+// A huge fake spreadable must throw as soon as the accumulated length exceeds the
+// maximum. The receiver already contributes one element, so appending length 2^53 - 1
+// overflows immediately, before the element-copying loop starts.
+shouldThrow(() => {
+    let huge = { length: 2 ** 53 - 1 };
+    huge[Symbol.isConcatSpreadable] = true;
+    [1].concat(huge, [2]);
+}, TypeError);

--- a/JSTests/stress/array-concat-multiple-arguments-scalars.js
+++ b/JSTests/stress/array-concat-multiple-arguments-scalars.js
@@ -1,0 +1,67 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("bad value: " + String(actual) + ", expected " + String(expected));
+}
+
+// Scalar arguments of every primitive kind are appended as single elements.
+for (let i = 0; i < testLoopCount; i++) {
+    shouldBe([1, 2].concat(3, 4).join(","), "1,2,3,4");
+    shouldBe([1, 2].concat(3, 4.5).join(","), "1,2,3,4.5");
+    shouldBe([1.5].concat(2, 3.5).join(","), "1.5,2,3.5");
+    shouldBe(["a"].concat("b", "c").join(","), "a,b,c");
+    shouldBe([1, 2].concat("x", 3).join(","), "1,2,x,3");
+    shouldBe([1.5].concat("x", 2).join(","), "1.5,x,2");
+
+    let r = [1].concat(undefined, null, true, false);
+    shouldBe(r.length, 5);
+    shouldBe(r.hasOwnProperty(1), true);
+    shouldBe(r[1], undefined);
+    shouldBe(r[2], null);
+    shouldBe(r[3], true);
+    shouldBe(r[4], false);
+
+    let sym = Symbol("s");
+    shouldBe([1].concat(sym, 2)[1], sym);
+}
+
+// Mixing arrays and scalars in one call.
+for (let i = 0; i < testLoopCount; i++) {
+    shouldBe([0].concat([1, 2], 3).join(","), "0,1,2,3");
+    shouldBe([0].concat(1, [2, 3]).join(","), "0,1,2,3");
+    shouldBe([].concat([1.5], 2, [3.5, 4.5]).join(","), "1.5,2,3.5,4.5");
+}
+
+// Object scalars keep their identity and are never coerced.
+for (let i = 0; i < testLoopCount; i++) {
+    let o = { x: 1 };
+    let r = [1].concat(o, [2]);
+    shouldBe(r.length, 3);
+    shouldBe(r[1], o);
+
+    let evil = { valueOf() { throw new Error("must not coerce"); } };
+    shouldBe([1].concat(evil, 2)[1], evil);
+}
+
+// Special double values survive the copy.
+for (let i = 0; i < testLoopCount; i++) {
+    let r = [0.5, NaN].concat(1, [2.5]);
+    shouldBe(r.length, 4);
+    shouldBe(Number.isNaN(r[1]), true);
+    shouldBe(r[2], 1);
+
+    r = [1.5].concat(-0, Infinity);
+    shouldBe(Object.is(r[1], -0), true);
+    shouldBe(r[2], Infinity);
+
+    r = [-0].concat(0.5, [1.5]);
+    shouldBe(Object.is(r[0], -0), true);
+}
+
+// Scalars appended after holey sources land at the right indices.
+for (let i = 0; i < testLoopCount; i++) {
+    let holey = [1, , 3];
+    let r = [0].concat(holey, 9);
+    shouldBe(r.length, 5);
+    shouldBe(2 in r, false);
+    shouldBe(r[4], 9);
+}

--- a/JSTests/stress/array-concat-multiple-arguments-species-and-exotic.js
+++ b/JSTests/stress/array-concat-multiple-arguments-species-and-exotic.js
@@ -1,0 +1,59 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("bad value: " + String(actual) + ", expected " + String(expected));
+}
+
+// Species of a subclassed receiver must be respected with multiple arguments.
+class MyArray extends Array {}
+for (let i = 0; i < testLoopCount; i++) {
+    let ma = new MyArray();
+    ma.push(1, 2);
+    let r = ma.concat([3], [4]);
+    shouldBe(r instanceof MyArray, true);
+    shouldBe(r.length, 4);
+    shouldBe(r.join(","), "1,2,3,4");
+}
+
+// A derived array argument is spreadable even though it is not a plain array.
+for (let i = 0; i < testLoopCount; i++) {
+    let da = MyArray.of(5, 6);
+    shouldBe([1].concat(da, [2]).join(","), "1,5,6,2");
+    shouldBe([1].concat([0], da).join(","), "1,0,5,6");
+}
+
+// A Proxy over an array is spreadable.
+for (let i = 0; i < testLoopCount; i++) {
+    let prox = new Proxy([9, 10], {});
+    shouldBe([1].concat(prox, [2]).join(","), "1,9,10,2");
+    shouldBe([1].concat([2], prox).join(","), "1,2,9,10");
+}
+
+// An indexed accessor on the receiver must be invoked.
+for (let i = 0; i < testLoopCount; i++) {
+    let evil = [1, 2];
+    Object.defineProperty(evil, 0, { get() { return 42; } });
+    let r = evil.concat([3], [4]);
+    shouldBe(r.join(","), "42,2,3,4");
+}
+
+// A Symbol.species getter on the receiver's constructor must be honored.
+for (let i = 0; i < testLoopCount; i++) {
+    let called = 0;
+    class Weird extends Array {
+        static get [Symbol.species]() {
+            called++;
+            return Array;
+        }
+    }
+    let hijacked = Weird.of(1);
+    let r = hijacked.concat([2], [3]);
+    shouldBe(called >= 1, true);
+    shouldBe(r instanceof Weird, false);
+    shouldBe(r.join(","), "1,2,3");
+}
+
+// Frozen sources are readable.
+for (let i = 0; i < testLoopCount; i++) {
+    let frozen = Object.freeze([7, 8]);
+    shouldBe([].concat(frozen, [9]).join(","), "7,8,9");
+}

--- a/JSTests/stress/array-concat-multiple-arguments.js
+++ b/JSTests/stress/array-concat-multiple-arguments.js
@@ -1,0 +1,86 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("bad value: " + String(actual) + ", expected " + String(expected));
+}
+
+function arrayEq(a, b) {
+    if (a.length !== b.length)
+        return false;
+    for (let i = 0; i < a.length; i++) {
+        if (a[i] !== b[i])
+            return false;
+    }
+    return true;
+}
+
+// All indexing type combinations across receiver and multiple arguments.
+for (let i = 0; i < testLoopCount; i++) {
+    shouldBe([].concat([1, 2], [3, 4]).join(","), "1,2,3,4");
+    shouldBe([0].concat([1, 2], [3], [4, 5, 6]).join(","), "0,1,2,3,4,5,6");
+    shouldBe([1, 2].concat([1.5, 2.5], [3, 4]).join(","), "1,2,1.5,2.5,3,4");
+    shouldBe([0.5].concat([1.5], [2.5, 3.5]).join(","), "0.5,1.5,2.5,3.5");
+    shouldBe(["a"].concat([1, 2], [1.5]).join(","), "a,1,2,1.5");
+    shouldBe(["a", "b"].concat(["c"], [1, 2]).join(","), "a,b,c,1,2");
+    shouldBe([].concat([], []).length, 0);
+    shouldBe([].concat([], [1], []).join(","), "1");
+}
+
+// Undecided (allocated but unset) arrays as sources.
+for (let i = 0; i < testLoopCount; i++) {
+    let und = new Array(2);
+    let r = [1].concat(und, [2]);
+    shouldBe(r.length, 4);
+    shouldBe(1 in r, false);
+    shouldBe(2 in r, false);
+    shouldBe(r[3], 2);
+
+    r = [].concat(new Array(3), new Array(2));
+    shouldBe(r.length, 5);
+    shouldBe(0 in r, false);
+}
+
+// Self concat only reads the sources.
+for (let i = 0; i < testLoopCount; i++) {
+    let s = [1, 2];
+    shouldBe(s.concat(s, s).join(","), "1,2,1,2,1,2");
+    shouldBe(s.length, 2);
+}
+
+// The result must not share storage with any (copy-on-write) source.
+for (let i = 0; i < testLoopCount; i++) {
+    let a = [1, 2, 3];
+    let r = [].concat(a, [4]);
+    r[0] = 99;
+    shouldBe(a[0], 1);
+    let r2 = [].concat(a, []);
+    r2[1] = 88;
+    shouldBe(a[1], 2);
+}
+
+// Many arguments.
+{
+    let args = [];
+    let expected = [];
+    for (let i = 0; i < 64; i++) {
+        args.push([i, i + 0.5]);
+        expected.push(i, i + 0.5);
+    }
+    for (let i = 0; i < testLoopCount; i++) {
+        let r = Array.prototype.concat.apply([], args);
+        if (!arrayEq(r, expected))
+            throw new Error("bad many-args result");
+    }
+}
+
+// Total size crossing the sparse array threshold must still produce a correct result.
+{
+    let big1 = new Array(50000).fill(1);
+    let big2 = new Array(60000).fill(2);
+    let r = [].concat(big1, big2, [3]);
+    shouldBe(r.length, 110001);
+    shouldBe(r[0], 1);
+    shouldBe(r[49999], 1);
+    shouldBe(r[50000], 2);
+    shouldBe(r[109999], 2);
+    shouldBe(r[110000], 3);
+}

--- a/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
@@ -1627,6 +1627,106 @@ JSArray* tryConcatOneArgFast(JSGlobalObject* globalObject, VM& vm, JSArray* firs
     RELEASE_AND_RETURN(scope, tryConcatAppendArrayFastWithWatchpoints(globalObject, vm, firstArray, secondArray));
 }
 
+static JSArray* tryConcatMultipleArraysFast(JSGlobalObject* globalObject, VM& vm, JSArray* firstArray, CallFrame* callFrame)
+{
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    ASSERT(!globalObject->isHavingABadTime());
+    ASSERT(callFrame->argumentCount() >= 2);
+
+    unsigned argumentCount = callFrame->argumentCount();
+
+    if (firstArray->holesMustForwardToPrototype()) [[unlikely]]
+        return nullptr;
+
+    IndexingType type = firstArray->indexingType();
+    CheckedUint32 checkedResultSize = firstArray->butterfly()->publicLength();
+    for (unsigned i = 0; i < argumentCount; ++i) {
+        JSValue argumentValue = callFrame->uncheckedArgument(i);
+        if (argumentValue.isObject()) {
+            JSObject* argumentObject = asObject(argumentValue);
+            if (!arrayMissingIsConcatSpreadable(vm, argumentObject)) [[unlikely]]
+                return nullptr;
+            if (isJSArray(argumentObject)) [[likely]] {
+                JSArray* array = uncheckedDowncast<JSArray>(argumentObject);
+                if (array->holesMustForwardToPrototype()) [[unlikely]]
+                    return nullptr;
+                type = mergeIndexingTypesForCopying(type, array->indexingType(), /* allowPromotion */ true);
+                if (type == NonArray) [[unlikely]]
+                    return nullptr;
+                checkedResultSize += array->butterfly()->publicLength();
+                continue;
+            }
+            JSType objectType = argumentObject->type();
+            if (objectType == ProxyObjectType || objectType == DerivedArrayType) [[unlikely]]
+                return nullptr;
+        }
+        type = mergeIndexingTypesForCopying(type, indexingTypeForValue(argumentValue) | IsArray, /* allowPromotion */ true);
+        if (type == NonArray) [[unlikely]]
+            return nullptr;
+        checkedResultSize += 1;
+    }
+
+    if (checkedResultSize.hasOverflowed() || checkedResultSize.value() >= MIN_SPARSE_ARRAY_INDEX) [[unlikely]]
+        return nullptr;
+
+    unsigned resultSize = checkedResultSize;
+    if (!resultSize)
+        RELEASE_AND_RETURN(scope, constructEmptyArray(globalObject, nullptr));
+
+    Structure* resultStructure = globalObject->arrayStructureForIndexingTypeDuringAllocation(type);
+    ASSERT(!hasAnyArrayStorage(resultStructure->indexingType()));
+
+    auto vectorLength = Butterfly::optimalContiguousVectorLength(resultStructure, resultSize);
+    if (vectorLength > MAX_STORAGE_VECTOR_LENGTH) [[unlikely]]
+        return nullptr;
+
+    ASSERT(!resultStructure->outOfLineCapacity());
+    void* memory = vm.auxiliarySpace().allocate(vm, Butterfly::totalSize(0, 0, true, vectorLength * sizeof(EncodedJSValue)), nullptr, AllocationFailureMode::ReturnNull);
+    if (!memory) [[unlikely]] {
+        throwOutOfMemoryError(globalObject, scope);
+        return nullptr;
+    }
+    auto* butterfly = Butterfly::fromBase(memory, 0, 0);
+    butterfly->setVectorLength(vectorLength);
+    butterfly->setPublicLength(resultSize);
+
+    unsigned offset = 0;
+    auto copySource = [&](JSArray* array) {
+        Butterfly* sourceButterfly = array->butterfly();
+        unsigned sourceSize = sourceButterfly->publicLength();
+        IndexingType sourceType = array->indexingType();
+        if (type == ArrayWithDouble) {
+            double* buffer = butterfly->contiguousDouble().data();
+            if (sourceType == ArrayWithDouble)
+                copyArrayElements<ArrayFillMode::Empty, NeedsGCSafeOps::No>(buffer, offset, sourceButterfly->contiguousDouble().data(), 0, sourceSize, sourceType);
+            else
+                copyArrayElements<ArrayFillMode::Empty, NeedsGCSafeOps::No>(buffer, offset, sourceButterfly->contiguous().data(), 0, sourceSize, sourceType);
+        } else if (type != ArrayWithUndecided) {
+            WriteBarrier<Unknown>* buffer = butterfly->contiguous().data();
+            copyArrayElements<ArrayFillMode::Empty, NeedsGCSafeOps::No>(buffer, offset, sourceButterfly->contiguous().data(), 0, sourceSize, sourceType);
+        }
+        offset += sourceSize;
+    };
+    copySource(firstArray);
+    for (unsigned i = 0; i < argumentCount; ++i) {
+        JSValue argumentValue = callFrame->uncheckedArgument(i);
+        if (argumentValue.isObject() && isJSArray(asObject(argumentValue))) [[likely]] {
+            copySource(uncheckedDowncast<JSArray>(asObject(argumentValue)));
+            continue;
+        }
+        if (type == ArrayWithDouble)
+            butterfly->contiguousDouble().data()[offset] = argumentValue.asNumber();
+        else
+            butterfly->contiguous().data()[offset].setWithoutWriteBarrier(argumentValue);
+        ++offset;
+    }
+    ASSERT(offset == resultSize);
+
+    Butterfly::clearRange(type, butterfly, resultSize, vectorLength);
+    return JSArray::createWithButterfly(vm, nullptr, resultStructure, butterfly);
+}
+
 JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncConcat, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();
@@ -1644,19 +1744,18 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncConcat, (JSGlobalObject* globalObject, Ca
                     return JSValue::encode(result);
             }
         }
-    } else if (callFrame->argumentCount() == 1) {
-        JSValue argumentValue = callFrame->uncheckedArgument(0);
-        if (isJSArray(thisValue)) [[likely]] {
-            auto* firstArray = uncheckedDowncast<JSArray>(thisValue);
-            if (!globalObject->isHavingABadTime() && arrayMissingIsConcatSpreadable(vm, firstArray) && arraySpeciesWatchpointIsValid(vm, firstArray) && !firstArray->mayInterceptIndexedAccesses()) [[likely]] {
-                // This code assumes that neither array has set Symbol.isConcatSpreadable. If the first array
-                // has indexed accessors then one of those accessors might change the value of Symbol.isConcatSpreadable
-                // on the second argument.
-                JSArray* result = tryConcatOneArgFast(globalObject, vm, firstArray, argumentValue);
-                RETURN_IF_EXCEPTION(scope, { });
-                if (result) [[likely]]
-                    return JSValue::encode(result);
-            }
+    } else if (isJSArray(thisValue)) [[likely]] {
+        auto* firstArray = uncheckedDowncast<JSArray>(thisValue);
+        if (!globalObject->isHavingABadTime() && arrayMissingIsConcatSpreadable(vm, firstArray) && arraySpeciesWatchpointIsValid(vm, firstArray) && !firstArray->mayInterceptIndexedAccesses()) [[likely]] {
+            // This code assumes that neither array has set Symbol.isConcatSpreadable. If the first array
+            // has indexed accessors then one of those accessors might change the value of Symbol.isConcatSpreadable
+            // on the second argument.
+            JSArray* result = callFrame->argumentCount() == 1
+                ? tryConcatOneArgFast(globalObject, vm, firstArray, callFrame->uncheckedArgument(0))
+                : tryConcatMultipleArraysFast(globalObject, vm, firstArray, callFrame);
+            RETURN_IF_EXCEPTION(scope, { });
+            if (result) [[likely]]
+                return JSValue::encode(result);
         }
     }
 

--- a/Source/JavaScriptCore/runtime/JSArrayInlines.h
+++ b/Source/JavaScriptCore/runtime/JSArrayInlines.h
@@ -95,9 +95,8 @@ inline Structure* JSArray::createStructure(VM& vm, JSGlobalObject* globalObject,
     return Structure::create(vm, globalObject, prototype, TypeInfo(ArrayType, StructureFlags), info(), indexingType);
 }
 
-inline IndexingType JSArray::mergeIndexingTypeForCopying(IndexingType other, bool allowPromotion)
+inline IndexingType mergeIndexingTypesForCopying(IndexingType type, IndexingType other, bool allowPromotion)
 {
-    IndexingType type = indexingType();
     if (!(type & IsArray && other & IsArray))
         return NonArray;
 
@@ -131,6 +130,11 @@ inline IndexingType JSArray::mergeIndexingTypeForCopying(IndexingType other, boo
         return NonArray;
 
     return type;
+}
+
+inline IndexingType JSArray::mergeIndexingTypeForCopying(IndexingType other, bool allowPromotion)
+{
+    return mergeIndexingTypesForCopying(indexingType(), other, allowPromotion);
 }
 
 ALWAYS_INLINE bool JSArray::holesMustForwardToPrototype() const


### PR DESCRIPTION
#### 485bcf1b176ab39831836fcfb40af6232ea21fc5
<pre>
[JSC] Add fast path for `Array#concat` with multiple arguments
<a href="https://bugs.webkit.org/show_bug.cgi?id=318655">https://bugs.webkit.org/show_bug.cgi?id=318655</a>

Reviewed by Yusuke Suzuki.

Array.prototype.concat had fast paths only for 0 and 1 argument; more
arguments fell through to the generic loop, which grows the result
incrementally. This matters because @babel/plugin-transform-spread
compiles [...a, ...b] into [].concat(a, b), so transpiled code hits
multi-argument concat on hot paths.

Add tryConcatMultipleArraysFast: when the receiver and all arguments are
plain JSArrays or non-spreadable scalars, compute the total length in one
pass, allocate the butterfly once at exactly the right size, then memcpy
each source at a running offset. Proxies and derived arrays bail out.

                                                   Baseline                  Patched

concat-multiarg-strings                       133.8260+-0.9464     ^     46.1617+-1.2060        ^ definitely 2.8991x faster
concat-multiarg-receiver                      134.4724+-1.5618     ^     46.5028+-0.9827        ^ definitely 2.8917x faster
concat-multiarg-int32-three                   150.9612+-2.3111     ^     59.5219+-1.2661        ^ definitely 2.5362x faster
concat-multiarg-scalar                        172.1870+-2.0075     ^     71.6830+-1.8256        ^ definitely 2.4021x faster

Tests: JSTests/microbenchmarks/concat-multiarg-int32-three.js
       JSTests/microbenchmarks/concat-multiarg-receiver.js
       JSTests/microbenchmarks/concat-multiarg-scalar.js
       JSTests/microbenchmarks/concat-multiarg-strings.js
       JSTests/stress/array-concat-multiple-arguments-holes.js
       JSTests/stress/array-concat-multiple-arguments-is-concat-spreadable.js
       JSTests/stress/array-concat-multiple-arguments-scalars.js
       JSTests/stress/array-concat-multiple-arguments-species-and-exotic.js
       JSTests/stress/array-concat-multiple-arguments.js

* JSTests/microbenchmarks/concat-multiarg-int32-three.js: Added.
* JSTests/microbenchmarks/concat-multiarg-receiver.js: Added.
* JSTests/microbenchmarks/concat-multiarg-scalar.js: Added.
* JSTests/microbenchmarks/concat-multiarg-strings.js: Added.
* JSTests/stress/array-concat-multiple-arguments-holes.js: Added.
(shouldBe):
* JSTests/stress/array-concat-multiple-arguments-is-concat-spreadable.js: Added.
(shouldBe):
(shouldThrow):
(2.join):
(i.let.tricky.get Symbol):
* JSTests/stress/array-concat-multiple-arguments-scalars.js: Added.
(shouldBe):
(i.let.evil.valueOf):
* JSTests/stress/array-concat-multiple-arguments-species-and-exotic.js: Added.
(shouldBe):
(MyArray):
(i.Weird.get Symbol):
(i.Weird):
* JSTests/stress/array-concat-multiple-arguments.js: Added.
(shouldBe):
(arrayEq):
(throw.new.Error):
* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
(JSC::tryConcatMultipleArraysFast):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/JSArrayInlines.h:
(JSC::mergeIndexingTypesForCopying):
(JSC::JSArray::mergeIndexingTypeForCopying):

Canonical link: <a href="https://commits.webkit.org/316619@main">https://commits.webkit.org/316619@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c277830bc139e77e535844a709fb7d8e900d566d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172708 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46626 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40078 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182166 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130264 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47919 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46301 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134323 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94800 "1 flakes 21 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175666 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37721 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154869 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114795 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36356 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34672 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30765 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/3395 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146785 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34372 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184699 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/33969 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37410 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38873 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143114 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46298 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142991 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38656 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46976 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31211 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111937 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37997 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118728 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/205386 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45493 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9321 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54832 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44893 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45125 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44952 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->