### PR TITLE
IDBObjectStore.openKeyCursor() with a key value returns a value-carrying cursor instead of a key-only cursor

### DIFF
--- a/LayoutTests/storage/indexeddb/openkeycursor-key-only-expected.txt
+++ b/LayoutTests/storage/indexeddb/openkeycursor-key-only-expected.txt
@@ -1,0 +1,27 @@
+Test that IDBObjectStore.openKeyCursor() called with a key value returns a key-only cursor that does not expose 'value'.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+indexedDB = self.indexedDB || self.webkitIndexedDB || self.mozIndexedDB || self.msIndexedDB || self.OIndexedDB;
+
+indexedDB.deleteDatabase(dbname)
+indexedDB.open(dbname)
+objectStore = db.createObjectStore('store');
+objectStore.put('some value', 5);
+
+testKeyOnlyCursor():
+trans = db.transaction('store', 'readonly');
+objectStore = trans.objectStore('store');
+request = objectStore.openKeyCursor(5);
+PASS cursor is non-null.
+PASS cursor instanceof IDBCursorWithValue is false
+PASS 'value' in cursor is false
+PASS cursor.key is 5
+PASS cursor.primaryKey is 5
+cursor.continue();
+PASS cursor is null
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/storage/indexeddb/openkeycursor-key-only.html
+++ b/LayoutTests/storage/indexeddb/openkeycursor-key-only.html
@@ -1,0 +1,9 @@
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<script src="resources/shared.js"></script>
+</head>
+<body>
+<script src="resources/openkeycursor-key-only.js"></script>
+</body>
+</html>

--- a/LayoutTests/storage/indexeddb/resources/openkeycursor-key-only.js
+++ b/LayoutTests/storage/indexeddb/resources/openkeycursor-key-only.js
@@ -1,0 +1,46 @@
+if (this.importScripts) {
+    importScripts('../../../resources/js-test.js');
+    importScripts('shared.js');
+}
+
+description("Test that IDBObjectStore.openKeyCursor() called with a key value returns a key-only cursor that does not expose 'value'.");
+
+indexedDBTest(prepareDatabase, testKeyOnlyCursor);
+
+function prepareDatabase()
+{
+    db = event.target.result;
+    event.target.transaction.onabort = unexpectedAbortCallback;
+    objectStore = evalAndLog("objectStore = db.createObjectStore('store');");
+    evalAndLog("objectStore.put('some value', 5);");
+}
+
+function testKeyOnlyCursor()
+{
+    debug("");
+    debug("testKeyOnlyCursor():");
+    trans = evalAndLog("trans = db.transaction('store', 'readonly');");
+    trans.onabort = unexpectedAbortCallback;
+    objectStore = evalAndLog("objectStore = trans.objectStore('store');");
+
+    request = evalAndLog("request = objectStore.openKeyCursor(5);");
+    request.onerror = unexpectedErrorCallback;
+    count = 0;
+    request.onsuccess = function() {
+        cursor = event.target.result;
+        if (count == 0) {
+            shouldBeNonNull("cursor");
+            shouldBeFalse("cursor instanceof IDBCursorWithValue");
+            shouldBeFalse("'value' in cursor");
+            shouldBe("cursor.key", "5");
+            shouldBe("cursor.primaryKey", "5");
+            evalAndLog("cursor.continue();");
+        } else if (count == 1) {
+            shouldBeNull("cursor");
+        } else {
+            testFailed("Unexpected extra iteration");
+        }
+        count++;
+    };
+    trans.oncomplete = finishJSTest;
+}

--- a/Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -216,7 +216,7 @@ ExceptionOr<Ref<IDBRequest>> IDBObjectStore::openKeyCursor(RefPtr<IDBKeyRange>&&
 
 ExceptionOr<Ref<IDBRequest>> IDBObjectStore::openKeyCursor(JSGlobalObject& execState, JSValue key, IDBCursorDirection direction)
 {
-    return doOpenCursor(direction, [state = &execState, key]() {
+    return doOpenKeyCursor(direction, [state = &execState, key]() {
         auto onlyResult = IDBKeyRange::only(*state, key);
         if (onlyResult.hasException())
             return ExceptionOr<RefPtr<IDBKeyRange>> { Exception(ExceptionCode::DataError, "Failed to execute 'openKeyCursor' on 'IDBObjectStore': The parameter is not a valid key."_s) };


### PR DESCRIPTION
#### f0adce087927aedb358889dc066681d9dc3b40df
<pre>
IDBObjectStore.openKeyCursor() with a key value returns a value-carrying cursor instead of a key-only cursor
<a href="https://bugs.webkit.org/show_bug.cgi?id=318654">https://bugs.webkit.org/show_bug.cgi?id=318654</a>
<a href="https://rdar.apple.com/181463337">rdar://181463337</a>

Reviewed by Sihui Liu.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

IDBObjectStore::openKeyCursor(JSGlobalObject&amp;, JSValue, IDBCursorDirection),
the overload taking a single key value, incorrectly routed through
doOpenCursor() (which creates a CursorType::KeyAndValue cursor) instead of
doOpenKeyCursor() (CursorType::KeyOnly). As a result,
store.openKeyCursor(someKey) returned an IDBCursorWithValue that fetched the
full record value, rather than a key-only cursor exposing only key and
primaryKey.

Only this JSValue overload was affected; the RefPtr&lt;IDBKeyRange&gt; and no-argument
paths already routed to doOpenKeyCursor(). Chrome and Firefox already return a
key-only cursor here, so this aligns WebKit with the other engines and the
IndexedDB specification.

Test: storage/indexeddb/openkeycursor-key-only.html

* LayoutTests/storage/indexeddb/openkeycursor-key-only-expected.txt: Added.
* LayoutTests/storage/indexeddb/openkeycursor-key-only.html: Added.
* LayoutTests/storage/indexeddb/resources/openkeycursor-key-only.js: Added.
(prepareDatabase):
(testKeyOnlyCursor.request.onsuccess):
(testKeyOnlyCursor):
* Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp:
(WebCore::IDBObjectStore::openKeyCursor):

Canonical link: <a href="https://commits.webkit.org/316584@main">https://commits.webkit.org/316584@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b2e412f6ddbd0b65bac56f1d193b06a526eaf1a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172717 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46635 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40089 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182175 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130273 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b4aee075-8fe4-4943-9b44-8b83c371a815) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174582 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47928 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46310 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134325 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5b227711-3f24-447b-8cff-a44bbb0805f6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175675 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37728 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154876 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114797 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f64e9f8d-1908-4618-8f8c-48280a55309c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36363 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34678 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30774 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146792 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34379 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184708 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37420 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38880 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143116 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46307 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154448 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142993 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38634 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46985 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31218 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111947 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38003 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118737 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45502 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9328 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44902 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45134 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44961 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->