### PR TITLE
[JSC] Speculate on `String#concat` arguments based on profiling

### DIFF
--- a/JSTests/microbenchmarks/string-prototype-concat-int32.js
+++ b/JSTests/microbenchmarks/string-prototype-concat-int32.js
@@ -1,0 +1,18 @@
+function build(x, y) {
+    return "translate3d(".concat(x, "px, ").concat(y, "px, 0)");
+}
+noInline(build);
+
+var xs = [];
+var ys = [];
+for (var i = 0; i < 16; ++i) {
+    xs.push(i * 3);
+    ys.push(i * 7);
+}
+
+var len = 0;
+for (var i = 0; i < 3000000; ++i)
+    len += build(xs[i & 15], ys[i & 15]).length;
+
+if (len != 77062500)
+    throw "Error: bad result: " + len;

--- a/JSTests/stress/string-prototype-concat-object-arguments-osr-exit.js
+++ b/JSTests/stress/string-prototype-concat-object-arguments-osr-exit.js
@@ -1,0 +1,171 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}, expected: ${expected}`);
+}
+
+function shouldThrow(func, errorType) {
+    let threw = false;
+    try {
+        func();
+    } catch (error) {
+        threw = true;
+        if (!(error instanceof errorType))
+            throw new Error(`bad error: ${error}`);
+    }
+    if (!threw)
+        throw new Error("should throw");
+}
+
+function makeCountingObject(result) {
+    const counters = { toString: 0, valueOf: 0 };
+    const object = {
+        toString() {
+            ++counters.toString;
+            return result;
+        },
+        valueOf() {
+            ++counters.valueOf;
+            throw new Error("valueOf should not be called");
+        },
+    };
+    return { object, counters };
+}
+
+// Warmed up with string arguments, then an object argument causes OSR exit.
+// toString() must be observed exactly once per call and valueOf() never.
+function concatAfterStringWarmUp(str, x) {
+    return str.concat(x, "!");
+}
+noInline(concatAfterStringWarmUp);
+
+for (let i = 0; i < testLoopCount; ++i)
+    shouldBe(concatAfterStringWarmUp("foo", "bar"), "foobar!");
+{
+    const { object, counters } = makeCountingObject("object");
+    for (let i = 0; i < 100; ++i)
+        shouldBe(concatAfterStringWarmUp("foo", object), "fooobject!");
+    shouldBe(counters.toString, 100);
+    shouldBe(counters.valueOf, 0);
+}
+
+// Warmed up with int32 arguments (non-cell speculation), then an object argument.
+function concatAfterInt32WarmUp(str, x) {
+    return str.concat(x, "px");
+}
+noInline(concatAfterInt32WarmUp);
+
+for (let i = 0; i < testLoopCount; ++i)
+    shouldBe(concatAfterInt32WarmUp("w:", 42), "w:42px");
+{
+    const { object, counters } = makeCountingObject("object");
+    for (let i = 0; i < 100; ++i)
+        shouldBe(concatAfterInt32WarmUp("w:", object), "w:objectpx");
+    shouldBe(counters.toString, 100);
+    shouldBe(counters.valueOf, 0);
+}
+
+// Warmed up with string-or-undefined/null arguments, then an object argument.
+function concatAfterStringOrOtherWarmUp(str, x) {
+    return str.concat(x);
+}
+noInline(concatAfterStringOrOtherWarmUp);
+
+for (let i = 0; i < testLoopCount; ++i) {
+    if (i & 1)
+        shouldBe(concatAfterStringOrOtherWarmUp("v:", undefined), "v:undefined");
+    else
+        shouldBe(concatAfterStringOrOtherWarmUp("v:", null), "v:null");
+}
+{
+    const { object, counters } = makeCountingObject("object");
+    for (let i = 0; i < 100; ++i)
+        shouldBe(concatAfterStringOrOtherWarmUp("v:", object), "v:object");
+    shouldBe(counters.toString, 100);
+    shouldBe(counters.valueOf, 0);
+}
+
+// Warmed up with a string receiver, then an object receiver causes OSR exit.
+function concatWithReceiver(receiver, x) {
+    return String.prototype.concat.call(receiver, x);
+}
+noInline(concatWithReceiver);
+
+for (let i = 0; i < testLoopCount; ++i)
+    shouldBe(concatWithReceiver("head", "tail"), "headtail");
+{
+    const { object, counters } = makeCountingObject("object");
+    for (let i = 0; i < 100; ++i)
+        shouldBe(concatWithReceiver(object, "tail"), "objecttail");
+    shouldBe(counters.toString, 100);
+    shouldBe(counters.valueOf, 0);
+}
+
+// More than maxStrCatArguments arguments so that chained StrCat nodes are
+// emitted. Objects in the middle of the argument list must observe toString()
+// exactly once per call and in argument order, even though the OSR exit
+// happens after some of the chained StrCat nodes.
+function concatManyArguments(receiver, a, b, c, d, e) {
+    return String.prototype.concat.call(receiver, a, b, c, d, e);
+}
+noInline(concatManyArguments);
+
+for (let i = 0; i < testLoopCount; ++i)
+    shouldBe(concatManyArguments("A", "B", "C", "D", "E", "F"), "ABCDEF");
+{
+    const order = [];
+    function makeOrderedObject(name) {
+        return {
+            toString() {
+                order.push(name);
+                return name;
+            },
+        };
+    }
+    const receiver = makeOrderedObject("R");
+    const b = makeOrderedObject("b");
+    const e = makeOrderedObject("e");
+    for (let i = 0; i < 100; ++i) {
+        order.length = 0;
+        shouldBe(concatManyArguments(receiver, "1", b, "3", e, "5"), "R1b3e5");
+        shouldBe(order.join(","), "R,b,e");
+    }
+}
+
+// An object whose Symbol.toPrimitive is used for the conversion.
+function concatToPrimitive(str, x) {
+    return str.concat(x);
+}
+noInline(concatToPrimitive);
+
+for (let i = 0; i < testLoopCount; ++i)
+    shouldBe(concatToPrimitive("foo", "bar"), "foobar");
+{
+    let toPrimitiveCalls = 0;
+    const object = {
+        [Symbol.toPrimitive](hint) {
+            ++toPrimitiveCalls;
+            shouldBe(hint, "string");
+            return "object";
+        },
+        toString() {
+            throw new Error("toString should not be called");
+        },
+        valueOf() {
+            throw new Error("valueOf should not be called");
+        },
+    };
+    for (let i = 0; i < 100; ++i)
+        shouldBe(concatToPrimitive("foo", object), "fooobject");
+    shouldBe(toPrimitiveCalls, 100);
+}
+
+// A symbol argument must throw a TypeError even after warming up with strings.
+function concatSymbol(str, x) {
+    return str.concat(x);
+}
+noInline(concatSymbol);
+
+for (let i = 0; i < testLoopCount; ++i)
+    shouldBe(concatSymbol("foo", "bar"), "foobar");
+for (let i = 0; i < 100; ++i)
+    shouldThrow(() => concatSymbol("foo", Symbol("sym")), TypeError);

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -3519,11 +3519,11 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
 
             insertChecks();
             Node* thisNode = get(virtualRegisterForArgumentIncludingThis(0, registerOffset));
-            addToGraph(Check, Edge(thisNode, StringUse));
 
             unsigned numArguments = argumentCountIncludingThis - 1;
 
             if (!numArguments) {
+                addToGraph(Check, Edge(thisNode, StringUse));
                 setResult(addToGraph(ToString, thisNode));
                 return CallOptimizationResult::Inlined;
             }
@@ -3536,19 +3536,17 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
 
             for (unsigned i = 0; i < numArguments; ++i) {
                 if (indexInOperands == maxStrCatArguments) {
-                    operands[0] = addToGraph(StrCat, operands[0], operands[1], operands[2]);
+                    operands[0] = addToGraph(StrCat, OpInfo(StringPrototypeConcatIntrinsic), operands[0], operands[1], operands[2]);
                     for (unsigned j = 1; j < AdjacencyList::Size; ++j)
                         operands[j] = nullptr;
                     indexInOperands = 1;
                 }
                 ASSERT(indexInOperands < AdjacencyList::Size);
                 ASSERT(indexInOperands < maxStrCatArguments);
-                Node* arg = get(virtualRegisterForArgumentIncludingThis(i + 1, registerOffset));
-                addToGraph(Check, Edge(arg, StringUse));
-                operands[indexInOperands++] = arg;
+                operands[indexInOperands++] = get(virtualRegisterForArgumentIncludingThis(i + 1, registerOffset));
             }
 
-            setResult(addToGraph(StrCat, operands[0], operands[1], operands[2]));
+            setResult(addToGraph(StrCat, OpInfo(StringPrototypeConcatIntrinsic), operands[0], operands[1], operands[2]));
             return CallOptimizationResult::Inlined;
         }
 

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -591,6 +591,26 @@ private:
             if (attemptToMakeFastStringAdd(node))
                 break;
 
+            if (node->intrinsic() == StringPrototypeConcatIntrinsic) {
+                auto speculateChild = [&] (Edge& edge, UseKind useKind) {
+                    m_insertionSet.insertNode(m_indexInBlock, SpecNone, Check, node->origin, Edge(edge.node(), useKind));
+                    fixEdge<KnownPrimitiveUse>(edge);
+                };
+                auto useKindForArgument = [&] (Edge& edge) {
+                    if (edge->shouldSpeculateNotCell())
+                        return NotCellUse;
+                    if (edge->shouldSpeculateStringOrOther())
+                        return StringOrOtherUse;
+                    return StringUse;
+                };
+
+                speculateChild(node->child1(), StringUse);
+                speculateChild(node->child2(), useKindForArgument(node->child2()));
+                if (node->child3())
+                    speculateChild(node->child3(), useKindForArgument(node->child3()));
+                break;
+            }
+
             // FIXME: Remove empty string arguments and possibly turn this into a ToString operation. That
             // would require a form of ToString that takes a KnownPrimitiveUse. This is necessary because
             // the implementation of StrCat doesn't dynamically optimize for empty strings.

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -1972,6 +1972,7 @@ public:
         case DateGetTime:
         case DateGetInt32OrNaN:
         case StringTrim:
+        case StrCat:
             return true;
         default:
             return false;


### PR DESCRIPTION
#### 6a9868495cb975b48825c3332a25ca1b857e7e23
<pre>
[JSC] Speculate on `String#concat` arguments based on profiling
<a href="https://bugs.webkit.org/show_bug.cgi?id=318660">https://bugs.webkit.org/show_bug.cgi?id=318660</a>

Reviewed by Yusuke Suzuki.

@babel/preset-env compiles `${x}px` into &quot;&quot;.concat(x, &quot;px&quot;), but the DFG
intrinsic emits Check(StringUse) on every argument, so the first number
argument takes a BadType OSR exit and permanently disables the intrinsic.

This patch defers the argument speculation to FixupPhase, which picks the
use kinds based on profiling instead.

                                        baseline                  patched

string-concat-long-convert         103.0186+-1.4840     ^     16.1301+-0.2485        ^ definitely 6.3867x faster
string-prototype-concat-int32       79.0260+-0.6463     ^     24.9199+-0.3324        ^ definitely 3.1712x faster
string-concat-convert              112.5050+-1.0153     ^     18.6171+-0.1443        ^ definitely 6.0431x faster

Test: JSTests/microbenchmarks/string-prototype-concat-int32.js

* JSTests/microbenchmarks/string-prototype-concat-int32.js: Added.
(build):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGNode.h:
(JSC::DFG::Node::hasIntrinsic):

Canonical link: <a href="https://commits.webkit.org/316696@main">https://commits.webkit.org/316696@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6bef24f29330c997a275d76cde7a72e3f6ec21a9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173207 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47139 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40643 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182780 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130763 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48432 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46821 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134681 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176165 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/38092 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/155302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115152 "Found 1 new API test failure: WPE/TestWebKitWebView:/webkit/WebKitWebView/save (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36737 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/35080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31265 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/3818 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/147161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34801 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185202 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/34469 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/38026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/39282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143524 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46807 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143395 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38707 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47486 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112567 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38356 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/119235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45992 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9746 "Passed tests") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45394 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45625 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45451 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->