### PR TITLE
[GLIB][JSC] Remove stale test262 expectations that now pass on WPE

### DIFF
--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -478,24 +478,9 @@ test/intl402/DateTimeFormat/prototype/formatToParts/temporal-objects-not-overlap
 test/intl402/DateTimeFormat/prototype/formatToParts/temporal-zoneddatetime-not-supported.js:
   default: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(0n, timeZone)')"
   strict mode: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(0n, timeZone)')"
-test/intl402/Intl/supportedValuesOf/calendars-accepted-by-DisplayNames.js:
-  default: 'Test262Error: bangla is supported by DisplayNames Expected SameValue(«"undefined"», «"string"») to be true'
-  strict mode: 'Test262Error: bangla is supported by DisplayNames Expected SameValue(«"undefined"», «"string"») to be true'
 test/intl402/Locale/extensions-grandfathered.js:
   default: 'Test262Error: Expected SameValue(«"fr-Cyrl-FR-gaulish-u-nu-latn"», «"fr-Cyrl-FR-u-nu-latn"») to be true'
   strict mode: 'Test262Error: Expected SameValue(«"fr-Cyrl-FR-gaulish-u-nu-latn"», «"fr-Cyrl-FR-u-nu-latn"») to be true'
-test/intl402/NumberFormat/prototype/format/unit-ja-JP.js:
-  default: 'Test262Error: Expected SameValue(«"時速-987キロメートル"», «"時速 -987 キロメートル"») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«"時速-987キロメートル"», «"時速 -987 キロメートル"») to be true'
-test/intl402/NumberFormat/prototype/format/unit-zh-TW.js:
-  default: 'Test262Error: Expected SameValue(«"-987公里/小時"», «"-987 公里/小時"») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«"-987公里/小時"», «"-987 公里/小時"») to be true'
-test/intl402/NumberFormat/prototype/formatToParts/unit-ja-JP.js:
-  default: 'Test262Error: undefined: length Expected SameValue(«4», «6») to be true'
-  strict mode: 'Test262Error: undefined: length Expected SameValue(«4», «6») to be true'
-test/intl402/NumberFormat/prototype/formatToParts/unit-zh-TW.js:
-  default: 'Test262Error: undefined: length Expected SameValue(«3», «4») to be true'
-  strict mode: 'Test262Error: undefined: length Expected SameValue(«3», «4») to be true'
 test/intl402/Temporal/Duration/compare/relativeto-sub-minute-offset.js:
   default: 'RangeError: Cannot compare a duration of years, months, or weeks without a relativeTo option'
   strict mode: 'RangeError: Cannot compare a duration of years, months, or weeks without a relativeTo option'
@@ -626,30 +611,6 @@ test/language/expressions/yield/star-rhs-iter-thrw-res-done-no-value.js:
   strict mode: 'Test262Error: access count (second iteration) Expected SameValue(«1», «0») to be true'
 test/language/identifier-resolution/assign-to-global-undefined.js:
   strict mode: Expected uncaught exception with name 'ReferenceError' but none was thrown
-test/language/identifiers/part-unicode-17.0.0-class-escaped.js:
-  default: "SyntaxError: Invalid unicode escape in identifier: '#_\\u1ACF'"
-  strict mode: "SyntaxError: Invalid unicode escape in identifier: '#_\\u1ACF'"
-test/language/identifiers/part-unicode-17.0.0-class.js:
-  default: "SyntaxError: Invalid character '\\u1acf'"
-  strict mode: "SyntaxError: Invalid character '\\u1acf'"
-test/language/identifiers/part-unicode-17.0.0-escaped.js:
-  default: "SyntaxError: Invalid unicode escape in identifier: '_\\u1ACF'"
-  strict mode: "SyntaxError: Invalid unicode escape in identifier: '_\\u1ACF'"
-test/language/identifiers/part-unicode-17.0.0.js:
-  default: "SyntaxError: Invalid character '\\u1acf'"
-  strict mode: "SyntaxError: Invalid character '\\u1acf'"
-test/language/identifiers/start-unicode-17.0.0-class-escaped.js:
-  default: "SyntaxError: Invalid unicode escape in identifier: '#\\u088F'"
-  strict mode: "SyntaxError: Invalid unicode escape in identifier: '#\\u088F'"
-test/language/identifiers/start-unicode-17.0.0-class.js:
-  default: "SyntaxError: Invalid character: '#'"
-  strict mode: "SyntaxError: Invalid character: '#'"
-test/language/identifiers/start-unicode-17.0.0-escaped.js:
-  default: "SyntaxError: Invalid unicode escape in identifier: '\\u088F'"
-  strict mode: "SyntaxError: Invalid unicode escape in identifier: '\\u088F'"
-test/language/identifiers/start-unicode-17.0.0.js:
-  default: "SyntaxError: Invalid character '\\u088f'"
-  strict mode: "SyntaxError: Invalid character '\\u088f'"
 test/language/module-code/top-level-await/async-module-does-not-block-sibling-modules.js:
   module: 'Test262Error: Expected SameValue(«true», «false») to be true'
 test/language/module-code/top-level-await/dynamic-import-of-waiting-module.js:


### PR DESCRIPTION
#### fc8a3cc498cce90b6d49045d0b0229ad91964334
<pre>
[GLIB][JSC] Remove stale test262 expectations that now pass on WPE

Unreviewed gardening.

These tests are recorded as expected failures but pass consistently on the
WPE-Linux-ARM64-Release bot: the Unicode 17 identifier tests and several
Intl.NumberFormat unit and calendar locale tests. Remove the stale entries so
future regressions are no longer masked.

Canonical link: <a href="https://commits.webkit.org/305877.954@webkitglib/2.52">https://commits.webkit.org/305877.954@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7bf3727ee2d5d76d29266c41e4b11f3c9f17e26c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172728 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/46646 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/40101 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182186 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/130284 "The change is no longer eligible for processing.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/47939 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/46321 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134336 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/130284 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175686 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/47939 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/40101 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114808 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/47939 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/46321 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30785 "Built successfully") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/40101 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/47939 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/40101 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184719 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/33989 "The change is no longer eligible for processing.") | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/46321 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143128 "Passed tests") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/46318 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/40101 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143005 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/46996 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/40101 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/111962 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26207 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/46996 "The change is no longer eligible for processing.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/205406 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/45513 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/40101 "The change is no longer eligible for processing.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54842 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/44913 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/45145 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/44972 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->