### PR TITLE
[LBSE] Cache the concatenated SVG transform attribute matrix

### DIFF
--- a/Source/WebCore/rendering/RenderLayerModelObject.cpp
+++ b/Source/WebCore/rendering/RenderLayerModelObject.cpp
@@ -451,7 +451,7 @@ void RenderLayerModelObject::mapLocalToSVGContainer(const RenderLayerModelObject
 
 void RenderLayerModelObject::applySVGTransform(TransformationMatrix& transform, const SVGGraphicsElement& graphicsElement, const Style::ComputedStyle& style, const FloatRect& boundingBox, const std::optional<AffineTransform>& preApplySVGTransformMatrix, const std::optional<AffineTransform>& postApplySVGTransformMatrix, OptionSet<Style::TransformResolverOption> options) const
 {
-    auto svgTransform = graphicsElement.transform().concatenate().value_or(identity);
+    auto svgTransform = graphicsElement.concatenatedTransform();
     auto* supplementalTransform = graphicsElement.supplementalTransform(); // SMIL <animateMotion>
 
     // This check does not use style.hasTransformRelatedProperty() on purpose -- we only want to know if either the 'transform' property, an

--- a/Source/WebCore/svg/SVGGraphicsElement.cpp
+++ b/Source/WebCore/svg/SVGGraphicsElement.cpp
@@ -174,10 +174,9 @@ AffineTransform SVGGraphicsElement::animatedLocalTransform() const
 {
     // LBSE handles transforms via RenderLayer, no need to handle CSS transforms here.
     if (document().settings().layerBasedSVGEngineEnabled()) {
-        auto concatenatedTransform = protect(transform())->concatenate();
-        if (concatenatedTransform && m_supplementalTransform)
-            return *m_supplementalTransform * *concatenatedTransform;
-        return m_supplementalTransform ? *m_supplementalTransform : concatenatedTransform.value_or(identity);
+        if (m_supplementalTransform)
+            return *m_supplementalTransform * concatenatedTransform();
+        return concatenatedTransform();
     }
 
     AffineTransform matrix;
@@ -230,6 +229,8 @@ void SVGGraphicsElement::svgAttributeChanged(const QualifiedName& attrName)
     if (PropertyRegistry::isKnownAttribute(attrName)) {
         ASSERT(attrName == SVGNames::transformAttr);
         InstanceInvalidationGuard guard(*this);
+
+        invalidateConcatenatedTransformCache();
 
         if (document().settings().layerBasedSVGEngineEnabled()) {
             updateSVGRendererForElementChange(Style::SVGRendererUpdateType::TransformAttributeOnly);

--- a/Source/WebCore/svg/SVGGraphicsElement.h
+++ b/Source/WebCore/svg/SVGGraphicsElement.h
@@ -58,7 +58,15 @@ public:
     AffineTransform* ensureSupplementalTransform() override;
     AffineTransform* supplementalTransform() const LIFETIME_BOUND override { return m_supplementalTransform.get(); }
 
-    virtual bool hasTransformRelatedAttributes() const { return (!transform().isEmpty() && !transform().concatenate()->isIdentity()) || m_supplementalTransform; }
+    const AffineTransform& concatenatedTransform() const
+    {
+        if (!m_cachedConcatenatedTransform)
+            m_cachedConcatenatedTransform = transform().concatenate().value_or(AffineTransform { });
+        return *m_cachedConcatenatedTransform;
+    }
+    void invalidateConcatenatedTransformCache() const { m_cachedConcatenatedTransform = std::nullopt; }
+
+    virtual bool hasTransformRelatedAttributes() const { return !concatenatedTransform().isIdentity() || m_supplementalTransform; }
 
     Ref<SVGRect> getBBoxForBindings();
     virtual FloatRect getBBox(StyleUpdateStrategy = StyleUpdateStrategy::Allow);
@@ -96,6 +104,8 @@ private:
 
     // Used by <animateMotion>
     std::unique_ptr<AffineTransform> m_supplementalTransform;
+
+    mutable std::optional<AffineTransform> m_cachedConcatenatedTransform;
 
     // Used to isolate blend operations caused by masking.
     bool m_shouldIsolateBlending { false };


### PR DESCRIPTION
#### 8b35ecea6411bb80f91177f032958dcd174302ff
<pre>
[LBSE] Cache the concatenated SVG transform attribute matrix
<a href="https://bugs.webkit.org/show_bug.cgi?id=318661">https://bugs.webkit.org/show_bug.cgi?id=318661</a>

Reviewed by Rob Buis.

SVGTransformList::concatenate() walks the transform list and multiplies every
item on each read ~ 3 times per animation frame: updateHasSVGTransformFlags -&gt;
hasTransformRelatedAttributes, updateLocalTransform via applySVGTransform,
and computeRendererTransformForSVG. The result only changes when the transform
list mutates, which always routes through SVGGraphicsElement::svgAttributeChanged.

Cache it on SVGGraphicsElement and flush it in svgAttributeChanged, to fix that.
Covered by existing tests.

* Source/WebCore/rendering/RenderLayerModelObject.cpp:
(WebCore::RenderLayerModelObject::applySVGTransform const):
* Source/WebCore/svg/SVGGraphicsElement.cpp:
(WebCore::SVGGraphicsElement::animatedLocalTransform const):
(WebCore::SVGGraphicsElement::svgAttributeChanged):
* Source/WebCore/svg/SVGGraphicsElement.h:
(WebCore::SVGGraphicsElement::concatenatedTransform const):
(WebCore::SVGGraphicsElement::invalidateConcatenatedTransformCache const):
(WebCore::SVGGraphicsElement::hasTransformRelatedAttributes const):

Canonical link: <a href="https://commits.webkit.org/316543@main">https://commits.webkit.org/316543@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/284c5cc9062c86730e393837de4ee0b11fc5738d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172730 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46649 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40103 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182188 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130286 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174595 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47941 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46323 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134338 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175688 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37736 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154886 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114810 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36371 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34686 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30787 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146800 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34389 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184721 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37434 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38888 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143130 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46320 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143016 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38609 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46998 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111964 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38011 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118750 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45515 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/9339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44915 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45147 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44974 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->