### PR TITLE
[LBSE] Reuse cached m_localTransform at paint instead of re-resolving from style

### DIFF
--- a/Source/WebCore/rendering/RenderLayerSVGAdditions.cpp
+++ b/Source/WebCore/rendering/RenderLayerSVGAdditions.cpp
@@ -551,13 +551,29 @@ std::optional<RenderLayer::SVGRendererTransform> RenderLayer::computeRendererTra
     CheckedRef layerModelObject = downcast<RenderLayerModelObject>(rendererRef.get());
     TransformationMatrix transform;
     CheckedRef style = layerModelObject->style();
-    auto referenceBoxRect = layerModelObject->transformReferenceBoxRect(style);
 
-    // For non-layer renderers, undo the alignReferenceBox shift applied in transformReferenceBoxRect().
-    if (!rendererRef->hasSelfPaintingLayer() && rendererRef->isSVGLayerAwareRenderer())
-        referenceBoxRect.moveBy(layerModelObject->nominalSVGLayoutLocation());
+    // Fast path: a non-layer SVG renderer already caches 'transform' in m_localTransform.
+    // The only difference from the paint transform is the reference-box + nominal shift, which
+    // just moves the transform-origin, so the paint transform equals:
+    // translate(nominal) * m_localTransform * translate(-nominal).
+    bool isNonLayerSVG = !rendererRef->hasSelfPaintingLayer() && rendererRef->isSVGLayerAwareRenderer();
+    CheckedPtr useTransformRenderer = (isNonLayerSVG && !is<RenderSVGViewportContainer>(rendererRef.get()))
+        ? dynamicDowncast<RenderSVGModelObject>(rendererRef.get()) : nullptr;
 
-    layerModelObject->applyTransform(transform, style, referenceBoxRect, Style::TransformResolver::allTransformOperations);
+    if (useTransformRenderer) {
+        auto nominal = useTransformRenderer->nominalSVGLayoutLocation();
+        transform.translate(nominal.x().toFloat(), nominal.y().toFloat());
+        transform.multiply(TransformationMatrix(useTransformRenderer->localTransform()));
+        transform.translate(-nominal.x().toFloat(), -nominal.y().toFloat());
+    } else {
+        auto referenceBoxRect = layerModelObject->transformReferenceBoxRect(style);
+
+        // For non-layer renderers, undo the alignReferenceBox shift applied in transformReferenceBoxRect().
+        if (isNonLayerSVG)
+            referenceBoxRect.moveBy(layerModelObject->nominalSVGLayoutLocation());
+
+        layerModelObject->applyTransform(transform, style, referenceBoxRect, Style::TransformResolver::allTransformOperations);
+    }
 
     // For the outermost viewport container (anonymous child of RenderSVGRoot), apply the
     // content-box origin offset (border+padding).


### PR DESCRIPTION
#### 74a7d27a4cc3b9285e775856a3e642ed966df371
<pre>
[LBSE] Reuse cached m_localTransform at paint instead of re-resolving from style
<a href="https://bugs.webkit.org/show_bug.cgi?id=318662">https://bugs.webkit.org/show_bug.cgi?id=318662</a>

Reviewed by Rob Buis.

computeRendererTransformForSVG() re-resolved the SVG transform from style on every
paint (applyTransform: concatenate + transform-origin + matrix multiplies), even
though a non-layer SVG renderer already caches that transform in m_localTransform,
just with a different transform-origin, aligned for the nominal layer paint code
path. We can easily compute the desired paint transform: translate(nominal) *
m_localTransform * translate(-nominal), to save the recomputation.

Covered by existing tests.

* Source/WebCore/rendering/RenderLayerSVGAdditions.cpp:
(WebCore::RenderLayer::computeRendererTransformForSVG const):

Canonical link: <a href="https://commits.webkit.org/316544@main">https://commits.webkit.org/316544@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8bddb091387162dca3e0c87eea30873db5080355

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172741 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46660 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40114 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182199 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130297 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174606 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47952 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46334 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134347 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175699 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37748 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154897 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114819 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36383 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34699 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30798 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/146812 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34400 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184732 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37446 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38899 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143140 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46331 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143018 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38611 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47009 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111975 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38022 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118761 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45526 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/9350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44926 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45158 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44985 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->