### PR TITLE
[JSC] Yarr should collect BM info for fixed-count terms

### DIFF
--- a/JSTests/microbenchmarks/regexp-quantified-class-boyer-moore.js
+++ b/JSTests/microbenchmarks/regexp-quantified-class-boyer-moore.js
@@ -1,0 +1,29 @@
+// Unanchored RegExp.test with a counted-quantifier character class (e.g. /\b\d{3}-\d{2}-\d{4}\b/)
+// over mostly non-matching subjects. Stresses the Boyer-Moore fast-skip path: the {n} quantifier
+// must not prevent BoyerMooreInfo collection, otherwise every subject position re-runs the whole
+// body alternative.
+
+function test(re, string)
+{
+    return re.test(string);
+}
+noInline(test);
+
+var base = [
+    "Unhandled rejection in checkout worker 12 while reconciling the cart totals for session 8842171: the upstream pricing service returned an unexpected payload shape after 3 retries and the fallback path recomputed the discount tier from the cached promotion table before retrying the idempotent write to the orders store",
+    "Slow query took 1842 ms on the reporting replica while aggregating weekly engagement metrics for dashboard 91: the planner chose a sequential scan over the composite index because the statistics were stale after the nightly bulk load of 250000 rows finished later than usual and autovacuum had not caught up",
+    "Retrying webhook delivery to partner endpoint 44 after receiving status 504 in 30000 ms: the request will be retried with exponential backoff and jitter until the maximum attempt count of 10 is reached, at which point event 77120 will be parked in the dead letter queue for inspection by the integrations team",
+    "Customer support note for account 55023: user reported that the ssn on file 078-05-1120 was entered incorrectly during onboarding and asked us to verify the masked value shown in the profile settings page before resubmitting the identity verification form to the compliance vendor for another review pass",
+];
+
+var strings = [];
+for (var i = 0; i < 16; ++i)
+    strings.push(base[i & 3] + " rid " + i);
+
+var re = /\b\d{3}-\d{2}-\d{4}\b/;
+var count = 0;
+for (var i = 0; i < 3e5; ++i)
+    count += test(re, strings[i & 15]) ? 1 : 0;
+
+if (count !== 3e5 / 4)
+    throw new Error("bad count: " + count);

--- a/JSTests/stress/regexp-boyer-moore-counted-quantifier.js
+++ b/JSTests/stress/regexp-boyer-moore-counted-quantifier.js
@@ -1,0 +1,97 @@
+// Verifies that the Boyer-Moore fast-skip tables built for counted quantifiers
+// ({n} on character classes and pattern characters) never skip over a real match.
+// Each pattern is slid across every alignment 0..maxPad so that every residue of
+// the skip stride is exercised, including expansions truncated at the BM table
+// length cap (32) and 16-bit subject strings.
+
+function shouldBe(actual, expected, context)
+{
+    if (actual !== expected)
+        throw new Error("bad value: " + actual + ", expected: " + expected + " (" + context + ")");
+}
+
+function slide(re, matchStr, pad, maxPad)
+{
+    for (var p = 0; p <= maxPad; ++p) {
+        var string = pad.repeat(p) + matchStr + pad.repeat(5);
+        for (var k = 0; k < 50; ++k) {
+            var m = re.exec(string);
+            shouldBe(m !== null, true, re + " pad=" + p);
+            shouldBe(m.index, p * pad.length, re + " pad=" + p);
+            shouldBe(m[0], matchStr, re + " pad=" + p);
+        }
+    }
+}
+
+function never(re, string)
+{
+    for (var k = 0; k < 50; ++k)
+        shouldBe(re.exec(string), null, re + " on " + string);
+}
+
+// Basic counted character classes, all alignments.
+slide(/\d{3}/, "123", "x", 40);
+slide(/\d{3}-\d{2}-\d{4}/, "078-05-1120", "x", 40);
+slide(/\b\d{3}-\d{2}-\d{4}\b/, "078-05-1120", " ", 40);
+
+// Counted pattern characters.
+slide(/a{3}b/, "aaab", "x", 40);
+slide(/a{30}b/, "a".repeat(30) + "b", "x", 40);
+
+// Expansion truncated at the BM table length cap (32): minimum size crosses the cap.
+slide(/\d{31}x/, "7".repeat(31) + "x", "q", 40);
+slide(/\d{32}y/, "7".repeat(32) + "y", "q", 40);
+slide(/\d{33}z/, "7".repeat(33) + "z", "q", 40);
+slide(/z{40}!/, "z".repeat(40) + "!", "q", 40);
+
+// Cursor starts mid-table, then the counted term crosses the cap.
+slide(/ab\d{31}c/, "ab" + "5".repeat(31) + "c", "x", 40);
+
+// Case-insensitive counted pattern character: both cases must be in the table.
+slide(/a{4}b/i, "aAaAb", "x", 40);
+slide(/a{4}b/i, "AAAAB", "x", 40);
+
+// Inverted class and dot (setAll path) with counted quantifiers.
+slide(/[^0-9]{3}=/, "abc=", "5", 40);
+slide(/.{4}#/, "abcd#", "\n", 20);
+slide(/.{4}#/s, "abcd#", "\n", 20);
+
+// 16-bit subject strings.
+slide(/\d{3}-\d{2}/, "123-45", "あ", 20);
+slide(/[あ-ん]{3}!/, "あいう!", "z", 20);
+
+// Counted quantifiers inside alternatives of a group: both alternative lengths.
+slide(/(\d{3}|ab)z/, "123z", "x", 20);
+slide(/(\d{3}|ab)z/, "abz", "x", 20);
+
+// Counted group containing a counted class (group-level {3} still bails; must stay correct).
+slide(/(?:\d{2}){3}x/, "123456x", "q", 20);
+
+// {m,n} splits into fixed prefix + greedy remainder.
+slide(/w\d{2,4}z/, "w12z", "x", 20);
+slide(/w\d{2,4}z/, "w1234z", "x", 20);
+
+// Unicode flag (BM collection disabled; sanity-check identical results).
+slide(/\d{3}-\d{2}-\d{4}/u, "078-05-1120", "x", 20);
+
+// Global matching from a nonzero lastIndex.
+var globalRe = /\d{3}-\d{2}/g;
+for (var k = 0; k < 50; ++k) {
+    globalRe.lastIndex = 0;
+    var m1 = globalRe.exec("xx 123-45 yy 678-90 zz");
+    shouldBe(m1.index, 3, "global first");
+    shouldBe(m1[0], "123-45", "global first");
+    var m2 = globalRe.exec("xx 123-45 yy 678-90 zz");
+    shouldBe(m2.index, 13, "global second");
+    shouldBe(m2[0], "678-90", "global second");
+    shouldBe(globalRe.exec("xx 123-45 yy 678-90 zz"), null, "global third");
+}
+
+// Near-misses: partial shapes that the skip loop flies over must stay non-matches.
+never(/\d{3}-\d{2}-\d{4}/, "x".repeat(20) + "12-345-6789 12a-45-6789 123-4-51120" + "x".repeat(20));
+never(/w\d{2,4}z/, "x".repeat(30) + "w1z w12345z" + "x".repeat(30));
+never(/\d{31}x/, "q".repeat(10) + "7".repeat(30) + "x" + "q".repeat(10));
+never(/a{4}b/i, "x".repeat(20) + "aAaB AaAB" + "x".repeat(20));
+
+// Long scan with digit runs shorter than the counted quantifier: skip loop runs many strides.
+never(/\d{3}-\d{2}-\d{4}/, "ab1cd23ef-45gh".repeat(100));

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -5897,42 +5897,43 @@ class YarrGenerator final : public YarrJITInfo {
         case PatternTerm::Type::CharacterClass: {
             if (term.quantityType != QuantifierType::FixedCount && term.quantityType != QuantifierType::Greedy)
                 return std::nullopt;
-            if (term.quantityMaxCount != 1)
+            if (term.quantityMaxCount != 1 && term.quantityType != QuantifierType::FixedCount)
                 return std::nullopt;
             if (term.inputPosition != cursor)
                 return std::nullopt;
             auto& characterClass = *term.characterClass;
-            if (term.invert() || characterClass.m_anyCharacter) {
-                bmInfo.setAll(cursor);
-                // If this is greedy one-character pattern "a?", we should not increase cursor.
-                // If we see greedy pattern, then we cut bmInfo here to avoid possibility explosion.
-                if (term.quantityType == QuantifierType::FixedCount)
-                    ++cursor;
-                else
-                    bmInfo.shortenLength(cursor + 1);
+            auto addCharacterClass = [&](unsigned index) {
+                if (term.invert() || characterClass.m_anyCharacter) {
+                    bmInfo.setAll(index);
+                    return;
+                }
+                if (!characterClass.m_ranges32.isEmpty())
+                    bmInfo.addRanges(index, characterClass.m_ranges32);
+                if (!characterClass.m_matches32.isEmpty())
+                    bmInfo.addCharacters(index, characterClass.m_matches32);
+                if (!characterClass.m_ranges8.isEmpty())
+                    bmInfo.addRanges(index, characterClass.m_ranges8);
+                if (!characterClass.m_matches8.isEmpty())
+                    bmInfo.addCharacters(index, characterClass.m_matches8);
+            };
+
+            if (term.quantityType == QuantifierType::FixedCount) {
+                unsigned count = term.quantityMaxCount;
+                for (unsigned i = 0; i < count && cursor < bmInfo.length(); ++i)
+                    addCharacterClass(cursor++);
                 return cursor;
             }
-            if (!characterClass.m_ranges32.isEmpty())
-                bmInfo.addRanges(cursor, characterClass.m_ranges32);
-            if (!characterClass.m_matches32.isEmpty())
-                bmInfo.addCharacters(cursor, characterClass.m_matches32);
-            if (!characterClass.m_ranges8.isEmpty())
-                bmInfo.addRanges(cursor, characterClass.m_ranges8);
-            if (!characterClass.m_matches8.isEmpty())
-                bmInfo.addCharacters(cursor, characterClass.m_matches8);
 
             // If this is greedy one-character pattern "a?", we should not increase cursor.
             // If we see greedy pattern, then we cut bmInfo here to avoid possibility explosion.
-            if (term.quantityType == QuantifierType::FixedCount)
-                ++cursor;
-            else
-                bmInfo.shortenLength(cursor + 1);
+            addCharacterClass(cursor);
+            bmInfo.shortenLength(cursor + 1);
             return cursor;
         }
         case PatternTerm::Type::PatternCharacter: {
             if (term.quantityType != QuantifierType::FixedCount && term.quantityType != QuantifierType::Greedy)
                 return std::nullopt;
-            if (term.quantityMaxCount != 1)
+            if (term.quantityMaxCount != 1 && term.quantityType != QuantifierType::FixedCount)
                 return std::nullopt;
             if (term.inputPosition != cursor)
                 return std::nullopt;
@@ -5941,18 +5942,25 @@ class YarrGenerator final : public YarrJITInfo {
             // For case-insesitive compares, non-ascii characters that have different
             // upper & lower case representations are already converted to a character class.
             ASSERT(!term.ignoreCase() || isASCIIAlpha(term.patternCharacter) || isCanonicallyUnique(term.patternCharacter, m_canonicalMode));
-            if (term.ignoreCase() && isASCIIAlpha(term.patternCharacter)) {
-                bmInfo.set(cursor, toASCIIUpper(term.patternCharacter));
-                bmInfo.set(cursor, toASCIILower(term.patternCharacter));
-            } else
-                bmInfo.set(cursor, term.patternCharacter);
+            auto addCharacter = [&](unsigned index) {
+                if (term.ignoreCase() && isASCIIAlpha(term.patternCharacter)) {
+                    bmInfo.set(index, toASCIIUpper(term.patternCharacter));
+                    bmInfo.set(index, toASCIILower(term.patternCharacter));
+                } else
+                    bmInfo.set(index, term.patternCharacter);
+            };
+
+            if (term.quantityType == QuantifierType::FixedCount) {
+                unsigned count = term.quantityMaxCount;
+                for (unsigned i = 0; i < count && cursor < bmInfo.length(); ++i)
+                    addCharacter(cursor++);
+                return cursor;
+            }
 
             // If this is greedy one-character pattern "a?", we should not increase cursor.
             // If we see greedy pattern, then we cut bmInfo here to avoid possibility explosion.
-            if (term.quantityType == QuantifierType::FixedCount)
-                ++cursor;
-            else
-                bmInfo.shortenLength(cursor + 1);
+            addCharacter(cursor);
+            bmInfo.shortenLength(cursor + 1);
             return cursor;
         }
         }


### PR DESCRIPTION
#### 7a764d7acc545eff4dcd690bbf1ae75c64a67796
<pre>
[JSC] Yarr should collect BM info for fixed-count terms
<a href="https://bugs.webkit.org/show_bug.cgi?id=318665">https://bugs.webkit.org/show_bug.cgi?id=318665</a>

Reviewed by Yusuke Suzuki.

collectBoyerMooreInfoFromTerm bails out on any term with
quantityMaxCount != 1, so patterns spelled with counted quantifiers
like /\b\d{3}-\d{2}-\d{4}\b/ never get the unanchored fast-skip loop
while the identical manual expansion /\d\d\d-\d\d-\d\d\d\d/ does,
making the common spelling ~10x slower on non-matching subjects.

Handle fixed-count CharacterClass and PatternCharacter terms by adding
the character set at each of the quantityMaxCount consecutive
positions. The expansion is capped by the BoyerMooreInfo length, and
greedy terms keep the previous behavior.

    regexp-quantified-class-boyer-moore    69.7101+-1.0631    ^    6.4635+-0.1791    ^ definitely 10.7851x faster

Tests: JSTests/microbenchmarks/regexp-quantified-class-boyer-moore.js
       JSTests/stress/regexp-boyer-moore-counted-quantifier.js

* JSTests/microbenchmarks/regexp-quantified-class-boyer-moore.js: Added.
(test):
* JSTests/stress/regexp-boyer-moore-counted-quantifier.js: Added.
(shouldBe):
(slide):
(never):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:

Canonical link: <a href="https://commits.webkit.org/316790@main">https://commits.webkit.org/316790@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b5be2704a6cda381a2029187caaea56be13f390

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172733 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46652 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40106 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182191 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130289 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47944 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46326 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134339 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94821 "23 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175691 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37742 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154887 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114811 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36377 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34688 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30790 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/3413 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146806 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34390 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184724 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/33994 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37437 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38890 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143132 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46323 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143009 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38751 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47001 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31229 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111967 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38012 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118753 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/205411 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45518 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9340 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54844 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44918 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45150 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44977 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->