### PR TITLE
Make sure that MicrotaskQueue::drainImpl cannot have its micro task dispatcher being GCed while running

### DIFF
--- a/LayoutTests/streams/tee-byob-microtask-gc-crash-expected.txt
+++ b/LayoutTests/streams/tee-byob-microtask-gc-crash-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Teeing a byte ReadableStream and reading both branches under continuous GC should not crash
+

--- a/LayoutTests/streams/tee-byob-microtask-gc-crash.html
+++ b/LayoutTests/streams/tee-byob-microtask-gc-crash.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html><!-- webkit-test-runner [ jscOptions=--collectContinuously=true ] -->
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+promise_test(async () => {
+    function readAll(reader) {
+        return new Promise(resolve => {
+            (function loop() {
+                reader.read().then(result => {
+                    if (result.done)
+                        resolve();
+                    else
+                        loop();
+                }, () => resolve());
+            })();
+        });
+    }
+
+    function makeChain() {
+        let chunksLeft = 32;
+        let current = new ReadableStream({
+            type: "bytes",
+            pull(controller) {
+                if (--chunksLeft <= 0) {
+                    controller.close();
+                    return;
+                }
+                controller.enqueue(new Uint8Array(16384));
+            }
+        });
+
+        const readers = [];
+        for (let i = 0; i < 2; ++i) {
+            const teed = current.tee();
+            readers.push(teed[1].getReader());
+            current = teed[0];
+        }
+        readers.push(current.getReader());
+        return Promise.all(readers.map(readAll));
+    }
+
+    const chains = [];
+    for (let i = 0; i < 4; ++i)
+        chains.push(makeChain());
+    await Promise.all(chains);
+}, "Teeing a byte ReadableStream and reading both branches under continuous GC should not crash");
+</script>
+</body>
+</html>

--- a/Source/JavaScriptCore/runtime/MicrotaskQueue.cpp
+++ b/Source/JavaScriptCore/runtime/MicrotaskQueue.cpp
@@ -200,6 +200,8 @@ ALWAYS_INLINE std::pair<JSGlobalObject*, bool> MicrotaskQueue::drainImpl(JSGloba
             if (globalObject != currentGlobalObject) [[unlikely]]
                 return { globalObject, false };
 
+            EnsureStillAliveScope dispatcherScope(jsMicrotaskDispatcher);
+
             auto task = m_queue.dequeue();
             QueuedTask::Result result;
             {


### PR DESCRIPTION
#### a48d2303546c4bb4cce553fc3d8158d1d8e6a4d0
<pre>
Make sure that MicrotaskQueue::drainImpl cannot have its micro task dispatcher being GCed while running
<a href="https://bugs.webkit.org/show_bug.cgi?id=318667">https://bugs.webkit.org/show_bug.cgi?id=318667</a>
<a href="https://rdar.apple.com/179017690">rdar://179017690</a>

Reviewed by Yusuke Suzuki.

When the dispatcher runs, GC can happen, which could destroy the JS microtask dispatcher and its internal dispatcher.
To prevent this, we keep the JS micro task dispatcher alive with EnsureStillAliveScope.

Test: streams/tee-byob-microtask-gc-crash.html

* LayoutTests/streams/tee-byob-microtask-gc-crash-expected.txt: Added.
* LayoutTests/streams/tee-byob-microtask-gc-crash.html: Added.
* Source/JavaScriptCore/runtime/MicrotaskQueue.cpp:
(JSC::MicrotaskQueue::drainImpl):

Canonical link: <a href="https://commits.webkit.org/316546@main">https://commits.webkit.org/316546@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d0b651493e6fd00b3c4aba7754f9221325b02e09

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172751 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46670 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40124 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182209 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130307 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0eba44b2-d030-4d75-a08e-fd88364a2f0d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47962 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46345 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134356 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b3c2ac37-be5e-4430-b69b-bb4f8a1c3645) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175709 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37759 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154907 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114828 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/62da5907-982a-42d0-b87d-e004c00a8dda) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36394 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34711 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30808 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/3433 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146823 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34410 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184742 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/34012 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37461 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38911 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143151 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46341 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154479 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143028 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38613 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47019 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111988 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38032 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118771 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/205429 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45536 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/9360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54851 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44936 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45168 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44995 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->