### PR TITLE
[JSC] Add LoadVarargs operation's fast path for TypedArrays

### DIFF
--- a/JSTests/microbenchmarks/load-varargs-typed-array.js
+++ b/JSTests/microbenchmarks/load-varargs-typed-array.js
@@ -1,0 +1,52 @@
+// Microbenchmark for the typed-array fast path in loadVarargs: spreading a typed
+// array through Function.prototype.apply (and f(...ta)). This is the pattern the
+// TextDecoder polyfill hits via String.fromCharCode.apply(null, uint16Array).
+
+function sink() {
+    "use strict";
+    let sum = 0;
+    for (let i = 0; i < arguments.length; ++i)
+        sum += arguments[i];
+    return sum;
+}
+noInline(sink);
+
+// Small per-element values keep the accumulated sum well below 2^53 so the exact
+// equality check below stays valid for any testLoopCount.
+const i8 = new Int8Array(64);
+const u16 = new Uint16Array(64);
+const i32 = new Int32Array(64);
+const f64 = new Float64Array(64);
+for (let i = 0; i < 64; ++i) {
+    i8[i] = i % 100;
+    u16[i] = i % 100;
+    i32[i] = i % 100;
+    f64[i] = i % 100;
+}
+
+let perElementSum = 0;
+for (let i = 0; i < 64; ++i)
+    perElementSum += i % 100;
+
+const count = testLoopCount;
+
+let total = 0;
+for (let i = 0; i < count; ++i) {
+    total += sink.apply(null, i8);
+    total += sink.apply(null, u16);
+    total += sink.apply(null, i32);
+    total += sink.apply(null, f64);
+    total += sink(...u16);
+}
+if (total !== perElementSum * 5 * count)
+    throw new Error("bad sum: " + total);
+
+// Real-world hot pattern: build a string from a Uint16Array of char codes.
+const codes = new Uint16Array(200);
+for (let i = 0; i < codes.length; ++i)
+    codes[i] = 65 + (i % 26);
+let length = 0;
+for (let i = 0; i < count; ++i)
+    length += String.fromCharCode.apply(null, codes).length;
+if (length !== codes.length * count)
+    throw new Error("bad length: " + length);

--- a/JSTests/stress/load-varargs-typed-array.js
+++ b/JSTests/stress/load-varargs-typed-array.js
@@ -1,0 +1,92 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: expected ${expected} but got ${actual}`);
+}
+
+function makeTA(ctor, values) {
+    let ta = new ctor(values.length);
+    for (let i = 0; i < values.length; ++i)
+        ta[i] = values[i];
+    return ta;
+}
+
+// Sum via apply-spread; exercises loadVarargs on a typed array argument.
+function sumApply(...args) {
+    let s = 0;
+    for (let i = 0; i < args.length; ++i)
+        s += Number(args[i]);
+    return s;
+}
+noInline(sumApply);
+
+function collect(...args) { return args; }
+noInline(collect);
+
+const numberCtors = [Int8Array, Uint8Array, Uint8ClampedArray, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+
+function oracleSum(ta) {
+    let s = 0;
+    for (let i = 0; i < ta.length; ++i)
+        s += Number(ta[i]);
+    return s;
+}
+
+function test() {
+    for (const ctor of numberCtors) {
+        const ta = makeTA(ctor, [1, 2, 3, 4, 5, 6, 7]);
+        const expected = oracleSum(ta);
+
+        // f.apply(null, ta)
+        shouldBe(sumApply.apply(null, ta), expected);
+        // f(...ta)
+        shouldBe(sumApply(...ta), expected);
+        // [...ta] length and content
+        const spread = [...ta];
+        shouldBe(spread.length, ta.length);
+        for (let i = 0; i < ta.length; ++i)
+            shouldBe(spread[i], ta[i]);
+        // leading args + spread (non-zero offset in the callee frame)
+        const withLead = collect(100, 200, ...ta);
+        shouldBe(withLead.length, ta.length + 2);
+        shouldBe(withLead[0], 100);
+        shouldBe(withLead[1], 200);
+        for (let i = 0; i < ta.length; ++i)
+            shouldBe(withLead[i + 2], ta[i]);
+    }
+
+    // Empty typed array spread.
+    shouldBe(sumApply.apply(null, new Uint8Array(0)), 0);
+    shouldBe(collect(...new Float64Array(0)).length, 0);
+
+    // BigInt typed arrays go through the same path.
+    // BigInt typed arrays go through the same path. Include large values that require
+    // heap allocation (cannot be a BigInt32) and the .apply spelling, since boxing them
+    // needs a real globalObject.
+    {
+        const ta = new BigInt64Array(4);
+        ta[0] = 10n; ta[1] = 20n; ta[2] = 9223372036854775807n; ta[3] = -9223372036854775808n;
+        const expected = [10n, 20n, 9223372036854775807n, -9223372036854775808n];
+        const out = collect(...ta);
+        shouldBe(out.length, 4);
+        for (let i = 0; i < 4; ++i)
+            shouldBe(out[i], expected[i]);
+        const out2 = collect.apply(null, ta);
+        shouldBe(out2.length, 4);
+        for (let i = 0; i < 4; ++i)
+            shouldBe(out2[i], expected[i]);
+
+        const bu = new BigUint64Array([0n, 18446744073709551615n]);
+        const out3 = collect.apply(null, bu);
+        shouldBe(out3[0], 0n);
+        shouldBe(out3[1], 18446744073709551615n);
+    }
+
+    // fromCharCode.apply over a Uint16Array (mirrors the TextDecoder polyfill hot path).
+    {
+        const codes = new Uint16Array([72, 101, 108, 108, 111]);
+        shouldBe(String.fromCharCode.apply(null, codes), "Hello");
+    }
+}
+
+for (let i = 0; i < testLoopCount; ++i)
+    test();

--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -56,6 +56,7 @@
 #include "JSBoundFunctionInlines.h"
 #include "JSCInlines.h"
 #include "JSCellButterfly.h"
+#include "JSGenericTypedArrayViewInlines.h"
 #include "JSLexicalEnvironment.h"
 #include "JSModuleEnvironment.h"
 #include "JSModuleRecord.h"
@@ -311,6 +312,32 @@ unsigned sizeFrameForVarargs(JSGlobalObject* globalObject, CallFrame* callFrame,
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
+static bool NEVER_INLINE loadTypedArrayVarargs(JSCell* cell, JSValue* firstElementDest, uint32_t offset, uint32_t length)
+{
+    switch (cell->type()) {
+#define JSC_LOAD_VARARGS_TYPED_ARRAY_CASE(name) \
+    case name##ArrayType: { \
+        if constexpr (!JS##name##Array::Adaptor::canConvertToJSQuickly) \
+            return false; \
+        else { \
+            auto* typedArray = uncheckedDowncast<JS##name##Array>(cell); \
+            uint64_t arrayLength = typedArray->length(); \
+            uint64_t inBounds = arrayLength > offset ? std::min<uint64_t>(length, arrayLength - offset) : 0; \
+            uint64_t i = 0; \
+            for (; i < inBounds; ++i) \
+                firstElementDest[i] = typedArray->getIndexQuickly(i + offset); \
+            for (; i < length; ++i) \
+                firstElementDest[i] = jsUndefined(); \
+            return true; \
+        } \
+    }
+        FOR_EACH_TYPED_ARRAY_TYPE_EXCLUDING_DATA_VIEW(JSC_LOAD_VARARGS_TYPED_ARRAY_CASE)
+#undef JSC_LOAD_VARARGS_TYPED_ARRAY_CASE
+    default:
+        return false;
+    }
+}
+
 void loadVarargs(JSGlobalObject* globalObject, JSValue* firstElementDest, JSValue arguments, uint32_t offset, uint32_t length)
 {
     if (!arguments.isCell()) [[unlikely]]
@@ -347,6 +374,8 @@ void loadVarargs(JSGlobalObject* globalObject, JSValue* firstElementDest, JSValu
             uncheckedDowncast<JSArray>(object)->copyToArguments(globalObject, firstElementDest, offset, length);
             return;
         }
+        if (loadTypedArrayVarargs(cell, firstElementDest, offset, length))
+            return;
         unsigned i;
         for (i = 0; i < length && object->canGetIndexQuickly(i + offset); ++i)
             firstElementDest[i] = object->getIndexQuickly(i + offset);


### PR DESCRIPTION
#### ed1cdcc9fbc2934625d33e7fe246fcebcea684d7
<pre>
[JSC] Add LoadVarargs operation&apos;s fast path for TypedArrays
<a href="https://bugs.webkit.org/show_bug.cgi?id=318670">https://bugs.webkit.org/show_bug.cgi?id=318670</a>
<a href="https://rdar.apple.com/181477718">rdar://181477718</a>

Reviewed by Keith Miller.

This patch adds LoadVarargs operation&apos;s fast path for TypedArrays.

                                         ToT                     Patched

    load-varargs-typed-array       32.3672+-0.2021     ^     15.8150+-0.1745        ^ definitely 2.0466x faster

Tests: JSTests/microbenchmarks/load-varargs-typed-array.js
       JSTests/stress/load-varargs-typed-array.js

* JSTests/microbenchmarks/load-varargs-typed-array.js: Added.
(sink):
* JSTests/stress/load-varargs-typed-array.js: Added.
(shouldBe):
(sumApply):
(collect):
(oracleSum):
(test):
* Source/JavaScriptCore/interpreter/Interpreter.cpp:
(JSC::loadTypedArrayVarargs):
(JSC::loadVarargs):

Canonical link: <a href="https://commits.webkit.org/316598@main">https://commits.webkit.org/316598@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5b724ece345a2e7fbb6b39c6202e6bac5e99167

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172901 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46820 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40290 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182361 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130457 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48113 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46496 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134467 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/8c127670-b156-4c03-acd1-fc9ba7ffe3a0/e3e18849-5b7a-4eff-9ca3-55da248accd3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175859 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37857 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155028 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114936 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/8c127670-b156-4c03-acd1-fc9ba7ffe3a0/40272141-e6ae-445a-ade2-31fb7de1f534) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/36502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30959 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/3550 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146925 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34533 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184895 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/34163 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37648 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/39028 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143274 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46491 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143146 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47169 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112171 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26246 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38129 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118929 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/205579 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45686 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9476 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54884 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45087 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45319 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45145 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->