### PR TITLE
[css-mixins-1] Evaluate container queries inside @function

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-conditionals-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-conditionals-expected.txt
@@ -13,12 +13,12 @@ PASS Locals within @media
 PASS @supports within @media
 PASS @media within @supports
 PASS Basic @container
-FAIL Basic @container (false) assert_equals: expected "PASS" but got "FAIL"
-FAIL Nested @container assert_equals: expected "PASS" but got "FAIL"
-FAIL Nested @container (false) assert_equals: expected "PASS" but got "FAIL"
+PASS Basic @container (false)
+PASS Nested @container
+PASS Nested @container (false)
 PASS Locals within @container
 PASS @supports within @container
-FAIL @container within @supports assert_equals: expected "PASS" but got "FAIL"
+PASS @container within @supports
 PASS @container, @media, @supports
 PASS @supports, @media, @container
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-container-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-container-dynamic-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Custom Functions: @container responds to changes assert_equals: --actual before resize expected "A" but got "D"
+FAIL Custom Functions: @container responds to changes assert_equals: --actual after resize to 100px expected "B" but got "A"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-container-self-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-container-self-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Custom Functions: @container can not query self assert_equals: expected "B" but got "C"
+PASS Custom Functions: @container can not query self
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-shadow-container-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-shadow-container-expected.txt
@@ -1,5 +1,5 @@
 
 PASS Can query named container in shadow
-FAIL ::part() can see inner named containers assert_equals: expected "5px" but got "10px"
-FAIL ::slotted() can see inner named containers assert_equals: expected "5px 5px" but got "10px 10px"
+PASS ::part() can see inner named containers
+PASS ::slotted() can see inner named containers
 

--- a/Source/WebCore/style/CustomFunctionRegistry.cpp
+++ b/Source/WebCore/style/CustomFunctionRegistry.cpp
@@ -25,8 +25,6 @@
 #include "config.h"
 #include "CustomFunctionRegistry.h"
 
-#include "ImmutableStyleProperties.h"
-#include "MutableStyleProperties.h"
 #include "StylePropertiesInlines.h"
 
 namespace WebCore {
@@ -35,32 +33,20 @@ namespace Style {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(CustomFunction);
 WTF_MAKE_TZONE_ALLOCATED_IMPL(CustomFunctionRegistry);
 
-CustomFunction::CustomFunction(const AtomString& name, const Vector<StyleRuleFunction::Parameter>& parameters, const CSSCustomPropertySyntax& returnType, const StyleProperties& properties)
+CustomFunction::CustomFunction(const AtomString& name, const Vector<StyleRuleFunction::Parameter>& parameters, const CSSCustomPropertySyntax& returnType, DeclarationsBlocks&& declarationBlocks)
     : name(name)
     , parameters(parameters)
     , returnType(returnType)
-    , properties(properties)
+    , declarationBlocks(WTF::move(declarationBlocks))
 {
 }
 
-void CustomFunctionRegistry::registerFunction(const StyleRuleFunction& function, const Vector<Ref<const StyleRuleFunctionDeclarations>>& declarationsList)
+void CustomFunctionRegistry::registerFunction(const StyleRuleFunction& function, CustomFunction::DeclarationsBlocks&& declarationBlocks)
 {
-    if (declarationsList.isEmpty())
+    if (declarationBlocks.isEmpty())
         return;
 
-    auto mergedProperties = [&]() -> Ref<const StyleProperties> {
-        if (declarationsList.size() == 1)
-            return declarationsList.first()->properties();
-
-        auto mutableProperties = MutableStyleProperties::create();
-        for (auto& declarations : declarationsList) {
-            Ref properties = declarations->properties();
-            mutableProperties->mergeAndOverrideOnConflict(properties.get());
-        }
-        return mutableProperties->immutableCopy();
-    };
-
-    auto customFunction = makeUniqueRef<CustomFunction>(function.name(), function.parameters(), function.returnType(), mergedProperties());
+    auto customFunction = makeUniqueRef<CustomFunction>(function.name(), function.parameters(), function.returnType(), WTF::move(declarationBlocks));
 
     // Last function with the same name wins.
     m_functions.set(function.name(), WTF::move(customFunction));
@@ -73,4 +59,3 @@ const CustomFunction* CustomFunctionRegistry::functionForName(const AtomString& 
 
 }
 }
-

--- a/Source/WebCore/style/CustomFunctionRegistry.h
+++ b/Source/WebCore/style/CustomFunctionRegistry.h
@@ -29,16 +29,25 @@
 namespace WebCore {
 namespace Style {
 
-// CustomFunction registration represents @function after things like conditional group rules (@media) and cascade layers have been resolved.
+// CustomFunction registration represents @function after things like @media and cascade layers have
+// been resolved.
 // https://drafts.csswg.org/css-mixins/#evaluating-custom-functions
 
 struct CustomFunction : CanMakeCheckedPtr<CustomFunction> {
+    struct DeclarationsBlock {
+        Ref<const StyleProperties> properties;
+        Vector<Ref<const StyleRuleContainer>> containerQueries;
+    };
+
+    // A function body without conditional group rules is a single block.
+    using DeclarationsBlocks = Vector<DeclarationsBlock, 1>;
+
     AtomString name;
     const Vector<StyleRuleFunction::Parameter> parameters;
     const CSSCustomPropertySyntax returnType;
-    Ref<const StyleProperties> properties;
+    DeclarationsBlocks declarationBlocks;
 
-    CustomFunction(const AtomString&, const Vector<StyleRuleFunction::Parameter>&, const CSSCustomPropertySyntax& returnType, const StyleProperties&);
+    CustomFunction(const AtomString&, const Vector<StyleRuleFunction::Parameter>&, const CSSCustomPropertySyntax& returnType, DeclarationsBlocks&&);
 
     WTF_MAKE_STRUCT_TZONE_ALLOCATED(CustomFunction);
     WTF_STRUCT_OVERRIDE_DELETE_FOR_CHECKED_PTR(CustomFunction);
@@ -51,7 +60,7 @@ public:
     CustomFunctionRegistry() = default;
 
     const CustomFunction* NODELETE functionForName(const AtomString&) const;
-    void registerFunction(const StyleRuleFunction&, const Vector<Ref<const StyleRuleFunctionDeclarations>>&);
+    void registerFunction(const StyleRuleFunction&, CustomFunction::DeclarationsBlocks&&);
 
 private:
     HashMap<AtomString, UniqueRef<const CustomFunction>> m_functions;

--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -710,8 +710,8 @@ bool ElementRuleCollector::containerQueriesMatch(const RuleData& ruleData, const
 
     // "Style rules defined on an element inside multiple nested container queries apply when all of the wrapping container queries are true for that element."
     ContainerQueryEvaluator evaluator(element(), selectionMode, matchRequest.styleScopeOrdinal, containerQueryEvaluationState);
-    for (auto* query : queries) {
-        if (!evaluator.evaluate(*query))
+    for (auto& containerRule : queries) {
+        if (!evaluator.evaluate(containerRule->containerQuery()))
             return false;
     }
     return true;

--- a/Source/WebCore/style/RuleSet.h
+++ b/Source/WebCore/style/RuleSet.h
@@ -140,7 +140,7 @@ public:
     CascadeLayerPriority cascadeLayerPriorityFor(const RuleData&) const;
 
     bool hasContainerQueries() const { return !m_containerQueries.isEmpty(); }
-    Vector<const CQ::ContainerQuery*> containerQueriesFor(const RuleData&) const;
+    Vector<Ref<const StyleRuleContainer>> containerQueriesFor(const RuleData&) const;
     Vector<Ref<const StyleRuleContainer>> containerQueryRules() const;
 
     bool hasScopeRules() const { return !m_scopeRules.isEmpty(); }
@@ -195,6 +195,8 @@ private:
         Ref<const StyleRuleContainer> containerRule;
         ContainerQueryIdentifier parent;
     };
+    const ContainerQueryAndParent& containerQueryForIdentifier(ContainerQueryIdentifier identifier) const LIFETIME_BOUND { return m_containerQueries[identifier - 1]; }
+    Vector<Ref<const StyleRuleContainer>> containerQueryChainFor(ContainerQueryIdentifier) const;
 
     struct DynamicMediaQueryRules {
         Vector<MQ::MediaQueryList> mediaQueries;
@@ -292,21 +294,23 @@ inline CascadeLayerPriority RuleSet::cascadeLayerPriorityFor(const RuleData& rul
     return cascadeLayerPriorityForIdentifier(identifier);
 }
 
-inline Vector<const CQ::ContainerQuery*> RuleSet::containerQueriesFor(const RuleData& ruleData) const
+inline Vector<Ref<const StyleRuleContainer>> RuleSet::containerQueryChainFor(ContainerQueryIdentifier identifier) const
+{
+    Vector<Ref<const StyleRuleContainer>> chain;
+    while (identifier) {
+        auto& query = containerQueryForIdentifier(identifier);
+        chain.append(query.containerRule);
+        identifier = query.parent;
+    }
+    return chain;
+}
+
+inline Vector<Ref<const StyleRuleContainer>> RuleSet::containerQueriesFor(const RuleData& ruleData) const
 {
     if (m_containerQueryIdentifierForRulePosition.size() <= ruleData.position())
         return { };
 
-    Vector<const CQ::ContainerQuery*> queries;
-
-    auto identifier = m_containerQueryIdentifierForRulePosition[ruleData.position()];
-    while (identifier) {
-        auto& query = m_containerQueries[identifier - 1];
-        queries.append(&query.containerRule->containerQuery());
-        identifier = query.parent;
-    };
-
-    return queries;
+    return containerQueryChainFor(m_containerQueryIdentifierForRulePosition[ruleData.position()]);
 }
 
 } // namespace Style

--- a/Source/WebCore/style/RuleSetBuilder.cpp
+++ b/Source/WebCore/style/RuleSetBuilder.cpp
@@ -256,7 +256,7 @@ void RuleSetBuilder::addChildRule(Ref<StyleRuleBase> rule)
         disallowDynamicMediaQueryEvaluationIfNeeded();
 
         auto functionDeclarations = uncheckedDowncast<StyleRuleFunctionDeclarations>(WTF::move(rule));
-        m_currentFunctionDeclarationsList.append(WTF::move(functionDeclarations));
+        m_currentFunctionDeclarationsList.append({ WTF::move(functionDeclarations), m_currentContainerQueryIdentifier });
         return;
     }
 
@@ -568,8 +568,18 @@ void RuleSetBuilder::addMutatingRulesToResolver()
 
         if (RefPtr functionRule = dynamicDowncast<StyleRuleFunction>(rule.get())) {
             auto declarationsList = m_functionDeclarationsMap.get(*functionRule);
+
+            // Keep each block's wrapping @container chain rather than merging it away. @container in a
+            // function body depends on the calling element, so it is evaluated when the function is called.
+            auto declarationBlocks = WTF::map<1>(declarationsList, [&](auto& block) {
+                return CustomFunction::DeclarationsBlock {
+                    block.declarations->properties(),
+                    m_ruleSet->containerQueryChainFor(block.containerQueryIdentifier)
+                };
+            });
+
             CheckedRef registry = resolver->ensureCustomFunctionRegistry();
-            registry->registerFunction(*functionRule, declarationsList);
+            registry->registerFunction(*functionRule, WTF::move(declarationBlocks));
             // The cache keys on matched properties, not on the function registry. Mirrors @property.
             resolver->invalidateMatchedDeclarationsCache();
         }

--- a/Source/WebCore/style/RuleSetBuilder.h
+++ b/Source/WebCore/style/RuleSetBuilder.h
@@ -98,7 +98,11 @@ private:
 
     IsStartingStyle m_isStartingStyle { IsStartingStyle::No };
 
-    using FunctionDeclarationsList = Vector<Ref<const StyleRuleFunctionDeclarations>>;
+    struct FunctionDeclarationsBlock {
+        Ref<const StyleRuleFunctionDeclarations> declarations;
+        RuleSet::ContainerQueryIdentifier containerQueryIdentifier { 0 };
+    };
+    using FunctionDeclarationsList = Vector<FunctionDeclarationsBlock>;
     FunctionDeclarationsList m_currentFunctionDeclarationsList;
     HashMap<Ref<StyleRuleFunction>, FunctionDeclarationsList> m_functionDeclarationsMap;
 

--- a/Source/WebCore/style/StyleSubstitutionResolver.cpp
+++ b/Source/WebCore/style/StyleSubstitutionResolver.cpp
@@ -44,6 +44,7 @@
 #include "CSSVariableData.h"
 #include "CSSWideKeyword.h"
 #include "ConstantPropertyMap.h"
+#include "ContainerQueryEvaluator.h"
 #include "CustomFunctionRegistry.h"
 #include "Document.h"
 #include "Element.h"
@@ -394,9 +395,35 @@ bool SubstitutionResolver::substituteDashedFunction(StringView functionName, CSS
     // "Let body rule be the function body."
     // The body resolves tree-scoped references (var(), nested dashed-functions) relative to the scope
     // where the function was defined, not the calling element's scope.
+    // Merge the body's declaration blocks now, dropping blocks whose @container conditions do not
+    // match the calling element. https://drafts.csswg.org/css-mixins/#evaluating-custom-functions
+    auto bodyProperties = [&]() -> Ref<const StyleProperties> {
+        auto& blocks = customFunction->declarationBlocks;
+
+        // The common case is a single block with no container queries.
+        if (blocks.size() == 1 && blocks.first().containerQueries.isEmpty())
+            return blocks.first().properties;
+
+        ContainerQueryEvaluator evaluator(*element, ContainerQueryEvaluator::SelectionMode::Element, foundScopeOrdinal, nullptr);
+        auto containerQueriesMatch = [&](const auto& chain) {
+            for (auto& containerRule : chain) {
+                if (!evaluator.evaluate(containerRule->containerQuery()))
+                    return false;
+            }
+            return true;
+        };
+
+        auto mutableProperties = MutableStyleProperties::create();
+        for (auto& block : blocks) {
+            if (containerQueriesMatch(block.containerQueries))
+                mutableProperties->mergeAndOverrideOnConflict(block.properties.get());
+        }
+        return mutableProperties;
+    }();
+
     auto bodyMatchResult = MatchResult::create();
     bodyMatchResult->authorDeclarations.append({ *resolvedArgumentProperties });
-    bodyMatchResult->authorDeclarations.append({ .properties = customFunction->properties, .styleScopeOrdinal = foundScopeOrdinal });
+    bodyMatchResult->authorDeclarations.append({ .properties = bodyProperties, .styleScopeOrdinal = foundScopeOrdinal });
 
     // "Resolve function styles using custom function, body rule, registrations, and calling context."
     // The hypothetical element acts as a child of the calling element, inheriting its computed custom


### PR DESCRIPTION
#### 5732b008eeaebce67a602a047966d8339b101c20
<pre>
[css-mixins-1] Evaluate container queries inside @function
<a href="https://bugs.webkit.org/show_bug.cgi?id=318668">https://bugs.webkit.org/show_bug.cgi?id=318668</a>
<a href="https://rdar.apple.com/181471414">rdar://181471414</a>

Reviewed by Alan Baradlay.

* LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-conditionals-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-container-dynamic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-container-self-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-shadow-container-expected.txt:
* Source/WebCore/style/CustomFunctionRegistry.cpp:
(WebCore::Style::CustomFunction::CustomFunction):
(WebCore::Style::CustomFunctionRegistry::registerFunction):

Instead of smashing all StyleRuleFunctionDeclarations together eagerly during registration
we now pair them with their associated container queries so we can resolve them at
computed style time.

* Source/WebCore/style/CustomFunctionRegistry.h:
* Source/WebCore/style/RuleSetBuilder.cpp:
(WebCore::Style::RuleSetBuilder::addChildRule):
(WebCore::Style::RuleSetBuilder::addMutatingRulesToResolver):
* Source/WebCore/style/RuleSetBuilder.h:
* Source/WebCore/style/StyleSubstitutionResolver.cpp:
(WebCore::Style::SubstitutionResolver::substituteDashedFunction):

Evaluate any container queries to determine which properties to apply in function body.

* Source/WebCore/style/RuleSet.h:
(WebCore::Style::RuleSet::containerQueryForIdentifier):
(WebCore::Style::RuleSet::containerQueryChainFor):
(WebCore::Style::RuleSet::containerQueriesFor):
* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::containerQueriesMatch):

Add helpers for resolving a container query identifier to its wrapping rule chain.
containerQueriesFor now returns the container rules rather than the queries.

Canonical link: <a href="https://commits.webkit.org/316551@main">https://commits.webkit.org/316551@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/765a244dd40162a8f8024356d73bc296ed36cdbc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172769 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46688 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40144 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182227 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130325 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/aa0b69f4-ff6d-4cf6-84ee-6345b8d9f5e6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174634 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47980 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46363 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134368 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/605713b4-a038-4999-86aa-eb1beb002e33) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175727 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37771 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154922 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114839 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7abf9c1e-6845-4bcd-8c65-e9e95fc831c5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36406 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34722 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30826 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146835 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34425 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184760 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37481 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38922 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143166 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46359 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143043 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38616 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47037 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112010 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38045 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118789 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45554 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/9375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44954 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45186 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45013 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->