### PR TITLE
[JSC] Compact Air::Arg size

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirArg.cpp
+++ b/Source/JavaScriptCore/b3/air/AirArg.cpp
@@ -116,14 +116,9 @@ unsigned Arg::jsHash() const
     case BigImm:
     case BitImm64:
     case FPImm64:
-        result += static_cast<unsigned>(m_offset);
-        result += static_cast<unsigned>(m_offset >> 32);
-        break;
     case FPImm128:
         result += static_cast<unsigned>(m_offset);
         result += static_cast<unsigned>(m_offset >> 32);
-        result += static_cast<unsigned>(m_additional);
-        result += static_cast<unsigned>(m_additional >> 32);
         break;
     case SimpleAddr:
         result += m_base.internalValue();

--- a/Source/JavaScriptCore/b3/air/AirArg.h
+++ b/Source/JavaScriptCore/b3/air/AirArg.h
@@ -594,7 +594,7 @@ public:
         Arg result;
         result.m_kind = FPImm128;
         result.m_offset = value.u64x2[0];
-        result.m_additional = value.u64x2[0];
+        ASSERT(bitEquals(value, result.asV128()));
         return result;
     }
 
@@ -1510,6 +1510,7 @@ public:
         if (!isARM64() && !isX86_64())
             return false;
 
+        // This condition is important as we only hold FPImm128 which value.u64x2[0] == value.u64x2[1].
         WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         if (value.u64x2[0] == value.u64x2[1])
             return isValidFPImm64Form(value.u64x2[0]);
@@ -1729,7 +1730,7 @@ public:
         if constexpr (is32Bit())
             UNREACHABLE_FOR_PLATFORM();
         ASSERT(isFPImm128());
-        return v128_t(m_offset, m_additional);
+        return v128_t(m_offset, m_offset);
     }
 
     decltype(auto) asTrustedBigImm() const
@@ -1900,7 +1901,6 @@ public:
 
 private:
     int64_t m_offset { 0 };
-    int64_t m_additional { 0 };
     Kind m_kind { Invalid };
     MacroAssembler::Extend m_extend { MacroAssembler::Extend::None };
     JSC::SIMDInfo m_simdInfo;


### PR DESCRIPTION
#### 674917cb5f4d588c52ba90f416b2388af80b237b
<pre>
[JSC] Compact Air::Arg size
<a href="https://bugs.webkit.org/show_bug.cgi?id=318671">https://bugs.webkit.org/show_bug.cgi?id=318671</a>
<a href="https://rdar.apple.com/181480616">rdar://181480616</a>

Reviewed by Tadeu Zagallo.

Since valid FPImm128 is always u64x2[0] == u64x2[1], only uint64_t is
enough to hold to represent. This patch drops m_additional and shrinking
the size from 32 to 24.

* Source/JavaScriptCore/b3/air/AirArg.cpp:
(JSC::B3::Air::Arg::jsHash const):
* Source/JavaScriptCore/b3/air/AirArg.h:
(JSC::B3::Air::Arg::fpImm128):
(JSC::B3::Air::Arg::isValidFPImm128Form):
(JSC::B3::Air::Arg::asV128 const):

Canonical link: <a href="https://commits.webkit.org/316555@main">https://commits.webkit.org/316555@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e42c5286ad503ee8bf601dbb03ae36703e0d6320

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172756 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46675 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40130 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182214 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130312 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b0785f9f-9b12-4520-a628-b7eee401d05b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47967 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46350 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134362 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7892400c-2383-4515-87f1-9a6eea2a6cfe) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175714 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37763 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154916 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114833 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f6d9ecc0-e3ad-496b-8b96-6d4ee8cc3010) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36398 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34714 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30813 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/3442 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146827 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34419 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184747 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/34017 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37467 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38914 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143155 "Found 1 new test failure: compositing/color-matching/image-color-matching.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46346 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143032 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47024 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111994 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26219 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38037 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118776 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/205434 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45541 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/9369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54854 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44941 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45173 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45000 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->