### PR TITLE
Parse @font-face metric override descriptors behind a flag

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-metric-overrides-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-metric-overrides-expected.txt
@@ -1,0 +1,23 @@
+
+PASS Check that ascent-override: normal is valid
+PASS Check that ascent-override: 0% is valid
+PASS Check that ascent-override: 50% is valid
+PASS Check that ascent-override: 110% is valid
+PASS Check that ascent-override: 100000000000% is valid
+PASS Check that ascent-override: -1% is invalid
+PASS Check that ascent-override: 10px is invalid
+PASS Check that descent-override: normal is valid
+PASS Check that descent-override: 0% is valid
+PASS Check that descent-override: 50% is valid
+PASS Check that descent-override: 110% is valid
+PASS Check that descent-override: 100000000000% is valid
+PASS Check that descent-override: -1% is invalid
+PASS Check that descent-override: 10px is invalid
+PASS Check that line-gap-override: normal is valid
+PASS Check that line-gap-override: 0% is valid
+PASS Check that line-gap-override: 50% is valid
+PASS Check that line-gap-override: 110% is valid
+PASS Check that line-gap-override: 100000000000% is valid
+PASS Check that line-gap-override: -1% is invalid
+PASS Check that line-gap-override: 10px is invalid
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-metric-overrides.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-metric-overrides.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<title>CSS Fonts 4 test: parsing @font-face metric override descriptors</title>
+<link rel="help" href="https://drafts.csswg.org/css-fonts-4/#font-metrics-override-desc">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style id="testStyle">
+</style>
+<script>
+  const sheet = testStyle.sheet;
+  const descriptors = ["ascent-override", "descent-override", "line-gap-override"];
+  const values = [
+    { value: "normal", valid: true, expected: "normal" },
+    { value: "0%", valid: true, expected: "0%" },
+    { value: "50%", valid: true, expected: "50%" },
+    { value: "110%", valid: true, expected: "110%" },
+    { value: "100000000000%", valid: true, expected: "100000000000%" },
+    { value: "-1%", valid: false },
+    { value: "10px", valid: false },
+  ];
+
+  for (const descriptor of descriptors) {
+    for (const { value, valid, expected } of values) {
+      test(() => {
+        assert_equals(sheet.cssRules.length, 0, "test sheet should initially be empty");
+        sheet.insertRule(`@font-face { ${descriptor}: ${value} }`);
+
+        try {
+          assert_equals(sheet.cssRules[0].style.getPropertyValue(descriptor), valid ? expected : "");
+        } finally {
+          sheet.deleteRule(0);
+        }
+      }, `Check that ${descriptor}: ${value} is ${valid ? "valid" : "invalid"}`);
+    }
+  }
+</script>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1170,6 +1170,20 @@ CSSFieldSizingEnabled:
     WebCore:
       default: true
 
+CSSFontFaceMetricOverrideDescriptorsEnabled:
+  type: bool
+  status: testable
+  category: css
+  humanReadableName: "CSS @font-face metric override descriptors"
+  humanReadableDescription: "Enable CSS @font-face metric override descriptors"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 CSSFontSynthesisStyleObliqueOnlyEnabled:
   type: bool
   status: preview

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -13844,6 +13844,36 @@
                     "url": "https://drafts.csswg.org/css-fonts-4/#descdef-font-face-src"
                 }
             },
+            "ascent-override": {
+                "codegen-properties": {
+                    "parser-grammar": "normal | <percentage [0,inf]>",
+                    "settings-flag": "cssFontFaceMetricOverrideDescriptorsEnabled"
+                },
+                "specification": {
+                    "category": "css-fonts-4",
+                    "url": "https://drafts.csswg.org/css-fonts-4/#descdef-font-face-ascent-override"
+                }
+            },
+            "descent-override": {
+                "codegen-properties": {
+                    "parser-grammar": "normal | <percentage [0,inf]>",
+                    "settings-flag": "cssFontFaceMetricOverrideDescriptorsEnabled"
+                },
+                "specification": {
+                    "category": "css-fonts-4",
+                    "url": "https://drafts.csswg.org/css-fonts-4/#descdef-font-face-descent-override"
+                }
+            },
+            "line-gap-override": {
+                "codegen-properties": {
+                    "parser-grammar": "normal | <percentage [0,inf]>",
+                    "settings-flag": "cssFontFaceMetricOverrideDescriptorsEnabled"
+                },
+                "specification": {
+                    "category": "css-fonts-4",
+                    "url": "https://drafts.csswg.org/css-fonts-4/#descdef-font-face-line-gap-override"
+                }
+            },
             "size-adjust": {
                 "codegen-properties": {
                     "parser-grammar": "<percentage [0,inf]>",


### PR DESCRIPTION
#### ab58f961d64a49182b54930a5bb5a78e80ea6e92
<pre>
Parse @font-face metric override descriptors behind a flag

<a href="https://bugs.webkit.org/show_bug.cgi?id=219735">https://bugs.webkit.org/show_bug.cgi?id=219735</a>

Reviewed by Elika Etemad.

Add a testable feature flag for CSS Fonts 4 @font-face metric override
descriptors and register ascent-override, descent-override, and
line-gap-override with the generated CSS parser.

This initial patch accepts normal and non-negative percentages in
@font-face rules and preserves the parsed CSSOM descriptor values. The
FontFace/CSSFontFaceDescriptors API plumbing and the font metrics
application will be handled in follow-up patches.

Test: imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-metric-overrides.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-metric-overrides-expected.txt: Added expected results.
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-metric-overrides.html:
Added WPT coverage for valid and invalid metric override descriptor values.
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
Added the CSSFontFaceMetricOverrideDescriptorsEnabled feature flag.
* Source/WebCore/css/CSSProperties.json:
Added gated @font-face descriptor definitions for ascent-override,
descent-override, and line-gap-override.

Canonical link: <a href="https://commits.webkit.org/316829@main">https://commits.webkit.org/316829@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb27ccf7fe7b04f1320a87b5f0e64a676378703f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173450 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47382 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/41332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183023 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/131318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175315 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48675 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47064 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134869 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/131318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176408 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38293 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155537 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115345 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36934 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35288 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31508 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/4050 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147358 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35033 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185448 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/34712 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38319 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39489 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143734 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47050 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155095 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143600 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38770 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47729 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/41332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/112840 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38537 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119480 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/210483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46235 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9981 "Passed tests") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/210483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45637 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45868 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45694 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->