### PR TITLE
crashIfBorrowed in Vector

### DIFF
--- a/Source/WTF/wtf/Vector.h
+++ b/Source/WTF/wtf/Vector.h
@@ -221,6 +221,7 @@ public:
     bool allocateBuffer(size_t newCapacity)
     {
         static_assert(action == FailureAction::Crash || action == FailureAction::Report);
+        crashIfBorrowed();
         ASSERT(newCapacity);
         if (!isValidCapacityForVector<T>(newCapacity)) {
             if constexpr (action == FailureAction::Crash)
@@ -253,6 +254,7 @@ public:
 
     void reallocateBuffer(size_t newCapacity)
     {
+        crashIfBorrowed();
         ASSERT(shouldReallocateBuffer(newCapacity));
         if (newCapacity > std::numeric_limits<size_t>::max() / sizeof(T))
             CRASH();
@@ -263,6 +265,7 @@ public:
 
     void deallocateBuffer(T* bufferToDeallocate)
     {
+        crashIfBorrowed();
         if (!bufferToDeallocate)
             return;
         
@@ -284,6 +287,7 @@ public:
 
     MallocSpan<T, Malloc> releaseBuffer()
     {
+        crashIfBorrowed();
         m_capacity = 0;
         return adoptMallocSpan<T, Malloc>(unsafeMakeSpan(std::exchange(m_buffer, nullptr), std::exchange(m_size, 0)));
     }
@@ -307,6 +311,7 @@ protected:
 
     ~VectorBufferBase()
     {
+        crashIfBorrowed();
         // FIXME: It would be nice to find a way to ASSERT that m_buffer hasn't leaked here.
     }
 
@@ -370,6 +375,8 @@ public:
     
     void swap(VectorBuffer<T, 0, Malloc>& other, size_t, size_t)
     {
+        crashIfBorrowed();
+        other.crashIfBorrowed();
         std::swap(m_buffer, other.m_buffer);
         Base::swapCapacity(other);
     }
@@ -403,6 +410,7 @@ protected:
 
     VectorBuffer(VectorBuffer<T, 0, Malloc>&& other)
     {
+        other.crashIfBorrowed();
         m_buffer = std::exchange(other.m_buffer, nullptr);
         m_capacity = other.exchangeCapacity(0);
         m_size = std::exchange(other.m_size, 0);
@@ -410,6 +418,8 @@ protected:
 
     void adopt(VectorBuffer&& other)
     {
+        crashIfBorrowed();
+        other.crashIfBorrowed();
         deallocateBuffer(buffer());
         m_buffer = std::exchange(other.m_buffer, nullptr);
         m_capacity = other.exchangeCapacity(0);
@@ -448,6 +458,7 @@ public:
     template<FailureAction action>
     bool allocateBuffer(size_t newCapacity)
     {
+        crashIfBorrowed();
         // FIXME: This should ASSERT(!m_buffer) to catch misuse/leaks. https://bugs.webkit.org/show_bug.cgi?id=250801
         if (newCapacity > inlineCapacity)
             return Base::template allocateBuffer<action>(newCapacity);
@@ -461,6 +472,7 @@ public:
 
     void deallocateBuffer(T* bufferToDeallocate)
     {
+        crashIfBorrowed();
         if (bufferToDeallocate == inlineBuffer())
             return;
         Base::deallocateBuffer(bufferToDeallocate);
@@ -480,6 +492,8 @@ public:
 
     void swap(VectorBuffer& other, size_t mySize, size_t otherSize)
     {
+        crashIfBorrowed();
+        other.crashIfBorrowed();
         if (buffer() == inlineBuffer() && other.buffer() == other.inlineBuffer()) {
             swapInlineBuffer(other, mySize, otherSize);
             Base::swapCapacity(other);
@@ -543,6 +557,7 @@ protected:
     VectorBuffer(VectorBuffer&& other)
         : Base(inlineBuffer(), inlineCapacity, 0)
     {
+        other.crashIfBorrowed();
         if (other.buffer() == other.inlineBuffer())
             VectorTypeOperations<T>::move(other.inlineBuffer(), other.inlineBuffer() + other.m_size, inlineBuffer());
         else {
@@ -554,6 +569,8 @@ protected:
 
     void adopt(VectorBuffer&& other)
     {
+        crashIfBorrowed();
+        other.crashIfBorrowed();
         if (buffer() != inlineBuffer()) {
             deallocateBuffer(buffer());
             m_buffer = inlineBuffer();

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm
@@ -113,15 +113,19 @@ void ByteRangeRequest::completeWithAccumulatedData(PDFIncrementalLoader& loader)
 {
     ASSERT(isMainRunLoop());
 
-    Borrow accumulatedData = m_accumulatedData;
-    auto data = accumulatedData->span();
-    if (data.size() > m_count) {
-        RELEASE_LOG_ERROR(IncrementalPDF, "PDF byte range request got more bytes back from the server than requested. This is likely due to a misconfigured server. Capping result at the requested number of bytes.");
-        data = data.first(m_count);
-    }
+    size_t completionSize;
+    {
+        Borrow accumulatedData = m_accumulatedData;
+        auto data = accumulatedData->span();
+        if (data.size() > m_count) {
+            RELEASE_LOG_ERROR(IncrementalPDF, "PDF byte range request got more bytes back from the server than requested. This is likely due to a misconfigured server. Capping result at the requested number of bytes.");
+            data = data.first(m_count);
+        }
 
-    m_completionHandler(data);
-    loader.requestDidCompleteWithAccumulatedData(*this, data.size());
+        m_completionHandler(data);
+        completionSize = data.size();
+    }
+    loader.requestDidCompleteWithAccumulatedData(*this, completionSize);
 }
 
 bool ByteRangeRequest::completeIfPossible(PDFIncrementalLoader& loader)

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -158,6 +158,7 @@ set(TestWTF_SOURCES
     Tests/WTF/UniqueRef.cpp
     Tests/WTF/UniqueRefVector.cpp
     Tests/WTF/Vector.cpp
+    Tests/WTF/VectorBorrow.cpp
     Tests/WTF/WTFString.cpp
     Tests/WTF/WeakPtr.cpp
     Tests/WTF/WorkQueue.cpp

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1309,6 +1309,7 @@
 				WTF/UUID.cpp,
 				WTF/VariantList.cpp,
 				WTF/Vector.cpp,
+				WTF/VectorBorrow.cpp,
 				WTF/WeakPtr.cpp,
 				WTF/WorkerPool.cpp,
 				WTF/WorkQueue.cpp,

--- a/Tools/TestWebKitAPI/Tests/WTF/VectorBorrow.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/VectorBorrow.cpp
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include <wtf/Borrow.h>
+
+#include "Helpers/Test.h"
+#include <wtf/Vector.h>
+
+namespace TestWebKitAPI {
+
+TEST(WTF_Borrow, ReadWhileBorrowedThenInteriorDestroyAfter)
+{
+    Vector<uint8_t> vector { 1, 2, 3 };
+    {
+        auto borrowed = borrow(vector);
+        EXPECT_EQ(borrowed->size(), 3u);
+        EXPECT_EQ(borrowed.get().span().data(), vector.span().data());
+    }
+    // The borrow has been released, so interior destruction is allowed again.
+    vector.reserveCapacity(vector.capacity() + 1024);
+    vector.append(4);
+    EXPECT_EQ(vector.size(), 4u);
+}
+
+TEST(WTF_Borrow, NestedBorrows)
+{
+    Vector<uint8_t> vector { 1, 2, 3 };
+    {
+        auto outer = borrow(vector);
+        {
+            auto inner = borrow(vector);
+            EXPECT_EQ(inner->size(), 3u);
+        }
+        // The inner borrow restored the outer borrow's state, so the Vector is
+        // still borrowed here.
+        EXPECT_EQ(outer->size(), 3u);
+    }
+    vector.append(4);
+    EXPECT_EQ(vector.size(), 4u);
+}
+
+TEST(WTF_BorrowDeathTest, MAYBE_ASSERT_ENABLED_DEATH_TEST(ReallocateWhileBorrowedCrashes))
+{
+    auto shouldCrash = [] {
+        Vector<uint8_t> vector { 1, 2, 3 };
+        auto borrowed = borrow(vector);
+        vector.reserveCapacity(vector.capacity() + 1024);
+    };
+    ASSERT_DEATH_IF_SUPPORTED(shouldCrash(), "");
+}
+
+TEST(WTF_BorrowDeathTest, MAYBE_ASSERT_ENABLED_DEATH_TEST(DestroyWhileBorrowedCrashes))
+{
+    auto shouldCrash = [] {
+        auto* vector = new Vector<uint8_t> { 1, 2, 3 };
+        auto borrowed = borrow(*vector);
+        delete vector; // Destroys the Vector while the borrow is outstanding.
+    };
+    ASSERT_DEATH_IF_SUPPORTED(shouldCrash(), "");
+}
+
+TEST(WTF_BorrowDeathTest, MAYBE_ASSERT_ENABLED_DEATH_TEST(SwapWhileBorrowedCrashes))
+{
+    auto shouldCrash = [] {
+        Vector<uint8_t> vector { 1, 2, 3 };
+        Vector<uint8_t> other { 4, 5, 6 };
+        auto borrowed = borrow(vector);
+        vector.swap(other);
+    };
+    ASSERT_DEATH_IF_SUPPORTED(shouldCrash(), "");
+}
+
+TEST(WTF_BorrowDeathTest, MAYBE_ASSERT_ENABLED_DEATH_TEST(MoveWhileBorrowedCrashes))
+{
+    auto shouldCrash = [] {
+        Vector<uint8_t> vector { 1, 2, 3 };
+        auto borrowed = borrow(vector);
+        Vector<uint8_t> moved = WTF::move(vector);
+    };
+    ASSERT_DEATH_IF_SUPPORTED(shouldCrash(), "");
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### 8b661b920bebf0ba48bf772db0f98c28891b4dd9
<pre>
crashIfBorrowed in Vector
<a href="https://bugs.webkit.org/show_bug.cgi?id=318672">https://bugs.webkit.org/show_bug.cgi?id=318672</a>
<a href="https://rdar.apple.com/181484944">rdar://181484944</a>

Reviewed by Geoffrey Garen.

WTF::Vector already supports the WTF::CanBorrow protocol, by which code can
indicate that the vector&apos;s data is temporarily borrowed and in use elsewhere -
thus the vector should not be structurally changed (reallocated/resized/etc.)
during that period. The intention of the CanBorrow protocol is that such
interior destructions should cause a clean crash rather than an exploitable
memory safety bug.

This change does the last bit of the work, which is to actually call
crashIfBorrowed at such mutation sites.

We had an over-long borrow in PDFIncrementalLoader.mm which needed to be fixed
for enforcement to succeed. This was a false-positive, not a real
vulnerability.

Test: Tools/TestWebKitAPI/Tests/WTF/Borrow.cpp
Canonical link: <a href="https://commits.webkit.org/318890@main">https://commits.webkit.org/318890@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fe0ed80729c43399db108ae37a6d303757001825

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179778 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53717 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47516 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189611 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144089 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/536a58f3-b93f-454b-a70e-95167c85cf6c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181641 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55011 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53429 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140242 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b5de71f1-f771-49ea-b61c-ec2368272a62) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182735 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43845 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160973 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120693 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/67679d6e-3d0f-4d74-91bd-9f8d7866919c) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/40833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2662 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9458 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152916 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40494 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1064 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41053 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46323 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45082 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191832 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53387 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149518 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40053 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54068 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149252 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43905 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126340 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121370 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52585 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15493 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51970 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52211 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52031 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->