### PR TITLE
[GTK][WPE] Skia compositor: enable MSAA for tile rendering when using DDL

### DIFF
--- a/Source/WebCore/platform/SourcesSkia.txt
+++ b/Source/WebCore/platform/SourcesSkia.txt
@@ -70,6 +70,7 @@ platform/graphics/skia/SkiaHarfBuzzFontCache.cpp
 platform/graphics/skia/SkiaImageAtlasLayout.cpp
 platform/graphics/skia/SkiaImageAtlasLayoutBuilder.cpp
 platform/graphics/skia/SkiaPaintingEngine.cpp
+platform/graphics/skia/SkiaRecordCanvas.cpp
 platform/graphics/skia/SkiaRecordingResult.cpp
 platform/graphics/skia/SkiaReplayAtlas.cpp
 platform/graphics/skia/SkiaReplayCanvas.cpp

--- a/Source/WebCore/platform/graphics/skia/SkiaBackingStore.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaBackingStore.cpp
@@ -199,12 +199,13 @@ void SkiaBackingStore::Tile::update(const IntRect& dirtyRect, const IntRect& til
             auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
             ASSERT(grContext);
 
-            if (!m_surface) {
-                const auto& characterization = displayList->characterization();
+            const auto& characterization = displayList->characterization();
+            if (!m_surface || !m_surface->isCompatible(characterization))
                 m_surface = SkSurfaces::RenderTarget(grContext, skgpu::Budgeted::kYes, characterization.imageInfo(), characterization.sampleCount(), characterization.origin(), &characterization.surfaceProps());
-            }
 
             skgpu::ganesh::DrawDDL(m_surface.get(), displayList);
+            if (characterization.sampleCount())
+                grContext->flush(m_surface.get());
         } else if (auto texture = acceleratedBuffer.texture()) {
             ASSERT(!m_surface);
 

--- a/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp
@@ -40,6 +40,7 @@
 #include "RenderingMode.h"
 #include "SkiaGPUAtlas.h"
 #include "SkiaImageAtlasLayout.h"
+#include "SkiaRecordCanvas.h"
 #include "SkiaRecordingResult.h"
 #include "SkiaReplayCanvas.h"
 #include "SkiaUtilities.h"
@@ -116,11 +117,11 @@ void SkiaPaintingEngine::paintIntoGraphicsContext(const GraphicsLayer& layer, Gr
     layer.paintGraphicsLayerContents(context, clipRect);
 }
 
-Ref<CoordinatedTileBuffer> SkiaPaintingEngine::createBuffer(RenderingMode renderingMode, const IntSize& size, bool contentsOpaque) const
+Ref<CoordinatedTileBuffer> SkiaPaintingEngine::createBuffer(RenderingMode renderingMode, const IntSize& size, bool contentsOpaque, unsigned msaaSampleCount) const
 {
     if (renderingMode == RenderingMode::Accelerated) {
         if (useThreadedRendering() && canUseDDL())
-            return CoordinatedAcceleratedTileBuffer::create(m_threadSafeGrContext, size, contentsOpaque ? CoordinatedTileBuffer::NoFlags : CoordinatedTileBuffer::SupportsAlpha);
+            return CoordinatedAcceleratedTileBuffer::create(m_threadSafeGrContext, size, contentsOpaque ? CoordinatedTileBuffer::NoFlags : CoordinatedTileBuffer::SupportsAlpha, msaaSampleCount);
 
         PlatformDisplay::sharedDisplay().skiaGLContext()->makeContextCurrent();
 
@@ -214,7 +215,7 @@ Ref<CoordinatedTileBuffer> SkiaPaintingEngine::paint(const GraphicsLayerCoordina
     return buffer;
 }
 
-Ref<SkiaRecordingResult> SkiaPaintingEngine::record(const GraphicsLayerCoordinated& layer, const IntRect& recordRect, bool contentsOpaque, float contentsScale)
+Ref<SkiaRecordingResult> SkiaPaintingEngine::record(const GraphicsLayerCoordinated& layer, const IntRect& recordRect, bool contentsOpaque, float contentsScale, unsigned msaaSampleCount)
 {
     // ### Asynchronous rendering on worker threads ###
     ASSERT(useThreadedRendering());
@@ -222,18 +223,35 @@ Ref<SkiaRecordingResult> SkiaPaintingEngine::record(const GraphicsLayerCoordinat
 
     auto renderingMode = canPerformAcceleratedRendering() ? RenderingMode::Accelerated : RenderingMode::Unaccelerated;
 
+    auto recordLayer = [&](SkCanvas& canvas) -> SkiaRecordingData {
+        GraphicsContextSkia recordingContext(canvas, renderingMode, RenderingPurpose::LayerBacking);
+        recordingContext.beginRecording(GraphicsContextSkia::RecordingMode::Tile, renderingMode == RenderingMode::Accelerated && canUseDDL() ? m_threadSafeGrContext : nullptr);
+        paintIntoGraphicsContext(layer, recordingContext, recordRect, contentsOpaque, contentsScale);
+        return recordingContext.endRecording();
+    };
+
     WTFBeginSignpost(this, RecordTile);
     SkPictureRecorder pictureRecorder;
     auto* recordingCanvas = pictureRecorder.beginRecording(recordRect.width(), recordRect.height());
-    GraphicsContextSkia recordingContext(*recordingCanvas, renderingMode, RenderingPurpose::LayerBacking);
-    recordingContext.beginRecording(GraphicsContextSkia::RecordingMode::Tile, canUseDDL() ? m_threadSafeGrContext : nullptr);
-    paintIntoGraphicsContext(layer, recordingContext, recordRect, contentsOpaque, contentsScale);
-    auto recordingData = recordingContext.endRecording();
+    SkiaRecordingData recordingData;
+    if (renderingMode == RenderingMode::Accelerated && canUseDDL() && !msaaSampleCount && PlatformDisplay::sharedDisplay().msaaSampleCount()) {
+        SkiaRecordCanvas recordCanvas(recordRect.size());
+        recordCanvas.addCanvas(recordingCanvas);
+        recordingData = recordLayer(recordCanvas);
+        recordCanvas.removeCanvas(recordingCanvas);
+        if (recordCanvas.shouldEnableMSAA()) {
+            msaaSampleCount = PlatformDisplay::sharedDisplay().msaaSampleCount();
+            // Use 4 samples on HiDPI.
+            if (msaaSampleCount && contentsScale >= 2)
+                msaaSampleCount = 4;
+        }
+    } else
+        recordingData = recordLayer(*recordingCanvas);
 
     auto picture = pictureRecorder.finishRecordingAsPicture();
     WTFEndSignpost(this, RecordTile);
 
-    auto result = SkiaRecordingResult::create(WTF::move(picture), WTF::move(recordingData), recordRect, renderingMode, contentsOpaque, contentsScale);
+    auto result = SkiaRecordingResult::create(WTF::move(picture), WTF::move(recordingData), recordRect, renderingMode, contentsOpaque, contentsScale, msaaSampleCount);
 
     // Prepare GPU atlases on main thread before dispatching to workers.
     if (result->hasAtlasLayouts()) {
@@ -277,7 +295,7 @@ Ref<SkiaRecordingResult> SkiaPaintingEngine::record(const GraphicsLayerCoordinat
     return result;
 }
 
-Ref<CoordinatedTileBuffer> SkiaPaintingEngine::replay(const GraphicsLayerCoordinated& layer, Ref<SkiaRecordingResult>&& recording, const IntRect& tileRect, const IntRect& dirtyRect)
+Ref<CoordinatedTileBuffer> SkiaPaintingEngine::replay(const GraphicsLayerCoordinated& layer, Ref<SkiaRecordingResult>&& recording, const IntRect& tileRect, const IntRect& dirtyRect, unsigned msaaSampleCount)
 {
     // ### Asynchronous rendering on worker threads ###
     ASSERT(useThreadedRendering());
@@ -290,7 +308,7 @@ Ref<CoordinatedTileBuffer> SkiaPaintingEngine::replay(const GraphicsLayerCoordin
         threadSafeGrContext = m_threadSafeGrContext;
     auto renderingMode = recording->renderingMode();
     auto bufferSize = renderingMode == RenderingMode::Accelerated && useThreadedRendering() && threadSafeGrContext ? tileRect.size() : dirtyRect.size();
-    auto buffer = createBuffer(renderingMode, bufferSize, recording->contentsOpaque());
+    auto buffer = createBuffer(renderingMode, bufferSize, recording->contentsOpaque(), msaaSampleCount);
     buffer->beginPainting();
 
     m_paintingWorkerPool->postTask([platformLayer = WTF::move(platformLayer), buffer = Ref { buffer }, tileRect, dirtyRect, recording = WTF::move(recording), threadSafeGrContext = WTF::move(threadSafeGrContext)]() mutable {

--- a/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.h
@@ -68,11 +68,11 @@ public:
     const sk_sp<GrContextThreadSafeProxy>& threadSafeGrContext() const { return m_threadSafeGrContext; }
 
     Ref<CoordinatedTileBuffer> paint(const GraphicsLayerCoordinated&, const IntRect& dirtyRect, bool contentsOpaque, float contentsScale);
-    Ref<SkiaRecordingResult> record(const GraphicsLayerCoordinated&, const IntRect& recordRect, bool contentsOpaque, float contentsScale);
-    Ref<CoordinatedTileBuffer> replay(const GraphicsLayerCoordinated&, Ref<SkiaRecordingResult>&&, const IntRect& tileRect, const IntRect& dirtyRect);
+    Ref<SkiaRecordingResult> record(const GraphicsLayerCoordinated&, const IntRect& recordRect, bool contentsOpaque, float contentsScale, unsigned msaaSampleCount);
+    Ref<CoordinatedTileBuffer> replay(const GraphicsLayerCoordinated&, Ref<SkiaRecordingResult>&&, const IntRect& tileRect, const IntRect& dirtyRect, unsigned msaaSampleCount);
 
 private:
-    Ref<CoordinatedTileBuffer> createBuffer(RenderingMode, const IntSize&, bool contentsOpaque) const;
+    Ref<CoordinatedTileBuffer> createBuffer(RenderingMode, const IntSize&, bool contentsOpaque, unsigned msaaSampleCount = 0) const;
     void paintIntoGraphicsContext(const GraphicsLayer&, GraphicsContext&, const IntRect&, bool contentsOpaque, float contentsScale) const;
     RefPtr<SkiaGPUAtlas> createAtlas(const SkiaImageAtlasLayout&, AtlasUploadCondition&);
     bool tryReuseCachedAtlases(SkiaRecordingResult&, unsigned fingerprint);

--- a/Source/WebCore/platform/graphics/skia/SkiaRecordCanvas.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaRecordCanvas.cpp
@@ -1,0 +1,164 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "SkiaRecordCanvas.h"
+
+#if USE(SKIA)
+#include "IntSize.h"
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/core/SkPaint.h>
+#include <skia/core/SkPath.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
+
+namespace WebCore {
+
+static constexpr unsigned s_minSlowPathsForMSAA = 6;
+
+SkiaRecordCanvas::SkiaRecordCanvas(const IntSize& size)
+    : SkNWayCanvas(size.width(), size.height())
+{
+}
+
+SkiaRecordCanvas::~SkiaRecordCanvas() = default;
+
+bool SkiaRecordCanvas::shouldEnableMSAA() const
+{
+    // Do not enable MSAA if there are operations with antialias disabled.
+    if (m_hasNonAntialiasPaint)
+        return false;
+
+    return m_slowPathForMSAACount >= s_minSlowPathsForMSAA;
+}
+
+void SkiaRecordCanvas::checkSlowPathsForPaint(const SkPaint& paint)
+{
+    m_hasNonAntialiasPaint |= !paint.isAntiAlias();
+    if (m_hasNonAntialiasPaint || m_slowPathForMSAACount >= s_minSlowPathsForMSAA)
+        return;
+
+    if (paint.getPathEffect())
+        m_slowPathForMSAACount++;
+}
+
+void SkiaRecordCanvas::onDrawPoints(PointMode mode, size_t count, const SkPoint pts[], const SkPaint& paint)
+{
+    m_hasNonAntialiasPaint |= !paint.isAntiAlias();
+    if (!m_hasNonAntialiasPaint && m_slowPathForMSAACount < s_minSlowPathsForMSAA) {
+        if (paint.getPathEffect() && paint.getStrokeCap() == SkPaint::kRound_Cap)
+            m_slowPathForMSAACount++;
+    }
+    SkNWayCanvas::onDrawPoints(mode, count, pts, paint);
+}
+
+void SkiaRecordCanvas::onDrawDRRect(const SkRRect& outer, const SkRRect& inner, const SkPaint& paint)
+{
+    checkSlowPathsForPaint(paint);
+    SkNWayCanvas::onDrawDRRect(outer, inner, paint);
+}
+
+void SkiaRecordCanvas::onDrawGlyphRunList(const sktext::GlyphRunList& glyphRunList, const SkPaint& paint)
+{
+    checkSlowPathsForPaint(paint);
+    SkNWayCanvas::onDrawGlyphRunList(glyphRunList, paint);
+}
+
+void SkiaRecordCanvas::onDrawTextBlob(const SkTextBlob* blob, SkScalar x, SkScalar y, const SkPaint& paint)
+{
+    checkSlowPathsForPaint(paint);
+    SkNWayCanvas::onDrawTextBlob(blob, x, y, paint);
+}
+
+void SkiaRecordCanvas::onDrawRect(const SkRect& rect, const SkPaint& paint)
+{
+    checkSlowPathsForPaint(paint);
+    SkNWayCanvas::onDrawRect(rect, paint);
+}
+
+void SkiaRecordCanvas::onDrawRegion(const SkRegion& region, const SkPaint& paint)
+{
+    checkSlowPathsForPaint(paint);
+    SkNWayCanvas::onDrawRegion(region, paint);
+}
+
+void SkiaRecordCanvas::onDrawOval(const SkRect& rect, const SkPaint& paint)
+{
+    checkSlowPathsForPaint(paint);
+    SkNWayCanvas::onDrawOval(rect, paint);
+}
+
+void SkiaRecordCanvas::onDrawArc(const SkRect& rect, SkScalar startAngle, SkScalar sweepAngle, bool useCenter, const SkPaint& paint)
+{
+    checkSlowPathsForPaint(paint);
+    SkNWayCanvas::onDrawArc(rect, startAngle, sweepAngle, useCenter, paint);
+}
+
+void SkiaRecordCanvas::onDrawRRect(const SkRRect& rect, const SkPaint& paint)
+{
+    checkSlowPathsForPaint(paint);
+    SkNWayCanvas::onDrawRRect(rect, paint);
+}
+
+void SkiaRecordCanvas::onDrawPath(const SkPath& path, const SkPaint& paint)
+{
+    checkSlowPathsForPaint(paint);
+    if (!m_hasNonAntialiasPaint && paint.isAntiAlias()) {
+        if (!path.isConvex() && m_slowPathForMSAACount < s_minSlowPathsForMSAA) {
+            if (paint.getStyle() == SkPaint::kStroke_Style && paint.getStrokeWidth())
+                m_slowPathForMSAACount++;
+            else if (paint.getStyle() == SkPaint::kFill_Style) {
+                const auto& pathBounds = path.getBounds();
+                if (pathBounds.width() >= 64 || pathBounds.height() >= 64 || path.isVolatile())
+                    m_slowPathForMSAACount++;
+            }
+        }
+    }
+    SkNWayCanvas::onDrawPath(path, paint);
+}
+
+void SkiaRecordCanvas::onDrawImageRect2(const SkImage* image, const SkRect& src, const SkRect& dst, const SkSamplingOptions& sampling, const SkPaint* paint, SrcRectConstraint constraint)
+{
+    if (paint)
+        checkSlowPathsForPaint(*paint);
+    SkNWayCanvas::onDrawImageRect2(image, src, dst, sampling, paint, constraint);
+}
+
+void SkiaRecordCanvas::onClipRRect(const SkRRect& rect, SkClipOp op, ClipEdgeStyle edgeStyle)
+{
+    m_hasNonAntialiasPaint |= edgeStyle == kHard_ClipEdgeStyle;
+    SkNWayCanvas::onClipRRect(rect, op, edgeStyle);
+}
+
+void SkiaRecordCanvas::onClipPath(const SkPath& path, SkClipOp op, ClipEdgeStyle edgeStyle)
+{
+    m_hasNonAntialiasPaint |= edgeStyle == kHard_ClipEdgeStyle;
+    if (!m_hasNonAntialiasPaint && edgeStyle == kSoft_ClipEdgeStyle && m_slowPathForMSAACount < s_minSlowPathsForMSAA)
+        m_slowPathForMSAACount += path.isConvex() ? 0 : 1;
+    SkNWayCanvas::onClipPath(path, op, edgeStyle);
+}
+
+} // namespace WebCore
+
+#endif // USE(SKIA)

--- a/Source/WebCore/platform/graphics/skia/SkiaRecordCanvas.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaRecordCanvas.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(SKIA)
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/utils/SkNWayCanvas.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
+
+namespace WebCore {
+
+class IntSize;
+
+class SkiaRecordCanvas final : public SkNWayCanvas {
+public:
+    SkiaRecordCanvas(const IntSize&);
+    ~SkiaRecordCanvas() override;
+
+    bool shouldEnableMSAA() const;
+
+private:
+    void checkSlowPathsForPaint(const SkPaint&);
+
+    // SkNWayCanvas overrides
+    void onDrawPoints(PointMode, size_t count, const SkPoint pts[], const SkPaint&) override;
+    void onDrawDRRect(const SkRRect&, const SkRRect&, const SkPaint&) override;
+    void onDrawGlyphRunList(const sktext::GlyphRunList&, const SkPaint&) override;
+    void onDrawTextBlob(const SkTextBlob*, SkScalar x, SkScalar y, const SkPaint&) override;
+
+    void onDrawRect(const SkRect&, const SkPaint&) override;
+    void onDrawRegion(const SkRegion&, const SkPaint&) override;
+    void onDrawOval(const SkRect&, const SkPaint&) override;
+    void onDrawArc(const SkRect&, SkScalar, SkScalar, bool, const SkPaint&) override;
+    void onDrawRRect(const SkRRect&, const SkPaint&) override;
+    void onDrawPath(const SkPath&, const SkPaint&) override;
+
+    void onDrawImageRect2(const SkImage*, const SkRect&, const SkRect&, const SkSamplingOptions&, const SkPaint*, SrcRectConstraint) override;
+
+    void onClipRRect(const SkRRect&, SkClipOp, ClipEdgeStyle) override;
+    void onClipPath(const SkPath&, SkClipOp, ClipEdgeStyle) override;
+
+    unsigned m_slowPathForMSAACount { 0 };
+    bool m_hasNonAntialiasPaint { false };
+};
+
+} // namespace WebCore
+
+#endif // USE(SKIA)

--- a/Source/WebCore/platform/graphics/skia/SkiaRecordingResult.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaRecordingResult.cpp
@@ -30,7 +30,7 @@
 
 namespace WebCore {
 
-SkiaRecordingResult::SkiaRecordingResult(sk_sp<SkPicture>&& picture, SkiaRecordingData&& recordingData, const IntRect& recordRect, RenderingMode renderingMode, bool contentsOpaque, float contentsScale)
+SkiaRecordingResult::SkiaRecordingResult(sk_sp<SkPicture>&& picture, SkiaRecordingData&& recordingData, const IntRect& recordRect, RenderingMode renderingMode, bool contentsOpaque, float contentsScale, unsigned msaaSampleCount)
     : m_picture(WTF::move(picture))
     , m_imageToFenceMap(WTF::move(recordingData.imageToFenceMap))
     , m_atlasLayouts(WTF::move(recordingData.atlasLayouts))
@@ -39,14 +39,15 @@ SkiaRecordingResult::SkiaRecordingResult(sk_sp<SkPicture>&& picture, SkiaRecordi
     , m_renderingMode(renderingMode)
     , m_contentsOpaque(contentsOpaque)
     , m_contentsScale(contentsScale)
+    , m_msaaSampleCount(msaaSampleCount)
 {
 }
 
 SkiaRecordingResult::~SkiaRecordingResult() = default;
 
-Ref<SkiaRecordingResult> SkiaRecordingResult::create(sk_sp<SkPicture>&& picture, SkiaRecordingData&& recordingData, const IntRect& recordRect, RenderingMode renderingMode, bool contentsOpaque, float contentsScale)
+Ref<SkiaRecordingResult> SkiaRecordingResult::create(sk_sp<SkPicture>&& picture, SkiaRecordingData&& recordingData, const IntRect& recordRect, RenderingMode renderingMode, bool contentsOpaque, float contentsScale, unsigned msaaSampleCount)
 {
-    return adoptRef(*new SkiaRecordingResult(WTF::move(picture), WTF::move(recordingData), recordRect, renderingMode, contentsOpaque, contentsScale));
+    return adoptRef(*new SkiaRecordingResult(WTF::move(picture), WTF::move(recordingData), recordRect, renderingMode, contentsOpaque, contentsScale, msaaSampleCount));
 }
 
 bool SkiaRecordingResult::hasFences()

--- a/Source/WebCore/platform/graphics/skia/SkiaRecordingResult.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaRecordingResult.h
@@ -54,7 +54,7 @@ struct SkiaRecordingData {
 class SkiaRecordingResult final : public ThreadSafeRefCounted<SkiaRecordingResult, WTF::DestructionThread::Main> {
 public:
     ~SkiaRecordingResult();
-    static Ref<SkiaRecordingResult> create(sk_sp<SkPicture>&&, SkiaRecordingData&&, const IntRect& recordRect, RenderingMode, bool contentsOpaque, float contentsScale);
+    static Ref<SkiaRecordingResult> create(sk_sp<SkPicture>&&, SkiaRecordingData&&, const IntRect& recordRect, RenderingMode, bool contentsOpaque, float contentsScale, unsigned msaaSampleCount = 0);
 
     void waitForFenceIfNeeded(const SkImage&);
     bool hasFences();
@@ -64,6 +64,7 @@ public:
     RenderingMode renderingMode() const { return m_renderingMode; }
     bool contentsOpaque() const { return m_contentsOpaque; }
     float contentsScale() const { return m_contentsScale; }
+    unsigned msaaSampleCount() const { return m_msaaSampleCount; }
 
     // Atlas layouts for batched raster image uploads.
     bool hasAtlasLayouts() const { return !m_atlasLayouts.isEmpty(); }
@@ -80,7 +81,7 @@ public:
     const Vector<Ref<SkiaGPUAtlas>>& gpuAtlases() const LIFETIME_BOUND { return m_gpuAtlases; }
 
 private:
-    SkiaRecordingResult(sk_sp<SkPicture>&&, SkiaRecordingData&&, const IntRect& recordRect, RenderingMode, bool contentsOpaque, float contentsScale);
+    SkiaRecordingResult(sk_sp<SkPicture>&&, SkiaRecordingData&&, const IntRect& recordRect, RenderingMode, bool contentsOpaque, float contentsScale, unsigned msaaSampleCount);
 
     sk_sp<SkPicture> m_picture;
     SkiaImageToFenceMap m_imageToFenceMap WTF_GUARDED_BY_LOCK(m_imageToFenceMapLock);
@@ -92,6 +93,7 @@ private:
     RenderingMode m_renderingMode { RenderingMode::Unaccelerated };
     bool m_contentsOpaque : 1 { true };
     float m_contentsScale { 0 };
+    unsigned m_msaaSampleCount { 0 };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.cpp
@@ -124,14 +124,33 @@ OptionSet<CoordinatedBackingStoreProxy::UpdateResult> CoordinatedBackingStorePro
 
     Vector<Update::TileUpdate> tilesToUpdate;
     if (dirtyTilesCount) {
-        WTFBeginSignpost(this, UpdateTiles, "dirty tiles: %u", dirtyTilesCount);
-
 #if USE(SKIA)
         // Record only once the whole layer.
         RefPtr<SkiaRecordingResult> recording;
-        if (layer.client().paintingEngine().useThreadedRendering()) [[likely]]
-            recording = layer.record(tileDirtyRectUnion);
+        if (layer.client().paintingEngine().useThreadedRendering()) [[likely]] {
+            recording = layer.record(tileDirtyRectUnion, m_msaaSampleCount);
+            if (!m_msaaSampleCount) {
+                m_msaaSampleCount = recording->msaaSampleCount();
+                if (m_msaaSampleCount) {
+                    WTFEmitSignpost(this, UpdateTiles, "Enabling MSAA with %u samples", m_msaaSampleCount);
+
+                    // Switching to MSAA, we need to invalidate all tiles.
+                    tileDirtyRectUnion = { };
+                    for (auto& tile : m_tiles.values()) {
+                        tile.setDirtyRect(tile.rect);
+                        tileDirtyRectUnion.unite(tile.dirtyRect);
+                    }
+                    dirtyTilesCount = m_tiles.size();
+
+                    // If the new dirty area is not already covered we need to record again.
+                    if (!recording->recordRect().contains(tileDirtyRectUnion))
+                        recording = layer.record(tileDirtyRectUnion, m_msaaSampleCount);
+                }
+            }
+        }
 #endif
+
+        WTFBeginSignpost(this, UpdateTiles, "dirty tiles: %u", dirtyTilesCount);
 
         unsigned dirtyTileIndex = 0;
         for (auto& tile : m_tiles.values()) {
@@ -142,7 +161,7 @@ OptionSet<CoordinatedBackingStoreProxy::UpdateResult> CoordinatedBackingStorePro
                 tile.rect.x(), tile.rect.y(), tile.rect.width(), tile.rect.height(), tile.dirtyRect.x(), tile.dirtyRect.y(), tile.dirtyRect.width(), tile.dirtyRect.height());
 
 #if USE(SKIA)
-            auto buffer = recording ? layer.replay(Ref { *recording }, tile.rect, tile.dirtyRect) : layer.paint(tile.dirtyRect);
+            auto buffer = recording ? layer.replay(Ref { *recording }, tile.rect, tile.dirtyRect, m_msaaSampleCount) : layer.paint(tile.dirtyRect);
 #else
             auto buffer = layer.paint(tile.dirtyRect);
 #endif
@@ -229,6 +248,9 @@ void CoordinatedBackingStoreProxy::createOrDestroyTiles(const IntRect& unscaledV
         if (tileSizeChanged || contentsScaleChanged || m_contentsRect.isEmpty()) {
             m_coverRect = { };
             m_keepRect = { };
+#if USE(SKIA)
+            m_msaaSampleCount = 0;
+#endif
             if (!m_tiles.isEmpty()) {
                 for (const auto& tile : m_tiles.values())
                     tilesToRemove.append(tile.id);

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.h
@@ -104,7 +104,7 @@ private:
         void resize(const IntSize& size)
         {
             rect.setSize(size);
-            dirtyRect = rect;
+            setDirtyRect(rect);
         }
 
         void addDirtyRect(const IntRect& dirty)
@@ -112,6 +112,11 @@ private:
             auto tileDirtyRect = intersection(dirty, rect);
             ASSERT(!tileDirtyRect.isEmpty());
             dirtyRect.unite(tileDirtyRect);
+        }
+
+        void setDirtyRect(const IntRect& dirty)
+        {
+            dirtyRect = dirty;
         }
 
         bool isDirty() const
@@ -152,6 +157,9 @@ private:
     IntRect m_visibleRect;
     IntRect m_coverRect;
     IntRect m_keepRect;
+#if USE(SKIA)
+    unsigned m_msaaSampleCount { 0 };
+#endif
     HashMap<IntPoint, Tile> m_tiles;
     struct {
         Lock lock;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
@@ -934,24 +934,24 @@ sk_sp<GrContextThreadSafeProxy> CoordinatedPlatformLayer::threadSafeGrContext() 
     return m_client->paintingEngine().threadSafeGrContext();
 }
 
-Ref<SkiaRecordingResult> CoordinatedPlatformLayer::record(const IntRect& recordRect)
+Ref<SkiaRecordingResult> CoordinatedPlatformLayer::record(const IntRect& recordRect, unsigned msaaSampleCount)
 {
     ASSERT(m_lock.isHeld());
     ASSERT(m_client);
     ASSERT(m_owner);
     auto& paintingEngine = m_client->paintingEngine();
     ASSERT(paintingEngine.useThreadedRendering());
-    return paintingEngine.record(*m_owner, recordRect, m_contentsOpaque, m_contentsScale);
+    return paintingEngine.record(*m_owner, recordRect, m_contentsOpaque, m_contentsScale, msaaSampleCount);
 }
 
-Ref<CoordinatedTileBuffer> CoordinatedPlatformLayer::replay(Ref<SkiaRecordingResult>&& recording, const IntRect& tileRect, const IntRect& dirtyRect)
+Ref<CoordinatedTileBuffer> CoordinatedPlatformLayer::replay(Ref<SkiaRecordingResult>&& recording, const IntRect& tileRect, const IntRect& dirtyRect, unsigned msaaSampleCount)
 {
     ASSERT(m_lock.isHeld());
     ASSERT(m_client);
     ASSERT(m_owner);
     auto& paintingEngine = m_client->paintingEngine();
     ASSERT(paintingEngine.useThreadedRendering());
-    return paintingEngine.replay(*m_owner, WTF::move(recording), tileRect, dirtyRect);
+    return paintingEngine.replay(*m_owner, WTF::move(recording), tileRect, dirtyRect, msaaSampleCount);
 }
 #endif
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
@@ -208,8 +208,8 @@ public:
 
     Ref<CoordinatedTileBuffer> paint(const IntRect&);
 #if USE(SKIA)
-    Ref<SkiaRecordingResult> record(const IntRect&);
-    Ref<CoordinatedTileBuffer> replay(Ref<SkiaRecordingResult>&&, const IntRect&, const IntRect&);
+    Ref<SkiaRecordingResult> record(const IntRect&, unsigned msaaSampleCount);
+    Ref<CoordinatedTileBuffer> replay(Ref<SkiaRecordingResult>&&, const IntRect&, const IntRect&, unsigned msaaSampleCount);
 #endif
     void willPaintTile();
     void didPaintTile();

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.cpp
@@ -156,14 +156,14 @@ CoordinatedAcceleratedTileBuffer::CoordinatedAcceleratedTileBuffer(Ref<BitmapTex
 {
 }
 
-Ref<CoordinatedTileBuffer> CoordinatedAcceleratedTileBuffer::create(const sk_sp<GrContextThreadSafeProxy>& threadSafeGrContext, const IntSize& size, Flags flags)
+Ref<CoordinatedTileBuffer> CoordinatedAcceleratedTileBuffer::create(const sk_sp<GrContextThreadSafeProxy>& threadSafeGrContext, const IntSize& size, Flags flags, unsigned msaaSampleCount)
 {
     auto imageInfo = SkImageInfo::Make(size.width(), size.height(), kRGBA_8888_SkColorType, kPremul_SkAlphaType, SkColorSpace::MakeSRGB());
     auto backendFormat = threadSafeGrContext->defaultBackendFormat(kRGBA_8888_SkColorType, GrRenderable::kYes);
     ASSERT(backendFormat.isValid());
     auto properties = FontRenderOptions::singleton().createSurfaceProps();
     auto maxResourceCacheBytes = PlatformDisplay::sharedDisplay().maxSkiaResourceCacheBytes();
-    auto characterization = threadSafeGrContext->createCharacterization(maxResourceCacheBytes, imageInfo, backendFormat, 0, kTopLeft_GrSurfaceOrigin, properties, skgpu::Mipmapped::kNo);
+    auto characterization = threadSafeGrContext->createCharacterization(maxResourceCacheBytes, imageInfo, backendFormat, msaaSampleCount, kTopLeft_GrSurfaceOrigin, properties, skgpu::Mipmapped::kNo);
     return adoptRef(*new CoordinatedAcceleratedTileBuffer(WTF::move(characterization), flags));
 }
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.h
@@ -146,7 +146,7 @@ private:
 class CoordinatedAcceleratedTileBuffer final : public CoordinatedTileBuffer {
 public:
     WEBCORE_EXPORT static Ref<CoordinatedTileBuffer> create(Ref<BitmapTexture>&&);
-    WEBCORE_EXPORT static Ref<CoordinatedTileBuffer> create(const sk_sp<GrContextThreadSafeProxy>&, const IntSize&, Flags);
+    WEBCORE_EXPORT static Ref<CoordinatedTileBuffer> create(const sk_sp<GrContextThreadSafeProxy>&, const IntSize&, Flags, unsigned msaaSampleCount);
     WEBCORE_EXPORT virtual ~CoordinatedAcceleratedTileBuffer();
 
     RefPtr<BitmapTexture> texture() const { return m_texture; }


### PR DESCRIPTION
#### 7b6d8730f95d2f7514a8333c56a123f1d8c76ed2
<pre>
[GTK][WPE] Skia compositor: enable MSAA for tile rendering when using DDL
<a href="https://bugs.webkit.org/show_bug.cgi?id=318678">https://bugs.webkit.org/show_bug.cgi?id=318678</a>

Reviewed by NOBODY (OOPS!).

When using DDL we can enable MSAA for tile rendering. However, we don&apos;t
want to enable MSAA if it&apos;s not gooing to help, so this patch introduces
a SkiaRecordCanvas class, similar to SkiaReplayCanvas, but used while
recording to analyze the recorded operations. If it detects 6 or more
slow paths that would make MSAA worth it, we enable MSAA for the layer.
When switching to use MSAA we need to invalidate all existing tiles and
if it was a partial update re-record the layer with the new dirty area.
This can only happen once per layer, because once we start using MSAA
for the layer we keep it to avoid re-checking all the time, unless the
tiles are destroyed due to a geometry change.

* Source/WebCore/platform/SourcesSkia.txt:
* Source/WebCore/platform/graphics/skia/SkiaBackingStore.cpp:
(WebCore::SkiaBackingStore::Tile::update):
* Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp:
(WebCore::SkiaPaintingEngine::createBuffer const):
(WebCore::SkiaPaintingEngine::record):
(WebCore::SkiaPaintingEngine::replay):
(WebCore::SkiaPaintingEngine::paintIntoGraphicsContext const):
* Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.h:
* Source/WebCore/platform/graphics/skia/SkiaRecordCanvas.cpp: Added.
(WebCore::SkiaRecordCanvas::SkiaRecordCanvas):
(WebCore::SkiaRecordCanvas::shouldEnableMSAA const):
(WebCore::SkiaRecordCanvas::checkSlowPathsForPaint):
(WebCore::SkiaRecordCanvas::onDrawPoints):
(WebCore::SkiaRecordCanvas::onDrawDRRect):
(WebCore::SkiaRecordCanvas::onDrawGlyphRunList):
(WebCore::SkiaRecordCanvas::onDrawTextBlob):
(WebCore::SkiaRecordCanvas::onDrawRect):
(WebCore::SkiaRecordCanvas::onDrawRegion):
(WebCore::SkiaRecordCanvas::onDrawOval):
(WebCore::SkiaRecordCanvas::onDrawArc):
(WebCore::SkiaRecordCanvas::onDrawRRect):
(WebCore::SkiaRecordCanvas::onDrawPath):
(WebCore::SkiaRecordCanvas::onDrawImageRect2):
(WebCore::SkiaRecordCanvas::onClipRRect):
(WebCore::SkiaRecordCanvas::onClipPath):
* Source/WebCore/platform/graphics/skia/SkiaRecordCanvas.h: Added.
* Source/WebCore/platform/graphics/skia/SkiaRecordingResult.cpp:
(WebCore::SkiaRecordingResult::SkiaRecordingResult):
(WebCore::SkiaRecordingResult::create):
* Source/WebCore/platform/graphics/skia/SkiaRecordingResult.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.cpp:
(WebCore::CoordinatedBackingStoreProxy::updateIfNeeded):
(WebCore::CoordinatedBackingStoreProxy::invalidateRegion):
(WebCore::CoordinatedBackingStoreProxy::createOrDestroyTiles):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp:
(WebCore::CoordinatedPlatformLayer::replay):
(WebCore::CoordinatedPlatformLayer::record):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.cpp:
(WebCore::CoordinatedAcceleratedTileBuffer::create):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b6d8730f95d2f7514a8333c56a123f1d8c76ed2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172779 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46698 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40156 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182237 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130335 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174644 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47990 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46373 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134377 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94855 "1 flakes 22 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175737 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37778 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154931 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114848 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36413 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34732 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30836 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146842 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34434 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184770 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37495 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38929 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143174 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46369 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143051 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47047 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31273 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112028 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38052 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118799 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45564 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9384 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44964 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45196 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45023 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->