### PR TITLE
Cherry-pick 311993@main (ceeb43425c27). https://bugs.webkit.org/show_bug.cgi?id=313277

### DIFF
--- a/LayoutTests/fast/images/animated-avif.html
+++ b/LayoutTests/fast/images/animated-avif.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <title>AVIF animation reftest: when animation ends, compare its last frame against the reference static avif image.</title>
-<meta name="fuzzy" content="maxDifference=1-9; totalPixels=258-484" />
+<meta name="fuzzy" content="maxDifference=1-9; totalPixels=258-512" />
 <style>
     canvas {
         width: 63px;


### PR DESCRIPTION
#### b0827be91446b2ac900b38717e95dcc2364d109b
<pre>
Cherry-pick 311993@main (ceeb43425c27). <a href="https://bugs.webkit.org/show_bug.cgi?id=313277">https://bugs.webkit.org/show_bug.cgi?id=313277</a>

    [WPE][ARM64] Test fast/images/animated-avif.html gives ImageOnlyFailure but the images match
    <a href="https://bugs.webkit.org/show_bug.cgi?id=313277">https://bugs.webkit.org/show_bug.cgi?id=313277</a>

    Unreviewed gardening.

    Increment the number of maximum pixels allowed in the fuzzy match
    from 484 to 512. This allows this test to pass on WPE ARM64.
    As far as my eye can tell, the expected image generated is the same
    than the generated one in this case. If this test fails the number
    of pixels should be way more than 512.
    This test has around 215x80 relevant pixels, 512 is just 3% of it.

    * LayoutTests/fast/images/animated-avif.html:

    Canonical link: <a href="https://commits.webkit.org/311993@main">https://commits.webkit.org/311993@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.957@webkitglib/2.52">https://commits.webkit.org/305877.957@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b025aae2083e8071e210e4425408ba2f417f7fb8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172780 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/46699 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/40157 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182238 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/130336 "The change is no longer eligible for processing.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/47991 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/46374 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134378 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/130336 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175738 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/47991 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/40157 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114849 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/47991 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/46374 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30837 "Built successfully") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/40157 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/47991 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/40157 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184771 "Built successfully") | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/46374 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143175 "Passed tests") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/46370 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/40157 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143052 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/47048 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/40157 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/112024 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26211 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/47048 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/45565 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/40157 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/44965 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/45197 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/45024 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->