### PR TITLE
[visionOS] Skip InteractionRegions when ancestor has opacity: 0

### DIFF
--- a/LayoutTests/interaction-region/layer-tree-expected.txt
+++ b/LayoutTests/interaction-region/layer-tree-expected.txt
@@ -4,6 +4,10 @@
   (layer position [x: 400 y: 400])
   (sublayers
     (
+      (layer bounds [x: 0 y: 0 width: 200 height: 200])
+      (layer position [x: 100 y: 100])
+      (layer opacity 0))
+    (
       (layer bounds [x: 0 y: 0 width: 0 height: 0])
       (sublayers
         (
@@ -41,19 +45,6 @@
             (frame [x: 0 y: 0 width: 100 height: 100]))
           (layer bounds [x: 0 y: 0 width: 100 height: 100])
           (layer position [x: 350 y: 350]))))
-    (
-      (layer bounds [x: 0 y: 0 width: 200 height: 200])
-      (layer position [x: 100 y: 100])
-      (layer opacity 0)
-      (sublayers
-        (
-          (layer bounds [x: 0 y: 0 width: 0 height: 0])
-          (sublayers
-            (
-              (type 0)
-              (layer bounds [x: 0 y: 0 width: 75.9921875 height: 27])
-              (layer position [x: 33.99609375 y: 33.99609375])
-              (layer cornerRadius 8))))))
     (
       (layer bounds [x: 0 y: 0 width: 800 height: 600])
       (layer position [x: 400 y: 400])

--- a/LayoutTests/interaction-region/opacity-expected.txt
+++ b/LayoutTests/interaction-region/opacity-expected.txt
@@ -1,0 +1,17 @@
+Some text  but also a button  and another that overflows
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (drawsContent 1)
+      (backgroundColor #FFFFFF)
+      (event region
+        (rect (0,0) width=800 height=600)
+      )
+    )
+  )
+)
+

--- a/LayoutTests/interaction-region/opacity.html
+++ b/LayoutTests/interaction-region/opacity.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<style>
+    body { margin: 20px; }
+    a {
+        display: block;
+        width: 400px;
+        border: 1px black solid;
+        padding: 20px;
+        line-height: 25px;
+        opacity: 0;
+    }
+</style>
+<body>
+<a href="#">
+    Some text
+    <button class="styled">but also a button</button>
+    <button class="styled-native">and another that overflows</button>
+</a>
+
+<pre id="results"></pre>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+window.onload = function () {
+    if (window.internals)
+       results.textContent = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_EVENT_REGION | internals.LAYER_TREE_INCLUDES_ROOT_LAYER_PROPERTIES);
+};
+</script>
+</body>
+</html>

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -432,6 +432,9 @@ std::optional<InteractionRegion> interactionRegionForRenderedRegion(const Render
     if (renderer->usedPointerEvents() == PointerEvents::None)
         return std::nullopt;
 
+    if (renderer->style().isEffectivelyTransparent())
+        return std::nullopt;
+
     bool isOriginalMatch = matchedElement == originalElement;
 
     // FIXME: Consider also allowing elements that only receive touch events.


### PR DESCRIPTION
#### 2697079134d5692e1d4f5835dec913e849ccdee6
<pre>
[visionOS] Skip InteractionRegions when ancestor has opacity: 0
<a href="https://bugs.webkit.org/show_bug.cgi?id=318682">https://bugs.webkit.org/show_bug.cgi?id=318682</a>
&lt;<a href="https://rdar.apple.com/175277028">rdar://175277028</a>&gt;

Reviewed by Simon Fraser.

Check if the renderer or any ancestor has a 0 opacity before generating
an InteractionRegion. This fixes some &quot;phantom&quot; glow effects appearing
on transparent content.

Test: interaction-region/opacity.html

* LayoutTests/interaction-region/layer-tree-expected.txt:
Updated expectations since this test had an `opacity: 0` element.
* LayoutTests/interaction-region/opacity-expected.txt: Added.
* LayoutTests/interaction-region/opacity.html: Added.
Add a new test covering this.

* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::interactionRegionForRenderedRegion):
Add `isEffectivelyTransparent()` check.

Canonical link: <a href="https://commits.webkit.org/316590@main">https://commits.webkit.org/316590@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7bc3983707a48a773645423f0ccd59f368f8d113

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172802 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46721 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40181 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182289 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130358 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/808df6b7-4bbd-4dd5-9910-795e9d516eec) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174667 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48013 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46396 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134420 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fb53cb9f-cbf4-4b91-b285-dbb383aa935e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175760 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37791 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154947 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.CrossProcessHistoryTraversalCoalesce (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114889 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/89db45ca-fc0b-4181-a4ea-b4c78f712a26) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36440 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34752 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30859 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146855 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34450 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184793 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37521 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38956 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143192 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46392 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154520 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143069 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38637 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47070 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112059 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38066 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118834 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45587 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9400 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44987 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45219 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45046 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->