### PR TITLE
Cherry-pick(s) 02c6dfb19415. rdar://180437219

### DIFF
--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -18677,7 +18677,10 @@
 				1A6FB7AF11E64B6800DB1371 /* PluginView.h in Headers */,
 				49ECA41C23FCA5D80023358D /* PolicyDecision.h in Headers */,
 				57FD318122B3515B008D0E8B /* PopUpSOAuthorizationSession.h in Headers */,
+<<<<<<< HEAD
 				07AE8FC82F3BCF1600A4C0CA /* PositionInformationForWebPage.h in Headers */,
+=======
+>>>>>>> 02c6dfb19415 ([WebKit Networking] missing MESSAGE_CHECK and unvalidated shouldPreconnectOnly in NetworkConnectionToWebProcess::preconnectTo / sendH2Ping)
 				1D3F2E8A99B47C6E5F7A2D11 /* PreconnectRequest.h in Headers */,
 				83A0ED351F747CCF003299EB /* PreconnectTask.h in Headers */,
 				C15CBB3623F3777100300CC7 /* PreferenceObserver.h in Headers */,

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -1047,7 +1047,11 @@ void WebLoaderStrategy::preconnectTo(WebCore::ResourceRequest&& request, WebPage
     }
 
     OptionSet<WebCore::AdvancedPrivacyProtections> advancedPrivacyProtections;
+<<<<<<< HEAD
     if (RefPtr loader = policySourceDocumentLoaderForFrame(*protect(webFrame.coreLocalFrame())))
+=======
+    if (RefPtr loader = policySourceDocumentLoaderForFrame(*webFrame.protectedCoreLocalFrame()))
+>>>>>>> 02c6dfb19415 ([WebKit Networking] missing MESSAGE_CHECK and unvalidated shouldPreconnectOnly in NetworkConnectionToWebProcess::preconnectTo / sendH2Ping)
         advancedPrivacyProtections = loader->advancedPrivacyProtections();
 
     std::optional<NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain;


### PR DESCRIPTION
Integration has hit a merge conflict while cherry-picking rdar://180437219 to main. [02c6dfb19415] caused a merge conflict. 

```
[WebKit Networking] missing MESSAGE_CHECK and unvalidated shouldPreconnectOnly in NetworkConnectionToWebProcess::preconnectTo / sendH2Ping
https://bugs.webkit.org/show_bug.cgi?id=314864
rdar://176911922

Reviewed by Alex Christensen.

NetworkConnectionToWebProcess::preconnectTo and sendH2Ping previously
accepted a full NetworkResourceLoadParameters from WebContent. That
struct carries shouldPreconnectOnly, an httpBody on the request, a
foreign firstPartyForCookies, and many other fields that have no
legitimate use for a preconnect or H2 ping. A compromised WebContent
process could send shouldPreconnectOnly=No together with a file-backed
FormData body and a foreign firstPartyForCookies, and the
NetworkProcess would issue a full credentialed POST that streamed an
arbitrary NetworkProcess-readable file to an attacker-controlled
server. The only guards on this path were two debug ASSERTs.

Fix by replacing the wire types with purpose-built ones that carry
only the fields these operations actually need, and assembling the
NetworkLoadParameters in the NetworkProcess:

- SendH2Ping now takes (URL, webPageProxyID, webPageID, webFrameID,
  isNavigatingToAppBoundDomain). The NetworkProcess constructs a fresh
  ResourceRequest{url} locally, so no WebContent-supplied httpBody or
  shouldPreconnectOnly=No can reach PreconnectTask: the IPC contract
  itself enforces what previously needed a MESSAGE_CHECK.

- PreconnectTo now takes a new WebKit::PreconnectRequest struct with
  the small set of fields the WebContent legitimately provides
  (ResourceRequest, page/frame IDs, storedCredentialsPolicy,
  advancedPrivacyProtections, isNavigatingToAppBoundDomain,
  preconnectionIdentifier). The NetworkProcess builds the
  NetworkLoadParameters and forces shouldPreconnectOnly=Yes. The
  ResourceRequest can still carry an httpBody on the wire, so
  MESSAGE_CHECK(!request.httpBody()) is retained at the IPC boundary.

PreconnectTask::create keeps the defense-in-depth from the prior
revision (force shouldPreconnectOnly=Yes and clear any httpBody) so a
future caller cannot accidentally reintroduce the issue.

Test: ipc/preconnect-to-message-checks.html

* LayoutTests/ipc/preconnect-to-message-checks-expected.txt:
* LayoutTests/ipc/preconnect-to-message-checks.html: Updated to encode
the new PreconnectRequest wire format with a hostile httpBody.
* Source/WebKit/CMakeLists.txt:
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::sendH2Ping):
(WebKit::NetworkConnectionToWebProcess::preconnectTo):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in:
* Source/WebKit/NetworkProcess/PreconnectRequest.h: Added.
* Source/WebKit/NetworkProcess/PreconnectRequest.serialization.in: Added.
* Source/WebKit/Scripts/webkit/messages.py: Add PreconnectRequest to
types_that_must_be_moved().
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::WebLoaderStrategy::preconnectTo):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::sendH2Ping):

Originally-landed-as: 305413.927@safari-7624-branch (02c6dfb19415). rdar://180437219


```

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/86cbbb43ee944fdaf1fbcfae422f13216dd10031

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172789 "") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46708 "") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40167 "") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182247 "") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130345 "") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48000 "") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46383 "") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/182247 "") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/130345 "") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175747 "") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/48000 "") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/40167 "") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/182247 "") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/48000 "") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/46383 "") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30846 "") | 
| [❌ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/168/builds/40167 "") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/48000 "") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/40167 "") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184780 "") | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37507 "") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/46383 "") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/184780 "") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46379 "") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/40167 "") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/184780 "") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47057 "") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/40167 "") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112037 "") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/47057 "") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118809 "") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45574 "") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/40167 "") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44974 "") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45206 "") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45033 "") | | | 
<!--EWS-Status-Bubble-End-->