### PR TITLE
Cherry-pick 316479@main (7d6af3d9a4c3). https://bugs.webkit.org/show_bug.cgi?id=318505

### DIFF
--- a/Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp
+++ b/Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp
@@ -878,7 +878,8 @@ void NetworkStorageSession::stopListeningForCookieChangeNotifications(CookieChan
 {
     for (auto& host : hosts) {
         auto it = m_cookieChangeObservers.find(host);
-        ASSERT(it != m_cookieChangeObservers.end());
+        if (it == m_cookieChangeObservers.end())
+            continue;
 
         auto& observers = it->value;
         ASSERT(observers.contains(observer));

--- a/Tools/Scripts/run-jsc-stress-tests
+++ b/Tools/Scripts/run-jsc-stress-tests
@@ -514,46 +514,38 @@ def determineArchitectureFromMachOBinary
 end
 
 def determineArchitectureFromELFBinary
-    f = File.open($jscPath.to_s)
+    f = File.open($jscPath.to_s, "rb")
     data = f.read(20)
 
-    if !(data[0,4] == "\x7F\x45\x4C\x46")
+    if data[0, 4].bytes != [0x7F, 0x45, 0x4C, 0x46]
         $stderr.puts "Warning: Missing ELF magic in file #{Shellwords.shellescape($jscPath.to_s)}"
         return nil
     end
 
     # MIPS and PowerPC may be either big- or little-endian. S390 (which includes
     # S390x) is big-endian. The rest are little-endian.
-    # For RISC-V, to avoid encoding problems, construct the comparison string
-    # by packing a char array matching the ELF's RISC-V machine value.
-    code = data[18, 20]
+    code = data[18, 2].bytes
     case code
-    when "\x03\0"
+    when [0x03, 0]
         "x86"
-    when "\x08\0"
+    when [0x08, 0], [0, 0x08]
         "mips"
-    when "\0\x08"
-        "mips"
-    when "\x14\0"
+    when [0x14, 0], [0, 0x14]
         "powerpc"
-    when "\0\x14"
-        "powerpc"
-    when "\x15\0"
+    when [0x15, 0], [0, 0x15]
         "powerpc64"
-    when "\0\x15"
-        "powerpc64"
-    when "\0\x16"
+    when [0, 0x16]
         "s390"
-    when "\x28\0"
+    when [0x28, 0]
         "arm"
-    when "\x3E\0"
+    when [0x3E, 0]
         "x86_64"
-    when "\xB7\0"
+    when [0xB7, 0]
         "arm64"
-    when [243, 0].pack("cc")
+    when [0xF3, 0]
         "riscv64"
     else
-        $stderr.puts "Warning: unable to determine architecture from code: #{code}"
+        $stderr.puts "Warning: unable to determine architecture from code: #{code.inspect}"
         nil
     end
 end


### PR DESCRIPTION
#### c9710b82a657c7f334320ea01fb0fe450846844f
<pre>
Cherry-pick 316479@main (7d6af3d9a4c3). <a href="https://bugs.webkit.org/show_bug.cgi?id=318505">https://bugs.webkit.org/show_bug.cgi?id=318505</a>

    Update arch detection in run-jsc-stress-tests
    <a href="https://bugs.webkit.org/show_bug.cgi?id=318505">https://bugs.webkit.org/show_bug.cgi?id=318505</a>

    Reviewed by Yusuke Suzuki.

    arm64 and riscv64 have arch identifiers that don&apos;t look like ascii.
    Let&apos;s compare them as bytes instead to avoid string encoding headaches.

    Canonical link: <a href="https://commits.webkit.org/316479@main">https://commits.webkit.org/316479@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.961@webkitglib/2.52">https://commits.webkit.org/305877.961@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 235b222f37a97a7e8136f7bc31961f6149b0592d
<pre>
Cherry-pick 316492@main (86ec57b01ddf). <a href="https://bugs.webkit.org/show_bug.cgi?id=318463">https://bugs.webkit.org/show_bug.cgi?id=318463</a>

    [Soup] Null deref in NetworkStorageSession::stopListeningForCookieChangeNotifications when a host is absent from m_cookieChangeObservers
    <a href="https://bugs.webkit.org/show_bug.cgi?id=318463">https://bugs.webkit.org/show_bug.cgi?id=318463</a>

    Reviewed by Patrick Griffis.

    Safely ignore a given host if it&apos;s not found in m_cookieChangeObservers,
    avoiding a potential null deref. This mirrors the Cocoa port&apos;s release
    behavior. For debug builds, as the ASSERT_UNUSED(removed, removed) in
    NetworkConnectionToWebProcess::unsubscribeFromCookieChangeNotifications
    would have triggered earlier, we&apos;re also removing the redundant ASSERT.

    This scenario can happen after a previous NetworkProcess with cookie
    listeners crashes. As currently the WebCookieJar is not notified of such
    crashes, it does not tell the replacement process&apos;s NetworkStorageSession
    about the existing listeners. Then, when the WebCookieJar sends an
    unsubscribe request, we hit the assertion or trigger the null deref on
    the empty map on the storage session.

    * Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp:
    (WebCore::NetworkStorageSession::stopListeningForCookieChangeNotifications):

    Canonical link: <a href="https://commits.webkit.org/316492@main">https://commits.webkit.org/316492@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.960@webkitglib/2.52">https://commits.webkit.org/305877.960@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6362ba2202477e8e1d546ba1aafc6084520caf13

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172792 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/46711 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/40170 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182250 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/130348 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174657 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/48003 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/46386 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134387 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/130348 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175750 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/48003 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/40170 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114858 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/48003 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/46386 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30849 "Built successfully") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/40170 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/48003 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/40170 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184783 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/34053 "The change is no longer eligible for processing.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/37510 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/46386 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143184 "Passed tests") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/46382 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/40170 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143061 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/47060 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/40170 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/112042 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26220 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/47060 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/118812 "The change is no longer eligible for processing.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/205470 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/45577 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/40170 "The change is no longer eligible for processing.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54865 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/44977 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/45209 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/45036 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->