### PR TITLE
[LBSE] Dynamic marker attribute change must repaint the referencing element's old bounds

### DIFF
--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/repaint/marker-markerUnits-dynamic-update-repaint-expected.txt
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/repaint/marker-markerUnits-dynamic-update-repaint-expected.txt
@@ -1,0 +1,5 @@
+ (repaint rects
+  (rect 108 108 100 100)
+  (rect 148 148 20 20)
+)
+

--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/repaint/marker-orient-dynamic-update-repaint-expected.txt
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/repaint/marker-orient-dynamic-update-repaint-expected.txt
@@ -1,0 +1,5 @@
+ (repaint rects
+  (rect 118 148 80 20)
+  (rect 148 118 20 80)
+)
+

--- a/Source/WebCore/rendering/ReferencedSVGResources.cpp
+++ b/Source/WebCore/rendering/ReferencedSVGResources.cpp
@@ -102,6 +102,13 @@ void CSSSVGResourceElementClient::resourceChanged(SVGElement& element)
 
     // Invalidate cached visual overflow rect since resource bounds may have changed.
     if (CheckedPtr layerModelObject = dynamicDowncast<RenderLayerModelObject>(m_clientRenderer.get())) {
+        // A marker change (markerUnits, orient) can resize the client, but a layer-less client has no
+        // post-layout position update, so the repaint below only covers its current bounds. Repaint the old
+        // bounds now, while the cached visual overflow still holds them, so a shrinking marker erases the area
+        // it used to cover. Gradients and patterns leave the bounds unchanged, so one repaint below suffices.
+        if (is<SVGMarkerElement>(element) && !layerModelObject->hasLayer() && !m_clientRenderer->document().view()->layoutContext().isInLayout())
+            m_clientRenderer->repaint();
+
         layerModelObject->invalidateCachedVisualOverflowRect();
         // Ensure the post-layout recursiveUpdateLayerPositions() processes this client layer
         // and generates repaint rects, even if the client's own geometry didn't change.

--- a/Source/WebCore/rendering/svg/RenderSVGModelObject.h
+++ b/Source/WebCore/rendering/svg/RenderSVGModelObject.h
@@ -83,6 +83,8 @@ public:
             m_cachedVisualOverflowRect = SVGBoundingBoxComputation::computeVisualOverflowRect(*this);
         return *m_cachedVisualOverflowRect;
     }
+
+    void updateCachedVisualOverflowRect() { m_cachedVisualOverflowRect = SVGBoundingBoxComputation::computeVisualOverflowRect(*this); }
     LayoutSize locationOffsetEquivalent() const { return toLayoutSize(currentSVGLayoutLocation()); }
 
     bool hasVisualOverflow() const { return !borderBoxRectEquivalent().contains(visualOverflowRectEquivalent()); }

--- a/Source/WebCore/rendering/svg/RenderSVGShape.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGShape.cpp
@@ -150,6 +150,7 @@ void RenderSVGShape::layout()
     }
 
     updateLayerTransform();
+    updateCachedVisualOverflowRect();
 
     repainter.repaintAfterLayout();
     clearNeedsLayout();


### PR DESCRIPTION
#### 7ea764bf2f3ac43ca79698a51ee8e84248d958ee
<pre>
[LBSE] Dynamic marker attribute change must repaint the referencing element&apos;s old bounds
<a href="https://bugs.webkit.org/show_bug.cgi?id=318684">https://bugs.webkit.org/show_bug.cgi?id=318684</a>

Reviewed by Rob Buis.

Changing a marker&apos;s markerUnits or orient resizes the element that references it, but a
referencing shape without a layer gets no post-layout position update, so resourceChanged()
only repainted its new (current) bounds. A shrinking marker then left its former area behind.

Record the visual overflow, including markers, at the end of RenderSVGShape::layout() via the
new updateCachedVisualOverflowRect(), so the old bounds are cached while the geometry is still
current. On a marker change, resourceChanged() repaints those old bounds before invalidating the
cache and recomputing the new ones. The extra repaint is gated to markers, since gradients and
patterns do not change the client&apos;s bounds.

Fixes svg/repaint/marker-markerUnits-dynamic-update-repaint.html and
svg/repaint/marker-orient-dynamic-update-repaint.html, with more accurate repaint rects
than the legacy engine had. The repaint rects dump tests were created instead of trying to
catch the repaint issue in a reftest to also cover that we&apos;re not overpainting.

* LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/repaint/marker-markerUnits-dynamic-update-repaint-expected.txt: Added.
* LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/repaint/marker-orient-dynamic-update-repaint-expected.txt: Added.
* Source/WebCore/rendering/ReferencedSVGResources.cpp:
(WebCore::CSSSVGResourceElementClient::resourceChanged):
* Source/WebCore/rendering/svg/RenderSVGModelObject.h:
(WebCore::RenderSVGModelObject::updateCachedVisualOverflowRect):
* Source/WebCore/rendering/svg/RenderSVGShape.cpp:
(WebCore::RenderSVGShape::layout):

Canonical link: <a href="https://commits.webkit.org/316702@main">https://commits.webkit.org/316702@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/99da2cee61a42b9e4dd798cce7c0a076c7ac4f81

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173232 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/47164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/40677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/182805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/130788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175097 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/48457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46846 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/182805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/130788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176190 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/48457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/40677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/182805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/48457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/35101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/31290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/40677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/48457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/40677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185227 "Failed to checkout and rebase branch from PR 68748") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/38058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/39302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/185227 "Failed to checkout and rebase branch from PR 68748") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/46832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/40677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/185227 "Failed to checkout and rebase branch from PR 68748") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/47511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/40677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/112597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26295 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/47511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/119260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46017 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/40677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/45419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/45650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45476 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->