### PR TITLE
[css-conditional-5] Support style query ranges

### DIFF
--- a/LayoutTests/fast/css/container-style-range-query-invalidation-expected.txt
+++ b/LayoutTests/fast/css/container-style-range-query-invalidation-expected.txt
@@ -1,0 +1,5 @@
+
+PASS style(10px < --foo): changing the bound custom property re-evaluates
+PASS style(--a > --b): changing the right operand re-evaluates
+PASS style(var(--x) > 10px): changing the var()-referenced property re-evaluates
+

--- a/LayoutTests/fast/css/container-style-range-query-invalidation.html
+++ b/LayoutTests/fast/css/container-style-range-query-invalidation.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Dynamic invalidation of container style range queries on custom property changes</title>
+<link rel="help" href="https://drafts.csswg.org/css-conditional-5/#typedef-style-range">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<style>
+  #container { container-name: c; }
+
+  /* The queried custom property is a comparison bound, not the range center. */
+  @container c style(10px < --foo) { #t1 { --applied: yes; } }
+
+  /* The queried custom property is the right operand of a two-property comparison. */
+  @container c style(--a > --b) { #t2 { --applied: yes; } }
+
+  /* The queried custom property is referenced via var() in the range center. */
+  @container c style(var(--x) > 10px) { #t3 { --applied: yes; } }
+</style>
+<div id="container">
+  <div id="t1"></div>
+  <div id="t2"></div>
+  <div id="t3"></div>
+</div>
+<script>
+function applied(id) {
+  return getComputedStyle(document.getElementById(id)).getPropertyValue('--applied').trim();
+}
+const container = document.getElementById('container');
+
+test(() => {
+  container.style.setProperty('--foo', '20px'); // 10px < 20px -> true
+  assert_equals(applied('t1'), 'yes', 'matches before change');
+  container.style.setProperty('--foo', '5px'); // 10px < 5px -> false
+  assert_equals(applied('t1'), '', 're-evaluated after change');
+}, 'style(10px < --foo): changing the bound custom property re-evaluates');
+
+test(() => {
+  container.style.setProperty('--a', '10px');
+  container.style.setProperty('--b', '5px'); // 10px > 5px -> true
+  assert_equals(applied('t2'), 'yes', 'matches before change');
+  container.style.setProperty('--b', '20px'); // 10px > 20px -> false
+  assert_equals(applied('t2'), '', 're-evaluated after change');
+}, 'style(--a > --b): changing the right operand re-evaluates');
+
+test(() => {
+  container.style.setProperty('--x', '20px'); // 20px > 10px -> true
+  assert_equals(applied('t3'), 'yes', 'matches before change');
+  container.style.setProperty('--x', '5px'); // 5px > 10px -> false
+  assert_equals(applied('t3'), '', 're-evaluated after change');
+}, 'style(var(--x) > 10px): changing the var()-referenced property re-evaluates');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/at-container-style-parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/at-container-style-parsing-expected.txt
@@ -8,31 +8,31 @@ PASS Query condition should be valid: style(--my-prop: )
 PASS Query condition should be valid: style(--foo: bar !important)
 PASS Query condition should be valid: style(--foo)
 PASS Query condition should be valid: style(--my-prop: attr(data-foo))
-FAIL Query condition should be valid: style(--foo >= --bar) assert_equals: expected "true" but got ""
-FAIL Query condition should be valid: style(--foo = --bar) assert_equals: expected "true" but got ""
-FAIL Query condition should be valid: style(--foo <= --bar) assert_equals: expected "true" but got ""
-FAIL Query condition should be valid: style(10px > 10em) assert_equals: expected "true" but got ""
-FAIL Query condition should be valid: style(--foo >= 10em) assert_equals: expected "true" but got ""
-FAIL Query condition should be valid: style(10px > --bar) assert_equals: expected "true" but got ""
-FAIL Query condition should be valid: style(10px = --bar) assert_equals: expected "true" but got ""
-FAIL Query condition should be valid: style(--foo < --bar) assert_equals: expected "true" but got ""
-FAIL Query condition should be valid: style(10px <= 10em) assert_equals: expected "true" but got ""
-FAIL Query condition should be valid: style(10px = 10em) assert_equals: expected "true" but got ""
-FAIL Query condition should be valid: style(10px <= calc(10em + 20em)) assert_equals: expected "true" but got ""
-FAIL Query condition should be valid: style(calc(10em + 20em) < 10px) assert_equals: expected "true" but got ""
-FAIL Query condition should be valid: style(--foo < 10em) assert_equals: expected "true" but got ""
-FAIL Query condition should be valid: style(10px <= --bar) assert_equals: expected "true" but got ""
-FAIL Query condition should be valid: style(--foo < --bar <= --baz) assert_equals: expected "true" but got ""
-FAIL Query condition should be valid: style(--foo >= --bar > --baz) assert_equals: expected "true" but got ""
-FAIL Query condition should be valid: style(--foo > 10px > 10em) assert_equals: expected "true" but got ""
-FAIL Query condition should be valid: style(10px < --foo < 10em) assert_equals: expected "true" but got ""
-FAIL Query condition should be valid: style(10px < --foo <= 10em) assert_equals: expected "true" but got ""
-FAIL Query condition should be valid: style(10px <= --foo < 10em) assert_equals: expected "true" but got ""
-FAIL Query condition should be valid: style(10px > 10em > --foo) assert_equals: expected "true" but got ""
-FAIL Query condition should be valid: style(10px < 10em < 10) assert_equals: expected "true" but got ""
-FAIL Query condition should be valid: style(var(--p) < calc(100 + 200)) assert_equals: expected "true" but got ""
-FAIL Query condition should be valid: style(attr(data-foo type(<number>)) < var(--p) < var(--q)) assert_equals: expected "true" but got ""
-FAIL Query condition should be valid: style(--foo < initial) assert_equals: expected "true" but got ""
+PASS Query condition should be valid: style(--foo >= --bar)
+PASS Query condition should be valid: style(--foo = --bar)
+PASS Query condition should be valid: style(--foo <= --bar)
+PASS Query condition should be valid: style(10px > 10em)
+PASS Query condition should be valid: style(--foo >= 10em)
+PASS Query condition should be valid: style(10px > --bar)
+PASS Query condition should be valid: style(10px = --bar)
+PASS Query condition should be valid: style(--foo < --bar)
+PASS Query condition should be valid: style(10px <= 10em)
+PASS Query condition should be valid: style(10px = 10em)
+PASS Query condition should be valid: style(10px <= calc(10em + 20em))
+PASS Query condition should be valid: style(calc(10em + 20em) < 10px)
+PASS Query condition should be valid: style(--foo < 10em)
+PASS Query condition should be valid: style(10px <= --bar)
+PASS Query condition should be valid: style(--foo < --bar <= --baz)
+PASS Query condition should be valid: style(--foo >= --bar > --baz)
+PASS Query condition should be valid: style(--foo > 10px > 10em)
+PASS Query condition should be valid: style(10px < --foo < 10em)
+PASS Query condition should be valid: style(10px < --foo <= 10em)
+PASS Query condition should be valid: style(10px <= --foo < 10em)
+PASS Query condition should be valid: style(10px > 10em > --foo)
+PASS Query condition should be valid: style(10px < 10em < 10)
+PASS Query condition should be valid: style(var(--p) < calc(100 + 200))
+PASS Query condition should be valid: style(attr(data-foo type(<number>)) < var(--p) < var(--q))
+PASS Query condition should be valid: style(--foo < initial)
 PASS Query condition should be valid but unknown: style(--foo: bar;)
 PASS Query condition should be valid but unknown: style(style(--foo: bar))
 PASS Query condition should be valid but unknown: style(10px < 10em > 10)

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/at-container-style-serialization-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/at-container-style-serialization-expected.txt
@@ -15,5 +15,5 @@ PASS Subexpressions and extra parens
 PASS Multiple subexpressions and extra parens
 PASS Multiple subexpressions and unknowns
 PASS Escape custom property identifier
-FAIL Escape custom property identifier - range syntax assert_equals: expected "style(100px > --\\{foo > 10px)" but got "style(100px > --\\{foo >10px)"
+PASS Escape custom property identifier - range syntax
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/query-evaluation-style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/query-evaluation-style-expected.txt
@@ -30,42 +30,42 @@ PASS style(not ((--foo: bar) and (--baz: qux)))
 PASS style((--foo: bar) and (not ((--baz: qux) or (--foo: bar))))
 PASS style((--baz: qux) or (not ((--baz: qux) and (--foo: bar))))
 PASS style((--baz: qux) or ((--baz: qux) and (--foo: bar)))
-FAIL style(5 >= calc(3 + 1)) assert_equals: expected "true" but got "false"
-FAIL style(1px <= 1em) assert_equals: expected "true" but got "false"
-FAIL style(5 >= 3) assert_equals: expected "true" but got "false"
-FAIL style(0 = 0px) assert_equals: expected "true" but got "false"
+PASS style(5 >= calc(3 + 1))
+PASS style(1px <= 1em)
+PASS style(5 >= 3)
+PASS style(0 = 0px)
 PASS style(0 = 0deg)
-FAIL style(0 >= 0px) assert_equals: expected "true" but got "false"
-FAIL style(0 < 3px) assert_equals: expected "true" but got "false"
-FAIL style(3px >= 3px) assert_equals: expected "true" but got "false"
+PASS style(0 >= 0px)
+PASS style(0 < 3px)
+PASS style(3px >= 3px)
 PASS style(3px > 3px)
-FAIL style(1em > 1px) assert_equals: expected "true" but got "false"
+PASS style(1em > 1px)
 PASS style(1em <= 1px)
-FAIL style(3turn > 3deg) assert_equals: expected "true" but got "false"
-FAIL style(3% >= 3%) assert_equals: expected "true" but got "false"
-FAIL style(3s > 3ms) assert_equals: expected "true" but got "false"
-FAIL style(3dppx > 96dpi) assert_equals: expected "true" but got "false"
-FAIL style(3 <= --x) assert_equals: expected "true" but got "false"
-FAIL style(--x >= 3) assert_equals: expected "true" but got "false"
-FAIL style(--x <= --x) assert_equals: expected "true" but got "false"
-FAIL style(--x >= --y) assert_equals: expected "true" but got "false"
-FAIL style(--length > 3px) assert_equals: expected "true" but got "false"
-FAIL style(--x > 3px) assert_equals: expected "true" but got "false"
-FAIL style(--number >= 3) assert_equals: expected "true" but got "false"
-FAIL style(--x >= 1) assert_equals: expected "true" but got "false"
-FAIL style(--percentage > 3%) assert_equals: expected "true" but got "false"
-FAIL style(--x > 3%) assert_equals: expected "true" but got "false"
-FAIL style(--angle < 1turn) assert_equals: expected "true" but got "false"
-FAIL style(--x < 1turn) assert_equals: expected "true" but got "false"
-FAIL style(--time <= 1000ms) assert_equals: expected "true" but got "false"
-FAIL style(--x <= 1000ms) assert_equals: expected "true" but got "false"
-FAIL style(3dppx > --resolution) assert_equals: expected "true" but got "false"
-FAIL style(3dppx > --x) assert_equals: expected "true" but got "false"
-FAIL style(--x >= calc(3px + 3px)) assert_equals: expected "true" but got "false"
-FAIL style(--x <= var(--x)) assert_equals: expected "true" but got "false"
-FAIL style(calc(var(--x) + 1) >= var(--y)) assert_equals: expected "true" but got "false"
-FAIL style(var(--x) >= --x) assert_equals: expected "true" but got "false"
-FAIL style(--x <= 10em) assert_equals: expected "true" but got "false"
+PASS style(3turn > 3deg)
+PASS style(3% >= 3%)
+PASS style(3s > 3ms)
+PASS style(3dppx > 96dpi)
+PASS style(3 <= --x)
+PASS style(--x >= 3)
+PASS style(--x <= --x)
+PASS style(--x >= --y)
+PASS style(--length > 3px)
+PASS style(--x > 3px)
+PASS style(--number >= 3)
+PASS style(--x >= 1)
+PASS style(--percentage > 3%)
+PASS style(--x > 3%)
+PASS style(--angle < 1turn)
+PASS style(--x < 1turn)
+PASS style(--time <= 1000ms)
+PASS style(--x <= 1000ms)
+PASS style(3dppx > --resolution)
+PASS style(3dppx > --x)
+PASS style(--x >= calc(3px + 3px))
+PASS style(--x <= var(--x))
+PASS style(calc(var(--x) + 1) >= var(--y))
+PASS style(var(--x) >= --x)
+PASS style(--x <= 10em)
 PASS style(--x + 1 >= --y)
 PASS style(--x >= --y + 1)
 PASS style(calc(--x + 1) >= --y)
@@ -76,8 +76,8 @@ PASS style(1px >= 1%) or style(1px <= 1%)
 PASS style(--length > 3)
 PASS style(--number > 3px)
 PASS style(--x >= 3ms)
-FAIL style(--length <= 30px) assert_equals: expected "true" but got "false"
-FAIL style(10px <= 10px < 11px) assert_equals: expected "true" but got "false"
-FAIL style(3 < --x <= 5) assert_equals: expected "true" but got "false"
-FAIL style(--x >= --y > --z) assert_equals: expected "true" but got "false"
+PASS style(--length <= 30px)
+PASS style(10px <= 10px < 11px)
+PASS style(3 < --x <= 5)
+PASS style(--x >= --y > --z)
 

--- a/Source/WebCore/css/CSSCustomPropertyValue.cpp
+++ b/Source/WebCore/css/CSSCustomPropertyValue.cpp
@@ -120,9 +120,8 @@ const Vector<CSSParserToken>& CSSCustomPropertyValue::tokens() const
     static NeverDestroyed<Vector<CSSParserToken>> emptyTokens;
 
     return WTF::switchOn(m_value,
-        [&](const Ref<CSSSubstitutionValue>&) -> const Vector<CSSParserToken>& {
-            ASSERT_NOT_REACHED();
-            return emptyTokens;
+        [&](const Ref<CSSSubstitutionValue>& value) -> const Vector<CSSParserToken>& {
+            return value->data().tokens();
         },
         [&](const Ref<CSSVariableData>& value) -> const Vector<CSSParserToken>& {
             return value->tokens();

--- a/Source/WebCore/css/CSSCustomPropertyValue.h
+++ b/Source/WebCore/css/CSSCustomPropertyValue.h
@@ -61,6 +61,9 @@ public:
 
     std::optional<CSSWideKeyword> tryCSSWideKeyword() const;
 
+    // The value's tokens (empty for a CSS-wide keyword).
+    const Vector<CSSParserToken>& tokens() const;
+
     String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSCustomPropertyValue&) const;
     IterationStatus customVisitChildren(NOESCAPE const Function<IterationStatus(CSSValue&)>&) const;
@@ -72,8 +75,6 @@ private:
         , m_value(WTF::move(value))
     {
     }
-
-    const Vector<CSSParserToken>& tokens() const;
 
     const AtomString m_name;
     const VariantValue m_value;

--- a/Source/WebCore/css/query/ContainerQuery.cpp
+++ b/Source/WebCore/css/query/ContainerQuery.cpp
@@ -25,9 +25,14 @@
 #include "config.h"
 #include "ContainerQuery.h"
 
+#include "CSSCustomPropertyValue.h"
 #include "CSSMarkup.h"
+#include "CSSPropertyParser.h"
+#include "CSSTokenizer.h"
 #include "CSSValue.h"
+#include "CSSValueKeywords.h"
 #include "ContainerQueryFeatures.h"
+#include "GenericMediaQueryParser.h"
 #include "GenericMediaQuerySerialization.h"
 #include <wtf/NeverDestroyed.h>
 #include <wtf/text/StringBuilder.h>
@@ -50,6 +55,48 @@ OptionSet<Axis> requiredAxesForFeature(const MQ::Feature& feature)
     return { };
 }
 
+void collectCustomPropertyNames(const MQ::Feature& feature, HashSet<AtomString>& names)
+{
+    auto collectFromCustomPropertyValue = [&](const CSSCustomPropertyValue& value) {
+        auto& tokens = value.tokens();
+
+        // A bare <custom-property-name> operand is evaluated as var(--name).
+        if (auto name = MQ::bareCustomPropertyName(tokens.span()); !name.isNull())
+            names.add(name);
+
+        // var() references, at any nesting depth.
+        for (size_t i = 0; i < tokens.size(); ++i) {
+            if (tokens[i].type() != FunctionToken || tokens[i].functionId() != CSSValueVar)
+                continue;
+            for (size_t j = i + 1; j < tokens.size(); ++j) {
+                if (CSSTokenizer::isWhitespace(tokens[j].type()))
+                    continue;
+                if (tokens[j].type() == IdentToken && isCustomPropertyName(tokens[j].value()))
+                    names.add(tokens[j].value().toAtomString());
+                break;
+            }
+        }
+    };
+
+    auto collectFromValue = [&](const std::optional<MQ::Value>& value) {
+        if (!value)
+            return;
+        if (auto* customProperty = std::get_if<Ref<CSSCustomPropertyValue>>(&*value))
+            collectFromCustomPropertyValue(customProperty->get());
+    };
+
+    // The queried property of a plain/boolean feature, or the bare-name center of a range.
+    if (isCustomPropertyName(feature.name))
+        names.add(feature.name);
+
+    // Range operands: a non-name center and the comparison bounds may reference further properties.
+    collectFromValue(feature.subject);
+    if (feature.leftComparison)
+        collectFromValue(feature.leftComparison->value);
+    if (feature.rightComparison)
+        collectFromValue(feature.rightComparison->value);
+}
+
 void serialize(StringBuilder& builder, const ContainerQuery& query)
 {
     auto name = query.name;
@@ -63,4 +110,3 @@ void serialize(StringBuilder& builder, const ContainerQuery& query)
 
 }
 }
-

--- a/Source/WebCore/css/query/ContainerQuery.h
+++ b/Source/WebCore/css/query/ContainerQuery.h
@@ -26,6 +26,7 @@
 
 #include <WebCore/GenericMediaQueryTypes.h>
 #include <wtf/Forward.h>
+#include <wtf/HashSet.h>
 #include <wtf/OptionSet.h>
 #include <wtf/text/AtomString.h>
 
@@ -52,6 +53,10 @@ enum class Axis : uint8_t {
     Height  = 1 << 3,
 };
 OptionSet<Axis> requiredAxesForFeature(const MQ::Feature&);
+
+// Custom properties a feature reads, so changes to them on a container re-evaluate style queries:
+// the queried property and, for style ranges, bare <custom-property-name> operands and var() references.
+void collectCustomPropertyNames(const MQ::Feature&, HashSet<AtomString>&);
 
 enum class ContainsUnknownFeature : bool { No, Yes };
 

--- a/Source/WebCore/css/query/ContainerQueryFeatures.cpp
+++ b/Source/WebCore/css/query/ContainerQueryFeatures.cpp
@@ -27,15 +27,30 @@
 
 #include "BoxSides.h"
 #include "CSSCustomPropertyValue.h"
+#include "CSSParserContext.h"
+#include "CSSParserIdioms.h"
+#include "CSSParserTokenRange.h"
 #include "CSSPrimitiveNumericCategory.h"
+#include "CSSPropertyParserConsumer+AngleDefinitions.h"
+#include "CSSPropertyParserConsumer+FrequencyDefinitions.h"
+#include "CSSPropertyParserConsumer+LengthDefinitions.h"
+#include "CSSPropertyParserConsumer+MetaConsumer.h"
+#include "CSSPropertyParserConsumer+NumberDefinitions.h"
+#include "CSSPropertyParserConsumer+PercentageDefinitions.h"
+#include "CSSPropertyParserConsumer+ResolutionDefinitions.h"
+#include "CSSPropertyParserConsumer+TimeDefinitions.h"
+#include "CSSPropertyParserState.h"
 #include "ComputedStyleDependencies.h"
 #include "ContainerQueryEvaluator.h"
+#include "GenericMediaQueryParser.h"
 #include "RenderBoxInlines.h"
 #include "RenderElementInlines.h"
 #include "RenderObjectInlines.h"
 #include "StyleBuilder.h"
 #include "StyleCustomProperty.h"
 #include "StyleCustomPropertyRegistry.h"
+#include "StylePrimitiveNumericTypes+Conversions.h"
+#include "StylePrimitiveNumericTypes+Evaluation.h"
 #include <wtf/NeverDestroyed.h>
 
 namespace WebCore::CQ {
@@ -177,9 +192,99 @@ struct OrientationFeatureSchema : public SizeFeatureSchema {
     }
 };
 
+// https://drafts.csswg.org/css-conditional-5/#typedef-style-range
+enum class StyleRangeCategory : uint8_t { Number, Length, Percentage, Angle, Time, Frequency, Resolution };
+
+struct StyleRangeValue {
+    StyleRangeCategory category;
+    double value; // In the canonical unit of the category.
+    bool isUnitlessZero { false };
+};
+
+// Evaluates the (already substituted) computed value of a <style-range-value> into one of
+// <number>, <length>, <percentage>, <angle>, <time>, <frequency> or <resolution>, computed
+// with respect to the query container. Returns nullopt if it doesn't parse as a single value.
+static std::optional<StyleRangeValue> evaluateStyleRangeValue(const Vector<CSSParserToken>& tokens, const FeatureEvaluationContext& context)
+{
+    using namespace CSSPropertyParserHelpers;
+
+    CSSParserTokenRange range { tokens };
+    range.consumeWhitespace();
+    if (range.atEnd())
+        return { };
+
+    auto& conversionData = context.conversionData;
+    auto parserState = CSS::PropertyParserState { .context = protect(context.document.get())->cssParserContext() };
+
+    auto isFullyConsumed = [](CSSParserTokenRange consumed) {
+        consumed.consumeWhitespace();
+        return consumed.atEnd();
+    };
+
+    // <number> is tried first so that a unitless zero is categorized as a number (and can act as a
+    // zero <length> when compared against a length).
+    if (auto subrange = range; auto value = MetaConsumer<CSS::Number<>>::consume(subrange, parserState)) {
+        if (isFullyConsumed(subrange)) {
+            auto number = Style::evaluate<double>(Style::toStyle(*value, conversionData));
+            return StyleRangeValue { StyleRangeCategory::Number, number, !number };
+        }
+    }
+    // overrideParserMode matches MQ::consumeValue's <length> parsing so quirky/quirks-mode lengths behave
+    // identically here. See the FIXME there.
+    if (auto subrange = range; auto value = MetaConsumer<CSS::Length<>>::consume(subrange, parserState, { .overrideParserMode = HTMLStandardMode })) {
+        if (isFullyConsumed(subrange))
+            return StyleRangeValue { StyleRangeCategory::Length, Style::evaluate<double>(Style::toStyle(*value, conversionData), Style::ZoomNeeded { }) };
+    }
+    if (auto subrange = range; auto value = MetaConsumer<CSS::Percentage<>>::consume(subrange, parserState)) {
+        if (isFullyConsumed(subrange))
+            return StyleRangeValue { StyleRangeCategory::Percentage, Style::evaluate<double>(Style::toStyle(*value, conversionData)) };
+    }
+    if (auto subrange = range; auto value = MetaConsumer<CSS::Angle<>>::consume(subrange, parserState)) {
+        if (isFullyConsumed(subrange))
+            return StyleRangeValue { StyleRangeCategory::Angle, Style::evaluate<double>(Style::toStyle(*value, conversionData)) };
+    }
+    if (auto subrange = range; auto value = MetaConsumer<CSS::Time<>>::consume(subrange, parserState)) {
+        if (isFullyConsumed(subrange))
+            return StyleRangeValue { StyleRangeCategory::Time, Style::evaluate<double>(Style::toStyle(*value, conversionData)) };
+    }
+    if (auto subrange = range; auto value = MetaConsumer<CSS::Frequency<>>::consume(subrange, parserState)) {
+        if (isFullyConsumed(subrange))
+            return StyleRangeValue { StyleRangeCategory::Frequency, Style::evaluate<double>(Style::toStyle(*value, conversionData)) };
+    }
+    if (auto subrange = range; auto value = MetaConsumer<CSS::Resolution<>>::consume(subrange, parserState)) {
+        if (isFullyConsumed(subrange))
+            return StyleRangeValue { StyleRangeCategory::Resolution, Style::evaluate<double>(Style::toStyle(*value, conversionData)) };
+    }
+
+    return { };
+}
+
+// "If each <style-range-value> from the range have the same type" — a unitless zero is treated as a
+// zero <length> when compared against a <length>.
+static bool styleRangeValuesShareCategory(std::initializer_list<const std::optional<StyleRangeValue>*> operands)
+{
+    std::optional<StyleRangeCategory> category;
+    bool hasUnitlessZero = false;
+    for (auto* operand : operands) {
+        if (!*operand)
+            continue;
+        if ((*operand)->isUnitlessZero) {
+            hasUnitlessZero = true;
+            continue;
+        }
+        if (!category)
+            category = (*operand)->category;
+        else if (*category != (*operand)->category)
+            return false;
+    }
+    if (hasUnitlessZero && category && *category != StyleRangeCategory::Number && *category != StyleRangeCategory::Length)
+        return false;
+    return true;
+}
+
 struct StyleFeatureSchema : public FeatureSchema {
     StyleFeatureSchema()
-        : FeatureSchema("style"_s, FeatureSchema::Type::Discrete, FeatureSchema::ValueType::CustomProperty, { })
+        : FeatureSchema("style"_s, FeatureSchema::Type::Range, FeatureSchema::ValueType::CustomProperty, { })
     {
     }
 
@@ -190,6 +295,9 @@ struct StyleFeatureSchema : public FeatureSchema {
         CheckedPtr style = context.conversionData.style();
         if (!style || !context.conversionData.parentStyle())
             return EvaluationResult::False;
+
+        if (feature.syntax == Syntax::Range)
+            return evaluateRange(feature, context, *style);
 
         RefPtr customPropertyValue = style->customPropertyValue(feature.name);
         if (!feature.rightComparison)
@@ -223,6 +331,85 @@ struct StyleFeatureSchema : public FeatureSchema {
 
         ASSERT(feature.rightComparison->op == ComparisonOperator::Equal);
         return toEvaluationResult(customPropertyValue && customPropertyValue->valueEquals(*resolvedFeatureValue));
+    }
+
+    // https://drafts.csswg.org/css-conditional-5/#ref-for-typedef-style-range
+    EvaluationResult evaluateRange(const MQ::Feature& feature, const FeatureEvaluationContext& context, const Style::ComputedStyle& style) const
+    {
+        // A builder is only needed to resolve var()/attr() substitutions and css-wide keywords against
+        // the container. It is created lazily so literal-only ranges like style(10px < 10em) skip it.
+        std::optional<Style::ComputedStyle> dummyStyle;
+        RefPtr<Style::MatchResult> dummyMatchResult;
+        std::optional<Style::Builder> styleBuilder;
+        auto ensureBuilder = [&]() -> Style::Builder& {
+            if (!styleBuilder) {
+                auto builderContext = Style::BuilderContext {
+                    context.document.get(),
+                    context.conversionData.parentStyle(),
+                    context.conversionData.rootStyle(),
+                    context.conversionData.elementForContainerUnitResolution()
+                };
+                dummyStyle = Style::ComputedStyle::clone(protect(style));
+                dummyMatchResult = Style::MatchResult::create();
+                styleBuilder.emplace(protect(*dummyStyle), WTF::move(builderContext), *dummyMatchResult);
+            }
+            return *styleBuilder;
+        };
+
+        auto resolveValue = [&](const CSSCustomPropertyValue& value) -> RefPtr<const Style::CustomProperty> {
+            // A bare <custom-property-name> is substituted as if wrapped in var(): read it from the container.
+            if (auto name = MQ::bareCustomPropertyName(value.tokens().span()); !name.isNull())
+                return style.customPropertyValue(name);
+            // Plain values (literals, calc()) are already final; only var()/attr()/css-wide keywords need resolution.
+            if (auto* data = std::get_if<Ref<CSSVariableData>>(&value.value()))
+                return Style::CustomProperty::createForVariableData(value.name(), data->copyRef());
+            return ensureBuilder().resolveCustomPropertyForContainerQueries(value);
+        };
+
+        auto resolveOperand = [&](const std::optional<Value>& operandValue, const AtomString& centerName) -> std::optional<StyleRangeValue> {
+            RefPtr<const Style::CustomProperty> customProperty;
+            if (!centerName.isNull())
+                customProperty = style.customPropertyValue(centerName);
+            else {
+                if (!operandValue)
+                    return { };
+                auto* value = std::get_if<Ref<CSSCustomPropertyValue>>(&*operandValue);
+                if (!value)
+                    return { };
+                customProperty = resolveValue(value->get());
+            }
+            if (!customProperty || customProperty->isGuaranteedInvalid())
+                return { };
+            return evaluateStyleRangeValue(customProperty->tokens(), context);
+        };
+
+        auto center = resolveOperand(feature.subject, feature.name);
+        if (!center)
+            return EvaluationResult::False;
+
+        std::optional<StyleRangeValue> leftValue;
+        if (feature.leftComparison) {
+            leftValue = resolveOperand(feature.leftComparison->value, nullAtom());
+            if (!leftValue)
+                return EvaluationResult::False;
+        }
+
+        std::optional<StyleRangeValue> rightValue;
+        if (feature.rightComparison) {
+            rightValue = resolveOperand(feature.rightComparison->value, nullAtom());
+            if (!rightValue)
+                return EvaluationResult::False;
+        }
+
+        if (!styleRangeValuesShareCategory({ &center, &leftValue, &rightValue }))
+            return EvaluationResult::False;
+
+        if (feature.leftComparison && !compare(feature.leftComparison->op, leftValue->value, center->value))
+            return EvaluationResult::False;
+        if (feature.rightComparison && !compare(feature.rightComparison->op, center->value, rightValue->value))
+            return EvaluationResult::False;
+
+        return EvaluationResult::True;
     }
 };
 

--- a/Source/WebCore/css/query/ContainerQueryParser.cpp
+++ b/Source/WebCore/css/query/ContainerQueryParser.cpp
@@ -25,12 +25,152 @@
 #include "config.h"
 #include "ContainerQueryParser.h"
 
+#include "CSSCustomPropertyValue.h"
+#include "CSSPropertyParser.h"
 #include "CSSPropertyParserConsumer+Ident.h"
+#include "CSSSubstitutionParser.h"
 #include "ContainerQueryFeatures.h"
 #include "MediaQueryParserContext.h"
+#include <wtf/NeverDestroyed.h>
 
 namespace WebCore {
 namespace CQ {
+
+using namespace MQ;
+
+// Parses a <style-range> per css-conditional-5 §6.2:
+//   <style-range> = <style-range-value> <mf-comparison> <style-range-value>
+//                 | <style-range-value> <mf-lt> <style-range-value> <mf-lt> <style-range-value>
+//                 | <style-range-value> <mf-gt> <style-range-value> <mf-gt> <style-range-value>
+//   <style-range-value> = <custom-property-name> | <style-feature-value>
+// Each operand is captured as an unresolved declaration value and resolved against the query
+// container during evaluation; a bare <custom-property-name> is detected there and treated as var().
+static std::optional<Feature> consumeStyleRangeFeature(CSSParserTokenRange& range, const MediaQueryParserContext& context)
+{
+    auto isComparisonDelimiter = [](const CSSParserToken& token) {
+        return token.type() == DelimiterToken
+            && (token.delimiter() == '<' || token.delimiter() == '>' || token.delimiter() == '=');
+    };
+
+    // A <style-feature-value> can't contain comparison tokens, so any comparison delimiter at the
+    // top level of the block separates operands. consumeComponentValue() skips over whole blocks
+    // (calc(), var(), attr(), ...), keeping their inner tokens out of the split.
+    auto consumeOperandRange = [&]() -> CSSParserTokenRange {
+        auto start = range;
+        while (!range.atEnd() && !isComparisonDelimiter(range.peek()))
+            range.consumeComponentValue();
+        auto operand = start.rangeUntil(range);
+        operand.consumeWhitespace();
+        operand.trimTrailingWhitespace();
+        return operand;
+    };
+
+    struct Operand {
+        AtomString customPropertyName;
+        Ref<CSSCustomPropertyValue> value;
+    };
+
+    auto consumeOperand = [&]() -> std::optional<Operand> {
+        auto operandRange = consumeOperandRange();
+        if (operandRange.atEnd())
+            return { };
+
+        auto customPropertyName = MQ::bareCustomPropertyName(operandRange.span());
+
+        // A non-name operand (literal, calc(), var(), attr(), ...) still needs a valid custom-property
+        // name for parsing/resolution; it is never looked up as a real property.
+        static MainThreadNeverDestroyed<const AtomString> operandName("--style-range-operand"_s);
+        auto name = customPropertyName.isNull() ? operandName.get() : customPropertyName;
+        auto value = CSSSubstitutionParser::parseDeclarationValue(name, operandRange, context.context);
+        if (!value)
+            return { };
+
+        return Operand { customPropertyName, value.releaseNonNull() };
+    };
+
+    auto firstOperand = consumeOperand();
+    if (!firstOperand)
+        return { };
+
+    auto firstOperator = FeatureParser::consumeRangeComparisonOperator(range);
+    if (!firstOperator)
+        return { };
+
+    auto secondOperand = consumeOperand();
+    if (!secondOperand)
+        return { };
+
+    std::optional<ComparisonOperator> secondOperator;
+    std::optional<Operand> thirdOperand;
+    if (!range.atEnd()) {
+        secondOperator = FeatureParser::consumeRangeComparisonOperator(range);
+        if (!secondOperator)
+            return { };
+        thirdOperand = consumeOperand();
+        if (!thirdOperand)
+            return { };
+    }
+
+    if (!range.atEnd())
+        return { };
+
+    if (secondOperator && !isConsistentThreeWayComparison(*firstOperator, *secondOperator))
+        return { };
+
+    // The center operand is the second one for three-operand ranges, the first otherwise. A bare
+    // <custom-property-name> center is stored as the feature name (matching the plain/size model, so
+    // serialization and custom-property invalidation keep working); other centers go in `subject`.
+    auto setCenter = [](Feature& feature, Operand&& center) {
+        if (!center.customPropertyName.isNull())
+            feature.name = center.customPropertyName;
+        else
+            feature.subject = Value { WTF::move(center.value) };
+    };
+
+    Feature feature;
+    feature.syntax = Syntax::Range;
+
+    if (!thirdOperand) {
+        setCenter(feature, WTF::move(*firstOperand));
+        feature.rightComparison = Comparison { *firstOperator, Value { WTF::move(secondOperand->value) } };
+        return feature;
+    }
+
+    feature.leftComparison = Comparison { *firstOperator, Value { WTF::move(firstOperand->value) } };
+    setCenter(feature, WTF::move(*secondOperand));
+    feature.rightComparison = Comparison { *secondOperator, Value { WTF::move(thirdOperand->value) } };
+    return feature;
+}
+
+// A style() feature queries a single custom property, in boolean (style(--foo)), plain
+// (style(--foo: value)) or <style-range> form. Unlike size features, style features are always
+// custom properties, so this is simpler than the generic boolean/plain/range path.
+static std::optional<Feature> consumeStyleFeature(CSSParserTokenRange& range, const MediaQueryParserContext& context)
+{
+    auto rangeForStyleRange = range;
+
+    auto name = FeatureParser::consumeFeatureName(range);
+    if (isCustomPropertyName(name)) {
+        range.consumeWhitespace();
+        if (range.atEnd())
+            return Feature { .name = name, .syntax = Syntax::Boolean };
+
+        if (range.peek().type() == ColonToken) {
+            range.consumeIncludingWhitespace();
+            auto value = FeatureParser::consumeCustomPropertyValue(name, range, context);
+            if (!value || !range.atEnd())
+                return { };
+            return Feature {
+                .name = name,
+                .syntax = Syntax::Plain,
+                .rightComparison = Comparison { ComparisonOperator::Equal, WTF::move(value) }
+            };
+        }
+    }
+
+    range = rangeForStyleRange;
+    return consumeStyleRangeFeature(range, context);
+}
 
 Vector<const MQ::FeatureSchema*> ContainerQueryParser::featureSchemas()
 {
@@ -86,6 +226,21 @@ const MQ::FeatureSchema* ContainerQueryParser::schemaForFeatureName(const AtomSt
     }
 
     return GenericMediaQueryParser<ContainerQueryParser>::schemaForFeatureName(name, context, state);
+}
+
+std::optional<MQ::Feature> ContainerQueryParser::consumeAndValidateFeature(CSSParserTokenRange& range, const MediaQueryParserContext& context, State& state)
+{
+    // style() features (boolean, plain and <style-range>) are all custom-property queries.
+    if (state.inFunctionId == CSSValueStyle) {
+        auto feature = consumeStyleFeature(range, context);
+        if (!feature)
+            return { };
+
+        feature->schema = &Features::style();
+        return feature;
+    }
+
+    return GenericMediaQueryParser<ContainerQueryParser>::consumeAndValidateFeature(range, context, state);
 }
 
 }

--- a/Source/WebCore/css/query/ContainerQueryParser.h
+++ b/Source/WebCore/css/query/ContainerQueryParser.h
@@ -37,6 +37,7 @@ struct ContainerQueryParser : MQ::GenericMediaQueryParser<ContainerQueryParser> 
 
     static bool NODELETE isValidFunctionId(CSSValueID);
     static const MQ::FeatureSchema* schemaForFeatureName(const AtomString&, const MediaQueryParserContext&, State&);
+    static std::optional<MQ::Feature> consumeAndValidateFeature(CSSParserTokenRange&, const MediaQueryParserContext&, State&);
     static Vector<const MQ::FeatureSchema*> featureSchemas();
 };
 

--- a/Source/WebCore/css/query/GenericMediaQueryEvaluator.cpp
+++ b/Source/WebCore/css/query/GenericMediaQueryEvaluator.cpp
@@ -125,24 +125,6 @@ static CSSValueID resolveIdent(const Value& value)
     );
 }
 
-template<typename T>
-bool NODELETE compare(ComparisonOperator op, T left, T right)
-{
-    switch (op) {
-    case ComparisonOperator::LessThan:
-        return left < right;
-    case ComparisonOperator::GreaterThan:
-        return left > right;
-    case ComparisonOperator::LessThanOrEqual:
-        return left <= right;
-    case ComparisonOperator::GreaterThanOrEqual:
-        return left >= right;
-    case ComparisonOperator::Equal:
-        return left == right;
-    }
-    RELEASE_ASSERT_NOT_REACHED();
-};
-
 enum class Side : uint8_t { Left, Right };
 static EvaluationResult evaluateLengthComparison(LayoutUnit size, const std::optional<Comparison>& comparison, Side side, const CSSToLengthConversionData& conversionData)
 {

--- a/Source/WebCore/css/query/GenericMediaQueryParser.cpp
+++ b/Source/WebCore/css/query/GenericMediaQueryParser.cpp
@@ -40,12 +40,13 @@
 #include "CSSSubstitutionParser.h"
 #include "CSSUnevaluatedCalc.h"
 #include "MediaQueryParserContext.h"
+#include <wtf/NeverDestroyed.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
 namespace MQ {
 
-static AtomString consumeFeatureName(CSSParserTokenRange& range)
+AtomString FeatureParser::consumeFeatureName(CSSParserTokenRange& range)
 {
     if (range.peek().type() != IdentToken)
         return nullAtom();
@@ -53,6 +54,13 @@ static AtomString consumeFeatureName(CSSParserTokenRange& range)
     if (isCustomPropertyName(name))
         return name.toAtomString();
     return name.convertToASCIILowercaseAtom();
+}
+
+AtomString bareCustomPropertyName(std::span<const CSSParserToken> tokens)
+{
+    if (tokens.size() == 1 && tokens[0].type() == IdentToken && isCustomPropertyName(tokens[0].value()))
+        return tokens[0].value().toAtomString();
+    return nullAtom();
 }
 
 std::optional<Feature> FeatureParser::consumeFeature(CSSParserTokenRange& range, const MediaQueryParserContext& context)
@@ -65,7 +73,7 @@ std::optional<Feature> FeatureParser::consumeFeature(CSSParserTokenRange& range,
     return consumeRangeFeature(range, context);
 };
 
-static std::optional<Value> consumeCustomPropertyValue(AtomString propertyName, CSSParserTokenRange& range, const MediaQueryParserContext& context)
+std::optional<Value> FeatureParser::consumeCustomPropertyValue(const AtomString& propertyName, CSSParserTokenRange& range, const MediaQueryParserContext& context)
 {
     auto valueRange = range;
     range.consumeAll();
@@ -142,7 +150,7 @@ std::optional<Feature> FeatureParser::consumeBooleanOrPlainFeature(CSSParserToke
         if (op != ComparisonOperator::Equal)
             return { };
 
-        return Feature { featureName, Syntax::Boolean, { }, { } };
+        return Feature { .name = featureName, .syntax = Syntax::Boolean };
     }
 
     if (range.peek().type() != ColonToken)
@@ -158,39 +166,48 @@ std::optional<Feature> FeatureParser::consumeBooleanOrPlainFeature(CSSParserToke
     if (!range.atEnd())
         return { };
 
-    return Feature { featureName, Syntax::Plain, { }, Comparison { op, WTF::move(value) } };
+    return Feature {
+        .name = featureName,
+        .syntax = Syntax::Plain,
+        .rightComparison = Comparison { op, WTF::move(value) }
+    };
+}
+
+std::optional<ComparisonOperator> FeatureParser::consumeRangeComparisonOperator(CSSParserTokenRange& range)
+{
+    if (range.atEnd())
+        return { };
+    auto opToken = range.consume();
+    if (range.atEnd() || opToken.type() != DelimiterToken)
+        return { };
+
+    switch (opToken.delimiter()) {
+    case '=':
+        range.consumeWhitespace();
+        return ComparisonOperator::Equal;
+    case '<':
+        if (range.peek().type() == DelimiterToken && range.peek().delimiter() == '=') {
+            range.consumeIncludingWhitespace();
+            return ComparisonOperator::LessThanOrEqual;
+        }
+        range.consumeWhitespace();
+        return ComparisonOperator::LessThan;
+    case '>':
+        if (range.peek().type() == DelimiterToken && range.peek().delimiter() == '=') {
+            range.consumeIncludingWhitespace();
+            return ComparisonOperator::GreaterThanOrEqual;
+        }
+        range.consumeWhitespace();
+        return ComparisonOperator::GreaterThan;
+    default:
+        return { };
+    }
 }
 
 std::optional<Feature> FeatureParser::consumeRangeFeature(CSSParserTokenRange& range, const MediaQueryParserContext& context)
 {
-    auto consumeRangeOperator = [&]() -> std::optional<ComparisonOperator> {
-        if (range.atEnd())
-            return { };
-        auto opToken = range.consume();
-        if (range.atEnd() || opToken.type() != DelimiterToken)
-            return { };
-
-        switch (opToken.delimiter()) {
-        case '=':
-            range.consumeWhitespace();
-            return ComparisonOperator::Equal;
-        case '<':
-            if (range.peek().type() == DelimiterToken && range.peek().delimiter() == '=') {
-                range.consumeIncludingWhitespace();
-                return ComparisonOperator::LessThanOrEqual;
-            }
-            range.consumeWhitespace();
-            return ComparisonOperator::LessThan;
-        case '>':
-            if (range.peek().type() == DelimiterToken && range.peek().delimiter() == '=') {
-                range.consumeIncludingWhitespace();
-                return ComparisonOperator::GreaterThanOrEqual;
-            }
-            range.consumeWhitespace();
-            return ComparisonOperator::GreaterThan;
-        default:
-            return { };
-        }
+    auto consumeRangeOperator = [&] {
+        return consumeRangeComparisonOperator(range);
     };
 
     bool didFailParsing = false;
@@ -238,19 +255,18 @@ std::optional<Feature> FeatureParser::consumeRangeFeature(CSSParserTokenRange& r
             return false;
         if (!leftComparison || !rightComparison)
             return true;
-        // Disallow comparisons like (a=b=c), (a=b<c).
-        if (leftComparison->op == ComparisonOperator::Equal || rightComparison->op == ComparisonOperator::Equal)
-            return false;
-        // Disallow comparisons like (a<b>c).
-        bool leftIsLess = leftComparison->op == ComparisonOperator::LessThan || leftComparison->op == ComparisonOperator::LessThanOrEqual;
-        bool rightIsLess = rightComparison->op == ComparisonOperator::LessThan || rightComparison->op == ComparisonOperator::LessThanOrEqual;
-        return leftIsLess == rightIsLess;
+        return isConsistentThreeWayComparison(leftComparison->op, rightComparison->op);
     };
 
     if (!range.atEnd() || !validateComparisons())
         return { };
 
-    return Feature { WTF::move(featureName), Syntax::Range, WTF::move(leftComparison), WTF::move(rightComparison) };
+    return Feature {
+        .name = WTF::move(featureName),
+        .syntax = Syntax::Range,
+        .leftComparison = WTF::move(leftComparison),
+        .rightComparison = WTF::move(rightComparison)
+    };
 }
 
 bool FeatureParser::validateFeatureAgainstSchema(Feature& feature, const FeatureSchema& schema)
@@ -329,7 +345,9 @@ bool FeatureParser::validateFeatureAgainstSchema(Feature& feature, const Feature
                 );
 
             case FeatureSchema::ValueType::CustomProperty:
-                return WTF::holdsAlternative<Ref<CSSCustomPropertyValue>>(*value);
+                // style() features are parsed and validated by consumeStyleFeature, not here.
+                ASSERT_NOT_REACHED();
+                return false;
             }
             ASSERT_NOT_REACHED();
             return false;
@@ -339,10 +357,6 @@ bool FeatureParser::validateFeatureAgainstSchema(Feature& feature, const Feature
             if (feature.syntax == Syntax::Range)
                 return false;
             if (feature.rightComparison && feature.rightComparison->op != ComparisonOperator::Equal)
-                return false;
-        }
-        if (schema.valueType == FeatureSchema::ValueType::CustomProperty) {
-            if (!isCustomPropertyName(feature.name))
                 return false;
         }
         if (feature.leftComparison) {

--- a/Source/WebCore/css/query/GenericMediaQueryParser.h
+++ b/Source/WebCore/css/query/GenericMediaQueryParser.h
@@ -38,10 +38,18 @@ struct MediaQueryParserContext;
 
 namespace MQ {
 
+// A <style-range-value> that is a bare <custom-property-name> is substituted as if wrapped in var().
+// Returns the referenced property name, or nullAtom() if the tokens are anything else.
+AtomString bareCustomPropertyName(std::span<const CSSParserToken>);
+
 struct FeatureParser {
     static std::optional<Feature> consumeFeature(CSSParserTokenRange&, const MediaQueryParserContext&);
     static std::optional<Feature> consumeBooleanOrPlainFeature(CSSParserTokenRange&, const MediaQueryParserContext&);
     static std::optional<Feature> consumeRangeFeature(CSSParserTokenRange&, const MediaQueryParserContext&);
+
+    static AtomString consumeFeatureName(CSSParserTokenRange&);
+    static std::optional<Value> consumeCustomPropertyValue(const AtomString& propertyName, CSSParserTokenRange&, const MediaQueryParserContext&);
+    static std::optional<ComparisonOperator> consumeRangeComparisonOperator(CSSParserTokenRange&);
 
     static bool validateFeatureAgainstSchema(Feature&, const FeatureSchema&);
 };
@@ -153,7 +161,7 @@ std::optional<QueryInParens> GenericMediaQueryParser<ConcreteParser>::consumeQue
     }
 
     auto featureRange = blockRange;
-    if (auto feature = consumeAndValidateFeature(featureRange, context, state)) {
+    if (auto feature = ConcreteParser::consumeAndValidateFeature(featureRange, context, state)) {
         feature->functionId = functionId;
         return { *feature };
     }

--- a/Source/WebCore/css/query/GenericMediaQuerySerialization.cpp
+++ b/Source/WebCore/css/query/GenericMediaQuerySerialization.cpp
@@ -131,7 +131,10 @@ void serialize(StringBuilder& builder, const Feature& feature)
             serializeRangeComparisonOperator(feature.leftComparison->op);
         }
 
-        serializeIdentifier(builder, feature.name);
+        if (feature.subject)
+            serialize(builder, *feature.subject);
+        else
+            serializeIdentifier(builder, feature.name);
 
         if (feature.rightComparison) {
             serializeRangeComparisonOperator(feature.rightComparison->op);

--- a/Source/WebCore/css/query/GenericMediaQueryTypes.h
+++ b/Source/WebCore/css/query/GenericMediaQueryTypes.h
@@ -45,6 +45,36 @@ enum class LogicalOperator : uint8_t { And, Or, Not };
 enum class ComparisonOperator : uint8_t { LessThan, LessThanOrEqual, Equal, GreaterThan, GreaterThanOrEqual };
 enum class Syntax : uint8_t { Boolean, Plain, Range };
 
+template<typename T>
+bool compare(ComparisonOperator op, T left, T right)
+{
+    switch (op) {
+    case ComparisonOperator::LessThan:
+        return left < right;
+    case ComparisonOperator::LessThanOrEqual:
+        return left <= right;
+    case ComparisonOperator::Equal:
+        return left == right;
+    case ComparisonOperator::GreaterThan:
+        return left > right;
+    case ComparisonOperator::GreaterThanOrEqual:
+        return left >= right;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+// The two comparisons of a three-operand range must point the same direction and neither may be '='.
+inline bool isConsistentThreeWayComparison(ComparisonOperator first, ComparisonOperator second)
+{
+    auto isLessFamily = [](ComparisonOperator op) {
+        return op == ComparisonOperator::LessThan || op == ComparisonOperator::LessThanOrEqual;
+    };
+    auto isGreaterFamily = [](ComparisonOperator op) {
+        return op == ComparisonOperator::GreaterThan || op == ComparisonOperator::GreaterThanOrEqual;
+    };
+    return (isLessFamily(first) && isLessFamily(second)) || (isGreaterFamily(first) && isGreaterFamily(second));
+}
+
 struct Condition;
 struct FeatureSchema;
 
@@ -66,8 +96,13 @@ struct Comparison {
 struct Feature {
     AtomString name;
     Syntax syntax;
-    std::optional<Comparison> leftComparison;
-    std::optional<Comparison> rightComparison;
+    std::optional<Comparison> leftComparison { };
+    std::optional<Comparison> rightComparison { };
+
+    // The center operand of a style range, used when it is not a bare <custom-property-name>
+    // (those are stored in `name`, matching the plain/size feature model). For example, the
+    // subject of `style(10px < 10em)` or `style(calc(1px + 1px) > --foo)`.
+    std::optional<Value> subject { };
 
     std::optional<CSSValueID> functionId { };
 

--- a/Source/WebCore/style/StyleScopeRuleSets.cpp
+++ b/Source/WebCore/style/StyleScopeRuleSets.cpp
@@ -445,8 +445,7 @@ const HashSet<AtomString>& ScopeRuleSets::customPropertyNamesInStyleContainerQue
                 return;
             for (auto query : ruleSet->containerQueryRules()) {
                 traverseFeatures(query->containerQuery().condition, [&](auto& containerFeature) {
-                    if (isCustomPropertyName(containerFeature.name))
-                        propertyNames.add(containerFeature.name);
+                    CQ::collectCustomPropertyNames(containerFeature, propertyNames);
                 });
             }
         };


### PR DESCRIPTION
#### deb93ad60b5703b71dfdccc9aee62753e6ca4612
<pre>
[css-conditional-5] Support style query ranges
<a href="https://bugs.webkit.org/show_bug.cgi?id=318679">https://bugs.webkit.org/show_bug.cgi?id=318679</a>
<a href="https://rdar.apple.com/181488548">rdar://181488548</a>

Reviewed by Alan Baradlay.

Support range syntax in style queries:

    @container style(10px &lt; --foo &lt;= 100px) { ... }

<a href="https://drafts.csswg.org/css-conditional-5/#typedef-style-range">https://drafts.csswg.org/css-conditional-5/#typedef-style-range</a>

Test: fast/css/container-style-range-query-invalidation.html
* LayoutTests/fast/css/container-style-range-query-invalidation-expected.txt: Added.
* LayoutTests/fast/css/container-style-range-query-invalidation.html: Added.

Covers invalidation when the queried property is a comparison bound, the far operand of a
two-property comparison, or referenced via var() in the range center.

* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/at-container-style-parsing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/query-evaluation-style-expected.txt:

Now passing.

* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/at-container-style-serialization-expected.txt:

Rebaselined: range operators now serialize with a trailing space per spec.

* Source/WebCore/css/CSSCustomPropertyValue.cpp:
(WebCore::CSSCustomPropertyValue::tokens const):

Return the tokens of an unresolved (substitution) value instead of asserting. Style range
operands inspect these tokens to detect a bare &lt;custom-property-name&gt;.

* Source/WebCore/css/CSSCustomPropertyValue.h:

Make tokens() public.

* Source/WebCore/css/query/ContainerQuery.cpp:
(WebCore::CQ::collectCustomPropertyNames):

Collect every custom property a feature reads so mutations on the container invalidate style:
the queried property, a bare-name range operand, and var() references at any depth.

* Source/WebCore/css/query/ContainerQuery.h:
* Source/WebCore/css/query/ContainerQueryFeatures.cpp:
(WebCore::CQ::Features::evaluateStyleRangeValue):

Evaluate a resolved operand into a categorized value. &lt;number&gt; is tried first so a unitless
zero categorizes as a number.

(WebCore::CQ::Features::styleRangeValuesShareCategory):

The comparison is invalid unless the operands share a category, with a unitless zero allowed
against a &lt;number&gt; or &lt;length&gt;.

(WebCore::CQ::Features::StyleFeatureSchema::StyleFeatureSchema):

style() is now a Range feature.

(WebCore::CQ::Features::StyleFeatureSchema::evaluateRange const):

Resolve the center and bounds against the container and evaluate the comparisons. The
resolution builder is created lazily so literal-only ranges skip it, and plain (non-substitution)
values bypass the builder entirely.

* Source/WebCore/css/query/ContainerQueryParser.cpp:
(WebCore::CQ::consumeStyleRangeFeature):

Split operands on top-level comparison delimiters, capture each as an unresolved declaration
value, and store a bare-name center in `name` (other centers in `subject`). Reject three-operand
ranges whose comparisons disagree in direction or use &apos;=&apos;.

(WebCore::CQ::consumeStyleFeature):

Parse boolean, plain and &lt;style-range&gt; style() features.

(WebCore::CQ::ContainerQueryParser::consumeAndValidateFeature):

Route style() features through the dedicated custom-property parser. Its operands are custom
properties captured unresolved, and fitting that into the generic boolean/plain/range path is
more trouble than a dedicated one.

* Source/WebCore/css/query/ContainerQueryParser.h:
* Source/WebCore/css/query/GenericMediaQueryEvaluator.cpp:

Use the shared compare() helper.

* Source/WebCore/css/query/GenericMediaQueryParser.cpp:
(WebCore::MQ::bareCustomPropertyName):

Shared helper: a single ident token that is a custom-property name.

(WebCore::MQ::FeatureParser::consumeFeatureName):
(WebCore::MQ::FeatureParser::consumeCustomPropertyValue):

Expose as FeatureParser members so the container-query style() parser can reuse them.

(WebCore::MQ::FeatureParser::consumeRangeComparisonOperator):

Split the range operator parsing out of consumeRangeFeature so &lt;style-range&gt; can reuse it.

(WebCore::MQ::FeatureParser::consumeRangeFeature):

Use the shared isConsistentThreeWayComparison() helper.

(WebCore::MQ::FeatureParser::validateFeatureAgainstSchema):

style() features are validated by consumeStyleFeature, not here.

* Source/WebCore/css/query/GenericMediaQueryParser.h:
(WebCore::MQ::GenericMediaQueryParser&lt;ConcreteParser&gt;::consumeQueryInParens):

Dispatch consumeAndValidateFeature through the concrete parser so ContainerQueryParser can
override it for style().

* Source/WebCore/css/query/GenericMediaQuerySerialization.cpp:
(WebCore::MQ::serialize):

Serialize a non-name range center from `subject`.

* Source/WebCore/css/query/GenericMediaQueryTypes.h:

Add Feature::subject for a non-name style-range center. Move the shared compare() and
isConsistentThreeWayComparison() helpers here so the size-range and style-range parsers and
evaluators share them.

* Source/WebCore/style/StyleScopeRuleSets.cpp:
(WebCore::Style::ScopeRuleSets::customPropertyNamesInStyleContainerQueries const):

Use collectCustomPropertyNames so range operands register for invalidation.

Canonical link: <a href="https://commits.webkit.org/316653@main">https://commits.webkit.org/316653@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/15e6ef3f07afb0cca0b7ee6d3b13356f593900cd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173053 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46983 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/40465 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/182626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130609 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174918 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/48278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46667 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/182626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176011 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/48278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/155182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/182626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/48278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31111 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/48278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/34681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185048 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37834 "Found 1 new failure in css/query/ContainerQueryFeatures.cpp") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/39168 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143410 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46653 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/154743 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143282 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38677 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/47332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112404 "Built successfully") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/47332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/119081 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45838 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/9624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45240 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45471 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45297 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->