### PR TITLE
Set explicit allowed_origins for Buildbot www configuration

### DIFF
--- a/Tools/CISupport/build-webkit-org-webserver/master.cfg
+++ b/Tools/CISupport/build-webkit-org-webserver/master.cfg
@@ -60,7 +60,7 @@ if use_multi_master:
 
 c['change_source'] = PBChangeSource(port=16000)
 
-c['www'] = dict(port='tcp:8710:interface=127.0.0.1', plugins=dict(waterfall_view={}, console_view={}, grid_view={}), allowed_origins=["*"])
+c['www'] = dict(port='tcp:8710:interface=127.0.0.1', plugins=dict(waterfall_view={}, console_view={}, grid_view={}), allowed_origins=['https://build.webkit*.org', 'https://*.apple.com'])
 c['www']['ui_default_config'] = {
     'Builders.show_workers_name': True,
     'Builders.buildFetchLimit': 1000,

--- a/Tools/CISupport/ews-build-webserver/master.cfg
+++ b/Tools/CISupport/ews-build-webserver/master.cfg
@@ -40,7 +40,7 @@ if use_multi_master:
         'wamp_debug_level': 'info'
     }
 
-c['www'] = dict(port='tcp:8010:interface=127.0.0.1', allowed_origins=["*"])
+c['www'] = dict(port='tcp:8010:interface=127.0.0.1', allowed_origins=['https://ews-build.webkit*.org', 'https://*.apple.com'])
 c['www']['custom_templates_dir'] = 'templates'
 c['www']['ui_default_config'] = {
     'Builders.show_workers_name': True,

--- a/Tools/CISupport/ews-build/master.cfg
+++ b/Tools/CISupport/ews-build/master.cfg
@@ -38,7 +38,7 @@ if use_multi_master:
     }
 
 if is_test_mode_enabled:
-    c['www'] = dict(port='tcp:8010:interface=127.0.0.1', allowed_origins=["*"])
+    c['www'] = dict(port='tcp:8010:interface=127.0.0.1')
     c['www']['custom_templates_dir'] = 'templates'
     c['www']['ui_default_config'] = {
         'Builders.show_workers_name': True,


### PR DESCRIPTION
#### e91c6d086e046c43736bb61a471e214a19b3a4ee
<pre>
Set explicit allowed_origins for Buildbot www configuration
<a href="https://bugs.webkit.org/show_bug.cgi?id=318580">https://bugs.webkit.org/show_bug.cgi?id=318580</a>
<a href="https://rdar.apple.com/problem/180322016">rdar://problem/180322016</a>

Reviewed by Ryan Haddad.

Replace the wildcard allowed_origins with an explicit list.

* Tools/CISupport/build-webkit-org-webserver/master.cfg:
* Tools/CISupport/ews-build-webserver/master.cfg:
* Tools/CISupport/ews-build/master.cfg:

Canonical link: <a href="https://commits.webkit.org/316560@main">https://commits.webkit.org/316560@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6758a1f0ea4324df74368f7b0813d2dde68e4a9c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172816 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/46735 "Build was cancelled. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/40200 "Build was cancelled. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182274 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/130372 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/19d77161-8463-435b-a081-50604150fc83) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174681 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/48028 "Build was cancelled. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46411 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/134401 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/130372 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/674513bf-b6e5-41c2-b2dd-899b37db34ff) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175774 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/48028 "Build was cancelled. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/40200 "Build was cancelled. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114872 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/646132f2-a68b-4292-8ad6-0641e08c51ea) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/48028 "Build was cancelled. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34762 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30873 "Built successfully") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/40200 "Build was cancelled. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/48028 "Build was cancelled. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/40200 "Build was cancelled. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184807 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/38964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/143201 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/172216 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46406 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/40200 "Build was cancelled. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143078 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47084 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/40200 "Build was cancelled. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112082 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26222 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/38074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45601 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/40200 "Build was cancelled. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45001 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/45233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45060 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->