### PR TITLE
[Grid] Clarify grid item min content contributions when the grid item "behaves as auto"

### DIFF
--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
@@ -1193,12 +1193,17 @@ LayoutUnit GridTrackSizingAlgorithmStrategy::minContributionForGridItem(RenderBo
     auto& gridItemSize = isRowAxis ? gridItem.style().logicalWidth() : gridItem.style().logicalHeight();
 
     auto behavesAsAuto = [&gridItemSize] {
-        // FIXME: fully implement behavesAsAuto.
         // https://www.w3.org/TR/css-sizing-3/#behave-as-auto
+        // "Behaves as auto" also covers a block-axis percentage size
+        // resolving against an indefinite containing block (CSS2§10.5),
+        // but that is a subset of dependsOnContainingBlockSize() below, so
+        // only the literal 'auto' case needs testing here.
         return gridItemSize.isAuto();
     };
 
     auto dependsOnContainingBlockSize = [&gridItemSize] {
+        // The spec's "depends on the size of its containing block":
+        // percentages resolve against it, and stretch fills it.
         return gridItemSize.isPercentOrCalculated()
             || gridItemSize.isStretch();
     };


### PR DESCRIPTION
#### 176cd6ce42f9c81d68c5583eceb8d93c693e4307
<pre>
[Grid] Clarify grid item min content contributions when the grid item &quot;behaves as auto&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=318355">https://bugs.webkit.org/show_bug.cgi?id=318355</a>
&lt;<a href="https://rdar.apple.com/181146154">rdar://181146154</a>&gt;

Reviewed by Sammy Gill.

This PR removes an incorrect FIXME and updates inline documentation
to clarify behavior.

Per spec:

<a href="https://drafts.csswg.org/css-grid/#algo-single-span-items">https://drafts.csswg.org/css-grid/#algo-single-span-items</a>

Specifically, if the item’s computed preferred size behaves as auto
or depends on the size of its containing block in the relevant axis,
its minimum contribution is the outer size that would result from assuming
the item’s used minimum size as its preferred size; else the item’s
minimum contribution is its min-content contribution.

Per the &apos;behaves as auto&apos; and html &apos;width&apos;/&apos;height&apos; spec:

<a href="https://www.w3.org/TR/css-sizing-3/#behave-as-auto">https://www.w3.org/TR/css-sizing-3/#behave-as-auto</a>
<a href="https://www.w3.org/TR/CSS2/visudet.html#the-width-property">https://www.w3.org/TR/CSS2/visudet.html#the-width-property</a>
<a href="https://www.w3.org/TR/CSS2/visudet.html#the-height-property">https://www.w3.org/TR/CSS2/visudet.html#the-height-property</a>

&apos;width&apos; and &apos;height&apos; behave as auto when the &apos;width&apos; or &apos;height&apos;
depend on the values of other properties. Note that these cases
are caught by dependsOnContainingBlockSize(), so we do not need
to test for these cases in behavesAsAuto().

* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
(WebCore::GridTrackSizingAlgorithmStrategy::minContributionForGridItem const):

Canonical link: <a href="https://commits.webkit.org/316697@main">https://commits.webkit.org/316697@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9922928295f40cbe2ff792e15180200174c76220

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173058 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46988 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40652 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182631 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130614 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174923 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48283 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46672 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134590 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176016 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37990 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/155305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115059 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36635 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34968 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31116 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147059 "Found 1 new API test failure: TestWebKitAPI.WebAuthenticationPanel.PanelHidCtapNoCredentialsFound (failure)") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/34804 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185053 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37845 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39169 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143417 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46658 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143289 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47337 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112410 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26291 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38259 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119086 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45843 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9750 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45245 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45476 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45302 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->