### PR TITLE
IndexedDB: put() that fails a unique index constraint deletes the record it would have overwritten

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore-put-unique-index-constraint-is-atomic.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore-put-unique-index-constraint-is-atomic.any-expected.txt
@@ -1,0 +1,3 @@
+
+PASS A put() that fails a unique index constraint must not delete the record it would have overwritten
+

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore-put-unique-index-constraint-is-atomic.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore-put-unique-index-constraint-is-atomic.any.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore-put-unique-index-constraint-is-atomic.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore-put-unique-index-constraint-is-atomic.any.js
@@ -1,0 +1,60 @@
+// META: title=IndexedDB: a put() that fails a unique index constraint must be atomic
+// META: global=window,worker
+// META: script=resources/support.js
+
+// Spec: https://w3c.github.io/IndexedDB/#object-store-storage-operation
+
+'use strict';
+
+indexeddb_test(
+    (t, db) => {
+      const store = db.createObjectStore('store', {keyPath: 'id'});
+      store.createIndex('username', 'username', {unique: true});
+      store.add({id: 1, username: 'foo'});
+      store.add({id: 2, username: 'bar'});
+    },
+    (t, db) => {
+      // Overwriting id:1 with username 'bar' collides with id:2's unique index
+      // entry, so the put() must fail with a ConstraintError and leave the
+      // store exactly as it was.
+      const tx = db.transaction('store', 'readwrite');
+      const store = tx.objectStore('store');
+      const request = store.put({id: 1, username: 'bar'});
+
+      request.onsuccess =
+          t.unreached_func('put() should fail with a ConstraintError');
+      request.onerror = t.step_func(e => {
+        assert_equals(request.error.name, 'ConstraintError');
+        // Handle the error so the transaction commits instead of aborting;
+        // this is what exposes the non-atomic delete-then-add bug.
+        e.preventDefault();
+      });
+
+      tx.onabort =
+          t.unreached_func('transaction should commit, not abort');
+      tx.oncomplete = t.step_func(() => {
+        const readTx = db.transaction('store', 'readonly');
+        const readStore = readTx.objectStore('store');
+
+        const getRequest = readStore.get(1);
+        getRequest.onsuccess = t.step_func(() => {
+          assert_not_equals(
+              getRequest.result, undefined,
+              'the record that would have been overwritten must still exist');
+          assert_equals(
+              getRequest.result.username, 'foo',
+              'the pre-existing record must be unchanged');
+        });
+
+        const countRequest = readStore.count();
+        countRequest.onsuccess = t.step_func(() => {
+          assert_equals(
+              countRequest.result, 2,
+              'the store must still contain both original records');
+        });
+
+        readTx.oncomplete = t.step_func_done();
+      });
+    },
+    'A put() that fails a unique index constraint must not delete the record ' +
+        'it would have overwritten');

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore-put-unique-index-constraint-is-atomic.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore-put-unique-index-constraint-is-atomic.any.serviceworker-expected.txt
@@ -1,0 +1,3 @@
+
+PASS A put() that fails a unique index constraint must not delete the record it would have overwritten
+

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore-put-unique-index-constraint-is-atomic.any.serviceworker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore-put-unique-index-constraint-is-atomic.any.serviceworker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore-put-unique-index-constraint-is-atomic.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore-put-unique-index-constraint-is-atomic.any.sharedworker-expected.txt
@@ -1,0 +1,3 @@
+
+PASS A put() that fails a unique index constraint must not delete the record it would have overwritten
+

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore-put-unique-index-constraint-is-atomic.any.sharedworker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore-put-unique-index-constraint-is-atomic.any.sharedworker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore-put-unique-index-constraint-is-atomic.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore-put-unique-index-constraint-is-atomic.any.worker-expected.txt
@@ -1,0 +1,3 @@
+
+PASS A put() that fails a unique index constraint must not delete the record it would have overwritten
+

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore-put-unique-index-constraint-is-atomic.any.worker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore-put-unique-index-constraint-is-atomic.any.worker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/storage/indexeddb/put-record-unique-index-constraint-is-atomic-private-expected.txt
+++ b/LayoutTests/storage/indexeddb/put-record-unique-index-constraint-is-atomic-private-expected.txt
@@ -1,0 +1,34 @@
+A put() that fails a unique index constraint must be atomic: the record it would have overwritten must remain in the object store unchanged.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+indexedDB = self.indexedDB || self.webkitIndexedDB || self.mozIndexedDB || self.msIndexedDB || self.OIndexedDB;
+
+indexedDB.deleteDatabase(dbname)
+indexedDB.open(dbname)
+store = db.createObjectStore('users', { keyPath: 'id' })
+store.createIndex('username', 'username', { unique: true })
+store.add({ id: 1, username: 'foo' })
+store.add({ id: 2, username: 'bar' })
+
+Put {id:1, username:'bar'}: this overwrites id:1 but its username collides with id:2's unique index entry.
+transaction = db.transaction('users', 'readwrite')
+store = transaction.objectStore('users')
+request = store.put({ id: 1, username: 'bar' })
+PASS errorName is "ConstraintError"
+Preventing default so the transaction commits instead of aborting.
+Transaction committed.
+
+The failed put() must have left the store untouched.
+transaction = db.transaction('users', 'readonly')
+store = transaction.objectStore('users')
+getRequest = store.get(1)
+countRequest = store.count()
+PASS record is non-null.
+PASS username is "foo"
+PASS count is 2
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/storage/indexeddb/put-record-unique-index-constraint-is-atomic-private.html
+++ b/LayoutTests/storage/indexeddb/put-record-unique-index-constraint-is-atomic-private.html
@@ -1,0 +1,10 @@
+<!-- webkit-test-runner [ useEphemeralSession=true ] -->
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<script src="resources/shared.js"></script>
+</head>
+<body>
+<script src="resources/put-record-unique-index-constraint-is-atomic.js"></script>
+</body>
+</html>

--- a/LayoutTests/storage/indexeddb/resources/put-record-unique-index-constraint-is-atomic.js
+++ b/LayoutTests/storage/indexeddb/resources/put-record-unique-index-constraint-is-atomic.js
@@ -1,0 +1,76 @@
+if (this.importScripts) {
+    importScripts('../../../resources/js-test.js');
+    importScripts('shared.js');
+}
+
+description("A put() that fails a unique index constraint must be atomic: the record it would have overwritten must remain in the object store unchanged.");
+
+indexedDBTest(prepareDatabase, onOpen);
+
+var db;
+var errorName;
+var record;
+var username;
+var count;
+
+function prepareDatabase(event)
+{
+    db = event.target.result;
+    var store = evalAndLog("store = db.createObjectStore('users', { keyPath: 'id' })");
+    evalAndLog("store.createIndex('username', 'username', { unique: true })");
+    evalAndLog("store.add({ id: 1, username: 'foo' })");
+    evalAndLog("store.add({ id: 2, username: 'bar' })");
+}
+
+function onOpen(event)
+{
+    db = event.target.result;
+    debug("");
+    debug("Put {id:1, username:'bar'}: this overwrites id:1 but its username collides with id:2's unique index entry.");
+    var transaction = evalAndLog("transaction = db.transaction('users', 'readwrite')");
+    var store = evalAndLog("store = transaction.objectStore('users')");
+    var request = evalAndLog("request = store.put({ id: 1, username: 'bar' })");
+    request.onsuccess = function() {
+        testFailed("put() unexpectedly succeeded; it should have failed with a ConstraintError.");
+    };
+    request.onerror = function(event) {
+        errorName = request.error.name;
+        shouldBeEqualToString("errorName", "ConstraintError");
+        debug("Preventing default so the transaction commits instead of aborting.");
+        event.preventDefault();
+    };
+    transaction.oncomplete = function() {
+        debug("Transaction committed.");
+        verifyStoreUnchanged();
+    };
+    transaction.onabort = function() {
+        testFailed("Transaction was aborted: " + (transaction.error && transaction.error.name));
+        finishJSTest();
+    };
+}
+
+function verifyStoreUnchanged()
+{
+    debug("");
+    debug("The failed put() must have left the store untouched.");
+    var transaction = evalAndLog("transaction = db.transaction('users', 'readonly')");
+    var store = evalAndLog("store = transaction.objectStore('users')");
+
+    var getRequest = evalAndLog("getRequest = store.get(1)");
+    getRequest.onsuccess = function() {
+        record = getRequest.result;
+        shouldBeNonNull("record");
+        if (record) {
+            username = record.username;
+            shouldBeEqualToString("username", "foo");
+        }
+    };
+
+    var countRequest = evalAndLog("countRequest = store.count()");
+    countRequest.onsuccess = function() {
+        count = countRequest.result;
+        shouldBe("count", "2");
+    };
+
+    transaction.oncomplete = finishJSTest;
+}

--- a/Source/WebCore/Modules/indexeddb/server/IDBBackingStore.h
+++ b/Source/WebCore/Modules/indexeddb/server/IDBBackingStore.h
@@ -80,7 +80,12 @@ public:
     virtual IDBError renameIndex(const IDBResourceIdentifier& transactionIdentifier, IDBObjectStoreIdentifier, IDBIndexIdentifier, const String& newName) = 0;
     virtual IDBError keyExistsInObjectStore(const IDBResourceIdentifier& transactionIdentifier, IDBObjectStoreIdentifier, const IDBKeyData&, bool& keyExists) = 0;
     virtual IDBError deleteRange(const IDBResourceIdentifier& transactionIdentifier, IDBObjectStoreIdentifier, const IDBKeyRangeData&) = 0;
-    virtual IDBError addRecord(const IDBResourceIdentifier& transactionIdentifier, const IDBObjectStoreInfo&, const IDBKeyData&, const IndexIDToIndexKeyMap&, const IDBValue&) = 0;
+    // Implements the spec's "store a record into an object store" algorithm: if storing a record with the given
+    // key and index keys would violate a unique index, returns a ConstraintError without mutating the store, so
+    // that a failed put() leaves any pre-existing record with the same key intact. Otherwise, any existing record
+    // with the same key is removed and the given key/value is stored along with its index entries.
+    // https://w3c.github.io/IndexedDB/#object-store-storage-operation
+    virtual IDBError overwriteRecord(const IDBResourceIdentifier& transactionIdentifier, const IDBObjectStoreInfo&, const IDBKeyData&, const IndexIDToIndexKeyMap&, const IDBValue&) = 0;
     virtual IDBError getRecord(const IDBResourceIdentifier& transactionIdentifier, IDBObjectStoreIdentifier, const IDBKeyRangeData&, IDBGetRecordDataType, IDBGetResult& outValue) = 0;
     virtual IDBError getAllRecords(const IDBResourceIdentifier& transactionIdentifier, const IDBGetAllRecordsData&, IDBGetAllResult& outValue) = 0;
     virtual IDBError getIndexRecord(const IDBResourceIdentifier& transactionIdentifier, IDBObjectStoreIdentifier, IDBIndexIdentifier, IndexedDB::IndexRecordType, const IDBKeyRangeData&, IDBGetResult& outValue) = 0;

--- a/Source/WebCore/Modules/indexeddb/server/MemoryIDBBackingStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryIDBBackingStore.cpp
@@ -341,9 +341,9 @@ IDBError MemoryIDBBackingStore::deleteRange(const IDBResourceIdentifier& transac
     return IDBError { };
 }
 
-IDBError MemoryIDBBackingStore::addRecord(const IDBResourceIdentifier& transactionIdentifier, const IDBObjectStoreInfo& objectStoreInfo, const IDBKeyData& keyData, const IndexIDToIndexKeyMap& indexKeys, const IDBValue& value)
+IDBError MemoryIDBBackingStore::overwriteRecord(const IDBResourceIdentifier& transactionIdentifier, const IDBObjectStoreInfo& objectStoreInfo, const IDBKeyData& keyData, const IndexIDToIndexKeyMap& indexKeys, const IDBValue& value)
 {
-    LOG(IndexedDB, "MemoryIDBBackingStore::addRecord");
+    LOG(IndexedDB, "MemoryIDBBackingStore::overwriteRecord");
 
     RefPtr transaction = m_transactions.get(transactionIdentifier);
     if (!transaction)
@@ -353,7 +353,7 @@ IDBError MemoryIDBBackingStore::addRecord(const IDBResourceIdentifier& transacti
     if (!objectStore)
         return IDBError { ExceptionCode::UnknownError, "No backing store object store found to put record"_s };
 
-    return objectStore->addRecord(*transaction, keyData, indexKeys, value);
+    return objectStore->overwriteRecord(*transaction, keyData, indexKeys, value);
 }
 
 IDBError MemoryIDBBackingStore::getRecord(const IDBResourceIdentifier& transactionIdentifier, IDBObjectStoreIdentifier objectStoreIdentifier, const IDBKeyRangeData& range, IDBGetRecordDataType type, IDBGetResult& outValue)

--- a/Source/WebCore/Modules/indexeddb/server/MemoryIDBBackingStore.h
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryIDBBackingStore.h
@@ -70,7 +70,7 @@ private:
     IDBError renameIndex(const IDBResourceIdentifier& transactionIdentifier, IDBObjectStoreIdentifier, IDBIndexIdentifier, const String& newName) final;
     IDBError keyExistsInObjectStore(const IDBResourceIdentifier& transactionIdentifier, IDBObjectStoreIdentifier, const IDBKeyData&, bool& keyExists) final;
     IDBError deleteRange(const IDBResourceIdentifier& transactionIdentifier, IDBObjectStoreIdentifier, const IDBKeyRangeData&) final;
-    IDBError addRecord(const IDBResourceIdentifier& transactionIdentifier, const IDBObjectStoreInfo&, const IDBKeyData&, const IndexIDToIndexKeyMap&, const IDBValue&) final;
+    IDBError overwriteRecord(const IDBResourceIdentifier& transactionIdentifier, const IDBObjectStoreInfo&, const IDBKeyData&, const IndexIDToIndexKeyMap&, const IDBValue&) final;
     IDBError getRecord(const IDBResourceIdentifier& transactionIdentifier, IDBObjectStoreIdentifier, const IDBKeyRangeData&, IDBGetRecordDataType, IDBGetResult& outValue) final;
     IDBError getAllRecords(const IDBResourceIdentifier& transactionIdentifier, const IDBGetAllRecordsData&, IDBGetAllResult& outValue) final;
     IDBError getIndexRecord(const IDBResourceIdentifier& transactionIdentifier, IDBObjectStoreIdentifier, IDBIndexIdentifier, IndexedDB::IndexRecordType, const IDBKeyRangeData&, IDBGetResult& outValue) final;

--- a/Source/WebCore/Modules/indexeddb/server/MemoryIndex.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryIndex.cpp
@@ -235,6 +235,26 @@ IDBError MemoryIndex::putIndexKey(const IDBKeyData& valueKey, const IndexKey& in
     return IDBError { };
 }
 
+bool MemoryIndex::hasRecordForOtherPrimaryKey(const IDBKeyData& indexKey, const IDBKeyData& primaryKey)
+{
+    ASSERT(m_info.unique());
+
+    CheckedPtr records = m_records.get();
+    if (!records)
+        return false;
+
+    auto valueKeys = records->valueKeys(indexKey);
+    if (!valueKeys)
+        return false;
+
+    for (auto& valueKey : *valueKeys) {
+        if (valueKey != primaryKey)
+            return true;
+    }
+
+    return false;
+}
+
 void MemoryIndex::removeRecord(const IDBKeyData& valueKey, const IndexKey& indexKey)
 {
     LOG(IndexedDB, "MemoryIndex::removeRecord");

--- a/Source/WebCore/Modules/indexeddb/server/MemoryIndex.h
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryIndex.h
@@ -75,6 +75,8 @@ public:
 
     IDBError putIndexKey(const IDBKeyData&, const IndexKey&);
 
+    bool hasRecordForOtherPrimaryKey(const IDBKeyData& indexKey, const IDBKeyData& primaryKey);
+
     void removeEntriesWithValueKey(const IDBKeyData&);
     void removeRecord(const IDBKeyData&, const IndexKey&);
 

--- a/Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.cpp
@@ -310,6 +310,56 @@ void MemoryObjectStore::addRecordWithoutUpdatingIndexes(MemoryBackingStoreTransa
     updateCursorsForPutRecord(listResult.first);
 }
 
+// https://w3c.github.io/IndexedDB/#object-store-storage-operation
+IDBError MemoryObjectStore::overwriteRecord(MemoryBackingStoreTransaction& transaction, const IDBKeyData& keyData, const IndexIDToIndexKeyMap& indexKeys, const IDBValue& value)
+{
+    LOG(IndexedDB, "MemoryObjectStore::overwriteRecord");
+
+    // Before mutating anything, verify the record does not violate a unique index constraint. Otherwise deleting
+    // the record being overwritten below would leave the store with neither the old nor the new record if adding
+    // the new record then failed. A failed put() must leave the store unchanged.
+    auto error = checkIndexConstraintsForPut(keyData, indexKeys);
+    if (!error.isNull())
+        return error;
+
+    // If a record already exists in store, then remove the record from store using the steps for deleting records
+    // from an object store. This is important because formally deleting it from the object store also removes it
+    // from the appropriate indexes.
+    deleteRecord(keyData);
+
+    return addRecord(transaction, keyData, indexKeys, value);
+}
+
+IDBError MemoryObjectStore::checkIndexConstraintsForPut(const IDBKeyData& keyData, const IndexIDToIndexKeyMap& indexKeys)
+{
+    LOG(IndexedDB, "MemoryObjectStore::checkIndexConstraintsForPut");
+
+    for (const auto& [indexID, indexKey] : indexKeys) {
+        RefPtr index = m_indexesByIdentifier.get(indexID);
+        ASSERT(index);
+        if (!index)
+            return IDBError { ExceptionCode::InvalidStateError, "Missing index metadata"_s };
+
+        if (!index->info().unique())
+            continue;
+
+        Vector<IDBKeyData> keys;
+        if (index->info().multiEntry())
+            keys = indexKey.multiEntry();
+        else
+            keys.append(indexKey.asOneKey());
+
+        for (auto& key : keys) {
+            if (!key.isValid())
+                continue;
+            if (index->hasRecordForOtherPrimaryKey(key, keyData))
+                return IDBError { ExceptionCode::ConstraintError, "Unable to store record in object store because it does not satisfy the uniqueness requirements of an index"_s };
+        }
+    }
+
+    return IDBError { };
+}
+
 IDBError MemoryObjectStore::addRecord(MemoryBackingStoreTransaction& transaction, const IDBKeyData& keyData, const IndexIDToIndexKeyMap& indexKeys, const IDBValue& value)
 {
     LOG(IndexedDB, "MemoryObjectStore::addRecord");

--- a/Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.h
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.h
@@ -79,7 +79,7 @@ public:
     bool containsRecord(const IDBKeyData&);
     void deleteRecord(const IDBKeyData&);
     void deleteRange(const IDBKeyRangeData&);
-    IDBError addRecord(MemoryBackingStoreTransaction&, const IDBKeyData&, const IndexIDToIndexKeyMap&, const IDBValue&);
+    IDBError overwriteRecord(MemoryBackingStoreTransaction&, const IDBKeyData&, const IndexIDToIndexKeyMap&, const IDBValue&);
 
     uint64_t currentKeyGeneratorValue() const { return m_keyGeneratorValue; }
     void setKeyGeneratorValue(uint64_t value) { m_keyGeneratorValue = value; }
@@ -114,6 +114,9 @@ private:
     MemoryObjectStore(const IDBObjectStoreInfo&);
 
     IDBKeyDataSet::iterator lowestIteratorInRange(const IDBKeyRangeData&, bool reverse) const;
+
+    IDBError checkIndexConstraintsForPut(const IDBKeyData&, const IndexIDToIndexKeyMap&);
+    IDBError addRecord(MemoryBackingStoreTransaction&, const IDBKeyData&, const IndexIDToIndexKeyMap&, const IDBValue&);
 
     IDBError updateIndexesForPutRecord(const IDBKeyData&, const IndexIDToIndexKeyMap&);
     void updateIndexesForDeleteRecord(const IDBKeyData& value);

--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
@@ -1409,17 +1409,17 @@ IDBError SQLiteIDBBackingStore::clearObjectStore(const IDBResourceIdentifier& tr
     return IDBError { };
 }
 
-IDBError SQLiteIDBBackingStore::uncheckedHasIndexRecord(const IDBIndexInfo& info, const IDBKeyData& indexKey, bool& hasRecord)
+IDBError SQLiteIDBBackingStore::uncheckedGetExistingPrimaryKeyForIndexKey(const IDBIndexInfo& info, const IDBKeyData& indexKey, std::optional<IDBKeyData>& existingPrimaryKey)
 {
-    hasRecord = false;
+    existingPrimaryKey = std::nullopt;
 
     auto indexKeyBuffer = serializeIDBKeyData(indexKey);
     if (!indexKeyBuffer) {
-        LOG_ERROR("Unable to serialize index key to be stored in the database");
+        LOG_ERROR("Unable to serialize index key to be checked in the database");
         return IDBError { ExceptionCode::UnknownError, "Unable to serialize IDBKey to check for index record in database"_s };
     }
 
-    auto sql = cachedStatement(SQL::HasIndexRecord, "SELECT rowid FROM IndexRecords WHERE indexID = ? AND key = CAST(? AS TEXT);"_s);
+    auto sql = cachedStatement(SQL::GetExistingPrimaryKeyForIndexKey, "SELECT value FROM IndexRecords WHERE indexID = ? AND key = CAST(? AS TEXT);"_s);
     CheckedPtr statement = sql.get();
     if (!statement
         || statement->bindInt64(1, info.identifier().toRawValue()) != SQLITE_OK
@@ -1439,7 +1439,80 @@ IDBError SQLiteIDBBackingStore::uncheckedHasIndexRecord(const IDBIndexInfo& info
         return IDBError { ExceptionCode::UnknownError, "Error checking for existence of IDBKey in index"_s };
     }
 
-    hasRecord = true;
+    IDBKeyData primaryKey;
+    if (!deserializeIDBKeyData(statement->columnBlobAsSpan(0), primaryKey)) {
+        LOG_ERROR("Unable to deserialize primary key referenced by index record");
+        return IDBError { ExceptionCode::UnknownError, "Unable to deserialize primary key referenced by index record"_s };
+    }
+
+    existingPrimaryKey = primaryKey;
+    return IDBError { };
+}
+
+// https://w3c.github.io/IndexedDB/#object-store-storage-operation
+IDBError SQLiteIDBBackingStore::overwriteRecord(const IDBResourceIdentifier& transactionIdentifier, const IDBObjectStoreInfo& objectStoreInfo, const IDBKeyData& keyData, const IndexIDToIndexKeyMap& indexKeys, const IDBValue& value)
+{
+    LOG(IndexedDB, "SQLiteIDBBackingStore::overwriteRecord - key %s, object store %" PRIu64, keyData.loggingString().utf8().data(), objectStoreInfo.identifier().toRawValue());
+
+    // Before mutating anything, verify the record does not violate a unique index constraint. Otherwise deleting
+    // the record being overwritten below would leave the store with neither the old nor the new record if adding
+    // the new record then failed. A failed put() must leave the store unchanged.
+    auto error = checkIndexConstraintsForPut(transactionIdentifier, objectStoreInfo, keyData, indexKeys);
+    if (!error.isNull())
+        return error;
+
+    // If a record already exists in store, then remove the record from store using the steps for deleting records
+    // from an object store. This is important because formally deleting it from the object store also removes it
+    // from the appropriate indexes.
+    error = deleteRange(transactionIdentifier, objectStoreInfo.identifier(), keyData);
+    if (!error.isNull())
+        return error;
+
+    return addRecord(transactionIdentifier, objectStoreInfo, keyData, indexKeys, value);
+}
+
+IDBError SQLiteIDBBackingStore::checkIndexConstraintsForPut(const IDBResourceIdentifier& transactionIdentifier, const IDBObjectStoreInfo& objectStoreInfo, const IDBKeyData& keyData, const IndexIDToIndexKeyMap& indexKeys)
+{
+    LOG(IndexedDB, "SQLiteIDBBackingStore::checkIndexConstraintsForPut - object store %" PRIu64, objectStoreInfo.identifier().toRawValue());
+
+    ASSERT(m_sqliteDB);
+    ASSERT(m_sqliteDB->isOpen());
+
+    CheckedPtr transaction = m_transactions.get(transactionIdentifier);
+    if (!transaction || !transaction->inProgress())
+        return IDBError { ExceptionCode::UnknownError, "Attempt to check index constraints without an in-progress transaction"_s };
+
+    const auto& indexMap = objectStoreInfo.indexMap();
+    for (const auto& [indexID, indexKey] : indexKeys) {
+        auto indexIterator = indexMap.find(indexID);
+        ASSERT(indexIterator != indexMap.end());
+        if (indexIterator == indexMap.end())
+            return IDBError { ExceptionCode::InvalidStateError, "Missing index metadata"_s };
+
+        const auto& indexInfo = indexIterator->value;
+        if (!indexInfo.unique())
+            continue;
+
+        Vector<IDBKeyData> keys;
+        if (indexInfo.multiEntry())
+            keys = indexKey.multiEntry();
+        else
+            keys.append(indexKey.asOneKey());
+
+        for (auto& key : keys) {
+            if (!key.isValid())
+                continue;
+
+            std::optional<IDBKeyData> existingPrimaryKey;
+            auto error = uncheckedGetExistingPrimaryKeyForIndexKey(indexInfo, key, existingPrimaryKey);
+            if (!error.isNull())
+                return error;
+
+            if (existingPrimaryKey && *existingPrimaryKey != keyData)
+                return IDBError { ExceptionCode::ConstraintError, "Unable to store record in object store because it does not satisfy the uniqueness requirements of an index"_s };
+        }
+    }
+
     return IDBError { };
 }
 
@@ -1454,15 +1527,15 @@ IDBError SQLiteIDBBackingStore::uncheckedPutIndexKey(const IDBIndexInfo& info, c
         indexKeys.append(indexKey.asOneKey());
 
     if (info.unique()) {
-        bool hasRecord;
+        std::optional<IDBKeyData> existingPrimaryKey;
         IDBError error;
         for (auto& indexKey : indexKeys) {
             if (!indexKey.isValid())
                 continue;
-            error = uncheckedHasIndexRecord(info, indexKey, hasRecord);
+            error = uncheckedGetExistingPrimaryKeyForIndexKey(info, indexKey, existingPrimaryKey);
             if (!error.isNull())
                 return error;
-            if (hasRecord)
+            if (existingPrimaryKey)
                 return IDBError { ExceptionCode::ConstraintError, "Index key is not unique"_s };
         }
     }

--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.h
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.h
@@ -75,7 +75,7 @@ public:
     IDBError renameIndex(const IDBResourceIdentifier& transactionIdentifier, IDBObjectStoreIdentifier, IDBIndexIdentifier, const String& newName) final;
     IDBError keyExistsInObjectStore(const IDBResourceIdentifier& transactionIdentifier, IDBObjectStoreIdentifier, const IDBKeyData&, bool& keyExists) final;
     IDBError deleteRange(const IDBResourceIdentifier& transactionIdentifier, IDBObjectStoreIdentifier, const IDBKeyRangeData&) final;
-    IDBError addRecord(const IDBResourceIdentifier& transactionIdentifier, const IDBObjectStoreInfo&, const IDBKeyData&, const IndexIDToIndexKeyMap&, const IDBValue&) final;
+    IDBError overwriteRecord(const IDBResourceIdentifier& transactionIdentifier, const IDBObjectStoreInfo&, const IDBKeyData&, const IndexIDToIndexKeyMap&, const IDBValue&) final;
     IDBError getRecord(const IDBResourceIdentifier& transactionIdentifier, IDBObjectStoreIdentifier, const IDBKeyRangeData&, IDBGetRecordDataType, IDBGetResult& outValue) final;
     IDBError getAllRecords(const IDBResourceIdentifier& transactionIdentifier, const IDBGetAllRecordsData&, IDBGetAllResult& outValue) final;
     IDBError getIndexRecord(const IDBResourceIdentifier& transactionIdentifier, IDBObjectStoreIdentifier, IDBIndexIdentifier, IndexedDB::IndexRecordType, const IDBKeyRangeData&, IDBGetResult& outValue) final;
@@ -139,6 +139,8 @@ protected:
     void setDatabaseInfo(std::unique_ptr<IDBDatabaseInfo>&&);
 
 private:
+    IDBError checkIndexConstraintsForPut(const IDBResourceIdentifier& transactionIdentifier, const IDBObjectStoreInfo&, const IDBKeyData&, const IndexIDToIndexKeyMap&);
+    IDBError addRecord(const IDBResourceIdentifier& transactionIdentifier, const IDBObjectStoreInfo&, const IDBKeyData&, const IndexIDToIndexKeyMap&, const IDBValue&);
     IDBError deleteRecord(SQLiteIDBTransaction&, IDBObjectStoreIdentifier, const IDBKeyData&);
     IDBError uncheckedGetKeyGeneratorValue(IDBObjectStoreIdentifier, uint64_t& outValue);
     IDBError uncheckedSetKeyGeneratorValue(IDBObjectStoreIdentifier, uint64_t value);
@@ -146,7 +148,7 @@ private:
     IDBError updateAllIndexesForAddRecord(const IDBObjectStoreInfo&, const IDBKeyData&, const IndexIDToIndexKeyMap&, int64_t recordID);
     IDBError uncheckedPutIndexKey(const IDBIndexInfo&, const IDBKeyData& keyValue, const IndexKey&, int64_t recordID);
     IDBError uncheckedPutIndexRecord(IDBObjectStoreIdentifier, IDBIndexIdentifier, const IDBKeyData& keyValue, const IDBKeyData& indexKey, int64_t recordID);
-    IDBError uncheckedHasIndexRecord(const IDBIndexInfo&, const IDBKeyData&, bool& hasRecord);
+    IDBError uncheckedGetExistingPrimaryKeyForIndexKey(const IDBIndexInfo&, const IDBKeyData& indexKey, std::optional<IDBKeyData>& existingPrimaryKey);
     IDBError uncheckedGetIndexRecordForOneKey(IDBIndexIdentifier, IDBObjectStoreIdentifier, IndexedDB::IndexRecordType, const IDBKeyData&, IDBGetResult&);
 
     IDBError deleteUnusedBlobFileRecords(SQLiteIDBTransaction&);
@@ -179,7 +181,7 @@ private:
         CreateTempIndexInfo,
         DeleteIndexInfo,
         RemoveIndexInfo,
-        HasIndexRecord,
+        GetExistingPrimaryKeyForIndexKey,
         PutIndexRecord,
         PutTempIndexRecord,
         GetIndexRecordForOneKey,

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.cpp
@@ -1007,13 +1007,8 @@ void UniqueIDBDatabase::putOrAddAfterSpaceCheck(const IDBRequestData& requestDat
 
     if (spaceCheckResult != SpaceCheckResult::Pass)
         return callback(IDBError { ExceptionCode::QuotaExceededError, quotaErrorMessageName("PutOrAdd"_s) }, keyData);
-    // If a record already exists in store, then remove the record from store using the steps for deleting records from an object store.
-    // This is important because formally deleting it from the object store also removes it from the appropriate indexes.
-    IDBError error = protect(m_backingStore)->deleteRange(transactionIdentifier, objectStoreIdentifier, keyData);
-    if (!error.isNull())
-        return callback(error, keyData);
 
-    error = protect(m_backingStore)->addRecord(transactionIdentifier, objectStoreInfo, keyData, indexKeys, value);
+    IDBError error = protect(m_backingStore)->overwriteRecord(transactionIdentifier, objectStoreInfo, keyData, indexKeys, value);
     if (!error.isNull())
         return callback(error, keyData);
 


### PR DESCRIPTION
#### 6b45d5d99db753d2bc2c3c470b1164bd1839c527
<pre>
IndexedDB: put() that fails a unique index constraint deletes the record it would have overwritten
<a href="https://bugs.webkit.org/show_bug.cgi?id=318659">https://bugs.webkit.org/show_bug.cgi?id=318659</a>
<a href="https://rdar.apple.com/181513905">rdar://181513905</a>

Reviewed by Sihui Liu.

A put() that violates a unique index constraint was not atomic: putOrAddAfterSpaceCheck()
deleted any existing record with the same primary key before adding the new one, so a failed
put() left the store with neither the old nor the new record. Fix by folding the
check-then-overwrite sequence into a single new backing store method, overwriteRecord(),
matching the spec&apos;s storage algorithm: verify the record would not violate a unique index
before mutating anything, then remove any existing record with the same key and store the
new key/value with its index entries.

In SQLiteIDBBackingStore, merge uncheckedHasIndexRecord() and
uncheckedHasIndexRecordForOtherPrimaryKey() into uncheckedGetExistingPrimaryKeyForIndexKey(),
so both call sites share one query instead of two nearly-identical ones.

Tests: imported/w3c/web-platform-tests/IndexedDB/idbobjectstore-put-unique-index-constraint-is-atomic.any.js
       storage/indexeddb/put-record-unique-index-constraint-is-atomic-private.html

* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore-put-unique-index-constraint-is-atomic.any-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore-put-unique-index-constraint-is-atomic.any.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore-put-unique-index-constraint-is-atomic.any.js: Added.
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore-put-unique-index-constraint-is-atomic.any.serviceworker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore-put-unique-index-constraint-is-atomic.any.serviceworker.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore-put-unique-index-constraint-is-atomic.any.sharedworker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore-put-unique-index-constraint-is-atomic.any.sharedworker.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore-put-unique-index-constraint-is-atomic.any.worker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore-put-unique-index-constraint-is-atomic.any.worker.html: Added.
* LayoutTests/storage/indexeddb/put-record-unique-index-constraint-is-atomic-private-expected.txt: Added.
* LayoutTests/storage/indexeddb/put-record-unique-index-constraint-is-atomic-private.html: Added.
* LayoutTests/storage/indexeddb/resources/put-record-unique-index-constraint-is-atomic.js: Added.
* Source/WebCore/Modules/indexeddb/server/IDBBackingStore.h:
* Source/WebCore/Modules/indexeddb/server/MemoryIDBBackingStore.cpp:
(WebCore::IDBServer::MemoryIDBBackingStore::overwriteRecord):
* Source/WebCore/Modules/indexeddb/server/MemoryIDBBackingStore.h:
* Source/WebCore/Modules/indexeddb/server/MemoryIndex.cpp:
(WebCore::IDBServer::MemoryIndex::hasRecordForOtherPrimaryKey):
* Source/WebCore/Modules/indexeddb/server/MemoryIndex.h:
* Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.cpp:
(WebCore::IDBServer::MemoryObjectStore::overwriteRecord):
(WebCore::IDBServer::MemoryObjectStore::checkIndexConstraintsForPut):
* Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.h:
* Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp:
(WebCore::IDBServer::SQLiteIDBBackingStore::uncheckedGetExistingPrimaryKeyForIndexKey):
(WebCore::IDBServer::SQLiteIDBBackingStore::overwriteRecord):
(WebCore::IDBServer::SQLiteIDBBackingStore::checkIndexConstraintsForPut):
(WebCore::IDBServer::SQLiteIDBBackingStore::uncheckedPutIndexKey):
* Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.h:
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.cpp:
(WebCore::IDBServer::UniqueIDBDatabase::putOrAddAfterSpaceCheck):

Canonical link: <a href="https://commits.webkit.org/317632@main">https://commits.webkit.org/317632@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/87b9ed82ec71c9275459c70f100d21b0c2b62ed4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175840 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49773 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43557 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185433 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138031 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9612d15f-b3ed-48ee-a1dd-ede4b006efb5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177703 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51065 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49455 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136920 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138031 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ab929c6b-18f7-4045-9d12-b1b9fb0c17c9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178796 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40383 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157701 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117399 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/63681326-7739-4da0-bc0f-4c2332b891fd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39025 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37406 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149444 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37193 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33903 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41473 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41612 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187854 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49440 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/157252 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145918 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39262 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50120 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33817 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145758 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40549 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122316 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116158 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48627 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12173 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48029 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48261 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48086 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->