### PR TITLE
[CMake] TestWebKitAPI is missing the mac GamepadMappings sources and the HID framework link

### DIFF
--- a/Tools/TestWebKitAPI/PlatformMac.cmake
+++ b/Tools/TestWebKitAPI/PlatformMac.cmake
@@ -160,6 +160,16 @@ list(APPEND TestWebKit_SOURCES
     Helpers/mac/WKWebViewForTestingImmediateActions.mm
     Helpers/mac/WebKitAgnosticTest.mm
 
+    Helpers/mac/GamepadMappings/GoogleStadia.mm
+    Helpers/mac/GamepadMappings/LogitechF310.mm
+    Helpers/mac/GamepadMappings/LogitechF710.mm
+    Helpers/mac/GamepadMappings/MicrosoftXboxOne.mm
+    Helpers/mac/GamepadMappings/ShenzhenLongshengweiTechnologyGamepad.mm
+    Helpers/mac/GamepadMappings/SonyDualShock3.mm
+    Helpers/mac/GamepadMappings/SonyDualShock4.mm
+    Helpers/mac/GamepadMappings/SteelSeriesNimbus.mm
+    Helpers/mac/GamepadMappings/SunLightApplicationGenericNES.mm
+
     Tests/WebCore/ASN1Utilities.cpp
 
     Tests/WebCore/cocoa/ISOBMFFTrackInfoParserTests.cpp
@@ -196,6 +206,7 @@ list(APPEND TestWebKit_PRIVATE_INCLUDE_DIRECTORIES
 
 list(APPEND TestWebKit_LIBRARIES
     "-framework AuthenticationServices"
+    "-framework HID"
     "-framework LocalAuthentication"
     "-framework Network"
     "-framework QuartzCore"


### PR DESCRIPTION
#### 703147b98b786c615736c059bd305e2e80e8084b
<pre>
[CMake] TestWebKitAPI is missing the mac GamepadMappings sources and the HID framework link
<a href="https://bugs.webkit.org/show_bug.cgi?id=318698">https://bugs.webkit.org/show_bug.cgi?id=318698</a>
<a href="https://rdar.apple.com/181513616">rdar://181513616</a>

Reviewed by Elliott Williams and Zak Ridouh.

Xcode&apos;s TestWebKitAPILibrary compiles the nine
Tools/TestWebKitAPI/Helpers/mac/GamepadMappings/*.mm files that define
TestWebKitAPI::VirtualGamepad::*Mapping(), referenced by
Helpers/mac/VirtualGamepad.mm and the HID gamepad tests, and links the
HID framework for HIDUserDevice (WK_HID_LDFLAGS_macosx = -framework HID).

The CMake port&apos;s PlatformMac.cmake lists VirtualGamepad.mm but omits the
mapping sources and the HID link, so TestWebKitAPI fails to link with
undefined VirtualGamepad mapping symbols and _OBJC_CLASS_$_HIDUserDevice.
Add the mapping sources and -framework HID to match Xcode.

* Tools/TestWebKitAPI/PlatformMac.cmake:

Canonical link: <a href="https://commits.webkit.org/316733@main">https://commits.webkit.org/316733@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a81ff23303ccabbb068b061d784a501149a2349f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172831 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46750 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40220 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182291 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130387 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174696 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48043 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46426 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134422 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94884 "22 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175789 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37817 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154979 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114891 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36462 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34776 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30888 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146885 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34484 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184823 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38978 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143219 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46421 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143092 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47099 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31315 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112101 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26313 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38086 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45616 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9427 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45017 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45249 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45075 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->