### PR TITLE
[CMake] WebKitTestRunner is missing TestRunnerShared/mac/NSPasteboardAdditions.mm

### DIFF
--- a/Tools/WebKitTestRunner/PlatformMac.cmake
+++ b/Tools/WebKitTestRunner/PlatformMac.cmake
@@ -153,6 +153,8 @@ list(APPEND WebKitTestRunner_SOURCES
     ${WebKitTestRunner_SHARED_DIR}/cocoa/PlatformViewHelpers.mm
     ${WebKitTestRunner_SHARED_DIR}/cocoa/PoseAsClass.mm
 
+    ${WebKitTestRunner_SHARED_DIR}/mac/NSPasteboardAdditions.mm
+
     ${WebKitTestRunner_SHARED_DIR}/EventSerialization/mac/EventSerializerMac.mm
     ${WebKitTestRunner_SHARED_DIR}/EventSerialization/mac/SharedEventStreamsMac.mm
 )


### PR DESCRIPTION
#### 0d1d436701c7e749dc28aa8dd85e533e055d3f79
<pre>
[CMake] WebKitTestRunner is missing TestRunnerShared/mac/NSPasteboardAdditions.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=318699">https://bugs.webkit.org/show_bug.cgi?id=318699</a>
<a href="https://rdar.apple.com/181513833">rdar://181513833</a>

Reviewed by NOBODY (OOPS!).

Xcode&apos;s WebKitTestRunner tool and its Library compile
TestRunnerShared/mac/NSPasteboardAdditions.mm, which defines
+[NSPasteboard _modernPasteboardType:], called by
mac/WebKitTestRunnerPasteboard.mm.

The CMake port&apos;s PlatformMac.cmake omits it; the link only survives
because -undefined dynamic_lookup turns the missing selector into a stub,
so it is unimplemented at runtime and crashes with an unrecognized
selector on any pasteboard or drag layout test. Compile the file,
matching Xcode.

* Tools/WebKitTestRunner/PlatformMac.cmake:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d1d436701c7e749dc28aa8dd85e533e055d3f79

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172833 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46752 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40222 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182293 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130389 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5f606fef-cfc6-4a56-9848-f2c20ec8d587) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174698 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48045 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46428 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134419 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94885 "21 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4a470e19-3255-451d-876b-6ac4e6a3197d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175791 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37815 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154978 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114888 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/037210e3-b27e-41cd-be21-d58634af33ed) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36460 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34778 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30890 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146883 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34483 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184825 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38980 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143222 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46423 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143094 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47101 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31314 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112103 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38087 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45618 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9426 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45019 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45251 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45077 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->