### PR TITLE
FetchHeaders::appendToHeaderMap does a redundant header-map lookup on every append

### DIFF
--- a/Source/WebCore/Modules/fetch/FetchHeaders.cpp
+++ b/Source/WebCore/Modules/fetch/FetchHeaders.cpp
@@ -80,8 +80,10 @@ static ExceptionOr<void> appendToHeaderMap(const String& name, const String& val
         return appendSetCookie(normalizedValue, setCookieValues, guard);
 
     String combinedValue = normalizedValue;
-    if (headers.contains(name))
-        combinedValue = makeString(headers.get(name), ", "_s, normalizedValue);
+    String existingValue = headers.get(name);
+    ASSERT(!existingValue.isNull() || !headers.contains(name));
+    if (!existingValue.isNull())
+        combinedValue = makeString(existingValue, ", "_s, normalizedValue);
     auto canWriteResult = canWriteHeader(name, normalizedValue, combinedValue, guard);
     if (canWriteResult.hasException())
         return canWriteResult.releaseException();


### PR DESCRIPTION
#### b0d52573ef1d019347c8f3ef4d5fc95866106572
<pre>
FetchHeaders::appendToHeaderMap does a redundant header-map lookup on every append
<a href="https://bugs.webkit.org/show_bug.cgi?id=318701">https://bugs.webkit.org/show_bug.cgi?id=318701</a>
<a href="https://rdar.apple.com/181516418">rdar://181516418</a>

Reviewed by Chris Dumez.

When appending a header, appendToHeaderMap() called HTTPHeaderMap::contains(name)
and then HTTPHeaderMap::get(name) to build the combined value. Both calls perform
the same resolution work -- findHTTPHeaderName() followed by a common-header probe
or a linear scan of the uncommon headers -- so every appended header paid for two
identical lookups.

HTTPHeaderMap::get() already returns a null String when the header is absent, and
a present header always stores a non-null value, so a single get() plus an
isNull() check is equivalent to the contains()/get() pair. Collapse the two
lookups into one.

The optimization relies on the invariant that a header present in the map never
stores a null value. To guard against that invariant silently breaking, assert
it in debug builds before relying on the isNull() check.

No change in behavior; covered by existing fetch tests.

* Source/WebCore/Modules/fetch/FetchHeaders.cpp:
(WebCore::appendToHeaderMap):

Canonical link: <a href="https://commits.webkit.org/317044@main">https://commits.webkit.org/317044@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2795f8e35d6e09504c788e5724d78ea95d5a273c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174187 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48120 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41901 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183761 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132055 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7951c6dd-9ab2-4b5e-8b13-6968532ad2db) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176052 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49412 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47802 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135483 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a0e0f74e-7090-493b-ad85-8987454364fa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177145 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38917 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156275 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115961 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/762803d6-a171-4754-a40a-e7c63a30cf2f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37557 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35926 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32245 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147981 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35768 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186187 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39351 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40124 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144389 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47787 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144249 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38880 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48466 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32388 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113978 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39154 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120372 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46972 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10730 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46375 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46606 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46433 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->