### PR TITLE
Add warning when OptionSet enum values are missing in serialization.in files

### DIFF
--- a/Source/WebCore/animation/WebAnimationTypes.h
+++ b/Source/WebCore/animation/WebAnimationTypes.h
@@ -66,7 +66,6 @@ using AnimatableCSSProperty = Variant<CSSPropertyID, AtomString>;
 using AnimatableCSSPropertyToTransitionMap = HashMap<AnimatableCSSProperty, Ref<CSSTransition>>;
 
 enum class AcceleratedEffectProperty : uint16_t {
-    Invalid = 1 << 0,
     Opacity = 1 << 1,
     Transform = 1 << 2,
     Translate = 1 << 3,

--- a/Source/WebCore/platform/animation/AcceleratedEffect.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.cpp
@@ -108,7 +108,7 @@ AcceleratedEffect::Keyframe AcceleratedEffect::Keyframe::clone() const
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(AcceleratedEffect);
 
-static AcceleratedEffectProperty acceleratedPropertyFromCSSProperty(AnimatableCSSProperty property, const Settings& settings)
+static OptionSet<AcceleratedEffectProperty> acceleratedPropertyFromCSSProperty(AnimatableCSSProperty property, const Settings& settings)
 {
 #if ASSERT_ENABLED
     ASSERT(Style::Interpolation::isAccelerated(property, settings));
@@ -145,7 +145,7 @@ static AcceleratedEffectProperty acceleratedPropertyFromCSSProperty(AnimatableCS
         return AcceleratedEffectProperty::BackdropFilter;
     default:
         ASSERT_NOT_REACHED();
-        return AcceleratedEffectProperty::Invalid;
+        return { };
     }
 }
 
@@ -257,7 +257,7 @@ AcceleratedEffect::AcceleratedEffect(const KeyframeEffect& effect, const IntRect
         for (auto animatedCSSProperty : srcKeyframe.properties()) {
             if (Style::Interpolation::isAccelerated(animatedCSSProperty, settings)) {
                 auto acceleratedProperty = acceleratedPropertyFromCSSProperty(animatedCSSProperty, settings);
-                if (disallowedProperties.contains(acceleratedProperty))
+                if (disallowedProperties.containsAny(acceleratedProperty))
                     continue;
                 animatedProperties.add(acceleratedProperty);
                 m_animatedProperties.add(acceleratedProperty);
@@ -412,9 +412,6 @@ static void blend(AcceleratedEffectProperty property, AcceleratedEffectValues& o
         break;
     case AcceleratedEffectProperty::BackdropFilter:
         output.backdropFilter = from.backdropFilter.blend(to.backdropFilter, blendingContext);
-        break;
-    case AcceleratedEffectProperty::Invalid:
-        ASSERT_NOT_REACHED();
         break;
     }
 }

--- a/Source/WebKit/Scripts/generate-serializers.py
+++ b/Source/WebKit/Scripts/generate-serializers.py
@@ -1553,9 +1553,19 @@ def generate_impl(serialized_types, serialized_enums, headers, generating_webkit
         result.append(f'template<> bool {enum.function_name()}<{enum.namespace_and_name()}>({enum.parameter()} value)')
         result.append('{')
         if enum.is_option_set():
+            result.append('    // Empty switch to catch missing values.')
+            result.append(f'    switch (static_cast<{enum.namespace_and_name()}>(value.toRaw())) {{')
+            for valid_value in enum.valid_values:
+                if valid_value.condition is not None:
+                    result.append(f'#if {valid_value.condition}')
+                result.append(f'    case {enum.namespace_and_name()}::{valid_value.name}:')
+                if valid_value.condition is not None:
+                    result.append('#endif')
+            result.append('        (void)0;')
+            result.append('    }')
+            result.append('')
             result.append(f'    constexpr {enum.underlying_type} allValidBitsValue = 0')
-            for i in range(0, len(enum.valid_values)):
-                valid_value = enum.valid_values[i]
+            for valid_value in enum.valid_values:
                 if valid_value.condition is not None:
                     result.append(f'#if {valid_value.condition}')
                 result.append(f'        | static_cast<{enum.underlying_type}>({enum.namespace_and_name()}::{valid_value.name})')

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
@@ -1662,6 +1662,19 @@ template<> bool isValidEnum<EnumNamespace::EnumType>(uint16_t value)
 
 template<> bool isValidOptionSet<EnumNamespace2::OptionSetEnumType>(OptionSet<EnumNamespace2::OptionSetEnumType> value)
 {
+    // Empty switch to catch missing values.
+    switch (static_cast<EnumNamespace2::OptionSetEnumType>(value.toRaw())) {
+    case EnumNamespace2::OptionSetEnumType::OptionSetFirstValue:
+#if ENABLE(OPTION_SET_SECOND_VALUE)
+    case EnumNamespace2::OptionSetEnumType::OptionSetSecondValue:
+#endif
+#if !(ENABLE(OPTION_SET_SECOND_VALUE))
+    case EnumNamespace2::OptionSetEnumType::OptionSetSecondValueElse:
+#endif
+    case EnumNamespace2::OptionSetEnumType::OptionSetThirdValue:
+        (void)0;
+    }
+
     constexpr uint8_t allValidBitsValue = 0
         | static_cast<uint8_t>(EnumNamespace2::OptionSetEnumType::OptionSetFirstValue)
 #if ENABLE(OPTION_SET_SECOND_VALUE)
@@ -1677,6 +1690,16 @@ template<> bool isValidOptionSet<EnumNamespace2::OptionSetEnumType>(OptionSet<En
 
 template<> bool isValidOptionSet<OptionSetEnumFirstCondition>(OptionSet<OptionSetEnumFirstCondition> value)
 {
+    // Empty switch to catch missing values.
+    switch (static_cast<OptionSetEnumFirstCondition>(value.toRaw())) {
+#if ENABLE(OPTION_SET_FIRST_VALUE)
+    case OptionSetEnumFirstCondition::OptionSetFirstValue:
+#endif
+    case OptionSetEnumFirstCondition::OptionSetSecondValue:
+    case OptionSetEnumFirstCondition::OptionSetThirdValue:
+        (void)0;
+    }
+
     constexpr uint32_t allValidBitsValue = 0
 #if ENABLE(OPTION_SET_FIRST_VALUE)
         | static_cast<uint32_t>(OptionSetEnumFirstCondition::OptionSetFirstValue)
@@ -1689,6 +1712,16 @@ template<> bool isValidOptionSet<OptionSetEnumFirstCondition>(OptionSet<OptionSe
 
 template<> bool isValidOptionSet<OptionSetEnumLastCondition>(OptionSet<OptionSetEnumLastCondition> value)
 {
+    // Empty switch to catch missing values.
+    switch (static_cast<OptionSetEnumLastCondition>(value.toRaw())) {
+    case OptionSetEnumLastCondition::OptionSetFirstValue:
+    case OptionSetEnumLastCondition::OptionSetSecondValue:
+#if ENABLE(OPTION_SET_THIRD_VALUE)
+    case OptionSetEnumLastCondition::OptionSetThirdValue:
+#endif
+        (void)0;
+    }
+
     constexpr uint32_t allValidBitsValue = 0
         | static_cast<uint32_t>(OptionSetEnumLastCondition::OptionSetFirstValue)
         | static_cast<uint32_t>(OptionSetEnumLastCondition::OptionSetSecondValue)
@@ -1701,6 +1734,20 @@ template<> bool isValidOptionSet<OptionSetEnumLastCondition>(OptionSet<OptionSet
 
 template<> bool isValidOptionSet<OptionSetEnumAllCondition>(OptionSet<OptionSetEnumAllCondition> value)
 {
+    // Empty switch to catch missing values.
+    switch (static_cast<OptionSetEnumAllCondition>(value.toRaw())) {
+#if ENABLE(OPTION_SET_FIRST_VALUE)
+    case OptionSetEnumAllCondition::OptionSetFirstValue:
+#endif
+#if ENABLE(OPTION_SET_SECOND_VALUE)
+    case OptionSetEnumAllCondition::OptionSetSecondValue:
+#endif
+#if ENABLE(OPTION_SET_THIRD_VALUE)
+    case OptionSetEnumAllCondition::OptionSetThirdValue:
+#endif
+        (void)0;
+    }
+
     constexpr uint32_t allValidBitsValue = 0
 #if ENABLE(OPTION_SET_FIRST_VALUE)
         | static_cast<uint32_t>(OptionSetEnumAllCondition::OptionSetFirstValue)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1574,15 +1574,18 @@ header: <WebCore/ScrollingStateNode.h>
     MinLayoutViewportOrigin
     MaxLayoutViewportOrigin
     OverrideVisualViewportSize
-    RelatedOverflowScrollingNodes
-    LayoutConstraintData
-    ViewportConstraints
-    ViewportAnchorLayer
-    OverflowScrollingNode
+#if USE(COORDINATED_GRAPHICS_ASYNC_SCROLLBAR)
+    ScrollbarOpacity
+#endif
+#    RelatedOverflowScrollingNodes - Duplicate value
+#    LayoutConstraintData - Duplicate value
+#    ViewportConstraints - Duplicate value
+#    ViewportAnchorLayer - Duplicate value
+#    OverflowScrollingNode - Duplicate value
     KeyboardScrollData
     OverlayScrollbarsEnabled
     ChildNodes
-    LayerHostingContextIdentifier
+#    LayerHostingContextIdentifier - Duplicate value
 };
 #endif
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationUtilities.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationUtilities.cpp
@@ -54,8 +54,6 @@ namespace WebKit {
 String toStringForTesting(WebCore::AcceleratedEffectProperty property)
 {
     switch (property) {
-    case WebCore::AcceleratedEffectProperty::Invalid:
-        return "invalid"_s;
     case WebCore::AcceleratedEffectProperty::Opacity:
         return "opacity"_s;
     case WebCore::AcceleratedEffectProperty::Transform:


### PR DESCRIPTION
#### 784d018fbec56db6387fd59aea1e060471f85706
<pre>
Add warning when OptionSet enum values are missing in serialization.in files
<a href="https://bugs.webkit.org/show_bug.cgi?id=318703">https://bugs.webkit.org/show_bug.cgi?id=318703</a>
<a href="https://rdar.apple.com/181517451">rdar://181517451</a>

Reviewed by Antoine Quint.

After 316565@main only one value was missing: AcceleratedEffectProperty::Invalid, which
is actually not needed at all.  Make acceleratedPropertyFromCSSProperty return an OptionSet
so we can return an empty set instead of a value in the theoretically impossible case.
WebCore::ScrollingStateNodeProperty has a few duplicate values, but that needs to stay,
so I left the values as comments.  The generator now makes an empty switch statement
to make a warning if we&apos;ve missed a value to protect against future mistakes.

* Source/WebCore/animation/WebAnimationTypes.h:
* Source/WebCore/platform/animation/AcceleratedEffect.cpp:
(WebCore::acceleratedPropertyFromCSSProperty):
(WebCore::AcceleratedEffect::AcceleratedEffect):
(WebCore::blend):
* Source/WebKit/Scripts/generate-serializers.py:
(generate_impl):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp:
(WTF::isValidOptionSet&lt;EnumNamespace2::OptionSetEnumType&gt;):
(WTF::isValidOptionSet&lt;OptionSetEnumFirstCondition&gt;):
(WTF::isValidOptionSet&lt;OptionSetEnumLastCondition&gt;):
(WTF::isValidOptionSet&lt;OptionSetEnumAllCondition&gt;):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationUtilities.cpp:
(WebKit::toStringForTesting):

Canonical link: <a href="https://commits.webkit.org/316630@main">https://commits.webkit.org/316630@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/88b1139676c6078cc97ea38ab35b80b4bbde647f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172865 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46784 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40254 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182325 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130421 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6e9afd49-2b8f-427c-8d6d-fe321b4355ae) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174730 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48077 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46460 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134438 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94897 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7185ac53-1f74-4ce3-b183-92c32e4fdf39) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175823 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37837 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155004 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114907 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/27b7b00e-c4fb-426d-92e0-28468d06693a) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/172186 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36482 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34800 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30922 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146905 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34509 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184859 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37604 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39002 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143249 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46455 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143121 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47133 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31340 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112135 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26258 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38113 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118893 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45650 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9452 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45051 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45283 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45109 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->