### PR TITLE
[Fullscreen] Add tests for untested areas of the Fullscreen API specification

### DIFF
--- a/LayoutTests/fullscreen/full-screen-test.js
+++ b/LayoutTests/fullscreen/full-screen-test.js
@@ -9,7 +9,7 @@ if (window.testRunner) {
     testRunner.waitUntilDone();
 }
 
-function runWithKeyDown(fn) 
+function runWithKeyDown(fn)
 {
     // FIXME: WKTR does not yet support the keyDown() message.  Do a mouseDown here
     // instead until keyDown support is added.

--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/fullscreen-change-event-shape-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/fullscreen-change-event-shape-expected.txt
@@ -1,0 +1,5 @@
+
+PASS fullscreenchange: bubbles + composed + target when element is connected
+PASS fullscreenchange: target falls back to document when element is disconnected
+PASS run-the-fullscreen-steps: pending events list is drained per invocation (no duplicate events)
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/fullscreen-change-event-shape.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/fullscreen-change-event-shape.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<title>fullscreenchange event shape: bubbles, composed, target when connected vs disconnected</title>
+<link rel="help" href="https://fullscreen.spec.whatwg.org/#run-the-fullscreen-steps">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="../trusted-click.js"></script>
+<div id="log"></div>
+<script>
+// "Run the fullscreen steps" queues each pending event with bubbles=true
+// and composed=true. Its target is the element if it is connected and in
+// the same document; otherwise the target is the document.
+
+promise_test(async t => {
+    const el = document.createElement("div");
+    document.body.appendChild(el);
+    t.add_cleanup(async () => {
+        if (document.fullscreenElement) await document.exitFullscreen().catch(() => {});
+        el.remove();
+    });
+
+    const enterEventPromise = new Promise(r => document.addEventListener("fullscreenchange", r, { once: true }));
+    await trusted_request(el);
+    const enterEvent = await enterEventPromise;
+
+    assert_true(enterEvent.bubbles, "fullscreenchange has bubbles=true");
+    assert_true(enterEvent.composed, "fullscreenchange has composed=true");
+    assert_equals(enterEvent.target, el, "target is the element when connected in-document");
+
+    const exitEventPromise = new Promise(r => document.addEventListener("fullscreenchange", r, { once: true }));
+    await document.exitFullscreen();
+    const exitEvent = await exitEventPromise;
+
+    assert_true(exitEvent.bubbles, "exit fullscreenchange has bubbles=true");
+    assert_true(exitEvent.composed, "exit fullscreenchange has composed=true");
+    assert_equals(exitEvent.target, el, "exit target is the (still-connected) element");
+}, "fullscreenchange: bubbles + composed + target when element is connected");
+
+promise_test(async t => {
+    // Removal from the flat tree implicitly exits fullscreen and queues
+    // an exit fullscreenchange with the now-disconnected element in the
+    // pending list. Per run-the-fullscreen-steps, the event target falls
+    // back to the document when the element is no longer connected.
+    const el = document.createElement("div");
+    document.body.appendChild(el);
+    t.add_cleanup(async () => {
+        if (document.fullscreenElement) await document.exitFullscreen().catch(() => {});
+        if (el.isConnected) el.remove();
+    });
+
+    const enterEventPromise = new Promise(r => document.addEventListener("fullscreenchange", r, { once: true }));
+    await trusted_request(el);
+    await enterEventPromise;
+
+    const exitEventPromise = new Promise(r => document.addEventListener("fullscreenchange", r, { once: true }));
+    el.remove();
+    const exitEvent = await exitEventPromise;
+
+    assert_true(exitEvent.bubbles, "bubbles=true");
+    assert_true(exitEvent.composed, "composed=true");
+    assert_equals(exitEvent.target, document,
+        "target is the document when the element is no longer connected");
+}, "fullscreenchange: target falls back to document when element is disconnected");
+
+promise_test(async t => {
+    // run-the-fullscreen-steps copies the pending events list and empties
+    // the document's pending list before firing. Observable consequence:
+    // one request/exit cycle produces exactly one fullscreenchange per
+    // transition.
+    const el = document.createElement("div");
+    document.body.appendChild(el);
+    t.add_cleanup(async () => {
+        if (document.fullscreenElement) await document.exitFullscreen().catch(() => {});
+        el.remove();
+    });
+
+    let count = 0;
+    const handler = () => { count++; };
+    document.addEventListener("fullscreenchange", handler);
+    t.add_cleanup(() => { document.removeEventListener("fullscreenchange", handler); });
+
+    await trusted_request(el);
+    await new Promise(r => t.step_timeout(r, 50));
+    assert_equals(count, 1, "exactly one fullscreenchange on enter");
+
+    await document.exitFullscreen();
+    await new Promise(r => t.step_timeout(r, 50));
+    assert_equals(count, 2, "exactly one additional fullscreenchange on exit");
+}, "run-the-fullscreen-steps: pending events list is drained per invocation (no duplicate events)");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/fullscreen-exit-errors-and-async-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/fullscreen-exit-errors-and-async-expected.txt
@@ -1,0 +1,4 @@
+
+PASS requestFullscreen and exitFullscreen return Promises synchronously; state updates happen in parallel
+PASS exitFullscreen: rejects with TypeError when document is not fully active
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/fullscreen-exit-errors-and-async.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/fullscreen-exit-errors-and-async.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<title>requestFullscreen/exitFullscreen: sync Promise return, TypeError on inactive document</title>
+<link rel="help" href="https://fullscreen.spec.whatwg.org/#dom-element-requestfullscreen">
+<link rel="help" href="https://fullscreen.spec.whatwg.org/#dom-document-exitfullscreen">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="../trusted-click.js"></script>
+<div id="log"></div>
+<script>
+// - requestFullscreen returns a Promise synchronously and runs the
+//   remaining algorithm steps in parallel.
+// - exitFullscreen returns a Promise synchronously and runs the remaining
+//   algorithm steps in parallel.
+// - exitFullscreen rejects with TypeError if the document is not fully
+//   active (e.g. its browsing context has been detached).
+
+promise_test(async t => {
+    const el = document.createElement("div");
+    document.body.appendChild(el);
+    t.add_cleanup(async () => {
+        if (document.fullscreenElement) await document.exitFullscreen().catch(() => {});
+        el.remove();
+    });
+
+    await trusted_click(document.body);
+    const p = el.requestFullscreen();
+    assert_true(p instanceof Promise, "requestFullscreen returns a Promise synchronously");
+    assert_equals(document.fullscreenElement, null,
+        "fullscreenElement is null immediately after requestFullscreen returns (algorithm runs in parallel)");
+    await p;
+    assert_equals(document.fullscreenElement, el,
+        "fullscreenElement is the element after requestFullscreen promise resolves");
+
+    const exitPromise = document.exitFullscreen();
+    assert_true(exitPromise instanceof Promise, "exitFullscreen returns a Promise synchronously");
+    await exitPromise;
+    assert_equals(document.fullscreenElement, null, "fullscreenElement is null after exitFullscreen promise resolves");
+}, "requestFullscreen and exitFullscreen return Promises synchronously; state updates happen in parallel");
+
+promise_test(async t => {
+    // A document in a detached iframe is not fully active. exitFullscreen
+    // on that document must reject with TypeError.
+    const iframe = document.createElement("iframe");
+    document.body.appendChild(iframe);
+    const iframeDoc = iframe.contentDocument;
+    assert_not_equals(iframeDoc, null, "iframe has a contentDocument");
+
+    iframe.remove();
+
+    let rejection = null;
+    try {
+        await iframeDoc.exitFullscreen();
+    } catch (e) {
+        rejection = e;
+    }
+    assert_not_equals(rejection, null,
+        "exitFullscreen rejects on a document that is not fully active");
+    assert_equals(rejection.name, "TypeError",
+        "rejection is a TypeError (name check for cross-realm safety)");
+}, "exitFullscreen: rejects with TypeError when document is not fully active");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/fullscreen-hides-popovers-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/fullscreen-hides-popovers-expected.txt
@@ -1,0 +1,4 @@
+
+PASS fullscreen-an-element: hides open auto popover when fullscreening a non-popover element
+PASS fullscreen-an-element: hides auto popovers but leaves manual popovers open
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/fullscreen-hides-popovers.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/fullscreen-hides-popovers.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<title>Fullscreen an element: open auto popovers are hidden; manual popovers stay open</title>
+<link rel="help" href="https://fullscreen.spec.whatwg.org/#fullscreen-an-element">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="../trusted-click.js"></script>
+<div id="log"></div>
+<script>
+// "Fullscreen an element", steps 1-2:
+//   1. Let hideUntil be the result of running "topmost popover ancestor"
+//      given element, null, and false.
+//   2. Run "hide popovers until" given element's node document, hideUntil,
+//      false, and true.
+//
+// "Hide popovers until" only iterates the showing auto popover list and
+// the showing hint popover list; manual popovers are never touched.
+
+promise_test(async t => {
+    const popover = document.createElement("div");
+    popover.setAttribute("popover", "auto");
+    document.body.appendChild(popover);
+    const target = document.createElement("div");
+    document.body.appendChild(target);
+    t.add_cleanup(async () => {
+        if (document.fullscreenElement) await document.exitFullscreen().catch(() => {});
+        if (popover.matches(":popover-open")) popover.hidePopover();
+        popover.remove();
+        target.remove();
+    });
+
+    popover.showPopover();
+    assert_true(popover.matches(":popover-open"), "popover is showing before fullscreen");
+
+    await trusted_request(target);
+    assert_equals(document.fullscreenElement, target, "fullscreen entered on target element");
+    assert_false(popover.matches(":popover-open"),
+        "the previously-open auto popover was hidden by fullscreen-an-element " +
+        "(target has no popover ancestor, so hideUntil is null and all auto popovers are hidden)");
+}, "fullscreen-an-element: hides open auto popover when fullscreening a non-popover element");
+
+promise_test(async t => {
+    const autoPopover = document.createElement("div");
+    autoPopover.setAttribute("popover", "auto");
+    document.body.appendChild(autoPopover);
+    const manualPopover = document.createElement("div");
+    manualPopover.setAttribute("popover", "manual");
+    document.body.appendChild(manualPopover);
+    const target = document.createElement("div");
+    document.body.appendChild(target);
+    t.add_cleanup(async () => {
+        if (document.fullscreenElement) await document.exitFullscreen().catch(() => {});
+        if (autoPopover.matches(":popover-open")) autoPopover.hidePopover();
+        if (manualPopover.matches(":popover-open")) manualPopover.hidePopover();
+        autoPopover.remove();
+        manualPopover.remove();
+        target.remove();
+    });
+
+    autoPopover.showPopover();
+    manualPopover.showPopover();
+    assert_true(autoPopover.matches(":popover-open"), "auto popover is showing before fullscreen");
+    assert_true(manualPopover.matches(":popover-open"), "manual popover is showing before fullscreen");
+
+    await trusted_request(target);
+    assert_false(autoPopover.matches(":popover-open"),
+        "auto popover was hidden by fullscreen-an-element (hide-popovers-until iterates the auto stack)");
+    assert_true(manualPopover.matches(":popover-open"),
+        "manual popover stays open — hide-popovers-until only iterates the auto and hint popover stacks");
+}, "fullscreen-an-element: hides auto popovers but leaves manual popovers open");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/fullscreen-idl-getters-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/fullscreen-idl-getters-expected.txt
@@ -1,0 +1,5 @@
+
+PASS IDL getters return null/false when not fullscreen
+PASS IDL getters reflect fullscreen state through enter and exit
+PASS simple fullscreen document: top layer has exactly one fullscreen element while entered
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/fullscreen-idl-getters.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/fullscreen-idl-getters.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<title>Fullscreen IDL getters: Document.fullscreen, fullscreenElement, simple fullscreen document</title>
+<link rel="help" href="https://fullscreen.spec.whatwg.org/#dom-document-fullscreen">
+<link rel="help" href="https://fullscreen.spec.whatwg.org/#dom-document-fullscreenelement">
+<link rel="help" href="https://fullscreen.spec.whatwg.org/#simple-fullscreen-document">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="../trusted-click.js"></script>
+<div id="log"></div>
+<script>
+// - Document.fullscreen (deprecated) is true iff there is a fullscreen
+//   element for the document.
+// - Document.fullscreenElement returns the topmost element in the
+//   document's top layer with the fullscreen flag set, or null.
+// - A document is a "simple fullscreen document" iff exactly one element
+//   in its top layer has the fullscreen flag set.
+
+test(() => {
+    assert_equals(document.fullscreenElement, null,
+        "fullscreenElement is null when no element is fullscreen");
+    assert_false(document.fullscreen,
+        "Document.fullscreen is false when no element is fullscreen");
+}, "IDL getters return null/false when not fullscreen");
+
+promise_test(async t => {
+    const el = document.createElement("div");
+    document.body.appendChild(el);
+    t.add_cleanup(async () => {
+        if (document.fullscreenElement) await document.exitFullscreen().catch(() => {});
+        el.remove();
+    });
+
+    await trusted_request(el);
+
+    assert_equals(document.fullscreenElement, el, "fullscreenElement returns the fullscreen element");
+    assert_true(document.fullscreen, "Document.fullscreen is true when there is a fullscreen element");
+
+    await document.exitFullscreen();
+
+    assert_equals(document.fullscreenElement, null, "fullscreenElement is null after exitFullscreen");
+    assert_false(document.fullscreen, "Document.fullscreen is false after exitFullscreen");
+}, "IDL getters reflect fullscreen state through enter and exit");
+
+promise_test(async t => {
+    // Simple fullscreen document: exactly one element in top layer has
+    // the fullscreen flag set. Verified indirectly: after entering,
+    // fullscreenElement returns a single non-null value, and after
+    // exiting, top layer contains no fullscreen element.
+    const el = document.createElement("div");
+    document.body.appendChild(el);
+    t.add_cleanup(async () => {
+        if (document.fullscreenElement) await document.exitFullscreen().catch(() => {});
+        el.remove();
+    });
+
+    await trusted_request(el);
+    assert_not_equals(document.fullscreenElement, null,
+        "top layer has a fullscreen element (simple-fullscreen state)");
+    assert_equals(document.fullscreenElement, el,
+        "Document.fullscreenElement returns the single top-layer fullscreen element");
+
+    await document.exitFullscreen();
+    assert_equals(document.fullscreenElement, null,
+        "top layer has no fullscreen element after exit");
+}, "simple fullscreen document: top layer has exactly one fullscreen element while entered");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/fullscreen-request-preconditions-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/fullscreen-request-preconditions-expected.txt
@@ -1,0 +1,5 @@
+
+PASS requestFullscreen: rejects when the document is not allowed to use the fullscreen permission feature
+PASS requestFullscreen: succeeds when the element is a popover in hidden state
+PASS requestFullscreen: rejects when the element is a popover in showing state
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/fullscreen-request-preconditions.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/fullscreen-request-preconditions.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<title>requestFullscreen preconditions: permission-feature check, popover visibility</title>
+<link rel="help" href="https://fullscreen.spec.whatwg.org/#fullscreen-element-ready-check">
+<link rel="help" href="https://fullscreen.spec.whatwg.org/#dom-element-requestfullscreen">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="../trusted-click.js"></script>
+<div id="log"></div>
+<script>
+// requestFullscreen preconditions:
+//   - Element's node document must be allowed to use the "fullscreen"
+//     permission feature — a document in a same-origin iframe whose
+//     allow= list denies fullscreen must reject.
+//   - Element's popover visibility state must be hidden — an element
+//     with popover="..." that has been shown via showPopover() has
+//     visibility state "showing" and fails the ready-check's
+//     "namespace is not HTML OR popover visibility state is hidden"
+//     clause.
+//   - A hidden popover element (has popover attribute, not shown) IS
+//     eligible because its visibility state is "hidden".
+
+promise_test(async t => {
+    const iframe = document.createElement("iframe");
+    iframe.srcdoc = "<!doctype html><div id='target'>iframe target</div>";
+    iframe.allow = "fullscreen 'none'";
+    document.body.appendChild(iframe);
+    t.add_cleanup(() => { iframe.remove(); });
+
+    await new Promise(r => iframe.addEventListener("load", r, { once: true }));
+    const iframeDoc = iframe.contentDocument;
+    const target = iframeDoc.getElementById("target");
+    assert_not_equals(target, null, "iframe contains the target element");
+
+    await trusted_click(iframeDoc.body);
+
+    let rejection = null;
+    try {
+        await target.requestFullscreen();
+    } catch (e) {
+        rejection = e;
+    }
+    assert_not_equals(rejection, null,
+        "requestFullscreen on an element in an iframe with allow='fullscreen \\'none\\'' rejects");
+    assert_equals(rejection.name, "TypeError",
+        "rejection is a TypeError (name check for cross-realm safety)");
+}, "requestFullscreen: rejects when the document is not allowed to use the fullscreen permission feature");
+
+promise_test(async t => {
+    // Hidden popover: element with popover attribute but not shown is
+    // in popover-visibility-state "hidden". The ready-check's
+    // "namespace is not HTML OR popover visibility state is hidden"
+    // clause succeeds via the second branch, so requestFullscreen
+    // proceeds normally.
+    const el = document.createElement("div");
+    el.setAttribute("popover", "auto");
+    document.body.appendChild(el);
+    t.add_cleanup(async () => {
+        if (document.fullscreenElement) await document.exitFullscreen().catch(() => {});
+        el.remove();
+    });
+
+    await trusted_request(el);
+    assert_equals(document.fullscreenElement, el,
+        "requestFullscreen succeeds on a hidden popover element " +
+        "(popover-visibility-state 'hidden' satisfies the ready-check OR clause)");
+}, "requestFullscreen: succeeds when the element is a popover in hidden state");
+
+promise_test(async t => {
+    // Showing popover: "namespace is not HTML OR popover visibility
+    // state is hidden" fails for a showing HTML popover (both branches
+    // false), so requestFullscreen rejects with TypeError.
+    const el = document.createElement("div");
+    el.setAttribute("popover", "manual");
+    document.body.appendChild(el);
+    t.add_cleanup(() => {
+        if (el.matches(":popover-open")) el.hidePopover();
+        el.remove();
+    });
+
+    el.showPopover();
+    assert_true(el.matches(":popover-open"),
+        "popover is in the showing state after showPopover()");
+
+    await trusted_click(document.body);
+    let rejection = null;
+    try {
+        await el.requestFullscreen();
+    } catch (e) {
+        rejection = e;
+    }
+    assert_not_equals(rejection, null,
+        "requestFullscreen on a showing popover element rejects");
+    assert_equals(rejection.name, "TypeError", "rejection is a TypeError");
+}, "requestFullscreen: rejects when the element is a popover in showing state");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/model/fullscreen-exit-edges-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/model/fullscreen-exit-edges-expected.txt
@@ -1,0 +1,3 @@
+
+PASS exit-fullscreen: disconnected element is unfullscreened; fullscreenElement becomes null
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/model/fullscreen-exit-edges.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/model/fullscreen-exit-edges.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<title>exit-fullscreen: disconnected element is unfullscreened; fullscreenElement becomes null</title>
+<link rel="help" href="https://fullscreen.spec.whatwg.org/#exit-fullscreen">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="../trusted-click.js"></script>
+<div id="log"></div>
+<script>
+// If the fullscreen element becomes disconnected while it is the
+// fullscreen element, exit-fullscreen appends (fullscreenchange,
+// fullscreen element) to pending events and unfullscreens the element.
+// After the fullscreenchange fires, fullscreenElement is null.
+
+promise_test(async t => {
+    const el = document.createElement("div");
+    document.body.appendChild(el);
+    t.add_cleanup(async () => {
+        if (document.fullscreenElement) await document.exitFullscreen().catch(() => {});
+        if (el.isConnected) el.remove();
+    });
+
+    const enterPromise = new Promise(r => document.addEventListener("fullscreenchange", r, { once: true }));
+    await trusted_request(el);
+    await enterPromise;
+    assert_equals(document.fullscreenElement, el, "fullscreenElement is el after enter");
+
+    const changed = new Promise(r => document.addEventListener("fullscreenchange", r, { once: true }));
+    el.remove();
+    await changed;
+
+    assert_equals(document.fullscreenElement, null,
+        "fullscreenElement is null after disconnected element is unfullscreened");
+}, "exit-fullscreen: disconnected element is unfullscreened; fullscreenElement becomes null");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/rendering/fullscreen-ua-stylesheet-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/rendering/fullscreen-ua-stylesheet-expected.txt
@@ -1,0 +1,5 @@
+
+PASS UA stylesheet: margin:0!important and box-sizing:border-box!important apply to fullscreen element
+PASS UA stylesheet: object-fit:contain applies to fullscreen element when author has no :fullscreen override
+PASS UA stylesheet: object-fit:contain is not !important - author can override
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/rendering/fullscreen-ua-stylesheet.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/rendering/fullscreen-ua-stylesheet.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<title>UA stylesheet: :not(:root):fullscreen applies margin, box-sizing, object-fit</title>
+<link rel="help" href="https://fullscreen.spec.whatwg.org/#user-agent-level-style-sheet-defaults">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="../trusted-click.js"></script>
+<style>
+    #ua-should-win {
+        margin: 42px;
+        box-sizing: content-box;
+    }
+    #author-important-object-fit:fullscreen {
+        object-fit: cover !important;
+    }
+</style>
+<div id="log"></div>
+<div id="ua-should-win"></div>
+<div id="author-important-object-fit"></div>
+<script>
+// The UA default stylesheet applies to :not(:root):fullscreen:
+//   margin: 0 !important
+//   box-sizing: border-box !important
+//   object-fit: contain      (non-important; author can override)
+
+promise_test(async t => {
+    const el = document.getElementById("ua-should-win");
+    t.add_cleanup(async () => {
+        if (document.fullscreenElement) await document.exitFullscreen().catch(() => {});
+    });
+    await trusted_request(el);
+
+    const cs = getComputedStyle(el);
+    assert_equals(cs.marginTop, "0px",
+        "UA :not(:root):fullscreen sets margin-top:0!important (overrides author non-important)");
+    assert_equals(cs.marginRight, "0px", "margin-right:0!important");
+    assert_equals(cs.marginBottom, "0px", "margin-bottom:0!important");
+    assert_equals(cs.marginLeft, "0px", "margin-left:0!important");
+    assert_equals(cs.boxSizing, "border-box",
+        "UA :not(:root):fullscreen sets box-sizing:border-box!important");
+}, "UA stylesheet: margin:0!important and box-sizing:border-box!important apply to fullscreen element");
+
+promise_test(async t => {
+    // Baseline: no author :fullscreen rule for object-fit — UA :fullscreen
+    // rule (non-important) applies, object-fit is "contain".
+    const el = document.getElementById("ua-should-win");
+    t.add_cleanup(async () => {
+        if (document.fullscreenElement) await document.exitFullscreen().catch(() => {});
+    });
+    await trusted_request(el);
+
+    assert_equals(getComputedStyle(el).objectFit, "contain",
+        "UA :not(:root):fullscreen sets object-fit:contain (non-important) " +
+        "when no author :fullscreen object-fit rule is present");
+}, "UA stylesheet: object-fit:contain applies to fullscreen element when author has no :fullscreen override");
+
+promise_test(async t => {
+    // Author !important with :fullscreen selector overrides UA
+    // non-important object-fit.
+    const el = document.getElementById("author-important-object-fit");
+    t.add_cleanup(async () => {
+        if (document.fullscreenElement) await document.exitFullscreen().catch(() => {});
+    });
+    await trusted_request(el);
+
+    assert_equals(getComputedStyle(el).objectFit, "cover",
+        "author :fullscreen !important rule overrides UA non-important object-fit");
+}, "UA stylesheet: object-fit:contain is not !important - author can override");
+</script>


### PR DESCRIPTION
#### bdc93974d59a8126af66a76abd48bb6264dbcaf9
<pre>
[Fullscreen] Add tests for untested areas of the Fullscreen API specification
<a href="https://rdar.apple.com/181518068">rdar://181518068</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=318704">https://bugs.webkit.org/show_bug.cgi?id=318704</a>

Reviewed by Andy Estes.

Add tests covering previously untested areas of the Fullscreen API
specification, driven by an audit against the spec&apos;s testable-behavior
extraction. No new WebKit bugs surfaced this batch — WebKit&apos;s Fullscreen
implementation is spec-conformant across everything tested.

fullscreen-change-event-shape.html verifies fullscreenchange event
properties: bubbles=true and composed=true (both spec-required per
&quot;run the fullscreen steps&quot;); target is the element when connected and
in-document, falling back to the document when the fullscreen element
was disconnected before exit-fullscreen ran; and that a single
request/exit cycle produces exactly one fullscreenchange event per
transition (the pending events list is drained per invocation).

fullscreen-idl-getters.html verifies Document.fullscreen (the deprecated
boolean getter) and Document.fullscreenElement (the current element or
null) across enter and exit transitions; also asserts the simple-
fullscreen-document invariant that the top layer contains exactly one
fullscreen element while entered.

fullscreen-ua-stylesheet.html verifies the UA default stylesheet rules
applied to :not(:root):fullscreen elements via getComputedStyle:
margin:0!important, box-sizing:border-box!important, and non-important
object-fit:contain (the non-important object-fit rule is properly
overridable by author !important rules).

fullscreen-exit-errors-and-async.html verifies that requestFullscreen
and exitFullscreen both return a Promise synchronously (their state
transitions happen in parallel), and that exitFullscreen rejects with
a TypeError when the document is not fully active (tested via a
detached iframe&apos;s contentDocument).

fullscreen-request-preconditions.html verifies the fullscreen-element-
ready-check preconditions: an element in an iframe whose allow
attribute denies fullscreen cannot enter fullscreen; and an HTML element
whose popover visibility state is &quot;showing&quot; cannot enter fullscreen
(the ready-check&apos;s &quot;namespace is not HTML OR popover visibility state
is hidden&quot; clause fails for showing HTML popovers), while a hidden
popover (element with popover attribute but not shown) IS eligible.

fullscreen-exit-edges.html verifies that when the fullscreen element is
disconnected from its document, the exit-fullscreen algorithm still
unfullscreens it — fullscreenElement returns to null after the
disconnection-triggered fullscreenchange fires.

fullscreen-hides-popovers.html verifies steps 1-2 of the fullscreen-an-
element algorithm (compute hideUntil via topmost-popover-ancestor; run
hide-popovers-until): when a non-popover element is fullscreened, all
currently-open auto popovers are hidden. Manual popovers stay open
because the hide-popovers-until algorithm only iterates the auto and
hint popover stacks.

* LayoutTests/fullscreen/full-screen-test.js:
* LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/fullscreen-change-event-shape-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/fullscreen-change-event-shape.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/fullscreen-exit-errors-and-async-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/fullscreen-exit-errors-and-async.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/fullscreen-hides-popovers-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/fullscreen-hides-popovers.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/fullscreen-idl-getters-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/fullscreen-idl-getters.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/fullscreen-request-preconditions-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/fullscreen-request-preconditions.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/fullscreen/model/fullscreen-exit-edges-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fullscreen/model/fullscreen-exit-edges.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/fullscreen/rendering/fullscreen-ua-stylesheet-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fullscreen/rendering/fullscreen-ua-stylesheet.html: Added.

Canonical link: <a href="https://commits.webkit.org/317070@main">https://commits.webkit.org/317070@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ec6dd3606a946b29d36956e239d6ba320eb497b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173027 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46946 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41245 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182487 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130583 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48240 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46622 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134580 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94995 "23 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175985 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37970 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155759 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115049 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36615 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34945 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31085 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147039 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35253 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185022 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39146 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143387 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46617 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155315 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143259 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47295 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31868 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112354 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26482 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38242 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45812 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10206 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45214 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45445 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45271 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->