### PR TITLE
[JSC] Push ArrayBuffer m_locked into the pinCount

### DIFF
--- a/Source/JavaScriptCore/runtime/ArrayBuffer.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayBuffer.cpp
@@ -433,14 +433,15 @@ RefPtr<ArrayBuffer> ArrayBuffer::sliceWithClampedIndex(size_t begin, size_t end)
 void ArrayBuffer::makeShared()
 {
     m_contents.makeShared();
-    m_locked = true;
+    pinAndLock();
     ASSERT(!isDetached());
 }
 
 void ArrayBuffer::makeWasmMemory()
 {
-    m_locked = true;
     m_isWasmMemory = true;
+    pinAndLock();
+    ASSERT(!isDetachable());
 }
 
 void ArrayBuffer::refreshAfterWasmMemoryGrow(Wasm::Memory* memory)

--- a/Source/JavaScriptCore/runtime/ArrayBuffer.h
+++ b/Source/JavaScriptCore/runtime/ArrayBuffer.h
@@ -282,8 +282,10 @@ public:
     inline void pin();
     inline void unpin();
     inline bool isDetachable() const;
+    // Calling this prevents the backing buffer from ever being detached. This can happen when an
+    // API user fetched m_contents directly from a TypedArray object, the buffer is backed by a
+    // WebAssembly.Memory, or is a SharedArrayBuffer.
     inline void pinAndLock();
-    inline bool isLocked();
 
     void NODELETE makeWasmMemory();
     inline bool isWasmMemory();
@@ -327,11 +329,9 @@ private:
 public:
     Weak<JSArrayBuffer> m_wrapper;
 private:
+    static constexpr unsigned s_lockedFlag = INT32_MIN;
     Checked<unsigned> m_pinCount { 0 };
     bool m_isWasmMemory { false };
-    // m_locked == true means that some API user fetched m_contents directly from a TypedArray object,
-    // the buffer is backed by a WebAssembly.Memory, or is a SharedArrayBuffer.
-    bool m_locked { false };
 };
 
 void* ArrayBuffer::data() LIFETIME_BOUND
@@ -382,22 +382,19 @@ void ArrayBuffer::pin()
 
 void ArrayBuffer::unpin()
 {
+    unsigned old = m_pinCount;
     m_pinCount--;
+    m_pinCount |= (old & s_lockedFlag);
 }
 
 bool ArrayBuffer::isDetachable() const
 {
-    return !m_pinCount && !m_locked && !isShared();
+    return !m_pinCount && !isShared();
 }
 
 void ArrayBuffer::pinAndLock()
 {
-    m_locked = true;
-}
-
-bool ArrayBuffer::isLocked()
-{
-    return m_locked;
+    m_pinCount |= s_lockedFlag;
 }
 
 bool ArrayBuffer::isWasmMemory()

--- a/Source/WTF/wtf/CheckedArithmetic.h
+++ b/Source/WTF/wtf/CheckedArithmetic.h
@@ -734,6 +734,20 @@ public:
         return *this;
     }
 
+    template<typename U> Checked& operator|=(U rhs)
+    {
+        // Bitwise operators can't overflow.
+        m_value |= rhs;
+        return *this;
+    }
+
+    template<typename U> Checked& operator&=(U rhs)
+    {
+        // Bitwise operators can't overflow.
+        m_value &= rhs;
+        return *this;
+    }
+
     template<typename U> Checked& operator/=(U rhs)
     {
         if (!safeDivide<OverflowHandler>(m_value, rhs, m_value))
@@ -760,6 +774,20 @@ public:
         if (rhs.hasOverflowed())
             this->overflowed();
         return *this *= rhs.m_value;
+    }
+
+    template<typename U, typename V> Checked& operator|=(Checked<U, V> rhs)
+    {
+        if (rhs.hasOverflowed())
+            this->overflowed();
+        return *this |= rhs.m_value;
+    }
+
+    template<typename U, typename V> Checked& operator&=(Checked<U, V> rhs)
+    {
+        if (rhs.hasOverflowed())
+            this->overflowed();
+        return *this &= rhs.m_value;
     }
 
     // Equality comparisons


### PR DESCRIPTION
#### 238d63ac9ef54a2b8dbe7634a64664fd8df946c7
<pre>
[JSC] Push ArrayBuffer m_locked into the pinCount
<a href="https://bugs.webkit.org/show_bug.cgi?id=318706">https://bugs.webkit.org/show_bug.cgi?id=318706</a>
<a href="https://rdar.apple.com/181518238">rdar://181518238</a>

Reviewed by Yusuke Suzuki.

Having a separate lock bit is somewhat confusing and makes the
isDetachable check more complex. Prevent underflowing the lock bit in
the pin by restoring it after any unpin for extra hardening.

No new tests, no behavior change. Covered by existing tests.

Canonical link: <a href="https://commits.webkit.org/316641@main">https://commits.webkit.org/316641@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94753913fe3e91627017e87fb8cd7ceadeb9e20e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173026 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46945 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40420 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182486 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130582 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48239 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46621 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134581 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175984 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37972 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/155159 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115050 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36617 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34947 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31084 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/3676 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147041 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34659 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185021 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/34288 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37803 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39148 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143390 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46616 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143262 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47294 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112350 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26264 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38244 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119054 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/206768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45811 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9602 "Passed tests") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/206768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45213 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45444 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45270 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->