### PR TITLE
[webkit-bot] Route the revert and rollout commands through git-webkit when USE_GIT_WEBKIT_REVERT is enabled

### DIFF
--- a/Tools/WebKitBot/src/WebKitBot.mjs
+++ b/Tools/WebKitBot/src/WebKitBot.mjs
@@ -270,9 +270,10 @@ e.g. \`dry-revert 260220 Ensure it is working after refactoring\`
     {
         let {revisions, reason} = extractRevisionsAndReason(args);
 
-        // For revert-with-pr, check if the "reason" is actually a bug URL
+        // For PR-based reverts (revert-with-pr, or revert/rollout when the
+        // git-webkit flag is on), check if the "reason" is actually a bug URL.
         let issueUrl = null;
-        if (usePR && reason) {
+        if ((usePR || process.env.USE_GIT_WEBKIT_REVERT === "true") && reason) {
             let bugId = parseBugId(reason);
             if (bugId) {
                 issueUrl = `https://bugs.webkit.org/show_bug.cgi?id=${bugId}`;
@@ -698,6 +699,9 @@ Type \`help COMMAND\` for help on my individual commands.`,
 
     async generateRevertingPatch(revisions, reason, issueUrl = null)
     {
+        if (process.env.USE_GIT_WEBKIT_REVERT === "true")
+            return this.generateRevertingPatchWithGitWebkit(revisions, reason, issueUrl);
+
         dataLogLn("Reverting ", revisions, reason);
         let revisionsArgument = revisions.join(" ");
 
@@ -762,8 +766,8 @@ Type \`help COMMAND\` for help on my individual commands.`,
         dataLogLn(task);
         switch (task.command) {
         case "revert": {
-            let {revisions, reason} = task;
-            return this.generateRevertingPatch(revisions, reason);
+            let {revisions, reason, issueUrl} = task;
+            return this.generateRevertingPatch(revisions, reason, issueUrl);
         }
         case "revert-with-pr": {
             let {revisions, reason, issueUrl} = task;


### PR DESCRIPTION
#### 9f895898189e7e34e5750971e58827056bdb0ee9
<pre>
[webkit-bot] Route the revert and rollout commands through git-webkit when USE_GIT_WEBKIT_REVERT is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=318281">https://bugs.webkit.org/show_bug.cgi?id=318281</a>
<a href="https://rdar.apple.com/181070392">rdar://181070392</a>

Reviewed by Aakash Jain.

The revert-with-pr command creates reverts as GitHub PRs via git-webkit, but the revert and
rollout commands still always use the webkit-patch (Bugzilla) flow. Gate generateRevertingPatch()
so that when USE_GIT_WEBKIT_REVERT is enabled, revert and rollout produce git-webkit PRs.

* Tools/WebKitBot/src/WebKitBot.mjs:
- generateRevertingPatch: When USE_GIT_WEBKIT_REVERT is enabled, delegate to
  generateRevertingPatchWithGitWebkit instead of using webkit-patch.
- revertCommand: Detect a bug URL argument when the flag is enabled (not only for
  revert-with-pr), so revert and rollout can also reuse an existing bug.
- action: Thread issueUrl through the &quot;revert&quot; task case.

Canonical link: <a href="https://commits.webkit.org/316743@main">https://commits.webkit.org/316743@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/843a816a1876a708787b7cc1f056e6fcc63f06c4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172851 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46770 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40240 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182311 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130407 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3e3c8865-9e43-45fd-bb1f-2a05ec898f8d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174716 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48063 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46446 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134430 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94891 "21 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/08157b92-cace-4134-9324-9d50c32613d6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175809 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37832 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154998 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.CrossProcessHistoryTraversalCoalesce (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114899 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4efff857-332f-44ac-b904-28c7bb75f5c0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36477 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34793 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30908 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146900 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34503 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184845 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38995 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143237 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46441 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143109 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47119 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31334 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112121 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26320 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38105 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45636 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9446 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45037 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45269 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45095 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->