### PR TITLE
Rename PDFDocument to PDFJSDocument

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1653,7 +1653,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     html/OffscreenCanvas.h
     html/Origin.h
     html/OwnerPermissionsPolicyData.h
-    html/PDFDocument.h
+    html/PDFJSDocument.h
     html/PermissionsPolicy.h
     html/PluginDocument.h
     html/ResolvedCaptionDisplaySettingsOptions.h

--- a/Source/WebCore/PlatformCocoa.cmake
+++ b/Source/WebCore/PlatformCocoa.cmake
@@ -791,7 +791,7 @@ list(REMOVE_ITEM WebCore_PRIVATE_FRAMEWORK_HEADERS
     html/HTMLArticleElement.h
     html/HTMLAudioElement.h
     html/Origin.h
-    html/PDFDocument.h
+    html/PDFJSDocument.h
 
     layout/FormattingState.h
 

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1713,7 +1713,7 @@ html/NavigatorUserActivation.cpp
 html/NumberInputType.cpp @header:RenderStyleGetters @cost:6
 html/OffscreenCanvas.cpp
 html/Origin.cpp
-html/PDFDocument.cpp
+html/PDFJSDocument.cpp
 html/PasswordInputType.cpp
 html/PermissionsPolicy.cpp
 html/PluginDocument.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -12223,8 +12223,8 @@
 		494BD79C0F55C94C00747828 /* JSWebKitPoint.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSWebKitPoint.h; sourceTree = "<group>"; };
 		494BDBDC2E16156A0079E324 /* FindRevealAlgorithms.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FindRevealAlgorithms.h; sourceTree = "<group>"; };
 		494BDBDD2E16156A0079E324 /* FindRevealAlgorithms.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = FindRevealAlgorithms.cpp; sourceTree = "<group>"; };
-		494EBD0627AA9C5300F4844F /* PDFDocument.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PDFDocument.h; sourceTree = "<group>"; };
-		494EBD0827AA9C5300F4844F /* PDFDocument.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = PDFDocument.cpp; sourceTree = "<group>"; };
+		494EBD0627AA9C5300F4844F /* PDFJSDocument.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PDFJSDocument.h; sourceTree = "<group>"; };
+		494EBD0827AA9C5300F4844F /* PDFJSDocument.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = PDFJSDocument.cpp; sourceTree = "<group>"; };
 		4958781F12A57DDF007238AC /* PlatformCAAnimationCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = PlatformCAAnimationCocoa.mm; sourceTree = "<group>"; };
 		4958782012A57DDF007238AC /* PlatformCALayerCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = PlatformCALayerCocoa.mm; sourceTree = "<group>"; };
 		4958F02D2FC903F3008AF649 /* CSSColorImageValue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CSSColorImageValue.h; sourceTree = "<group>"; };
@@ -33460,8 +33460,8 @@
 				3AD4AB892C3CABCD00A3E7F3 /* OwnerPermissionsPolicyData.h */,
 				F55B3D951251F12D003EF269 /* PasswordInputType.cpp */,
 				F55B3D961251F12D003EF269 /* PasswordInputType.h */,
-				494EBD0827AA9C5300F4844F /* PDFDocument.cpp */,
-				494EBD0627AA9C5300F4844F /* PDFDocument.h */,
+				494EBD0827AA9C5300F4844F /* PDFJSDocument.cpp */,
+				494EBD0627AA9C5300F4844F /* PDFJSDocument.h */,
 				41A0829B22932EF4008426E0 /* PermissionsPolicy.cpp */,
 				41A0829922932EF4008426E0 /* PermissionsPolicy.h */,
 				97205AB91239292700B17380 /* PluginDocument.cpp */,

--- a/Source/WebCore/dom/DOMImplementation.cpp
+++ b/Source/WebCore/dom/DOMImplementation.cpp
@@ -46,7 +46,7 @@
 #include "MediaPlayer.h"
 #include "MediaQueryParser.h"
 #include "NameValidation.h"
-#include "PDFDocument.h"
+#include "PDFJSDocument.h"
 #include "ParserContentPolicy.h"
 #include "PluginData.h"
 #include "PluginDocument.h"
@@ -174,7 +174,7 @@ Ref<Document> DOMImplementation::createDocument(const String& contentType, Local
 
 #if ENABLE(PDFJS)
     if (frame && settings.pdfJSViewerEnabled() && MIMETypeRegistry::isPDFMIMEType(contentType))
-        return PDFDocument::create(*frame, url);
+        return PDFJSDocument::create(*frame, url);
 #endif
 
     bool isImage = MIMETypeRegistry::isSupportedImageMIMEType(contentType);

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -690,7 +690,7 @@ public:
 #if ENABLE(MODEL_ELEMENT)
     bool isModelDocument() const { return m_documentClasses.contains(DocumentClass::Model); }
 #endif
-    bool isPDFDocument() const { return m_documentClasses.contains(DocumentClass::PDF); }
+    bool isPDFJSDocument() const { return m_documentClasses.contains(DocumentClass::PDFJS); }
 
     bool NODELETE hasSVGRootNode() const;
     virtual bool isFrameSet() const { return false; }

--- a/Source/WebCore/dom/DocumentClasses.h
+++ b/Source/WebCore/dom/DocumentClasses.h
@@ -41,7 +41,7 @@ enum class DocumentClass : uint16_t {
 #if ENABLE(MODEL_ELEMENT)
     Model = 1 << 8,
 #endif
-    PDF = 1 << 9,
+    PDFJS = 1 << 9,
 };
 
 using DocumentClasses = OptionSet<DocumentClass>;

--- a/Source/WebCore/dom/EventListener.h
+++ b/Source/WebCore/dom/EventListener.h
@@ -47,7 +47,7 @@ public:
         GObjectEventListenerType,
         NativeEventListenerType,
         SVGTRefTargetEventListenerType,
-        PDFDocumentEventListenerType,
+        PDFJSDocumentEventListenerType,
     };
 
     virtual ~EventListener() = default;

--- a/Source/WebCore/html/PDFJSDocument.cpp
+++ b/Source/WebCore/html/PDFJSDocument.cpp
@@ -23,7 +23,7 @@
  */
 
 #include "config.h"
-#include "PDFDocument.h"
+#include "PDFJSDocument.h"
 
 #if ENABLE(PDFJS)
 
@@ -55,57 +55,57 @@
 
 namespace WebCore {
 
-WTF_MAKE_TZONE_ALLOCATED_IMPL(PDFDocument);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PDFJSDocument);
 
 using namespace HTMLNames;
 
-/* PDFDocumentParser: this receives the PDF bytes */
+/* PDFJSDocumentParser: this receives the PDF bytes */
 
-class PDFDocumentParser final : public RawDataDocumentParser {
+class PDFJSDocumentParser final : public RawDataDocumentParser {
 public:
-    static Ref<PDFDocumentParser> create(PDFDocument& document)
+    static Ref<PDFJSDocumentParser> create(PDFJSDocument& document)
     {
-        return adoptRef(*new PDFDocumentParser(document));
+        return adoptRef(*new PDFJSDocumentParser(document));
     }
 
 private:
-    explicit PDFDocumentParser(PDFDocument& document)
+    explicit PDFJSDocumentParser(PDFJSDocument& document)
         : RawDataDocumentParser(document)
     {
     }
 
-    PDFDocument& document() const;
+    PDFJSDocument& document() const;
 
     void appendBytes(DocumentWriter&, std::span<const uint8_t>) override;
     void finish() override;
 };
 
-inline PDFDocument& PDFDocumentParser::document() const
+inline PDFJSDocument& PDFJSDocumentParser::document() const
 {
     // Only used during parsing, so document is guaranteed to be non-null.
     ASSERT(RawDataDocumentParser::document());
-    return downcast<PDFDocument>(*RawDataDocumentParser::document());
+    return downcast<PDFJSDocument>(*RawDataDocumentParser::document());
 }
 
-void PDFDocumentParser::appendBytes(DocumentWriter&, std::span<const uint8_t>)
+void PDFJSDocumentParser::appendBytes(DocumentWriter&, std::span<const uint8_t>)
 {
     document().updateDuringParsing();
 }
 
-void PDFDocumentParser::finish()
+void PDFJSDocumentParser::finish()
 {
     document().finishedParsing();
 }
 
-/* PDFDocumentEventListener: event listener for the PDFDocument iframe */
+/* PDFJSDocumentEventListener: event listener for the PDFJSDocument iframe */
 
-class PDFDocumentEventListener final : public EventListener {
+class PDFJSDocumentEventListener final : public EventListener {
 public:
-    static Ref<PDFDocumentEventListener> create(PDFDocument& document) { return adoptRef(*new PDFDocumentEventListener(document)); }
+    static Ref<PDFJSDocumentEventListener> create(PDFJSDocument& document) { return adoptRef(*new PDFJSDocumentEventListener(document)); }
 
 private:
-    explicit PDFDocumentEventListener(PDFDocument& document)
-        : EventListener(PDFDocumentEventListenerType)
+    explicit PDFJSDocumentEventListener(PDFJSDocument& document)
+        : EventListener(PDFJSDocumentEventListenerType)
         , m_document(document)
     {
     }
@@ -113,10 +113,10 @@ private:
     bool operator==(const EventListener&) const override;
     void handleEvent(ScriptExecutionContext&, Event&) override;
 
-    WeakPtr<PDFDocument, WeakPtrImplWithEventTargetData> m_document;
+    WeakPtr<PDFJSDocument, WeakPtrImplWithEventTargetData> m_document;
 };
 
-void PDFDocumentEventListener::handleEvent(ScriptExecutionContext&, Event& event)
+void PDFJSDocumentEventListener::handleEvent(ScriptExecutionContext&, Event& event)
 {
     if (is<HTMLIFrameElement>(event.target()) && event.type() == eventNames().loadEvent) {
         m_document->injectStyleAndContentScript();
@@ -128,27 +128,27 @@ void PDFDocumentEventListener::handleEvent(ScriptExecutionContext&, Event& event
         ASSERT_NOT_REACHED();
 }
 
-bool PDFDocumentEventListener::operator==(const EventListener& other) const
+bool PDFJSDocumentEventListener::operator==(const EventListener& other) const
 {
-    // All PDFDocumentEventListenerType objects compare as equal; OK since there is only one per document.
-    return other.type() == PDFDocumentEventListenerType;
+    // All PDFJSDocumentEventListenerType objects compare as equal; OK since there is only one per document.
+    return other.type() == PDFJSDocumentEventListenerType;
 }
 
-/* PDFDocument */
+/* PDFJSDocument */
 
-PDFDocument::PDFDocument(LocalFrame& frame, const URL& url)
-    : HTMLDocument(&frame, frame.settings(), url, { }, { DocumentClass::PDF })
+PDFJSDocument::PDFJSDocument(LocalFrame& frame, const URL& url)
+    : HTMLDocument(&frame, frame.settings(), url, { }, { DocumentClass::PDFJS })
 {
 }
 
-PDFDocument::~PDFDocument() = default;
+PDFJSDocument::~PDFJSDocument() = default;
 
-Ref<DocumentParser> PDFDocument::createParser()
+Ref<DocumentParser> PDFJSDocument::createParser()
 {
-    return PDFDocumentParser::create(*this);
+    return PDFJSDocumentParser::create(*this);
 }
 
-void PDFDocument::createDocumentStructure()
+void PDFJSDocument::createDocumentStructure()
 {
     // Description of parameters:
     // - Empty `?file=` parameter prevents default pdf from loading.
@@ -166,19 +166,19 @@ void PDFDocument::createDocumentStructure()
     m_iframe->setAttribute(srcAttr, AtomString(viewerURL));
     m_iframe->setAttribute(styleAttr, "width: 100%; height: 100%; border: 0; display: block;"_s);
 
-    m_listener = PDFDocumentEventListener::create(*this);
+    m_listener = PDFJSDocumentEventListener::create(*this);
     m_iframe->addEventListener(eventNames().loadEvent, *m_listener);
 
     body->appendChild(*m_iframe);
 }
 
-void PDFDocument::updateDuringParsing()
+void PDFJSDocument::updateDuringParsing()
 {
     if (!m_iframe)
         createDocumentStructure();
 }
 
-void PDFDocument::finishedParsing()
+void PDFJSDocument::finishedParsing()
 {
     ASSERT(m_iframe);
     m_isFinishedParsing = true;
@@ -186,7 +186,7 @@ void PDFDocument::finishedParsing()
         finishLoadingPDF();
 }
 
-void PDFDocument::postMessageToIframe(const String& name, JSC::JSObject* data)
+void PDFJSDocument::postMessageToIframe(const String& name, JSC::JSObject* data)
 {
     auto globalObject = this->globalObject();
     auto& vm = globalObject->vm();
@@ -211,7 +211,7 @@ void PDFDocument::postMessageToIframe(const String& name, JSC::JSObject* data)
         returnValue.releaseException();
 }
 
-void PDFDocument::sendPDFArrayBuffer()
+void PDFJSDocument::sendPDFArrayBuffer()
 {
     auto* documentLoader = loader();
     ASSERT(documentLoader);
@@ -225,7 +225,7 @@ void PDFDocument::sendPDFArrayBuffer()
     }
 }
 
-void PDFDocument::finishLoadingPDF()
+void PDFJSDocument::finishLoadingPDF()
 {
     sendPDFArrayBuffer();
 
@@ -237,7 +237,7 @@ void PDFDocument::finishLoadingPDF()
     m_listener = nullptr;
 }
 
-void PDFDocument::injectStyleAndContentScript()
+void PDFJSDocument::injectStyleAndContentScript()
 {
     if (m_injectedStyleAndScript)
         return;

--- a/Source/WebCore/html/PDFJSDocument.h
+++ b/Source/WebCore/html/PDFJSDocument.h
@@ -32,20 +32,20 @@
 namespace WebCore {
 
 class HTMLIFrameElement;
-class PDFDocumentEventListener;
+class PDFJSDocumentEventListener;
 
-class PDFDocument final : public HTMLDocument {
-    WTF_MAKE_TZONE_ALLOCATED(PDFDocument);
-    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PDFDocument);
+class PDFJSDocument final : public HTMLDocument {
+    WTF_MAKE_TZONE_ALLOCATED(PDFJSDocument);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PDFJSDocument);
 public:
-    static Ref<PDFDocument> create(LocalFrame& frame, const URL& url)
+    static Ref<PDFJSDocument> create(LocalFrame& frame, const URL& url)
     {
-        auto document = adoptRef(*new PDFDocument(frame, url));
+        Ref document = adoptRef(*new PDFJSDocument(frame, url));
         document->addToContextsMap();
         return document;
     }
 
-    ~PDFDocument();
+    ~PDFJSDocument();
 
     void updateDuringParsing();
     void finishedParsing();
@@ -58,7 +58,7 @@ public:
     void setContentScriptLoaded(bool loaded) { m_isContentScriptLoaded = loaded; }
 
 private:
-    PDFDocument(LocalFrame&, const URL&);
+    PDFJSDocument(LocalFrame&, const URL&);
 
     Ref<DocumentParser> createParser() override;
 
@@ -69,13 +69,13 @@ private:
     bool m_isContentScriptLoaded { false };
     RefPtr<HTMLIFrameElement> m_iframe;
     RefPtr<HTMLScriptElement> m_script;
-    RefPtr<PDFDocumentEventListener> m_listener;
+    RefPtr<PDFJSDocumentEventListener> m_listener;
 };
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::PDFDocument)
-    static bool isType(const WebCore::Document& document) { return document.isPDFDocument(); }
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::PDFJSDocument)
+    static bool isType(const WebCore::Document& document) { return document.isPDFJSDocument(); }
     static bool isType(const WebCore::Node& node)
     {
         auto* document = dynamicDowncast<WebCore::Document>(node);

--- a/Source/WebCore/loader/PolicyChecker.cpp
+++ b/Source/WebCore/loader/PolicyChecker.cpp
@@ -203,9 +203,9 @@ void PolicyChecker::checkNavigationPolicy(ResourceRequest&& request, const Resou
 
     ASSERT(frameOwnerElement == m_frame->ownerElement());
 
-    // Only the PDFDocument iframe is allowed to navigate to webkit-pdfjs-viewer URLs
-    bool isInPDFDocumentFrame = frameOwnerElement && frameOwnerElement->document().isPDFDocument();
-    if (isInPDFDocumentFrame && request.url().protocolIs("webkit-pdfjs-viewer"_s)) {
+    // Only the PDFJSDocument iframe is allowed to navigate to webkit-pdfjs-viewer URLs
+    bool isInPDFJSDocumentFrame = frameOwnerElement && frameOwnerElement->document().isPDFJSDocument();
+    if (isInPDFJSDocumentFrame && request.url().protocolIs("webkit-pdfjs-viewer"_s)) {
         POLICYCHECKER_RELEASE_LOG("checkNavigationPolicy: continuing because PDFJS URL");
         return function(WTF::move(request), formSubmission, NavigationPolicyDecision::ContinueLoad);
     }

--- a/Source/WebCore/loader/ResourceLoader.cpp
+++ b/Source/WebCore/loader/ResourceLoader.cpp
@@ -928,7 +928,7 @@ bool ResourceLoader::isPDFJSResourceLoad() const
 
     RefPtr frame = m_frame.get();
     RefPtr document = frame && frame->ownerElement() ? &frame->ownerElement()->document() : nullptr;
-    return document && document->isPDFDocument();
+    return document && document->isPDFJSDocument();
 #else
     return false;
 #endif

--- a/Source/WebCore/page/ContextMenuController.cpp
+++ b/Source/WebCore/page/ContextMenuController.cpp
@@ -91,7 +91,7 @@
 #include <wtf/unicode/CharacterNames.h>
 
 #if ENABLE(PDFJS)
-#include "PDFDocument.h"
+#include "PDFJSDocument.h"
 #endif
 
 #if ENABLE(SERVICE_CONTROLS)
@@ -1223,7 +1223,7 @@ void ContextMenuController::populate()
             
             RefPtr page = frame->page();
             RefPtr ownerElement = frame->ownerElement();
-            bool isPDFDocument = ownerElement && ownerElement->document().isPDFDocument();
+            bool isPDFJSDocument = ownerElement && ownerElement->document().isPDFJSDocument();
             bool isMainFrame = frame->isMainFrame();
 
             if (m_context.hitTestResult().isSelected()) {
@@ -1289,7 +1289,7 @@ void ContextMenuController::populate()
 #endif
                 }
 
-                if (page && !isMainFrame && !isPDFDocument) 
+                if (page && !isMainFrame && !isPDFJSDocument)
                     appendItem(OpenFrameItem, m_contextMenu.get());
                 if (!ShareMenuItem.isNull()) {
                     appendItem(*separatorItem(), m_contextMenu.get());
@@ -1297,7 +1297,7 @@ void ContextMenuController::populate()
                 }
             }
 #if ENABLE(PDFJS)
-            if (isPDFDocument) {
+            if (isPDFJSDocument) {
                 if (m_contextMenu && !m_contextMenu->items().isEmpty())
                     appendItem(*separatorItem(), m_contextMenu.get());
                 appendItem(PDFAutoSizeItem, m_contextMenu.get());
@@ -1521,7 +1521,7 @@ void ContextMenuController::addDebuggingItems()
     ASSERT(page->inspectorController().enabled());
 
 #if ENABLE(PDFJS)
-    if (RefPtr ownerElement = frame->ownerElement(); ownerElement && ownerElement->document().isPDFDocument())
+    if (RefPtr ownerElement = frame->ownerElement(); ownerElement && ownerElement->document().isPDFJSDocument())
         return;
 #endif
 
@@ -1946,7 +1946,7 @@ void ContextMenuController::showImageControlsMenu(Event& event)
 
 void ContextMenuController::performPDFJSAction(LocalFrame& frame, const String& action)
 {
-    if (RefPtr document = dynamicDowncast<PDFDocument>(frame.ownerElement()->document()))
+    if (RefPtr document = dynamicDowncast<PDFJSDocument>(frame.ownerElement()->document()))
         document->postMessageToIframe(action, nullptr);
 }
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -3989,7 +3989,7 @@ header: <WebCore/DocumentClasses.h>
 #if ENABLE(MODEL_ELEMENT)
     Model,
 #endif
-    PDF
+    PDFJS
 };
 
 #if ENABLE(MODEL_PROCESS)


### PR DESCRIPTION
#### d2f342eeb886f2a78aaf8be9e7970b5160638f9c
<pre>
Rename PDFDocument to PDFJSDocument
<a href="https://bugs.webkit.org/show_bug.cgi?id=318709">https://bugs.webkit.org/show_bug.cgi?id=318709</a>
<a href="https://rdar.apple.com/181523119">rdar://181523119</a>

Reviewed by Taher Ali.

Be more explicit since there are multiple PDF rendering paths.

* Source/WebCore/Headers.cmake:
* Source/WebCore/PlatformCocoa.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/DOMImplementation.cpp:
(WebCore::DOMImplementation::createDocument):
* Source/WebCore/dom/Document.h:
(WebCore::Document::isPDFJSDocument const):
(WebCore::Document::isPDFDocument const): Deleted.
* Source/WebCore/dom/DocumentClasses.h:
* Source/WebCore/dom/EventListener.h:
* Source/WebCore/html/PDFJSDocument.cpp: Renamed from Source/WebCore/html/PDFDocument.cpp.
(WebCore::PDFJSDocumentParser::document const):
(WebCore::PDFJSDocumentParser::appendBytes):
(WebCore::PDFJSDocumentParser::finish):
(WebCore::PDFJSDocumentEventListener::handleEvent):
(WebCore::PDFJSDocumentEventListener::operator== const):
(WebCore::PDFJSDocument::PDFJSDocument):
(WebCore::PDFJSDocument::createParser):
(WebCore::PDFJSDocument::createDocumentStructure):
(WebCore::PDFJSDocument::updateDuringParsing):
(WebCore::PDFJSDocument::finishedParsing):
(WebCore::PDFJSDocument::postMessageToIframe):
(WebCore::PDFJSDocument::sendPDFArrayBuffer):
(WebCore::PDFJSDocument::finishLoadingPDF):
(WebCore::PDFJSDocument::injectStyleAndContentScript):
* Source/WebCore/html/PDFJSDocument.h: Renamed from Source/WebCore/html/PDFDocument.h.
(isType):
* Source/WebCore/loader/PolicyChecker.cpp:
(WebCore::PolicyChecker::checkNavigationPolicy):
* Source/WebCore/loader/ResourceLoader.cpp:
(WebCore::ResourceLoader::isPDFJSResourceLoad const):
* Source/WebCore/page/ContextMenuController.cpp:
(WebCore::ContextMenuController::populate):
(WebCore::ContextMenuController::addDebuggingItems):
(WebCore::ContextMenuController::performPDFJSAction):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/316591@main">https://commits.webkit.org/316591@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/76199f8cdb4e1472a8819864a1d17a676b62428c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172877 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46796 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40266 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182337 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130433 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c660a7b9-345f-4747-ab1b-b56b8285689b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174742 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48089 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46472 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134453 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/384a919c-f8c0-440a-af7f-f16185d5049c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175835 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37842 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/155023 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114922 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5d7516dc-c53b-4724-a65f-4fe623e97040) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/36487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30934 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146910 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34528 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184871 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37621 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/39012 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143259 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46467 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143131 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/38639 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47145 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112147 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26243 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38122 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118905 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45662 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9471 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45063 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45295 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45121 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->