### PR TITLE
Cherry-pick 2693828e8d73. https://bugs.webkit.org/show_bug.cgi?id=308046

### DIFF
--- a/JSTests/stress/regexp-backreference-unicode-offset.js
+++ b/JSTests/stress/regexp-backreference-unicode-offset.js
@@ -1,0 +1,38 @@
+// Regression test for https://bugs.webkit.org/show_bug.cgi?id=XXXXX
+// Unicode backreference pattern character read offset was wrong when
+// checkedOffset != inputPosition (i.e., when there are terms after the backreference).
+
+function shouldBe(actual, expected, message) {
+    if (actual !== expected)
+        throw new Error("FAIL: " + message + ". Expected: " + JSON.stringify(expected) + ", Actual: " + JSON.stringify(actual));
+}
+
+// Warm up the JIT by running the tests many times.
+for (var i = 0; i < 500; i++) {
+    // Basic case: backreference followed by a literal character.
+    // This triggers checkedOffset != inputPosition for the backreference term.
+    var result = /(.)\1c/u.exec("\u{10000}\u{10000}c");
+    shouldBe(result !== null, true, "/(.)\u005C1c/u should match surrogate pair followed by same pair and 'c'");
+    shouldBe(result[0], "\u{10000}\u{10000}c", "/(.)\u005C1c/u matched string");
+    shouldBe(result[1], "\u{10000}", "/(.)\u005C1c/u capture group");
+
+    // Without trailing term (checkedOffset == inputPosition), this already worked.
+    var result2 = /(.)\1/u.exec("\u{10000}\u{10000}");
+    shouldBe(result2 !== null, true, "/(.)\u005C1/u should match");
+    shouldBe(result2[0], "\u{10000}\u{10000}", "/(.)\u005C1/u matched string");
+
+    // Multiple trailing terms.
+    var result3 = /(.)\1cd/u.exec("\u{10000}\u{10000}cd");
+    shouldBe(result3 !== null, true, "/(.)\u005C1cd/u should match");
+    shouldBe(result3[0], "\u{10000}\u{10000}cd", "/(.)\u005C1cd/u matched string");
+
+    // Case insensitive unicode backreference with trailing term.
+    var result4 = /(.)\1c/iu.exec("aac");
+    shouldBe(result4 !== null, true, "/(.)\u005C1c/iu should match 'aac'");
+    shouldBe(result4[0], "aac", "/(.)\u005C1c/iu matched string");
+
+    // Surrogate pair with case insensitive and trailing term.
+    var result5 = /(.)\1c/iu.exec("\u{10000}\u{10000}c");
+    shouldBe(result5 !== null, true, "/(.)\u005C1c/iu should match surrogate pair");
+    shouldBe(result5[0], "\u{10000}\u{10000}c", "/(.)\u005C1c/iu matched string");
+}

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -1757,7 +1757,7 @@ class YarrGenerator final : public YarrJITInfo {
         else {
             // For reading Unicode characters, use the standard resultReg so we can call the standard tryReadUnicodeChar()
             // helper instead of emitting an inlined version.
-            readCharacter(op.m_checkedOffset - term->inputPosition, character, patternIndex);
+            readCharacter(0, character, patternIndex);
             m_jit.move(character, patternCharacter);
         }
 #else


### PR DESCRIPTION
#### 7d0911f8910c8a0dfec86f34439d2ade21ef0c81
<pre>
Cherry-pick 2693828e8d73. <a href="https://bugs.webkit.org/show_bug.cgi?id=308046">https://bugs.webkit.org/show_bug.cgi?id=308046</a>

    [YARR] Fix incorrect offset when reading pattern character for Unicode backreference in JIT
    <a href="https://bugs.webkit.org/show_bug.cgi?id=308046">https://bugs.webkit.org/show_bug.cgi?id=308046</a>

    Reviewed by Yusuke Suzuki.

    In matchBackreference(), the Unicode (surrogate pair) path used
    `op.m_checkedOffset - term-&gt;inputPosition` as the offset for reading
    the captured pattern character via patternIndex. However, patternIndex
    holds an absolute position into the captured text, so the offset should
    be 0, as it already is in the non-Unicode path.

    When there are terms following the backreference (e.g., /(.)\1c/u),
    checkedOffset differs from inputPosition, causing the JIT to read from
    the wrong position in the captured text and incorrectly failing to match.

    Test: JSTests/stress/regexp-backreference-unicode-offset.js

    * JSTests/stress/regexp-backreference-unicode-offset.js: Added.
    (shouldBe):
    * Source/JavaScriptCore/yarr/YarrJIT.cpp:

    Canonical link: <a href="https://commits.webkit.org/307791@main">https://commits.webkit.org/307791@main</a>

    Identifier: 305413.695@safari-7624.4-branch

Canonical link: <a href="https://commits.webkit.org/305877.962@mcatanzaro/b308046">https://commits.webkit.org/305877.962@mcatanzaro/b308046</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/002f3b89e43b7bc1732d634097f916366ffdbf5b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172869 "134 style errors") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/46788 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/40258 "The change is no longer eligible for processing.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/182329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/130425 "The change is no longer eligible for processing.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/48081 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/46464 "The change is no longer eligible for processing.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/182329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/130425 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175827 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/48081 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/40258 "The change is no longer eligible for processing.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/182329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/48081 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/46464 "The change is no longer eligible for processing.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/30926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/40258 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/48081 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/40258 "The change is no longer eligible for processing.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184863 "Failed to checkout and rebase branch from PR 68774") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/34131 "The change is no longer eligible for processing.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/37608 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/46464 "The change is no longer eligible for processing.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/184863 "Failed to checkout and rebase branch from PR 68774") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/46459 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/40258 "The change is no longer eligible for processing.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/184863 "Failed to checkout and rebase branch from PR 68774") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/47137 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/40258 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/112139 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26234 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/47137 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/118897 "The change is no longer eligible for processing.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/205547 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/45654 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/40258 "The change is no longer eligible for processing.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/54876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45055 "Build is in progress. Recent messages:") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/45287 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/45113 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->