### PR TITLE
[JSC][Temporal] Polish Temporal.ZonedDateTime: spec alignment and step annotations

### DIFF
--- a/JSTests/stress/temporal-zoned-datetime-until-since.js
+++ b/JSTests/stress/temporal-zoned-datetime-until-since.js
@@ -1,0 +1,117 @@
+//@ requireOptions("--useTemporal=1")
+
+function shouldBe(actual, expected, msg) {
+    if (actual !== expected)
+        throw new Error(`${msg}: expected "${expected}" but got "${actual}"`);
+}
+function shouldThrow(fn, errorType, msg) {
+    let caught;
+    try { fn(); } catch (e) { caught = e; }
+    if (!caught) throw new Error(`${msg}: expected ${errorType.name}, no throw`);
+    if (!(caught instanceof errorType))
+        throw new Error(`${msg}: expected ${errorType.name} but got ${caught.constructor.name}`);
+}
+
+// ------------------------------------------------------------------
+// (a) same-tz + time-largestUnit
+// ------------------------------------------------------------------
+{
+    const a = Temporal.ZonedDateTime.from("2024-01-01T00:00:00-05:00[America/New_York]");
+    const b = Temporal.ZonedDateTime.from("2024-01-01T03:15:30-05:00[America/New_York]");
+
+    shouldBe(a.until(b).toString(), "PT3H15M30S", "(a) default (auto→hour) largestUnit");
+    shouldBe(a.until(b, { largestUnit: "hour" }).toString(), "PT3H15M30S", "(a) largestUnit=hour");
+    shouldBe(a.until(b, { largestUnit: "minute" }).toString(), "PT195M30S", "(a) largestUnit=minute");
+    shouldBe(a.until(b, { largestUnit: "second" }).toString(), "PT11730S", "(a) largestUnit=second");
+
+    // since = -until
+    shouldBe(a.since(b).toString(), "-PT3H15M30S", "(a) since = negated until");
+    shouldBe(b.since(a).toString(), "PT3H15M30S", "(a) since with reversed operands");
+}
+
+// ------------------------------------------------------------------
+// (b) same-tz + date-largestUnit
+// ------------------------------------------------------------------
+{
+    const a = Temporal.ZonedDateTime.from("2024-01-15T00:00:00-05:00[America/New_York]");
+    const b = Temporal.ZonedDateTime.from("2024-04-20T12:30:00-04:00[America/New_York]");
+
+    shouldBe(a.until(b, { largestUnit: "day" }).toString(), "P96DT12H30M", "(b) largestUnit=day");
+    shouldBe(a.until(b, { largestUnit: "month" }).toString(), "P3M5DT12H30M", "(b) largestUnit=month");
+    shouldBe(a.until(b, { largestUnit: "year" }).toString(), "P3M5DT12H30M", "(b) largestUnit=year (<1yr → month)");
+    shouldBe(a.until(b, { largestUnit: "week" }).toString(), "P13W5DT12H30M", "(b) largestUnit=week");
+}
+
+// ------------------------------------------------------------------
+// (c) cross-tz + time-largestUnit — spec allows this (Step 5 fast path)
+// ------------------------------------------------------------------
+{
+    const nyc = Temporal.ZonedDateTime.from("2024-06-01T12:00:00-04:00[America/New_York]");
+    const tky = Temporal.ZonedDateTime.from("2024-06-02T05:00:00+09:00[Asia/Tokyo]");
+    // Same instant: NYC 12:00 EDT (UTC-4) = Tokyo 01:00 JST (UTC+9) next day.
+    // 2024-06-02T05:00:00 JST = 2024-06-01T20:00 UTC = 2024-06-01T16:00 EDT → 4h after nyc.
+    shouldBe(nyc.until(tky, { largestUnit: "hour" }).toString(), "PT4H", "(c) cross-tz hour diff");
+    shouldBe(nyc.until(tky, { largestUnit: "minute" }).toString(), "PT240M", "(c) cross-tz minute diff");
+    shouldBe(nyc.until(tky, { largestUnit: "second" }).toString(), "PT14400S", "(c) cross-tz second diff");
+}
+
+// ------------------------------------------------------------------
+// (d) cross-tz + date-largestUnit — spec Step 7 RangeError
+// ------------------------------------------------------------------
+{
+    const nyc = Temporal.ZonedDateTime.from("2024-06-01T00:00:00-04:00[America/New_York]");
+    const tky = Temporal.ZonedDateTime.from("2024-07-01T00:00:00+09:00[Asia/Tokyo]");
+
+    shouldThrow(() => nyc.until(tky, { largestUnit: "day" }), RangeError,   "(d) day across tz");
+    shouldThrow(() => nyc.until(tky, { largestUnit: "week" }), RangeError,  "(d) week across tz");
+    shouldThrow(() => nyc.until(tky, { largestUnit: "month" }), RangeError, "(d) month across tz");
+    shouldThrow(() => nyc.until(tky, { largestUnit: "year" }), RangeError,  "(d) year across tz");
+
+    shouldThrow(() => nyc.since(tky, { largestUnit: "day" }),   RangeError, "(d) since day across tz");
+    shouldThrow(() => nyc.since(tky, { largestUnit: "month" }), RangeError, "(d) since month across tz");
+}
+
+// ------------------------------------------------------------------
+// (e) epochNs-equal — zero duration (all 10 fields zero)
+// ------------------------------------------------------------------
+{
+    const a = Temporal.ZonedDateTime.from("2024-06-01T12:00:00-04:00[America/New_York]");
+    // Same instant, expressed in a different zone.
+    const b = Temporal.ZonedDateTime.from("2024-06-02T01:00:00+09:00[Asia/Tokyo]");
+    // Verify same instant
+    if (a.epochNanoseconds !== b.epochNanoseconds)
+        throw new Error("(e) precondition: a and b must have equal epochNanoseconds");
+
+    // For time-largestUnit: same-instant across zones → zero (fast-path spec Step 5).
+    for (const largestUnit of ["hour", "minute", "second", "millisecond", "microsecond", "nanosecond"]) {
+        shouldBe(a.until(b, { largestUnit }).toString(), "PT0S", `(e) equal-epoch time-largestUnit ${largestUnit}`);
+        shouldBe(a.since(b, { largestUnit }).toString(), "PT0S", `(e) equal-epoch time-largestUnit ${largestUnit} since`);
+    }
+
+    // For date-largestUnit + same-tz + same epoch: also zero.
+    const c = Temporal.ZonedDateTime.from("2024-06-01T12:00:00-04:00[America/New_York]");
+    shouldBe(a.until(c, { largestUnit: "day" }).toString(),   "PT0S", "(e) same-tz day");
+    shouldBe(a.until(c, { largestUnit: "month" }).toString(), "PT0S", "(e) same-tz month");
+    shouldBe(a.until(c, { largestUnit: "year" }).toString(),  "PT0S", "(e) same-tz year");
+    shouldBe(a.since(c, { largestUnit: "year" }).toString(),  "PT0S", "(e) same-tz year since");
+
+    // Additional: verify Duration has ALL 10 fields = 0 (spec's Step 8 CreateTemporalDuration(0,0,0,0,0,0,0,0,0,0)).
+    const zero = a.until(c, { largestUnit: "year" });
+    for (const f of ["years", "months", "weeks", "days", "hours", "minutes", "seconds",
+                     "milliseconds", "microseconds", "nanoseconds"]) {
+        if (zero[f] !== 0)
+            throw new Error(`(e) zero-duration field ${f} = ${zero[f]}, expected 0`);
+    }
+}
+
+// ------------------------------------------------------------------
+// Sanity: calendar mismatch throws (spec Step 2)
+// ------------------------------------------------------------------
+{
+    const iso = Temporal.ZonedDateTime.from("2024-06-01T00:00:00+00:00[UTC]");
+    const heb = Temporal.ZonedDateTime.from("2024-06-01T00:00:00+00:00[UTC][u-ca=hebrew]");
+    shouldThrow(() => iso.until(heb),  RangeError, "Step 2: different calendars → RangeError");
+    shouldThrow(() => heb.since(iso), RangeError, "Step 2: different calendars (since) → RangeError");
+}
+
+print("PASS");

--- a/Source/JavaScriptCore/runtime/TemporalZonedDateTime.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalZonedDateTime.cpp
@@ -474,9 +474,8 @@ TemporalZonedDateTime* TemporalZonedDateTime::from(JSGlobalObject* globalObject,
             return nullptr;
     }
 
-    // Steps 10-12 (unified epilogue — both string and property-bag paths converge here).
-    // Steps 6-9 are encoded in args: offsetBehaviour (steps 6-8) and inlineOffsetNs (steps 9-10).
-    // Step 10: epochNanoseconds = ? InterpretISODateTimeOffset(...).
+    // Steps 6-10 are encoded in args: offsetBehaviour (Steps 6-8: exact/wall/option) and inlineOffsetNs (Steps 9-10: default 0, or ParseDateTimeUTCOffset(offsetString) when option).
+    // Step 11: epochNanoseconds = ? InterpretISODateTimeOffset(...).
     auto exactTimeResult = TemporalCore::interpretISODateTimeOffset(
         args->plainDate, args->plainTime, args->useStartOfDay,
         args->offsetBehaviour, args->offsetOpt, args->inlineOffsetNs,

--- a/Source/JavaScriptCore/runtime/TemporalZonedDateTimeConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalZonedDateTimeConstructor.cpp
@@ -155,14 +155,8 @@ JSC_DEFINE_HOST_FUNCTION(callTemporalZonedDateTime, (JSGlobalObject* globalObjec
 // https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.from
 JSC_DEFINE_HOST_FUNCTION(temporalZonedDateTimeConstructorFuncFrom, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
     // Step 1: Return ? ToTemporalZonedDateTime(item, options).
-    auto* zdt = TemporalZonedDateTime::from(globalObject, callFrame->argument(0), callFrame->argument(1));
-    RETURN_IF_EXCEPTION(scope, { });
-    ASSERT(zdt);
-    return JSValue::encode(zdt);
+    return JSValue::encode(TemporalZonedDateTime::from(globalObject, callFrame->argument(0), callFrame->argument(1)));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.compare

--- a/Source/JavaScriptCore/runtime/TemporalZonedDateTimePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalZonedDateTimePrototype.cpp
@@ -231,34 +231,32 @@ JSC_DEFINE_HOST_FUNCTION(temporalZonedDateTimePrototypeFuncWithPlainTime, (JSGlo
     if (!zdt) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.ZonedDateTime.prototype.withPlainTime called on value that's not a ZonedDateTime"_s);
 
-    // Steps 3-5: timeZone, calendar, isoDateTime = GetISODateTimeFor(timeZone, epochNanoseconds).
-    ISO8601::PlainTime newTime;
-    JSValue timeArg = callFrame->argument(0);
-    if (!timeArg.isUndefined()) {
-        // Step 7.a: plainTime = ? ToTemporalTime(plainTimeLike).
-        auto* pt = TemporalPlainTime::from(globalObject, timeArg, jsUndefined());
-        RETURN_IF_EXCEPTION(scope, { });
-        newTime = pt->plainTime();
-    }
-
+    // Step 3: Let timeZone be zonedDateTime.[[TimeZone]].
+    // Step 4: Let calendar be zonedDateTime.[[Calendar]].
+    // Step 5: Let isoDateTime be GetISODateTimeFor(timeZone, zonedDateTime.[[EpochNanoseconds]]).
     ISO8601::PlainDate date;
     ISO8601::PlainTime unused;
     zdt->getLocalDateAndTime(globalObject, date, unused);
     RETURN_IF_EXCEPTION(scope, { });
 
+    JSValue timeArg = callFrame->argument(0);
     ISO8601::ExactTime resultEpochNs;
     if (timeArg.isUndefined()) {
         // Step 6.a: epochNs = ? GetStartOfDay(timeZone, isoDateTime.[[ISODate]]).
-        auto sodResult2 = TemporalCore::getStartOfDay(zdt->timeZone(), date);
+        auto sodResult = TemporalCore::getStartOfDay(zdt->timeZone(), date);
         RETURN_IF_EXCEPTION(scope, { });
-        if (!sodResult2) [[unlikely]] {
-            throwRangeError(globalObject, scope, sodResult2.error().message);
+        if (!sodResult) [[unlikely]] {
+            throwRangeError(globalObject, scope, sodResult.error().message);
             return { };
         }
-        resultEpochNs = *sodResult2;
+        resultEpochNs = *sodResult;
     } else {
-        // Steps 7.b-7.c: CombineISODateAndTimeRecord + GetEpochNanosecondsFor(timeZone, result, ~compatible~).
-        auto epochNs = TemporalCore::getEpochNanosecondsFor(zdt->timeZone(), date, newTime, TemporalDisambiguation::Compatible);
+        // Step 7.a: plainTime = ? ToTemporalTime(plainTimeLike).
+        auto* pt = TemporalPlainTime::from(globalObject, timeArg, jsUndefined());
+        RETURN_IF_EXCEPTION(scope, { });
+        // Steps 7.b-7.c: resultISODateTime = CombineISODateAndTimeRecord(isoDate, plainTime.[[Time]]);
+        //                epochNs = ? GetEpochNanosecondsFor(timeZone, resultISODateTime, ~compatible~).
+        auto epochNs = TemporalCore::getEpochNanosecondsFor(zdt->timeZone(), date, pt->plainTime(), TemporalDisambiguation::Compatible);
         if (!epochNs) [[unlikely]] {
             throwRangeError(globalObject, scope, epochNs.error().message);
             return { };
@@ -329,28 +327,32 @@ JSC_DEFINE_HOST_FUNCTION(temporalZonedDateTimePrototypeFuncSubtract, (JSGlobalOb
 // Caller handles steps 1-2 (RequireInternalSlot). op selects ~until~ vs ~since~.
 static EncodedJSValue differenceTemporalZonedDateTime(JSGlobalObject* globalObject, ThrowScope& scope, TemporalZonedDateTime* zdt, JSValue otherArg, JSValue optionsArg, DifferenceOperation op)
 {
-    // Step 1: Set _other_ to ? ToTemporalZonedDateTime(_other_).
+    // Step 1: Set other to ? ToTemporalZonedDateTime(other).
     auto* other = TemporalZonedDateTime::from(globalObject, otherArg);
     RETURN_IF_EXCEPTION(scope, { });
     ASSERT(other);
 
     // Step 2: If CalendarEquals(zonedDateTime.[[Calendar]], other.[[Calendar]]) is false, throw RangeError.
-    // CalendarID is already canonical (from isBuiltinCalendar); direct comparison implements CalendarEquals.
+    //         CalendarID is already canonical (from isBuiltinCalendar); direct comparison = CalendarEquals.
     if (zdt->calendarID() != other->calendarID()) [[unlikely]] {
         throwRangeError(globalObject, scope, "cannot compute difference between ZonedDateTimes with different calendars"_s);
         return { };
     }
 
-    // Steps 3-4: GetOptionsObject + GetDifferenceSettings(op, options, ~datetime~, «», ~nanosecond~, ~hour~).
+    // Step 3: Let resolvedOptions be ? GetOptionsObject(options).
+    // Step 4: Let settings be ? GetDifferenceSettings(op, resolvedOptions, ~datetime~, «», ~nanosecond~, ~hour~).
+    //         Steps 3-4 fused into extractDifferenceOptions.
     auto [smallestUnit, largestUnit, roundingMode, increment] = extractDifferenceOptions(
         globalObject, optionsArg, UnitGroup::DateTime, TemporalUnit::Nanosecond, TemporalUnit::Hour, op);
     RETURN_IF_EXCEPTION(scope, { });
 
-    // Step 5: If TemporalUnitCategory(largestUnit) is ~time~, use DifferenceInstant fast path.
-    // We skip this optimization — differenceZonedDateTimeWithRounding handles both branches correctly.
+    // Step 5: If TemporalUnitCategory(settings.[[LargestUnit]]) is ~time~, fast path via DifferenceInstant.
+    //         Skipped — TemporalCore::differenceZonedDateTimeWithRounding handles time-largestUnit;
+    //         compensated at Step 10.
 
-    // Step 7: If TimeZoneEquals(zonedDateTime.[[TimeZone]], other.[[TimeZone]]) is false, throw RangeError.
-    // Only reached when largestUnit is not a time unit (spec step 5 otherwise returns early).
+    // Step 6: NOTE (spec) — day length varies across zones due to DST/offset shifts.
+
+    // Step 7: If TimeZoneEquals(zdt.[[TimeZone]], other.[[TimeZone]]) is false, throw RangeError.
     if (largestUnit <= TemporalUnit::Day) {
         if (!TemporalCore::timeZoneEquals(zdt->timeZone(), other->timeZone())) {
             throwRangeError(globalObject, scope, "cannot compute day-or-larger difference between ZonedDateTimes with different time zones"_s);
@@ -358,17 +360,20 @@ static EncodedJSValue differenceTemporalZonedDateTime(JSGlobalObject* globalObje
         }
     }
 
+    // Step 8: If zdt.epochNs = other.epochNs, return zero duration.
+    //         (Subsumed by TemporalCore::differenceZonedDateTimeWithRounding.)
+
     // Step 9: Let internalDuration be ? DifferenceZonedDateTimeWithRounding(...).
-    // (Spec step 8 "if epochNs equal return zero duration" is subsumed by the core function.)
     auto coreResult = TemporalCore::differenceZonedDateTimeWithRounding(zdt->exactTime(), other->exactTime(),
         zdt->timeZone(), largestUnit, smallestUnit, roundingMode, increment, zdt->calendarID());
     if (!coreResult) [[unlikely]] {
         throwTemporalError(globalObject, scope, coreResult.error());
         return { };
     }
+
     // Step 10: Let result be ! TemporalDurationFromInternal(internalDuration, ~hour~).
-    // The spec always uses ~hour~ here; for time-category largestUnit (skipped fast path),
-    // durationLargestUnit = largestUnit which matches the fast path's TemporalDurationFromInternal(dur, largestUnit).
+    //          Spec hardcodes ~hour~ (Step 5 early-returns for time-largestUnit); since we skipped
+    //          that fast path, pass largestUnit for time case — spec-equivalent output.
     TemporalUnit durationLargestUnit = (largestUnit <= TemporalUnit::Day) ? TemporalUnit::Hour : largestUnit;
     auto durResult = TemporalCore::temporalDurationFromInternal(*coreResult, durationLargestUnit);
     if (!durResult) [[unlikely]] {
@@ -376,10 +381,12 @@ static EncodedJSValue differenceTemporalZonedDateTime(JSGlobalObject* globalObje
         return { };
     }
     ISO8601::Duration result = *durResult;
-    // Step 11: For ~since~, negate the result.
+
+    // Step 11: If op is ~since~, set result to CreateNegatedTemporalDuration(result).
     if (op == DifferenceOperation::Since)
         result = -result;
 
+    // Step 12: Return result.
     RELEASE_AND_RETURN(scope, JSValue::encode(TemporalDuration::tryCreateIfValid(globalObject, WTF::move(result), globalObject->durationStructure())));
 }
 
@@ -944,30 +951,34 @@ static String temporalZonedDateTimeToString(JSGlobalObject* globalObject, const 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // Step 1: Round epoch nanoseconds (RoundTemporalInstant).
+    // Steps 1-3: Default increment/unit/roundingMode when not present.
+    //            (Callers already pass concrete values, so these defaults are effectively no-ops here.)
+    // Step 4: Let epochNs be zonedDateTime.[[EpochNanoseconds]].
+    // Step 5: Set epochNs to RoundTemporalInstant(epochNs, increment, unit, roundingMode).
     Int128 epochNs = zdt->exactTime().epochNanoseconds();
     Int128 incrementNs = static_cast<Int128>(lengthInNanoseconds(precision.unit)) * static_cast<Int128>(static_cast<int64_t>(precision.increment));
     if (incrementNs > 0)
         epochNs = TemporalCore::roundNumberToIncrementAsIfPositive(epochNs, incrementNs, roundingMode);
     ISO8601::ExactTime roundedExact(epochNs);
 
-    // Step 2: GetOffsetNanosecondsFor(outputTimeZone, roundedEpochNs).
+    // Step 6: Let timeZone be zonedDateTime.[[TimeZone]]. (already in zdt->timeZone())
+    // Step 7: Let offsetNanoseconds be GetOffsetNanosecondsFor(timeZone, epochNs).
     auto offsetOpt = TemporalCore::getOffsetNanosecondsFor(zdt->timeZone(), roundedExact);
     if (!offsetOpt) [[unlikely]] {
         throwRangeError(globalObject, scope, offsetOpt.error().message);
         return { };
     }
 
-    // Step 3: GetISODateTimeFor(outputTimeZone, roundedEpochNs) — derive local date/time.
+    // Step 8: Let isoDateTime be GetISODateTimeFor(timeZone, epochNs).
     ISO8601::PlainDate date;
     ISO8601::PlainTime time;
     TemporalCore::exactTimeToLocalDateAndTime(roundedExact, *offsetOpt, date, time);
 
-    // Step 4: ISODateTimeToString(isoDateTime, calendar, precision, ~never~).
+    // Step 9: Let dateTimeString be ISODateTimeToString(isoDateTime, "iso8601", precision, ~never~).
     StringBuilder sb;
     sb.append(ISO8601::temporalDateTimeToString(date, time, precision.precision));
 
-    // Step 5: If showOffset is not ~never~, FormatDateTimeUTCOffsetRounded(offsetNs).
+    // Steps 10-11: offsetString = if showOffset is ~never~ then "" else FormatDateTimeUTCOffsetRounded(offsetNs).
     if (showOffset != "never"_s) {
         int64_t offsetNs = *offsetOpt;
         int64_t offsetMinutes = offsetNs / 60'000'000'000;
@@ -979,7 +990,7 @@ static String temporalZonedDateTimeToString(JSGlobalObject* globalObject, const 
         sb.append(ISO8601::formatTimeZoneOffsetString(offsetMinutes * 60'000'000'000));
     }
 
-    // Step 6: If showTimeZone is not ~never~, append [!?timeZoneId].
+    // Steps 12-13: timeZoneString = if showTimeZone is ~never~ then "" else "[" + (critical ? "!" : "") + timeZone + "]".
     if (showTimeZone != "never"_s) {
         sb.append('[');
         if (showTimeZone == "critical"_s)
@@ -988,7 +999,7 @@ static String temporalZonedDateTimeToString(JSGlobalObject* globalObject, const 
         sb.append(']');
     }
 
-    // Step 7: If showCalendar warrants it, append [!?u-ca=calendarId].
+    // Step 14: calendarString = FormatCalendarAnnotation(calendar, showCalendar).
     bool appendCalendar = showCalendar == "always"_s || showCalendar == "critical"_s
         || (showCalendar == "auto"_s && !TemporalCore::calendarIsISO(calendarID));
     if (appendCalendar) {
@@ -1000,6 +1011,7 @@ static String temporalZonedDateTimeToString(JSGlobalObject* globalObject, const 
         sb.append(']');
     }
 
+    // Step 15: Return string-concatenation(dateTimeString, offsetString, timeZoneString, calendarString).
     return sb.toString();
 }
 
@@ -1186,10 +1198,12 @@ JSC_DEFINE_CUSTOM_GETTER(temporalZonedDateTimePrototypeGetterOffsetNanoseconds, 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // Steps 1-2: RequireInternalSlot.
     auto* zdt = dynamicDowncast<TemporalZonedDateTime>(JSValue::decode(thisValue));
     if (!zdt) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.ZonedDateTime.prototype.offsetNanoseconds called on value that's not a ZonedDateTime"_s);
 
+    // Step 3: Return 𝔽(GetOffsetNanosecondsFor(timeZone, epochNanoseconds)).
     auto offsetOpt = zdt->getOffsetNanoseconds(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
     ASSERT(offsetOpt);
@@ -1202,13 +1216,16 @@ JSC_DEFINE_CUSTOM_GETTER(temporalZonedDateTimePrototypeGetterOffset, (JSGlobalOb
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // Steps 1-2: RequireInternalSlot.
     auto* zdt = dynamicDowncast<TemporalZonedDateTime>(JSValue::decode(thisValue));
     if (!zdt) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.ZonedDateTime.prototype.offset called on value that's not a ZonedDateTime"_s);
 
+    // Step 3: offsetNanoseconds = GetOffsetNanosecondsFor(timeZone, epochNanoseconds).
     auto offsetOpt = zdt->getOffsetNanoseconds(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
     ASSERT(offsetOpt);
+    // Step 4: Return FormatUTCOffsetNanoseconds(offsetNanoseconds).
     return JSValue::encode(jsString(vm, ISO8601::formatTimeZoneOffsetString(*offsetOpt)));
 }
 
@@ -1651,6 +1668,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalZonedDateTimePrototypeGetterMonthsInYear, (JSGl
             return throwVMRangeError(globalObject, scope, result.error().message);
         return JSValue::encode(jsNumber(*result));
     }
+    // ISO calendar: always 12 months per year (spec Step 4's CalendarMonthsInYear returns 12 for iso8601).
     return JSValue::encode(jsNumber(12));
 }
 
@@ -1710,19 +1728,24 @@ JSC_DEFINE_CUSTOM_GETTER(temporalZonedDateTimePrototypeGetterEraYear, (JSGlobalO
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // Steps 1-2: RequireInternalSlot.
     auto* zdt = dynamicDowncast<TemporalZonedDateTime>(JSValue::decode(thisValue));
     if (!zdt) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.ZonedDateTime.prototype.eraYear called on value that's not a ZonedDateTime"_s);
 
+    // Step 3: isoDateTime = GetISODateTimeFor(timeZone, epochNanoseconds).
     ISO8601::PlainDate date;
     ISO8601::PlainTime time2;
     zdt->getLocalDateAndTime(globalObject, date, time2);
     RETURN_IF_EXCEPTION(scope, { });
+    // Step 4: result = CalendarISOToDate(calendar, isoDate).[[EraYear]].
     auto result = TemporalCore::calendarEraYear(zdt->calendarID(), date);
     if (!result) [[unlikely]]
         return throwVMRangeError(globalObject, scope, result.error().message);
+    // Step 5: If result is undefined, return undefined.
     if (!*result)
         return JSValue::encode(jsUndefined());
+    // Step 6: Return 𝔽(result).
     return JSValue::encode(jsNumber(**result));
 }
 


### PR DESCRIPTION
#### 1482a7ad4add5a700e3b6ca6403a2a5823ac8794
<pre>
[JSC][Temporal] Polish Temporal.ZonedDateTime: spec alignment and step annotations
<a href="https://bugs.webkit.org/show_bug.cgi?id=318714">https://bugs.webkit.org/show_bug.cgi?id=318714</a>
<a href="https://rdar.apple.com/181526020">rdar://181526020</a>

Reviewed by Yusuke Suzuki.

Add per-step spec annotations across every prototype op and fix a
spec-order divergence in withPlainTime (ToTemporalTime was called
before GetISODateTimeFor). Corrected a spec-numbering error in
TemporalZonedDateTime::from. Simplified funcFrom to drop an
unnecessary ThrowScope.

Added JSTests/stress/temporal-zoned-datetime-until-since.js covering
the five until/since cases (same-tz + time/date largestUnit, cross-tz
+ time/date largestUnit, epochNs-equal).

Tests:
JSTests/stress/temporal-zoned-datetime-until-since.js

Canonical link: <a href="https://commits.webkit.org/316587@main">https://commits.webkit.org/316587@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c4a5fc73c92152203731e8ecaae93cdd8890c0b2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172872 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46791 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40261 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182332 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130428 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2f684582-c89b-464a-a895-adbd49da5495) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48084 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46467 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134443 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/67a39c46-0642-457d-a2d2-06eb524781bf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175830 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37843 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/155012 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114912 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/88589dac-60ac-45c8-b554-0762cabe2a94) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/36488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30929 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/3534 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146911 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34517 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184866 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/34134 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37616 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39008 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143254 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46462 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143126 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47140 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112142 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26241 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38114 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118900 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/205550 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45657 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9460 "") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54878 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45058 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45290 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45116 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->