### PR TITLE
[css-mixins-1] Re-resolve functions with @container bodies when the container changes

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-container-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-container-dynamic-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Custom Functions: @container responds to changes assert_equals: --actual after resize to 100px expected "B" but got "A"
+PASS Custom Functions: @container responds to changes
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-container-style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-container-style-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Style query on #target should query parent element assert_equals: expected "D" but got "E"
-FAIL Style query on ::before should query originating element assert_equals: expected "C" but got "E"
+PASS Style query on #target should query parent element
+FAIL Style query on ::before should query originating element assert_equals: expected "C" but got "D"
 

--- a/Source/WebCore/animation/BlendingKeyframes.cpp
+++ b/Source/WebCore/animation/BlendingKeyframes.cpp
@@ -282,7 +282,7 @@ bool BlendingKeyframes::containsDirectionAwareProperty() const
 bool BlendingKeyframes::usesContainerUnits() const
 {
     for (auto& keyframe : m_keyframes) {
-        if (keyframe.style()->usesContainerUnits())
+        if (keyframe.style()->isContainerDependent())
             return true;
     }
     return false;

--- a/Source/WebCore/css/CSSToLengthConversionData.cpp
+++ b/Source/WebCore/css/CSSToLengthConversionData.cpp
@@ -166,7 +166,7 @@ FloatSize CSSToLengthConversionData::dynamicViewportFactor() const
 void CSSToLengthConversionData::setUsesContainerUnits() const
 {
     if (m_styleBuilderState)
-        m_styleBuilderState->setUsesContainerUnits();
+        m_styleBuilderState->setIsContainerDependent();
 }
 
 bool CSSToLengthConversionData::evaluationTimeZoomEnabled() const

--- a/Source/WebCore/style/MatchedDeclarationsCache.cpp
+++ b/Source/WebCore/style/MatchedDeclarationsCache.cpp
@@ -84,7 +84,7 @@ bool MatchedDeclarationsCache::isCacheable(const Element& element, const Style::
     if (style.writingMode().computedWritingMode() != Style::ComputedStyle::initialWritingMode()
         || style.writingMode().computedTextDirection() != Style::ComputedStyle::initialDirection())
         return false;
-    if (style.usesContainerUnits())
+    if (style.isContainerDependent())
         return false;
     if (style.useTreeCountingFunctions())
         return false;

--- a/Source/WebCore/style/StyleBuilderState.cpp
+++ b/Source/WebCore/style/StyleBuilderState.cpp
@@ -318,9 +318,9 @@ void BuilderState::setUsesViewportUnits()
     m_style.setUsesViewportUnits();
 }
 
-void BuilderState::setUsesContainerUnits()
+void BuilderState::setIsContainerDependent()
 {
-    m_style.setUsesContainerUnits();
+    m_style.setIsContainerDependent();
 }
 
 double BuilderState::lookupCSSRandomBaseValue(const CSSCalc::RandomCachingKey& key, std::optional<CSS::Keyword::ElementScoped> elementScoped) const

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -188,7 +188,7 @@ public:
     void NODELETE setCurrentPropertyInvalidAtComputedValueTime();
 
     void NODELETE setUsesViewportUnits();
-    void NODELETE setUsesContainerUnits();
+    void NODELETE setIsContainerDependent();
 
     double lookupCSSRandomBaseValue(const CSSCalc::RandomCachingKey&, std::optional<CSS::Keyword::ElementScoped>) const;
 

--- a/Source/WebCore/style/StyleSubstitutionResolver.cpp
+++ b/Source/WebCore/style/StyleSubstitutionResolver.cpp
@@ -420,6 +420,10 @@ bool SubstitutionResolver::substituteDashedFunction(StringView functionName, CSS
 
         auto mutableProperties = MutableStyleProperties::create();
         for (auto& block : blocks) {
+            // A container query in the body makes the result depend on the calling element's
+            // container, not just the matched declarations, so it must not be cached.
+            if (!block.containerQueries.isEmpty())
+                m_styleBuilder.state().setIsContainerDependent();
             if (containerQueriesMatch(block.containerQueries))
                 mutableProperties->mergeAndOverrideOnConflict(block.properties.get());
         }

--- a/Source/WebCore/style/computed/StyleComputedStyle.cpp
+++ b/Source/WebCore/style/computed/StyleComputedStyle.cpp
@@ -68,7 +68,7 @@ struct SameSizeAsComputedStyle : CanMakeCheckedPtr<SameSizeAsComputedStyle> {
         unsigned unicodeBidi : 3;
         unsigned floating : 3;
         bool usesViewportUnits : 1;
-        bool usesContainerUnits : 1;
+        bool isContainerDependent : 1;
         bool useTreeCountingFunctions : 1;
         bool hasExplicitlyInheritedProperties : 1;
         bool disallowsFastPathInheritance : 1;

--- a/Source/WebCore/style/computed/StyleComputedStyleBase+ConstructionInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase+ConstructionInlines.h
@@ -77,7 +77,7 @@ inline ComputedStyleBase::ComputedStyleBase(CreateDefaultStyleTag)
     m_nonInheritedFlags.floating = static_cast<unsigned>(ComputedStyle::initialFloating());
     m_nonInheritedFlags.textDecorationLine = ComputedStyle::initialTextDecorationLine().toRaw();
     m_nonInheritedFlags.usesViewportUnits = false;
-    m_nonInheritedFlags.usesContainerUnits = false;
+    m_nonInheritedFlags.isContainerDependent = false;
     m_nonInheritedFlags.useTreeCountingFunctions = false;
     m_nonInheritedFlags.hasExplicitlyInheritedProperties = false;
     m_nonInheritedFlags.disallowsFastPathInheritance = false;
@@ -125,7 +125,7 @@ inline void ComputedStyleBase::NonInheritedFlags::copyNonInheritedFrom(const Non
     floating = other.floating;
     textDecorationLine = other.textDecorationLine;
     usesViewportUnits = other.usesViewportUnits;
-    usesContainerUnits = other.usesContainerUnits;
+    isContainerDependent = other.isContainerDependent;
     useTreeCountingFunctions = other.useTreeCountingFunctions;
     hasExplicitlyInheritedProperties = other.hasExplicitlyInheritedProperties;
     disallowsFastPathInheritance = other.disallowsFastPathInheritance;

--- a/Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h
@@ -104,9 +104,9 @@ inline bool ComputedStyleBase::usesViewportUnits() const
     return m_nonInheritedFlags.usesViewportUnits;
 }
 
-inline bool ComputedStyleBase::usesContainerUnits() const
+inline bool ComputedStyleBase::isContainerDependent() const
 {
-    return m_nonInheritedFlags.usesContainerUnits;
+    return m_nonInheritedFlags.isContainerDependent;
 }
 
 inline bool ComputedStyleBase::useTreeCountingFunctions() const

--- a/Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h
@@ -63,9 +63,9 @@ inline void ComputedStyleBase::setUsesViewportUnits()
     m_nonInheritedFlags.usesViewportUnits = true;
 }
 
-inline void ComputedStyleBase::setUsesContainerUnits()
+inline void ComputedStyleBase::setIsContainerDependent()
 {
-    m_nonInheritedFlags.usesContainerUnits = true;
+    m_nonInheritedFlags.isContainerDependent = true;
 }
 
 inline void ComputedStyleBase::setUsesTreeCountingFunctions()

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.cpp
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.cpp
@@ -437,7 +437,7 @@ void ComputedStyleBase::NonInheritedFlags::dumpDifferences(TextStream& ts, const
     LOG_IF_DIFFERENT_WITH_CAST(Float, floating);
 
     LOG_IF_DIFFERENT(usesViewportUnits);
-    LOG_IF_DIFFERENT(usesContainerUnits);
+    LOG_IF_DIFFERENT(isContainerDependent);
     LOG_IF_DIFFERENT(useTreeCountingFunctions);
 
     LOG_IF_DIFFERENT_WITH_FROM_RAW(TextDecorationLine, textDecorationLine);

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.h
@@ -464,8 +464,8 @@ public:
     inline bool usesViewportUnits() const;
     inline void setUsesViewportUnits();
 
-    inline bool usesContainerUnits() const;
-    inline void setUsesContainerUnits();
+    inline bool isContainerDependent() const;
+    inline void setIsContainerDependent();
 
     inline bool useTreeCountingFunctions() const;
     inline void setUsesTreeCountingFunctions();
@@ -748,7 +748,7 @@ public:
         PREFERRED_TYPE(Float) unsigned floating : 3;
 
         PREFERRED_TYPE(bool) unsigned usesViewportUnits : 1;
-        PREFERRED_TYPE(bool) unsigned usesContainerUnits : 1;
+        PREFERRED_TYPE(bool) unsigned isContainerDependent : 1;
         PREFERRED_TYPE(bool) unsigned useTreeCountingFunctions : 1;
         PREFERRED_TYPE(bool) unsigned hasExplicitlyInheritedProperties : 1; // Explicitly inherits a non-inherited property.
         PREFERRED_TYPE(bool) unsigned disallowsFastPathInheritance : 1;


### PR DESCRIPTION
#### a8da394bc85e6b94c66f164cb809fa95af4dd6fc
<pre>
[css-mixins-1] Re-resolve functions with @container bodies when the container changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=318725">https://bugs.webkit.org/show_bug.cgi?id=318725</a>
<a href="https://rdar.apple.com/181530290">rdar://181530290</a>

Reviewed by Alan Baradlay.

Disallow styles generated by container-query-dependent functions from the matched declarations cache.

* LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-container-dynamic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-container-style-expected.txt:
* Source/WebCore/animation/BlendingKeyframes.cpp:
(WebCore::BlendingKeyframes::usesContainerUnits const):
* Source/WebCore/css/CSSToLengthConversionData.cpp:
(WebCore::CSSToLengthConversionData::setUsesContainerUnits const):
* Source/WebCore/style/MatchedDeclarationsCache.cpp:
(WebCore::Style::MatchedDeclarationsCache::isCacheable):
* Source/WebCore/style/StyleBuilderState.cpp:
(WebCore::Style::BuilderState::setIsContainerDependent):
(WebCore::Style::BuilderState::setUsesContainerUnits): Deleted.

Expand the scope of the bit to cover other container dependencies besides container units.

* Source/WebCore/style/StyleBuilderState.h:
* Source/WebCore/style/StyleSubstitutionResolver.cpp:
(WebCore::Style::SubstitutionResolver::substituteDashedFunction):

Mark the style container dependent if there is a container query to evaluate inside called function.

* Source/WebCore/style/computed/StyleComputedStyle.cpp:
* Source/WebCore/style/computed/StyleComputedStyleBase+ConstructionInlines.h:
(WebCore::Style::ComputedStyleBase::ComputedStyleBase):
(WebCore::Style::ComputedStyleBase::NonInheritedFlags::copyNonInheritedFrom):
* Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h:
(WebCore::Style::ComputedStyleBase::isContainerDependent const):
(WebCore::Style::ComputedStyleBase::usesContainerUnits const): Deleted.
* Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h:
(WebCore::Style::ComputedStyleBase::setIsContainerDependent):
(WebCore::Style::ComputedStyleBase::setUsesContainerUnits): Deleted.
* Source/WebCore/style/computed/StyleComputedStyleBase.cpp:
(WebCore::Style::ComputedStyleBase::NonInheritedFlags::dumpDifferences const):
* Source/WebCore/style/computed/StyleComputedStyleBase.h:

Canonical link: <a href="https://commits.webkit.org/316618@main">https://commits.webkit.org/316618@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ce0274dc18e9633619d23e87e2741ee7153de307

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172883 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46802 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40272 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182343 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130439 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174748 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48095 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46478 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134464 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175841 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37846 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155025 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114933 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36491 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34818 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30940 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146914 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34530 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184877 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37627 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39020 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143263 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46473 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143135 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38654 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47151 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31361 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112153 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38132 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118911 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45668 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9473 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45069 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45301 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45127 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->