### PR TITLE
[iOS] WKAVContentSource should conform to AVPlaybackUserInterfaceVideoControllable

### DIFF
--- a/Source/WebKit/Platform/ios/PlaybackSessionInterfaceAVKit.mm
+++ b/Source/WebKit/Platform/ios/PlaybackSessionInterfaceAVKit.mm
@@ -37,9 +37,9 @@
 #import <pal/cf/CoreMediaSoftLink.h>
 
 SOFTLINK_AVKIT_FRAMEWORK()
-SOFT_LINK_CLASS_OPTIONAL(AVKit, AVInterfaceMediaSelectionOptionSource)
-SOFT_LINK_CLASS_OPTIONAL(AVKit, AVInterfaceMetadata)
-SOFT_LINK_CLASS_OPTIONAL(AVKit, AVInterfaceTimelineSegment)
+SOFT_LINK_CLASS_OPTIONAL(AVKit, AVPlaybackUserInterfaceMediaSelectionOption)
+SOFT_LINK_CLASS_OPTIONAL(AVKit, AVPlaybackUserInterfaceContentMetadata)
+SOFT_LINK_CLASS_OPTIONAL(AVKit, AVPlaybackUserInterfaceTimelineSegment)
 
 namespace WebKit {
 
@@ -77,14 +77,14 @@ PlaybackSessionInterfaceAVKit::~PlaybackSessionInterfaceAVKit()
 void PlaybackSessionInterfaceAVKit::durationChanged(double duration)
 {
     [m_contentSource setTimeRange:PAL::CMTimeRangeMake(PAL::kCMTimeZero, PAL::CMTimeMakeWithSeconds(duration, 1000))];
-    [m_contentSource setSupportedSeekCapabilities:AVInterfaceSeekCapabilitiesSeek];
+    [m_contentSource setSupportedSeekCapabilities:AVPlaybackUserInterfaceSeekCapabilitiesSeek];
     [m_contentSource setHasAudio:YES];
     [m_contentSource setReady:YES];
 }
 
-void PlaybackSessionInterfaceAVKit::currentTimeChanged(double currentTime, double)
+void PlaybackSessionInterfaceAVKit::currentTimeChanged(double currentTime, double anchorTime)
 {
-    [m_contentSource setCurrentPlaybackPositionInternal:PAL::CMTimeMakeWithSeconds(currentTime, 1000)];
+    [m_contentSource setPlaybackPositionInternal:PAL::CMTimeMakeWithSeconds(currentTime, 1000) hostTime:PAL::CMTimeMakeWithSeconds(anchorTime, 1000)];
 }
 
 void PlaybackSessionInterfaceAVKit::rateChanged(OptionSet<WebCore::PlaybackSessionModel::PlaybackState> playbackState, double playbackRate, double)
@@ -100,9 +100,9 @@ void PlaybackSessionInterfaceAVKit::seekableRangesChanged(const WebCore::Platfor
     [m_contentSource setSeekableTimeRanges:makeNSArray(timeRanges).get()];
 }
 
-static RetainPtr<AVInterfaceMediaSelectionOptionSource> mediaSelectionOptionSource(const WebCore::MediaSelectionOption& option)
+static RetainPtr<AVPlaybackUserInterfaceMediaSelectionOption> mediaSelectionOptionSource(const WebCore::MediaSelectionOption& option)
 {
-    return adoptNS([allocAVInterfaceMediaSelectionOptionSourceInstance() initWithDisplayName:option.displayName.createNSString().get() identifier:[NSUUID UUID].UUIDString extendedLanguageTag:option.languageTag.createNSString().get()]);
+    return adoptNS([allocAVPlaybackUserInterfaceMediaSelectionOptionInstance() initWithDisplayName:option.displayName.createNSString().get() identifier:[NSUUID UUID].UUIDString extendedLanguageTag:option.languageTag.createNSString().get() mediaCharacteristics:[NSArray array]]);
 }
 
 void PlaybackSessionInterfaceAVKit::audioMediaSelectionOptionsChanged(const Vector<WebCore::MediaSelectionOption>& options, uint64_t selectedIndex)

--- a/Source/WebKit/Platform/ios/WKAVContentSource.h
+++ b/Source/WebKit/Platform/ios/WKAVContentSource.h
@@ -25,7 +25,7 @@
 
 #if HAVE(AVEXPERIENCECONTROLLER)
 
-#import <AVKit/AVInterfaceControllable_Private.h>
+#import <AVKit/AVPlaybackUserInterfaceControllable_Private.h>
 #import <CoreMedia/CoreMedia.h>
 #import <Foundation/Foundation.h>
 #import <wtf/Forward.h>
@@ -36,14 +36,14 @@ class PlaybackSessionModel;
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface WKAVContentSource : NSObject <AVInterfaceVideoPlaybackControllable>
+@interface WKAVContentSource : NSObject <AVPlaybackUserInterfaceVideoControllable>
 + (instancetype)new NS_UNAVAILABLE;
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithModel:(WebCore::PlaybackSessionModel&)model;
 
 - (void)setCurrentAudioOptionIndex:(NSUInteger)currentAudioOptionIndex;
 - (void)setCurrentLegibleOptionIndex:(NSUInteger)currentLegibleOptionIndex;
-- (void)setCurrentPlaybackPositionInternal:(CMTime)currentPlaybackPosition;
+- (void)setPlaybackPositionInternal:(CMTime)playbackPosition hostTime:(CMTime)hostTime;
 - (void)setPlayingInternal:(BOOL)playing;
 - (void)setPlaybackSpeedInternal:(float)playbackSpeed;
 - (void)setMutedInternal:(BOOL)muted;
@@ -53,17 +53,17 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSArray<NSValue *> *seekableTimeRanges;
 @property (nonatomic, getter=isReady) BOOL ready;
 @property (nonatomic, getter=isBuffering) BOOL buffering;
-@property (nonatomic) AVInterfaceSeekCapabilities supportedSeekCapabilities;
-@property (nonatomic, copy) NSArray<AVInterfaceMediaSelectionOptionSource *> *audioOptions;
-@property (nonatomic, copy) NSArray<AVInterfaceMediaSelectionOptionSource *> *legibleOptions;
+@property (nonatomic) AVPlaybackUserInterfaceSeekCapabilities supportedSeekCapabilities;
+@property (nonatomic, copy) NSArray<AVPlaybackUserInterfaceMediaSelectionOption *> *audioOptions;
+@property (nonatomic, copy) NSArray<AVPlaybackUserInterfaceMediaSelectionOption *> *legibleOptions;
 @property (nonatomic) BOOL hasAudio;
-@property (nonatomic, strong) AVInterfaceMetadata *metadata;
+@property (nonatomic, copy) AVPlaybackUserInterfaceContentMetadata *metadata;
 @property (nonatomic, strong, nullable) CALayer *videoLayer;
 @property (nonatomic) CGSize videoSize;
 @property (nonatomic, strong, nullable) CALayer *captionLayer;
 @end
 
-RetainPtr<AVInterfaceMetadata> createPlatformMetadata(NSString * _Nullable title, NSString * _Nullable subtitle);
+RetainPtr<AVPlaybackUserInterfaceContentMetadata> createPlatformMetadata(NSString * _Nullable title, NSString * _Nullable subtitle);
 
 NS_ASSUME_NONNULL_END
 

--- a/Source/WebKit/Platform/ios/WKAVContentSource.mm
+++ b/Source/WebKit/Platform/ios/WKAVContentSource.mm
@@ -34,8 +34,9 @@
 #import <pal/cf/CoreMediaSoftLink.h>
 
 SOFTLINK_AVKIT_FRAMEWORK()
-SOFT_LINK_CLASS_OPTIONAL(AVKit, AVInterfaceMetadata)
-SOFT_LINK_CLASS_OPTIONAL(AVKit, AVInterfaceTimelineSegment)
+SOFT_LINK_CLASS_OPTIONAL(AVKit, AVPlaybackUserInterfaceContentMetadata)
+SOFT_LINK_CLASS_OPTIONAL(AVKit, AVPlaybackUserInterfaceTimelineSegment)
+SOFT_LINK_CLASS_OPTIONAL(AVKit, AVPlaybackUserInterfacePlaybackPosition)
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -43,8 +44,8 @@ NS_ASSUME_NONNULL_BEGIN
     WeakPtr<WebCore::PlaybackSessionModel> _model;
 
     CMTimeRange _timeRange;
-    CMTime _currentPlaybackPosition;
-    RetainPtr<NSArray<AVInterfaceTimelineSegment *>> _segments;
+    RetainPtr<AVPlaybackUserInterfacePlaybackPosition> _playbackPosition;
+    RetainPtr<NSArray<AVPlaybackUserInterfaceTimelineSegment *>> _segments;
     NSUInteger _currentSegmentIndex;
     RetainPtr<NSArray<NSValue *>> _seekableTimeRanges;
     BOOL _ready;
@@ -52,29 +53,38 @@ NS_ASSUME_NONNULL_BEGIN
     BOOL _buffering;
     float _playbackSpeed;
     float _scanSpeed;
-    AVInterfacePlaybackState _state;
-    AVInterfaceSeekCapabilities _supportedSeekCapabilities;
+    AVPlaybackUserInterfacePlaybackState _state;
+    AVPlaybackUserInterfaceSeekCapabilities _supportedSeekCapabilities;
     BOOL _containsLiveStreamingContent;
-    RetainPtr<NSError> _playbackError;
+    RetainPtr<NSError> _error;
     float _defaultPlaybackSpeed;
     NSUInteger _currentAudioOptionIndex;
+    NSUInteger _currentAudioDescriptionOptionIndex;
     NSUInteger _currentLegibleOptionIndex;
-    RetainPtr<NSArray<AVInterfaceMediaSelectionOptionSource *>> _audioOptions;
-    RetainPtr<NSArray<AVInterfaceMediaSelectionOptionSource *>> _legibleOptions;
+    RetainPtr<NSArray<AVPlaybackUserInterfaceMediaSelectionOption *>> _audioOptions;
+    RetainPtr<NSArray<AVPlaybackUserInterfaceMediaSelectionOption *>> _audioDescriptionOptions;
+    RetainPtr<NSArray<AVPlaybackUserInterfaceMediaSelectionOption *>> _legibleOptions;
     BOOL _hasAudio;
     BOOL _muted;
     float _volume;
-    RetainPtr<AVInterfaceMetadata> _metadata;
+    RetainPtr<AVPlaybackUserInterfaceContentMetadata> _metadata;
     RetainPtr<CALayer> _videoLayer;
     CGSize _videoSize;
     RetainPtr<CALayer> _captionLayer;
 }
 
-static RetainPtr<AVInterfaceTimelineSegment> emptyTimelineSegment()
+static RetainPtr<AVPlaybackUserInterfaceTimelineSegment> emptyTimelineSegment()
 {
     using namespace PAL;
 
-    return adoptNS([allocAVInterfaceTimelineSegmentInstance() initWithTimeRange:kCMTimeRangeZero auxiliaryContent:NO marked:NO requiresLinearPlayback:NO identifier:nil]);
+    return adoptNS([allocAVPlaybackUserInterfaceTimelineSegmentInstance() initWithTimeRange:kCMTimeRangeZero segmentType:AVPlaybackUserInterfaceTimelineSegmentTypePrimary marked:NO requiresLinearPlayback:NO identifier:nil]);
+}
+
+static RetainPtr<AVPlaybackUserInterfacePlaybackPosition> playbackPosition(CMTime position, CMTime hostTime, float rate)
+{
+    using namespace PAL;
+
+    return adoptNS([allocAVPlaybackUserInterfacePlaybackPositionInstance() initWithPosition:position hostTime:hostTime rate:rate]);
 }
 
 - (instancetype)initWithModel:(WebCore::PlaybackSessionModel&)model
@@ -88,11 +98,13 @@ static RetainPtr<AVInterfaceTimelineSegment> emptyTimelineSegment()
     _model = model;
 
     _timeRange = kCMTimeRangeZero;
-    _currentPlaybackPosition = kCMTimeZero;
+    _playbackPosition = playbackPosition(kCMTimeZero, CMClockGetTime(CMClockGetHostTimeClock()), 0);
     _segments = [NSArray arrayWithObject:emptyTimelineSegment().get()];
     _currentAudioOptionIndex = NSNotFound;
+    _currentAudioDescriptionOptionIndex = NSNotFound;
     _currentLegibleOptionIndex = NSNotFound;
     _audioOptions = [NSArray array];
+    _audioDescriptionOptions = [NSArray array];
     _legibleOptions = [NSArray array];
     _metadata = createPlatformMetadata(nil, nil);
     _videoSize = CGSizeZero;
@@ -120,7 +132,7 @@ static RetainPtr<AVInterfaceTimelineSegment> emptyTimelineSegment()
     _buffering = buffering;
 }
 
-- (void)setSupportedSeekCapabilities:(AVInterfaceSeekCapabilities)supportedSeekCapabilities
+- (void)setSupportedSeekCapabilities:(AVPlaybackUserInterfaceSeekCapabilities)supportedSeekCapabilities
 {
     _supportedSeekCapabilities = supportedSeekCapabilities;
 }
@@ -139,12 +151,12 @@ static RetainPtr<AVInterfaceTimelineSegment> emptyTimelineSegment()
     [self didChangeValueForKey:@"currentLegibleOption"];
 }
 
-- (void)setAudioOptions:(NSArray<AVInterfaceMediaSelectionOptionSource *> *)audioOptions
+- (void)setAudioOptions:(NSArray<AVPlaybackUserInterfaceMediaSelectionOption *> *)audioOptions
 {
     _audioOptions = adoptNS([audioOptions copy]);
 }
 
-- (void)setLegibleOptions:(NSArray<AVInterfaceMediaSelectionOptionSource *> *)legibleOptions
+- (void)setLegibleOptions:(NSArray<AVPlaybackUserInterfaceMediaSelectionOption *> *)legibleOptions
 {
     _legibleOptions = adoptNS([legibleOptions copy]);
 }
@@ -154,7 +166,7 @@ static RetainPtr<AVInterfaceTimelineSegment> emptyTimelineSegment()
     _hasAudio = hasAudio;
 }
 
-- (void)setMetadata:(AVInterfaceMetadata *)metadata
+- (void)setMetadata:(AVPlaybackUserInterfaceContentMetadata *)metadata
 {
     _metadata = metadata;
 }
@@ -174,13 +186,11 @@ static RetainPtr<AVInterfaceTimelineSegment> emptyTimelineSegment()
     _captionLayer = captionLayer;
 }
 
-- (void)setCurrentPlaybackPositionInternal:(CMTime)currentPlaybackPosition
+- (void)setPlaybackPositionInternal:(CMTime)position hostTime:(CMTime)hostTime
 {
-    [self willChangeValueForKey:@"currentValue"];
-    [self willChangeValueForKey:@"currentPlaybackPosition"];
-    _currentPlaybackPosition = currentPlaybackPosition;
-    [self didChangeValueForKey:@"currentValue"];
-    [self didChangeValueForKey:@"currentPlaybackPosition"];
+    [self willChangeValueForKey:@"playbackPosition"];
+    _playbackPosition = playbackPosition(position, hostTime, _playing ? _playbackSpeed : 0);
+    [self didChangeValueForKey:@"playbackPosition"];
 }
 
 - (void)setPlayingInternal:(BOOL)playing
@@ -211,42 +221,32 @@ static RetainPtr<AVInterfaceTimelineSegment> emptyTimelineSegment()
     [self didChangeValueForKey:@"volume"];
 }
 
-#pragma mark - AVInterfaceVideoPlaybackControllable conformance
+#pragma mark - AVPlaybackUserInterfaceVideoControllable conformance
 
 - (CMTimeRange)timeRange
 {
     return _timeRange;
 }
 
-ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
-- (CMTime)currentValue
+- (AVPlaybackUserInterfacePlaybackPosition *)playbackPosition
 {
-    return [self currentPlaybackPosition];
+    return _playbackPosition.get();
 }
 
-- (void)setCurrentValue:(CMTime)currentValue
+- (void)seekToPosition:(CMTime)position tolerance:(CMTime)tolerance
 {
-    [self setCurrentPlaybackPosition:currentValue];
-}
-ALLOW_DEPRECATED_IMPLEMENTATIONS_END
-
-- (CMTime)currentPlaybackPosition
-{
-    return _currentPlaybackPosition;
+    if (CheckedPtr model = _model.get()) {
+        double toleranceSeconds = PAL::CMTimeGetSeconds(tolerance);
+        model->seekToTime(PAL::CMTimeGetSeconds(position), toleranceSeconds, toleranceSeconds);
+    }
 }
 
-- (void)setCurrentPlaybackPosition:(CMTime)currentPlaybackPosition
-{
-    if (CheckedPtr model = _model.get())
-        model->seekToTime(PAL::CMTimeGetSeconds(currentPlaybackPosition));
-}
-
-- (NSArray<AVInterfaceTimelineSegment *> *)segments
+- (NSArray<AVPlaybackUserInterfaceTimelineSegment *> *)segments
 {
     return _segments.get();
 }
 
-- (AVInterfaceTimelineSegment *)currentSegment
+- (AVPlaybackUserInterfaceTimelineSegment *)currentSegment
 {
     return [_segments objectAtIndex:_currentSegmentIndex];
 }
@@ -304,17 +304,17 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     _scanSpeed = scanSpeed;
 }
 
-- (AVInterfacePlaybackState)state
+- (AVPlaybackUserInterfacePlaybackState)state
 {
     return _state;
 }
 
-- (void)setState:(AVInterfacePlaybackState)state
+- (void)setState:(AVPlaybackUserInterfacePlaybackState)state
 {
     _state = state;
 }
 
-- (AVInterfaceSeekCapabilities)supportedSeekCapabilities
+- (AVPlaybackUserInterfaceSeekCapabilities)supportedSeekCapabilities
 {
     return _supportedSeekCapabilities;
 }
@@ -324,9 +324,9 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     return _containsLiveStreamingContent;
 }
 
-- (NSError * _Nullable)playbackError
+- (NSError * _Nullable)error
 {
-    return _playbackError;
+    return _error;
 }
 
 - (float)defaultPlaybackSpeed
@@ -339,7 +339,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     _defaultPlaybackSpeed = defaultPlaybackSpeed;
 }
 
-- (AVInterfaceMediaSelectionOptionSource * _Nullable)currentAudioOption
+- (AVPlaybackUserInterfaceMediaSelectionOption * _Nullable)currentAudioOption
 {
     if (_currentAudioOptionIndex == NSNotFound)
         return nil;
@@ -347,7 +347,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     return [_audioOptions objectAtIndex:_currentAudioOptionIndex];
 }
 
-- (void)setCurrentAudioOption:(AVInterfaceMediaSelectionOptionSource * _Nullable)currentAudioOption
+- (void)setCurrentAudioOption:(AVPlaybackUserInterfaceMediaSelectionOption * _Nullable)currentAudioOption
 {
     CheckedPtr model = _model.get();
     if (!model)
@@ -358,7 +358,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         return;
     }
 
-    NSUInteger index = [_audioOptions indexOfObjectPassingTest:^BOOL(AVInterfaceMediaSelectionOptionSource *option, NSUInteger, BOOL*) {
+    NSUInteger index = [_audioOptions indexOfObjectPassingTest:^BOOL(AVPlaybackUserInterfaceMediaSelectionOption *option, NSUInteger, BOOL*) {
         if (option == currentAudioOption)
             return YES;
         return [option.identifier isEqualToString:currentAudioOption.identifier];
@@ -368,7 +368,29 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         model->selectAudioMediaOption(index);
 }
 
-- (AVInterfaceMediaSelectionOptionSource * _Nullable)currentLegibleOption
+- (AVPlaybackUserInterfaceMediaSelectionOption * _Nullable)currentAudioDescriptionOption
+{
+    if (_currentAudioDescriptionOptionIndex == NSNotFound)
+        return nil;
+
+    return [_audioDescriptionOptions objectAtIndex:_currentAudioDescriptionOptionIndex];
+}
+
+- (void)setCurrentAudioDescriptionOption:(AVPlaybackUserInterfaceMediaSelectionOption * _Nullable)currentAudioDescriptionOption
+{
+    if (!currentAudioDescriptionOption) {
+        _currentAudioDescriptionOptionIndex = NSNotFound;
+        return;
+    }
+
+    _currentAudioDescriptionOptionIndex = [_audioDescriptionOptions indexOfObjectPassingTest:^BOOL(AVPlaybackUserInterfaceMediaSelectionOption *option, NSUInteger, BOOL*) {
+        if (option == currentAudioDescriptionOption)
+            return YES;
+        return [option.identifier isEqualToString:currentAudioDescriptionOption.identifier];
+    }];
+}
+
+- (AVPlaybackUserInterfaceMediaSelectionOption * _Nullable)currentLegibleOption
 {
     if (_currentLegibleOptionIndex == NSNotFound)
         return nil;
@@ -376,7 +398,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     return [_legibleOptions objectAtIndex:_currentLegibleOptionIndex];
 }
 
-- (void)setCurrentLegibleOption:(AVInterfaceMediaSelectionOptionSource * _Nullable)currentLegibleOption
+- (void)setCurrentLegibleOption:(AVPlaybackUserInterfaceMediaSelectionOption * _Nullable)currentLegibleOption
 {
     CheckedPtr model = _model.get();
     if (!model)
@@ -387,7 +409,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         return;
     }
 
-    NSUInteger index = [_legibleOptions indexOfObjectPassingTest:^BOOL(AVInterfaceMediaSelectionOptionSource *option, NSUInteger, BOOL*) {
+    NSUInteger index = [_legibleOptions indexOfObjectPassingTest:^BOOL(AVPlaybackUserInterfaceMediaSelectionOption *option, NSUInteger, BOOL*) {
         if (option == currentLegibleOption)
             return YES;
         return [option.identifier isEqualToString:currentLegibleOption.identifier];
@@ -397,12 +419,17 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         model->selectLegibleMediaOption(index);
 }
 
-- (NSArray<AVInterfaceMediaSelectionOptionSource *> *)audioOptions
+- (NSArray<AVPlaybackUserInterfaceMediaSelectionOption *> *)audioOptions
 {
     return _audioOptions.get();
 }
 
-- (NSArray<AVInterfaceMediaSelectionOptionSource *> *)legibleOptions
+- (NSArray<AVPlaybackUserInterfaceMediaSelectionOption *> *)audioDescriptionOptions
+{
+    return _audioDescriptionOptions.get();
+}
+
+- (NSArray<AVPlaybackUserInterfaceMediaSelectionOption *> *)legibleOptions
 {
     return _legibleOptions.get();
 }
@@ -434,7 +461,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         model->setVolume(volume);
 }
 
-- (AVInterfaceMetadata *)metadata
+- (AVPlaybackUserInterfaceContentMetadata *)metadata
 {
     return _metadata;
 }
@@ -456,10 +483,10 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 @end
 
-RetainPtr<AVInterfaceMetadata> createPlatformMetadata(NSString * _Nullable title, NSString * _Nullable subtitle)
+RetainPtr<AVPlaybackUserInterfaceContentMetadata> createPlatformMetadata(NSString * _Nullable title, NSString * _Nullable subtitle)
 {
     using namespace PAL;
-    return adoptNS([allocAVInterfaceMetadataInstance() initWithAudioOnly:NO presentationSize:CGSizeZero title:title subtitle:subtitle albumArtworkRepresentations:[NSArray array]]);
+    return adoptNS([allocAVPlaybackUserInterfaceContentMetadataInstance() initWithVideoProperties:nil title:title subtitle:subtitle artworkRepresentations:[NSArray array]]);
 }
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
#### e240526ac582e5f58ab171e07343eb76aeaf55ba
<pre>
[iOS] WKAVContentSource should conform to AVPlaybackUserInterfaceVideoControllable
<a href="https://bugs.webkit.org/show_bug.cgi?id=318727">https://bugs.webkit.org/show_bug.cgi?id=318727</a>
<a href="https://rdar.apple.com/181531817">rdar://181531817</a>

Reviewed by Jer Noble.

Migrated WKAVContentSource conformance from AVInterfaceVideoPlaybackControllable to
AVPlaybackUserInterfaceVideoControllable, as the former is deprecated.

* Source/WebKit/Platform/ios/PlaybackSessionInterfaceAVKit.mm:
(WebKit::PlaybackSessionInterfaceAVKit::durationChanged):
(WebKit::PlaybackSessionInterfaceAVKit::currentTimeChanged):
(WebKit::mediaSelectionOptionSource):
* Source/WebKit/Platform/ios/WKAVContentSource.h:
* Source/WebKit/Platform/ios/WKAVContentSource.mm:
(emptyTimelineSegment):
(playbackPosition):
(-[WKAVContentSource initWithModel:]):
(-[WKAVContentSource setSupportedSeekCapabilities:]):
(-[WKAVContentSource setAudioOptions:]):
(-[WKAVContentSource setLegibleOptions:]):
(-[WKAVContentSource setMetadata:]):
(-[WKAVContentSource setPlaybackPositionInternal:hostTime:]):
(-[WKAVContentSource playbackPosition]):
(-[WKAVContentSource seekToPosition:tolerance:]):
(-[WKAVContentSource segments]):
(-[WKAVContentSource currentSegment]):
(-[WKAVContentSource state]):
(-[WKAVContentSource setState:]):
(-[WKAVContentSource supportedSeekCapabilities]):
(-[WKAVContentSource error]):
(-[WKAVContentSource currentAudioOption]):
(-[WKAVContentSource setCurrentAudioOption:]):
(-[WKAVContentSource currentAudioDescriptionOption]):
(-[WKAVContentSource setCurrentAudioDescriptionOption:]):
(-[WKAVContentSource currentLegibleOption]):
(-[WKAVContentSource setCurrentLegibleOption:]):
(-[WKAVContentSource audioOptions]):
(-[WKAVContentSource audioDescriptionOptions]):
(-[WKAVContentSource legibleOptions]):
(-[WKAVContentSource metadata]):
(createPlatformMetadata):
(-[WKAVContentSource setCurrentPlaybackPositionInternal:]): Deleted.
(-[WKAVContentSource currentValue]): Deleted.
(-[WKAVContentSource setCurrentValue:]): Deleted.
(-[WKAVContentSource currentPlaybackPosition]): Deleted.
(-[WKAVContentSource setCurrentPlaybackPosition:]): Deleted.
(-[WKAVContentSource playbackError]): Deleted.

Canonical link: <a href="https://commits.webkit.org/316583@main">https://commits.webkit.org/316583@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a06261b0b7a41f461691af39af2377268bed2b36

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172885 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46804 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40274 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182345 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/130441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/8c127670-b156-4c03-acd1-fc9ba7ffe3a0/f225128d-f7d9-4496-b867-1e854326f9b2) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48097 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46480 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134456 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/130441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/8c127670-b156-4c03-acd1-fc9ba7ffe3a0/19934377-4536-46d6-8d3e-b116f599dfef) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175843 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37856 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/155016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114925 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/8c127670-b156-4c03-acd1-fc9ba7ffe3a0/0ff9412e-2803-4254-ab31-de98ff14a99c) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/36501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30942 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/146924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34521 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184879 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37629 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/39018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143264 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46475 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143136 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47153 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112155 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26239 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38127 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118913 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45670 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9464 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45071 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45303 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45129 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->