### PR TITLE
[GFC] Implement alignment safety.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-self-alignment-safe-overflow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-self-alignment-safe-overflow-expected.txt
@@ -1,0 +1,8 @@
+
+PASS justify-self: safe end on an item wider than its grid area clamps to the start edge
+PASS align-self: safe end on an item taller than its grid area clamps to the start edge
+PASS justify-self: safe center on an item wider than its grid area clamps to the start edge
+PASS align-self: safe center on an item taller than its grid area clamps to the start edge
+PASS justify-self: safe end on an item overflowing the second column clamps to that column's start edge
+PASS align-self: safe end on an item overflowing the second row clamps to that row's start edge
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-self-alignment-safe-overflow.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-self-alignment-safe-overflow.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<link rel="help" href="https://www.w3.org/TR/css-align-3/#overflow-values">
+<link rel="help" href="https://www.w3.org/TR/css-grid-1/#alignment">
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  /* Every item uses explicit grid-area placement (with explicit end lines). */
+  .grid { display: grid; }
+  .single        { grid-template: 50px / 50px; }
+  .three-columns { grid-template: 50px / 50px 50px 50px; }
+  .three-rows    { grid-template: 50px 50px 50px / 50px; }
+
+  .item { background: green; }
+  .wide { width: 100px; height: 50px; }
+  .tall { width: 50px; height: 100px; }
+
+  .cell   { grid-area: 1 / 1 / 2 / 2; }
+  .column2 { grid-area: 1 / 2 / 2 / 3; }
+  .row2    { grid-area: 2 / 1 / 3 / 2; }
+</style>
+<body>
+<div id="log"></div>
+
+<!-- An item larger than a single grid area: safe alignment must clamp it to the
+     area's start edge (offset 0) instead of overflowing past the start edge. -->
+<div class="grid single"><div class="item wide cell" id="justify-safe-end"    style="justify-self: safe end"></div></div>
+<div class="grid single"><div class="item tall cell" id="align-safe-end"      style="align-self: safe end"></div></div>
+<div class="grid single"><div class="item wide cell" id="justify-safe-center" style="justify-self: safe center"></div></div>
+<div class="grid single"><div class="item tall cell" id="align-safe-center"   style="align-self: safe center"></div></div>
+
+<!-- An item placed in the second track, larger than that track: safe alignment
+     must clamp it to that track's start edge (offset 50), not overflow toward
+     the first track. -->
+<div class="grid three-columns"><div class="item wide column2" id="justify-safe-end-second-column" style="justify-self: safe end"></div></div>
+<div class="grid three-rows"><div class="item tall row2" id="align-safe-end-second-row" style="align-self: safe end"></div></div>
+
+<script>
+function startEdgeOffset(id) {
+    const item = document.getElementById(id);
+    const gridRect = item.parentElement.getBoundingClientRect();
+    const itemRect = item.getBoundingClientRect();
+    return { left: itemRect.left - gridRect.left, top: itemRect.top - gridRect.top };
+}
+
+test(() => {
+    assert_equals(startEdgeOffset("justify-safe-end").left, 0);
+}, "justify-self: safe end on an item wider than its grid area clamps to the start edge");
+
+test(() => {
+    assert_equals(startEdgeOffset("align-safe-end").top, 0);
+}, "align-self: safe end on an item taller than its grid area clamps to the start edge");
+
+test(() => {
+    assert_equals(startEdgeOffset("justify-safe-center").left, 0);
+}, "justify-self: safe center on an item wider than its grid area clamps to the start edge");
+
+test(() => {
+    assert_equals(startEdgeOffset("align-safe-center").top, 0);
+}, "align-self: safe center on an item taller than its grid area clamps to the start edge");
+
+test(() => {
+    assert_equals(startEdgeOffset("justify-safe-end-second-column").left, 50);
+}, "justify-self: safe end on an item overflowing the second column clamps to that column's start edge");
+
+test(() => {
+    assert_equals(startEdgeOffset("align-safe-end-second-row").top, 50);
+}, "align-self: safe end on an item overflowing the second row clamps to that row's start edge");
+</script>
+</body>

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
@@ -268,6 +268,10 @@ BorderBoxPositions GridLayout::performInlineAxisSelfAlignment(const PlacedGridIt
         // Stretching should be handled by GridLayout::layoutGridItems.
         auto marginBoxPosition = StyleSelfAlignmentData::adjustmentFromStartEdge(remainingSpace, gridItem.inlineAxisAlignment().position(), LogicalBoxAxis::Inline, formattingContextWritingMode, gridItem.writingMode());
 
+        // Safe alignment must never overflow the start edge, so clamp any negative start-edge offset back to the start.
+        if (gridItem.inlineAxisAlignment().overflow() == OverflowAlignment::Safe)
+            marginBoxPosition = std::max(0_lu, marginBoxPosition);
+
         borderBoxPositions.append(marginBoxPosition + inlineMargins[gridItemIndex].marginStart);
     }
 
@@ -295,6 +299,10 @@ BorderBoxPositions GridLayout::performBlockAxisSelfAlignment(const PlacedGridIte
         //
         // Stretching should be handled by GridLayout::layoutGridItems.
         auto marginBoxPosition = StyleSelfAlignmentData::adjustmentFromStartEdge(remainingSpace, gridItem.blockAxisAlignment().position(), LogicalBoxAxis::Block, formattingContextWritingMode, gridItem.writingMode());
+
+        // Safe alignment must never overflow the start edge, so clamp any negative start-edge offset back to the start.
+        if (gridItem.blockAxisAlignment().overflow() == OverflowAlignment::Safe)
+            marginBoxPosition = std::max(0_lu, marginBoxPosition);
 
         borderBoxPositions.append(marginBoxPosition + blockMargins[gridItemIndex].marginStart);
     }


### PR DESCRIPTION
#### 9ea13515e70372ba3e175c21734d61967ce25a0b
<pre>
[GFC] Implement alignment safety.
<a href="https://bugs.webkit.org/show_bug.cgi?id=318729">https://bugs.webkit.org/show_bug.cgi?id=318729</a>
<a href="https://rdar.apple.com/181532612">rdar://181532612</a>

Reviewed by Elika Etemad.

In GFC we currently have very simple alignment logic which is basically
just unsafe alignment since we take and use the output from StyleSelfAlignmentData::adjustmentFromStartEdge
to determine the margin box position.

This doesn&apos;t work if safe alignment is specified since the output from
that value can be negative in order to satisfy the constraint of the
alignment position and would cause the content to be placed outside the
start edge of the grid.

To implement alignment safety all we need to do is clamp the result to 0
when safe is specified since that will align the margin box to the start
of the grid area.

Canonical link: <a href="https://commits.webkit.org/316632@main">https://commits.webkit.org/316632@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d55e9fe9b4437e0b121ee12b09a96a4c32e71a6d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172922 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46841 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40311 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182382 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130478 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/8c127670-b156-4c03-acd1-fc9ba7ffe3a0/d51e8e42-23ca-4a35-9c7f-07443107b28e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174787 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48134 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46517 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134488 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175880 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37879 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155048 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114957 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/8c127670-b156-4c03-acd1-fc9ba7ffe3a0/a332966d-d769-458c-b06d-2ecb0d6af3fa) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36524 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34846 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30980 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146948 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34553 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184916 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37675 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39048 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143294 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46512 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154615 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143165 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38668 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47190 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31384 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112193 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38149 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118950 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45707 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9496 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45108 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45340 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45166 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->