### PR TITLE
[WebGPU] RGBA16Float offscreen canvas appears opaque

### DIFF
--- a/LayoutTests/fast/webgpu/offscreen-canvas-rgba16float-transparency-expected.html
+++ b/LayoutTests/fast/webgpu/offscreen-canvas-rgba16float-transparency-expected.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>OffscreenCanvas WebGPU rgba16float premultiplied alpha composites transparently</title>
+<style>
+  body { margin: 0; }
+  #backdrop {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 200px;
+    height: 200px;
+    background: rgb(0, 128, 0);
+  }
+</style>
+</head>
+<body>
+  <!-- A transparent rgba16float canvas over the backdrop must render identically
+       to the backdrop alone. -->
+  <div id="backdrop"></div>
+</body>
+</html>

--- a/LayoutTests/fast/webgpu/offscreen-canvas-rgba16float-transparency.html
+++ b/LayoutTests/fast/webgpu/offscreen-canvas-rgba16float-transparency.html
@@ -1,0 +1,88 @@
+<!-- webkit-test-runner [ WebGPUHDREnabled=true ] -->
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+<meta charset="utf-8">
+<title>OffscreenCanvas WebGPU rgba16float premultiplied alpha composites transparently</title>
+<style>
+  body { margin: 0; }
+  /* Solid backdrop that must remain visible through the transparent canvas. */
+  #backdrop {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 200px;
+    height: 200px;
+    background: rgb(0, 128, 0);
+  }
+  #canvas {
+    position: absolute;
+    top: 0;
+    left: 0;
+  }
+</style>
+</head>
+<body>
+  <div id="backdrop"></div>
+  <canvas id="canvas" width="200" height="200"></canvas>
+  <script>
+    // Regression test for an rgba16float OffscreenCanvas losing its alpha when
+    // committed to its placeholder canvas: the readback forced the image opaque,
+    // so a transparent WebGPU canvas showed up as opaque black instead of letting
+    // the green backdrop show through.
+    function done() {
+      document.documentElement.classList.remove('reftest-wait');
+    }
+
+    async function run() {
+      const adapter = navigator.gpu && await navigator.gpu.requestAdapter();
+      if (!adapter) {
+        // Without WebGPU there is nothing to composite; the backdrop matches the
+        // reference on its own.
+        done();
+        return;
+      }
+      const device = await adapter.requestDevice();
+
+      const offscreen = document.getElementById("canvas").transferControlToOffscreen();
+      const context = offscreen.getContext("webgpu");
+      context.configure({
+        device,
+        format: "rgba16float",
+        alphaMode: "premultiplied",
+        toneMapping: { mode: "extended" },
+      });
+
+      // Clear to fully transparent every frame. With premultiplied alpha this must
+      // let the green backdrop show through unchanged.
+      function renderFrame() {
+        const encoder = device.createCommandEncoder();
+        const pass = encoder.beginRenderPass({
+          colorAttachments: [{
+            view: context.getCurrentTexture().createView(),
+            clearValue: { r: 0, g: 0, b: 0, a: 0 },
+            loadOp: "clear",
+            storeOp: "store",
+          }],
+        });
+        pass.end();
+        device.queue.submit([encoder.finish()]);
+      }
+
+      // Render several frames so the asynchronous offscreen->placeholder commit
+      // (a GPU process round-trip) has time to publish a real frame before we snapshot.
+      let framesRemaining = 10;
+      function tick() {
+        renderFrame();
+        if (--framesRemaining > 0)
+          requestAnimationFrame(tick);
+        else
+          requestAnimationFrame(done);
+      }
+      requestAnimationFrame(tick);
+    }
+
+    run();
+  </script>
+</body>
+</html>

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCompositorIntegrationImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCompositorIntegrationImpl.cpp
@@ -74,6 +74,7 @@ Vector<MachSendRight> CompositorIntegrationImpl::recreateRenderBuffers(int width
 {
     m_renderBuffers.clear();
     m_device = device;
+    m_alphaMode = alphaMode;
 
     if (RefPtr presentationContext = m_presentationContext) {
         static_cast<PresentationContext*>(presentationContext.get())->unconfigure();
@@ -131,7 +132,11 @@ void CompositorIntegrationImpl::withDisplayBufferAsNativeImage(uint32_t bufferIn
         if (!isIOSurfaceSupportedFormat)
             return completion(nullptr);
 
-        displayImage = m_renderBuffers[bufferIndex]->createNativeImage();
+        // A premultiplied canvas must keep its alpha channel so transparent pixels
+        // composite over the page; an opaque canvas forces the alpha to be ignored.
+        // This matters for RGBA16F, whose IOSurface format cannot itself encode opacity.
+        auto shouldForceOpaque = m_alphaMode == WebCore::AlphaPremultiplication::Premultiplied ? IOSurface::ShouldForceOpaque::No : IOSurface::ShouldForceOpaque::Yes;
+        displayImage = m_renderBuffers[bufferIndex]->createNativeImage(shouldForceOpaque);
     }
 
     if (!displayImage)

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCompositorIntegrationImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCompositorIntegrationImpl.h
@@ -98,6 +98,7 @@ private:
     Vector<MachSendRight> recreateRenderBuffers(int width, int height, WebCore::DestinationColorSpace&&, WebCore::AlphaPremultiplication, WebCore::WebGPU::TextureFormat, unsigned bufferCount, Device&) override;
 
     Vector<UniqueRef<WebCore::IOSurface>> m_renderBuffers;
+    WebCore::AlphaPremultiplication m_alphaMode { WebCore::AlphaPremultiplication::Premultiplied };
     WTF::Function<void(CFArrayRef)> m_renderBuffersWereRecreatedCallback;
 #endif
 

--- a/Source/WebCore/platform/graphics/cocoa/IOSurface.h
+++ b/Source/WebCore/platform/graphics/cocoa/IOSurface.h
@@ -166,11 +166,16 @@ public:
 
     WEBCORE_EXPORT WTF::MachSendRight createSendRight() const;
 
+    // Controls how the alpha channel is interpreted when creating a native image.
+    // Only meaningful for RGBA16F surfaces, whose format (unlike RGBA/RGBX or
+    // BGRA/BGRX) cannot itself encode whether the contents are opaque.
+    enum class ShouldForceOpaque : bool { No, Yes };
+
     // Any images created from a surface need to be released before releasing
     // the context, or an expensive GPU readback can result.
     // Passed in context is the context through which the contents was drawn.
     WEBCORE_EXPORT RetainPtr<CGImageRef> createImage(CGContextRef);
-    WEBCORE_EXPORT RefPtr<NativeImage> createNativeImage();
+    WEBCORE_EXPORT RefPtr<NativeImage> createNativeImage(ShouldForceOpaque = ShouldForceOpaque::Yes);
     // Passed in context is the context through which the contents was drawn.
     WEBCORE_EXPORT static RetainPtr<CGImageRef> sinkIntoImage(std::unique_ptr<IOSurface>, RetainPtr<CGContextRef> = nullptr);
 

--- a/Source/WebCore/platform/graphics/cocoa/IOSurface.mm
+++ b/Source/WebCore/platform/graphics/cocoa/IOSurface.mm
@@ -543,12 +543,19 @@ RetainPtr<CGImageRef> IOSurface::createImage(CGContextRef context)
     return adoptCF(CGIOSurfaceContextCreateImage(context));
 }
 
-RefPtr<NativeImage> IOSurface::createNativeImage()
+RefPtr<NativeImage> IOSurface::createNativeImage(ShouldForceOpaque shouldForceOpaque)
 {
     std::optional<CGImageAlphaInfo> alphaInfo;
 #if ENABLE(PIXEL_FORMAT_RGBA16F)
-    if (pixelFormat() == Format::RGBA16F)
+    // An RGBA16F surface always uses IOSurface::Format::RGBA16F regardless of whether
+    // its contents are opaque, so bitmapConfiguration() assumes premultiplied alpha.
+    // Callers presenting opaque contents must force the alpha channel to be ignored;
+    // otherwise (e.g. a premultiplied WebGPU canvas) the alpha must be preserved so
+    // the contents composite transparently.
+    if (shouldForceOpaque == ShouldForceOpaque::Yes && pixelFormat() == Format::RGBA16F)
         alphaInfo = kCGImageAlphaNoneSkipLast;
+#else
+    UNUSED_PARAM(shouldForceOpaque);
 #endif
     RetainPtr<CGContextRef> cgContext { createPlatformContext(0, alphaInfo) };
     if (!cgContext)


### PR DESCRIPTION
#### e2cab1a5b940053eff2db407b023974325f73556
<pre>
[WebGPU] RGBA16Float offscreen canvas appears opaque
<a href="https://bugs.webkit.org/show_bug.cgi?id=318726">https://bugs.webkit.org/show_bug.cgi?id=318726</a>
<a href="https://rdar.apple.com/181531622">rdar://181531622</a>

Reviewed by Tadeu Zagallo.

Unlike BGRX - BGRA, RGBA16Float doesn&apos;t encode the presence of the alpha channel into
the IOSurface format, so we need to consult the canvas behavior when reading back the contents.

Test: fast/webgpu/offscreen-canvas-rgba16float-transparency.html
* LayoutTests/fast/webgpu/offscreen-canvas-rgba16float-transparency-expected.html: Added.
* LayoutTests/fast/webgpu/offscreen-canvas-rgba16float-transparency.html: Added.
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUCompositorIntegrationImpl.cpp:
(WebCore::WebGPU::CompositorIntegrationImpl::recreateRenderBuffers):
(WebCore::WebGPU::CompositorIntegrationImpl::withDisplayBufferAsNativeImage):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUCompositorIntegrationImpl.h:
* Source/WebCore/platform/graphics/cocoa/IOSurface.h:
* Source/WebCore/platform/graphics/cocoa/IOSurface.mm:
(WebCore::IOSurface::createNativeImage):

Canonical link: <a href="https://commits.webkit.org/316628@main">https://commits.webkit.org/316628@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ff2838e7bdb81ba30905a8c6875dbbc4ffb83d2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172906 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46825 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40295 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182366 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130462 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174771 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48118 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46501 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134470 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/8c127670-b156-4c03-acd1-fc9ba7ffe3a0/e97b80b3-28df-4c33-965a-9935420d367c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175864 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37867 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155038 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114939 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/8c127670-b156-4c03-acd1-fc9ba7ffe3a0/00d3b10e-7bf8-43bb-b695-4e6978cfe57b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36512 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34834 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30964 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146935 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34543 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184900 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37654 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39036 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143279 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46496 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154605 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143151 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38662 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47174 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31374 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112176 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38137 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118934 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45691 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9486 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45092 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45324 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45150 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->