### PR TITLE
Change findIntersection() to return an std::optional<FloatPoint>

### DIFF
--- a/Source/WebCore/platform/graphics/FloatPointGraph.cpp
+++ b/Source/WebCore/platform/graphics/FloatPointGraph.cpp
@@ -58,8 +58,10 @@ void FloatPointGraph::reset()
 
 static bool NODELETE findLineSegmentIntersection(const FloatPointGraph::Edge& edgeA, const FloatPointGraph::Edge& edgeB, FloatPoint& intersectionPoint)
 {
-    if (!findIntersection(*edgeA.first, *edgeA.second, *edgeB.first, *edgeB.second, intersectionPoint))
+    auto intersection = findIntersection(*edgeA.first, *edgeA.second, *edgeB.first, *edgeB.second);
+    if (!intersection)
         return false;
+    intersectionPoint = *intersection;
 
     FloatPoint edgeAVec(*edgeA.second - *edgeA.first);
     FloatPoint edgeBVec(*edgeB.second - *edgeB.first);

--- a/Source/WebCore/platform/graphics/GeometryUtilities.cpp
+++ b/Source/WebCore/platform/graphics/GeometryUtilities.cpp
@@ -45,7 +45,7 @@ float euclidianDistance(const FloatPoint& p1, const FloatPoint& p2)
     return euclidianDistance(p1 - p2);
 }
 
-bool findIntersection(const FloatPoint& p1, const FloatPoint& p2, const FloatPoint& d1, const FloatPoint& d2, FloatPoint& intersection) 
+std::optional<FloatPoint> findIntersection(const FloatPoint& p1, const FloatPoint& p2, const FloatPoint& d1, const FloatPoint& d2)
 {
     float pxLength = p2.x() - p1.x();
     float pyLength = p2.y() - p1.y();
@@ -55,13 +55,11 @@ bool findIntersection(const FloatPoint& p1, const FloatPoint& p2, const FloatPoi
 
     float denom = pxLength * dyLength - pyLength * dxLength;
     if (!denom)
-        return false;
-    
+        return std::nullopt;
+
     float param = ((d1.x() - p1.x()) * dyLength - (d1.y() - p1.y()) * dxLength) / denom;
 
-    intersection.setX(p1.x() + param * pxLength);
-    intersection.setY(p1.y() + param * pyLength);
-    return true;
+    return FloatPoint(p1.x() + param * pxLength, p1.y() + param * pyLength);
 }
 
 IntRect unionRect(const Vector<IntRect>& rects)

--- a/Source/WebCore/platform/graphics/GeometryUtilities.h
+++ b/Source/WebCore/platform/graphics/GeometryUtilities.h
@@ -38,8 +38,8 @@ class FloatQuad;
 float NODELETE euclidianDistance(const FloatSize&);
 WEBCORE_EXPORT float euclidianDistance(const FloatPoint&, const FloatPoint&);
 
-// Find point where lines through the two pairs of points intersect. Returns false if the lines don't intersect.
-WEBCORE_EXPORT bool NODELETE findIntersection(const FloatPoint& p1, const FloatPoint& p2, const FloatPoint& d1, const FloatPoint& d2, FloatPoint& intersection);
+// Find point where lines through the two pairs of points intersect. Returns std::nullopt if the lines are parallel.
+WEBCORE_EXPORT std::optional<FloatPoint> NODELETE findIntersection(const FloatPoint& p1, const FloatPoint& p2, const FloatPoint& d1, const FloatPoint& d2);
 
 WEBCORE_EXPORT IntRect unionRect(const Vector<IntRect>&);
 WEBCORE_EXPORT IntRect unionRectIgnoringZeroRects(const Vector<IntRect>&);

--- a/Source/WebCore/rendering/BorderPainter.cpp
+++ b/Source/WebCore/rendering/BorderPainter.cpp
@@ -887,40 +887,40 @@ void BorderPainter::clipBorderSidePolygon(const BorderShape& borderShape, BoxSid
         quad = { outerRect.minXMinYCorner(), innerRect.minXMinYCorner(), innerRect.maxXMinYCorner(), outerRect.maxXMinYCorner() };
 
         if (!Style::isZero(innerBorder.radii().topLeft()))
-            findIntersection(outerRect.minXMinYCorner(), innerRect.minXMinYCorner(), innerRect.minXMaxYCorner(), innerRect.maxXMinYCorner(), quad[1]);
+            quad[1] = findIntersection(outerRect.minXMinYCorner(), innerRect.minXMinYCorner(), innerRect.minXMaxYCorner(), innerRect.maxXMinYCorner()).value_or(quad[1]);
 
         if (!Style::isZero(innerBorder.radii().topRight()))
-            findIntersection(outerRect.maxXMinYCorner(), innerRect.maxXMinYCorner(), innerRect.minXMinYCorner(), innerRect.maxXMaxYCorner(), quad[2]);
+            quad[2] = findIntersection(outerRect.maxXMinYCorner(), innerRect.maxXMinYCorner(), innerRect.minXMinYCorner(), innerRect.maxXMaxYCorner()).value_or(quad[2]);
         break;
 
     case BoxSide::Left:
         quad = { outerRect.minXMinYCorner(), innerRect.minXMinYCorner(), innerRect.minXMaxYCorner(), outerRect.minXMaxYCorner() };
 
         if (!Style::isZero(innerBorder.radii().topLeft()))
-            findIntersection(outerRect.minXMinYCorner(), innerRect.minXMinYCorner(), innerRect.minXMaxYCorner(), innerRect.maxXMinYCorner(), quad[1]);
+            quad[1] = findIntersection(outerRect.minXMinYCorner(), innerRect.minXMinYCorner(), innerRect.minXMaxYCorner(), innerRect.maxXMinYCorner()).value_or(quad[1]);
 
         if (!Style::isZero(innerBorder.radii().bottomLeft()))
-            findIntersection(outerRect.minXMaxYCorner(), innerRect.minXMaxYCorner(), innerRect.minXMinYCorner(), innerRect.maxXMaxYCorner(), quad[2]);
+            quad[2] = findIntersection(outerRect.minXMaxYCorner(), innerRect.minXMaxYCorner(), innerRect.minXMinYCorner(), innerRect.maxXMaxYCorner()).value_or(quad[2]);
         break;
 
     case BoxSide::Bottom:
         quad = { outerRect.minXMaxYCorner(), innerRect.minXMaxYCorner(), innerRect.maxXMaxYCorner(), outerRect.maxXMaxYCorner() };
 
         if (!Style::isZero(innerBorder.radii().bottomLeft()))
-            findIntersection(outerRect.minXMaxYCorner(), innerRect.minXMaxYCorner(), innerRect.minXMinYCorner(), innerRect.maxXMaxYCorner(), quad[1]);
+            quad[1] = findIntersection(outerRect.minXMaxYCorner(), innerRect.minXMaxYCorner(), innerRect.minXMinYCorner(), innerRect.maxXMaxYCorner()).value_or(quad[1]);
 
         if (!Style::isZero(innerBorder.radii().bottomRight()))
-            findIntersection(outerRect.maxXMaxYCorner(), innerRect.maxXMaxYCorner(), innerRect.maxXMinYCorner(), innerRect.minXMaxYCorner(), quad[2]);
+            quad[2] = findIntersection(outerRect.maxXMaxYCorner(), innerRect.maxXMaxYCorner(), innerRect.maxXMinYCorner(), innerRect.minXMaxYCorner()).value_or(quad[2]);
         break;
 
     case BoxSide::Right:
         quad = { outerRect.maxXMinYCorner(), innerRect.maxXMinYCorner(), innerRect.maxXMaxYCorner(), outerRect.maxXMaxYCorner() };
 
         if (!Style::isZero(innerBorder.radii().topRight()))
-            findIntersection(outerRect.maxXMinYCorner(), innerRect.maxXMinYCorner(), innerRect.minXMinYCorner(), innerRect.maxXMaxYCorner(), quad[1]);
+            quad[1] = findIntersection(outerRect.maxXMinYCorner(), innerRect.maxXMinYCorner(), innerRect.minXMinYCorner(), innerRect.maxXMaxYCorner()).value_or(quad[1]);
 
         if (!Style::isZero(innerBorder.radii().bottomRight()))
-            findIntersection(outerRect.maxXMaxYCorner(), innerRect.maxXMaxYCorner(), innerRect.maxXMinYCorner(), innerRect.minXMaxYCorner(), quad[2]);
+            quad[2] = findIntersection(outerRect.maxXMaxYCorner(), innerRect.maxXMaxYCorner(), innerRect.maxXMinYCorner(), innerRect.minXMaxYCorner()).value_or(quad[2]);
         break;
     }
 

--- a/Source/WebKit/UIProcess/Inspector/ios/WKInspectorHighlightView.mm
+++ b/Source/WebKit/UIProcess/Inspector/ios/WKInspectorHighlightView.mm
@@ -74,9 +74,10 @@
 static bool findIntersectionOnLineBetweenPoints(const WebCore::FloatPoint& p1, const WebCore::FloatPoint& p2, const WebCore::FloatPoint& d1, const WebCore::FloatPoint& d2, WebCore::FloatPoint& intersection) 
 {
     // Do the lines intersect?
-    WebCore::FloatPoint temporaryIntersectionPoint;
-    if (!findIntersection(p1, p2, d1, d2, temporaryIntersectionPoint))
+    auto intersectionPoint = findIntersection(p1, p2, d1, d2);
+    if (!intersectionPoint)
         return false;
+    WebCore::FloatPoint temporaryIntersectionPoint = *intersectionPoint;
 
     // Is the intersection between the two points on the line?
     if (p1.x() >= p2.x()) {

--- a/Source/WebKitLegacy/mac/WebInspector/WebNodeHighlightView.mm
+++ b/Source/WebKitLegacy/mac/WebInspector/WebNodeHighlightView.mm
@@ -131,9 +131,10 @@ using WebCore::findIntersection;
 static bool findIntersectionOnLineBetweenPoints(const FloatPoint& p1, const FloatPoint& p2, const FloatPoint& d1, const FloatPoint& d2, FloatPoint& intersection) 
 {
     // Do the lines intersect?
-    FloatPoint temporaryIntersectionPoint;
-    if (!findIntersection(p1, p2, d1, d2, temporaryIntersectionPoint))
+    auto intersectionPoint = findIntersection(p1, p2, d1, d2);
+    if (!intersectionPoint)
         return false;
+    FloatPoint temporaryIntersectionPoint = *intersectionPoint;
 
     // Is the intersection between the two points on the line?
     if (p1.x() >= p2.x()) {


### PR DESCRIPTION
#### cd777bb5eeec36aaf56789e8c414cebdcd3a7680
<pre>
Change findIntersection() to return an std::optional&lt;FloatPoint&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=318733">https://bugs.webkit.org/show_bug.cgi?id=318733</a>
<a href="https://rdar.apple.com/181535881">rdar://181535881</a>

Reviewed by Simon Fraser.

WebCore::findIntersection() (in GeometryUtilities) currently returns a bool and
writes the intersection point through a FloatPoint&amp; out-parameter. The changes
now return std::optional&lt;FloatPoint&gt;

No behavior change intended

* Source/WebCore/platform/graphics/FloatPointGraph.cpp:
(WebCore::findLineSegmentIntersection):
* Source/WebCore/platform/graphics/GeometryUtilities.cpp:
(WebCore::findIntersection):
* Source/WebCore/platform/graphics/GeometryUtilities.h:
* Source/WebCore/rendering/BorderPainter.cpp:
(WebCore::BorderPainter::clipBorderSidePolygon const):
* Source/WebKit/UIProcess/Inspector/ios/WKInspectorHighlightView.mm:
(findIntersectionOnLineBetweenPoints):
* Source/WebKitLegacy/mac/WebInspector/WebNodeHighlightView.mm:
(findIntersectionOnLineBetweenPoints):

Canonical link: <a href="https://commits.webkit.org/316633@main">https://commits.webkit.org/316633@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1598fda56a8288e52e8665f3034cfa7d5361928

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172913 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46832 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40302 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182373 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130469 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174778 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48125 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46508 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134477 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175871 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37869 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155041 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114946 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36514 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34838 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30971 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146937 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34546 "Found 1 new test failure: imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-origin.sub.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184907 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37661 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39040 "Found 1 new test failure: http/tests/site-isolation/page-zoom.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143285 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46503 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143157 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38664 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47181 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31377 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/112183 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38140 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118941 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45698 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9489 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45099 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45331 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45157 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->