### PR TITLE
Use protect() instead of Ref/RefPtr { } in mediasource code

### DIFF
--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -300,7 +300,7 @@ void MediaSource::open()
 #if ENABLE(MEDIA_SOURCE_IN_WORKERS)
     if (RefPtr handle = m_handle) {
         handle->setHasEverBeenAssignedAsSrcObject();
-        handle->mediaSourceDidOpen(Ref { *m_private });
+        handle->mediaSourceDidOpen(protect(*m_private));
     }
 #endif
 

--- a/Source/WebCore/Modules/mediasource/SampleMap.cpp
+++ b/Source/WebCore/Modules/mediasource/SampleMap.cpp
@@ -36,12 +36,13 @@ public:
     typedef typename M::value_type value_type;
     bool operator()(const value_type& value, const MediaTime& time)
     {
-        MediaTime presentationEndTime = Ref { value.second }->presentationTime() + Ref { value.second }->duration();
+        Ref sample { value.second };
+        MediaTime presentationEndTime = sample->presentationTime() + sample->duration();
         return presentationEndTime <= time;
     }
     bool operator()(const MediaTime& time, const value_type& value)
     {
-        MediaTime presentationStartTime = Ref { value.second }->presentationTime();
+        MediaTime presentationStartTime = protect(value.second)->presentationTime();
         return time < presentationStartTime;
     }
 };
@@ -52,12 +53,13 @@ public:
     typedef typename M::value_type value_type;
     bool operator()(const value_type& value, const MediaTime& time)
     {
-        MediaTime presentationStartTime = Ref { value.second }->presentationTime();
+        MediaTime presentationStartTime = protect(value.second)->presentationTime();
         return presentationStartTime > time;
     }
     bool operator()(const MediaTime& time, const value_type& value)
     {
-        MediaTime presentationEndTime = Ref { value.second }->presentationTime() + Ref { value.second }->duration();
+        Ref sample { value.second };
+        MediaTime presentationEndTime = sample->presentationTime() + sample->duration();
         return time >= presentationEndTime;
     }
 };
@@ -66,7 +68,7 @@ class SampleIsRandomAccess {
 public:
     bool operator()(DecodeOrderSampleMap::MapType::value_type& value)
     {
-        return Ref { value.second }->isSync();
+        return protect(value.second)->isSync();
     }
 };
 
@@ -271,7 +273,7 @@ DecodeOrderSampleMap::reverse_iterator DecodeOrderSampleMap::findSyncSamplePrior
     reverse_iterator foundSample = findSyncSamplePriorToDecodeIterator(reverseCurrentSampleDTS);
     if (foundSample == rend())
         return rend();
-    if (Ref { foundSample->second }->presentationTime() < time - threshold)
+    if (protect(foundSample->second)->presentationTime() < time - threshold)
         return rend();
     return foundSample;
 }
@@ -294,7 +296,7 @@ DecodeOrderSampleMap::iterator DecodeOrderSampleMap::findSyncSampleAfterPresenta
     iterator foundSample = std::find_if(currentSampleDTS, end(), SampleIsRandomAccess());
     if (foundSample == end())
         return end();
-    if (Ref { foundSample->second }->presentationTime() > upperBound)
+    if (protect(foundSample->second)->presentationTime() > upperBound)
         return end();
     return foundSample;
 }

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -214,7 +214,7 @@ ExceptionOr<Ref<TimeRanges>> SourceBuffer::buffered()
     // Handled by sourceBufferPrivateBufferedChanged().
 
     // 6. Return the current value of this attribute.
-    return Ref { m_buffered };
+    return protect(m_buffered);
 }
 
 double SourceBuffer::timestampOffset() const
@@ -349,7 +349,7 @@ ExceptionOr<void> SourceBuffer::abort()
     //    then throw an InvalidStateError exception and abort these steps.
     // 2. If the readyState attribute of the parent media source is not in the "open" state
     //    then throw an InvalidStateError exception and abort these steps.
-    if (isRemoved() || !Ref { *m_source }->isOpen())
+    if (isRemoved() || !protect(*m_source)->isOpen())
         return Exception { ExceptionCode::InvalidStateError };
 
     // 3. If the range removal algorithm is running, then throw an InvalidStateError exception and abort these steps.
@@ -815,53 +815,56 @@ Ref<MediaPromise> SourceBuffer::sourceBufferPrivateDidReceiveInitializationSegme
         // 3.2 Add the appropriate track descriptions from this initialization segment to each of the track buffers.
         ASSERT(segment.audioTracks.size() == audioTracks->length());
         for (auto& audioTrackInfo : segment.audioTracks) {
+            Ref audioTrackPrivate { *audioTrackInfo.track };
             if (audioTracks->length() == 1) {
                 RefPtr track = audioTracks->item(0);
                 auto oldId = track->trackId();
-                auto newId = RefPtr { audioTrackInfo.track }->id();
-                track->setPrivate(Ref { *audioTrackInfo.track });
+                auto newId = audioTrackPrivate->id();
+                track->setPrivate(audioTrackPrivate);
                 if (newId != oldId)
                     trackIdPairs.append(std::make_pair(oldId, newId));
                 break;
             }
 
-            auto audioTrack = audioTracks->getTrackById(RefPtr { audioTrackInfo.track }->id());
+            auto audioTrack = audioTracks->getTrackById(audioTrackPrivate->id());
             ASSERT(audioTrack);
-            audioTrack->setPrivate(Ref { *audioTrackInfo.track });
+            audioTrack->setPrivate(audioTrackPrivate);
         }
 
         ASSERT(segment.videoTracks.size() == videoTracks->length());
         for (auto& videoTrackInfo : segment.videoTracks) {
+            Ref videoTrackPrivate { *videoTrackInfo.track };
             if (videoTracks->length() == 1) {
                 RefPtr track = videoTracks->item(0);
                 auto oldId = track->trackId();
-                auto newId = RefPtr { videoTrackInfo.track }->id();
-                track->setPrivate(Ref { *videoTrackInfo.track });
+                auto newId = videoTrackPrivate->id();
+                track->setPrivate(videoTrackPrivate);
                 if (newId != oldId)
                     trackIdPairs.append(std::make_pair(oldId, newId));
                 break;
             }
 
-            auto videoTrack = videoTracks->getTrackById(RefPtr { videoTrackInfo.track }->id());
+            auto videoTrack = videoTracks->getTrackById(videoTrackPrivate->id());
             ASSERT(videoTrack);
-            videoTrack->setPrivate(Ref { *videoTrackInfo.track });
+            videoTrack->setPrivate(videoTrackPrivate);
         }
 
         ASSERT(segment.textTracks.size() == textTracks->length());
         for (auto& textTrackInfo : segment.textTracks) {
+            Ref textTrackPrivate { *textTrackInfo.track };
             if (textTracks->length() == 1) {
                 RefPtr track = downcast<InbandTextTrack>(textTracks->item(0));
                 auto oldId = track->trackId();
-                auto newId = RefPtr { textTrackInfo.track }->id();
-                track->setPrivate(Ref { *textTrackInfo.track });
+                auto newId = textTrackPrivate->id();
+                track->setPrivate(textTrackPrivate);
                 if (newId != oldId)
                     trackIdPairs.append(std::make_pair(oldId, newId));
                 break;
             }
 
-            auto textTrack = textTracks->getTrackById(RefPtr { textTrackInfo.track }->id());
+            auto textTrack = textTracks->getTrackById(textTrackPrivate->id());
             ASSERT(textTrack);
-            downcast<InbandTextTrack>(*textTrack).setPrivate(Ref { *textTrackInfo.track });
+            downcast<InbandTextTrack>(*textTrack).setPrivate(textTrackPrivate);
         }
 
         if (!trackIdPairs.isEmpty())
@@ -900,10 +903,12 @@ Ref<MediaPromise> SourceBuffer::sourceBufferPrivateDidReceiveInitializationSegme
 
         // 5.2 For each audio track in the initialization segment, run following steps:
         for (auto& audioTrackInfo : segment.audioTracks) {
+            Ref audioTrackPrivate { *audioTrackInfo.track };
+
             // FIXME: Implement steps 5.2.1-5.2.8.1 as per Editor's Draft 09 January 2015, and reorder this
             // 5.2.1 Let new audio track be a new AudioTrack object.
             // 5.2.2 Generate a unique ID and assign it to the id property on new video track.
-            Ref newAudioTrack = AudioTrack::create(protect(scriptExecutionContext()).get(), Ref { *audioTrackInfo.track });
+            Ref newAudioTrack = AudioTrack::create(protect(scriptExecutionContext()).get(), audioTrackPrivate);
             newAudioTrack->addClient(*this);
             newAudioTrack->setSourceBuffer(this);
 
@@ -936,21 +941,23 @@ Ref<MediaPromise> SourceBuffer::sourceBufferPrivateDidReceiveInitializationSegme
                 // Let mirrored audio track be a new AudioTrack object.
                 // Assign the same property values to mirrored audio track as were determined for new audio track.
                 // Add mirrored audio track to the audioTracks attribute on the HTMLMediaElement.
-                source->addAudioTrackMirrorToElement(*audioTrackInfo.track, enabled);
+                source->addAudioTrackMirrorToElement(audioTrackPrivate.get(), enabled);
             }
 
             m_audioCodecs.append(audioTrackInfo.description->codec().toAtomString());
 
             // 5.2.8 Create a new track buffer to store coded frames for this track.
-            m_private->addTrackBuffer(RefPtr { audioTrackInfo.track }->id(), WTF::move(audioTrackInfo.description));
+            m_private->addTrackBuffer(audioTrackPrivate->id(), WTF::move(audioTrackInfo.description));
         }
 
         // 5.3 For each video track in the initialization segment, run following steps:
         for (auto& videoTrackInfo : segment.videoTracks) {
+            Ref videoTrackPrivate { *videoTrackInfo.track };
+
             // FIXME: Implement steps 5.3.1-5.3.8.1 as per Editor's Draft 09 January 2015, and reorder this
             // 5.3.1 Let new video track be a new VideoTrack object.
             // 5.3.2 Generate a unique ID and assign it to the id property on new video track.
-            Ref newVideoTrack = VideoTrack::create(protect(scriptExecutionContext()).get(), Ref { *videoTrackInfo.track });
+            Ref newVideoTrack = VideoTrack::create(protect(scriptExecutionContext()).get(), videoTrackPrivate);
             newVideoTrack->addClient(*this);
             newVideoTrack->setSourceBuffer(this);
 
@@ -983,13 +990,13 @@ Ref<MediaPromise> SourceBuffer::sourceBufferPrivateDidReceiveInitializationSegme
                 // Let mirrored audio track be a new VideoTrack object.
                 // Assign the same property values to mirrored video track as were determined for new video track.
                 // Add mirrored video track to the videoTracks attribute on the HTMLMediaElement.
-                source->addVideoTrackMirrorToElement(*videoTrackInfo.track, selected);
+                source->addVideoTrackMirrorToElement(videoTrackPrivate.get(), selected);
             }
 
             m_videoCodecs.append(videoTrackInfo.description->codec().toAtomString());
 
             // 5.3.8 Create a new track buffer to store coded frames for this track.
-            m_private->addTrackBuffer(RefPtr { videoTrackInfo.track }->id(), WTF::move(videoTrackInfo.description));
+            m_private->addTrackBuffer(videoTrackPrivate->id(), WTF::move(videoTrackInfo.description));
         }
 
         // 5.4 For each text track in the initialization segment, run following steps:
@@ -1494,9 +1501,10 @@ Ref<MediaPromise> SourceBuffer::sourceBufferPrivateDidAttach(SourceBufferPrivate
     // 3.2 Add the appropriate track descriptions from this initialization segment to each of the track buffers.
     ASSERT(segment.audioTracks.size() == protect(audioTracksIfExists())->length());
     for (auto& audioTrackInfo : segment.audioTracks) {
-        auto audioTrack = protect(audioTracksIfExists())->getTrackById(RefPtr { audioTrackInfo.track }->id());
+        Ref audioTrackPrivate { *audioTrackInfo.track };
+        auto audioTrack = protect(audioTracksIfExists())->getTrackById(audioTrackPrivate->id());
         ASSERT(audioTrack);
-        audioTrack->setPrivate(Ref { *audioTrackInfo.track });
+        audioTrack->setPrivate(audioTrackPrivate);
         if (isMainThread())
             source->addAudioTrackToElement(*audioTrack);
         else {
@@ -1505,16 +1513,17 @@ Ref<MediaPromise> SourceBuffer::sourceBufferPrivateDidAttach(SourceBufferPrivate
             // Let mirrored audio track be a new AudioTrack object.
             // Assign the same property values to mirrored audio track as were determined for new audio track.
             // Add mirrored audio track to the audioTracks attribute on the HTMLMediaElement.
-            source->addAudioTrackMirrorToElement(*audioTrackInfo.track, audioTrack->enabled());
+            source->addAudioTrackMirrorToElement(audioTrackPrivate.get(), audioTrack->enabled());
         }
     }
 
     Ref videoTracks = this->videoTracks();
     ASSERT(segment.videoTracks.size() == videoTracks->length());
     for (auto& videoTrackInfo : segment.videoTracks) {
-        auto videoTrack = videoTracks->getTrackById(RefPtr { videoTrackInfo.track }->id());
+        Ref videoTrackPrivate { *videoTrackInfo.track };
+        auto videoTrack = videoTracks->getTrackById(videoTrackPrivate->id());
         ASSERT(videoTrack);
-        videoTrack->setPrivate(Ref { *videoTrackInfo.track });
+        videoTrack->setPrivate(videoTrackPrivate);
         // 5.3.6 Add new video track to the videoTracks attribute on the HTMLMediaElement.
         // 5.3.7 Queue a task to fire a trusted event named addtrack, that does not bubble and is
         // not cancelable, and that uses the TrackEvent interface, at the VideoTrackList object
@@ -1527,16 +1536,17 @@ Ref<MediaPromise> SourceBuffer::sourceBufferPrivateDidAttach(SourceBufferPrivate
             // Let mirrored audio track be a new VideoTrack object.
             // Assign the same property values to mirrored video track as were determined for new video track.
             // Add mirrored video track to the videoTracks attribute on the HTMLMediaElement.
-            source->addVideoTrackMirrorToElement(*videoTrackInfo.track, videoTrack->selected());
+            source->addVideoTrackMirrorToElement(videoTrackPrivate.get(), videoTrack->selected());
         }
     }
 
     Ref textTracks = this->textTracks();
     ASSERT(segment.textTracks.size() == textTracks->length());
     for (auto& textTrackInfo : segment.textTracks) {
-        auto textTrack = textTracks->getTrackById(RefPtr { textTrackInfo.track }->id());
+        Ref textTrackPrivate { *textTrackInfo.track };
+        auto textTrack = textTracks->getTrackById(textTrackPrivate->id());
         ASSERT(textTrack);
-        downcast<InbandTextTrack>(*textTrack).setPrivate(Ref { *textTrackInfo.track });
+        downcast<InbandTextTrack>(*textTrack).setPrivate(textTrackPrivate);
         // 5.4.5 Add new text track to the textTracks attribute on the HTMLMediaElement.
         // 5.4.6 Queue a task to fire a trusted event named addtrack, that does not bubble and is
         // not cancelable, and that uses the TrackEvent interface, at the TextTrackList object
@@ -1549,7 +1559,7 @@ Ref<MediaPromise> SourceBuffer::sourceBufferPrivateDidAttach(SourceBufferPrivate
             // Let mirrored text track be a new TextTrack object.
             // Assign the same property values to mirrored text track as were determined for new text track.
             // Add mirrored text track to the textTracks attribute on the HTMLMediaElement.
-            source->addTextTrackMirrorToElement(*textTrackInfo.track);
+            source->addTextTrackMirrorToElement(textTrackPrivate.get());
         }
     }
 

--- a/Source/WebCore/Modules/mediasource/SourceBufferList.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBufferList.cpp
@@ -69,7 +69,7 @@ void SourceBufferList::add(Ref<SourceBuffer>&& buffer)
 
 bool SourceBufferList::contains(SourceBuffer& buffer) const
 {
-    return m_list.find(Ref { buffer } ) != notFound;
+    return m_list.find(protect(buffer)) != notFound;
 }
 
 RefPtr<SourceBuffer> SourceBufferList::item(unsigned index) const
@@ -81,7 +81,7 @@ RefPtr<SourceBuffer> SourceBufferList::item(unsigned index) const
 
 void SourceBufferList::remove(SourceBuffer& buffer)
 {
-    size_t index = m_list.find(Ref { buffer });
+    size_t index = m_list.find(protect(buffer));
     if (index == notFound)
         return;
     m_list.removeAt(index);


### PR DESCRIPTION
#### fa8971b085b36ea6ab104104aae3a39fd10452e2
<pre>
Use protect() instead of Ref/RefPtr { } in mediasource code
<a href="https://bugs.webkit.org/show_bug.cgi?id=318734">https://bugs.webkit.org/show_bug.cgi?id=318734</a>
<a href="https://rdar.apple.com/181536967">rdar://181536967</a>

Reviewed by Anne van Kesteren.

Mechanical migration from brace-initialized Ref/RefPtr temporaries to the
protect() free function in Source/WebCore/Modules/mediasource/, aligning
with the codebase-wide transition.

No new tests needed (no behavioral change, style-only refactor).

* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::open):
* Source/WebCore/Modules/mediasource/SampleMap.cpp:
(WebCore::SampleIsLessThanMediaTimeComparator::operator()):
(WebCore::SampleIsGreaterThanMediaTimeComparator::operator()):
(WebCore::SampleIsRandomAccess::operator()):
* Source/WebCore/Modules/mediasource/SourceBuffer.cpp:
(WebCore::SourceBuffer::buffered):
(WebCore::SourceBuffer::abort):
(WebCore::SourceBuffer::sourceBufferPrivateDidReceiveInitializationSegment):
(WebCore::SourceBuffer::sourceBufferPrivateDidAttach):
* Source/WebCore/Modules/mediasource/SourceBufferList.cpp:
(WebCore::SourceBufferList::contains const):
(WebCore::SourceBufferList::remove):

Canonical link: <a href="https://commits.webkit.org/316747@main">https://commits.webkit.org/316747@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a56233393b69eb3a6905dd33719030bcc099c9bb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173221 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47153 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40666 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182794 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130777 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6a1213f1-e9dd-4161-96f4-615546bfdaef) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175086 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48446 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46835 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134690 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/395d2ecb-5325-4e07-bf0a-cb3e716d5630) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176179 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38169 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155317 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115220 "Found 1 new API test failure: WPE/TestWebKitWebView:/webkit/WebKitWebView/save (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/80181bf3-3290-4ea5-b60b-c393129b5197) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36747 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35089 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31279 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147171 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34815 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185216 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38045 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39291 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143533 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46821 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143404 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38726 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47500 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112585 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38363 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119249 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46006 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9847 "Passed tests") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45408 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45639 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45465 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->