### PR TITLE
Fix PrintStream truncation of long strings written to files

### DIFF
--- a/Source/WTF/wtf/FilePrintStream.h
+++ b/Source/WTF/wtf/FilePrintStream.h
@@ -47,6 +47,8 @@ public:
     void vprintf(const char* format, va_list) final WTF_ATTRIBUTE_PRINTF(2, 0);
     void flush() final;
 
+    bool truncatesLongStrings() const final { return false; }
+
 private:
     FILE* m_file;
     AdoptionMode m_adoptionMode;

--- a/Source/WTF/wtf/JSONValues.cpp
+++ b/Source/WTF/wtf/JSONValues.cpp
@@ -621,14 +621,7 @@ void Value::dump(PrintStream& out) const
     }, [&](const String& string) {
         StringBuilder builder;
         builder.appendQuotedJSONString(string);
-        // PrintStream truncates >5 MB CStrings for log readability, which would corrupt JSON. Bypass via const char*.
-        // FIXME: needs a systematic fix in PrintStream — log-output truncation
-        // should not apply to file persistence. Every site that prints large
-        // Strings to disk (this JSON dumper, SamplingProfiler reports, future
-        // text dumps, ...) is silently exposed to the same corruption; this
-        // patch only covers the JSON path.
-        auto utf8 = builder.toString().utf8();
-        out.print(utf8.data());
+        out.print(builder.toString());
     }, [&](ObjectTypeTag) {
         // Safety: This lambda runs synchronously so it is safe to capture `this` without refing.
         SUPPRESS_UNCOUNTED_LAMBDA_CAPTURE auto& object = *static_cast<const ObjectBase*>(this);

--- a/Source/WTF/wtf/PrintStream.cpp
+++ b/Source/WTF/wtf/PrintStream.cpp
@@ -104,7 +104,7 @@ void printInternal(PrintStream& out, StringView string)
 
 void printInternal(PrintStream& out, const CString& string)
 {
-    if (string.length() > stringLengthThresholdToTriggerTruncation) [[unlikely]] {
+    if (out.truncatesLongStrings() && string.length() > stringLengthThresholdToTriggerTruncation) [[unlikely]] {
         size_t lengthNotPrinted = string.length() - stringLengthToTruncateToForPrinting;
         auto subString = makeString(string.span().first(stringLengthToTruncateToForPrinting), "...["_s, lengthNotPrinted, " characters not shown]"_s);
         printInternal(out, subString.utf8().data());

--- a/Source/WTF/wtf/PrintStream.h
+++ b/Source/WTF/wtf/PrintStream.h
@@ -66,7 +66,9 @@ public:
     // Typically a no-op for many subclasses of PrintStream, this is a hint that
     // the implementation should flush its buffers if it had not done so already.
     WTF_EXPORT_PRIVATE virtual void flush();
-    
+
+    virtual bool truncatesLongStrings() const { return true; }
+
     template<typename Func>
     void atomically(NOESCAPE const Func& func)
     {

--- a/Source/WTF/wtf/ScopedPrintStream.h
+++ b/Source/WTF/wtf/ScopedPrintStream.h
@@ -51,6 +51,8 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     }
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
+    bool truncatesLongStrings() const final { return m_out.truncatesLongStrings(); }
+
     void reset() { m_buffer.reset(); }
 
 private:


### PR DESCRIPTION
#### 287641e1e1170d0f8dc4f1e0047f4b5fc0940818
<pre>
Fix PrintStream truncation of long strings written to files
<a href="https://bugs.webkit.org/show_bug.cgi?id=318735">https://bugs.webkit.org/show_bug.cgi?id=318735</a>
<a href="https://rdar.apple.com/181536755">rdar://181536755</a>

Reviewed by Yusuke Suzuki.

PrintStream truncates strings over 5MB for readability, which is fine
for terminal output but corrupts data meant to be persisted exactly
(e.g. JSON::Value::dump, previously patched around this one call site
in cd07e3f6c0c0 with a FIXME noting the fix should be systemic).

Add PrintStream::truncatesLongStrings(), true by default, overridden
to false in FilePrintStream and forwarded through ScopedPrintStream.
Revert the JSONValues.cpp workaround now that the root cause is fixed.

Canonical link: <a href="https://commits.webkit.org/316622@main">https://commits.webkit.org/316622@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/93886acdf7dcdd2204a02009b3b64fe50f396b42

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172912 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46831 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40301 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182372 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130468 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/8c127670-b156-4c03-acd1-fc9ba7ffe3a0/decebd1c-7da4-4f29-8e1d-34f6a9d2f168) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48124 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46507 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134494 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/8c127670-b156-4c03-acd1-fc9ba7ffe3a0/6113d8f7-c955-467a-ab06-e4b1e83ac69b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175870 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37872 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155046 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114963 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/8c127670-b156-4c03-acd1-fc9ba7ffe3a0/a8cec8f5-1012-4983-a310-568a7bfeb2fe) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36517 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34842 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30970 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/3568 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146940 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34551 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184906 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/34174 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37660 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39044 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143291 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46502 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143162 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38657 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47180 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31382 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112182 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38146 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118940 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/205590 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45697 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9494 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54886 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45098 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45330 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45156 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->