### PR TITLE
[CMake] Codesign MiniBrowser.app with its entitlements

### DIFF
--- a/Source/cmake/WebKitXcodeSDK.cmake
+++ b/Source/cmake/WebKitXcodeSDK.cmake
@@ -102,20 +102,45 @@ function(WEBKIT_RESOLVE_TOOL OUTPUT_VAR _tool)
     endif ()
 endfunction()
 
-# Run Source/${PROJECT}/Scripts/process-entitlements.sh against an executable
-# target and ad-hoc codesign it with the resulting entitlements. Mirrors the
-# Xcode build's "Process Entitlements" build phase plus the signing step.
+# Ad-hoc codesign a target with entitlements, mirroring the Xcode build. For
+# MACOSX_BUNDLE targets the whole .app bundle is signed; otherwise the target
+# executable. Two modes select where the entitlements come from:
 #
-# Usage:
 #   WEBKIT_PROCESS_ENTITLEMENTS(target PROJECT name [PRODUCT_NAME name])
+#       Generate entitlements at build time by running
+#       Source/<PROJECT>/Scripts/process-entitlements.sh, mirroring Xcode's
+#       "Process Entitlements" build phase. PROJECT names the directory under
+#       Source/ containing the script (e.g. JavaScriptCore, WebKit).
+#       PRODUCT_NAME defaults to the CMake target name; set it explicitly when
+#       the script's dispatcher keys off a different name.
 #
-# PROJECT names the directory under Source/ containing Scripts/process-entitlements.sh
-# (e.g. JavaScriptCore, WebKit). PRODUCT_NAME defaults to the CMake target name;
-# set it explicitly when the script's dispatcher keys off a different name.
+#   WEBKIT_PROCESS_ENTITLEMENTS(target ENTITLEMENTS path)
+#       Sign with a static, checked-in entitlements file, mirroring Xcode's
+#       CODE_SIGN_ENTITLEMENTS setting (e.g. MiniBrowser).
 function(WEBKIT_PROCESS_ENTITLEMENTS _target)
-    cmake_parse_arguments(_arg "" "PROJECT;PRODUCT_NAME" "" ${ARGN})
+    cmake_parse_arguments(_arg "" "PROJECT;PRODUCT_NAME;ENTITLEMENTS" "" ${ARGN})
+    if (_arg_PROJECT AND _arg_ENTITLEMENTS)
+        message(FATAL_ERROR "WEBKIT_PROCESS_ENTITLEMENTS(${_target}): PROJECT and ENTITLEMENTS are mutually exclusive")
+    endif ()
+
+    # Sign the .app bundle for bundled targets, otherwise the executable.
+    get_target_property(_is_bundle ${_target} MACOSX_BUNDLE)
+    if (_is_bundle)
+        set(_sign_path $<TARGET_BUNDLE_DIR:${_target}>)
+    else ()
+        set(_sign_path $<TARGET_FILE:${_target}>)
+    endif ()
+
+    if (_arg_ENTITLEMENTS)
+        add_custom_command(TARGET ${_target} POST_BUILD
+            COMMAND codesign --force --sign - --entitlements ${_arg_ENTITLEMENTS} ${_sign_path}
+            VERBATIM
+        )
+        return()
+    endif ()
+
     if (NOT _arg_PROJECT)
-        message(FATAL_ERROR "WEBKIT_PROCESS_ENTITLEMENTS(${_target}): PROJECT is required")
+        message(FATAL_ERROR "WEBKIT_PROCESS_ENTITLEMENTS(${_target}): PROJECT or ENTITLEMENTS is required")
     endif ()
     if (NOT _arg_PRODUCT_NAME)
         set(_arg_PRODUCT_NAME ${_target})
@@ -127,7 +152,7 @@ function(WEBKIT_PROCESS_ENTITLEMENTS _target)
             WK_PLATFORM_NAME=${WEBKIT_SDK_NAME}
             PRODUCT_NAME=${_arg_PRODUCT_NAME}
             ${CMAKE_SOURCE_DIR}/Source/${_arg_PROJECT}/Scripts/process-entitlements.sh
-        COMMAND codesign --force --sign - --entitlements ${_xcent} $<TARGET_FILE:${_target}>
+        COMMAND codesign --force --sign - --entitlements ${_xcent} ${_sign_path}
         VERBATIM
     )
 endfunction()

--- a/Tools/MiniBrowser/mac/CMakeLists.txt
+++ b/Tools/MiniBrowser/mac/CMakeLists.txt
@@ -87,3 +87,7 @@ exec \"\$DIR/MiniBrowser.app/Contents/MacOS/MiniBrowser\" \"\$@\"
 ")
 file(CHMOD ${CMAKE_BINARY_DIR}/run-minibrowser PERMISSIONS
     OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+
+if (TARGET MiniBrowser)
+    WEBKIT_PROCESS_ENTITLEMENTS(MiniBrowser ENTITLEMENTS ${TOOLS_DIR}/MiniBrowser/MiniBrowser.entitlements)
+endif ()


### PR DESCRIPTION
#### 11ab0556ff3d5ee324f8f90eeb6d309a04cdf3a3
<pre>
[CMake] Codesign MiniBrowser.app with its entitlements
<a href="https://bugs.webkit.org/show_bug.cgi?id=318722">https://bugs.webkit.org/show_bug.cgi?id=318722</a>
<a href="https://rdar.apple.com/181531065">rdar://181531065</a>

Reviewed by NOBODY (OOPS!).

Xcode signs MiniBrowser with its checked-in MiniBrowser.entitlements
(CODE_SIGN_ENTITLEMENTS, CODE_SIGN_IDENTITY = -). The CMake port builds
MiniBrowser.app but never signs it, so at runtime it lacks its entitlements.

The CMake port already ad-hoc codesigns with entitlements via
WEBKIT_PROCESS_ENTITLEMENTS() (used by the JSC shell/test targets), but
that helper only supported script-generated entitlements
(Source/&lt;PROJECT&gt;/Scripts/process-entitlements.sh) signed onto a target
executable. MiniBrowser instead uses a static checked-in entitlements
file signed onto the .app bundle, matching Xcode&apos;s CODE_SIGN_ENTITLEMENTS.
Unlike the script path, MiniBrowser&apos;s entitlements are SDK-independent in
Xcode (no [sdk=...] variant), so a single static file covers both the
public and internal SDK.

Generalize WEBKIT_PROCESS_ENTITLEMENTS() to add an ENTITLEMENTS &lt;path&gt;
mode for static entitlements files (mutually exclusive with PROJECT), and
have it sign the .app bundle for MACOSX_BUNDLE targets and the executable
otherwise. Route MiniBrowser through it so the port shares one signing
helper instead of duplicating the codesign invocation. The JSC targets are
plain executables and are unaffected.

* Source/cmake/WebKitXcodeSDK.cmake:
* Tools/MiniBrowser/mac/CMakeLists.txt:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/11ab0556ff3d5ee324f8f90eeb6d309a04cdf3a3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172917 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46836 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40306 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182377 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130473 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/8c127670-b156-4c03-acd1-fc9ba7ffe3a0/ae3c9437-ae51-4fcf-ba66-19544367b958) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174782 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48129 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46512 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134481 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94927 "2 flakes 21 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/8c127670-b156-4c03-acd1-fc9ba7ffe3a0/5c9e1b06-ad49-4292-9520-3bb1146b7b83) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175875 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37874 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155057 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114950 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/8c127670-b156-4c03-acd1-fc9ba7ffe3a0/47c4eea6-f0dc-4395-8de7-85fd774025ec) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36519 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34844 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30975 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/3579 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146942 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34562 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184911 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/34179 "Built successfully and passed tests") | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39046 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143290 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46507 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143161 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47185 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31393 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112187 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38143 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/205595 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45702 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9505 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54888 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45103 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45335 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45161 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->