### PR TITLE
[Site Isolation] Web Inspector: Network domain sourceMappingURL is not forwarded for memory-cached cross-origin iframe stylesheets

### DIFF
--- a/LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-network-memory-cache-source-map-url-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-network-memory-cache-source-map-url-expected.txt
@@ -1,0 +1,11 @@
+Test that Network.requestServedFromMemoryCache forwards the sourceMapURL for a cross-origin iframe stylesheet served from the in-memory cache under Site Isolation.
+
+
+
+== Running test suite: SiteIsolation.Network.CrossOriginIFrameMemoryCacheSourceMapURL
+-- Running test case: SiteIsolation.Network.CrossOriginIFrame.MemoryCacheSourceMapURLFromHeader
+Cold load in frame A finished; loading the same URL in frame B.
+PASS: Resource should be a stylesheet.
+PASS: Resource should be served from the memory cache.
+PASS: requestServedFromMemoryCache should carry the SourceMap header value.
+

--- a/LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-network-memory-cache-source-map-url.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-network-memory-cache-source-map-url.html
@@ -1,0 +1,77 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script src="../debugger/resources/site-isolation-debugger-test-utilities.js"></script>
+<script>
+function test() {
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.Network.CrossOriginIFrameMemoryCacheSourceMapURL");
+
+    // Spy on downloadSourceMap to capture the sourceMapURL that
+    // Network.requestServedFromMemoryCache forwards (via the CachedResource object),
+    // without performing the (flaky, network-dependent) source map download.
+    let capturedSourceMapURL;
+    WI.networkManager.downloadSourceMap = function(sourceMapURL) {
+        capturedSourceMapURL = sourceMapURL;
+    };
+
+    // Add a <link> for `href` in the given frame and resolve with the resulting resource once it
+    // has finished loading. responseSource is only set after ResourceWasAdded (during response/
+    // finish handling), so callers inspect it after this resolves, not at add time. The listener
+    // is registered before the load is triggered so no event is missed.
+    async function loadStylesheetAndAwaitResource(frameTarget, href) {
+        let added = new Promise((resolve) => {
+            function handler(event) {
+                let resource = event.data.resource;
+                if (!resource.url.includes(href))
+                    return;
+                WI.Frame.removeEventListener(WI.Frame.Event.ResourceWasAdded, handler);
+                resolve(resource);
+            }
+            WI.Frame.addEventListener(WI.Frame.Event.ResourceWasAdded, handler);
+        });
+        await frameTarget.RuntimeAgent.evaluate.invoke({expression: `loadStylesheet(${JSON.stringify(href)})`, objectGroup: "test"});
+        let resource = await added;
+        if (!resource.finished)
+            await new Promise((resolve) => resource.singleFireEventListener(WI.Resource.Event.LoadingDidFinish, resolve));
+        return resource;
+    }
+
+    async function frameTargetContaining(substring) {
+        let target = await frameTargetForURLContaining(substring);
+        InspectorTest.assert(target instanceof WI.FrameTarget, `Frame target for "${substring}" should exist.`);
+        await waitForExpressionInTarget(target, "typeof loadStylesheet === 'function'");
+        return target;
+    }
+
+    suite.addTestCase({
+        name: "SiteIsolation.Network.CrossOriginIFrame.MemoryCacheSourceMapURLFromHeader",
+        description: "requestServedFromMemoryCache for a cross-origin iframe stylesheet should carry the SourceMap header value.",
+        async test() {
+            let href = "stylesheet-with-source-map-header-cacheable.py";
+
+            // Frames A and B are the same origin (both localhost:8000), so under Site Isolation they
+            // share one WebContent process and its memory cache. Cold-load the stylesheet in A and
+            // keep its <link> alive so the resource stays cached in the shared process.
+            let frameA = await frameTargetContaining("iframe-with-stylesheet.html?a");
+            await loadStylesheetAndAwaitResource(frameA, href);
+            InspectorTest.log("Cold load in frame A finished; loading the same URL in frame B.");
+
+            // Loading the same URL in frame B is served from the shared memory cache.
+            let frameB = await frameTargetContaining("iframe-with-stylesheet.html?b");
+            capturedSourceMapURL = undefined;
+            let cached = await loadStylesheetAndAwaitResource(frameB, href);
+
+            InspectorTest.expectEqual(cached.type, WI.Resource.Type.StyleSheet, "Resource should be a stylesheet.");
+            InspectorTest.expectEqual(cached.responseSource, WI.Resource.ResponseSource.MemoryCache, "Resource should be served from the memory cache.");
+            InspectorTest.expectEqual(capturedSourceMapURL, "stylesheet-header.css.map", "requestServedFromMemoryCache should carry the SourceMap header value.");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+
+<body onload="runTest()">
+<p>Test that Network.requestServedFromMemoryCache forwards the sourceMapURL for a cross-origin iframe stylesheet served from the in-memory cache under Site Isolation.</p>
+<iframe src="http://localhost:8000/site-isolation/inspector/network/resources/iframe-with-stylesheet.html?a"></iframe>
+<iframe src="http://localhost:8000/site-isolation/inspector/network/resources/iframe-with-stylesheet.html?b"></iframe>
+</body>

--- a/LayoutTests/http/tests/site-isolation/inspector/network/resources/stylesheet-with-source-map-header-cacheable.py
+++ b/LayoutTests/http/tests/site-isolation/inspector/network/resources/stylesheet-with-source-map-header-cacheable.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+
+import sys
+
+# Cacheable (no "no-store") so the second load in the test is served from the
+# in-memory cache, exercising the RequestServedFromMemoryCache path.
+sys.stdout.write('Content-Type: text/css\r\n')
+sys.stdout.write('Cache-Control: max-age=3600\r\n')
+sys.stdout.write('SourceMap: stylesheet-header.css.map\r\n')
+sys.stdout.write('\r\n')
+sys.stdout.flush()
+
+sys.stdout.write('body { color: green; }\n')

--- a/Source/WebCore/inspector/InspectorResourceUtilities.h
+++ b/Source/WebCore/inspector/InspectorResourceUtilities.h
@@ -104,7 +104,7 @@ WEBCORE_EXPORT Ref<Inspector::Protocol::Page::FrameResource> buildResourceObject
 void resourceContent(Inspector::Protocol::ErrorString&, WebCore::LocalFrame*, const URL&, String* result, bool* base64Encoded);
 WEBCORE_EXPORT bool mainResourceContent(WebCore::LocalFrame*, bool withBase64Encode, String* result);
 
-String sourceMapURLForResource(WebCore::CachedResource*);
+WEBCORE_EXPORT String sourceMapURLForResource(WebCore::CachedResource*);
 RefPtr<WebCore::CachedResource> WEBCORE_EXPORT cachedResource(const WebCore::LocalFrame*, const URL&);
 Inspector::ResourceType WEBCORE_EXPORT inspectorResourceType(WebCore::CachedResource::Type);
 Inspector::ResourceType WEBCORE_EXPORT inspectorResourceType(const WebCore::CachedResource&);

--- a/Source/WebCore/loader/cache/CachedResource.h
+++ b/Source/WebCore/loader/cache/CachedResource.h
@@ -180,7 +180,7 @@ public:
     }
 
     unsigned size() const { return encodedSize() + decodedSize() + overheadSize(); }
-    unsigned NODELETE encodedSize() const;
+    WEBCORE_EXPORT unsigned NODELETE encodedSize() const;
     unsigned NODELETE decodedSize() const;
     unsigned overheadSize() const;
 

--- a/Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.cpp
+++ b/Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.cpp
@@ -474,7 +474,7 @@ void ProxyingNetworkAgent::loadingFailed(ResourceID resourceID, double timestamp
     m_frontendDispatcher->loadingFailed(requestId, timestamp, errorText, canceled);
 }
 
-void ProxyingNetworkAgent::requestServedFromMemoryCache(ResourceID resourceID, FrameID frameID, ContextID contextID, const String& documentURL, const ResourceRequest& request, const ResourceResponse& response, ResourceType resourceType, double timestamp)
+void ProxyingNetworkAgent::requestServedFromMemoryCache(ResourceID resourceID, FrameID frameID, ContextID contextID, const String& documentURL, const ResourceResponse& response, ResourceType resourceType, const String& sourceMapURL, uint64_t bodySize, double timestamp)
 {
     if (!m_enabled)
         return;
@@ -482,17 +482,24 @@ void ProxyingNetworkAgent::requestServedFromMemoryCache(ResourceID resourceID, F
     auto requestId = IdentifierRegistry::protocolRequestId(resourceID.processIdentifier(), resourceID.object());
     auto frameIdString = IdentifierRegistry::protocolFrameId(frameID, resourceID.processIdentifier());
     auto loaderId = IdentifierRegistry::protocolLoaderId(contextID);
-    auto requestObject = buildObjectForResourceRequest(request);
-    auto responseObject = buildObjectForResourceResponse(response);
+
+    auto cachedResourceObject = Protocol::Network::CachedResource::create()
+        .setUrl(response.url().string())
+        .setType(toProtocolResourceType(resourceType))
+        .setBodySize(bodySize)
+        .release();
+
+    if (auto responseObject = buildObjectForResourceResponse(response))
+        cachedResourceObject->setResponse(responseObject.releaseNonNull());
+
+    if (!sourceMapURL.isEmpty())
+        cachedResourceObject->setSourceMapURL(sourceMapURL);
 
     auto initiatorObject = Protocol::Network::Initiator::create()
         .setType(Protocol::Network::Initiator::Type::Other)
         .release();
 
-    m_frontendDispatcher->requestWillBeSent(requestId, frameIdString, loaderId, documentURL, WTF::move(requestObject), timestamp, timestamp, WTF::move(initiatorObject), nullptr, toProtocolResourceType(resourceType), String());
-
-    if (responseObject)
-        m_frontendDispatcher->responseReceived(requestId, frameIdString, loaderId, timestamp, toProtocolResourceType(resourceType), responseObject.releaseNonNull());
+    m_frontendDispatcher->requestServedFromMemoryCache(requestId, frameIdString, loaderId, documentURL, timestamp, WTF::move(initiatorObject), WTF::move(cachedResourceObject));
 }
 
 } // namespace Inspector

--- a/Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.h
+++ b/Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.h
@@ -106,7 +106,7 @@ private:
     void dataReceived(ResourceID, int dataLength, int encodedDataLength, double timestamp);
     void loadingFinished(ResourceID, double timestamp, const String& sourceMapURL);
     void loadingFailed(ResourceID, double timestamp, const String& errorText, bool canceled);
-    void requestServedFromMemoryCache(ResourceID, FrameID, ContextID, const String& documentURL, const WebCore::ResourceRequest&, const WebCore::ResourceResponse&, ResourceType, double timestamp);
+    void requestServedFromMemoryCache(ResourceID, FrameID, ContextID, const String& documentURL, const WebCore::ResourceResponse&, ResourceType, const String& sourceMapURL, uint64_t bodySize, double timestamp);
 
     void removeAllRegisteredReceivers();
 

--- a/Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.messages.in
+++ b/Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.messages.in
@@ -36,5 +36,5 @@ messages -> Inspector::ProxyingNetworkAgent {
 
     LoadingFailed(WebCore::ScopedResourceLoaderIdentifier resourceID, double timestamp, String errorText, bool canceled)
 
-    RequestServedFromMemoryCache(WebCore::ScopedResourceLoaderIdentifier resourceID, WebCore::FrameIdentifier frameID, WebCore::ScriptExecutionContextIdentifier contextID, String documentURL, WebCore::ResourceRequest request, WebCore::ResourceResponse response, Inspector::ResourceType resourceType, double timestamp)
+    RequestServedFromMemoryCache(WebCore::ScopedResourceLoaderIdentifier resourceID, WebCore::FrameIdentifier frameID, WebCore::ScriptExecutionContextIdentifier contextID, String documentURL, WebCore::ResourceResponse response, Inspector::ResourceType resourceType, String sourceMapURL, uint64_t bodySize, double timestamp)
 }

--- a/Source/WebKit/WebProcess/Inspector/FrameNetworkAgentProxy.cpp
+++ b/Source/WebKit/WebProcess/Inspector/FrameNetworkAgentProxy.cpp
@@ -348,16 +348,19 @@ void FrameNetworkAgentProxy::didLoadResourceFromMemoryCache(DocumentLoader* load
     if (ResourceUtilities::cachedResourceContent(cachedResource, &content, &base64Encoded))
         m_resourcesData->setResourceContent(resourceID, content, base64Encoded);
 
-    // FIXME: Unlike the network path (didFinishLoading), the CSS sourceMappingURL is not
-    // forwarded for memory-cached stylesheets: it is neither computed from the CachedResource
-    // here nor carried by the RequestServedFromMemoryCache message. Tracked in webkit.org/b/??????.
+    // Compute the CSS sourceMappingURL and body size directly from the CachedResource (we hold
+    // it here, unlike the network path), so the UIProcess can build the Network.CachedResource
+    // protocol object. sourceMapURLForResource is CSS-only, matching the legacy Network agent.
+    auto sourceMapURL = ResourceUtilities::sourceMapURLForResource(&cachedResource);
+    auto bodySize = cachedResource.encodedSize();
+
     auto timestamp = MonotonicTime::now().secondsSinceEpoch().value();
     auto documentURL = protectedLoader->url().string();
 
     protect(WebProcess::singleton().parentProcessConnection())->send(
         Messages::ProxyingNetworkAgent::RequestServedFromMemoryCache(
-            qualifyResourceID(resourceID), *frameID, contextID, documentURL, cachedResource.resourceRequest(),
-            cachedResource.response(), resourceType, timestamp),
+            qualifyResourceID(resourceID), *frameID, contextID, documentURL,
+            cachedResource.response(), resourceType, sourceMapURL, bodySize, timestamp),
         page->identifier());
 }
 


### PR DESCRIPTION
#### 5ff5b2cf4386431d725cf5ad25a10442e21f3022
<pre>
[Site Isolation] Web Inspector: Network domain sourceMappingURL is not forwarded for memory-cached cross-origin iframe stylesheets
<a href="https://bugs.webkit.org/show_bug.cgi?id=318740">https://bugs.webkit.org/show_bug.cgi?id=318740</a>

Reviewed by BJ Burg.

Follow-up to the cold-load sourceMappingURL work, <a href="https://github.com/WebKit/WebKit/pull/68571.">https://github.com/WebKit/WebKit/pull/68571.</a>
Under Site Isolation, network events for cross-origin iframe resources
are reported by FrameNetworkAgentProxy (WebProcess) to ProxyingNetworkAgent
(UIProcess). A resource served from WebCore&apos;s in-memory cache does not
go through the willSendRequest/didReceiveResponse/didFinishLoading
sequence; instead FrameNetworkAgentProxy::didLoadResourceFromMemoryCache
fires once. That path previously synthesized requestWillBeSent +
responseReceived and forwarded no sourceMappingURL, so source maps for
stylesheets served from the memory cache did not auto-link in the
Network tab (they linked on the cold load but stopped once cached).

Finish the memory-cache path so it mirrors the legacy Network agent
instead of the synthesized requestWillBeSent + responseReceived it
emitted before. didLoadResourceFromMemoryCache has the CachedResource
in hand, so the CSS sourceMappingURL is resolved there (CSS-only by
design; scripts flow through the Debugger domain) and threaded through
to ProxyingNetworkAgent, which now dispatches the real
Network.requestServedFromMemoryCache event. The frontend already
consumes that event&apos;s sourceMapURL, so no frontend changes are needed;
emitting the real event (rather than the synthesized pair) also gives
memory-cached cross-origin iframe resources a proper finished state and
MemoryCache response-source classification under SI.

Test: http/tests/site-isolation/inspector/network/cross-origin-iframe-network-memory-cache-source-map-url.html

* LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-network-memory-cache-source-map-url-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-network-memory-cache-source-map-url.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/network/resources/stylesheet-with-source-map-header-cacheable.py: Added.
* Source/WebCore/inspector/InspectorResourceUtilities.h:
* Source/WebCore/loader/cache/CachedResource.h:
* Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.cpp:
(Inspector::ProxyingNetworkAgent::requestServedFromMemoryCache):
* Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.h:
* Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.messages.in:
* Source/WebKit/WebProcess/Inspector/FrameNetworkAgentProxy.cpp:
(WebKit::FrameNetworkAgentProxy::didLoadResourceFromMemoryCache):

Canonical link: <a href="https://commits.webkit.org/316778@main">https://commits.webkit.org/316778@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f0477011d1003951fa89dff8a9ab4ca809aec3e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173373 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47305 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40858 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182946 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130929 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/71ff6156-fba9-488d-8982-c2ba0e9ba97e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175238 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48598 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46987 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134807 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/29b648a9-6d16-48e8-9e1c-a1ccbe120ba2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176331 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38230 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/155469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115283 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cc2862ac-d39c-47ac-ac50-b149d68f53b1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36872 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/35223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31431 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147296 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34966 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185371 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/38238 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39425 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143676 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46973 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155028 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143539 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47652 "Built successfully") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112755 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26340 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38484 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/119401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46158 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9928 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45560 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45791 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45617 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->