### PR TITLE
REGRESSION(310112@main): Copy link with highlight just uses the original page link

### DIFF
--- a/LayoutTests/http/tests/scroll-to-text-fragment/generation-inside-display-contents-expected.txt
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/generation-inside-display-contents-expected.txt
@@ -1,0 +1,1 @@
+:~:text=A%20quick%20unique%20sentence%20inside%20display%20contents.

--- a/LayoutTests/http/tests/scroll-to-text-fragment/generation-inside-display-contents-start-and-end-expected.txt
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/generation-inside-display-contents-start-and-end-expected.txt
@@ -1,0 +1,1 @@
+:~:text=This%20is%20a,display%20contents%20subtree.

--- a/LayoutTests/http/tests/scroll-to-text-fragment/generation-inside-display-contents-start-and-end.html
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/generation-inside-display-contents-start-and-end.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<head>
+<meta charset="utf-8" />
+<title>Scroll to text fragment generation - a long selection inside a display:contents subtree still resolves its end text</title>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+window.addEventListener('load', () => {
+    const range = document.createRange();
+    range.selectNodeContents(document.getElementById("test"));
+    document.body.innerText = internals.textFragmentDirectiveForRange(range).split('#')[1];
+});
+</script>
+</head>
+<body>Prefix words here. <div style="display: contents"><span id="test">This is a long sentence that is being used to test that when a selection exceeds the maximum inline string length the fragment directive generator uses start and end text inside a display contents subtree.</span></div> And suffix words here.</body>
+</html>

--- a/LayoutTests/http/tests/scroll-to-text-fragment/generation-inside-display-contents.html
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/generation-inside-display-contents.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<head>
+<meta charset="utf-8" />
+<title>Scroll to text fragment generation - a selection inside a display:contents subtree is still found</title>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+window.addEventListener('load', () => {
+    const range = document.createRange();
+    range.selectNodeContents(document.getElementById("test"));
+    document.body.innerText = internals.textFragmentDirectiveForRange(range).split('#')[1];
+});
+</script>
+</head>
+<body><div style="display: contents"><span id="test">A quick unique sentence inside display contents.</span></div></body>
+</html>

--- a/Source/WebCore/dom/FragmentDirectiveRangeFinder.cpp
+++ b/Source/WebCore/dom/FragmentDirectiveRangeFinder.cpp
@@ -62,7 +62,10 @@ enum class WordBounded : bool { No, Yes };
 // https://wicg.github.io/scroll-to-text-fragment/#search-invisible
 static bool NODELETE isSearchInvisible(const Node& node)
 {
-    if (!node.renderStyle() || node.renderStyle()->display() == Style::DisplayType::None)
+    // display:contents has no RenderStyle but its subtree is rendered; the element type checks below still apply.
+    RefPtr element = dynamicDowncast<Element>(node);
+    bool isDisplayContents = element && element->hasDisplayContents();
+    if (!isDisplayContents && (!node.renderStyle() || node.renderStyle()->display() == Style::DisplayType::None))
         return true;
     
     // FIXME: If the node serializes as void.


### PR DESCRIPTION
#### 0f96b26db8ad2125cb066fc544ee76f7b0cc93c8
<pre>
REGRESSION(310112@main): Copy link with highlight just uses the original page link
<a href="https://bugs.webkit.org/show_bug.cgi?id=318741">https://bugs.webkit.org/show_bug.cgi?id=318741</a>
<a href="https://rdar.apple.com/178547114">rdar://178547114</a>

Reviewed by Tim Horton and Abrar Rahman Protyasha.

The range finder skips anything in a &quot;search-invisible&quot; subtree, and it wrongly
counted display:contents as invisible: such an element has no renderer (so no RenderStyle)
even though its subtree is rendered and searchable. This latent bug only bites
the *second* search the finder runs, because the first one starts at the top of the
document and findPlainText locates the text before the block walk&apos;s skip matters.
That&apos;s why 310112@main exposed it: dropping the inline limit from 300 to 100 turned
these mid-length selections into start+end text instead of one inlined string, and the
end-text search begins inside the display:contents subtree (right after the start
match) where the whole subtree gets skipped -- so we never find the end and fall back
to the plain page URL. GitHub wraps pull-request content in display:contents wrappers,
which is why it shows up there. Fix: don&apos;t treat display:contents as search-invisible.

Test: http/tests/scroll-to-text-fragment/generation-inside-display-contents.html

* LayoutTests/http/tests/scroll-to-text-fragment/generation-inside-display-contents-expected.txt: Added.
* LayoutTests/http/tests/scroll-to-text-fragment/generation-inside-display-contents-start-and-end-expected.txt: Added.
* LayoutTests/http/tests/scroll-to-text-fragment/generation-inside-display-contents-start-and-end.html: Added.
* LayoutTests/http/tests/scroll-to-text-fragment/generation-inside-display-contents.html: Added.
* Source/WebCore/dom/FragmentDirectiveRangeFinder.cpp:
(WebCore::FragmentDirectiveRangeFinder::isSearchInvisible):

Canonical link: <a href="https://commits.webkit.org/316597@main">https://commits.webkit.org/316597@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69e0b36108feced6c538e7effdb7423966872525

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172942 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46861 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/40331 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182402 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/130498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/8c127670-b156-4c03-acd1-fc9ba7ffe3a0/0592c20f-2987-4b04-b20e-bd2a0ec7e8d4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174807 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48154 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46537 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/134498 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/130498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/8c127670-b156-4c03-acd1-fc9ba7ffe3a0/fd3fb5db-852a-403c-a018-309ff4bd6b97) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175900 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/37894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/155068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114967 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/8c127670-b156-4c03-acd1-fc9ba7ffe3a0/df872c97-77fa-4aee-b0fc-999a5da125dc) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/36539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31000 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/146963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/34573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184936 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/37698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/39068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/143308 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46532 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/154635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143179 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38640 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47210 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112214 "Built successfully") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/38164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/118970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45727 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/9516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45128 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45360 "Built successfully") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45186 "Failed to checkout and rebase branch from PR 68798") | | | | 
<!--EWS-Status-Bubble-End-->