### PR TITLE
[GFC] refactor PlacedGridItem::preferredAspectRatio into GridLayoutUtils.

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
@@ -28,6 +28,7 @@
 
 #include "GridFormattingContext.h"
 #include "GridSizeTypes.h"
+#include "LayoutElementBox.h"
 #include "LayoutIntegrationUtils.h"
 #include "NotImplemented.h"
 #include "PlacedGridItem.h"
@@ -45,6 +46,48 @@ LayoutUnit totalGuttersSize(size_t tracksCount, LayoutUnit gapsSize)
 {
     ASSERT(tracksCount);
     return gapsSize * (tracksCount - 1);
+}
+
+// https://drafts.csswg.org/css-sizing-4/#aspect-ratio
+std::optional<double> preferredAspectRatio(const ElementBox& gridItem)
+{
+    ASSERT(gridItem.isGridItem());
+
+    auto& computedAspectRatio = gridItem.style().aspectRatio();
+
+    auto isDegenerateRatio = [&] {
+        auto ratio = computedAspectRatio.tryRatio();
+        return !ratio || !ratio->numerator.value || !ratio->denominator.value;
+    };
+
+    // "If the <ratio> is degenerate, the property instead behaves as auto."
+    //
+    // auto: "Replaced elements with a natural aspect ratio use that aspect ratio;
+    // otherwise the box has no preferred aspect ratio."
+    if (computedAspectRatio.isAuto() || isDegenerateRatio()) {
+        if (gridItem.isReplacedBox() && gridItem.hasIntrinsicRatio())
+            return gridItem.intrinsicRatio();
+        return { };
+    }
+
+    // <ratio>: "The box's preferred aspect ratio is the specified ratio of width / height."
+    if (computedAspectRatio.isRatio()) {
+        auto ratio = *computedAspectRatio.tryRatio();
+        return ratio.numerator.value / ratio.denominator.value;
+    }
+
+    // auto && <ratio>: "The preferred aspect ratio is the specified ratio of width / height
+    // unless it is a replaced element with a natural aspect ratio, in which case that aspect
+    // ratio is used instead."
+    if (computedAspectRatio.isAutoAndRatio()) {
+        if (gridItem.isReplacedBox() && gridItem.hasIntrinsicRatio())
+            return gridItem.intrinsicRatio();
+        auto ratio = *computedAspectRatio.tryRatio();
+        return ratio.numerator.value / ratio.denominator.value;
+    }
+
+    ASSERT_NOT_REACHED();
+    return { };
 }
 
 static bool NODELETE spansAutoMinTrackSizingFunction(WTF::Range<size_t> spannedTrackIndexes, const TrackSizingFunctionsList& trackSizingFunctions)
@@ -86,7 +129,7 @@ static std::optional<LayoutUnit> NODELETE inlineTransferredSizeSuggestion(const 
 
 static BorderBoxSize inlineContentSizeSuggestion(const PlacedGridItem& gridItem, LayoutUnit borderAndPadding, const IntegrationUtils& integrationUtils)
 {
-    ASSERT(!gridItem.preferredAspectRatio(), "Grid items with preferred aspect ratio not supported yet.");
+    ASSERT(!preferredAspectRatio(gridItem.layoutBox()), "Grid items with preferred aspect ratio not supported yet.");
     return BorderBoxSize { ContentBoxSize { integrationUtils.minContentWidth(gridItem.layoutBox()) }, borderAndPadding };
 }
 
@@ -117,7 +160,7 @@ static std::optional<BorderBoxSize> NODELETE blockTransferredSizeSuggestion(cons
 static BorderBoxSize blockContentSizeSuggestion(const PlacedGridItem& gridItem, LayoutUnit inlineAxisConstraint, const GridFormattingContext& formattingContext)
 {
     // FIXME: Clamp by opposite-axis min/max sizes converted through the aspect ratio.
-    ASSERT(!gridItem.preferredAspectRatio(), "Grid items with preferred aspect ratio not supported yet.");
+    ASSERT(!preferredAspectRatio(gridItem.layoutBox()), "Grid items with preferred aspect ratio not supported yet.");
     return BorderBoxSize::fromIntegrationFunction(formattingContext.integrationUtils().minContentHeightForGridItem(gridItem.layoutBox(), inlineAxisConstraint));
 }
 
@@ -159,7 +202,7 @@ LayoutUnit inlinePreferredSize(const PlacedGridItem& placedGridItem, LayoutUnit 
         // necessary to make its outer size as close to filling the alignment container as possible.
         auto& marginStart = inlineAxisSizes.marginStart;
         auto& marginEnd = inlineAxisSizes.marginEnd;
-        if ((alignmentPosition == ItemPosition::Normal) && !placedGridItem.preferredAspectRatio() && !placedGridItem.isReplacedElement()
+        if ((alignmentPosition == ItemPosition::Normal) && !preferredAspectRatio(placedGridItem.layoutBox()) && !placedGridItem.isReplacedElement()
             && !marginStart.isAuto() && !marginEnd.isAuto()) {
             auto& usedZoom = placedGridItem.usedZoom();
             auto usedMarginStart = LayoutUnit { marginStart.tryFixed()->resolveZoom(usedZoom) };
@@ -287,7 +330,7 @@ bool hasStretchedBlockSize(const PlacedGridItem& placedGridItem)
 {
     if (!placedGridItem.blockAxisSizes().preferredSize.isAuto())
         return false;
-    if (placedGridItem.preferredAspectRatio() || placedGridItem.isReplacedElement())
+    if (preferredAspectRatio(placedGridItem.layoutBox()) || placedGridItem.isReplacedElement())
         return false;
     auto& marginStart = placedGridItem.blockAxisSizes().marginStart;
     auto& marginEnd = placedGridItem.blockAxisSizes().marginEnd;

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h
@@ -27,6 +27,7 @@
 
 #include "GridTypeAliases.h"
 #include "LayoutUnit.h"
+#include <optional>
 
 namespace WebCore {
 
@@ -36,6 +37,7 @@ struct PreferredSize;
 
 namespace Layout {
 
+class ElementBox;
 class GridFormattingContext;
 class IntegrationUtils;
 class PlacedGridItem;
@@ -67,6 +69,8 @@ LayoutUnit blockAxisMaxContentContribution(const PlacedGridItem&, LayoutUnit inl
 
 bool preferredSizeBehavesAsAuto(const Style::PreferredSize&);
 bool NODELETE preferredSizeDependsOnContainingBlockSize(const Style::PreferredSize&);
+
+std::optional<double> preferredAspectRatio(const ElementBox&);
 
 } // namespace GridLayoutUtils
 } // namespace Layout

--- a/Source/WebCore/layout/formattingContexts/grid/PlacedGridItem.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/PlacedGridItem.cpp
@@ -55,45 +55,5 @@ PlacedGridItem::PlacedGridItem(const ElementBox& gridItem, const GridAreaLines& 
 {
 }
 
-// https://drafts.csswg.org/css-sizing-4/#aspect-ratio
-std::optional<double> PlacedGridItem::preferredAspectRatio() const
-{
-    auto& computedAspectRatio = protect(m_layoutBox->style())->aspectRatio();
-
-    auto isDegenerateRatio = [&] {
-        auto ratio = computedAspectRatio.tryRatio();
-        return !ratio || !ratio->numerator.value || !ratio->denominator.value;
-    };
-
-    // "If the <ratio> is degenerate, the property instead behaves as auto."
-    //
-    // auto: "Replaced elements with a natural aspect ratio use that aspect ratio;
-    // otherwise the box has no preferred aspect ratio."
-    if (computedAspectRatio.isAuto() || isDegenerateRatio()) {
-        if (m_layoutBox->isReplacedBox() && m_layoutBox->hasIntrinsicRatio())
-            return m_layoutBox->intrinsicRatio();
-        return { };
-    }
-
-    // <ratio>: "The box's preferred aspect ratio is the specified ratio of width / height."
-    if (computedAspectRatio.isRatio()) {
-        auto ratio = *computedAspectRatio.tryRatio();
-        return ratio.numerator.value / ratio.denominator.value;
-    }
-
-    // auto && <ratio>: "The preferred aspect ratio is the specified ratio of width / height
-    // unless it is a replaced element with a natural aspect ratio, in which case that aspect
-    // ratio is used instead."
-    if (computedAspectRatio.isAutoAndRatio()) {
-        if (m_layoutBox->isReplacedBox() && m_layoutBox->hasIntrinsicRatio())
-            return m_layoutBox->intrinsicRatio();
-        auto ratio = *computedAspectRatio.tryRatio();
-        return ratio.numerator.value / ratio.denominator.value;
-    }
-
-    ASSERT_NOT_REACHED();
-    return { };
-}
-
 } // namespace Layout
 } // namespace WebCore

--- a/Source/WebCore/layout/formattingContexts/grid/PlacedGridItem.h
+++ b/Source/WebCore/layout/formattingContexts/grid/PlacedGridItem.h
@@ -69,7 +69,6 @@ public:
 
     const WritingMode& writingMode() const LIFETIME_BOUND { return m_writingMode; }
 
-    std::optional<double> preferredAspectRatio() const;
     bool isReplacedElement() const { return m_layoutBox->isReplacedBox(); }
 
     const GridAreaLines& gridAreaLines() const LIFETIME_BOUND { return m_gridAreaLines; }


### PR DESCRIPTION
#### 4c799f966e9b51b984e346de2de590eb57c1eb51
<pre>
[GFC] refactor PlacedGridItem::preferredAspectRatio into GridLayoutUtils.
<a href="https://bugs.webkit.org/show_bug.cgi?id=318731">https://bugs.webkit.org/show_bug.cgi?id=318731</a>
&lt;<a href="https://rdar.apple.com/181534087">rdar://181534087</a>&gt;

Reviewed by Sammy Gill.

Refactor the logic for computing preferredAspectRatio()
to GridLayoutUtils() to make it reachable before construction
of PlacedGridItem().

* Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp:
(WebCore::Layout::GridLayoutUtils::preferredAspectRatio):
(WebCore::Layout::GridLayoutUtils::inlineContentSizeSuggestion):
(WebCore::Layout::GridLayoutUtils::blockContentSizeSuggestion):
(WebCore::Layout::GridLayoutUtils::inlinePreferredSize):
(WebCore::Layout::GridLayoutUtils::hasStretchedBlockSize):
* Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h:
* Source/WebCore/layout/formattingContexts/grid/PlacedGridItem.cpp:
(WebCore::Layout::PlacedGridItem::preferredAspectRatio const): Deleted.
* Source/WebCore/layout/formattingContexts/grid/PlacedGridItem.h:

Canonical link: <a href="https://commits.webkit.org/316604@main">https://commits.webkit.org/316604@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f7c4ac31bc6ba97e9782749329d0f826f70eb4e6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172961 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46880 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/40350 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182421 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/130517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/8c127670-b156-4c03-acd1-fc9ba7ffe3a0/d242d9da-b67f-4115-902d-8d8f34c83253) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174826 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48173 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46556 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/134519 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/130517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/8c127670-b156-4c03-acd1-fc9ba7ffe3a0/fa9d8586-be0e-4058-a14b-62f048435855) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175919 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/37914 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/155087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114988 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/8c127670-b156-4c03-acd1-fc9ba7ffe3a0/a6084a13-fbf7-4378-9c3a-5e7008d133d3) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/36559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31019 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/146983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/34592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184955 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/37720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/39087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/143326 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46551 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/154654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143197 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47229 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112235 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26248 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38183 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/118989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45746 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/9535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45147 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45379 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45205 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->