### PR TITLE
Small updates to various new APIs

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentWorld.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentWorld.h
@@ -64,7 +64,7 @@ Repeated calls will retrieve the same WKContentWorld instance.
 @discussion Unlike all other worlds, worlds created with this factory method cannot be retrieved later.
 Clients therefore need to take care to reference them for as long as they are needed.
 */
-+ (WKContentWorld *)worldWithConfiguration:(WKContentWorldConfiguration *)configuration NS_SWIFT_NAME(world(configuration:)) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
++ (WKContentWorld *)worldWithConfiguration:(WKContentWorldConfiguration *)configuration NS_SWIFT_NAME(init(configuration:)) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 /*! @abstract Retrieves a named content world for API client use.
 @param name The name of the WKContentWorld to retrieve.

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentWorld.swift
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentWorld.swift
@@ -27,7 +27,17 @@ extension WKContentWorld {
     // SPI factory to keep others building for now
     // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     @_spi(APIAdoptionStaging)
-    public static func world(with configuration: WKContentWorldConfiguration) -> WKContentWorld {
-        world(configuration: configuration)
+    public static func world(with configuration: WKContentWorld.Configuration) -> WKContentWorld {
+        WKContentWorld(configuration: configuration)
+    }
+}
+
+extension WKContentWorld.Configuration {
+    // SPI property declaration to keep others building for now
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    @_spi(_)
+    public var isInspectable: Bool {
+        get { inspectable }
+        set { inspectable = newValue }
     }
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentWorldConfiguration.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentWorldConfiguration.h
@@ -37,20 +37,21 @@ For example:
 */
 WK_SWIFT_UI_ACTOR
 NS_SWIFT_SENDABLE
+NS_SWIFT_NAME(WKContentWorld.Configuration)
 WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
 @interface WKContentWorldConfiguration : NSObject<NSCopying, NSSecureCoding>
 
 /*! @abstract A boolean value indicating whether every shadow root should be treated as open mode shadow root or not. */
-@property (nonatomic) BOOL openClosedShadowRootsEnabled;
+@property (nonatomic) BOOL allowAccessingClosedShadowRoots;
 
 /*! @abstract A boolean value indicating whether the capability to trigger autofill is exposed to scripts or not. */
-@property (nonatomic) BOOL autofillScriptingEnabled;
+@property (nonatomic, getter=isAutofillScriptingEnabled) BOOL autofillScriptingEnabled NS_SWIFT_NAME(autofillScriptingEnabled);
 
 /*! @abstract A boolean value indicating whether the ability to attach user info on an element is exposed to scripts or not. */
-@property (nonatomic) BOOL elementUserInfoEnabled;
+@property (nonatomic, getter=isElementUserInfoEnabled) BOOL elementUserInfoEnabled NS_SWIFT_NAME(elementUserInfoEnabled);
 
 /*! @abstract A boolean value indicating whether the behavior that elements with a name attribute overrides builtin methods on document object should be enabled or not. */
-@property (nonatomic) BOOL legacyBuiltinOverridesEnabled;
+@property (nonatomic, getter=isLegacyBuiltinOverridesEnabled) BOOL legacyBuiltinOverridesEnabled NS_SWIFT_NAME(legacyBuiltinOverridesEnabled);
 
 /*! @abstract A boolean indicating whether or not `window.webkit.serializeNode` is available.
  @discussion JavaScript can call `window.webkit.serializeNode` with a return value to create a `WKJSSerializedNode`
@@ -63,7 +64,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
 @property (nonatomic, setter=setJSHandleCreationEnabled:) BOOL jsHandleCreationEnabled;
 
 /*! @abstract A boolean indicating whether the JavaScript in this world is visible to the Web Inspector. */
-@property (nonatomic, getter=isInspectable) BOOL inspectable;
+@property (nonatomic, getter=isInspectable) BOOL inspectable NS_SWIFT_NAME(inspectable);
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentWorldConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentWorldConfiguration.mm
@@ -107,17 +107,17 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
     return *_worldConfiguration;
 }
 
-- (BOOL)openClosedShadowRootsEnabled
+- (BOOL)allowAccessingClosedShadowRoots
 {
     return _worldConfiguration->allowAccessToClosedShadowRoots();
 }
 
-- (void)setOpenClosedShadowRootsEnabled:(BOOL)allow
+- (void)setAllowAccessingClosedShadowRoots:(BOOL)allow
 {
     _worldConfiguration->setAllowAccessToClosedShadowRoots(allow);
 }
 
-- (BOOL)autofillScriptingEnabled
+- (BOOL)isAutofillScriptingEnabled
 {
     return _worldConfiguration->allowAutofill();
 }
@@ -127,7 +127,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
     _worldConfiguration->setAllowAutofill(enabled);
 }
 
-- (BOOL)elementUserInfoEnabled
+- (BOOL)isElementUserInfoEnabled
 {
     return _worldConfiguration->allowElementUserInfo();
 }
@@ -137,7 +137,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
     _worldConfiguration->setAllowElementUserInfo(enabled);
 }
 
-- (BOOL)legacyBuiltinOverridesEnabled
+- (BOOL)isLegacyBuiltinOverridesEnabled
 {
     return !_worldConfiguration->disableLegacyBuiltinOverrides();
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.h
@@ -61,7 +61,7 @@ WK_SWIFT_UI_ACTOR
  @param url The URL to fetch the matching cookies for.
  @param completionHandler A block to invoke with the fetched cookies.
  */
-- (void)getCookiesForURL:(NSURL *)url completionHandler:(NS_SWIFT_UI_ACTOR void (^)(NSArray<NSHTTPCookie *> *))completionHandler NS_SWIFT_NAME(getCookies(for:completionHandler:)) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+- (void)getCookiesForURL:(NSURL *)url completionHandler:(NS_SWIFT_UI_ACTOR void (^)(NSArray<NSHTTPCookie *> *))completionHandler NS_SWIFT_NAME(getCookies(for:completionHandler:)) WK_SWIFT_ASYNC_NAME(cookies(for:)) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 /*! @abstract Set a cookie.
  @param cookie The cookie to set.

--- a/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegate.h
@@ -299,7 +299,7 @@ WK_SWIFT_UI_ACTOR
  @param frame The frame that initiated the request.
  @param decisionHandler The decision handler to call once the app has made its decision.
  */
-- (void)webView:(WKWebView *)webView requestGeolocationPermissionForOrigin:(WKSecurityOrigin*)origin initiatedByFrame:(WKFrameInfo *)frame decisionHandler:(WK_SWIFT_UI_ACTOR void (^)(WKPermissionDecision decision))decisionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+- (void)webView:(WKWebView *)webView requestGeolocationPermissionForOrigin:(WKSecurityOrigin*)origin initiatedByFrame:(WKFrameInfo *)frame decisionHandler:(WK_SWIFT_UI_ACTOR void (^)(WKPermissionDecision decision))decisionHandler WK_SWIFT_ASYNC_NAME(webView(_:requestGeolocationPermissionFor:initiatedBy:)) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 #if TARGET_OS_IOS && !TARGET_OS_MACCATALYST && __IPHONE_OS_VERSION_MIN_REQUIRED >= 180400
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageTests.swift
@@ -150,9 +150,9 @@ struct WebPageTests {
 
     @Test
     func clearContentWorld() async throws {
-        let worldConfiguration = WKContentWorldConfiguration()
+        let worldConfiguration = WKContentWorld.Configuration()
         worldConfiguration.nodeSerializationEnabled = true
-        let world = WKContentWorld.world(configuration: worldConfiguration)
+        let world = WKContentWorld(configuration: worldConfiguration)
 
         let page = WebPage()
         try await page.load(html: "<body></body>").wait()


### PR DESCRIPTION
#### 1ef95fe531cc2f43866229874c5e16c90696d0ba
<pre>
Small updates to various new APIs
<a href="https://rdar.apple.com/181542734">rdar://181542734</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=318743">https://bugs.webkit.org/show_bug.cgi?id=318743</a>

Reviewed by Richard Robinson.

Feedback-based tweaks to these APIs to make them better for the platforms going forward.

Test: Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageTests.swift

* Source/WebKit/UIProcess/API/Cocoa/WKContentWorld.h:
* Source/WebKit/UIProcess/API/Cocoa/WKContentWorld.swift:
(WKContentWorld.world(with:)):
(WKContentWorld.isInspectable):
* Source/WebKit/UIProcess/API/Cocoa/WKContentWorldConfiguration.h:
* Source/WebKit/UIProcess/API/Cocoa/WKContentWorldConfiguration.mm:
(-[WKContentWorldConfiguration allowAccessingClosedShadowRoots]):
(-[WKContentWorldConfiguration setAllowAccessingClosedShadowRoots:]):
(-[WKContentWorldConfiguration isAutofillScriptingEnabled]):
(-[WKContentWorldConfiguration isElementUserInfoEnabled]):
(-[WKContentWorldConfiguration isLegacyBuiltinOverridesEnabled]):
(-[WKContentWorldConfiguration openClosedShadowRootsEnabled]): Deleted.
(-[WKContentWorldConfiguration setOpenClosedShadowRootsEnabled:]): Deleted.
(-[WKContentWorldConfiguration autofillScriptingEnabled]): Deleted.
(-[WKContentWorldConfiguration elementUserInfoEnabled]): Deleted.
(-[WKContentWorldConfiguration legacyBuiltinOverridesEnabled]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.h:
* Source/WebKit/UIProcess/API/Cocoa/WKUIDelegate.h:
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageTests.swift:
(WebPageTests.clearContentWorld):

Canonical link: <a href="https://commits.webkit.org/316611@main">https://commits.webkit.org/316611@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cbcf0ba8314982b96248074288791ed0f8fe7b52

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172938 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46857 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40327 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182398 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130494 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/8c127670-b156-4c03-acd1-fc9ba7ffe3a0/26e2a9b1-0bf8-485a-b3b3-421d547d78d2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174803 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48150 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46533 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134500 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/8c127670-b156-4c03-acd1-fc9ba7ffe3a0/1a1ee794-0a89-48bb-b81e-550a9fc4ff38) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175896 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37897 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/155069 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114969 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/8c127670-b156-4c03-acd1-fc9ba7ffe3a0/8ee6020e-6e8e-4350-8041-149323d2d8cd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36542 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30996 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146966 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34574 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184932 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37692 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39067 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143306 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46528 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143177 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38650 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47206 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112210 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38163 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118966 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45723 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9517 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45124 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45356 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45182 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->