### PR TITLE
[JSC] Add LoadMegamorphicGetter IC

### DIFF
--- a/JSTests/stress/megamorphic-getter-ic.js
+++ b/JSTests/stress/megamorphic-getter-ic.js
@@ -1,0 +1,175 @@
+// Exercises the megamorphic getter inline cache (LoadMegamorphicGetter): a GetById site that is
+// megamorphic on structure but always resolves to a plain JS getter. Each shape has its own getter
+// returning a value derived from a shape-specific constant and the receiver, so a mis-resolved
+// holder/offset produces an observably wrong value rather than just a slow path.
+
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error("expected " + b + " got " + a);
+}
+
+const shapeCount = 100;
+
+// Build many distinct structures, all exposing a getter named "value": half as an OWN property
+// (holder == base), half on a per-shape PROTOTYPE (holder != base). Padding fields vary the offset.
+function makeShapes() {
+    const shapes = [];
+    for (let i = 0; i < shapeCount; i++) {
+        const shapeConst = (i + 1) * 7;
+        const getter = function () { return this.id * 1000 + shapeConst; };
+
+        if (i % 2 === 0) {
+            const o = {};
+            for (let p = 0; p < (i % 5); p++)
+                o["pad" + i + "_" + p] = p;
+            o.id = i;
+            Object.defineProperty(o, "value", { get: getter, configurable: true });
+            shapes.push({ object: o, expected: i * 1000 + shapeConst });
+        } else {
+            const proto = {};
+            for (let p = 0; p < (i % 5); p++)
+                proto["ppad" + i + "_" + p] = p;
+            Object.defineProperty(proto, "value", { get: getter, configurable: true });
+            const o = Object.create(proto);
+            for (let p = 0; p < (i % 3); p++)
+                o["opad" + i + "_" + p] = p;
+            o.id = i;
+            shapes.push({ object: o, expected: i * 1000 + shapeConst });
+        }
+    }
+    return shapes;
+}
+
+const shapes = makeShapes();
+
+function access(base) {
+    return base.value;
+}
+noInline(access);
+
+// Warm up across every shape to make the site megamorphic and tier up.
+for (let i = 0; i < 200; i++) {
+    for (let j = 0; j < shapes.length; j++)
+        access(shapes[j].object);
+}
+
+// Hammer the IC and verify every shape returns its own getter's value.
+for (let i = 0; i < testLoopCount; i++) {
+    const shape = shapes[i % shapes.length];
+    shouldBe(access(shape.object), shape.expected);
+}
+
+// The getter must actually be invoked on every access: a getter with a side effect must observe
+// every call. If the IC ever short-circuited to a value load, the counter would be wrong.
+{
+    let calls = 0;
+    const sideProto = {};
+    Object.defineProperty(sideProto, "value", { get: function () { calls++; return this.id; }, configurable: true });
+    const sideShapes = [];
+    for (let i = 0; i < shapeCount; i++) {
+        const o = Object.create(sideProto);
+        o["s" + i] = i; // distinct structure per shape
+        o.id = i;
+        sideShapes.push(o);
+    }
+    function accessSide(base) { return base.value; }
+    noInline(accessSide);
+    for (let i = 0; i < 200; i++)
+        for (let j = 0; j < sideShapes.length; j++)
+            accessSide(sideShapes[j]);
+
+    calls = 0;
+    const iterations = testLoopCount;
+    for (let i = 0; i < iterations; i++) {
+        const o = sideShapes[i % sideShapes.length];
+        shouldBe(accessSide(o), o.id);
+    }
+    shouldBe(calls, iterations);
+}
+
+// After the site is megamorphic, redefining a getter on a live shape must be reflected (epoch
+// invalidation), not served stale from the getter cache.
+{
+    const proto = {};
+    Object.defineProperty(proto, "value", { get: function () { return this.id + 1; }, configurable: true });
+    const objects = [];
+    for (let i = 0; i < shapeCount; i++) {
+        const o = Object.create(proto);
+        o["r" + i] = i;
+        o.id = i;
+        objects.push(o);
+    }
+    function accessReconf(base) { return base.value; }
+    noInline(accessReconf);
+    for (let i = 0; i < 200; i++)
+        for (let j = 0; j < objects.length; j++)
+            accessReconf(objects[j]);
+    for (let i = 0; i < testLoopCount; i++) {
+        const o = objects[i % objects.length];
+        shouldBe(accessReconf(o), o.id + 1);
+    }
+
+    // Redefine the shared getter; every subsequent read must use the new getter.
+    Object.defineProperty(proto, "value", { get: function () { return this.id + 100000; }, configurable: true });
+    for (let i = 0; i < testLoopCount; i++) {
+        const o = objects[i % objects.length];
+        shouldBe(accessReconf(o), o.id + 100000);
+    }
+}
+
+// A getter that throws must have its exception propagated on every access through the megamorphic
+// getter IC. Each shape's getter throws a shape-specific error object, so a mis-resolved holder/offset
+// would surface as the wrong thrown value rather than merely a slow path.
+{
+    const errors = [];
+    const throwShapes = [];
+    for (let i = 0; i < shapeCount; i++) {
+        const error = new Error("throw" + i);
+        errors.push(error);
+        const getter = function () { throw error; };
+
+        let object;
+        if (i % 2 === 0) {
+            object = {};
+            for (let p = 0; p < (i % 5); p++)
+                object["tpad" + i + "_" + p] = p;
+            object.id = i;
+            Object.defineProperty(object, "value", { get: getter, configurable: true });
+        } else {
+            const proto = {};
+            for (let p = 0; p < (i % 5); p++)
+                proto["tppad" + i + "_" + p] = p;
+            Object.defineProperty(proto, "value", { get: getter, configurable: true });
+            object = Object.create(proto);
+            object["t" + i] = i; // distinct structure per shape
+            object.id = i;
+        }
+        throwShapes.push({ object, error });
+    }
+    function accessThrow(base) { return base.value; }
+    noInline(accessThrow);
+
+    // Warm up across every shape to make the site megamorphic and tier up.
+    for (let i = 0; i < 200; i++) {
+        for (let j = 0; j < throwShapes.length; j++) {
+            try {
+                accessThrow(throwShapes[j].object);
+                throw new Error("getter did not throw");
+            } catch (e) {
+                shouldBe(e, throwShapes[j].error);
+            }
+        }
+    }
+
+    // Hammer the IC and verify every shape throws its own getter's error.
+    for (let i = 0; i < testLoopCount; i++) {
+        const shape = throwShapes[i % throwShapes.length];
+        let thrown = null;
+        try {
+            accessThrow(shape.object);
+        } catch (e) {
+            thrown = e;
+        }
+        shouldBe(thrown, shape.error);
+    }
+}

--- a/Source/JavaScriptCore/bytecode/AccessCase.cpp
+++ b/Source/JavaScriptCore/bytecode/AccessCase.cpp
@@ -68,6 +68,7 @@ Ref<AccessCase> AccessCase::create(VM& vm, JSCell* owner, AccessType type, Cache
 {
     switch (type) {
     case LoadMegamorphic:
+    case LoadMegamorphicGetter:
     case StoreMegamorphic:
     case InMegamorphic:
     case InHit:
@@ -376,6 +377,7 @@ bool AccessCase::guardedByStructureCheckSkippingConstantIdentifierCheck() const
 
     switch (m_type) {
     case LoadMegamorphic:
+    case LoadMegamorphicGetter:
     case StoreMegamorphic:
     case InMegamorphic:
     case ArrayLength:
@@ -524,6 +526,7 @@ bool AccessCase::requiresIdentifierNameMatch() const
     switch (m_type) {
     case Load:
     case LoadMegamorphic:
+    case LoadMegamorphicGetter:
     case StoreMegamorphic:
     case InMegamorphic:
     // We don't currently have a by_val for these puts, but we do care about the identifier.
@@ -672,6 +675,7 @@ bool AccessCase::requiresInt32PropertyCheck() const
     switch (m_type) {
     case Load:
     case LoadMegamorphic:
+    case LoadMegamorphicGetter:
     case StoreMegamorphic:
     case InMegamorphic:
     case Transition:
@@ -860,6 +864,7 @@ void AccessCase::forEachDependentCell(VM&, const Functor& functor) const
         break;
     case Load:
     case LoadMegamorphic:
+    case LoadMegamorphicGetter:
     case StoreMegamorphic:
     case InMegamorphic:
     case Transition:
@@ -1015,6 +1020,7 @@ bool AccessCase::doesCalls(VM&) const
     case IndexedProxyObjectStore:
     case StoreMegamorphic:
     case IndexedMegamorphicStore:
+    case LoadMegamorphicGetter:
         doesCalls = true;
         break;
     case IntrinsicGetter: {
@@ -1194,6 +1200,7 @@ bool AccessCase::canReplace(const AccessCase& other) const
     
     switch (type()) {
     case LoadMegamorphic:
+    case LoadMegamorphicGetter:
     case StoreMegamorphic:
     case InMegamorphic:
     case IndexedMegamorphicLoad:
@@ -1464,6 +1471,7 @@ inline void AccessCase::runWithDowncast(const Func& func)
 {
     switch (m_type) {
     case LoadMegamorphic:
+    case LoadMegamorphicGetter:
     case StoreMegamorphic:
     case InMegamorphic:
     case Transition:
@@ -1662,6 +1670,7 @@ bool AccessCase::canBeShared(const AccessCase& lhs, const AccessCase& rhs)
     switch (lhs.m_type) {
     case Load:
     case LoadMegamorphic:
+    case LoadMegamorphicGetter:
     case StoreMegamorphic:
     case InMegamorphic:
     case Transition:

--- a/Source/JavaScriptCore/bytecode/AccessCase.h
+++ b/Source/JavaScriptCore/bytecode/AccessCase.h
@@ -57,6 +57,7 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(AccessCase);
 #define JSC_FOR_EACH_ACCESS_TYPE(macro) \
     macro(Load) \
     macro(LoadMegamorphic) \
+    macro(LoadMegamorphicGetter) \
     macro(Transition) \
     macro(StoreMegamorphic) \
     macro(Delete) \

--- a/Source/JavaScriptCore/bytecode/GetByStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/GetByStatus.cpp
@@ -298,6 +298,13 @@ GetByStatus GetByStatus::computeForPropertyInlineCacheWithoutExitSiteFeedback(co
                     return GetByStatus(Megamorphic, /* wasSeenInJIT */ true);
                 break;
             }
+            case AccessCase::LoadMegamorphicGetter: {
+                // FIXME: Using MakesCalls, not Megamorphic. The value-only GetByIdMegamorphic DFG node can't
+                // service accessors, so keep it a regular GetById and let DFG/FTL install the handler.
+                if (!propertyCache->tookSlowPath)
+                    return GetByStatus(MakesCalls, /* wasSeenInJIT */ true);
+                break;
+            }
             default:
                 break;
             }

--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
@@ -236,6 +236,7 @@ static bool NODELETE needsScratchFPR(AccessCase::AccessType type)
     switch (type) {
     case AccessCase::Load:
     case AccessCase::LoadMegamorphic:
+    case AccessCase::LoadMegamorphicGetter:
     case AccessCase::StoreMegamorphic:
     case AccessCase::InMegamorphic:
     case AccessCase::Transition:
@@ -385,6 +386,7 @@ static bool NODELETE forInBy(AccessCase::AccessType type)
     switch (type) {
     case AccessCase::Load:
     case AccessCase::LoadMegamorphic:
+    case AccessCase::LoadMegamorphicGetter:
     case AccessCase::StoreMegamorphic:
     case AccessCase::Transition:
     case AccessCase::Delete:
@@ -559,6 +561,7 @@ static bool NODELETE isStateless(AccessCase::AccessType type)
     case AccessCase::IndexedFalseKeyReplace:
     case AccessCase::IndexedFalseKeyTransition:
     case AccessCase::Getter:
+    case AccessCase::LoadMegamorphicGetter:
     case AccessCase::Setter:
     case AccessCase::ProxyObjectIn:
     case AccessCase::ProxyObjectLoad:
@@ -682,6 +685,7 @@ bool NODELETE doesJSCalls(AccessCase::AccessType type)
 {
     switch (type) {
     case AccessCase::Getter:
+    case AccessCase::LoadMegamorphicGetter:
     case AccessCase::Setter:
     case AccessCase::ProxyObjectIn:
     case AccessCase::ProxyObjectLoad:
@@ -832,6 +836,7 @@ static bool NODELETE isMegamorphic(AccessCase::AccessType type)
 {
     switch (type) {
     case AccessCase::LoadMegamorphic:
+    case AccessCase::LoadMegamorphicGetter:
     case AccessCase::StoreMegamorphic:
     case AccessCase::InMegamorphic:
     case AccessCase::IndexedMegamorphicLoad:
@@ -1029,6 +1034,7 @@ bool canBeViaGlobalProxy(AccessCase::AccessType type)
     case AccessCase::IndexedNoIndexingInMiss:
     case AccessCase::InMegamorphic:
     case AccessCase::LoadMegamorphic:
+    case AccessCase::LoadMegamorphicGetter:
     case AccessCase::StoreMegamorphic:
     case AccessCase::ArrayLength:
     case AccessCase::StringLength:
@@ -3232,6 +3238,10 @@ void InlineCacheCompiler::generateWithGuard(unsigned index, AccessCase& accessCa
         return;
     }
 
+    case AccessCase::LoadMegamorphicGetter:
+        // No structure guard; the getter cache lookup in generateAccessCase validates (structure, uid).
+        break;
+
     default:
         emitDefaultGuard();
         break;
@@ -3508,45 +3518,75 @@ void InlineCacheCompiler::generateAccessCase(unsigned index, AccessCase& accessC
 
     case AccessCase::Getter:
     case AccessCase::Setter:
+    case AccessCase::LoadMegamorphicGetter:
     case AccessCase::IntrinsicGetter: {
-        Structure* currStructure = accessCase.structure();
-        if (auto* object = accessCase.tryGetAlternateBase())
-            currStructure = object->structure();
+        if (accessCase.m_type == AccessCase::LoadMegamorphicGetter) {
+            // Resolve the GetterSetter cell from the getter cache into scratchGPR, then fall through
+            // to the shared getter-call sequence. A cache miss repatches to the generic slow path.
+            ASSERT(!accessCase.viaGlobalProxy());
+            auto* uid = accessCase.m_identifier.uid();
 
-        if (isValidOffset(accessCase.m_offset))
-            currStructure->startWatchingPropertyForReplacements(vm, accessCase.offset());
+            auto allocator = makeDefaultScratchAllocator(scratchGPR);
+            GPRReg scratch2GPR = allocator.allocateScratchGPR();
+            GPRReg scratch3GPR = allocator.allocateScratchGPR();
+            GPRReg scratch4GPR = allocator.allocateScratchGPR();
 
-        {
-            GPRReg propertyOwnerGPR = baseGPR;
-            if (accessCase.polyProtoAccessChain()) {
-                // This isn't pretty, but we know we got here via generateWithGuard,
-                // and it left the baseForAccess inside scratchGPR. We could re-derive the base,
-                // but it'd require emitting the same code to load the base twice.
-                propertyOwnerGPR = scratchGPR;
-            } else if (auto* object = accessCase.tryGetAlternateBase()) {
-                jit.move(CCallHelpers::TrustedImmPtr(object), scratchGPR);
-                propertyOwnerGPR = scratchGPR;
-            } else if (accessCase.viaGlobalProxy()) {
-                ASSERT(canBeViaGlobalProxy(accessCase.m_type));
-                // We only need this when loading an inline or out of line property. For customs accessors,
-                // we can invoke with a receiver value that is a JSGlobalProxy. For custom values, we unbox to the
-                // JSGlobalProxy's target. For getters/setters, we'll also invoke them with the JSGlobalProxy as |this|,
-                // but we need to load the actual GetterSetter cell from the JSGlobalProxy's target.
-                jit.loadPtr(CCallHelpers::Address(baseGPR, JSGlobalProxy::targetOffset()), scratchGPR);
-                propertyOwnerGPR = scratchGPR;
-            }
+            ScratchRegisterAllocator::PreservedState preservedState = allocator.preserveReusedRegistersByPushing(jit, ScratchRegisterAllocator::ExtraStackSpace::NoExtraSpace);
 
-            GPRReg storageGPR = propertyOwnerGPR;
-            if (!isInlineOffset(accessCase.m_offset)) {
-                jit.loadPtr(CCallHelpers::Address(propertyOwnerGPR, JSObject::butterflyOffset()), scratchGPR);
-                storageGPR = scratchGPR;
-            }
+            CCallHelpers::JumpList slowCases;
+            ASSERT(!useHandlerIC());
+            slowCases.append(jit.loadMegamorphicGetterSetter(vm, baseGPR, InvalidGPRReg, uid, scratchGPR, scratch2GPR, scratch3GPR, scratch4GPR));
+
+            allocator.restoreReusedRegistersByPopping(jit, preservedState);
+
+            if (allocator.didReuseRegisters()) {
+                CCallHelpers::Jump ok = jit.jump();
+                slowCases.link(&jit);
+                allocator.restoreReusedRegistersByPopping(jit, preservedState);
+                m_failAndRepatch.append(jit.jump());
+                ok.link(&jit);
+            } else
+                m_failAndRepatch.append(slowCases);
+        } else {
+            Structure* currStructure = accessCase.structure();
+            if (auto* object = accessCase.tryGetAlternateBase())
+                currStructure = object->structure();
+
+            if (isValidOffset(accessCase.m_offset))
+                currStructure->startWatchingPropertyForReplacements(vm, accessCase.offset());
+
+            {
+                GPRReg propertyOwnerGPR = baseGPR;
+                if (accessCase.polyProtoAccessChain()) {
+                    // This isn't pretty, but we know we got here via generateWithGuard,
+                    // and it left the baseForAccess inside scratchGPR. We could re-derive the base,
+                    // but it'd require emitting the same code to load the base twice.
+                    propertyOwnerGPR = scratchGPR;
+                } else if (auto* object = accessCase.tryGetAlternateBase()) {
+                    jit.move(CCallHelpers::TrustedImmPtr(object), scratchGPR);
+                    propertyOwnerGPR = scratchGPR;
+                } else if (accessCase.viaGlobalProxy()) {
+                    ASSERT(canBeViaGlobalProxy(accessCase.m_type));
+                    // We only need this when loading an inline or out of line property. For customs accessors,
+                    // we can invoke with a receiver value that is a JSGlobalProxy. For custom values, we unbox to the
+                    // JSGlobalProxy's target. For getters/setters, we'll also invoke them with the JSGlobalProxy as |this|,
+                    // but we need to load the actual GetterSetter cell from the JSGlobalProxy's target.
+                    jit.loadPtr(CCallHelpers::Address(baseGPR, JSGlobalProxy::targetOffset()), scratchGPR);
+                    propertyOwnerGPR = scratchGPR;
+                }
+
+                GPRReg storageGPR = propertyOwnerGPR;
+                if (!isInlineOffset(accessCase.m_offset)) {
+                    jit.loadPtr(CCallHelpers::Address(propertyOwnerGPR, JSObject::butterflyOffset()), scratchGPR);
+                    storageGPR = scratchGPR;
+                }
 
 #if USE(JSVALUE64)
-            jit.load64(CCallHelpers::Address(storageGPR, offsetRelativeToBase(accessCase.m_offset)), scratchGPR);
+                jit.load64(CCallHelpers::Address(storageGPR, offsetRelativeToBase(accessCase.m_offset)), scratchGPR);
 #else
-            jit.load32(CCallHelpers::Address(storageGPR, offsetRelativeToBase(accessCase.m_offset) + PayloadOffset), scratchGPR);
+                jit.load32(CCallHelpers::Address(storageGPR, offsetRelativeToBase(accessCase.m_offset) + PayloadOffset), scratchGPR);
 #endif
+            }
         }
 
         if (accessCase.m_type == AccessCase::IntrinsicGetter) {
@@ -3556,7 +3596,7 @@ void InlineCacheCompiler::generateAccessCase(unsigned index, AccessCase& accessC
             return;
         }
 
-        bool isGetter = accessCase.m_type == AccessCase::Getter;
+        bool isGetter = accessCase.m_type == AccessCase::Getter || accessCase.m_type == AccessCase::LoadMegamorphicGetter;
 
         // This also does the necessary calculations of whether or not we're an
         // exception handling call site.
@@ -4825,6 +4865,23 @@ RefPtr<AccessCase> InlineCacheCompiler::tryFoldToMegamorphic(CodeBlock* codeBloc
         case AccessType::GetById:
         case AccessType::GetByIdWithThis: {
             auto identifier = m_propertyCache.m_identifier;
+
+            // Currently, we do not apply megamorphic cache for "length" property since Array#length and String#length are too common.
+            if (!canUseMegamorphicGetById(vm(), identifier.uid()))
+                return nullptr;
+
+            if (m_propertyCache.accessType == AccessType::GetById) {
+                bool allGetters = !cases.empty();
+                for (auto& accessCase : cases) {
+                    if (accessCase->type() != AccessCase::Getter || accessCase->viaGlobalProxy() || accessCase->usesPolyProto()) {
+                        allGetters = false;
+                        break;
+                    }
+                }
+                if (allGetters)
+                    return AccessCase::create(vm(), codeBlock, AccessCase::LoadMegamorphicGetter, identifier);
+            }
+
             unsigned numberOfUndesiredMegamorphicAccessVariants = 0;
             for (auto& accessCase : cases) {
                 if (accessCase->type() != AccessCase::Load && accessCase->type() != AccessCase::Miss)
@@ -4836,10 +4893,6 @@ RefPtr<AccessCase> InlineCacheCompiler::tryFoldToMegamorphic(CodeBlock* codeBloc
                 if (accessCase->usesPolyProto())
                     ++numberOfUndesiredMegamorphicAccessVariants;
             }
-
-            // Currently, we do not apply megamorphic cache for "length" property since Array#length and String#length are too common.
-            if (!canUseMegamorphicGetById(vm(), identifier.uid()))
-                return nullptr;
 
             if (numberOfUndesiredMegamorphicAccessVariants) {
                 if ((numberOfUndesiredMegamorphicAccessVariants / static_cast<double>(cases.size())) >= Options::thresholdForUndesiredMegamorphicAccessVariantListSize())
@@ -5552,28 +5605,9 @@ MacroAssemblerCodeRef<JITThunkPtrTag> getByIdCustomValueHandler(VM& vm)
     return getByIdCustomHandlerImpl<isAccessor>(vm);
 }
 
-static void getterHandlerImpl(VM&, CCallHelpers& jit, JSValueRegs baseJSR, [[maybe_unused]] JSValueRegs resultJSR, GPRReg propertyCacheGPR, GPRReg scratch1GPR, GPRReg scratch2GPR)
+static void getterCallFromGetterSetterImpl(CCallHelpers& jit, JSValueRegs baseJSR, [[maybe_unused]] JSValueRegs resultJSR, GPRReg propertyCacheGPR, GPRReg scratch1GPR)
 {
-    jit.loadPtr(CCallHelpers::Address(GPRInfo::handlerGPR, InlineCacheHandler::offsetOfHolder()), scratch1GPR);
-    jit.moveConditionally64(CCallHelpers::Equal, scratch1GPR, CCallHelpers::TrustedImm32(0), baseJSR.payloadGPR(), scratch1GPR, scratch1GPR);
-    jit.load32(CCallHelpers::Address(GPRInfo::handlerGPR, InlineCacheHandler::offsetOfOffset()), scratch2GPR);
-    jit.loadProperty(scratch1GPR, scratch2GPR, JSValueRegs { scratch1GPR });
-
     jit.transfer32(CCallHelpers::Address(propertyCacheGPR, PropertyInlineCache::offsetOfCallSiteIndex()), CCallHelpers::tagFor(CallFrameSlot::argumentCountIncludingThis));
-
-    // Create a JS call using a JS call inline cache. Assume that:
-    //
-    // - SP is aligned and represents the extent of the calling compiler's stack usage.
-    //
-    // - FP is set correctly (i.e. it points to the caller's call frame header).
-    //
-    // - SP - FP is an aligned difference.
-    //
-    // - Any byte between FP (exclusive) and SP (inclusive) could be live in the calling
-    //   code.
-    //
-    // Therefore, we temporarily grow the stack for the purpose of the call and then
-    // shrink it after.
 
     // There is a "this" argument.
     constexpr unsigned numberOfParameters = 1;
@@ -5612,6 +5646,15 @@ static void getterHandlerImpl(VM&, CCallHelpers& jit, JSValueRegs baseJSR, [[may
     InlineCacheCompiler::emitDataICRestoreAfterCall(jit);
 }
 
+static void getterHandlerImpl(VM&, CCallHelpers& jit, JSValueRegs baseJSR, JSValueRegs resultJSR, GPRReg propertyCacheGPR, GPRReg scratch1GPR, GPRReg scratch2GPR)
+{
+    jit.loadPtr(CCallHelpers::Address(GPRInfo::handlerGPR, InlineCacheHandler::offsetOfHolder()), scratch1GPR);
+    jit.moveConditionally64(CCallHelpers::Equal, scratch1GPR, CCallHelpers::TrustedImm32(0), baseJSR.payloadGPR(), scratch1GPR, scratch1GPR);
+    jit.load32(CCallHelpers::Address(GPRInfo::handlerGPR, InlineCacheHandler::offsetOfOffset()), scratch2GPR);
+    jit.loadProperty(scratch1GPR, scratch2GPR, JSValueRegs { scratch1GPR });
+    getterCallFromGetterSetterImpl(jit, baseJSR, resultJSR, propertyCacheGPR, scratch1GPR);
+}
+
 MacroAssemblerCodeRef<JITThunkPtrTag> getByIdGetterHandler(VM& vm)
 {
     CCallHelpers jit;
@@ -5638,6 +5681,41 @@ MacroAssemblerCodeRef<JITThunkPtrTag> getByIdGetterHandler(VM& vm)
 
     LinkBuffer patchBuffer(jit, GLOBAL_THUNK_ID, LinkBuffer::Profile::InlineCache);
     return FINALIZE_THUNK(patchBuffer, JITThunkPtrTag, "GetById Getter handler"_s, "GetById Getter handler");
+}
+
+MacroAssemblerCodeRef<JITThunkPtrTag> getByIdMegamorphicGetterHandler(VM& vm)
+{
+    CCallHelpers jit;
+
+    using BaselineJITRegisters::GetById::baseJSR;
+    using BaselineJITRegisters::GetById::propertyCacheGPR;
+    using BaselineJITRegisters::GetById::scratch1GPR;
+    using BaselineJITRegisters::GetById::scratch2GPR;
+    using BaselineJITRegisters::GetById::scratch3GPR;
+    using BaselineJITRegisters::GetById::scratch4GPR;
+    using BaselineJITRegisters::GetById::scratch5GPR;
+    using BaselineJITRegisters::GetById::resultJSR;
+
+    InlineCacheCompiler::emitDataICPrologue(jit);
+    traceHandler(jit, ICEvent::GetByIdMegamorphicGetterHandler);
+
+    CCallHelpers::JumpList fallThrough;
+
+    // The base must be a cell (getters live on objects).
+    fallThrough.append(jit.branchIfNotCell(baseJSR));
+
+    jit.loadPtr(CCallHelpers::Address(GPRInfo::handlerGPR, InlineCacheHandler::offsetOfUid()), scratch5GPR);
+    // On a hit scratch1GPR holds the GetterSetter cell.
+    fallThrough.append(jit.loadMegamorphicGetterSetter(vm, baseJSR.payloadGPR(), scratch5GPR, nullptr, scratch1GPR, scratch2GPR, scratch3GPR, scratch4GPR));
+    getterCallFromGetterSetterImpl(jit, baseJSR, resultJSR, propertyCacheGPR, scratch1GPR);
+    InlineCacheCompiler::emitDataICEpilogue(jit);
+    jit.ret();
+
+    fallThrough.link(&jit);
+    InlineCacheCompiler::emitDataICJumpNextHandler(jit);
+
+    LinkBuffer patchBuffer(jit, GLOBAL_THUNK_ID, LinkBuffer::Profile::InlineCache);
+    return FINALIZE_THUNK(patchBuffer, JITThunkPtrTag, "GetById Megamorphic Getter handler"_s, "GetById Megamorphic Getter handler");
 }
 
 MacroAssemblerCodeRef<JITThunkPtrTag> getByIdProxyObjectLoadHandler(VM&)
@@ -7484,6 +7562,13 @@ AccessGenerationResult InlineCacheCompiler::compileOneAccessCaseHandler(const Ve
                         }
                     }
                     break;
+                }
+                case AccessCase::LoadMegamorphicGetter: {
+                    // No watchpoints: the getter cache is (structure, uid)-keyed and epoch-validated.
+                    auto code = vm.getCTIStub(CommonJITThunkID::GetByIdMegamorphicGetterHandler).retagged<JITStubRoutinePtrTag>();
+                    auto stub = createPreCompiledICJITStubRoutine(WTF::move(code), vm, codeBlock);
+                    connectWatchpointSets(stub.get(), { }, WTF::move(additionalWatchpointSets));
+                    return finishPreCompiledCodeGeneration(WTF::move(stub));
                 }
                 case AccessCase::ProxyObjectLoad: {
                     ASSERT(!accessCase.viaGlobalProxy());

--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.h
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.h
@@ -331,6 +331,7 @@ MacroAssemblerCodeRef<JITThunkPtrTag> getByIdMissHandler(VM&);
 MacroAssemblerCodeRef<JITThunkPtrTag> getByIdCustomAccessorHandler(VM&);
 MacroAssemblerCodeRef<JITThunkPtrTag> getByIdCustomValueHandler(VM&);
 MacroAssemblerCodeRef<JITThunkPtrTag> getByIdGetterHandler(VM&);
+MacroAssemblerCodeRef<JITThunkPtrTag> getByIdMegamorphicGetterHandler(VM&);
 MacroAssemblerCodeRef<JITThunkPtrTag> getByIdProxyObjectLoadHandler(VM&);
 MacroAssemblerCodeRef<JITThunkPtrTag> getByIdModuleNamespaceLoadHandler(VM&);
 MacroAssemblerCodeRef<JITThunkPtrTag> putByIdReplaceHandler(VM&);

--- a/Source/JavaScriptCore/jit/AssemblyHelpers.cpp
+++ b/Source/JavaScriptCore/jit/AssemblyHelpers.cpp
@@ -489,10 +489,12 @@ void AssemblyHelpers::storeProperty(JSValueRegs value, GPRReg object, GPRReg off
 }
 
 #if USE(JSVALUE64)
-AssemblyHelpers::JumpList AssemblyHelpers::loadMegamorphicProperty(VM& vm, GPRReg baseGPR, GPRReg uidGPR, UniquedStringImpl* uid, GPRReg resultGPR, GPRReg scratch1GPR, GPRReg scratch2GPR, GPRReg scratch3GPR)
+template<uint32_t primaryMask, ptrdiff_t primaryEntriesOffset, uint32_t secondaryMask, ptrdiff_t secondaryEntriesOffset>
+AssemblyHelpers::JumpList AssemblyHelpers::findMegamorphicCacheEntry(VM& vm, GPRReg baseGPR, GPRReg uidGPR, UniquedStringImpl* uid, GPRReg scratch1GPR, GPRReg scratch2GPR, GPRReg scratch3GPR)
 {
-    // uidGPR can be InvalidGPRReg if uid is non-nullptr.
+    using Entry = MegamorphicCache::LoadEntry;
 
+    // uidGPR can be InvalidGPRReg if uid is non-nullptr.
     if (!uid)
         ASSERT(uidGPR != InvalidGPRReg);
 
@@ -522,35 +524,30 @@ AssemblyHelpers::JumpList AssemblyHelpers::loadMegamorphicProperty(VM& vm, GPRRe
         add32(scratch2GPR, scratch3GPR);
     }
 
-    and32(TrustedImm32(MegamorphicCache::loadCachePrimaryMask), scratch3GPR);
-    if (hasOneBitSet(sizeof(MegamorphicCache::LoadEntry))) // is a power of 2
-        lshift32(TrustedImm32(getLSBSet(sizeof(MegamorphicCache::LoadEntry))), scratch3GPR);
+    and32(TrustedImm32(primaryMask), scratch3GPR);
+    if (hasOneBitSet(sizeof(Entry))) // is a power of 2
+        lshift32(TrustedImm32(getLSBSet(sizeof(Entry))), scratch3GPR);
     else
-        mul32(TrustedImm32(sizeof(MegamorphicCache::LoadEntry)), scratch3GPR, scratch3GPR);
+        mul32(TrustedImm32(sizeof(Entry)), scratch3GPR, scratch3GPR);
     auto& cache = vm.ensureMegamorphicCache();
     move(TrustedImmPtr(&cache), scratch2GPR);
-    static_assert(!MegamorphicCache::offsetOfLoadCachePrimaryEntries());
     addPtr(scratch2GPR, scratch3GPR);
+    if constexpr (primaryEntriesOffset)
+        addPtr(TrustedImm32(primaryEntriesOffset), scratch3GPR);
 
     load16(Address(scratch2GPR, MegamorphicCache::offsetOfEpoch()), scratch2GPR);
 
-    primaryFail.append(branch32(NotEqual, scratch1GPR, Address(scratch3GPR, MegamorphicCache::LoadEntry::offsetOfStructureID())));
+    primaryFail.append(branch32(NotEqual, scratch1GPR, Address(scratch3GPR, Entry::offsetOfStructureID())));
     if (uid)
-        primaryFail.append(branchPtr(NotEqual, Address(scratch3GPR, MegamorphicCache::LoadEntry::offsetOfUid()), TrustedImmPtr(uid)));
+        primaryFail.append(branchPtr(NotEqual, Address(scratch3GPR, Entry::offsetOfUid()), TrustedImmPtr(uid)));
     else
-        primaryFail.append(branchPtr(NotEqual, Address(scratch3GPR, MegamorphicCache::LoadEntry::offsetOfUid()), uidGPR));
+        primaryFail.append(branchPtr(NotEqual, Address(scratch3GPR, Entry::offsetOfUid()), uidGPR));
     // We already hit StructureID and uid. And we get stale epoch for this entry.
     // Since all entries in the secondary cache has stale epoch for this StructureID and uid pair, we should just go to the slow case.
-    slowCases.append(branch32WithMemory16(NotEqual, Address(scratch3GPR, MegamorphicCache::LoadEntry::offsetOfEpoch()), scratch2GPR));
+    slowCases.append(branch32WithMemory16(NotEqual, Address(scratch3GPR, Entry::offsetOfEpoch()), scratch2GPR));
 
-    // Cache hit!
-    Label cacheHit = label();
-    loadPtr(Address(scratch3GPR, MegamorphicCache::LoadEntry::offsetOfHolder()), scratch2GPR);
-    auto missed = branchTestPtr(Zero, scratch2GPR);
-    moveConditionally64(Equal, scratch2GPR, TrustedImm32(std::bit_cast<uintptr_t>(JSCell::seenMultipleCalleeObjects())), baseGPR, scratch2GPR, scratch1GPR);
-    load16(Address(scratch3GPR, MegamorphicCache::LoadEntry::offsetOfOffset()), scratch2GPR);
-    loadProperty(scratch1GPR, scratch2GPR, JSValueRegs { resultGPR });
-    auto done = jump();
+    // Primary hit: scratch3GPR points at the matching entry. Skip the secondary lookup.
+    Jump primaryHit = jump();
 
     // Secondary cache lookup. Now,
     //   1. scratch1GPR holds StructureID.
@@ -561,25 +558,61 @@ AssemblyHelpers::JumpList AssemblyHelpers::loadMegamorphicProperty(VM& vm, GPRRe
     else
         add32(uidGPR, scratch1GPR, scratch3GPR);
     addUnsignedRightShift32(scratch3GPR, scratch3GPR, TrustedImm32(MegamorphicCache::structureIDHashShift3), scratch3GPR);
-    and32(TrustedImm32(MegamorphicCache::loadCacheSecondaryMask), scratch3GPR);
-    if constexpr (hasOneBitSet(sizeof(MegamorphicCache::LoadEntry))) // is a power of 2
-        lshift32(TrustedImm32(getLSBSet(sizeof(MegamorphicCache::LoadEntry))), scratch3GPR);
+    and32(TrustedImm32(secondaryMask), scratch3GPR);
+    if constexpr (hasOneBitSet(sizeof(Entry))) // is a power of 2
+        lshift32(TrustedImm32(getLSBSet(sizeof(Entry))), scratch3GPR);
     else
-        mul32(TrustedImm32(sizeof(MegamorphicCache::LoadEntry)), scratch3GPR, scratch3GPR);
-    addPtr(TrustedImmPtr(std::bit_cast<uint8_t*>(&cache) + MegamorphicCache::offsetOfLoadCacheSecondaryEntries()), scratch3GPR);
+        mul32(TrustedImm32(sizeof(Entry)), scratch3GPR, scratch3GPR);
+    addPtr(TrustedImmPtr(std::bit_cast<uint8_t*>(&cache) + secondaryEntriesOffset), scratch3GPR);
 
-    slowCases.append(branch32(NotEqual, scratch1GPR, Address(scratch3GPR, MegamorphicCache::LoadEntry::offsetOfStructureID())));
+    slowCases.append(branch32(NotEqual, scratch1GPR, Address(scratch3GPR, Entry::offsetOfStructureID())));
     if (uid)
-        slowCases.append(branchPtr(NotEqual, Address(scratch3GPR, MegamorphicCache::LoadEntry::offsetOfUid()), TrustedImmPtr(uid)));
+        slowCases.append(branchPtr(NotEqual, Address(scratch3GPR, Entry::offsetOfUid()), TrustedImmPtr(uid)));
     else
-        slowCases.append(branchPtr(NotEqual, Address(scratch3GPR, MegamorphicCache::LoadEntry::offsetOfUid()), uidGPR));
-    slowCases.append(branch32WithMemory16(NotEqual, Address(scratch3GPR, MegamorphicCache::LoadEntry::offsetOfEpoch()), scratch2GPR));
-    jump().linkTo(cacheHit, this);
+        slowCases.append(branchPtr(NotEqual, Address(scratch3GPR, Entry::offsetOfUid()), uidGPR));
+    slowCases.append(branch32WithMemory16(NotEqual, Address(scratch3GPR, Entry::offsetOfEpoch()), scratch2GPR));
+
+    // Secondary hit falls through; the primary hit converges here. scratch3GPR points at the entry.
+    primaryHit.link(this);
+
+    return slowCases;
+}
+
+AssemblyHelpers::JumpList AssemblyHelpers::loadMegamorphicProperty(VM& vm, GPRReg baseGPR, GPRReg uidGPR, UniquedStringImpl* uid, GPRReg resultGPR, GPRReg scratch1GPR, GPRReg scratch2GPR, GPRReg scratch3GPR)
+{
+    using Entry = MegamorphicCache::LoadEntry;
+    JumpList slowCases = findMegamorphicCacheEntry<
+        MegamorphicCache::loadCachePrimaryMask, MegamorphicCache::offsetOfLoadCachePrimaryEntries(),
+        MegamorphicCache::loadCacheSecondaryMask, MegamorphicCache::offsetOfLoadCacheSecondaryEntries()>(
+            vm, baseGPR, uidGPR, uid, scratch1GPR, scratch2GPR, scratch3GPR);
+
+    loadPtr(Address(scratch3GPR, Entry::offsetOfHolder()), scratch2GPR);
+    auto missed = branchTestPtr(Zero, scratch2GPR);
+    moveConditionally64(Equal, scratch2GPR, TrustedImm32(std::bit_cast<uintptr_t>(JSCell::seenMultipleCalleeObjects())), baseGPR, scratch2GPR, scratch1GPR);
+    load16(Address(scratch3GPR, Entry::offsetOfOffset()), scratch2GPR);
+    loadProperty(scratch1GPR, scratch2GPR, JSValueRegs { resultGPR });
+    auto done = jump();
 
     missed.link(this);
     moveTrustedValue(jsUndefined(), JSValueRegs { resultGPR });
 
     done.link(this);
+
+    return slowCases;
+}
+
+AssemblyHelpers::JumpList AssemblyHelpers::loadMegamorphicGetterSetter(VM& vm, GPRReg baseGPR, GPRReg uidGPR, UniquedStringImpl* uid, GPRReg resultGPR, GPRReg scratch1GPR, GPRReg scratch2GPR, GPRReg scratch3GPR)
+{
+    using Entry = MegamorphicCache::GetterEntry;
+    JumpList slowCases = findMegamorphicCacheEntry<
+        MegamorphicCache::getterCachePrimaryMask, MegamorphicCache::offsetOfGetterCachePrimaryEntries(),
+        MegamorphicCache::getterCacheSecondaryMask, MegamorphicCache::offsetOfGetterCacheSecondaryEntries()>(
+            vm, baseGPR, uidGPR, uid, scratch1GPR, scratch2GPR, scratch3GPR);
+
+    loadPtr(Address(scratch3GPR, Entry::offsetOfHolder()), scratch1GPR);
+    moveConditionally64(Equal, scratch1GPR, TrustedImm32(std::bit_cast<uintptr_t>(JSCell::seenMultipleCalleeObjects())), baseGPR, scratch1GPR, scratch1GPR);
+    load16(Address(scratch3GPR, Entry::offsetOfOffset()), scratch2GPR);
+    loadProperty(scratch1GPR, scratch2GPR, JSValueRegs { resultGPR });
 
     return slowCases;
 }

--- a/Source/JavaScriptCore/jit/AssemblyHelpers.h
+++ b/Source/JavaScriptCore/jit/AssemblyHelpers.h
@@ -316,6 +316,9 @@ public:
     void storeProperty(JSValueRegs value, GPRReg object, GPRReg offset, GPRReg scratch);
 
     JumpList loadMegamorphicProperty(VM&, GPRReg baseGPR, GPRReg uidGPR, UniquedStringImpl*, GPRReg resultGPR, GPRReg scratch1GPR, GPRReg scratch2GPR, GPRReg scratch3GPR);
+    JumpList loadMegamorphicGetterSetter(VM&, GPRReg baseGPR, GPRReg uidGPR, UniquedStringImpl*, GPRReg resultGPR, GPRReg scratch1GPR, GPRReg scratch2GPR, GPRReg scratch3GPR);
+    template<uint32_t primaryMask, ptrdiff_t primaryEntriesOffset, uint32_t secondaryMask, ptrdiff_t secondaryEntriesOffset>
+    JumpList findMegamorphicCacheEntry(VM&, GPRReg baseGPR, GPRReg uidGPR, UniquedStringImpl*, GPRReg scratch1GPR, GPRReg scratch2GPR, GPRReg scratch3GPR);
     std::tuple<JumpList, JumpList> storeMegamorphicProperty(VM&, GPRReg baseGPR, GPRReg uidGPR, UniquedStringImpl*, GPRReg valueGPR, GPRReg scratch1GPR, GPRReg scratch2GPR, GPRReg scratch3GPR);
     JumpList hasMegamorphicProperty(VM&, GPRReg baseGPR, GPRReg uidGPR, UniquedStringImpl*, GPRReg resultGPR, GPRReg scratch1GPR, GPRReg scratch2GPR, GPRReg scratch3GPR);
     JumpList loadCacheableIdentifierImpl(GPRReg propertyGPR, GPRReg destGPR, bool propertyIsString, bool propertyIsSymbol, bool canBeRope = true);

--- a/Source/JavaScriptCore/jit/ICStats.h
+++ b/Source/JavaScriptCore/jit/ICStats.h
@@ -123,6 +123,7 @@ static constexpr bool traceHandlerChains = false;
     macro(GetByIdCustomAccessorHandler) \
     macro(GetByIdCustomValueHandler) \
     macro(GetByIdGetterHandler) \
+    macro(GetByIdMegamorphicGetterHandler) \
     macro(GetByIdProxyObjectLoadHandler) \
     macro(GetByIdModuleNamespaceLoadHandler) \
     /* PutById handlers */ \

--- a/Source/JavaScriptCore/jit/JITOperations.cpp
+++ b/Source/JavaScriptCore/jit/JITOperations.cpp
@@ -347,7 +347,8 @@ JSC_DEFINE_JIT_OPERATION(operationGetByIdDirectOptimize, EncodedJSValue, (Encode
     OPERATION_RETURN(scope, JSValue::encode(found ? slot.getValue(globalObject, identifier) : jsUndefined()));
 }
 
-static ALWAYS_INLINE JSValue getByIdMegamorphic(JSGlobalObject* globalObject, VM& vm, CallFrame* callFrame, PropertyInlineCache* propertyCache, JSValue baseValue, JSValue thisValue, CacheableIdentifier identifier, GetByKind kind)
+template<GetByKind kind>
+static ALWAYS_INLINE JSValue getByIdMegamorphic(JSGlobalObject* globalObject, VM& vm, CallFrame* callFrame, PropertyInlineCache* propertyCache, JSValue baseValue, JSValue thisValue, CacheableIdentifier identifier)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
 
@@ -397,6 +398,20 @@ static ALWAYS_INLINE JSValue getByIdMegamorphic(JSGlobalObject* globalObject, VM
                             repatchGetBySlowPathCall(callFrame->codeBlock(), *propertyCache, kind);
                     }
                 }
+            } else if constexpr (kind == GetByKind::ById) {
+                if (cacheable && slot.isCacheableGetter() && slot.cachedOffset() <= MegamorphicCache::maxOffset) [[likely]] {
+                    if (slot.slotBase() == baseObject || !baseObject->structure()->isDictionary())
+                        vm.megamorphicCache()->initAsGetterHit(baseObject->structureID(), uid, slot.slotBase(), slot.cachedOffset(), slot.slotBase() == baseValue);
+                    else {
+                        if (baseObject->structure()->hasBeenFlattenedBefore()) [[unlikely]] {
+                            if (propertyCache && propertyCache->considerRepatchingCacheMegamorphic(vm))
+                                repatchGetBySlowPathCall(callFrame->codeBlock(), *propertyCache, kind);
+                        }
+                    }
+                } else {
+                    if (shouldGiveUp && propertyCache && propertyCache->considerRepatchingCacheMegamorphic(vm))
+                        repatchGetBySlowPathCall(callFrame->codeBlock(), *propertyCache, kind);
+                }
             } else {
                 if (shouldGiveUp && propertyCache && propertyCache->considerRepatchingCacheMegamorphic(vm))
                     repatchGetBySlowPathCall(callFrame->codeBlock(), *propertyCache, kind);
@@ -439,7 +454,7 @@ JSC_DEFINE_JIT_OPERATION(operationGetByIdMegamorphic, EncodedJSValue, (EncodedJS
     JSValue baseValue = JSValue::decode(base);
     CacheableIdentifier identifier = propertyCache->identifier();
 
-    OPERATION_RETURN(scope, JSValue::encode(getByIdMegamorphic(globalObject, vm, callFrame, propertyCache, baseValue, baseValue, identifier, GetByKind::ById)));
+    OPERATION_RETURN(scope, JSValue::encode(getByIdMegamorphic<GetByKind::ById>(globalObject, vm, callFrame, propertyCache, baseValue, baseValue, identifier)));
 }
 
 JSC_DEFINE_JIT_OPERATION(operationGetByIdMegamorphicGeneric, EncodedJSValue, (JSGlobalObject* globalObject, EncodedJSValue base, uintptr_t rawCacheableIdentifier))
@@ -452,7 +467,7 @@ JSC_DEFINE_JIT_OPERATION(operationGetByIdMegamorphicGeneric, EncodedJSValue, (JS
     JSValue baseValue = JSValue::decode(base);
     CacheableIdentifier identifier = CacheableIdentifier::createFromRawBits(rawCacheableIdentifier);
 
-    OPERATION_RETURN(scope, JSValue::encode(getByIdMegamorphic(globalObject, vm, callFrame, nullptr, baseValue, baseValue, identifier, GetByKind::ById)));
+    OPERATION_RETURN(scope, JSValue::encode(getByIdMegamorphic<GetByKind::ById>(globalObject, vm, callFrame, nullptr, baseValue, baseValue, identifier)));
 }
 
 JSC_DEFINE_JIT_OPERATION(operationGetByIdGaveUp, EncodedJSValue, (EncodedJSValue base, PropertyInlineCache* propertyCache))
@@ -464,9 +479,9 @@ JSC_DEFINE_JIT_OPERATION(operationGetByIdGaveUp, EncodedJSValue, (EncodedJSValue
     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
     ICSlowPathCallFrameTracer tracer(vm, callFrame, propertyCache);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    
+
     propertyCache->tookSlowPath = true;
-    
+
     JSValue baseValue = JSValue::decode(base);
     PropertySlot slot(baseValue, PropertySlot::InternalMethodType::Get);
     CacheableIdentifier identifier = propertyCache->identifier();
@@ -604,7 +619,7 @@ JSC_DEFINE_JIT_OPERATION(operationGetByIdWithThisMegamorphic, EncodedJSValue, (E
 
     CacheableIdentifier identifier = propertyCache->identifier();
 
-    OPERATION_RETURN(scope, JSValue::encode(getByIdMegamorphic(globalObject, vm, callFrame, propertyCache, JSValue::decode(base), JSValue::decode(encodedThis), identifier, GetByKind::ByIdWithThis)));
+    OPERATION_RETURN(scope, JSValue::encode(getByIdMegamorphic<GetByKind::ByIdWithThis>(globalObject, vm, callFrame, propertyCache, JSValue::decode(base), JSValue::decode(encodedThis), identifier)));
 }
 
 JSC_DEFINE_JIT_OPERATION(operationGetByIdWithThisMegamorphicGeneric, EncodedJSValue, (JSGlobalObject* globalObject, EncodedJSValue base, EncodedJSValue encodedThis, uintptr_t rawCacheableIdentifier))
@@ -616,7 +631,7 @@ JSC_DEFINE_JIT_OPERATION(operationGetByIdWithThisMegamorphicGeneric, EncodedJSVa
 
     CacheableIdentifier identifier = CacheableIdentifier::createFromRawBits(rawCacheableIdentifier);
 
-    OPERATION_RETURN(scope, JSValue::encode(getByIdMegamorphic(globalObject, vm, callFrame, nullptr, JSValue::decode(base), JSValue::decode(encodedThis), identifier, GetByKind::ByIdWithThis)));
+    OPERATION_RETURN(scope, JSValue::encode(getByIdMegamorphic<GetByKind::ByIdWithThis>(globalObject, vm, callFrame, nullptr, JSValue::decode(base), JSValue::decode(encodedThis), identifier)));
 }
 
 JSC_DEFINE_JIT_OPERATION(operationInByIdGaveUp, EncodedJSValue, (EncodedJSValue base, PropertyInlineCache* propertyCache))

--- a/Source/JavaScriptCore/jit/JITThunks.h
+++ b/Source/JavaScriptCore/jit/JITThunks.h
@@ -81,6 +81,7 @@ class NativeExecutable;
     macro(GetByIdCustomAccessorHandler, getByIdCustomAccessorHandler) \
     macro(GetByIdCustomValueHandler, getByIdCustomValueHandler) \
     macro(GetByIdGetterHandler, getByIdGetterHandler) \
+    macro(GetByIdMegamorphicGetterHandler, getByIdMegamorphicGetterHandler) \
     macro(GetByIdProxyObjectLoadHandler, getByIdProxyObjectLoadHandler) \
     macro(GetByIdModuleNamespaceLoadHandler, getByIdModuleNamespaceLoadHandler) \
     macro(PutByIdReplaceHandler, putByIdReplaceHandler) \

--- a/Source/JavaScriptCore/runtime/MegamorphicCache.cpp
+++ b/Source/JavaScriptCore/runtime/MegamorphicCache.cpp
@@ -63,6 +63,14 @@ void MegamorphicCache::age(CollectionScope collectionScope)
             entry.m_uid = nullptr;
             entry.m_epoch = invalidEpoch;
         }
+        for (auto& entry : m_getterCachePrimaryEntries) {
+            entry.m_uid = nullptr;
+            entry.m_epoch = invalidEpoch;
+        }
+        for (auto& entry : m_getterCacheSecondaryEntries) {
+            entry.m_uid = nullptr;
+            entry.m_epoch = invalidEpoch;
+        }
         if (m_epoch == invalidEpoch)
             m_epoch = 1;
     }
@@ -81,6 +89,10 @@ void MegamorphicCache::clearEntries()
     for (auto& entry : m_hasCachePrimaryEntries)
         entry.m_epoch = invalidEpoch;
     for (auto& entry : m_hasCacheSecondaryEntries)
+        entry.m_epoch = invalidEpoch;
+    for (auto& entry : m_getterCachePrimaryEntries)
+        entry.m_epoch = invalidEpoch;
+    for (auto& entry : m_getterCacheSecondaryEntries)
         entry.m_epoch = invalidEpoch;
     m_epoch = 1;
 }

--- a/Source/JavaScriptCore/runtime/MegamorphicCache.h
+++ b/Source/JavaScriptCore/runtime/MegamorphicCache.h
@@ -57,6 +57,13 @@ public:
     static constexpr uint32_t hasCachePrimaryMask = hasCachePrimarySize - 1;
     static constexpr uint32_t hasCacheSecondaryMask = hasCacheSecondarySize - 1;
 
+    static constexpr uint32_t getterCachePrimarySize = 256;
+    static constexpr uint32_t getterCacheSecondarySize = 64;
+    static_assert(hasOneBitSet(getterCachePrimarySize), "size should be a power of two.");
+    static_assert(hasOneBitSet(getterCacheSecondarySize), "size should be a power of two.");
+    static constexpr uint32_t getterCachePrimaryMask = getterCachePrimarySize - 1;
+    static constexpr uint32_t getterCacheSecondaryMask = getterCacheSecondarySize - 1;
+
     static constexpr uint16_t invalidEpoch = 0;
     static constexpr PropertyOffset maxOffset = UINT16_MAX;
 
@@ -138,6 +145,8 @@ public:
         uint16_t m_result { false };
     };
 
+    using GetterEntry = LoadEntry;
+
     static constexpr ptrdiff_t offsetOfLoadCachePrimaryEntries() { return OBJECT_OFFSETOF(MegamorphicCache, m_loadCachePrimaryEntries); }
     static constexpr ptrdiff_t offsetOfLoadCacheSecondaryEntries() { return OBJECT_OFFSETOF(MegamorphicCache, m_loadCacheSecondaryEntries); }
 
@@ -146,6 +155,9 @@ public:
 
     static constexpr ptrdiff_t offsetOfHasCachePrimaryEntries() { return OBJECT_OFFSETOF(MegamorphicCache, m_hasCachePrimaryEntries); }
     static constexpr ptrdiff_t offsetOfHasCacheSecondaryEntries() { return OBJECT_OFFSETOF(MegamorphicCache, m_hasCacheSecondaryEntries); }
+
+    static constexpr ptrdiff_t offsetOfGetterCachePrimaryEntries() { return OBJECT_OFFSETOF(MegamorphicCache, m_getterCachePrimaryEntries); }
+    static constexpr ptrdiff_t offsetOfGetterCacheSecondaryEntries() { return OBJECT_OFFSETOF(MegamorphicCache, m_getterCacheSecondaryEntries); }
 
     static constexpr ptrdiff_t offsetOfEpoch() { return OBJECT_OFFSETOF(MegamorphicCache, m_epoch); }
 
@@ -227,6 +239,17 @@ public:
         m_loadCachePrimaryEntries[primaryIndex].initAsHit(structureID, uid, m_epoch, holder, offset, ownProperty);
     }
 
+    void initAsGetterHit(StructureID structureID, UniquedStringImpl* uid, JSCell* holder, uint16_t offset, bool ownProperty)
+    {
+        uint32_t primaryIndex = MegamorphicCache::primaryHash(structureID, uid) & getterCachePrimaryMask;
+        auto& entry = m_getterCachePrimaryEntries[primaryIndex];
+        if (entry.m_epoch == m_epoch) {
+            uint32_t secondaryIndex = MegamorphicCache::secondaryHash(entry.m_structureID, entry.m_uid.get()) & getterCacheSecondaryMask;
+            m_getterCacheSecondaryEntries[secondaryIndex] = WTF::move(entry);
+        }
+        m_getterCachePrimaryEntries[primaryIndex].initAsHit(structureID, uid, m_epoch, holder, offset, ownProperty);
+    }
+
     void initAsTransition(StructureID oldStructureID, StructureID newStructureID, UniquedStringImpl* uid, uint16_t offset, bool reallocating)
     {
         uint32_t primaryIndex = MegamorphicCache::storeCachePrimaryHash(oldStructureID, uid) & storeCachePrimaryMask;
@@ -289,6 +312,8 @@ private:
     std::array<StoreEntry, storeCacheSecondarySize> m_storeCacheSecondaryEntries { };
     std::array<HasEntry, hasCachePrimarySize> m_hasCachePrimaryEntries { };
     std::array<HasEntry, hasCacheSecondarySize> m_hasCacheSecondaryEntries { };
+    std::array<GetterEntry, getterCachePrimarySize> m_getterCachePrimaryEntries { };
+    std::array<GetterEntry, getterCacheSecondarySize> m_getterCacheSecondaryEntries { };
     uint16_t m_epoch { 1 };
 };
 


### PR DESCRIPTION
#### 6d70d346c664d6619e364953fbccc4122cc493ed
<pre>
[JSC] Add LoadMegamorphicGetter IC
<a href="https://bugs.webkit.org/show_bug.cgi?id=318745">https://bugs.webkit.org/show_bug.cgi?id=318745</a>
<a href="https://rdar.apple.com/181544093">rdar://181544093</a>

Reviewed by Keith Miller.

Currently our Megamorphic IC is supporting plain properties, and getter
is always going to the slow path. But we may have some places which is
repeatedly calling a getter with various structures. Then Megamorphic IC
for getter is beneficial (setter is also beneficial, so we are planning
to have that later).

Key observation is that megamorphic IC getter site is just handling getters.
It is very rare that one property access site is having normal
properties and getters. It is typically either normal-properties-only or
getters-only. Thus this patch adds LoadMegamorphicGetter which handles
getter well so that we can keep LoadMegamorphic clean and extremely
optimized while we start handling getter sites as well.

* JSTests/stress/megamorphic-getter-ic.js: Added.
(shouldBe):
(makeShapes.const.getter):
(makeShapes.get shapes):
(makeShapes.else.get const):
(makeShapes):
(access):
(shouldBe.access.):
(shouldBe.access.get const):
(shouldBe.access.accessSide):
(shouldBe.access):
(shouldBe.):
(shouldBe.get const):
(shouldBe.accessReconf):
(shouldBe.get for):
(shouldBe.const.getter):
(shouldBe.accessThrow):
(shouldBe.get else.get object):
(shouldBe.get else):
* Source/JavaScriptCore/bytecode/AccessCase.cpp:
(JSC::AccessCase::create):
(JSC::AccessCase::guardedByStructureCheckSkippingConstantIdentifierCheck const):
(JSC::AccessCase::requiresIdentifierNameMatch const):
(JSC::AccessCase::requiresInt32PropertyCheck const):
(JSC::AccessCase::forEachDependentCell const):
(JSC::AccessCase::doesCalls const):
(JSC::AccessCase::canReplace const):
(JSC::AccessCase::runWithDowncast):
(JSC::AccessCase::canBeShared):
* Source/JavaScriptCore/bytecode/AccessCase.h:
* Source/JavaScriptCore/bytecode/GetByStatus.cpp:
(JSC::GetByStatus::computeForPropertyInlineCacheWithoutExitSiteFeedback):
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::needsScratchFPR):
(JSC::forInBy):
(JSC::isStateless):
(JSC::doesJSCalls):
(JSC::isMegamorphic):
(JSC::canBeViaGlobalProxy):
(JSC::InlineCacheCompiler::generateWithGuard):
(JSC::InlineCacheCompiler::generateAccessCase):
(JSC::InlineCacheCompiler::tryFoldToMegamorphic):
(JSC::getterCallFromGetterSetterImpl):
(JSC::getterHandlerImpl):
(JSC::getByIdMegamorphicGetterHandler):
(JSC::InlineCacheCompiler::compileOneAccessCaseHandler):
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.h:
* Source/JavaScriptCore/jit/AssemblyHelpers.cpp:
(JSC::AssemblyHelpers::findMegamorphicCacheEntry):
(JSC::AssemblyHelpers::loadMegamorphicProperty):
(JSC::AssemblyHelpers::loadMegamorphicGetterSetter):
* Source/JavaScriptCore/jit/AssemblyHelpers.h:
* Source/JavaScriptCore/jit/ICStats.h:
* Source/JavaScriptCore/jit/JITOperations.cpp:
(JSC::getByIdMegamorphic):
(JSC::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/jit/JITThunks.h:
* Source/JavaScriptCore/runtime/MegamorphicCache.cpp:
(JSC::MegamorphicCache::age):
(JSC::MegamorphicCache::clearEntries):
* Source/JavaScriptCore/runtime/MegamorphicCache.h:
(JSC::MegamorphicCache::offsetOfGetterCachePrimaryEntries):
(JSC::MegamorphicCache::offsetOfGetterCacheSecondaryEntries):
(JSC::MegamorphicCache::initAsGetterHit):

Canonical link: <a href="https://commits.webkit.org/316687@main">https://commits.webkit.org/316687@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7619443b267672830a7d570818cb052edbe19962

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173111 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47042 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40530 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182684 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130667 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3be44f01-b346-4c5e-a2a3-2a0306938acb) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48336 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46725 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134615 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176069 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38016 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155215 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115084 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/00122cc3-7320-4331-9be1-c5f9bda4e2fc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36661 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/35004 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31169 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/3731 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147085 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34714 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185106 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/34373 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37907 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39206 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143456 "Passed tests") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/172511 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46711 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143328 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47390 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112463 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26286 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38283 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119139 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45896 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9657 "Passed tests") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45298 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45529 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45355 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->