### PR TITLE
Re-enabled WebSocket cookie tests

### DIFF
--- a/TestExpectations/apitests
+++ b/TestExpectations/apitests
@@ -329,8 +329,6 @@ webkit.org/b/315119 [ ios ] TestWebKitAPI.WKAttachmentTestsIOS.InsertPastedFiles
 webkit.org/b/314846 [ ios ] TestWebKitAPI.WKAttachmentTestsIOS.InsertPastedMapItemAsAttachment [ Skip ]
 webkit.org/b/314846 [ ios ] TestWebKitAPI.WKAttachmentTestsIOS.PasteRichTextCopiedFromNotes [ Skip ]
 rdar://95391568 [ release arm64 ] TestWebKitAPI.WKContentRuleListStoreTest.CrossOriginCookieBlocking [ Skip ]
-webkit.org/b/317144 TestWebKitAPI.WKHTTPCookieStore.WebSocketCookiesFromRedirect [ Skip ]
-webkit.org/b/317144 TestWebKitAPI.WKHTTPCookieStore.WebSocketCookiesThroughRedirect [ Skip ]
 rdar://137088246 [ mac debug ] TestWebKitAPI.WKInspectorExtension.EvaluateScriptOnPage [ Skip ]
 rdar://137088246 [ mac debug ] TestWebKitAPI.WKInspectorExtension.ExtensionTabIsPersistent [ Skip ]
 webkit.org/b/257332 [ mac ] TestWebKitAPI.WKInspectorExtensionDelegate.ExtensionTabNavigatedCallbacks [ Skip ]

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKHTTPCookieStore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKHTTPCookieStore.mm
@@ -796,7 +796,7 @@ TEST(WKHTTPCookieStore, CookieAccessAfterNetworkProcessTermination)
     EXPECT_WK_STREQ([webView stringByEvaluatingJavaScript:@"document.cookie"], "key=value");
 }
 
-TEST(WKHTTPCookieStore, DISABLED_WebSocketCookies)
+TEST(WKHTTPCookieStore, WebSocketCookies)
 {
     using namespace TestWebKitAPI;
     bool receivedThirdRequest { false };


### PR DESCRIPTION
#### ee886f64ac5a9292867c7bd47fb4bbc8142bbb5b
<pre>
Re-enabled WebSocket cookie tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=317144">https://bugs.webkit.org/show_bug.cgi?id=317144</a>
<a href="https://rdar.apple.com/180974061">rdar://180974061</a>

Reviewed by Brent Fulgham.

Re-enable the tests that were disabled or skipped.

* TestExpectations/apitests:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKHTTPCookieStore.mm:
(TEST(WKHTTPCookieStore, WebSocketCookies)):
(TEST(WKHTTPCookieStore, DISABLED_WebSocketCookies)): Deleted.

Canonical link: <a href="https://commits.webkit.org/316942@main">https://commits.webkit.org/316942@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9bb6707fad57b38d13ef965693a8edcc6e6a60bb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173815 "69 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47748 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41529 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183389 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/131683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d643b1ba-c436-46c9-9ff8-01a040538f47) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175680 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49040 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47430 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135166 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/131683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3c0c77d6-32aa-49e0-958e-d6a84257fb3d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176773 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38594 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155953 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115644 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/11a86f00-703a-4e48-9e8d-e9bf79e1a1e7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37235 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35600 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31873 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147659 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35446 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185815 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39799 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144058 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47415 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143917 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38828 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48094 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32062 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113384 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38836 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46600 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10401 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46002 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46233 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46061 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->