### PR TITLE
WKWebExtensionController.Configuration.nonPersistent() should use a non-persistent datastore by default.

### DIFF
--- a/Source/WebKit/Shared/Extensions/WebExtensionContextParameters.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionContextParameters.h
@@ -32,6 +32,7 @@
 #include "WebExtensionContextIdentifier.h"
 #include "WebExtensionTabIdentifier.h"
 #include "WebExtensionWindowIdentifier.h"
+#include <pal/SessionID.h>
 #include <wtf/URL.h>
 
 namespace WebKit {
@@ -51,6 +52,8 @@ struct WebExtensionContextParameters {
 
     double manifestVersion { 0 };
     bool isSessionStorageAllowedInContentScripts { false };
+
+    PAL::SessionID defaultSessionID;
 
     std::optional<WebCore::PageIdentifier> backgroundPageIdentifier;
 #if ENABLE(INSPECTOR_EXTENSIONS)

--- a/Source/WebKit/Shared/Extensions/WebExtensionContextParameters.serialization.in
+++ b/Source/WebKit/Shared/Extensions/WebExtensionContextParameters.serialization.in
@@ -38,6 +38,8 @@ struct WebKit::WebExtensionContextParameters {
     double manifestVersion;
     bool isSessionStorageAllowedInContentScripts;
 
+    PAL::SessionID defaultSessionID;
+
     std::optional<WebCore::PageIdentifier> backgroundPageIdentifier;
 #if ENABLE(INSPECTOR_EXTENSIONS)
     Vector<WebKit::WebExtensionContext::PageIdentifierTuple> inspectorPageIdentifiers;

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -2490,8 +2490,10 @@ WebsiteDataStore* WebExtensionContext::websiteDataStore(std::optional<PAL::Sessi
         return nullptr;
 
     WeakPtr weakDataStore = extensionController->websiteDataStore(sessionID);
-    if (weakDataStore && !weakDataStore->isPersistent() && !hasAccessToPrivateData())
-        return nullptr;
+    if (weakDataStore && !weakDataStore->isPersistent() && !hasAccessToPrivateData()) {
+        if (weakDataStore.get() != &extensionController->configuration().defaultWebsiteDataStore())
+            return nullptr;
+    }
 
     return weakDataStore.get();
 }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
@@ -385,7 +385,8 @@ void WebExtensionController::addPage(WebPageProxy& page)
     addWebsiteDataStore(dataStore);
 
     Ref controller = page.userContentController();
-    addUserContentController(controller, dataStore->isPersistent() ? ForPrivateBrowsing::No : ForPrivateBrowsing::Yes);
+    bool isOwnStore = !dataStore->isPersistent() && (&dataStore.get() == &m_configuration->defaultWebsiteDataStore());
+    addUserContentController(controller, (dataStore->isPersistent() || isOwnStore) ? ForPrivateBrowsing::No : ForPrivateBrowsing::Yes);
 }
 
 void WebExtensionController::removePage(WebPageProxy& page)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerConfigurationCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerConfigurationCocoa.mm
@@ -79,8 +79,12 @@ Ref<WebExtensionControllerConfiguration> WebExtensionControllerConfiguration::co
 
 WKWebViewConfiguration *WebExtensionControllerConfiguration::webViewConfiguration()
 {
-    if (!m_webViewConfiguration)
+    if (!m_webViewConfiguration) {
         m_webViewConfiguration = [[WKWebViewConfiguration alloc] init];
+        if (m_defaultWebsiteDataStore)
+            m_webViewConfiguration.get().websiteDataStore = (WKWebsiteDataStore *)m_defaultWebsiteDataStore->wrapper();
+    }
+
     return m_webViewConfiguration.get();
 }
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
@@ -1686,6 +1686,7 @@ WebExtensionContextParameters WebExtensionContext::parameters(IncludePrivilegedI
         extension->serializeManifest(),
         extension->manifestVersion(),
         isSessionStorageAllowedInContentScripts(),
+        extensionController()->configuration().defaultWebsiteDataStore().sessionID(),
         backgroundPageIdentifier(),
 #if ENABLE(INSPECTOR_EXTENSIONS)
         inspectorPageIdentifiers(),
@@ -1737,8 +1738,10 @@ WebExtensionContext::WebProcessProxySet WebExtensionContext::processes(EventList
                 if (!page)
                     continue;
 
-                if (!hasAccessToPrivateData() && page->sessionID().isEphemeral())
-                    continue;
+                if (!hasAccessToPrivateData() && page->sessionID().isEphemeral()) {
+                    if (RefPtr controller = extensionController(); !controller || page->sessionID() != controller->configuration().defaultWebsiteDataStore().sessionID())
+                        continue;
+                }
 
                 Ref webProcess = frame->process();
                 if (predicate && !predicate(webProcess, *page, frame))

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.cpp
@@ -33,6 +33,8 @@ namespace WebKit {
 WebExtensionControllerConfiguration::WebExtensionControllerConfiguration(IsPersistent persistent)
     : m_storageDirectory(persistent == IsPersistent::Yes ? createStorageDirectoryPath() : nullString())
 {
+    if (persistent == IsPersistent::No)
+        m_defaultWebsiteDataStore = WebsiteDataStore::createNonPersistent();
 }
 
 WebExtensionControllerConfiguration::WebExtensionControllerConfiguration(TemporaryTag, const String& storageDirectory)

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPICookiesCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPICookiesCocoa.mm
@@ -115,7 +115,7 @@ static inline NSDictionary *toWebAPI(const WebExtensionCookieParameters& cookieP
     return [result copy];
 }
 
-static inline NSArray *toWebAPI(const HashMap<PAL::SessionID, Vector<WebExtensionTabIdentifier>>& stores)
+static inline NSArray *toWebAPI(const HashMap<PAL::SessionID, Vector<WebExtensionTabIdentifier>>& stores, PAL::SessionID ownSessionID)
 {
     auto *result = [NSMutableArray arrayWithCapacity:stores.size()];
 
@@ -124,7 +124,8 @@ static inline NSArray *toWebAPI(const HashMap<PAL::SessionID, Vector<WebExtensio
             return @(toWebAPI(tabIdentifier));
         }).get();
 
-        [result addObject:@{ idKey: toWebAPI(entry.key), tabIdsKey: tabIdentifiers, incognitoKey: @(entry.key.isEphemeral()) }];
+        bool incognito = entry.key.isEphemeral() && entry.key != ownSessionID;
+        [result addObject:@{ idKey: toWebAPI(entry.key), tabIdsKey: tabIdentifiers, incognitoKey: @(incognito) }];
     }
 
     return [result copy];
@@ -354,7 +355,7 @@ void WebExtensionAPICookies::getAllCookieStores(Ref<WebExtensionCallbackHandler>
             return;
         }
 
-        callback->call(toJSValueRef(callback->globalContext(), toWebAPI(result.value())));
+        callback->call(toJSValueRef(callback->globalContext(), toWebAPI(result.value(), protectedThis->extensionContext().defaultSessionID())));
     }, extensionContext().identifier());
 }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIExtensionCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIExtensionCocoa.mm
@@ -38,6 +38,7 @@
 #import "WebExtensionAPIWindows.h"
 #import "WebExtensionContextMessages.h"
 #import "WebExtensionUtilities.h"
+#import "WebFrame.h"
 #import "WebPage.h"
 #import "WebProcess.h"
 
@@ -156,6 +157,14 @@ NSArray *WebExtensionAPIExtension::getViews(JSContextRef context, NSDictionary *
 bool WebExtensionAPIExtension::isInIncognitoContext(WebPage& page)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extension/inIncognitoContext
+
+    // Extension pages (background, popup, etc.) are never in an incognito context.
+    if (protect(extensionContext())->isURLForThisExtension(page.mainWebFrame().url()))
+        return false;
+
+    // Pages in the controller's own non-persistent session are not incognito.
+    if (page.sessionID() == extensionContext().defaultSessionID())
+        return false;
 
     return page.usesEphemeralSession();
 }

--- a/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm
@@ -88,6 +88,7 @@ Ref<WebExtensionContextProxy> WebExtensionContextProxy::getOrCreate(const WebExt
         context.m_manifest = parseJSON(manifestJSON);
         context.m_manifestVersion = parameters.manifestVersion;
         context.m_isSessionStorageAllowedInContentScripts = parameters.isSessionStorageAllowedInContentScripts;
+        context.m_defaultSessionID = parameters.defaultSessionID;
 
         if (parameters.privilegedIdentifier)
             context.m_privilegedIdentifier = parameters.privilegedIdentifier;

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
@@ -96,6 +96,8 @@ public:
 
     bool isSessionStorageAllowedInContentScripts() const { return m_isSessionStorageAllowedInContentScripts; }
 
+    PAL::SessionID defaultSessionID() const { return m_defaultSessionID; }
+
     bool NODELETE inTestingMode() const;
 
     bool hasDOMWrapperWorld(WebExtensionContentWorldType contentWorldType) const { return contentWorldType != WebExtensionContentWorldType::ContentScript || hasContentScriptWorld(); }
@@ -251,6 +253,7 @@ private:
 #endif
     double m_manifestVersion { 0 };
     bool m_isSessionStorageAllowedInContentScripts { false };
+    PAL::SessionID m_defaultSessionID { PAL::SessionID::defaultSessionID() };
     mutable PermissionsMap m_grantedPermissions;
     mutable WallTime m_nextGrantedPermissionsExpirationDate { WallTime::nan() };
     RefPtr<WebCore::DOMWrapperWorld> m_contentScriptWorld;

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -134,8 +134,11 @@ void WebPage::platformInitializeAccessibility(ShouldInitializeNSAccessibility sh
 {
     RELEASE_LOG(Process, "WebPage::platformInitializeAccessibility shouldInitializeNSAccessibility = %d", shouldInitializeNSAccessibility == ShouldInitializeNSAccessibility::Yes);
 
-    // For performance reasons, we should have received the LS database before initializing NSApplication.
-    ASSERT(LaunchServicesDatabaseManager::singleton().hasReceivedLaunchServicesDatabase());
+    // Wait for the LaunchServices database before initializing NSApplication, since it is needed
+    // for accessibility initialization. Normally this has already been received, but in rare cases
+    // (e.g. process restart after network process termination) there can be a race where CreateWebPage
+    // arrives before the database XPC message is processed.
+    LaunchServicesDatabaseManager::singleton().waitForDatabaseUpdate();
 
     // Need to initialize accessibility for VoiceOver to work when the WebContent process is using NSRunLoop.
     // Currently, it is also needed to allocate and initialize an NSApplication object.

--- a/Tools/TestWebKitAPI/Helpers/cocoa/WebExtensionUtilities.mm
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/WebExtensionUtilities.mm
@@ -458,7 +458,7 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
 
         auto *configuration = [[WKWebViewConfiguration alloc] init];
         configuration.webExtensionController = extensionController;
-        configuration.websiteDataStore = usingPrivateBrowsing ? WKWebsiteDataStore.nonPersistentDataStore : WKWebsiteDataStore.defaultDataStore;
+        configuration.websiteDataStore = usingPrivateBrowsing ? WKWebsiteDataStore.nonPersistentDataStore : extensionController.configuration.defaultWebsiteDataStore;
         configuration.userContentController = userContentController(usingPrivateBrowsing);
 
         auto *preferences = configuration.preferences;
@@ -516,9 +516,11 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
     if ([_webView.URL.scheme isEqualToString:url.scheme])
         return;
 
-    auto *configuration = [url.scheme hasPrefix:@"http"] ? [[WKWebViewConfiguration alloc] init] : context.webViewConfiguration;
+    BOOL isHTTPFamilyURL = [url.scheme hasPrefix:@"http"];
+    auto *configuration = isHTTPFamilyURL ? [[WKWebViewConfiguration alloc] init] : context.webViewConfiguration;
     configuration.webExtensionController = _extensionController;
-    configuration.websiteDataStore = usingPrivateBrowsing ? WKWebsiteDataStore.nonPersistentDataStore : WKWebsiteDataStore.defaultDataStore;
+    if (isHTTPFamilyURL)
+        configuration.websiteDataStore = usingPrivateBrowsing ? WKWebsiteDataStore.nonPersistentDataStore : _extensionController.configuration.defaultWebsiteDataStore;
     configuration.userContentController = userContentController(usingPrivateBrowsing);
 
     auto *preferences = configuration.preferences;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPICookies.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPICookies.mm
@@ -198,7 +198,7 @@ TEST(WKWebExtensionAPICookies, GetAll)
     auto *matchPattern = [WKWebExtensionMatchPattern matchPatternWithString:@"*://*.example.com/*"];
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:matchPattern];
 
-    auto *cookieStore = WKWebsiteDataStore.defaultDataStore.httpCookieStore;
+    auto *cookieStore = manager.get().controller.configuration.defaultWebsiteDataStore.httpCookieStore;
 
     auto *cookie1 = [NSHTTPCookie cookieWithProperties:@{
         NSHTTPCookieName: @"testCookie1",
@@ -241,18 +241,9 @@ TEST(WKWebExtensionAPICookies, GetAllIncognito)
 {
     auto *backgroundScript = Util::constructScript(@[
         @"const allCookieStores = await browser.test.assertSafeResolve(() => browser.cookies.getAllCookieStores())",
+        @"browser.test.assertEq(allCookieStores?.length, 1, 'Should have one cookie store')",
         @"const incognitoStore = allCookieStores.find(store => store.incognito)",
         @"browser.test.assertEq(incognitoStore, undefined, 'Incognito store should not be found')",
-
-        @"await browser.test.assertRejects(browser.cookies.getAll({ storeId: 'ephemeral-1' }), /cookie store not found/i)",
-        @"await browser.test.assertRejects(browser.cookies.getAll({ storeId: 'ephemeral-2' }), /cookie store not found/i)",
-        @"await browser.test.assertRejects(browser.cookies.getAll({ storeId: 'ephemeral-3' }), /cookie store not found/i)",
-        @"await browser.test.assertRejects(browser.cookies.getAll({ storeId: 'ephemeral-4' }), /cookie store not found/i)",
-        @"await browser.test.assertRejects(browser.cookies.getAll({ storeId: 'ephemeral-5' }), /cookie store not found/i)",
-        @"await browser.test.assertRejects(browser.cookies.getAll({ storeId: 'ephemeral-6' }), /cookie store not found/i)",
-        @"await browser.test.assertRejects(browser.cookies.getAll({ storeId: 'ephemeral-7' }), /cookie store not found/i)",
-        @"await browser.test.assertRejects(browser.cookies.getAll({ storeId: 'ephemeral-8' }), /cookie store not found/i)",
-        @"await browser.test.assertRejects(browser.cookies.getAll({ storeId: 'ephemeral-9' }), /cookie store not found/i)",
 
         @"browser.test.notifyPass()"
     ]);
@@ -425,7 +416,7 @@ TEST(WKWebExtensionAPICookies, GetAllWithFilters)
     auto *matchPattern = [WKWebExtensionMatchPattern matchPatternWithString:@"*://*.example.com/*"];
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:matchPattern];
 
-    auto *cookieStore = WKWebsiteDataStore.defaultDataStore.httpCookieStore;
+    auto *cookieStore = manager.get().controller.configuration.defaultWebsiteDataStore.httpCookieStore;
 
     auto *nameCookie = [NSHTTPCookie cookieWithProperties:@{
         NSHTTPCookieName: @"nameCookie",
@@ -514,7 +505,7 @@ TEST(WKWebExtensionAPICookies, RemoveCookie)
     auto *matchPattern = [WKWebExtensionMatchPattern matchPatternWithString:@"*://*.example.com/*"];
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:matchPattern];
 
-    auto *cookieStore = WKWebsiteDataStore.defaultDataStore.httpCookieStore;
+    auto *cookieStore = manager.get().controller.configuration.defaultWebsiteDataStore.httpCookieStore;
 
     auto *testCookie = [NSHTTPCookie cookieWithProperties:@{
         NSHTTPCookieName: @"testCookie",
@@ -551,7 +542,7 @@ TEST(WKWebExtensionAPICookies, RemoveCookieNotFound)
     auto *matchPattern = [WKWebExtensionMatchPattern matchPatternWithString:@"*://*.example.com/*"];
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:matchPattern];
 
-    auto *cookieStore = WKWebsiteDataStore.defaultDataStore.httpCookieStore;
+    auto *cookieStore = manager.get().controller.configuration.defaultWebsiteDataStore.httpCookieStore;
 
     auto *testCookie = [NSHTTPCookie cookieWithProperties:@{
         NSHTTPCookieName: @"testCookie",
@@ -598,7 +589,7 @@ TEST(WKWebExtensionAPICookies, SetCookie)
     auto *matchPattern = [WKWebExtensionMatchPattern matchPatternWithString:@"*://*.example.com/*"];
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:matchPattern];
 
-    auto *cookieStore = WKWebsiteDataStore.defaultDataStore.httpCookieStore;
+    auto *cookieStore = manager.get().controller.configuration.defaultWebsiteDataStore.httpCookieStore;
 
     auto *testCookie = [NSHTTPCookie cookieWithProperties:@{
         NSHTTPCookieName: @"replacedCookie",
@@ -681,7 +672,7 @@ TEST(WKWebExtensionAPICookies, GetCookie)
     auto *matchPattern = [WKWebExtensionMatchPattern matchPatternWithString:@"*://*.example.com/*"];
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:matchPattern];
 
-    auto *cookieStore = WKWebsiteDataStore.defaultDataStore.httpCookieStore;
+    auto *cookieStore = manager.get().controller.configuration.defaultWebsiteDataStore.httpCookieStore;
 
     auto *testCookie = [NSHTTPCookie cookieWithProperties:@{
         NSHTTPCookieName: @"testGetCookie",
@@ -729,12 +720,12 @@ TEST(WKWebExtensionAPICookies, GetAllAfterNetworkProcessTermination)
         @"browser.test.notifyPass()"
     ]);
 
-    auto manager = Util::loadExtension(cookiesManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(cookiesManifest, @{ @"background.js": backgroundScript }, WKWebExtensionControllerConfiguration.defaultConfiguration);
 
     auto *matchPattern = [WKWebExtensionMatchPattern matchPatternWithString:@"*://*.example.com/*"];
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:matchPattern];
 
-    auto *cookieStore = WKWebsiteDataStore.defaultDataStore.httpCookieStore;
+    auto *cookieStore = manager.get().controller.configuration.defaultWebsiteDataStore.httpCookieStore;
     auto *cookie = [NSHTTPCookie cookieWithProperties:@{
         NSHTTPCookieName: @"testCookie",
         NSHTTPCookieValue: @"testValue",

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionControllerConfiguration.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionControllerConfiguration.mm
@@ -57,7 +57,9 @@ TEST(WKWebExtensionControllerConfiguration, Initialization)
     EXPECT_NE(configuration, WKWebExtensionControllerConfiguration.nonPersistentConfiguration);
     EXPECT_FALSE([configuration isEqual:WKWebExtensionControllerConfiguration.nonPersistentConfiguration]);
     EXPECT_FALSE([configuration.webViewConfiguration isEqual:WKWebExtensionControllerConfiguration.nonPersistentConfiguration.webViewConfiguration]);
-    EXPECT_NS_EQUAL(configuration.defaultWebsiteDataStore, WKWebsiteDataStore.defaultDataStore);
+    EXPECT_FALSE(configuration.defaultWebsiteDataStore.persistent);
+    EXPECT_FALSE(configuration.webViewConfiguration.websiteDataStore.persistent);
+    EXPECT_NS_EQUAL(configuration.defaultWebsiteDataStore, configuration.webViewConfiguration.websiteDataStore);
 
     auto *identifier = [NSUUID UUID];
     configuration = [WKWebExtensionControllerConfiguration configurationWithIdentifier:identifier];
@@ -122,11 +124,11 @@ TEST(WKWebExtensionControllerConfiguration, SecureCoding)
     EXPECT_FALSE(result._temporary);
     EXPECT_NS_EQUAL(result._storageDirectoryPath, configuration._storageDirectoryPath);
     EXPECT_NOT_NULL(result.webViewConfiguration);
-    EXPECT_NS_EQUAL(result.defaultWebsiteDataStore, WKWebsiteDataStore.defaultDataStore);
+    EXPECT_FALSE(result.defaultWebsiteDataStore.persistent);
+    EXPECT_FALSE(result.webViewConfiguration.websiteDataStore.persistent);
     EXPECT_NE(configuration, result);
     EXPECT_FALSE([result isEqual:configuration]);
     EXPECT_FALSE([result.webViewConfiguration isEqual:configuration.webViewConfiguration]);
-    EXPECT_NS_EQUAL(result.defaultWebsiteDataStore, configuration.defaultWebsiteDataStore);
 
     auto *identifier = [NSUUID UUID];
     configuration = [WKWebExtensionControllerConfiguration configurationWithIdentifier:identifier];
@@ -192,7 +194,8 @@ TEST(WKWebExtensionControllerConfiguration, Copying)
     EXPECT_FALSE(copy._temporary);
     EXPECT_NS_EQUAL(copy._storageDirectoryPath, configuration._storageDirectoryPath);
     EXPECT_NOT_NULL(copy.webViewConfiguration);
-    EXPECT_NS_EQUAL(copy.defaultWebsiteDataStore, WKWebsiteDataStore.defaultDataStore);
+    EXPECT_FALSE(copy.defaultWebsiteDataStore.persistent);
+    EXPECT_FALSE(copy.webViewConfiguration.websiteDataStore.persistent);
     EXPECT_NE(configuration, copy);
     EXPECT_FALSE([copy isEqual:configuration]);
     EXPECT_FALSE([copy.webViewConfiguration isEqual:configuration.webViewConfiguration]);


### PR DESCRIPTION
#### 0350073e737b173a5a7a80ad55a83d52e940b98d
<pre>
WKWebExtensionController.Configuration.nonPersistent() should use a non-persistent datastore by default.
<a href="https://webkit.org/b/318748">https://webkit.org/b/318748</a>
<a href="https://rdar.apple.com/181546335">rdar://181546335</a>

Reviewed by Brian Weinstein and Kiara Rose.

Despite its name, a non-persistent extension controller configuration resolved its website data
store to the persistent default. Fix this by ensuring the non-persistent configuration initializes
with an ephemeral data store that is used consistently across all internal code paths.

Extension pages (background, popup, etc.) run in the controller&apos;s own non-persistent session.
Ensure event dispatch, data store lookup, content injection, and incognito detection correctly
recognize pages in that session as belonging to the extension — not to an external
private-browsing session.

To propagate the controller&apos;s session identity to the WebProcess, add a defaultSessionID field
to WebExtensionContextParameters and thread it through to WebExtensionContextProxy so the cookies
and extension APIs can distinguish the controller&apos;s own ephemeral session from unrelated ones.

* Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp:
(WebKit::WebExtensionContext::processes): Allow processes in the controller&apos;s own non-persistent
session to receive extension events without requiring hasAccessToPrivateData.
(WebKit::WebExtensionContext::parameters): Populate defaultSessionID from the controller&apos;s
default data store session ID.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::websiteDataStore): Allow the controller&apos;s own non-persistent data
store to be returned without requiring hasAccessToPrivateData.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerConfigurationCocoa.mm:
(WebKit::WebExtensionControllerConfiguration::webViewConfiguration): Propagate the data store
into the lazily created web view configuration.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm:
(WebKit::WebExtensionController::addPage): Treat pages in the controller&apos;s own non-persistent
data store as non-private so injected content and declarative rules are registered for them.
* Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.cpp:
(WebKit::WebExtensionControllerConfiguration::WebExtensionControllerConfiguration): Initialize
the data store to a non-persistent store when the configuration is non-persistent.
* Source/WebKit/Shared/Extensions/WebExtensionContextParameters.h:
* Source/WebKit/Shared/Extensions/WebExtensionContextParameters.serialization.in:
Add defaultSessionID to carry the controller&apos;s session ID over IPC.
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h:
* Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm:
(WebKit::WebExtensionContextProxy::getOrCreate): Store defaultSessionID from the IPC parameters.
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIExtensionCocoa.mm:
(WebKit::WebExtensionAPIExtension::isInIncognitoContext): Extension pages are never incognito;
use isURLForThisExtension to identify them. Also return false for pages in the controller&apos;s own
non-persistent session so content scripts running in that session are not treated as incognito.
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPICookiesCocoa.mm:
(toWebAPI): Accept ownSessionID and mark a store as incognito only if it is ephemeral and not
the controller&apos;s own session, so getAllCookieStores does not misreport the controller&apos;s store.
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::platformInitializeAccessibility): Replace assertion with waitForDatabaseUpdate
so that rapid web process restart after network process termination does not crash; the database
arrives within milliseconds and the call becomes a no-op once it has been received.
* Tools/TestWebKitAPI/Helpers/cocoa/WebExtensionUtilities.mm:
(-[TestWebExtensionTab initWithWindow:extensionController:]): Use the controller&apos;s own default
website data store for non-private tab web views instead of the shared persistent store.
(-[TestWebExtensionTab changeWebViewIfNeededForURL:forExtensionContext:]): Do not override the
websiteDataStore on configurations sourced from the extension context; they already carry the
correct store and a relatedWebView pointing to the background page. Use the controller&apos;s own
default website data store for non-private HTTP tab web views. Rename isHTTPURL to isHTTPFamilyURL.
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPICookies.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPICookies, GetAll)): Use the controller&apos;s own data store.
(TestWebKitAPI::TEST(WKWebExtensionAPICookies, GetAllIncognito)): Replace hardcoded ephemeral
store ID rejection checks with a length assertion now that the controller&apos;s own ephemeral session
is not exposed as a separate incognito store.
(TestWebKitAPI::TEST(WKWebExtensionAPICookies, GetAllWithFilters)): Use the controller&apos;s store.
(TestWebKitAPI::TEST(WKWebExtensionAPICookies, RemoveCookie)): Use the controller&apos;s store.
(TestWebKitAPI::TEST(WKWebExtensionAPICookies, RemoveCookieNotFound)): Use the controller&apos;s store.
(TestWebKitAPI::TEST(WKWebExtensionAPICookies, SetCookie)): Use the controller&apos;s store.
(TestWebKitAPI::TEST(WKWebExtensionAPICookies, GetCookie)): Use the controller&apos;s store.
(TestWebKitAPI::TEST(WKWebExtensionAPICookies, GetAllAfterNetworkProcessTermination)): Use
defaultConfiguration so cookies are persisted to disk and survive a network process restart.
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionControllerConfiguration.mm:
(TestWebKitAPI::TEST(WKWebExtensionControllerConfiguration, Initialization)):
(TestWebKitAPI::TEST(WKWebExtensionControllerConfiguration, SecureCoding)):
(TestWebKitAPI::TEST(WKWebExtensionControllerConfiguration, Copying)): Update tests to expect
a non-persistent data store for non-persistent configurations, and verify both the default
data store and web view configuration use the same ephemeral store.

Canonical link: <a href="https://commits.webkit.org/316701@main">https://commits.webkit.org/316701@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9bc54ef8641fd5ff88409f7a8621e899b9988312

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173222 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/47154 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/40667 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182795 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130778 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175087 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48447 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46836 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/134691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176180 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/38103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/155319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/115162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/36748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/35092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31280 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/147172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/34817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185217 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/38047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/39294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/143535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46822 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/154879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/143406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47501 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112586 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26293 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/38364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/119250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46007 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/9763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45409 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45640 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45466 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->