### PR TITLE
run-webkit-tests should optionally consult the results database to identify pre-existing failures when running at desk

### DIFF
--- a/Tools/Scripts/run-api-tests
+++ b/Tools/Scripts/run-api-tests
@@ -252,6 +252,14 @@ def parse_args(args):
                              help='Reorganize and reformat API test expectations files (sections, alphabetical order). Does not run any tests.'),
         optparse.make_option('--print-expectations', action='store_true', default=False,
                              help='Print expected outcomes for given tests. Does not run any tests.'),
+        optparse.make_option('--check-pre-existing-failures', action='store_true',
+                             default=False, dest='check_pre_existing_failures',
+                             help='After the run, consult results.webkit.org to annotate each unexpected '
+                                  'failure as pre-existing (historically failing on CI) or possibly new.'),
+        optparse.make_option('--max-pre-existing-checks', type='int', default=0,
+                             dest='max_pre_existing_checks',
+                             help='Maximum number of failing tests to look up in results.webkit.org when '
+                                  '--check-pre-existing-failures is set. Use 0 for no limit. (default: 0)'),
     ]))
     option_group_definitions.append(('Upload Options', upload_options()))
 

--- a/Tools/Scripts/webkitpy/api_tests/manager.py
+++ b/Tools/Scripts/webkitpy/api_tests/manager.py
@@ -31,6 +31,7 @@ from webkitpy.api_tests.test_expectations import (
     APITestExpectations, PASS, FAIL, CRASH, TIMEOUT,
     runner_status_to_expectation,
 )
+from webkitpy.common.net import results_database
 from webkitpy.common.iteration_compatibility import iteritems
 from webkitpy.common.system.executive import ScriptError
 from webkitpy.results.upload import Upload
@@ -465,6 +466,14 @@ class Manager(object):
                 }.get(test_result[0], 'Failed')
                 result_dictionary['UnexpectedFailures'].append({'name': test, 'output': test_result[1], 'status': status_str})
                 result_dictionary[status_str].append({'name': test, 'output': test_result[1]})
+
+            if self._options.check_pre_existing_failures:
+                results_database.check_pre_existing_failures(
+                    unexpected_failures.keys(),
+                    self._options.suite or 'api-tests',
+                    self._options.max_pre_existing_checks,
+                    self._stream.writeln,
+                )
 
         if expected_failures:
             self._stream.writeln('Expected failures (not blocking):')

--- a/Tools/Scripts/webkitpy/common/net/results_database.py
+++ b/Tools/Scripts/webkitpy/common/net/results_database.py
@@ -1,0 +1,78 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import urllib.parse
+
+import requests
+
+RESULTS_DB_URL = 'https://results.webkit.org'
+
+_session = requests.Session()
+
+
+def get_results_summary(test, suite='layout-tests', timeout=10):
+    url = '{}/api/results-summary/{}/{}'.format(
+        RESULTS_DB_URL,
+        urllib.parse.quote(suite, safe=''),
+        urllib.parse.quote(test, safe=''),
+    )
+    try:
+        response = _session.get(url, timeout=timeout)
+        response.raise_for_status()
+        return response.json()
+    except Exception:
+        return {}
+
+
+def is_pre_existing_failure(test, suite='layout-tests', threshold=80):
+    # Threshold of 80 matches ResultsDatabase.PERCENT_SUCCESS_RATE_FOR_PRE_EXISTING_FAILURE used by EWS bots.
+    data = get_results_summary(test, suite=suite)
+    pass_rate = data.get('pass', 100) + data.get('warning', 0)
+    return pass_rate < threshold
+
+
+def check_pre_existing_failures(tests, suite, limit, writeln):
+    tests = list(tests)
+    checked = tests if not limit else tests[:limit]
+    skipped_count = len(tests) - len(checked)
+
+    writeln('')
+    writeln(f'Checking results.webkit.org for pre-existing failures ({len(checked)} of {len(tests)}) ...')
+
+    pre_existing = []
+    possibly_new = []
+    for test in checked:
+        if is_pre_existing_failure(test, suite=suite):
+            pre_existing.append(test)
+        else:
+            possibly_new.append(test)
+
+    if pre_existing:
+        writeln(f'Pre-existing on CI ({len(pre_existing)}):')
+        for t in pre_existing:
+            writeln(f'  [pre-existing] {t}')
+    if possibly_new:
+        writeln(f'Possibly new ({len(possibly_new)}):')
+        for t in possibly_new:
+            writeln(f'  [new?] {t}')
+    if skipped_count:
+        writeln(f'({skipped_count} further failures not checked; increase --max-pre-existing-checks to check all)')

--- a/Tools/Scripts/webkitpy/common/net/results_database_unittest.py
+++ b/Tools/Scripts/webkitpy/common/net/results_database_unittest.py
@@ -1,0 +1,149 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import unittest
+
+import requests
+from unittest.mock import MagicMock, patch
+
+from webkitpy.common.net import results_database
+
+
+def _make_response(data, status_code=200):
+    response = MagicMock()
+    response.status_code = status_code
+    response.json.return_value = data
+    if status_code >= 400:
+        response.raise_for_status.side_effect = requests.HTTPError(response=response)
+    else:
+        response.raise_for_status.return_value = None
+    return response
+
+
+class GetResultsSummaryTest(unittest.TestCase):
+
+    def test_returns_parsed_json_on_success(self):
+        payload = {'pass': 95.0, 'fail': 5.0}
+        with patch.object(results_database._session, 'get', return_value=_make_response(payload)):
+            result = results_database.get_results_summary('fast/css/foo.html')
+        self.assertEqual(result, payload)
+
+    def test_url_encodes_test_name(self):
+        captured = {}
+
+        def fake_get(url, params=None, timeout=None):
+            captured['url'] = url
+            return _make_response({'pass': 100.0})
+
+        with patch.object(results_database._session, 'get', side_effect=fake_get):
+            results_database.get_results_summary('fast/css/foo bar.html')
+
+        self.assertIn('foo%20bar', captured['url'])
+
+    def test_returns_empty_on_http_error(self):
+        with patch.object(results_database._session, 'get', return_value=_make_response({}, status_code=404)):
+            result = results_database.get_results_summary('fast/css/foo.html')
+        self.assertEqual(result, {})
+
+    def test_returns_empty_on_network_error(self):
+        with patch.object(results_database._session, 'get', side_effect=requests.ConnectionError()):
+            result = results_database.get_results_summary('fast/css/foo.html')
+        self.assertEqual(result, {})
+
+    def test_returns_empty_on_exception(self):
+        with patch.object(results_database._session, 'get', side_effect=Exception('unexpected')):
+            result = results_database.get_results_summary('fast/css/foo.html')
+        self.assertEqual(result, {})
+
+    def test_uses_custom_suite(self):
+        captured = {}
+
+        def fake_get(url, params=None, timeout=None):
+            captured['url'] = url
+            return _make_response({'pass': 100.0})
+
+        with patch.object(results_database._session, 'get', side_effect=fake_get):
+            results_database.get_results_summary('SomeTest', suite='api-tests')
+
+        self.assertIn('/api-tests/', captured['url'])
+
+    def test_treats_any_2xx_as_success(self):
+        payload = {'pass': 100.0}
+        response = _make_response(payload, status_code=202)
+        with patch.object(results_database._session, 'get', return_value=response):
+            result = results_database.get_results_summary('fast/css/foo.html')
+        self.assertEqual(result, payload)
+
+
+class IsPreExistingFailureTest(unittest.TestCase):
+
+    def test_true_when_pass_rate_below_threshold(self):
+        with patch.object(results_database._session, 'get', return_value=_make_response({'pass': 70.0})):
+            self.assertTrue(results_database.is_pre_existing_failure('fast/css/foo.html'))
+
+    def test_true_when_pass_plus_warning_below_threshold(self):
+        with patch.object(results_database._session, 'get', return_value=_make_response({'pass': 60.0, 'warning': 15.0})):
+            self.assertTrue(results_database.is_pre_existing_failure('fast/css/foo.html'))
+
+    def test_false_when_pass_rate_at_threshold(self):
+        with patch.object(results_database._session, 'get', return_value=_make_response({'pass': 80.0})):
+            self.assertFalse(results_database.is_pre_existing_failure('fast/css/foo.html'))
+
+    def test_false_when_pass_rate_above_threshold(self):
+        with patch.object(results_database._session, 'get', return_value=_make_response({'pass': 95.0})):
+            self.assertFalse(results_database.is_pre_existing_failure('fast/css/foo.html'))
+
+    def test_false_when_no_data_from_server(self):
+        with patch.object(results_database._session, 'get', side_effect=requests.ConnectionError()):
+            self.assertFalse(results_database.is_pre_existing_failure('fast/css/foo.html'))
+
+    def test_false_when_server_returns_error(self):
+        with patch.object(results_database._session, 'get', return_value=_make_response({}, status_code=404)):
+            self.assertFalse(results_database.is_pre_existing_failure('fast/css/foo.html'))
+
+    def test_true_for_zero_pass_rate(self):
+        with patch.object(results_database._session, 'get', return_value=_make_response({'pass': 0.0, 'fail': 100.0})):
+            self.assertTrue(results_database.is_pre_existing_failure('fast/css/foo.html'))
+
+    def test_respects_custom_threshold(self):
+        payload = {'pass': 85.0}
+        with patch.object(results_database._session, 'get', return_value=_make_response(payload)):
+            self.assertTrue(results_database.is_pre_existing_failure('fast/css/foo.html', threshold=90))
+        with patch.object(results_database._session, 'get', return_value=_make_response(payload)):
+            self.assertFalse(results_database.is_pre_existing_failure('fast/css/foo.html'))
+
+    def test_missing_pass_key_defaults_to_100(self):
+        with patch.object(results_database._session, 'get', return_value=_make_response({})):
+            self.assertFalse(results_database.is_pre_existing_failure('fast/css/foo.html'))
+
+    def test_uses_custom_suite(self):
+        captured = {}
+
+        def fake_get(url, params=None, timeout=None):
+            captured['url'] = url
+            return _make_response({'pass': 70.0})
+
+        with patch.object(results_database._session, 'get', side_effect=fake_get):
+            result = results_database.is_pre_existing_failure('SomeTest', suite='api-tests')
+
+        self.assertIn('/api-tests/', captured['url'])
+        self.assertTrue(result)

--- a/Tools/Scripts/webkitpy/layout_tests/controllers/manager.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/manager.py
@@ -50,6 +50,7 @@ from collections import OrderedDict, defaultdict
 
 from webkitcorepy.string_utils import pluralize
 
+from webkitpy.common.net import results_database
 from webkitpy.common.iteration_compatibility import iteritems, itervalues
 from webkitpy.layout_tests.controllers.layout_test_finder_legacy import LayoutTestFinder
 from webkitpy.layout_tests.controllers.layout_test_runner import LayoutTestRunner
@@ -697,6 +698,15 @@ class Manager(object):
                 flat_expectations[device_type] = exp
         summarized_results = test_run_results.summarize_results(self._port, flat_expectations, initial_results, retry_results, enabled_pixel_tests_in_retry)
         self._printer.print_results(end_time - start_time, initial_results, summarized_results)
+
+        if self._options.check_pre_existing_failures:
+            results = retry_results if retry_results else initial_results
+            results_database.check_pre_existing_failures(
+                results.unexpected_results_by_name.keys(),
+                self._options.suite or 'layout-tests',
+                self._options.max_pre_existing_checks,
+                _log.info,
+            )
 
         exit_code = -1
         if not self._options.dry_run:

--- a/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py
+++ b/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py
@@ -208,6 +208,15 @@ def parse_args(args):
                  "directories enumerated with the option. Some ports may ignore this "
                  "option while others can have a default value that can be overridden here."),
 
+        optparse.make_option("--check-pre-existing-failures", action="store_true",
+                             default=False, dest="check_pre_existing_failures",
+                             help="After the run, consult results.webkit.org to annotate each unexpected "
+                                  "failure as pre-existing (historically failing on CI) or possibly new. "
+                                  "Capped at --max-pre-existing-checks tests."),
+        optparse.make_option("--max-pre-existing-checks", type="int", default=0,
+                             dest="max_pre_existing_checks",
+                             help="Maximum number of failing tests to look up in results.webkit.org when "
+                                  "--check-pre-existing-failures is set. Use 0 for no limit. (default: 0)"),
         optparse.make_option("--skip-failing-tests", action="store_true",
             default=False, help="Skip tests that are marked as failing or flaky. "
                  "Note: When using this option, you might miss new crashes "


### PR DESCRIPTION
#### 2fcc121ad432b553922ce4a0e23315eb1d998cf8
<pre>
run-webkit-tests should optionally consult the results database to identify pre-existing failures when running at desk
<a href="https://bugs.webkit.org/show_bug.cgi?id=318754">https://bugs.webkit.org/show_bug.cgi?id=318754</a>
<a href="https://rdar.apple.com/180662445">rdar://180662445</a>

Reviewed by Sam Sneddon.

Add a --check-pre-existing-failures flag to run-webkit-tests and run-api-tests.
When set, each unexpected failure is looked up against results.webkit.org after
the run completes and classified as either pre-existing (historically failing on
the post-commit infrastructure) or possibly new. A test is considered
pre-existing when its combined pass+warning rate is strictly below 80%. A
companion --max-pre-existing-checks option (default: 0, no limit) caps the
number of lookups for use on slow connections or with very large failure sets.

* Tools/Scripts/run-api-tests:
(parse_args):
* Tools/Scripts/run-webkit-tests:
(parse_args):
* Tools/Scripts/webkitpy/api_tests/manager.py:
(Manager.run):
* Tools/Scripts/webkitpy/common/net/results_database.py: Added.
(get_results_summary):
(is_pre_existing_failure):
(check_pre_existing_failures):
* Tools/Scripts/webkitpy/common/net/results_database_unittest.py: Added.
* Tools/Scripts/webkitpy/layout_tests/controllers/manager.py:
(Manager._end_test_run):
* Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py:
(parse_args):

Canonical link: <a href="https://commits.webkit.org/317639@main">https://commits.webkit.org/317639@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/19d179b3b3f2b550d79ac0780e9583757ba3fcfb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175713 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49646 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43429 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185312 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177576 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50938 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49328 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136817 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178669 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40267 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157587 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117295 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/175036 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38909 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37292 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149328 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37079 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33775 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41498 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187727 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49313 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145806 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39230 "") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49993 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33703 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145648 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26722 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40442 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122189 "Build is in progress. Recent messages:") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/116014 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48500 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12057 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47902 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48134 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47959 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->