### PR TITLE
[Scroll anchoring] nfl.com scroll position jumps when hovering the top bar (changing scroll-padding)

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/scroll-padding-change-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/scroll-padding-change-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Changing scroll-padding on the scroller should not trigger a scroll anchoring adjustment
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/scroll-padding-change.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/scroll-padding-change.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="help" href="https://drafts.csswg.org/css-scroll-anchoring/">
+<style>
+:root { scroll-padding-top: 100px; }
+:root.no-padding { scroll-padding-top: 0px; }
+
+body { height: 4000px; margin: 0; }
+
+.spacer { height: 200px; }
+.anchor { height: 200px; background-color: green; }
+</style>
+<div class="spacer"></div>
+<div class="anchor"></div>
+<script>
+
+test(() => {
+  document.scrollingElement.scrollTop = 250;
+  assert_equals(document.scrollingElement.scrollTop, 250);
+
+  document.documentElement.classList.add("no-padding");
+  assert_equals(document.scrollingElement.scrollTop, 250);
+
+  document.documentElement.classList.remove("no-padding");
+  assert_equals(document.scrollingElement.scrollTop, 250);
+
+}, "Changing scroll-padding on the scroller should not trigger a scroll anchoring adjustment");
+
+</script>

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
@@ -224,7 +224,7 @@ static FloatRect candidateLocalRectForAnchoring(RenderObject& renderer)
     return { };
 }
 
-auto ScrollAnchoringController::computeScrollerRelativeRects(RenderObject& candidate) const -> Rects
+auto ScrollAnchoringController::computeScrollerRelativeRects(RenderObject& candidate, RespectScrollPadding respectScrollPadding) const -> Rects
 {
     CheckedPtr scrollerBox = scrollableAreaBox();
     if (!scrollerBox)
@@ -249,7 +249,8 @@ auto ScrollAnchoringController::computeScrollerRelativeRects(RenderObject& candi
         if (!docRenderer)
             return { };
 
-        scrollViewport.contract(docRenderer->scrollPaddingForViewportRect(scrollViewport));
+        if (respectScrollPadding == RespectScrollPadding::Yes)
+            scrollViewport.contract(docRenderer->scrollPaddingForViewportRect(scrollViewport));
 
         return {
             // Map to the RenderView to exclude page scale.
@@ -259,7 +260,8 @@ auto ScrollAnchoringController::computeScrollerRelativeRects(RenderObject& candi
     }
 
     auto scrollerRect = LayoutRect { m_owningScrollableArea->visibleContentRect() };
-    scrollerRect.contract(scrollerBox->scrollPaddingForViewportRect(scrollerRect));
+    if (respectScrollPadding == RespectScrollPadding::Yes)
+        scrollerRect.contract(scrollerBox->scrollPaddingForViewportRect(scrollerRect));
 
     // FIXME: Check for writing modes.
     // FIXME: This really needs to compute bounds relative to the padding box.
@@ -277,7 +279,7 @@ auto ScrollAnchoringController::computeScrollerRelativeRects(RenderObject& candi
 // relative to the block start edge of the scrolling content in the block flow direction of the scroller.
 FloatPoint ScrollAnchoringController::computeOffsetFromOwningScroller(RenderObject& candidate, RenderBox& scrollerBox) const
 {
-    auto rects = computeScrollerRelativeRects(candidate);
+    auto rects = computeScrollerRelativeRects(candidate, RespectScrollPadding::No);
 
     auto candidateCorner = inlineAndBlockStartCorner(rects.boundsRelativeToScrolledContent, candidate.writingMode());
     auto scrollerCorner = inlineAndBlockStartCorner(rects.scrollerContentsVisibleRect, scrollerBox.writingMode());
@@ -429,7 +431,7 @@ AnchorSearchStatus ScrollAnchoringController::examineAnchorCandidate(RenderObjec
         return false;
     };
 
-    auto rects = computeScrollerRelativeRects(candidate);
+    auto rects = computeScrollerRelativeRects(candidate, RespectScrollPadding::Yes);
     if (rects.boundsRelativeToScrolledContent.isEmpty()) {
         if (shouldDescendIntoObjectWithEmptyLayoutOverflow(candidate))
             return AnchorSearchStatus::Continue;

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.h
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.h
@@ -115,10 +115,11 @@ private:
 
     struct Rects {
         FloatRect boundsRelativeToScrolledContent;
-        FloatRect scrollerContentsVisibleRect; // Takes scroll-padding into account.
+        FloatRect scrollerContentsVisibleRect;
     };
 
-    Rects computeScrollerRelativeRects(RenderObject&) const;
+    enum class RespectScrollPadding : bool { No, Yes };
+    Rects computeScrollerRelativeRects(RenderObject&, RespectScrollPadding) const;
 
     FloatPoint computeOffsetFromOwningScroller(RenderObject&, RenderBox& scrollerBox) const;
 


### PR DESCRIPTION
#### 7ac7ce74ec82f418137c38209dc2d314000dca47
<pre>
[Scroll anchoring] nfl.com scroll position jumps when hovering the top bar (changing scroll-padding)
<a href="https://bugs.webkit.org/show_bug.cgi?id=318756">https://bugs.webkit.org/show_bug.cgi?id=318756</a>
<a href="https://rdar.apple.com/180597852">rdar://180597852</a>

Reviewed by Dan Glastonbury.

The scroll anchoring code re-used `computeScrollerRelativeRects()` for both anchor selection, and
scroll anchoring adjustment. However, only anchor selection should respect `scroll-padding`; this caused
an erroneous scroll anchoring adjustment on nfl.com when the page changes `scroll-padding` on the root
when the top bar is hovered.

Fix by passing in a flag to say whether `scroll-padding` should be respected; off for anchor adjustment,
and on for anchor selection.

Test: imported/w3c/web-platform-tests/css/css-scroll-anchoring/scroll-padding-change.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/scroll-padding-change-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/scroll-padding-change.html: Added.
* Source/WebCore/page/scrolling/ScrollAnchoringController.cpp:
(WebCore::ScrollAnchoringController::computeScrollerRelativeRects const):
(WebCore::ScrollAnchoringController::computeOffsetFromOwningScroller const):
(WebCore::ScrollAnchoringController::examineAnchorCandidate const):
* Source/WebCore/page/scrolling/ScrollAnchoringController.h:

Canonical link: <a href="https://commits.webkit.org/316662@main">https://commits.webkit.org/316662@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c1c88baafef4fec59e93fea215949abeb7e82d2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173040 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46959 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40438 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182620 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130596 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174905 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48253 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46635 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/134584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175998 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37981 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155171 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.CrossProcessHistoryTraversalCoalesce (failure)") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/115053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36626 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34957 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31098 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147050 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34671 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185035 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37822 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39158 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143400 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46630 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154733 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143272 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38690 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47308 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112386 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38253 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119068 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45825 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9614 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45227 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45458 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45284 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->