### PR TITLE
[DRAFT] Fix aspect-ratio with both max-width and max-height

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4615,7 +4615,6 @@ imported/w3c/web-platform-tests/css/css-sizing/max-content-input-001.html [ Imag
 imported/w3c/web-platform-tests/css/css-sizing/vert-block-size-small-or-larger-than-container-with-min-or-max-content-1.html [ ImageOnlyFailure ]
 webkit.org/b/214463 imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/flex-aspect-ratio-038.html [ ImageOnlyFailure ]
 webkit.org/b/214463 imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/floats-aspect-ratio-001.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/block-aspect-ratio-057.tentative.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/replaced-element-045.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/replaced-element-046.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-sizing/block-size-with-min-or-max-content-2.html [ ImageOnlyFailure ]

--- a/LayoutTests/fast/css/aspect-ratio-max-width-and-max-height-transfer-expected.html
+++ b/LayoutTests/fast/css/aspect-ratio-max-width-and-max-height-transfer-expected.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<div style="width: 100px; height: 100px; background-color: green;"></div>

--- a/LayoutTests/fast/css/aspect-ratio-max-width-and-max-height-transfer.html
+++ b/LayoutTests/fast/css/aspect-ratio-max-width-and-max-height-transfer.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<!-- https://bugs.webkit.org/show_bug.cgi?id=290024 : an explicit max-width must not suppress the
+     max-height transferred through the aspect-ratio. The 100px max-height caps the width to 100px. -->
+<div style="width: 200px; height: 100px;">
+  <div style="aspect-ratio: 1 / 1; max-width: 100%; max-height: 100%; background-color: green;"></div>
+</div>

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -724,25 +724,25 @@ void RenderBox::constrainLogicalMinMaxSizesByAspectRatio(LayoutUnit& computedMin
     if (logicalSize.isSpecified())
         return;
 
-    // Sizing constraints in either axis (the origin axis) should be transferred through the preferred aspect ratio. See https://www.w3.org/TR/css-sizing-4/#aspect-ratio-size-transfers
-    bool shouldCheckTransferredMinSize = dimension == ConstrainDimension::Width ? !styleToUse.logicalMinWidth().isSpecified() : !styleToUse.logicalMinHeight().isSpecified();
-    bool shouldCheckTransferredMaxSize = dimension == ConstrainDimension::Width ? !styleToUse.logicalMaxWidth().isSpecified() : !styleToUse.logicalMaxHeight().isSpecified();
-    if (!shouldCheckTransferredMaxSize && !shouldCheckTransferredMinSize)
-        return;
-
+    // Sizing constraints in the opposite (origin) axis are transferred through the preferred aspect ratio and
+    // applied to this (destination) axis. Per spec the transfer happens whenever the preferred size in this axis
+    // is indefinite (guaranteed by the early return above); an explicit min or max size in this axis does not
+    // suppress the transfer, it only bounds it. See https://www.w3.org/TR/css-sizing-4/#aspect-ratio-size-transfers
     auto [transferredLogicalMinSize, transferredLogicalMaxSize] = dimension == ConstrainDimension::Width ? computeMinMaxLogicalWidthFromAspectRatio() : computeMinMaxLogicalHeightFromAspectRatio();
-    if (shouldCheckTransferredMaxSize && transferredLogicalMaxSize != LayoutUnit::max()) {
-        // The transferred max size should be floored by the definite minimum size.
-        if (!shouldCheckTransferredMinSize && minimumSizeType == MinimumSizeIsAutomaticContentBased::No)
-            transferredLogicalMaxSize = std::max(transferredLogicalMaxSize, computedMinSize);
-        computedMaxSize = std::min(computedMaxSize, transferredLogicalMaxSize);
+
+    // "First, any definite minimum size is converted and transferred from the origin to destination axis. This
+    //  transferred minimum is capped by any definite preferred or maximum size in the destination axis."
+    if (transferredLogicalMinSize > LayoutUnit()) {
+        transferredLogicalMinSize = std::min(transferredLogicalMinSize, computedMaxSize);
+        computedMinSize = std::max(computedMinSize, transferredLogicalMinSize);
     }
 
-    if (shouldCheckTransferredMinSize && transferredLogicalMinSize > LayoutUnit()) {
-        // The transferred min size should be capped by the definite maximum size.
-        if (!shouldCheckTransferredMaxSize)
-            transferredLogicalMinSize = std::min(transferredLogicalMinSize, computedMaxSize);
-        computedMinSize = std::max(computedMinSize, transferredLogicalMinSize);
+    // "Then, any definite maximum size is converted and transferred from the origin to destination. This
+    //  transferred maximum is floored by any definite preferred or minimum size in the destination axis as well
+    //  as by the transferred minimum, if any." (computedMinSize already folds in the transferred minimum above.)
+    if (transferredLogicalMaxSize != LayoutUnit::max()) {
+        transferredLogicalMaxSize = std::max(transferredLogicalMaxSize, computedMinSize);
+        computedMaxSize = std::min(computedMaxSize, transferredLogicalMaxSize);
     }
 }
 


### PR DESCRIPTION
#### 8376221b78796c1afc62d13af715cda522cf36b4
<pre>
[DRAFT] Fix aspect-ratio with both max-width and max-height
<a href="https://bugs.webkit.org/show_bug.cgi?id=290024">https://bugs.webkit.org/show_bug.cgi?id=290024</a>
<a href="https://rdar.apple.com/147897043">rdar://147897043</a>

Reviewed by NOBODY (OOPS!).

* LayoutTests/TestExpectations:
* LayoutTests/fast/css/aspect-ratio-max-width-and-max-height-transfer-expected.html: Added.
* LayoutTests/fast/css/aspect-ratio-max-width-and-max-height-transfer.html: Added.
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::constrainLogicalMinMaxSizesByAspectRatio const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8376221b78796c1afc62d13af715cda522cf36b4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172984 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46903 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41344 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182444 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130540 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174849 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48196 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46579 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134539 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-sizing/nested-flexbox-image-percentage-max-height-computes-as-none.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94955 "2 flakes 23 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175942 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37932 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155809 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115008 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36577 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-sizing/nested-flexbox-image-percentage-max-height-computes-as-none.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34907 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31042 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147001 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35303 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-sizing/nested-flexbox-image-percentage-max-height-computes-as-none.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184979 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37750 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39109 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-sizing/nested-flexbox-image-percentage-max-height-computes-as-none.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143347 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-sizing/nested-flexbox-image-percentage-max-height-computes-as-none.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46574 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155365 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143219 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47252 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31919 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-sizing/nested-flexbox-image-percentage-max-height-computes-as-none.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112276 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38204 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119012 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45769 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10258 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45170 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45402 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45228 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->