### PR TITLE
[WTF] Use std::ranges::fill for the fill loops in StringConcatenate padding/indentation adapters

### DIFF
--- a/Source/WTF/wtf/text/StringConcatenate.h
+++ b/Source/WTF/wtf/text/StringConcatenate.h
@@ -351,8 +351,7 @@ public:
         unsigned count = 0;
         if (underlyingLength < m_padding.length) {
             count = m_padding.length - underlyingLength;
-            for (unsigned i = 0; i < count; ++i)
-                destination[i] = m_padding.character;
+            std::ranges::fill(destination.first(count), m_padding.character);
         }
         m_underlyingAdapter.writeTo(destination.subspan(count));
     }
@@ -405,7 +404,7 @@ public:
 
     template<typename CharacterType> void writeTo(std::span<CharacterType> destination) const
     {
-        std::fill_n(destination.data(), m_indentation.value * N, ' ');
+        std::ranges::fill(destination.first(m_indentation.value * N), ' ');
     }
 
 private:


### PR DESCRIPTION
#### 61ef996f296e2d18a6a671bdaa08c06430f50b2f
<pre>
[WTF] Use std::ranges::fill for the fill loops in StringConcatenate padding/indentation adapters
<a href="https://bugs.webkit.org/show_bug.cgi?id=318766">https://bugs.webkit.org/show_bug.cgi?id=318766</a>
<a href="https://rdar.apple.com/problem/181625114">rdar://problem/181625114</a>

Reviewed by Chris Dumez.

The PaddingSpecification and Indentation StringTypeAdapters both filled
their characters with std::fill_n(destination.data(), ...). Calling
data() strips the bounds off the span and hands the fill a raw pointer,
which defeats the memory-safety the span provides (and is the pattern
the unsafe-buffer warning targets).

Switch both to std::ranges::fill over a bounded subspan
(destination.first(count)) so the fills read as a single clear statement
and stay memory-safe: the span carries its length, so we never hand a
raw pointer to the fill.

* Source/WTF/wtf/text/StringConcatenate.h:
(WTF::StringTypeAdapter&lt;PaddingSpecification&lt;UnderlyingElementType&gt;&gt;::writeTo const):
(WTF::StringTypeAdapter&lt;Indentation&lt;N&gt;&gt;::writeTo const):

Canonical link: <a href="https://commits.webkit.org/317049@main">https://commits.webkit.org/317049@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eace27f2c362420c782c40a637cc071c29d2677a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174180 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48113 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41894 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183754 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132048 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/563497f3-5190-44b0-8ca1-59f4bbf038e3) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49405 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47795 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135497 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0f8d871b-7c90-4b0e-a191-2c3802f751c1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177138 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38914 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156277 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115975 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/67a8a9b5-5905-450c-837d-5ee34a1d759e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37554 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35921 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32238 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/4787 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147978 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35770 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186180 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/35442 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39339 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40119 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 344 new passes 16 flakes 5 failures; Uploaded test results; 344 new passes 16 flakes 5 failures; Compiled WebKit (warnings); layout-tests; Passed layout tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144388 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47780 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144248 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38881 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48459 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32390 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113971 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39155 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120365 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/211215 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46965 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10732 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55044 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46368 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46599 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46426 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->