### PR TITLE
Use prefix increment for std::set iterators in IndexValueStore

### DIFF
--- a/Source/WebCore/Modules/indexeddb/server/IndexValueStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/IndexValueStore.cpp
@@ -283,7 +283,7 @@ IndexValueStore::Iterator IndexValueStore::find(const IDBKeyData& key, const IDB
 
     // If we didn't find a primary key iterator in this entry,
     // we need to move on to start of the next record.
-    iterator++;
+    ++iterator;
     if (iterator == m_orderedKeys.end())
         return { };
 
@@ -339,7 +339,7 @@ IndexValueStore::Iterator IndexValueStore::reverseFind(const IDBKeyData& key, co
 
     // If we didn't find a primary key iterator in this entry,
     // we need to move on to start of the next record.
-    iterator++;
+    ++iterator;
     if (iterator == m_orderedKeys.rend())
         return { };
 


### PR DESCRIPTION
#### 66b6d48b3af443d2ac818813c4c39baaad0ad2d4
<pre>
Use prefix increment for std::set iterators in IndexValueStore
<a href="https://bugs.webkit.org/show_bug.cgi?id=318767">https://bugs.webkit.org/show_bug.cgi?id=318767</a>

Reviewed by Sihui Liu.

In IndexValueStore::find() and IndexValueStore::reverseFind(), the
fallback paths that advance to the next record used post-increment
(iterator++) on an IDBKeyDataSet (std::set) iterator. Since the return
value is discarded, this needlessly constructs a throwaway copy of the
iterator. Switch to prefix increment (++iterator).

No change in behavior.

* Source/WebCore/Modules/indexeddb/server/IndexValueStore.cpp:
(WebCore::IDBServer::IndexValueStore::find):
(WebCore::IDBServer::IndexValueStore::reverseFind):

Canonical link: <a href="https://commits.webkit.org/316664@main">https://commits.webkit.org/316664@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6d7a4efdf9b3991e515159445c9a2c543561b07

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172990 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46909 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40434 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182450 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130546 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174855 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48202 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46585 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134544 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175948 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37935 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155167 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.CrossProcessHistoryTraversalCoalesce (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115013 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36580 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34909 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31048 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147004 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34667 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184985 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37763 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39111 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143351 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46580 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143223 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38691 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47258 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112285 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38209 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119018 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45775 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9610 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45176 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45408 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45234 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->