### PR TITLE
SVG images like the logo at singlethreadfarms.com have non-working Save to Photos menu item

### DIFF
--- a/Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.h
+++ b/Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.h
@@ -79,6 +79,9 @@ struct InteractionInformationAtPosition {
 #endif
         bool isLink,
         bool isImage,
+#if PLATFORM(IOS_FAMILY)
+        bool hasSaveableImage,
+#endif
 #if ENABLE(MODEL_PROCESS)
         bool isInteractiveModel,
 #endif
@@ -151,6 +154,9 @@ struct InteractionInformationAtPosition {
 #endif
     bool isLink { false };
     bool isImage { false };
+#if PLATFORM(IOS_FAMILY)
+    bool hasSaveableImage { false };
+#endif
 #if ENABLE(MODEL_PROCESS)
     bool isInteractiveModel { false };
 #endif

--- a/Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.mm
+++ b/Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.mm
@@ -52,6 +52,9 @@ InteractionInformationAtPosition::InteractionInformationAtPosition(
 #endif
     bool isLink,
     bool isImage,
+#if PLATFORM(IOS_FAMILY)
+    bool hasSaveableImage,
+#endif
 #if ENABLE(MODEL_PROCESS)
     bool isInteractiveModel,
 #endif
@@ -119,6 +122,9 @@ InteractionInformationAtPosition::InteractionInformationAtPosition(
 #endif
     , isLink(isLink)
     , isImage(isImage)
+#if PLATFORM(IOS_FAMILY)
+    , hasSaveableImage(hasSaveableImage)
+#endif
 #if ENABLE(MODEL_PROCESS)
     , isInteractiveModel(isInteractiveModel)
 #endif

--- a/Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.serialization.in
@@ -50,6 +50,9 @@ struct WebKit::InteractionInformationAtPosition {
 #endif
     bool isLink;
     bool isImage;
+#if PLATFORM(IOS_FAMILY)
+    bool hasSaveableImage;
+#endif
 #if ENABLE(MODEL_PROCESS)
     bool isInteractiveModel;
 #endif

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKActivatedElementInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKActivatedElementInfo.mm
@@ -51,18 +51,40 @@
     BOOL _isAnimating;
     Vector<WebCore::ElementAnimationContext> _animationsUnderElement;
 #endif
-    BOOL _animatedImage;
+    BOOL _isAnimatedImage;
+#if PLATFORM(IOS_FAMILY)
     BOOL _isImage;
+    BOOL _hasSaveableImage;
     BOOL _isUsingAlternateURLForImage;
+#endif
 #if ENABLE(SPATIAL_IMAGE_DETECTION)
     BOOL _isSpatialImage;
 #endif
 }
 
 #if PLATFORM(IOS_FAMILY)
+
 + (instancetype)activatedElementInfoWithInteractionInformationAtPosition:(const WebKit::InteractionInformationAtPosition&)information userInfo:(NSDictionary *)userInfo
 {
     return adoptNS([[self alloc] _initWithInteractionInformationAtPosition:information isUsingAlternateURLForImage:NO userInfo:userInfo]).autorelease();
+}
+
+- (void)setFromInformation:(const WebKit::InteractionInformationAtPosition&)information
+{
+    // This sets the fields in common between the two different types of init method below.
+
+    _boundingRect = information.bounds;
+    _hasSaveableImage = information.hasSaveableImage;
+    _ID = information.idAttribute.createNSString();
+    _imageMIMEType = information.imageMIMEType.createNSString();
+    _interactionLocation = information.request.point;
+    _isAnimatedImage = information.isAnimatedImage;
+    _isAnimating = information.isAnimating;
+    _title = information.title.createNSString();
+
+#if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
+    _animationsUnderElement = information.animationsAtPoint;
+#endif
 }
 
 - (instancetype)_initWithInteractionInformationAtPosition:(const WebKit::InteractionInformationAtPosition&)information isUsingAlternateURLForImage:(BOOL)isUsingAlternateURLForImage userInfo:(NSDictionary *)userInfo
@@ -73,11 +95,7 @@
     _URL = information.url.createNSURL();
     _imageURL = information.imageURL.createNSURL();
     _modelURL = information.modelURL.createNSURL();
-    _imageMIMEType = information.imageMIMEType.createNSString().get();
-    _interactionLocation = information.request.point;
-    _title = information.title.createNSString().get();
-    _boundingRect = information.bounds;
-    
+
     if (information.isAttachment)
         _type = _WKActivatedElementTypeAttachment;
     else if (information.isLink)
@@ -88,18 +106,14 @@
         _type = _WKActivatedElementTypeUnspecified;
     
     _image = information.image;
-    _ID = information.idAttribute.createNSString().get();
-    _animatedImage = information.isAnimatedImage;
-    _isAnimating = information.isAnimating;
     _isImage = information.isImage;
     _isUsingAlternateURLForImage = isUsingAlternateURLForImage;
 #if ENABLE(SPATIAL_IMAGE_DETECTION)
     _isSpatialImage = information.isSpatialImage;
 #endif
     _userInfo = userInfo;
-#if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
-    _animationsUnderElement = information.animationsAtPoint;
-#endif
+
+    [self setFromInformation:information];
 
     return self;
 }
@@ -131,39 +145,21 @@
 
 - (instancetype)_initWithType:(_WKActivatedElementType)type URL:(NSURL *)url imageURL:(NSURL *)imageURL image:(WebCore::ShareableBitmap*)image userInfo:(NSDictionary *)userInfo information:(const WebKit::InteractionInformationAtPosition&)information
 {
-#if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
-    auto animationsAtPoint = information.animationsAtPoint;
-#else
-    Vector<WebCore::ElementAnimationContext> animationsAtPoint;
-#endif
-
-    return [self _initWithType:type URL:url imageURL:imageURL location:information.request.point title:information.title.createNSString().get() ID:information.idAttribute.createNSString().get() rect:information.bounds image:image imageMIMEType:information.imageMIMEType.createNSString().get() isAnimatedImage:information.isAnimatedImage isAnimating:information.isAnimating animationsUnderElement:animationsAtPoint userInfo:userInfo];
-}
-#endif // PLATFORM(IOS_FAMILY)
-
-- (instancetype)_initWithType:(_WKActivatedElementType)type URL:(NSURL *)url imageURL:(NSURL *)imageURL location:(const WebCore::IntPoint&)location title:(NSString *)title ID:(NSString *)ID rect:(CGRect)rect image:(WebCore::ShareableBitmap*)image imageMIMEType:(NSString *)imageMIMEType isAnimatedImage:(BOOL)isAnimatedImage isAnimating:(BOOL)isAnimating animationsUnderElement:(Vector<WebCore::ElementAnimationContext>)animationsUnderElement userInfo:(NSDictionary *)userInfo
-{
     if (!(self = [super init]))
         return nil;
 
     _URL = adoptNS([url copy]);
     _imageURL = adoptNS([imageURL copy]);
-    _imageMIMEType = adoptNS(imageMIMEType.copy);
-    _interactionLocation = location;
-    _title = adoptNS([title copy]);
-    _boundingRect = rect;
     _type = type;
     _image = image;
-    _ID = ID;
-#if PLATFORM(IOS_FAMILY)
     _userInfo = adoptNS([userInfo copy]);
-    _isAnimating = isAnimating;
-    _animationsUnderElement = animationsUnderElement;
-#endif
-    _animatedImage = isAnimatedImage;
+
+    [self setFromInformation:information];
 
     return self;
 }
+
+#endif // PLATFORM(IOS_FAMILY)
 
 - (NSURL *)URL
 {
@@ -202,22 +198,29 @@
 
 - (BOOL)isAnimatedImage
 {
-    return _animatedImage;
+    return _isAnimatedImage;
 }
+
+#if PLATFORM(IOS_FAMILY)
 
 - (BOOL)_isUsingAlternateURLForImage
 {
     return _isUsingAlternateURLForImage;
 }
 
+#endif
+
 #if ENABLE(SPATIAL_IMAGE_DETECTION)
+
 - (BOOL)isSpatialImage
 {
     return _isSpatialImage;
 }
+
 #endif
 
 #if PLATFORM(IOS_FAMILY)
+
 - (BOOL)isAnimating
 {
     return _isAnimating;
@@ -232,12 +235,18 @@
 {
     return _userInfo.get();
 }
-#endif
 
 - (BOOL)_isImage
 {
     return _isImage;
 }
+
+- (BOOL)_hasSaveableImage
+{
+    return _hasSaveableImage;
+}
+
+#endif
 
 - (CocoaImage *)image
 {

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKActivatedElementInfoInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKActivatedElementInfoInternal.h
@@ -24,8 +24,8 @@
  */
 
 #if PLATFORM(IOS_FAMILY)
+
 #import "InteractionInformationAtPosition.h"
-#endif
 #import <WebCore/ElementAnimationContext.h>
 #import <WebCore/IntPoint.h>
 #import <WebKit/_WKActivatedElementInfo.h>
@@ -36,7 +36,6 @@ class ShareableBitmap;
 
 @interface _WKActivatedElementInfo ()
 
-#if PLATFORM(IOS_FAMILY)
 + (instancetype)activatedElementInfoWithInteractionInformationAtPosition:(const WebKit::InteractionInformationAtPosition&)information userInfo:(NSDictionary *)userInfo;
 - (instancetype)_initWithInteractionInformationAtPosition:(const WebKit::InteractionInformationAtPosition&)information isUsingAlternateURLForImage:(BOOL)isUsingAlternateURLForImage userInfo:(NSDictionary *)userInfo;
 - (instancetype)_initWithType:(_WKActivatedElementType)type URL:(NSURL *)url information:(const WebKit::InteractionInformationAtPosition&)information;
@@ -44,13 +43,15 @@ class ShareableBitmap;
 - (instancetype)_initWithType:(_WKActivatedElementType)type URL:(NSURL *)url imageURL:(NSURL *)imageURL information:(const WebKit::InteractionInformationAtPosition&)information;
 - (instancetype)_initWithType:(_WKActivatedElementType)type URL:(NSURL *)url image:(WebCore::ShareableBitmap*)image information:(const WebKit::InteractionInformationAtPosition&)information;
 - (instancetype)_initWithType:(_WKActivatedElementType)type URL:(NSURL *)url imageURL:(NSURL *)imageURL userInfo:(NSDictionary *)userInfo information:(const WebKit::InteractionInformationAtPosition&)information;
-- (instancetype)_initWithType:(_WKActivatedElementType)type URL:(NSURL *)url imageURL:(NSURL *)imageURL location:(const WebCore::IntPoint&)location title:(NSString *)title ID:(NSString *)ID rect:(CGRect)rect image:(WebCore::ShareableBitmap*)image imageMIMEType:(NSString *)imageMIMEType isAnimatedImage:(BOOL)isAnimatedImage isAnimating:(BOOL)isAnimating animationsUnderElement:(Vector<WebCore::ElementAnimationContext>)animationsUnderElement userInfo:(NSDictionary *)userInfo;
-#endif // PLATFORM(IOS_FAMILY)
 
 @property (nonatomic, readonly) NSString *imageMIMEType;
 @property (nonatomic, readonly) WebCore::IntPoint _interactionLocation;
+
 @property (nonatomic, readonly) BOOL _isImage;
+@property (nonatomic, readonly) BOOL _hasSaveableImage;
 @property (nonatomic, readonly) BOOL _isUsingAlternateURLForImage;
 @property (nonatomic, readonly) const Vector<WebCore::ElementAnimationContext>& _animationsUnderElement;
 
 @end
+
+#endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm
+++ b/Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm
@@ -587,10 +587,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         [defaultActions addObject:[_WKElementAction _elementActionWithType:_WKElementActionTypeAddToReadingList info:elementInfo assistant:self]];
 #endif
 
-    if ([elementInfo imageURL]) {
-        if ([self _canShowSaveImageActionForImageURL:elementInfo.imageURL])
-            [defaultActions addObject:[_WKElementAction _elementActionWithType:_WKElementActionTypeSaveImage info:elementInfo assistant:self]];
-    }
+    if (elementInfo._hasSaveableImage && [self _canShowSaveImageActionForImageURL:elementInfo.imageURL])
+        [defaultActions addObject:[_WKElementAction _elementActionWithType:_WKElementActionTypeSaveImage info:elementInfo assistant:self]];
 
     if (!isJavaScriptURL(targetURL)) {
         [defaultActions addObject:[_WKElementAction _elementActionWithType:_WKElementActionTypeCopy info:elementInfo assistant:self]];
@@ -623,6 +621,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (BOOL)_canShowSaveImageActionForImageURL:(NSURL *)imageURL
 {
+    if (!imageURL)
+        return NO;
+
     if ([self _isPhotoLibraryAccessDenied])
         return NO;
 
@@ -652,7 +653,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if ([getSSReadingListClassSingleton() supportsURL:targetURL])
         [defaultActions addObject:[_WKElementAction _elementActionWithType:_WKElementActionTypeAddToReadingList info:elementInfo assistant:self]];
 #endif
-    if ([self _canShowSaveImageActionForImageURL:elementInfo.imageURL])
+    if (elementInfo._hasSaveableImage && [self _canShowSaveImageActionForImageURL:elementInfo.imageURL])
         [defaultActions addObject:[_WKElementAction _elementActionWithType:_WKElementActionTypeSaveImage info:elementInfo assistant:self]];
 
     [defaultActions addObject:[_WKElementAction _elementActionWithType:_WKElementActionTypeCopy info:elementInfo assistant:self]];

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/PositionInformationForWebPage.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/PositionInformationForWebPage.mm
@@ -251,6 +251,10 @@ static void imagePositionInformation(WebPage& page, WebCore::Element& element, c
 
     auto& [renderImage, image] = *rendererAndImage;
     info.isImage = true;
+#if PLATFORM(IOS_FAMILY)
+    // UIImageDataWriteToSavedPhotosAlbum works with resource data, and thus only for bitmap images.
+    info.hasSaveableImage = image.isBitmapImage() && !image.isNull();
+#endif
     info.imageURL = page.applyLinkDecorationFiltering(protect(element.document())->encodingParseURL(protect(renderImage.cachedImage())->url().string()), WebCore::LinkDecorationFilteringTrigger::Unspecified);
     info.imageMIMEType = image.mimeType();
     info.isAnimatedImage = image.isAnimated();

--- a/Tools/TestWebKitAPI/Resources/cocoa/svg-image-in-link.html
+++ b/Tools/TestWebKitAPI/Resources/cocoa/svg-image-in-link.html
@@ -1,0 +1,17 @@
+<head>
+    <meta name="viewport" content="width=device-width">
+        <style>
+        body {
+            width: 100%;
+            height: 100%;
+            margin: 0;
+        }
+        img {
+            width: 200px;
+            height: 200px;
+        }
+        </style>
+</head>
+<body>
+    <a href="https://www.apple.com"><img src="icon.svg"></img></a>
+</body>

--- a/Tools/TestWebKitAPI/Resources/cocoa/svg-image.html
+++ b/Tools/TestWebKitAPI/Resources/cocoa/svg-image.html
@@ -1,0 +1,17 @@
+<head>
+    <meta name="viewport" content="width=device-width">
+        <style>
+        body {
+            width: 100%;
+            height: 100%;
+            margin: 0;
+        }
+        img {
+            width: 200px;
+            height: 200px;
+        }
+        </style>
+</head>
+<body>
+    <img src="icon.svg"></img>
+</body>

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/ActionSheetTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/ActionSheetTests.mm
@@ -599,6 +599,16 @@ TEST(ActionSheetTests, LinkedImageSaveImageActionIsExcludedWhenImageURLIsManaged
     EXPECT_FALSE(saveImageActionIsPresent(@"image-in-link-and-input", CGPointMake(100, 50), MockManagedImageURL.class));
 }
 
+TEST(ActionSheetTests, SVGImageSaveImageActionIsExcluded)
+{
+    EXPECT_FALSE(saveImageActionIsPresent(@"svg-image", CGPointMake(100, 100)));
+}
+
+TEST(ActionSheetTests, LinkedSVGImageSaveImageActionIsExcluded)
+{
+    EXPECT_FALSE(saveImageActionIsPresent(@"svg-image-in-link", CGPointMake(100, 100)));
+}
+
 } // namespace TestWebKitAPI
 
 #endif // PLATFORM(IOS_FAMILY) && !PLATFORM(MACCATALYST)


### PR DESCRIPTION
#### 3c5fe4025419671f8a72aa954d94925c90bdb671
<pre>
SVG images like the logo at singlethreadfarms.com have non-working Save to Photos menu item
<a href="https://bugs.webkit.org/show_bug.cgi?id=318765">https://bugs.webkit.org/show_bug.cgi?id=318765</a>
<a href="https://rdar.apple.com/181399508">rdar://181399508</a>

Reviewed by Wenson Hsieh.

Added an isBitmapImage check so we won&apos;t have a Save to Photos menu item unless the
resource data is image data. This matches what UIImageWriteToSavedPhotosAlbum can do.

* Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.h: Added hasSaveableImage.
* Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.mm: Ditto.
(WebKit::InteractionInformationAtPosition::InteractionInformationAtPosition):
* Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.serialization.in: Ditto.

* Source/WebKit/UIProcess/API/Cocoa/_WKActivatedElementInfo.mm: Renamed _animatedImage
to _isAnimatedImage for consistency. Moved _isImage and _isUsingAlternateURLForImage
inside PLATFORM(IOS_FAMILY) since they are always NO otherwise. Added _hasSaveableImage.
(-[_WKActivatedElementInfo setFromInformation:]): Added method so the two _init method
families can share code, while preserving behavior for all existing fields. Added the
code to set _hasSaveableImage here.
(-[_WKActivatedElementInfo _initWithInteractionInformationAtPosition:isUsingAlternateURLForImage:userInfo:]):
Use setForInformation.
(-[_WKActivatedElementInfo _initWithType:URL:imageURL:image:userInfo:information:]):
Merged the unused longer method into this one, use setForInformation.
(-[_WKActivatedElementInfo isAnimatedImage]): Updated for the above changes.
(-[_WKActivatedElementInfo _hasSaveableImage]): Added.
(-[_WKActivatedElementInfo userInfo]):
(-[_WKActivatedElementInfo _initWithType:URL:imageURL:location:title:ID:rect:image:imageMIMEType:isAnimatedImage:isAnimating:animationsUnderElement:userInfo:]): Deleted.

* Source/WebKit/UIProcess/API/Cocoa/_WKActivatedElementInfoInternal.h: Put header
inside PLATFORM(IOS_FAMILY) since it is not used on Mac. Added _hasSaveableImage.

* Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm:
(-[WKActionSheetAssistant defaultActionsForLinkSheet:]): Check _hasSaveableImage.
Also removed null check of imageURL since _canShowSaveImageActionForImageURL: now
checks for that.
(-[WKActionSheetAssistant _canShowSaveImageActionForImageURL:]): Added a check for
a null imageURL so the caller doesn&apos;t have to do it.
(-[WKActionSheetAssistant defaultActionsForImageSheet:]): Check _hasSaveableImage.

* Source/WebKit/WebProcess/WebPage/Cocoa/PositionInformationForWebPage.mm:
(WebKit::imagePositionInformation): Set hasSaveableImage, only true for bitmap images
that are not the null image.

* Tools/TestWebKitAPI/Resources/cocoa/svg-image-in-link.html: Added.
* Tools/TestWebKitAPI/Resources/cocoa/svg-image.html: Added.

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/ActionSheetTests.mm:
(ActionSheetTests.SVGImageSaveImageActionIsExcluded): Added.
(ActionSheetTests.LinkedSVGImageSaveImageActionIsExcluded): Added.
(TestWebKitAPI::TEST(ActionSheetTests, SVGImageSaveImageActionIsExcluded)):
(TestWebKitAPI::TEST(ActionSheetTests, LinkedSVGImageSaveImageActionIsExcluded)):

Canonical link: <a href="https://commits.webkit.org/316983@main">https://commits.webkit.org/316983@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c7b6b499a5b9662ada5849c2e9f9c01b33c4a82

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174019 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47952 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41733 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183593 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131887 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1803b4fc-4179-451a-a0bc-0a1b43fc2d91) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175884 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49244 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47634 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135332 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/65e8f768-2204-4030-96d2-c59f74166a75) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176977 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38762 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/156123 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115810 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2e11a26d-5c26-48a8-b2a5-503b11f28c96) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37403 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35770 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32077 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147827 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35616 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186019 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39104 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39969 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144233 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47619 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144092 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38841 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48298 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32233 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113706 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39001 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120182 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46804 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10577 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46207 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46438 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46265 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->