### PR TITLE
[JSC] Add B3::eliminateWasmGCAllocations phase

### DIFF
--- a/JSTests/wasm/stress/wasm-gc-eliminate-allocations-basic.js
+++ b/JSTests/wasm/stress/wasm-gc-eliminate-allocations-basic.js
@@ -1,0 +1,108 @@
+//@ runDefaultWasm("-m", "--useConcurrentJIT=0", "--thresholdForOMGOptimizeAfterWarmUp=0", "--thresholdForBBQOptimizeAfterWarmUp=0")
+
+// Exercises B3's eliminateWasmGCAllocations (dead non-escaping struct removal) plus the
+// reduceStrength ref.eq folding of fresh allocations. Everything runs in a hot loop so the
+// OMG tier (where the pass runs) compiles and executes.
+
+import { instantiate } from "../gc/wast-wrapper.js"
+import * as assert from "../assert.js"
+
+const wat = `
+(module
+    (type $point (struct (field $x (mut i32)) (field $y (mut i32))))
+    (type $box (struct (field $p (mut (ref null $point)))))
+    (type $node (struct (field $v (mut i32)) (field $next (mut (ref null $node)))))
+
+    ;; Allocate a struct, initialize it, never read it: pure dead allocation.
+    (func (export "deadStruct") (param $a i32) (param $b i32) (result i32)
+        (local $p (ref $point))
+        (local.set $p (struct.new $point (local.get $a) (local.get $b)))
+        (i32.add (local.get $a) (local.get $b)))
+
+    ;; Allocate, set fields, read them back: CSE forwards the reads, the allocation is dead,
+    ;; and the returned value must still be correct.
+    (func (export "readBack") (param $a i32) (param $b i32) (result i32)
+        (local $p (ref $point))
+        (local.set $p (struct.new $point (local.get $a) (local.get $b)))
+        (i32.sub (struct.get $point $x (local.get $p))
+                 (struct.get $point $y (local.get $p))))
+
+    ;; The struct escapes into a longer-lived struct that is returned, so it must NOT be
+    ;; removed and the field read through the escaped reference must be correct.
+    (func (export "escapeIntoBox") (param $a i32) (result i32)
+        (local $p (ref $point))
+        (local $b (ref $box))
+        (local.set $p (struct.new $point (local.get $a) (i32.const 7)))
+        (local.set $b (struct.new $box (local.get $p)))
+        (struct.get $point $x (struct.get $box $p (local.get $b))))
+
+    ;; ref.eq of a fresh struct against itself is always true.
+    (func (export "eqSelf") (param $a i32) (result i32)
+        (local $p (ref $point))
+        (local.set $p (struct.new $point (local.get $a) (local.get $a)))
+        (ref.eq (local.get $p) (local.get $p)))
+
+    ;; ref.eq of two distinct fresh structs is always false.
+    (func (export "eqTwo") (param $a i32) (result i32)
+        (ref.eq (struct.new $point (local.get $a) (local.get $a))
+                (struct.new $point (local.get $a) (local.get $a))))
+
+    ;; ref.eq of a fresh struct against null is always false (fresh is non-null).
+    (func (export "eqNull") (param $a i32) (result i32)
+        (ref.eq (struct.new $point (local.get $a) (local.get $a))
+                (ref.null $point)))
+
+    ;; Self-referential store: the allocation's own pointer is written into its own field
+    ;; (child(0) is the base, so it stays a removal candidate), and it is never read. This
+    ;; is the a.next = a shape; it must be removed without miscompiling.
+    (func (export "selfRefDead") (param $a i32) (result i32)
+        (local $n (ref $node))
+        (local.set $n (struct.new $node (local.get $a) (ref.null $node)))
+        (struct.set $node $next (local.get $n) (local.get $n))
+        (local.get $a))
+
+    ;; Same self-referential store, but a field is read back afterwards (CSE forwards the
+    ;; read of $v). Still dead; result must be correct.
+    (func (export "selfRefRead") (param $a i32) (result i32)
+        (local $n (ref $node))
+        (local.set $n (struct.new $node (local.get $a) (ref.null $node)))
+        (struct.set $node $next (local.get $n) (local.get $n))
+        (struct.get $node $v (local.get $n)))
+
+    ;; Self-referential store AND the node escapes (returned via $makeNode); it must be kept
+    ;; and the cycle followed one hop must read the right value.
+    (func $makeNode (param $a i32) (result (ref $node))
+        (local $n (ref $node))
+        (local.set $n (struct.new $node (local.get $a) (ref.null $node)))
+        (struct.set $node $next (local.get $n) (local.get $n))
+        (local.get $n))
+    (func (export "selfRefEscape") (param $a i32) (result i32)
+        (local $n (ref $node))
+        (local.set $n (call $makeNode (local.get $a)))
+        ;; n.next.next.v -- follows the self-cycle twice, must equal a.
+        (struct.get $node $v
+            (struct.get $node $next
+                (struct.get $node $next (local.get $n)))))
+)
+`;
+
+globalThis.testLoopCount ??= 10000;
+
+async function test() {
+    const instance = await instantiate(wat, {});
+    const { deadStruct, readBack, escapeIntoBox, eqSelf, eqTwo, eqNull, selfRefDead, selfRefRead, selfRefEscape } = instance.exports;
+
+    for (let i = 0; i < testLoopCount; ++i) {
+        assert.eq(deadStruct(i, 3), i + 3);
+        assert.eq(readBack(i + 10, 4), i + 6);
+        assert.eq(escapeIntoBox(i), i);
+        assert.eq(eqSelf(i), 1);
+        assert.eq(eqTwo(i), 0);
+        assert.eq(eqNull(i), 0);
+        assert.eq(selfRefDead(i), i);
+        assert.eq(selfRefRead(i), i);
+        assert.eq(selfRefEscape(i), i);
+    }
+}
+
+await assert.asyncTest(test());

--- a/JSTests/wasm/stress/wasm-gc-eliminate-allocations-control-flow.js
+++ b/JSTests/wasm/stress/wasm-gc-eliminate-allocations-control-flow.js
@@ -1,0 +1,103 @@
+//@ runDefaultWasm("-m", "--useConcurrentJIT=0", "--thresholdForOMGOptimizeAfterWarmUp=0", "--thresholdForBBQOptimizeAfterWarmUp=0")
+
+// Exercises eliminateWasmGCAllocations against control-flow graph shapes that produce
+// Identity wrappers and Phi nodes for struct pointers: block results, if/else, select,
+// and loops. The pass must look through Identity (foldIdentity) and must treat a pointer
+// that flows into a Phi/select or an escaping position as observable (kept), while still
+// removing the genuinely-dead ones. All results are numeric so a miscompile is caught.
+
+import { instantiate } from "../gc/wast-wrapper.js"
+import * as assert from "../assert.js"
+
+const wat = `
+(module
+    (type $point (struct (field $x (mut i32)) (field $y (mut i32))))
+
+    ;; The struct pointer flows out of a block as its result (an Identity wrapper), then is
+    ;; read. Dead after CSE forwarding; result must be correct.
+    (func (export "blockResult") (param $a i32) (result i32)
+        (local $p (ref $point))
+        (local.set $p
+            (block (result (ref $point))
+                (struct.new $point (local.get $a) (i32.const 5))))
+        (struct.get $point $x (local.get $p)))
+
+    ;; Two fresh structs on the two arms of an if; the selected one is read. Both are
+    ;; non-escaping; the merge is a Phi of two allocations.
+    (func (export "ifElse") (param $a i32) (param $c i32) (result i32)
+        (local $p (ref $point))
+        (local.set $p
+            (if (result (ref $point)) (local.get $c)
+                (then (struct.new $point (local.get $a) (i32.const 1)))
+                (else (struct.new $point (i32.const 2) (local.get $a)))))
+        (struct.get $point $x (local.get $p)))
+
+    ;; select between two fresh structs, then read.
+    (func (export "selectStruct") (param $a i32) (param $c i32) (result i32)
+        (local $p (ref $point))
+        (local.set $p
+            (select (result (ref $point))
+                (struct.new $point (local.get $a) (i32.const 0))
+                (struct.new $point (i32.const 9) (i32.const 0))
+                (local.get $c)))
+        (struct.get $point $y (local.get $p)))
+
+    ;; A struct freshly allocated and read inside each loop iteration (the common
+    ;; steady-state shape). The loop carries an accumulator, not the pointer.
+    (func (export "loopLocal") (param $n i32) (result i32)
+        (local $i i32)
+        (local $sum i32)
+        (local $p (ref $point))
+        (block $done
+            (loop $loop
+                (br_if $done (i32.ge_s (local.get $i) (local.get $n)))
+                (local.set $p (struct.new $point (local.get $i) (i32.const 3)))
+                (local.set $sum
+                    (i32.add (local.get $sum)
+                        (i32.add (struct.get $point $x (local.get $p))
+                                 (struct.get $point $y (local.get $p)))))
+                (local.set $i (i32.add (local.get $i) (i32.const 1)))
+                (br $loop)))
+        (local.get $sum))
+
+    ;; The pointer is loop-carried through a Phi (escapes the simple pattern): must not be
+    ;; miscompiled. Returns the last-written x.
+    (func (export "loopCarried") (param $n i32) (result i32)
+        (local $i i32)
+        (local $p (ref $point))
+        (local.set $p (struct.new $point (i32.const -1) (i32.const 0)))
+        (block $done
+            (loop $loop
+                (br_if $done (i32.ge_s (local.get $i) (local.get $n)))
+                (local.set $p (struct.new $point (local.get $i) (i32.const 0)))
+                (local.set $i (i32.add (local.get $i) (i32.const 1)))
+                (br $loop)))
+        (struct.get $point $x (local.get $p)))
+)
+`;
+
+function loopLocalExpected(n) {
+    let sum = 0;
+    for (let i = 0; i < n; ++i)
+        sum += i + 3;
+    return sum;
+}
+
+globalThis.testLoopCount ??= 10000;
+
+async function test() {
+    const instance = await instantiate(wat, {});
+    const { blockResult, ifElse, selectStruct, loopLocal, loopCarried } = instance.exports;
+
+    for (let i = 0; i < testLoopCount; ++i) {
+        assert.eq(blockResult(i), i);
+        assert.eq(ifElse(i, 1), i);
+        assert.eq(ifElse(i, 0), 2);
+        assert.eq(selectStruct(i, 1), 0);
+        assert.eq(selectStruct(i, 0), 0);
+        assert.eq(loopLocal(i % 20), loopLocalExpected(i % 20));
+        assert.eq(loopCarried(i % 20 + 1), (i % 20 + 1) - 1);
+    }
+}
+
+await assert.asyncTest(test());

--- a/JSTests/wasm/stress/wasm-gc-eliminate-allocations-escape.js
+++ b/JSTests/wasm/stress/wasm-gc-eliminate-allocations-escape.js
@@ -1,0 +1,74 @@
+//@ runDefaultWasm("-m", "--useConcurrentJIT=0", "--thresholdForOMGOptimizeAfterWarmUp=0", "--thresholdForBBQOptimizeAfterWarmUp=0")
+
+// Exercises cases where a struct allocation must be KEPT (it escapes) and cases mixing
+// structs with arrays (which this pass does not touch). If the pass wrongly removed an
+// escaping allocation these results would be wrong or it would crash.
+
+import { instantiate } from "../gc/wast-wrapper.js"
+import * as assert from "../assert.js"
+
+const wat = `
+(module
+    (type $point (struct (field $x (mut i32)) (field $y (mut i32))))
+    (type $arr (array (mut (ref null $point))))
+
+    (global $g (mut (ref null $point)) (ref.null $point))
+
+    ;; Escapes into a global, then read back out: must be kept.
+    (func (export "escapeGlobal") (param $a i32) (result i32)
+        (global.set $g (struct.new $point (local.get $a) (i32.const 0)))
+        (struct.get $point $x (global.get $g)))
+
+    ;; Escapes by being returned from $make; the caller (returnStruct) reads a field. The
+    ;; returned reference must stay valid, so $make's allocation must be kept.
+    (func $make (param $a i32) (result (ref $point))
+        (struct.new $point (local.get $a) (i32.mul (local.get $a) (i32.const 2))))
+    (func (export "returnStruct") (param $a i32) (result i32)
+        (local $p (ref $point))
+        (local.set $p (call $make (local.get $a)))
+        (i32.add (struct.get $point $x (local.get $p))
+                 (struct.get $point $y (local.get $p))))
+
+    ;; Escapes into an array element, then read back: struct kept, array untouched by pass.
+    (func (export "escapeArray") (param $a i32) (result i32)
+        (local $arr (ref $arr))
+        (local.set $arr (array.new $arr (ref.null $point) (i32.const 4)))
+        (array.set $arr (local.get $arr) (i32.const 2)
+            (struct.new $point (local.get $a) (i32.const 0)))
+        (struct.get $point $x (array.get $arr (local.get $arr) (i32.const 2))))
+
+    ;; Escapes by being passed to a call: must be kept.
+    (func $readX (param $p (ref $point)) (result i32)
+        (struct.get $point $x (local.get $p)))
+    (func (export "escapeCall") (param $a i32) (result i32)
+        (call $readX (struct.new $point (local.get $a) (i32.const 0))))
+
+    ;; A dead struct alongside a live array in the same function: the struct is removed, the
+    ;; array is left alone and its element read is correct.
+    (func (export "deadStructLiveArray") (param $a i32) (result i32)
+        (local $dead (ref $point))
+        (local $arr (ref $arr))
+        (local.set $dead (struct.new $point (local.get $a) (local.get $a)))
+        (local.set $arr (array.new $arr (ref.null $point) (i32.const 2)))
+        (array.set $arr (local.get $arr) (i32.const 0)
+            (struct.new $point (local.get $a) (i32.const 0)))
+        (struct.get $point $x (array.get $arr (local.get $arr) (i32.const 0))))
+)
+`;
+
+globalThis.testLoopCount ??= 10000;
+
+async function test() {
+    const instance = await instantiate(wat, {});
+    const { escapeGlobal, returnStruct, escapeArray, escapeCall, deadStructLiveArray } = instance.exports;
+
+    for (let i = 0; i < testLoopCount; ++i) {
+        assert.eq(escapeGlobal(i), i);
+        assert.eq(returnStruct(i), i + i * 2);
+        assert.eq(escapeArray(i), i);
+        assert.eq(escapeCall(i), i);
+        assert.eq(deadStructLiveArray(i), i);
+    }
+}
+
+await assert.asyncTest(test());

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -968,6 +968,7 @@
 		31770C5827B94CE600308091 /* TemporalPlainDate.h in Headers */ = {isa = PBXBuildFile; fileRef = 31770C5227B94CE500308091 /* TemporalPlainDate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		33111B8B2397256500AA34CE /* Scribble.h in Headers */ = {isa = PBXBuildFile; fileRef = 33111B8A2397256500AA34CE /* Scribble.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3395C70722555F6D00BDBFAD /* B3EliminateDeadCode.h in Headers */ = {isa = PBXBuildFile; fileRef = 3395C70522555F6D00BDBFAD /* B3EliminateDeadCode.h */; };
+		0378445DC7A9472E81DD9A6A /* B3EliminateWasmGCAllocations.h in Headers */ = {isa = PBXBuildFile; fileRef = BE117353BAB446559D01F3D2 /* B3EliminateWasmGCAllocations.h */; };
 		33A920BD23DA2C6D000EBAF0 /* CommonSlowPathsInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 33A920BC23DA2C6D000EBAF0 /* CommonSlowPathsInlines.h */; };
 		33B2A54722653481005A0F79 /* B3ValueInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FEC84FB1BDACDAC0080FF74 /* B3ValueInlines.h */; };
 		33B2A548226543BF005A0F79 /* FTLLowerDFGToB3.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEA0A04170513DB00BB722C /* FTLLowerDFGToB3.cpp */; };
@@ -4305,6 +4306,8 @@
 		3374364A224D79EF00C8C227 /* B3OptimizeAssociativeExpressionTrees.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = B3OptimizeAssociativeExpressionTrees.h; path = b3/B3OptimizeAssociativeExpressionTrees.h; sourceTree = "<group>"; };
 		3395C70422555F6C00BDBFAD /* B3EliminateDeadCode.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = B3EliminateDeadCode.cpp; path = b3/B3EliminateDeadCode.cpp; sourceTree = "<group>"; };
 		3395C70522555F6D00BDBFAD /* B3EliminateDeadCode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = B3EliminateDeadCode.h; path = b3/B3EliminateDeadCode.h; sourceTree = "<group>"; };
+		A064075875F64769B8C0A842 /* B3EliminateWasmGCAllocations.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = B3EliminateWasmGCAllocations.cpp; path = b3/B3EliminateWasmGCAllocations.cpp; sourceTree = "<group>"; };
+		BE117353BAB446559D01F3D2 /* B3EliminateWasmGCAllocations.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = B3EliminateWasmGCAllocations.h; path = b3/B3EliminateWasmGCAllocations.h; sourceTree = "<group>"; };
 		33A920BC23DA2C6D000EBAF0 /* CommonSlowPathsInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CommonSlowPathsInlines.h; sourceTree = "<group>"; };
 		33B2A54522651D53005A0F79 /* MarkedSpace.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MarkedSpace.cpp; sourceTree = "<group>"; };
 		36A7683254F6484D925EA7FE /* B3WasmArrayLengthValue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = B3WasmArrayLengthValue.h; path = b3/B3WasmArrayLengthValue.h; sourceTree = "<group>"; };
@@ -7059,6 +7062,8 @@
 				0F725CA41C503DED00AD943A /* B3EliminateCommonSubexpressions.h */,
 				3395C70422555F6C00BDBFAD /* B3EliminateDeadCode.cpp */,
 				3395C70522555F6D00BDBFAD /* B3EliminateDeadCode.h */,
+				A064075875F64769B8C0A842 /* B3EliminateWasmGCAllocations.cpp */,
+				BE117353BAB446559D01F3D2 /* B3EliminateWasmGCAllocations.h */,
 				0F5BF16E1F23A5A10029D91D /* B3EnsureLoopPreHeaders.cpp */,
 				0F5BF16F1F23A5A10029D91D /* B3EnsureLoopPreHeaders.h */,
 				52E65A1A27682760002B4C0A /* B3EstimateStaticExecutionCounts.cpp */,
@@ -11232,6 +11237,7 @@
 				0FEC85C11BE167A00080FF74 /* B3Effects.h in Headers */,
 				0F725CA81C503DED00AD943A /* B3EliminateCommonSubexpressions.h in Headers */,
 				3395C70722555F6D00BDBFAD /* B3EliminateDeadCode.h in Headers */,
+				0378445DC7A9472E81DD9A6A /* B3EliminateWasmGCAllocations.h in Headers */,
 				0F5BF1711F23A5A10029D91D /* B3EnsureLoopPreHeaders.h in Headers */,
 				52E65A1E27682771002B4C0A /* B3EstimateStaticExecutionCounts.h in Headers */,
 				5318045C22EAAC4B004A7342 /* B3ExtractValue.h in Headers */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -138,6 +138,7 @@ b3/B3DuplicateTails.cpp
 b3/B3Effects.cpp
 b3/B3EliminateCommonSubexpressions.cpp
 b3/B3EliminateDeadCode.cpp
+b3/B3EliminateWasmGCAllocations.cpp
 b3/B3EnsureLoopPreHeaders.cpp
 b3/B3EstimateStaticExecutionCounts.cpp
 b3/B3ExtractValue.cpp

--- a/Source/JavaScriptCore/b3/B3EliminateWasmGCAllocations.cpp
+++ b/Source/JavaScriptCore/b3/B3EliminateWasmGCAllocations.cpp
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "B3EliminateWasmGCAllocations.h"
+
+#if ENABLE(B3_JIT)
+
+#include "B3PhaseScope.h"
+#include "B3Procedure.h"
+#include "B3ValueInlines.h"
+#include <optional>
+#include <wtf/HashMap.h>
+#include <wtf/Vector.h>
+
+namespace JSC { namespace B3 {
+
+bool eliminateWasmGCAllocations(Procedure& proc)
+{
+    PhaseScope phaseScope(proc, "eliminateWasmGCAllocations"_s);
+
+    // Key insight is that we only need to handle WasmStructSet, since a non-escaping struct's
+    // WasmStructGet reads have already been forwarded away by CSE.
+    //
+    // Map every WasmStructNew to its users, looking through Identity nodes (which just
+    // forward the pointer) via foldIdentity. Each user is classified as we record it: an
+    // Identity wrapper or a field store into the allocation itself keeps it a removal
+    // candidate; any other use escapes the allocation, which we mark by resetting its entry
+    // to nullopt. This way a single pass over the users decides removability.
+    unsigned removableCount = 0;
+    HashMap<Value*, std::optional<Vector<Value*>>> users;
+    for (Value* value : proc.values()) {
+        // Ensure zero-user allocations (trivially dead) get a candidate entry too.
+        if (value->opcode() == WasmStructNew) {
+            if (users.ensure(value, [] { return std::optional<Vector<Value*>>(std::in_place); }).isNewEntry)
+                ++removableCount;
+        }
+
+        for (Value* child : value->children()) {
+            Value* base = child->foldIdentity();
+            if (base->opcode() != WasmStructNew)
+                continue;
+
+            auto result = users.ensure(base, [] { return std::optional<Vector<Value*>>(std::in_place); });
+            if (result.isNewEntry)
+                ++removableCount;
+            auto& entry = result.iterator->value;
+            if (!entry)
+                continue; // Already known to escape.
+
+            Opcode opcode = value->opcode();
+            if (opcode == Identity || (opcode == WasmStructSet && value->child(0)->foldIdentity() == base))
+                entry->append(value);
+            else {
+                entry = std::nullopt; // Observable use: the allocation escapes.
+                --removableCount;
+            }
+        }
+    }
+
+    if (!removableCount)
+        return false;
+
+    // Delete each dead allocation and everything that only existed to serve it (its Identity
+    // wrappers and field stores are all recorded as its users).
+    for (auto& pair : users) {
+        auto& maybeUsers = pair.value;
+        if (!maybeUsers)
+            continue;
+        for (Value* user : *maybeUsers)
+            user->replaceWithNopIgnoringType();
+        pair.key->replaceWithNopIgnoringType();
+    }
+
+    return true;
+}
+
+} } // namespace JSC::B3
+
+#endif // ENABLE(B3_JIT)

--- a/Source/JavaScriptCore/b3/B3EliminateWasmGCAllocations.h
+++ b/Source/JavaScriptCore/b3/B3EliminateWasmGCAllocations.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(B3_JIT)
+
+namespace JSC { namespace B3 {
+
+class Procedure;
+
+// Removes non-escaping wasm-GC struct allocations. CSE runs before this and forwards
+// WasmStructGet loads to the stored values, so a struct whose reference never escapes
+// is left with only writes into itself.
+bool eliminateWasmGCAllocations(Procedure&);
+
+} } // namespace JSC::B3
+
+#endif // ENABLE(B3_JIT)

--- a/Source/JavaScriptCore/b3/B3Generate.cpp
+++ b/Source/JavaScriptCore/b3/B3Generate.cpp
@@ -34,6 +34,7 @@
 #include "B3DuplicateTails.h"
 #include "B3EliminateCommonSubexpressions.h"
 #include "B3EliminateDeadCode.h"
+#include "B3EliminateWasmGCAllocations.h"
 #include "B3FixSSA.h"
 #include "B3FoldPathConstants.h"
 #include "B3HoistLoopInvariantValues.h"
@@ -101,6 +102,8 @@ void generateToAir(Procedure& procedure)
             duplicateTails(procedure);
         fixSSA(procedure);
         foldPathConstants(procedure);
+        if (procedure.usesWasmGCStructAllocations() && Options::useB3EliminateWasmGCAllocations())
+            eliminateWasmGCAllocations(procedure);
         // FIXME: Add more optimizations here.
         // https://bugs.webkit.org/show_bug.cgi?id=150507
     } else if (procedure.optLevel() >= 1) {

--- a/Source/JavaScriptCore/b3/B3MemoryValue.h
+++ b/Source/JavaScriptCore/b3/B3MemoryValue.h
@@ -106,8 +106,8 @@ private:
     friend class Procedure;
     friend class Value;
 
-    inline bool isLegalOffsetImpl(int32_t offset) const;
-    bool isLegalOffsetImpl(int64_t offset) const;
+    inline bool NODELETE isLegalOffsetImpl(int32_t offset) const;
+    bool NODELETE isLegalOffsetImpl(int64_t offset) const;
 
     enum MemoryValueLoad { MemoryValueLoadTag };
     enum MemoryValueLoadImplied { MemoryValueLoadImpliedTag };

--- a/Source/JavaScriptCore/b3/B3Procedure.h
+++ b/Source/JavaScriptCore/b3/B3Procedure.h
@@ -318,6 +318,10 @@ public:
     void setIsWasm(bool flag) { m_isWasm = flag; }
     bool isWasm() const { return m_isWasm; }
 
+    void setUsesWasmGCStructAllocations(bool flag = true) { m_usesWasmGCStructAllocations = flag; }
+    bool usesWasmGCStructAllocations() const { return m_usesWasmGCStructAllocations; }
+    void setUsesWasmGCArrayAllocations(bool flag = true) { m_usesWasmGCArrayAllocations = flag; }
+    bool usesWasmGCArrayAllocations() const { return m_usesWasmGCArrayAllocations; }
 
     void setUsesColdCCall(bool flag) { m_usesColdCCall = flag; }
     bool usesColdCCall() const { return m_usesColdCCall; }
@@ -359,6 +363,8 @@ private:
     bool m_shouldDumpIR : 1 { false };
     bool m_usesSIMD : 1 { false };
     bool m_isWasm : 1 { false };
+    bool m_usesWasmGCStructAllocations : 1 { false };
+    bool m_usesWasmGCArrayAllocations : 1 { false };
     bool m_usesColdCCall : 1 { false };
     bool m_usesShuffle : 1 { false };
     bool m_usesEntrySwitch : 1 { false };

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -525,6 +525,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Unsigned, maxB3TailDupBlockSuccessors, 3, Normal, nullptr) \
     v(Bool, useB3HoistLoopInvariantValues, true, Normal, nullptr) \
     v(Bool, useB3CanonicalizePrePostIncrements, false, Normal, nullptr) \
+    v(Bool, useB3EliminateWasmGCAllocations, true, Normal, "eliminate non-escaping wasm-GC struct allocations in B3"_s) \
     v(Bool, useB3ReduceStrengthFixpoint, false, Normal, "iterate B3 reduceStrength to a fixpoint instead of a single pass (for debugging)"_s) \
     v(Bool, useAirOptimizePairedLoadStore, true, Normal, nullptr) \
     \

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -3677,6 +3677,7 @@ auto OMGIRGenerator::addArrayNew(TypeSignatureIndex typeIndex, ExpressionType si
 
     Ref<const RTT> rtt = m_info.rtt(typeIndex);
     int32_t allocatorsBaseOffset = safeCast<int32_t>(JSWebAssemblyInstance::offsetOfAllocatorForGCObject(m_info, 0));
+    m_proc.setUsesWasmGCArrayAllocations();
 
     auto* array = m_currentBlock->appendNew<WasmArrayNewValue>(m_proc, origin(), wasmRefType(), Ref { rtt }, typeIndex.rawIndex(), allocatorsBaseOffset, instanceValue(), structureID, sizeValue, initValue);
 
@@ -3717,6 +3718,7 @@ auto OMGIRGenerator::addArrayNewDefault(TypeSignatureIndex typeIndex, Expression
 
     Ref<const RTT> rtt = m_info.rtt(typeIndex);
     int32_t allocatorsBaseOffset = safeCast<int32_t>(JSWebAssemblyInstance::offsetOfAllocatorForGCObject(m_info, 0));
+    m_proc.setUsesWasmGCArrayAllocations();
 
     auto* array = m_currentBlock->appendNew<WasmArrayNewValue>(m_proc, origin(), wasmRefType(), Ref { rtt }, typeIndex.rawIndex(), allocatorsBaseOffset, instanceValue(), structureID, sizeValue, initValue);
 
@@ -3749,6 +3751,7 @@ auto OMGIRGenerator::addArrayNewFixed(TypeSignatureIndex typeIndex, ArgumentList
 
     Ref<const RTT> rtt = m_info.rtt(typeIndex);
     int32_t allocatorsBaseOffset = safeCast<int32_t>(JSWebAssemblyInstance::offsetOfAllocatorForGCObject(m_info, 0));
+    m_proc.setUsesWasmGCArrayAllocations();
 
     auto* object = m_currentBlock->appendNew<WasmArrayNewValue>(m_proc, origin(), wasmRefType(), Ref { rtt }, typeIndex.rawIndex(), allocatorsBaseOffset, instanceValue(), structureID, size);
 
@@ -4038,6 +4041,7 @@ auto OMGIRGenerator::addStructNew(TypeSignatureIndex typeIndex, ArgumentList& ar
     auto* structureID = loadGCObjectStructureID(typeIndex);
 
     int32_t allocatorsBaseOffset = safeCast<int32_t>(JSWebAssemblyInstance::offsetOfAllocatorForGCObject(m_info, 0));
+    m_proc.setUsesWasmGCStructAllocations();
 
     auto* structNew = m_currentBlock->appendNew<WasmStructNewValue>(m_proc, origin(), wasmRefType(), Ref { rtt }, typeIndex.rawIndex(), allocatorsBaseOffset, instanceValue(), structureID);
 
@@ -4057,6 +4061,7 @@ auto OMGIRGenerator::addStructNewDefault(TypeSignatureIndex typeIndex, Expressio
     auto* structureID = loadGCObjectStructureID(typeIndex);
 
     int32_t allocatorsBaseOffset = safeCast<int32_t>(JSWebAssemblyInstance::offsetOfAllocatorForGCObject(m_info, 0));
+    m_proc.setUsesWasmGCStructAllocations();
 
     auto* structNew = m_currentBlock->appendNew<WasmStructNewValue>(m_proc, origin(), wasmRefType(), Ref { rtt }, typeIndex.rawIndex(), allocatorsBaseOffset, instanceValue(), structureID);
 


### PR DESCRIPTION
#### c7bfc7c0ca52b4fea117da64c8f15d5fcab32167
<pre>
[JSC] Add B3::eliminateWasmGCAllocations phase
<a href="https://bugs.webkit.org/show_bug.cgi?id=318768">https://bugs.webkit.org/show_bug.cgi?id=318768</a>

Reviewed by Justin Michaud.

This patch adds B3::eliminateWasmGCAllocations phase. This is super
duper simple scalar replacement for WasmGC struct types. We record
usesWasmGCStructAllocations and run this phase only when this is
recorded as this phase is meaningless if we do not have WasmStructNew.

The key insight here is we already run CSE with WasmGC structs, which
can successfully remove load-elimination and store-elimination. Thus, at
this point, most of related WasmGC struct loads are no longer associated
with the WasmGC struct. Thus we only need to care about WasmStructSet
here since WasmStructGet should be already converted to the pointed
value if the struct is not escaped and CSE ran already. This assumption
(of course, this is not covering all the cases, but most of beneficial
cases should be in this class) makes this phase extremely simple.
Basically just collecting WasmStructSet-use-only WasmStructNew since it
is not escaped. And then we convert all of them into Nop.

Tests: JSTests/wasm/stress/wasm-gc-eliminate-allocations-basic.js
       JSTests/wasm/stress/wasm-gc-eliminate-allocations-control-flow.js
       JSTests/wasm/stress/wasm-gc-eliminate-allocations-escape.js

* JSTests/wasm/stress/wasm-gc-eliminate-allocations-basic.js: Added.
(async test):
* JSTests/wasm/stress/wasm-gc-eliminate-allocations-control-flow.js: Added.
(loopLocalExpected):
(async test):
* JSTests/wasm/stress/wasm-gc-eliminate-allocations-escape.js: Added.
(async test):
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/b3/B3EliminateWasmGCAllocations.cpp: Added.
(JSC::B3::eliminateWasmGCAllocations):
* Source/JavaScriptCore/b3/B3EliminateWasmGCAllocations.h: Added.
* Source/JavaScriptCore/b3/B3Generate.cpp:
(JSC::B3::generateToAir):
* Source/JavaScriptCore/b3/B3MemoryValue.h:
* Source/JavaScriptCore/b3/B3Procedure.h:
(JSC::B3::Procedure::setUsesWasmGCStructAllocations):
(JSC::B3::Procedure::usesWasmGCStructAllocations const):
(JSC::B3::Procedure::setUsesWasmGCArrayAllocations):
(JSC::B3::Procedure::usesWasmGCArrayAllocations const):
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::addArrayNew):
(JSC::Wasm::OMGIRGenerator::addArrayNewDefault):
(JSC::Wasm::OMGIRGenerator::addArrayNewFixed):
(JSC::Wasm::OMGIRGenerator::addStructNew):
(JSC::Wasm::OMGIRGenerator::addStructNewDefault):

Canonical link: <a href="https://commits.webkit.org/316659@main">https://commits.webkit.org/316659@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71d4e3ca3478f40a771055053848a968436ab154

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173095 "1 style error") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/47026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/40511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/182668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/130651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/48320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46709 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/182668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/130651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176053 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/48320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/40511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/182668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/48320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31153 "Failed to checkout and rebase branch from PR 68823") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/40511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/48320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/40511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185090 "Failed to checkout and rebase branch from PR 68823") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/34357 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/37888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/39193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/185090 "Failed to checkout and rebase branch from PR 68823") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/46695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/40511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/185090 "Failed to checkout and rebase branch from PR 68823") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/47374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/40511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/112447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26274 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/47374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/119123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45880 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/40511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/45282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/45513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/45339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->