### PR TITLE
Stop enforcing that the opener origin has access to first party cookies.

### DIFF
--- a/LayoutTests/http/wpt/storage-access/request-storage-access-under-opener-cross-site-opener-expected.txt
+++ b/LayoutTests/http/wpt/storage-access/request-storage-access-under-opener-cross-site-opener-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Storage-access-under-opener with a cross-site opener does not terminate the opened window's web process
+

--- a/LayoutTests/http/wpt/storage-access/request-storage-access-under-opener-cross-site-opener.html
+++ b/LayoutTests/http/wpt/storage-access/request-storage-access-under-opener-cross-site-opener.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>requestStorageAccessUnderOpener must not terminate the web process for a cross-site opener</title>
+<link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=999999">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<body>
+<script>
+// A cross-site iframe opens a blank popup (which inherits the iframe's process, keeping the iframe a
+// local opener) and navigates it cross-site. A user interaction in that popup makes the web process
+// send NetworkConnectionToWebProcess::RequestStorageAccessUnderOpener(popupDomain, openerPageID,
+// openerDomain). Before the fix (regression from 316149@main / bug 312798), the network process
+// rejected the message because the opened window's process does not "own" the cross-site opener
+// domain, terminating the web process (both popup and opener reload). This test passes if the
+// opened window survives the interaction.
+if (window.testRunner)
+    testRunner.setStatisticsEnabled(true);
+
+const hostInfo = get_host_info();
+const openerIframeURL = hostInfo.HTTP_NOTSAMESITE_ORIGIN +
+    "/WebKit/storage-access/resources/opener-iframe.html";
+
+async_test(t => {
+    window.addEventListener("message", t.step_func(e => {
+        if (e.data === "popup-survived-user-interaction") {
+            if (window.testRunner)
+                testRunner.setStatisticsEnabled(false);
+            t.done();
+        }
+    }));
+    const frame = document.createElement("iframe");
+    frame.src = openerIframeURL;
+    document.body.appendChild(frame);
+}, "Storage-access-under-opener with a cross-site opener does not terminate the opened window's web process");
+</script>
+</body>

--- a/LayoutTests/http/wpt/storage-access/resources/opener-iframe.html
+++ b/LayoutTests/http/wpt/storage-access/resources/opener-iframe.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<script src="/common/get-host-info.sub.js"></script>
+<script>
+// This iframe is cross-site to the top page. Open a blank popup (inherits this process so this
+// iframe stays a local opener), then navigate it cross-site to the top page's site.
+const popupURL = get_host_info().HTTP_ORIGIN + "/WebKit/storage-access/resources/popup.html";
+const popup = window.open("");
+setTimeout(() => { if (popup) popup.location.assign(popupURL); }, 200);
+</script>

--- a/LayoutTests/http/wpt/storage-access/resources/popup.html
+++ b/LayoutTests/http/wpt/storage-access/resources/popup.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<body>
+<script>
+function notifyTop(msg) {
+    try { if (window.opener && window.opener.top) window.opener.top.postMessage(msg, "*"); } catch (e) {}
+}
+// Simulate the user interaction that triggers WebResourceLoadObserver -> requestStorageAccessUnderOpener.
+if (window.internals)
+    internals.withUserGesture(() => {});
+// If the web process survived the request, report back. If it was terminated, this never runs.
+setTimeout(() => notifyTop("popup-survived-user-interaction"), 1000);
+</script>
+</body>

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -1489,7 +1489,6 @@ void NetworkConnectionToWebProcess::storageAccessQuirkForTopFrameDomain(URL&& to
 void NetworkConnectionToWebProcess::requestStorageAccessUnderOpener(WebCore::RegistrableDomain&& domainInNeedOfStorageAccess, PageIdentifier openerPageID, WebCore::RegistrableDomain&& openerDomain)
 {
     MESSAGE_CHECK(m_networkProcess->allowsFirstPartyForCookies(m_webProcessIdentifier, domainInNeedOfStorageAccess) == NetworkProcess::AllowCookieAccess::Allow);
-    MESSAGE_CHECK(m_networkProcess->allowsFirstPartyForCookies(m_webProcessIdentifier, openerDomain) == NetworkProcess::AllowCookieAccess::Allow);
 
     if (CheckedPtr networkSession = this->networkSession()) {
         if (RefPtr resourceLoadStatistics = networkSession->resourceLoadStatistics())


### PR DESCRIPTION
#### c5cf4420bc5816dbb4a9128fce5f71aa0782af04
<pre>
Stop enforcing that the opener origin has access to first party cookies.
<a href="https://bugs.webkit.org/show_bug.cgi?id=318772">https://bugs.webkit.org/show_bug.cgi?id=318772</a>

Reviewed by Charlie Wolfe.

The current code checks that the opener&apos;s domain has first-party cookie access.
There&apos;s no reason why the opener&apos;s domain needs that access, and there are cross-origin opener scenarios
where this is not the case. Currently those scenarios result in a crash.
This PR removes that check to prevent these crashes, and adds relevant tests.

Test: http/wpt/storage-access/request-storage-access-under-opener-cross-site-opener.html

* LayoutTests/http/wpt/storage-access/request-storage-access-under-opener-cross-site-opener-expected.txt: Added.
* LayoutTests/http/wpt/storage-access/request-storage-access-under-opener-cross-site-opener.html: Added.
* LayoutTests/http/wpt/storage-access/resources/opener-iframe.html: Added.
* LayoutTests/http/wpt/storage-access/resources/popup.html: Added.
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::requestStorageAccessUnderOpener):

Canonical link: <a href="https://commits.webkit.org/316624@main">https://commits.webkit.org/316624@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf314c305abfe96bda283dbd49334f8f1f5f6407

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173008 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46927 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40397 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182468 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130564 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48221 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46603 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134562 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175966 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37954 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/155132 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115031 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/172329 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36599 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31066 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147023 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34634 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185003 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37782 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/39130 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143370 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46598 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154696 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143242 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38659 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47276 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31465 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112310 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38226 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119036 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45793 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9577 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45195 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45426 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45252 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->