### PR TITLE
<font face> with a numeric-token family name (e.g. "Bodoni 72") reverts to the default font

### DIFF
--- a/LayoutTests/editing/style/font-face-numeric-family-expected.txt
+++ b/LayoutTests/editing/style/font-face-numeric-family-expected.txt
@@ -1,0 +1,13 @@
+A <font face> whose family name contains a numeric token (e.g. "Bodoni 72") is applied as the font-family instead of reverting to the inherited default. The relaxed parsing is scoped to the legacy face attribute: the same unquoted name remains invalid for the CSS font-family property.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS familyFromFace("Georgia") is familyFromCSS("Georgia")
+PASS familyFromFace("Bodoni 72") is familyFromCSS("'Bodoni 72'")
+PASS familyFromFace("Bodoni 72, Georgia") is familyFromCSS("'Bodoni 72', Georgia")
+PASS cssFontFamilySpecifiedValue("Bodoni 72") is ""
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/style/font-face-numeric-family.html
+++ b/LayoutTests/editing/style/font-face-numeric-family.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<script>
+description('A &lt;font face&gt; whose family name contains a numeric token (e.g. "Bodoni 72") is applied as the ' +
+    'font-family instead of reverting to the inherited default. The relaxed parsing is scoped to the legacy face ' +
+    'attribute: the same unquoted name remains invalid for the CSS font-family property.');
+
+// Computed font-family produced by a <font face="..."> element.
+function familyFromFace(face) {
+    var el = document.createElement('font');
+    el.setAttribute('face', face);
+    el.textContent = 'x';
+    document.body.appendChild(el);
+    var family = getComputedStyle(el).fontFamily;
+    document.body.removeChild(el);
+    return family;
+}
+
+// Computed font-family produced by an equivalent CSS font-family declaration (the reference).
+function familyFromCSS(css) {
+    var el = document.createElement('span');
+    el.style.fontFamily = css;
+    el.textContent = 'x';
+    document.body.appendChild(el);
+    var family = getComputedStyle(el).fontFamily;
+    document.body.removeChild(el);
+    return family;
+}
+
+// Value the CSS parser accepts for the font-family property (empty string if it rejects the value).
+function cssFontFamilySpecifiedValue(css) {
+    var el = document.createElement('span');
+    el.style.fontFamily = css;
+    return el.style.fontFamily;
+}
+
+// Control: an ordinary unquoted-identifier family already works via the strict parse.
+shouldBe('familyFromFace("Georgia")', 'familyFromCSS("Georgia")');
+
+// The radar case: a single numeric-token family name via <font face>.
+shouldBe('familyFromFace("Bodoni 72")', 'familyFromCSS("\'Bodoni 72\'")');
+
+// A comma-separated list mixing a numeric-token family with an ordinary one.
+shouldBe('familyFromFace("Bodoni 72, Georgia")', 'familyFromCSS("\'Bodoni 72\', Georgia")');
+
+// Scoping: the relaxation applies to <font face> only. The same unquoted numeric-token name is
+// still invalid for the CSS font-family property, so the CSS parser rejects it.
+shouldBeEqualToString('cssFontFamilySpecifiedValue("Bodoni 72")', '');
+</script>
+</body>
+</html>

--- a/Source/WebCore/css/CSSValuePool.cpp
+++ b/Source/WebCore/css/CSSValuePool.cpp
@@ -27,6 +27,7 @@
 #include "CSSValuePool.h"
 
 #include "CSSFontFamilyNameValue.h"
+#include "CSSParserContext.h"
 #include "CSSPropertyParser.h"
 #include "CSSValueKeywords.h"
 #include "CSSValueList.h"
@@ -114,9 +115,13 @@ RefPtr<CSSValueList> CSSValuePool::createFontFaceValue(const AtomString& string)
     if (m_fontFaceValueCache.size() >= maximumFontFaceCacheSize)
         m_fontFaceValueCache.remove(m_fontFaceValueCache.random());
 
-    return m_fontFaceValueCache.ensure(string, [&string]() -> RefPtr<CSSValueList> {
-        auto value = CSSPropertyParser::parseStylePropertyLonghand(CSSPropertyFontFamily, string, strictCSSParserContext());
-        return dynamicDowncast<CSSValueList>(value.get());
+    return m_fontFaceValueCache.ensure(string, [&string] {
+        // Parse the legacy <font face> attribute as a font-family value, relaxing the family-name
+        // grammar to accept numeric-token names such as "Bodoni 72" (legacyFontFaceAttributeMode).
+        // Regular CSS font-family parsing is unaffected and still rejects such names.
+        CSSParserContext context = strictCSSParserContext();
+        context.legacyFontFaceAttributeMode = true;
+        return dynamicDowncast<CSSValueList>(CSSPropertyParser::parseStylePropertyLonghand(CSSPropertyFontFamily, string, context));
     }).iterator->value;
 }
 

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -182,7 +182,8 @@ void add(Hasher& hasher, const CSSParserContext& context)
         context.cssScrollStateContainerQueriesEnabled,
         context.cssCalcMixEnabled,
         context.cssIdentFunctionEnabled,
-        context.cssIfFunctionEnabled
+        context.cssIfFunctionEnabled,
+        context.legacyFontFaceAttributeMode
     );
     add(hasher, context.baseURL, context.charset, context.propertySettings, context.mode, context.enclosingRuleType, bits);
 }

--- a/Source/WebCore/css/parser/CSSParserContext.h
+++ b/Source/WebCore/css/parser/CSSParserContext.h
@@ -96,6 +96,10 @@ struct CSSParserContext {
     bool cssIdentFunctionEnabled : 1 { false };
     bool cssIfFunctionEnabled : 1 { false };
 
+    // Enabled only for the legacy <font face> attribute: allows a numeric token within a family
+    // name (e.g. "Bodoni 72"). Regular CSS font-family parsing stays strict.
+    bool legacyFontFaceAttributeMode : 1 { false };
+
     // Settings, those affecting properties.
     CSSPropertySettings propertySettings;
 

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp
@@ -252,12 +252,14 @@ WebKitFontFamilyNames::FamilyNamesIndex genericFontFamilyIndex(CSSValueID ident)
     }
 }
 
-static AtomString concatenateFamilyName(CSSParserTokenRange& range)
+static AtomString concatenateFamilyName(CSSParserTokenRange& range, bool allowNumericTokens = false)
 {
     StringBuilder builder;
     bool addedSpace = false;
     const CSSParserToken& firstToken = range.peek();
-    while (range.peek().type() == IdentToken) {
+    // In legacyFontFaceAttributeMode (the <font face> attribute), a numeric token is allowed as
+    // part of a literal family name, e.g. "Bodoni 72" (its original text is preserved in value()).
+    while (range.peek().type() == IdentToken || (allowNumericTokens && range.peek().type() == NumberToken)) {
         if (!builder.isEmpty()) {
             builder.append(' ');
             addedSpace = true;
@@ -270,13 +272,13 @@ static AtomString concatenateFamilyName(CSSParserTokenRange& range)
     return builder.toAtomString();
 }
 
-static AtomString consumeFamilyNameUnresolved(CSSParserTokenRange& range)
+static AtomString consumeFamilyNameUnresolved(CSSParserTokenRange& range, bool allowNumericTokens = false)
 {
     if (range.peek().type() == StringToken)
         return range.consumeIncludingWhitespace().value().toAtomString();
     if (range.peek().type() != IdentToken)
         return nullAtom();
-    return concatenateFamilyName(range);
+    return concatenateFamilyName(range, allowNumericTokens);
 }
 
 static std::optional<CSSValueID> consumeGenericFamilyUnresolved(CSSParserTokenRange& range)
@@ -318,7 +320,7 @@ RefPtr<CSSValue> consumeFamilyName(CSSParserTokenRange& range, CSS::PropertyPars
 {
     // https://drafts.csswg.org/css-fonts-4/#family-name-syntax
 
-    auto familyName = consumeFamilyNameUnresolved(range);
+    auto familyName = consumeFamilyNameUnresolved(range, state.context.legacyFontFaceAttributeMode);
     if (familyName.isNull())
         return nullptr;
     return state.pool.createFontFamilyNameValue(familyName);


### PR DESCRIPTION
#### 430b0c73b84ed73df07e1647d00babf69adac351
<pre>
&lt;font face&gt; with a numeric-token family name (e.g. &quot;Bodoni 72&quot;) reverts to the default font
<a href="https://bugs.webkit.org/show_bug.cgi?id=318776">https://bugs.webkit.org/show_bug.cgi?id=318776</a>
<a href="https://rdar.apple.com/51409819">rdar://51409819</a>

Reviewed by Ryosuke Niwa.

The &lt;font face&gt; attribute accepts literal font family names (HTML legacy
semantics), but CSSValuePool::createFontFaceValue parsed it with the strict CSS
&lt;family-name&gt; grammar. Family names that are not valid unquoted CSS identifiers
-- notably names containing a numeric token such as &quot;Bodoni 72&quot; -- were rejected,
so font-family was never applied and the text silently reverted to the default
font.

Relax the family-name grammar to accept a numeric token as part of a literal
family name, but only for the &lt;font face&gt; attribute: add a
legacyFontFaceAttributeMode flag to CSSParserContext, enable it from
createFontFaceValue, and honor it in the font-family consumer. Regular CSS
font-family parsing is unaffected and still rejects such names, so
&quot;font-family: Bodoni 72&quot; (unquoted) remains invalid.

The value reaches the face attribute unquoted because StyleChange::extractTextStyles
unconditionally strips every quote from the serialized font-family for Outlook 2007
compatibility (EditingStyle.cpp, webkit.org/b/79448). That is broader than 79448
intended -- it meant to drop only superfluous quotes and keep them for names that
genuinely need them -- so the quotes &quot;Bodoni 72&quot; actually requires are stripped too.
Fixing the reader here also covers static or pasted &lt;font face&gt; values from any
source; tightening the emitter to strip quotes selectively could be a follow-up, but
it touches the 79448 compatibility behavior and is intentionally out of scope here.

* Source/WebCore/css/CSSValuePool.cpp:
(WebCore::CSSValuePool::createFontFaceValue):
* Source/WebCore/css/parser/CSSParserContext.h:
* Source/WebCore/css/parser/CSSParserContext.cpp:
(WebCore::add):
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp:
(WebCore::CSSPropertyParserHelpers::concatenateFamilyName):
(WebCore::CSSPropertyParserHelpers::consumeFamilyNameUnresolved):
(WebCore::CSSPropertyParserHelpers::consumeFamilyName):
* LayoutTests/editing/style/font-face-numeric-family.html: Added.
* LayoutTests/editing/style/font-face-numeric-family-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/316948@main">https://commits.webkit.org/316948@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e432631e1b7f7a9d3fb011c5d1512711d57dde6d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173379 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47311 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40866 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182952 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130935 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175244 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48604 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46993 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134829 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95195 "2 flakes 4 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176337 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38236 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155487 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115305 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36878 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35228 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31437 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147302 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34983 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185377 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/38922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39430 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143679 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46979 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155045 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143542 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38830 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47658 "Built successfully") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/112761 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38493 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119929 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46164 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9931 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45566 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45797 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45623 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->