### PR TITLE
Cherry-pick 313490@main (cd11ac52dbc4). https://bugs.webkit.org/show_bug.cgi?id=314951

### DIFF
--- a/LayoutTests/http/tests/security/cross-origin-iframe-fetch-after-crash-expected.txt
+++ b/LayoutTests/http/tests/security/cross-origin-iframe-fetch-after-crash-expected.txt
@@ -1,0 +1,5 @@
+Tests that a cross-origin iframe can still perform fetches after the network process crashes and restarts.
+
+Cross-origin iframe fetch succeeded before network process crash.
+PASS: Cross-origin iframe fetch succeeded after network process crash.
+

--- a/LayoutTests/http/tests/security/cross-origin-iframe-fetch-after-crash.html
+++ b/LayoutTests/http/tests/security/cross-origin-iframe-fetch-after-crash.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Cross-origin iframe works after network process crash</title>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+function log(message) {
+    document.getElementById("output").textContent += message + "\n";
+}
+
+window.addEventListener("message", async event => {
+    if (event.data === "pre-crash-ok") {
+        log("Cross-origin iframe fetch succeeded before network process crash.");
+        if (window.testRunner)
+            testRunner.terminateNetworkProcess();
+        await waitForNetworkProcessToRelaunch();
+        document.querySelector("iframe").contentWindow.postMessage("fetch-after-crash", "*");
+        return;
+    }
+    if (event.data === "post-crash-ok") {
+        log("PASS: Cross-origin iframe fetch succeeded after network process crash.");
+    } else {
+        log("FAIL: " + event.data);
+    }
+    if (window.testRunner)
+        testRunner.notifyDone();
+});
+
+let waitTime = 10;
+function waitForNetworkProcessToRelaunch() {
+    return fetch("cross-origin-iframe-fetch-after-crash.html").catch(() => {
+        return new Promise(resolve => {
+            waitTime *= 1.2;
+            setTimeout(() => waitForNetworkProcessToRelaunch().then(resolve), waitTime);
+        });
+    });
+}
+</script>
+</head>
+<body>
+<p>Tests that a cross-origin iframe can still perform fetches after the network process crashes and restarts.</p>
+<pre id="output"></pre>
+<iframe src="http://localhost:8000/security/resources/cross-origin-iframe-fetch-after-crash-iframe.html"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/security/resources/cross-origin-iframe-fetch-after-crash-iframe.html
+++ b/LayoutTests/http/tests/security/resources/cross-origin-iframe-fetch-after-crash-iframe.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<script>
+function report(message) {
+    parent.postMessage(message, "*");
+}
+
+window.addEventListener("message", event => {
+    if (event.data === "fetch-after-crash") {
+        fetch("cross-origin-iframe-fetch-after-crash-iframe.html").then(() => {
+            report("post-crash-ok");
+        }).catch(e => {
+            report("post-crash fetch failed: " + e);
+        });
+    }
+});
+
+fetch("cross-origin-iframe-fetch-after-crash-iframe.html").then(() => {
+    report("pre-crash-ok");
+}).catch(e => {
+    report("pre-crash fetch failed: " + e);
+});
+</script>

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -233,6 +233,7 @@ CheckedRef<DownloadManager> NetworkProcess::checkedDownloadManager()
 
 void NetworkProcess::removeNetworkConnectionToWebProcess(NetworkConnectionToWebProcess& connection)
 {
+    RELEASE_LOG(Process, "%p - NetworkProcess::removeNetworkConnectionToWebProcess: Removing process %" PRIu64, this, connection.webProcessIdentifier().toUInt64());
     ASSERT(m_webProcessConnections.contains(connection.webProcessIdentifier()));
     m_webProcessConnections.remove(connection.webProcessIdentifier());
     m_allowedFirstPartiesForCookies.remove(connection.webProcessIdentifier());
@@ -350,9 +351,6 @@ void NetworkProcess::initializeNetworkProcess(NetworkProcessCreationParameters&&
     setPrivateClickMeasurementEnabled(parameters.enablePrivateClickMeasurement);
     m_ftpEnabled = parameters.ftpEnabled;
 
-    for (auto [processIdentifier, domain] : parameters.allowedFirstPartiesForCookies)
-        addAllowedFirstPartyForCookies(processIdentifier, WTF::move(domain), LoadedWebArchive::No, [] { });
-
     for (auto& [processIdentifier, paths] : parameters.allowedFilePaths)
         allowFilesAccessFromWebProcess(processIdentifier, paths, [] { });
 
@@ -406,6 +404,14 @@ void NetworkProcess::createNetworkConnectionToWebProcess(ProcessIdentifier ident
         completionHandler({ }, HTTPCookieAcceptPolicy::Never);
         return;
     }
+
+    auto& [currentLoadedWebArchive, currentDomains] = m_allowedFirstPartiesForCookies.ensure(identifier, [&] {
+        return std::make_pair(parameters.loadedWebArchive, HashSet<RegistrableDomain> { });
+    }).iterator->value;
+    if (parameters.loadedWebArchive == LoadedWebArchive::Yes)
+        currentLoadedWebArchive = LoadedWebArchive::Yes;
+    for (auto& domain : parameters.allowedFirstPartiesForCookies)
+        currentDomains.add(domain);
 
     auto newConnection = NetworkConnectionToWebProcess::create(*this, identifier, sessionID, WTF::move(parameters), WTF::move(connectionIdentifiers->server));
     Ref connection = newConnection;

--- a/Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.h
@@ -80,7 +80,6 @@ struct NetworkProcessCreationParameters {
     bool enableModernDownloadProgress { false };
 #endif
     Vector<WebsiteDataStoreParameters> websiteDataStoreParameters;
-    Vector<std::pair<WebCore::ProcessIdentifier, WebCore::RegistrableDomain>> allowedFirstPartiesForCookies;
     HashMap<WebCore::ProcessIdentifier, Vector<String>> allowedFilePaths;
     HashSet<String> localhostAliasesForTesting;
     Vector<WebCore::OrganizationStorageAccessPromptQuirk> storageAccessPromptQuirksData;

--- a/Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.serialization.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.serialization.in
@@ -58,7 +58,6 @@ headers: "NetworkProcessCreationParameters.h" "AuxiliaryProcessCreationParameter
 #endif
 
     Vector<WebKit::WebsiteDataStoreParameters> websiteDataStoreParameters
-    Vector<std::pair<WebCore::ProcessIdentifier, WebCore::RegistrableDomain>> allowedFirstPartiesForCookies;
     HashMap<WebCore::ProcessIdentifier, Vector<String>> allowedFilePaths;
     HashSet<String> localhostAliasesForTesting;
     Vector<WebCore::OrganizationStorageAccessPromptQuirk> storageAccessPromptQuirksData;

--- a/Source/WebKit/Shared/NetworkProcessConnectionParameters.h
+++ b/Source/WebKit/Shared/NetworkProcessConnectionParameters.h
@@ -25,8 +25,10 @@
 
 #pragma once
 
+#include "LoadedWebArchive.h"
 #include "SharedPreferencesForWebProcess.h"
 #include "WebPageProxyIdentifier.h"
+#include <WebCore/RegistrableDomain.h>
 
 namespace WebKit {
 
@@ -36,6 +38,8 @@ struct NetworkProcessConnectionParameters {
     bool ignoreInvalidMessageForTesting { false };
 #endif
     Vector<WebPageProxyIdentifier> pagesWithRelaxedThirdPartyCookieBlocking;
+    LoadedWebArchive loadedWebArchive { LoadedWebArchive::No };
+    HashSet<WebCore::RegistrableDomain> allowedFirstPartiesForCookies;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/NetworkProcessConnectionParameters.serialization.in
+++ b/Source/WebKit/Shared/NetworkProcessConnectionParameters.serialization.in
@@ -26,4 +26,6 @@ struct WebKit::NetworkProcessConnectionParameters {
     bool ignoreInvalidMessageForTesting;
 #endif
     Vector<WebKit::WebPageProxyIdentifier> pagesWithRelaxedThirdPartyCookieBlocking;
+    WebKit::LoadedWebArchive loadedWebArchive;
+    HashSet<WebCore::RegistrableDomain> allowedFirstPartiesForCookies;
 };

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -224,7 +224,6 @@ void NetworkProcessProxy::sendCreationParametersToNewProcess()
 #if PLATFORM(COCOA)
     parameters.enableModernDownloadProgress = CFPreferencesGetAppBooleanValue(CFSTR("EnableModernDownloadProgress"), CFSTR("com.apple.WebKit"), nullptr);
 #endif
-    parameters.allowedFirstPartiesForCookies = WebProcessProxy::allowedFirstPartiesForCookies();
     for (auto it = m_allowedFilePathsByProcess.begin(); it != m_allowedFilePathsByProcess.end(); ++it)
         parameters.allowedFilePaths.add(it->key.coreProcessIdentifier(), copyToVector(it->value));
 
@@ -332,6 +331,9 @@ void NetworkProcessProxy::getNetworkProcessConnection(WebProcessProxy& webProces
         if (page->configuration().shouldRelaxThirdPartyCookieBlocking() == ShouldRelaxThirdPartyCookieBlocking::Yes)
             parameters.pagesWithRelaxedThirdPartyCookieBlocking.append(page->identifier());
     }
+    auto& cookiesData = webProcessProxy.allowedFirstPartiesForCookiesData();
+    parameters.loadedWebArchive = cookiesData.first;
+    parameters.allowedFirstPartiesForCookies = cookiesData.second;
     sendWithAsyncReply(Messages::NetworkProcess::CreateNetworkConnectionToWebProcess { webProcessProxy.coreProcessIdentifier(), webProcessProxy.sessionID(), parameters }, [weakThis = WeakPtr { *this }, reply = WTF::move(reply)](auto&& identifier, auto cookieAcceptPolicy) mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis) {
@@ -1988,6 +1990,8 @@ void NetworkProcessProxy::reloadExecutionContextsForOrigin(const WebCore::Client
 
 void NetworkProcessProxy::addAllowedFirstPartyForCookies(WebProcessProxy& webProcessProxy, const WebCore::RegistrableDomain& firstPartyForCookies, LoadedWebArchive loadedWebArchive, CompletionHandler<void()>&& completionHandler)
 {
+    webProcessProxy.addAllowedFirstPartyForCookies(firstPartyForCookies, loadedWebArchive);
+
     auto& pair = m_allowedFirstPartiesForCookies.ensure(webProcessProxy, [] {
         return std::make_pair(LoadedWebArchive::No, HashSet<RegistrableDomain> { });
     }).iterator->value;

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -277,12 +277,11 @@ void WebProcessProxy::forWebPagesWithOrigin(PAL::SessionID sessionID, const Secu
     }
 }
 
-Vector<std::pair<WebCore::ProcessIdentifier, WebCore::RegistrableDomain>> WebProcessProxy::allowedFirstPartiesForCookies()
+void WebProcessProxy::addAllowedFirstPartyForCookies(const WebCore::RegistrableDomain& domain, LoadedWebArchive loadedWebArchive)
 {
-    Vector<std::pair<WebCore::ProcessIdentifier, WebCore::RegistrableDomain>> result;
-    for (Ref page : globalPages())
-        result.append(std::make_pair(page->legacyMainFrameProcess().coreProcessIdentifier(), RegistrableDomain(URL(page->currentURL()))));
-    return result;
+    m_allowedFirstPartiesForCookies.second.add(domain);
+    if (loadedWebArchive == LoadedWebArchive::Yes)
+        m_allowedFirstPartiesForCookies.first = LoadedWebArchive::Yes;
 }
 
 Ref<WebProcessProxy> WebProcessProxy::create(WebProcessPool& processPool, WebsiteDataStore* websiteDataStore, LockdownMode lockdownMode, EnhancedSecurity enhancedSecurity, IsPrewarmed isPrewarmed, CrossOriginMode crossOriginMode, ShouldLaunchProcess shouldLaunchProcess)

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -30,6 +30,7 @@
 #include "BackgroundProcessResponsivenessTimer.h"
 #include "EnhancedSecurity.h"
 #include "GPUProcessConnectionIdentifier.h"
+#include "LoadedWebArchive.h"
 #include "MessageReceiverMap.h"
 #include "NetworkProcessProxy.h"
 #include "ProcessLauncher.h"
@@ -224,7 +225,8 @@ public:
     ~WebProcessProxy();
 
     static void forWebPagesWithOrigin(PAL::SessionID, const WebCore::SecurityOriginData&, NOESCAPE const Function<void(WebPageProxy&)>&);
-    static Vector<std::pair<WebCore::ProcessIdentifier, WebCore::RegistrableDomain>> allowedFirstPartiesForCookies();
+    void addAllowedFirstPartyForCookies(const WebCore::RegistrableDomain&, LoadedWebArchive);
+    const std::pair<LoadedWebArchive, HashSet<WebCore::RegistrableDomain>>& allowedFirstPartiesForCookiesData() const { return m_allowedFirstPartiesForCookies; }
 
     void initializeWebProcess(WebProcessCreationParameters&&);
 
@@ -834,6 +836,7 @@ private:
     HashSet<WebCore::Site> m_committedSites;
     std::optional<WebCore::Site> m_sharedProcessMainFrameSite;
     HashSet<WebCore::RegistrableDomain> m_sharedProcessDomains;
+    std::pair<LoadedWebArchive, HashSet<WebCore::RegistrableDomain>> m_allowedFirstPartiesForCookies { LoadedWebArchive::No, { } };
     bool m_isInProcessCache { false };
 
     enum class NoOrMaybe { No, Maybe } m_isResponsive;


### PR DESCRIPTION
#### f6c0b734bc648caf9b0d1abddf512e8b591a2c98
<pre>
Cherry-pick 313490@main (cd11ac52dbc4). <a href="https://bugs.webkit.org/show_bug.cgi?id=314951">https://bugs.webkit.org/show_bug.cgi?id=314951</a>

    [Site Isolation] NetworkProcess::m_allowedFirstPartiesForCookies not restored for subframe processes after crash
    <a href="https://bugs.webkit.org/show_bug.cgi?id=314951">https://bugs.webkit.org/show_bug.cgi?id=314951</a>
    <a href="https://rdar.apple.com/177247707">rdar://177247707</a>

    Reviewed by Charlie Wolfe.

    Under Site Isolation, when the network process crashes and restarts, cross-origin subframe processes might get killed
    for failing allowsFirstPartyForCookies message checkes in network process. The cause is the new network process only has
    cookies access information for the main frame process -- the existing implementation creates new network process with
    WebProcessProxy::allowedFirstPartiesForCookies(), which only checks page&apos;s main frame process and only gets the current
    url of page.

    To fix this, store allowedFirstPartiesForCookies on each WebProcessProxy (which outlives network process crashes) and
    send it via NetworkProcessConnectionParameters when the web process reconnects to the network process. Remove the old
    NetworkProcessCreationParameters path as it is no longer needed with the new implementation.

    Test: http/tests/security/cross-origin-iframe-fetch-after-crash.html

    * LayoutTests/http/tests/security/cross-origin-iframe-fetch-after-crash-expected.txt: Added.
    * LayoutTests/http/tests/security/cross-origin-iframe-fetch-after-crash.html: Added.
    * LayoutTests/http/tests/security/resources/cross-origin-iframe-fetch-after-crash-iframe.html: Added.
    * Source/WebKit/NetworkProcess/NetworkProcess.cpp:
    (WebKit::NetworkProcess::removeNetworkConnectionToWebProcess):
    (WebKit::NetworkProcess::initializeNetworkProcess):
    (WebKit::NetworkProcess::createNetworkConnectionToWebProcess):
    (WebKit::NetworkProcess::addAllowedFirstPartyForCookies):
    (WebKit::NetworkProcess::allowsFirstPartyForCookies):
    * Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.h:
    * Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.serialization.in:
    * Source/WebKit/Shared/NetworkProcessConnectionParameters.h:
    * Source/WebKit/Shared/NetworkProcessConnectionParameters.serialization.in:
    * Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
    (WebKit::NetworkProcessProxy::sendCreationParametersToNewProcess):
    (WebKit::NetworkProcessProxy::getNetworkProcessConnection):
    (WebKit::NetworkProcessProxy::addAllowedFirstPartyForCookies):
    * Source/WebKit/UIProcess/WebProcessProxy.cpp:
    (WebKit::WebProcessProxy::addAllowedFirstPartyForCookies):
    (WebKit::WebProcessProxy::allowedFirstPartiesForCookies): Deleted.
    * Source/WebKit/UIProcess/WebProcessProxy.h:

    Canonical link: <a href="https://commits.webkit.org/313490@main">https://commits.webkit.org/313490@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.964@webkitglib/2.52">https://commits.webkit.org/305877.964@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1db887e4f84170b20b3d68bf7aaf9f82150f3516

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173017 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/46936 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/40407 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182477 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/130573 "The change is no longer eligible for processing.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/48230 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/46612 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134571 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/130573 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175975 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/48230 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/40407 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115040 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/48230 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/46612 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31075 "Built successfully") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/40407 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/48230 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/40407 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185012 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/37791 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/46612 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143379 "Passed tests") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/46607 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/40407 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143251 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/47285 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/40407 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/112333 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26257 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/47285 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/119045 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/45802 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/40407 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/45204 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/45435 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/45261 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->