### PR TITLE
No names in Error's stacktrace for instantiateStreaming modules

### DIFF
--- a/JSTests/wasm/stress/stack-trace-streaming-name-section.js
+++ b/JSTests/wasm/stress/stack-trace-streaming-name-section.js
@@ -1,0 +1,63 @@
+// Regression test for https://bugs.webkit.org/show_bug.cgi?id=318710: streaming
+// compilation must resolve function names from the WASM "name" section in stack
+// traces, like non-streaming does. Uses the same module and expected frames as the
+// non-streaming wasm/function-tests/nameSection.js.
+
+import * as assert from '../assert.js';
+
+let stacktrace;
+
+function makeImportObject() {
+    return {
+        env: {
+            _silly: (i) => { stacktrace = (new Error).stack; return i + 42; },
+            memory: new WebAssembly.Memory({ initial: 256, maximum: 256 }),
+            DYNAMICTOP_PTR: 0,
+            STACKTOP: 0,
+            STACK_MAX: 0,
+            abort: function () { },
+            enlargeMemory: function () { },
+            getTotalMemory: function () { },
+            abortOnCannotGrowMemory: function () { },
+            _emscripten_memcpy_big: function () { },
+            ___lock: function () { },
+            _abort: function () { },
+            ___setErrNo: function () { },
+            ___syscall6: function () { },
+            ___syscall140: function () { },
+            ___syscall146: function () { },
+            ___syscall54: function () { },
+            ___unlock: function () { },
+            table: new WebAssembly.Table({ element: 'funcref', initial: 6, maximum: 6 }),
+            memoryBase: 0,
+            tableBase: 0,
+        }
+    };
+}
+
+async function main() {
+    let wasmBuffer = readFile("./nameSection.wasm", "binary");
+
+    // Small chunks so function bodies compile before the trailing name section is parsed.
+    let step = 10;
+    let result = await $vm.createWasmStreamingCompilerForInstantiate(function (compiler) {
+        for (let i = 0; i < wasmBuffer.byteLength; i += step)
+            compiler.addBytes(wasmBuffer.subarray(i, i + Math.min(step, wasmBuffer.byteLength - i)));
+    }, makeImportObject());
+
+    let value = result.instance.exports._parrot(1);
+    assert.eq(value, 1 + 42);
+
+    assert.isString(stacktrace);
+    let lines = stacktrace.split("\n");
+    assert.eq(lines[1], "_eggs@wasm-function[21]");
+    assert.eq(lines[2], "_bacon@wasm-function[22]");
+    assert.eq(lines[3], "_spam@wasm-function[23]");
+    assert.eq(lines[4], "_parrot@wasm-function[24]");
+}
+
+main().catch(function (error) {
+    print(String(error));
+    print(String(error.stack));
+    $vm.abort();
+});

--- a/Source/JavaScriptCore/wasm/WasmCallee.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCallee.cpp
@@ -93,6 +93,18 @@ Callee::Callee(Wasm::CompilationMode compilationMode, FunctionSpaceIndex index, 
 {
 }
 
+void Callee::setIndexOrName(IndexOrName&& indexOrName)
+{
+#if ASSERT_ENABLED
+    // Racy once the callee is registered, since the profiler and stack walker then read it.
+    {
+        Locker locker { NativeCalleeRegistry::singleton().getLock() };
+        ASSERT(!NativeCalleeRegistry::singleton().isValidCallee(this));
+    }
+#endif
+    m_indexOrName = WTF::move(indexOrName);
+}
+
 void Callee::reportToVMsForDestruction()
 {
     // We don't know which VMs a Module has ever run on so we just report to all of them.

--- a/Source/JavaScriptCore/wasm/WasmCallee.h
+++ b/Source/JavaScriptCore/wasm/WasmCallee.h
@@ -111,10 +111,12 @@ protected:
     template<typename Func>
     void runWithDowncast(const Func&) const;
 
+    void setIndexOrName(IndexOrName&&);
+
 private:
     const CompilationMode m_compilationMode;
     const FunctionSpaceIndex m_index;
-    const IndexOrName m_indexOrName;
+    IndexOrName m_indexOrName;
 
 protected:
     FixedVector<HandlerInfo> m_exceptionHandlers;
@@ -467,6 +469,7 @@ private:
 
 
 class IPIntCallee final : public Callee {
+    using Base = Callee;
     WTF_MAKE_COMPACT_TZONE_ALLOCATED(IPIntCallee);
     friend class JSC::LLIntOffsetsExtractor;
     friend class Callee;
@@ -479,6 +482,7 @@ public:
     FunctionCodeIndex functionIndex() const { return m_functionIndex; }
     void setEntrypoint(CodePtr<WasmEntryPtrTag>);
     void setEntrypointWithoutRegistration(CodePtr<WasmEntryPtrTag>);
+    void setName(std::pair<const Name*, RefPtr<NameSection>>&& name) { setIndexOrName(IndexOrName(index(), WTF::move(name))); }
     const uint8_t* bytecode() const { return m_bytecode; }
     const uint8_t* bytecodeEnd() const { return m_bytecodeEnd; }
     const uint8_t* metadata() const LIFETIME_BOUND { return m_metadata.span().data(); }

--- a/Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp
@@ -109,7 +109,7 @@ void IPIntPlan::compileFunction(FunctionCodeIndex functionIndex)
     m_wasmInternalFunctions[functionIndex] = WTF::move(*parseAndCompileResult);
 
     {
-        auto callee = IPIntCallee::create(*m_wasmInternalFunctions[functionIndex], functionIndexSpace, signature, m_moduleInformation->nameSection().get(functionIndexSpace));
+        auto callee = IPIntCallee::create(*m_wasmInternalFunctions[functionIndex], functionIndexSpace, signature, { });
         ASSERT(!callee->entrypoint());
         bool usesSIMD = m_moduleInformation->usesSIMD(functionIndex);
         // Immediately tier up to BBQ for SIMD, if necesary.
@@ -141,6 +141,12 @@ void IPIntPlan::didCompleteCompilation()
 
     unsigned functionCount = m_wasmInternalFunctions.size();
     if (!m_calleesAlreadyRegistered && functionCount) {
+        // Set names here rather than at IPIntCallee creation: during streaming the name section
+        // (which follows the code section) has not been parsed yet when a function is compiled.
+        auto& nameSection = m_moduleInformation->nameSection();
+        for (auto& callee : *m_ipintCallees)
+            callee->setName(nameSection.get(callee->index()));
+
         NativeCalleeRegistry::singleton().registerCallees(*m_ipintCallees);
         if (Options::useWasmTailCalls())
             RestoreFrameCallee::singleton();


### PR DESCRIPTION
#### 228685d7d2a31dc419f5ca00554e163bac349ea5
<pre>
No names in Error&apos;s stacktrace for instantiateStreaming modules
<a href="https://bugs.webkit.org/show_bug.cgi?id=318710">https://bugs.webkit.org/show_bug.cgi?id=318710</a>
<a href="https://rdar.apple.com/181523735">rdar://181523735</a>

Reviewed by Marcus Plutowski.

The &quot;name&quot; custom section typically follows the code section, so during
streaming an IPIntCallee resolved its name before that section was parsed
and fell back to the numeric function index. Resolve names in
IPIntPlan::didCompleteCompilation() instead, which both the streaming and
non-streaming paths reach after the whole module is parsed and before the
callees are registered. To support this, Callee::m_indexOrName is no
longer const and now has a setIndexOrName() setter. The setter asserts the
callee is not yet registered in the CalleeRegistry to ensure we don&apos;t race
setting the name at runtime.

Test: JSTests/wasm/stress/stack-trace-streaming-name-section.js

* JSTests/wasm/stress/stack-trace-streaming-name-section.js: Added.
(makeImportObject.return.env.abort):
(makeImportObject.return.env.enlargeMemory):
(makeImportObject.return.env.getTotalMemory):
(makeImportObject.return.env.abortOnCannotGrowMemory):
(makeImportObject.return.env._emscripten_memcpy_big):
(makeImportObject.return.env.___lock):
(makeImportObject.return.env._abort):
(makeImportObject.return.env.___setErrNo):
(makeImportObject.return.env.___syscall6):
(makeImportObject.return.env.___syscall140):
(makeImportObject.return.env.___syscall146):
(makeImportObject.return.env.___syscall54):
(makeImportObject.return.env.___unlock):
(makeImportObject):
(async main):
(main.catch):
* Source/JavaScriptCore/wasm/WasmCallee.cpp:
(JSC::Wasm::Callee::setIndexOrName):
* Source/JavaScriptCore/wasm/WasmCallee.h:
* Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp:
(JSC::Wasm::IPIntPlan::compileFunction):
(JSC::Wasm::IPIntPlan::didCompleteCompilation):

Canonical link: <a href="https://commits.webkit.org/316642@main">https://commits.webkit.org/316642@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e15a671cdf2f4521d3ed678ba060fce44c21ebd0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173020 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46939 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40413 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182480 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130576 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48233 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46615 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134576 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175978 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37965 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155147 "Found 8 new API test failures: TestWebKitAPI.WKWebExtensionController.WebAccessibleResourceInSubframeFromAboutBlank, TestWebKitAPI.WKWebExtensionAPICookies.ChangedEvent, TestWebKitAPI.WKWebExtension.ContentScriptNotInjectedForExcludedMatchPattern, TestWebKitAPI.WKWebExtensionAPICookies.GetAllCookieStoresWithPrivateAccess, TestWebKitAPI.WKWebExtension.MultipleContentScriptsInjectedWhenMatched, TestWebKitAPI.SiteIsolation.CrossProcessHistoryTraversalCoalesce, TestWebKitAPI.WKWebExtension.ContentScriptImport, TestWebKitAPI.WKWebExtension.MultipleContentScriptsNotInjectedWhenNotMatched (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115045 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36610 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31078 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/3665 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147034 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34648 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185015 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/34282 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37794 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39141 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143381 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46610 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143253 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47288 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112340 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26265 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38237 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119048 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/206747 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45805 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9591 "Passed tests") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/206747 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45207 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45438 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45264 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->