### PR TITLE
[GTK][WPE] ScrollingTreeCoordinated::eventListenerRegionTypesForPoint should return the topmost hit layer's region types

### DIFF
--- a/LayoutTests/tiled-drawing/scrolling/wheel-event-listener-region-overlapping-composited-layers-expected.txt
+++ b/LayoutTests/tiled-drawing/scrolling/wheel-event-listener-region-overlapping-composited-layers-expected.txt
@@ -1,0 +1,10 @@
+some long block will block will not block
+PASS frontWheelEventCount > 0 is true
+PASS frontCancelableWheelEventCount is 0
+PASS backWheelEventCount is 0
+PASS window.scrollY > 0 is true
+PASS windowScrollEventCount > 0 is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/tiled-drawing/scrolling/wheel-event-listener-region-overlapping-composited-layers.html
+++ b/LayoutTests/tiled-drawing/scrolling/wheel-event-listener-region-overlapping-composited-layers.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+<style>
+body {
+    margin: 0;
+}
+
+#container {
+    width: 500px;
+    height: 2000px;
+    background: #333;
+    color: white;
+}
+
+#back {
+    position: absolute;
+    left: 100px;
+    top: 100px;
+    width: 400px;
+    height: 400px;
+    background: #f8b;
+    will-change: transform;
+}
+
+#front {
+    position: absolute;
+    left: 200px;
+    top: 200px;
+    width: 200px;
+    height: 200px;
+    background: #8bf;
+    will-change: transform;
+}
+</style>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/ui-helper.js"></script>
+<script>
+window.jsTestIsAsync = true;
+
+var backWheelEventCount = 0;
+var frontWheelEventCount = 0;
+var frontCancelableWheelEventCount = 0;
+var windowScrollEventCount = 0;
+
+async function doTest()
+{
+    await UIHelper.renderingUpdate();
+    await UIHelper.mouseWheelScrollAt(250, 250);
+    await UIHelper.renderingUpdate();
+
+    shouldBe("frontWheelEventCount > 0", "true");
+    shouldBe("frontCancelableWheelEventCount", "0");
+    shouldBe("backWheelEventCount", "0");
+    shouldBe("window.scrollY > 0", "true");
+    shouldBe("windowScrollEventCount > 0", "true");
+
+    finishJSTest();
+}
+
+window.addEventListener("load", () => {
+    let back = document.getElementById("back");
+    let front = document.getElementById("front");
+
+    back.addEventListener("wheel", event => {
+        ++backWheelEventCount;
+        event.preventDefault();
+    }, { passive: false });
+
+    front.addEventListener("wheel", event => {
+        ++frontWheelEventCount;
+        if (event.cancelable)
+            ++frontCancelableWheelEventCount;
+    }, { passive: true });
+
+    window.addEventListener("scroll", () => ++windowScrollEventCount);
+
+    setTimeout(doTest, 0);
+}, false);
+</script>
+</head>
+<body>
+    <div id="container">
+        some long block
+        <div id="back">will block</div>
+        <div id="front">will not block</div>
+    </div>
+    <div id="console"></div>
+</body>
+</html>

--- a/Source/WebCore/page/scrolling/coordinated/ScrollingTreeCoordinated.cpp
+++ b/Source/WebCore/page/scrolling/coordinated/ScrollingTreeCoordinated.cpp
@@ -181,7 +181,7 @@ void ScrollingTreeCoordinated::hasNodeWithAnimatedScrollChanged(bool hasNodeWith
 static OptionSet<EventListenerRegionType> findEventListenerRegionTypes(const Ref<CoordinatedPlatformLayer>& parent, const FloatPoint& point)
 {
     bool existsOnLayer = parent->bounds().contains(point) && parent->eventRegion().contains(roundedIntPoint(point));
-    for (auto& child : parent->children()) {
+    for (auto& child : parent->children() | std::views::reverse) {
         Locker childLocker { child->lock() };
         FloatPoint transformedPoint(point);
         if (child->transform().isInvertible()) {


### PR DESCRIPTION
#### de0391e9c832384e850fff95e2393ab27e6d129c
<pre>
[GTK][WPE] ScrollingTreeCoordinated::eventListenerRegionTypesForPoint should return the topmost hit layer&apos;s region types
<a href="https://bugs.webkit.org/show_bug.cgi?id=318783">https://bugs.webkit.org/show_bug.cgi?id=318783</a>

Reviewed by Fujii Hironori.

In the findEventListenerRegionTypes, we iterate the children in top-down to match the hit testing order.

Test: tiled-drawing/scrolling/wheel-event-listener-region-overlapping-composited-layers.html

* LayoutTests/tiled-drawing/scrolling/wheel-event-listener-region-overlapping-composited-layers-expected.txt: Added.
* LayoutTests/tiled-drawing/scrolling/wheel-event-listener-region-overlapping-composited-layers.html: Added.
* Source/WebCore/page/scrolling/coordinated/ScrollingTreeCoordinated.cpp:
(WebCore::findEventListenerRegionTypes): Modified to reverse the iteration order.

Canonical link: <a href="https://commits.webkit.org/316712@main">https://commits.webkit.org/316712@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/088faedfa7fbd28a69caa86b319b722a75c3d652

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173241 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47173 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40693 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182814 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130797 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175106 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48466 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46855 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134706 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176199 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38121 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155339 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115177 "Found 1 new API test failure: WPE/TestWebKitWebView:/webkit/WebKitWebView/save (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36766 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/35111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31299 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147190 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34837 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185236 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38073 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39311 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143553 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46841 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154899 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143421 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47520 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/112610 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26300 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38381 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119269 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46026 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9783 "Passed tests") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45428 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45659 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45485 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->