### PR TITLE
[EvaluationTimeZoom] Convert remaining trivial to convert properties to evaluation time zoom

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/background-size-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/background-size-expected.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  background-size: 50px;
+  display: inline-block;
+}
+.container {
+  background-image: url("/images/pattern.png");
+  width: 40px;
+  height: 40px;
+}
+.container-zoom {
+  background-image: url("/images/pattern.png");
+  width: 80px;
+  height: 80px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="background-size: 50px;">
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="background-size: 50px;">
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container-zoom" style="background-size: 100px;">
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container-zoom" style="background-size: 100px;">
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/background-size.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/background-size.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Zoom applies to background-size</title>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+<link rel="match" href="reference/background-size-ref.html">
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  background-size: 50px;
+  display: inline-block;
+}
+.container {
+  background-image: url("/images/pattern.png");
+  width: 40px;
+  height: 40px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="background-size: 50px; zoom: 1;">
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="background-size: inherit; zoom: 1;">
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="background-size: 50px; zoom: 2;">
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="background-size: inherit; zoom: 2;">
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/block-step-size-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/block-step-size-expected.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  block-step-size: 50px;
+  display: inline-block;
+  width: 100px;
+  border: solid black 1px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="height: 100px;">
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="height: 100px;">
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="height: 200px;">
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="height: 200px;">
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/block-step-size.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/block-step-size.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Zoom applies to block-step-size</title>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+<link rel="match" href="reference/block-step-size-ref.html">
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  block-step-size: 50px;
+  display: inline-block;
+  width: 100px;
+  border: solid black 1px;
+}
+.container {
+  block-step-size: 50px;
+  height: 51px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="block-step-size: 50px; zoom: 1;">
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="block-step-size: inherit; zoom: 1;">
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="block-step-size: 50px; zoom: 2;">
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="block-step-size: inherit; zoom: 2;">
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/border-image-outset-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/border-image-outset-expected.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Zoom applies to border-image-outset</title>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+<link rel="match" href="reference/border-image-outset-ref.html">
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  border-image-outset: 5px;
+  display: inline-block;
+  padding: 10px;
+}
+.container {
+  border: 10px solid red;
+  border-image: url("/images/green.png") 2;
+}
+.container-zoom {
+  border: 20px solid red;
+  border-image: url("/images/green.png") 2;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="border-image-outset: 5px;">
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="border-image-outset: 5px;">
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container-zoom" style="border-image-outset: 10px;">
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container-zoom" style="border-image-outset: 10px;">
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/border-image-outset.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/border-image-outset.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Zoom applies to border-image-outset</title>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+<link rel="match" href="reference/border-image-outset-ref.html">
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  border-image-outset: 5px;
+  display: inline-block;
+  padding: 10px;
+}
+.container {
+  border: 10px solid red;
+  border-image: url("/images/green.png") 2;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="border-image-outset: 5px; zoom: 1;">
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="border-image-outset: inherit; zoom: 1;">
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="border-image-outset: 5px; zoom: 2;">
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="border-image-outset: inherit; zoom: 2;">
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/column-gap-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/column-gap-expected.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  display: block;
+  border: 1px solid black;
+  padding: 10px;
+  column-gap: 20px;
+}
+.container {
+  display: flex;
+  flex-direction: row;
+  width: 100px;
+}
+.container-zoom {
+  display: flex;
+  flex-direction: row;
+  width: 200px;
+}
+.container > div {
+  background-color: black;
+  width: 40px;
+  height: 10px;
+}
+.container-zoom > div {
+  background-color: black;
+  width: 80px;
+  height: 20px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="column-gap: 20px;">
+      <div></div>
+      <div></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="column-gap: 20px;">
+      <div></div>
+      <div></div>
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container-zoom" style="column-gap: 40px;">
+      <div></div>
+      <div></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container-zoom" style="column-gap: 40px;">
+      <div></div>
+      <div></div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/column-gap.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/column-gap.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Zoom applies to column-gap</title>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+<link rel="match" href="reference/column-gap-ref.html">
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  display: block;
+  border: 1px solid black;
+  padding: 10px;
+  column-gap: 20px;
+}
+.container {
+  display: flex;
+  flex-direction: row;
+  column-gap: 24px;
+  width: 100px;
+}
+.container > div {
+  background-color: black;
+  width: 40px;
+  height: 10px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="column-gap: 20px; zoom: 1;">
+      <div></div>
+      <div></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="column-gap: inherit; zoom: 1;">
+      <div></div>
+      <div></div>
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="column-gap: 20px; zoom: 2;">
+      <div></div>
+      <div></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="column-gap: inherit; zoom: 2;">
+      <div></div>
+      <div></div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/mask-border-outset-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/mask-border-outset-expected.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  mask-border-outset: 5px;
+  display: inline-block;
+}
+.container {
+  mask-border-source: url("/images/green.png");
+  mask-border-slice: 20;
+  background-color: black;
+  width: 50px;
+  height: 50px;
+}
+.container-zoom {
+  mask-border-source: url("/images/green.png");
+  mask-border-slice: 20;
+  background-color: black;
+  width: 100px;
+  height: 100px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="mask-border-outset: 5px;">
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="mask-border-outset: inherit;">
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container-zoom" style="mask-border-outset: 10px;">
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container-zoom" style="mask-border-outset: 10px;">
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/mask-border-outset.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/mask-border-outset.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Zoom applies to mask-border-outset</title>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+<link rel="match" href="reference/mask-border-outset-ref.html">
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  mask-border-outset: 5px;
+  display: inline-block;
+}
+.container {
+  mask-border-source: url("/images/green.png");
+  mask-border-slice: 20;
+  background-color: black;
+  width: 50px;
+  height: 50px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="mask-border-outset: 5px; zoom: 1;">
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="mask-border-outset: inherit; zoom: 1;">
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="mask-border-outset: 5px; zoom: 2;">
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="mask-border-outset: inherit; zoom: 2;">
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/background-size-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/background-size-ref.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  background-size: 50px;
+  display: inline-block;
+}
+.container {
+  background-image: url("/images/pattern.png");
+  width: 40px;
+  height: 40px;
+}
+.container-zoom {
+  background-image: url("/images/pattern.png");
+  width: 80px;
+  height: 80px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="background-size: 50px;">
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="background-size: 50px;">
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container-zoom" style="background-size: 100px;">
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container-zoom" style="background-size: 100px;">
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/block-step-size-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/block-step-size-ref.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  block-step-size: 50px;
+  display: inline-block;
+  width: 100px;
+  border: solid black 1px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="height: 100px;">
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="height: 100px;">
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="height: 200px;">
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="height: 200px;">
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/border-image-outset-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/border-image-outset-ref.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Zoom applies to border-image-outset</title>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+<link rel="match" href="reference/border-image-outset-ref.html">
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  border-image-outset: 5px;
+  display: inline-block;
+  padding: 10px;
+}
+.container {
+  border: 10px solid red;
+  border-image: url("/images/green.png") 2;
+}
+.container-zoom {
+  border: 20px solid red;
+  border-image: url("/images/green.png") 2;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="border-image-outset: 5px;">
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="border-image-outset: 5px;">
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container-zoom" style="border-image-outset: 10px;">
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container-zoom" style="border-image-outset: 10px;">
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/column-gap-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/column-gap-ref.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  display: block;
+  border: 1px solid black;
+  padding: 10px;
+  column-gap: 20px;
+}
+.container {
+  display: flex;
+  flex-direction: row;
+  width: 100px;
+}
+.container-zoom {
+  display: flex;
+  flex-direction: row;
+  width: 200px;
+}
+.container > div {
+  background-color: black;
+  width: 40px;
+  height: 10px;
+}
+.container-zoom > div {
+  background-color: black;
+  width: 80px;
+  height: 20px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="column-gap: 20px;">
+      <div></div>
+      <div></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="column-gap: 20px;">
+      <div></div>
+      <div></div>
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container-zoom" style="column-gap: 40px;">
+      <div></div>
+      <div></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container-zoom" style="column-gap: 40px;">
+      <div></div>
+      <div></div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/mask-border-outset-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/mask-border-outset-ref.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  mask-border-outset: 5px;
+  display: inline-block;
+}
+.container {
+  mask-border-source: url("/images/green.png");
+  mask-border-slice: 20;
+  background-color: black;
+  width: 50px;
+  height: 50px;
+}
+.container-zoom {
+  mask-border-source: url("/images/green.png");
+  mask-border-slice: 20;
+  background-color: black;
+  width: 100px;
+  height: 100px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="mask-border-outset: 5px;">
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="mask-border-outset: inherit;">
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container-zoom" style="mask-border-outset: 10px;">
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container-zoom" style="mask-border-outset: 10px;">
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/row-gap-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/row-gap-ref.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  display: inline-block;
+  border: 1px solid black;
+  padding: 10px;
+  row-gap: 20px; 
+}
+.container {
+  display: flex;
+  flex-wrap: wrap;
+  width: 150px;
+}
+.container-zoom {
+  display: flex;
+  flex-wrap: wrap;
+  width: 300px;
+}
+.container > div {
+  background-color: black;
+  flex: 1 1 auto;
+  width: 100px;
+  height: 20px;
+}
+.container-zoom > div {
+  background-color: black;
+  flex: 1 1 auto;
+  width: 200px;
+  height: 40px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="row-gap: 20px;">
+      <div></div>
+      <div></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="row-gap: 20px;">
+      <div></div>
+      <div></div>
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container-zoom" style="row-gap: 40px;">
+      <div></div>
+      <div></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container-zoom" style="row-gap: 40px;">
+      <div></div>
+      <div></div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/tab-size-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/tab-size-ref.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  display: inline-block;
+  tab-size: 40px;
+  border: solid black 1px;
+}
+.container {
+  display: inline-block;
+  font-size: 16px;
+}
+.container-zoom {
+  display: inline-block;
+  font-size: 32px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <pre class="container" style="tab-size: 40px;">	hello</pre>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <pre class="container" style="tab-size: 40px;">	hello</pre>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <pre class="container-zoom" style="tab-size: 80px;">	hello</pre>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <pre class="container-zoom" style="tab-size: 80px;">	hello</pre>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/vertical-align-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/vertical-align-ref.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  vertical-align: 20px;
+  display: inline-block;
+}
+.container {
+  width: 20px;
+  height: 20px;
+}
+.container-zoom {
+  width: 40px;
+  height: 40px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <img class="container" src="/images/green.png" style="vertical-align: 20px;">
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <img class="container" src="/images/green.png" style="vertical-align: 20px;">
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <img class="container-zoom" src="/images/green.png" style="vertical-align: 40px;">
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <img class="container-zoom" src="/images/green.png" style="vertical-align: 40px;">
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/row-gap-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/row-gap-expected.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  display: inline-block;
+  border: 1px solid black;
+  padding: 10px;
+  row-gap: 20px; 
+}
+.container {
+  display: flex;
+  flex-wrap: wrap;
+  width: 150px;
+}
+.container-zoom {
+  display: flex;
+  flex-wrap: wrap;
+  width: 300px;
+}
+.container > div {
+  background-color: black;
+  flex: 1 1 auto;
+  width: 100px;
+  height: 20px;
+}
+.container-zoom > div {
+  background-color: black;
+  flex: 1 1 auto;
+  width: 200px;
+  height: 40px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="row-gap: 20px;">
+      <div></div>
+      <div></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="row-gap: 20px;">
+      <div></div>
+      <div></div>
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container-zoom" style="row-gap: 40px;">
+      <div></div>
+      <div></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container-zoom" style="row-gap: 40px;">
+      <div></div>
+      <div></div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/row-gap.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/row-gap.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Zoom applies to row-gap</title>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+<link rel="match" href="reference/row-gap-ref.html">
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  display: inline-block;
+  border: 1px solid black;
+  padding: 10px;
+  row-gap: 20px; 
+}
+.container {
+  display: flex;
+  flex-wrap: wrap;
+  width: 150px;
+}
+.container > div {
+  background-color: black;
+  flex: 1 1 auto;
+  width: 100px;
+  height: 20px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="row-gap: 20px; zoom: 1;">
+      <div></div>
+      <div></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="row-gap: inherit; zoom: 1;">
+      <div></div>
+      <div></div>
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="row-gap: 20px; zoom: 2;">
+      <div></div>
+      <div></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="row-gap: inherit; zoom: 2;">
+      <div></div>
+      <div></div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/tab-size-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/tab-size-expected.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  display: inline-block;
+  tab-size: 40px;
+  border: solid black 1px;
+}
+.container {
+  display: inline-block;
+  font-size: 16px;
+}
+.container-zoom {
+  display: inline-block;
+  font-size: 32px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p> 
+<div class="group">
+  <div class="outer">
+    <pre class="container" style="tab-size: 40px;">	hello</pre>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <pre class="container" style="tab-size: 40px;">	hello</pre>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <pre class="container-zoom" style="tab-size: 80px;">	hello</pre>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <pre class="container-zoom" style="tab-size: 80px;">	hello</pre>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/tab-size.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/tab-size.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Zoom applies to tab-size</title>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+<link rel="match" href="reference/tab-size-ref.html">
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  display: inline-block;
+  tab-size: 40px;
+  border: solid black 1px;
+}
+.container {
+  display: inline-block;
+  font-size: 16px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <pre class="container" style="tab-size: 40px; zoom: 1;">	hello</pre>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <pre class="container" style="tab-size: inherit; zoom: 1;">	hello</pre>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <pre class="container" style="tab-size: 40px; zoom: 2;">	hello</pre>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <pre class="container" style="tab-size: inherit; zoom: 2;">	hello</pre>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/vertical-align-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/vertical-align-expected.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  vertical-align: 20px;
+  display: inline-block;
+}
+.container {
+  width: 20px;
+  height: 20px;
+}
+.container-zoom {
+  width: 40px;
+  height: 40px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <img class="container" src="/images/green.png" style="vertical-align: 20px;">
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <img class="container" src="/images/green.png" style="vertical-align: 20px;">
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <img class="container-zoom" src="/images/green.png" style="vertical-align: 40px;">
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <img class="container-zoom" src="/images/green.png" style="vertical-align: 40px;">
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/vertical-align.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/vertical-align.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Zoom applies to vertical-align</title>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+<link rel="match" href="reference/vertical-align-ref.html">
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  vertical-align: 20px;
+  display: inline-block;
+}
+.container {
+  width: 20px;
+  height: 20px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <img class="container" src="/images/green.png" style="vertical-align: 20px; zoom: 1;">
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <img class="container" src="/images/green.png" style="vertical-align: inherit; zoom: 1;">
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <img class="container" src="/images/green.png" style="vertical-align: 20px; zoom: 2;">
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <img class="container" src="/images/green.png" style="vertical-align: inherit; zoom: 2;">
+  </div>
+</div>
+</body>
+</html>

--- a/Source/WebCore/css/deprecated-cssom/DeprecatedCSSOMRect.cpp
+++ b/Source/WebCore/css/deprecated-cssom/DeprecatedCSSOMRect.cpp
@@ -36,7 +36,7 @@ static Ref<DeprecatedCSSOMPrimitiveValue> makeDeprecatedCSSOMPrimitiveValueForCl
         [&](CSS::Keyword::Auto keyword) {
             return DeprecatedCSSOMPrimitiveValue::create(CSS::Keyword { keyword.value }, owner);
         },
-        [&](const CSS::Length<>& length) {
+        [&](const CSS::Length<CSS::AllUnzoomed>& length) {
             return CSS::makeDeprecatedCSSOMPrimitiveValueForNumeric(length, owner);
         }
     );

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Background.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Background.cpp
@@ -79,12 +79,12 @@ template<SupportWebKitBorderRadiusQuirk supportQuirk> static std::optional<CSS::
     // <'border-radius'> = <length-percentage [0,∞]>{1,4} [ / <length-percentage [0,∞]>{1,4} ]?
     // https://drafts.csswg.org/css-backgrounds/#propdef-border-radius
 
-    using OptionalRadiiForAxis = std::array<std::optional<CSS::LengthPercentage<CSS::NonnegativeUnzoomed>>, 4>;
+    using OptionalRadiiForAxis = std::array<std::optional<CSS::BorderRadius::LengthPercentage>, 4>;
 
     OptionalRadiiForAxis horizontalRadii;
     unsigned i = 0;
     for (; i < 4 && !range.atEnd() && range.peek().type() != DelimiterToken; ++i) {
-        horizontalRadii[i] = MetaConsumer<CSS::LengthPercentage<CSS::NonnegativeUnzoomed>>::consume(range, state);
+        horizontalRadii[i] = MetaConsumer<CSS::BorderRadius::LengthPercentage>::consume(range, state);
         if (!horizontalRadii[i])
             return { };
     }
@@ -120,7 +120,7 @@ template<SupportWebKitBorderRadiusQuirk supportQuirk> static std::optional<CSS::
 
     OptionalRadiiForAxis verticalRadii;
     for (unsigned i = 0; i < 4 && !range.atEnd(); ++i) {
-        verticalRadii[i] = MetaConsumer<CSS::LengthPercentage<CSS::NonnegativeUnzoomed>>::consume(range, state);
+        verticalRadii[i] = MetaConsumer<CSS::BorderRadius::LengthPercentage>::consume(range, state);
         if (!verticalRadii[i])
             return { };
     }
@@ -299,10 +299,10 @@ std::optional<CSS::BorderImageWidth> consumeUnresolvedBorderImageWidth(CSSParser
 
         if (auto lengthPercentage = MetaConsumer<CSS::BorderImageWidth::Value::LengthPercentage>::consume(range, state, { .overrideParserMode = HTMLStandardMode })) {
             hasLength = WTF::switchOn(*lengthPercentage,
-                [](const CSS::LengthPercentage<CSS::Nonnegative>::Calc& calc) {
+                [](const CSS::BorderImageWidth::Value::LengthPercentage::Calc& calc) {
                     return calc.primitiveType() == CSSUnitType::CSS_PX;
                 },
-                [](const CSS::LengthPercentage<CSS::Nonnegative>::Raw& raw) {
+                [](const CSS::BorderImageWidth::Value::LengthPercentage::Raw& raw) {
                     return raw.unit != CSS::PercentageUnit::Percentage;
                 }
             );
@@ -402,7 +402,7 @@ template<CSSPropertyID property> static RefPtr<CSSValue> consumeBackgroundSize(C
     bool shouldCoalesce = true;
     RefPtr<CSSValue> horizontal = consumeIdent<CSSValueAuto>(range);
     if (!horizontal) {
-        horizontal = CSSPrimitiveValueResolver<CSS::LengthPercentage<CSS::Nonnegative>>::consumeAndResolve(range, state);
+        horizontal = CSSPrimitiveValueResolver<CSS::LengthPercentage<CSS::NonnegativeUnzoomed>>::consumeAndResolve(range, state);
         if (!horizontal)
             return nullptr;
         shouldCoalesce = false;
@@ -412,7 +412,7 @@ template<CSSPropertyID property> static RefPtr<CSSValue> consumeBackgroundSize(C
     if (!range.atEnd()) {
         vertical = consumeIdent<CSSValueAuto>(range);
         if (!vertical)
-            vertical = CSSPrimitiveValueResolver<CSS::LengthPercentage<CSS::Nonnegative>>::consumeAndResolve(range, state);
+            vertical = CSSPrimitiveValueResolver<CSS::LengthPercentage<CSS::NonnegativeUnzoomed>>::consumeAndResolve(range, state);
     }
     if (!vertical) {
         if constexpr (property == CSSPropertyWebkitBackgroundSize) {

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Filter.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Filter.cpp
@@ -90,7 +90,7 @@ static std::optional<CSS::BlurFunction> consumeFilterBlur(CSSParserTokenRange& r
     if (args.atEnd())
         return { CSS::BlurFunction { .parameters = { } } };
 
-    auto parsedValue = MetaConsumer<CSS::Length<CSS::Nonnegative>>::consume(args, state);
+    auto parsedValue = MetaConsumer<CSS::Length<CSS::NonnegativeUnzoomed>>::consume(args, state);
     if (!parsedValue || !args.atEnd())
         return { };
 

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Overflow.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Overflow.cpp
@@ -52,7 +52,7 @@ RefPtr<CSSValue> consumeOverflowClipMargin(CSSParserTokenRange& range, CSS::Prop
     RefPtr<CSSPrimitiveValue> length;
     auto tryConsumeLength = [&length](CSSParserTokenRange& range, CSS::PropertyParserState& state) -> bool {
         auto consumeLength = [](CSSParserTokenRange& range, CSS::PropertyParserState& state) -> RefPtr<CSSPrimitiveValue> {
-            return CSSPrimitiveValueResolver<CSS::Length<CSS::Range { 0, CSS::Range::infinity } >>::consumeAndResolve(range, state);
+            return CSSPrimitiveValueResolver<CSS::Length<CSS::NonnegativeUnzoomed>>::consumeAndResolve(range, state);
         };
         if (length)
             return false;

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+SVG.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+SVG.cpp
@@ -108,7 +108,7 @@ RefPtr<CSSValue> consumeStrokeDasharray(CSSParserTokenRange& range, CSS::Propert
     CSSValueListBuilder dashes;
     do {
         // FIXME: Figure out and document why overrideParserMode is explicitly set to HTMLStandardMode here or remove the special case.
-        auto dash = CSSPrimitiveValueResolver<CSS::LengthPercentage<CSS::Nonnegative>>::consumeAndResolve(range, state, { .overrideParserMode = HTMLStandardMode, .unitlessZeroLength = UnitlessZeroQuirk::Forbid });
+        auto dash = CSSPrimitiveValueResolver<CSS::LengthPercentage<CSS::NonnegativeUnzoomed>>::consumeAndResolve(range, state, { .overrideParserMode = HTMLStandardMode, .unitlessZeroLength = UnitlessZeroQuirk::Forbid });
         if (!dash)
             dash = CSSPrimitiveValueResolver<CSS::Number<CSS::Nonnegative>>::consumeAndResolve(range, state);
         if (!dash || (consumeCommaIncludingWhitespace(range) && range.atEnd()))

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Timeline.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Timeline.cpp
@@ -186,14 +186,14 @@ RefPtr<CSSValue> consumeSingleAnimationRange(CSSParserTokenRange& range, CSS::Pr
         return normal;
 
     if (auto name = consumeTimelineRangeName(range)) {
-        if (auto offset = CSSPrimitiveValueResolver<CSS::LengthPercentage<>>::consumeAndResolve(range, state)) {
+        if (auto offset = CSSPrimitiveValueResolver<CSS::LengthPercentage<CSS::AllUnzoomed>>::consumeAndResolve(range, state)) {
             if (isDefault(*offset, type))
                 return name;
             return CSSValuePair::createNoncoalescing(name.releaseNonNull(), offset.releaseNonNull());
         }
         return name;
     }
-    return CSSPrimitiveValueResolver<CSS::LengthPercentage<>>::consumeAndResolve(range, state);
+    return CSSPrimitiveValueResolver<CSS::LengthPercentage<CSS::AllUnzoomed>>::consumeAndResolve(range, state);
 }
 
 RefPtr<CSSValue> consumeSingleAnimationRangeStart(CSSParserTokenRange& range, CSS::PropertyParserState& state)

--- a/Source/WebCore/css/parser/CSSPropertyParserCustom.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserCustom.h
@@ -541,12 +541,12 @@ inline bool PropertyParserCustom::consumeTextDecorationSkipShorthand(CSSParserTo
 
 inline bool PropertyParserCustom::consumeBorderSpacingShorthand(CSSParserTokenRange& range, PropertyParserState& state, const StylePropertyShorthand&, PropertyParserResult& result)
 {
-    RefPtr horizontalSpacing = CSSPrimitiveValueResolver<Length<Nonnegative>>::consumeAndResolve(range, state);
+    RefPtr horizontalSpacing = CSSPrimitiveValueResolver<Length<NonnegativeUnzoomed>>::consumeAndResolve(range, state);
     if (!horizontalSpacing)
         return false;
     RefPtr verticalSpacing = horizontalSpacing;
     if (!range.atEnd())
-        verticalSpacing = CSSPrimitiveValueResolver<Length<Nonnegative>>::consumeAndResolve(range, state);
+        verticalSpacing = CSSPrimitiveValueResolver<Length<NonnegativeUnzoomed>>::consumeAndResolve(range, state);
     if (!verticalSpacing || !range.atEnd())
         return false;
 
@@ -639,7 +639,7 @@ inline bool PropertyParserCustom::consumeFlexShorthand(CSSParserTokenRange& rang
                 if (isFlexBasisIdent(range.peek().id()))
                     flexBasis = consumeIdent(range);
                 if (!flexBasis)
-                    flexBasis = CSSPrimitiveValueResolver<LengthPercentage<Nonnegative>>::consumeAndResolve(range, state);
+                    flexBasis = CSSPrimitiveValueResolver<LengthPercentage<NonnegativeUnzoomed>>::consumeAndResolve(range, state);
                 if (index == 2 && !range.atEnd())
                     return false;
             }
@@ -1777,7 +1777,7 @@ inline bool PropertyParserCustom::consumeTransformOriginShorthand(CSSParserToken
     if (auto position = consumeOneOrTwoComponentPositionUnresolved(range, state)) {
         range.consumeWhitespace();
         bool atEnd = range.atEnd();
-        auto resultZ = CSSPrimitiveValueResolver<Length<>>::consumeAndResolve(range, state);
+        auto resultZ = CSSPrimitiveValueResolver<Length<CSS::AllUnzoomed>>::consumeAndResolve(range, state);
         if ((!resultZ && !atEnd) || !range.atEnd())
             return false;
 

--- a/Source/WebCore/css/values/backgrounds/CSSBorderImageOutset.h
+++ b/Source/WebCore/css/values/backgrounds/CSSBorderImageOutset.h
@@ -32,7 +32,7 @@ namespace CSS {
 
 // <border-image-outset-value> = <length [0,∞]> | <number [0,∞]>
 struct BorderImageOutsetValue {
-    using Length = CSS::Length<CSS::Nonnegative, float>;
+    using Length = CSS::Length<CSS::NonnegativeUnzoomed, float>;
     using Number = CSS::Number<CSS::Nonnegative, float>;
 
     BorderImageOutsetValue(Length length) : m_value { length } { }

--- a/Source/WebCore/css/values/backgrounds/CSSBorderImageWidth.h
+++ b/Source/WebCore/css/values/backgrounds/CSSBorderImageWidth.h
@@ -30,8 +30,8 @@ namespace WebCore {
 namespace CSS {
 
 struct BorderImageWidthValue {
-    using LengthPercentage = CSS::LengthPercentage<CSS::Nonnegative, float>;
-    using Number = CSS::Number<CSS::Nonnegative, float>;
+    using LengthPercentage = CSS::LengthPercentage<NonnegativeUnzoomed, float>;
+    using Number = CSS::Number<Nonnegative, float>;
 
     BorderImageWidthValue(Keyword::Auto value) : m_value { value } { }
     BorderImageWidthValue(LengthPercentage&& value) : m_value { WTF::move(value) } { }

--- a/Source/WebCore/css/values/borders/CSSBorderRadius.cpp
+++ b/Source/WebCore/css/values/borders/CSSBorderRadius.cpp
@@ -31,7 +31,7 @@
 namespace WebCore {
 namespace CSS {
 
-static bool hasDefaultValueForAxis(const SpaceSeparatedArray<LengthPercentage<NonnegativeUnzoomed>, 4>& values)
+static bool hasDefaultValueForAxis(const BorderRadius::Axis& values)
 {
     return values.value[3] == values.value[1]
         && values.value[2] == values.value[0]
@@ -41,14 +41,15 @@ static bool hasDefaultValueForAxis(const SpaceSeparatedArray<LengthPercentage<No
 
 bool hasDefaultValue(const BorderRadius& borderRadius)
 {
-    return hasDefaultValueForAxis(borderRadius.horizontal) && hasDefaultValueForAxis(borderRadius.vertical);
+    return hasDefaultValueForAxis(borderRadius.horizontal)
+        && hasDefaultValueForAxis(borderRadius.vertical);
 }
 
-static std::pair<SpaceSeparatedVector<LengthPercentage<NonnegativeUnzoomed>, 4>, bool> gatherSerializableRadiiForAxis(const SpaceSeparatedArray<LengthPercentage<NonnegativeUnzoomed>, 4>& values)
+static std::pair<SpaceSeparatedVector<BorderRadius::LengthPercentage, 4>, bool> gatherSerializableRadiiForAxis(const BorderRadius::Axis& values)
 {
     bool isDefaultValue = false;
 
-    SpaceSeparatedVector<LengthPercentage<NonnegativeUnzoomed>, 4>::Container result;
+    SpaceSeparatedVector<BorderRadius::LengthPercentage, 4>::Container result;
     result.append(values.value[0]);
 
     if (values.value[3] != values.value[1]) {

--- a/Source/WebCore/css/values/borders/CSSBorderRadius.h
+++ b/Source/WebCore/css/values/borders/CSSBorderRadius.h
@@ -32,8 +32,9 @@ namespace CSS {
 // <'border-radius'> = <length-percentage [0,∞]>{1,4} [ / <length-percentage [0,∞]>{1,4} ]?
 // https://drafts.csswg.org/css-backgrounds-3/#propdef-border-radius
 struct BorderRadius {
-    using Axis = SpaceSeparatedArray<LengthPercentage<NonnegativeUnzoomed>, 4>;
-    using Corner = MinimallySerializingSpaceSeparatedSize<LengthPercentage<NonnegativeUnzoomed>>;
+    using LengthPercentage = CSS::LengthPercentage<NonnegativeUnzoomed>;
+    using Axis = SpaceSeparatedArray<LengthPercentage, 4>;
+    using Corner = MinimallySerializingSpaceSeparatedSize<LengthPercentage>;
 
     static BorderRadius defaultValue();
 

--- a/Source/WebCore/css/values/filter-effects/CSSBlurFunction.h
+++ b/Source/WebCore/css/values/filter-effects/CSSBlurFunction.h
@@ -32,7 +32,7 @@ namespace CSS {
 // blur() = blur( <length [0,∞]>? )
 // https://drafts.fxtf.org/filter-effects/#funcdef-filter-blur
 struct Blur {
-    using Parameter = Length<Nonnegative>;
+    using Parameter = Length<NonnegativeUnzoomed>;
 
     Markable<Parameter> value;
 

--- a/Source/WebCore/css/values/masking/CSSClip.h
+++ b/Source/WebCore/css/values/masking/CSSClip.h
@@ -30,7 +30,7 @@ namespace WebCore {
 namespace CSS {
 
 // <clip-edge> = <length> | auto
-struct ClipEdge : ValueOrKeyword<Length<>, Keyword::Auto> {
+struct ClipEdge : ValueOrKeyword<Length<CSS::AllUnzoomed>, Keyword::Auto> {
     using Base::Base;
     using Length = typename Base::Value;
 

--- a/Source/WebCore/css/values/masking/CSSMaskBorderOutset.h
+++ b/Source/WebCore/css/values/masking/CSSMaskBorderOutset.h
@@ -32,7 +32,7 @@ namespace CSS {
 
 // <mask-border-outset-value> = <length [0,∞]> | <number [0,∞]>
 struct MaskBorderOutsetValue {
-    using Length = CSS::Length<CSS::Nonnegative, float>;
+    using Length = CSS::Length<CSS::NonnegativeUnzoomed, float>;
     using Number = CSS::Number<CSS::Nonnegative, float>;
 
     MaskBorderOutsetValue(Length length) : m_value { length } { }

--- a/Source/WebCore/css/values/masking/CSSMaskBorderWidth.h
+++ b/Source/WebCore/css/values/masking/CSSMaskBorderWidth.h
@@ -32,7 +32,7 @@ namespace CSS {
 
 // <mask-border-width-value> = <length-percentage [0,∞]> | <number [0,∞]> | auto
 struct MaskBorderWidthValue {
-    using LengthPercentage = CSS::LengthPercentage<CSS::Nonnegative, float>;
+    using LengthPercentage = CSS::LengthPercentage<CSS::NonnegativeUnzoomed, float>;
     using Number = CSS::Number<CSS::Nonnegative, float>;
 
     MaskBorderWidthValue(Keyword::Auto value) : m_value { value } { }

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -3439,9 +3439,10 @@ void Document::pageSizeAndMarginsInPixels(int pageIndex, IntSize& pageSize, int&
             return pageSize;
         },
         [&](const Style::PageSize::Lengths& lengths) -> IntSize {
+            // FIXME: Document why <length> `page-size` ignores `zoom`.
             return {
-                static_cast<int>(lengths.width().resolveZoom(Style::ZoomNeeded { })),
-                static_cast<int>(lengths.height().resolveZoom(Style::ZoomNeeded { })),
+                Style::evaluate<int>(lengths.width(), Style::ZoomFactor::none()),
+                Style::evaluate<int>(lengths.height(), Style::ZoomFactor::none()),
             };
         }
     );

--- a/Source/WebCore/layout/formattingContexts/flex/FlexFormattingUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/flex/FlexFormattingUtils.cpp
@@ -95,7 +95,7 @@ LayoutUnit FlexFormattingUtils::mainAxisGapValue(const ElementBox& flexContainer
     auto flexDirection = flexContainer.style().flexDirection();
     auto isMainAxisInlineAxis = flexDirection == FlexDirection::Row || flexDirection == FlexDirection::RowReverse;
     auto& gap = isMainAxisInlineAxis ? flexContainer.style().columnGap() : flexContainer.style().rowGap();
-    return Style::evaluateMinimum<LayoutUnit>(gap, flexContainerContentBoxWidth, Style::ZoomNeeded { });
+    return Style::evaluateMinimum<LayoutUnit>(gap, flexContainerContentBoxWidth, flexContainer.style().usedZoomForLength());
 }
 
 LayoutUnit FlexFormattingUtils::crossAxisGapValue(const ElementBox& flexContainer, LayoutUnit flexContainerContentBoxHeight)
@@ -104,7 +104,7 @@ LayoutUnit FlexFormattingUtils::crossAxisGapValue(const ElementBox& flexContaine
     auto flexDirection = flexContainer.style().flexDirection();
     auto isMainAxisInlineAxis = flexDirection == FlexDirection::Row || flexDirection == FlexDirection::RowReverse;
     auto& gap = isMainAxisInlineAxis ? flexContainer.style().rowGap() : flexContainer.style().columnGap();
-    return Style::evaluateMinimum<LayoutUnit>(gap, flexContainerContentBoxHeight, Style::ZoomNeeded { });
+    return Style::evaluateMinimum<LayoutUnit>(gap, flexContainerContentBoxHeight, flexContainer.style().usedZoomForLength());
 }
 
 // flex container  direction  flex item    main axis size

--- a/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
@@ -194,7 +194,7 @@ UsedTrackSizes GridFormattingContext::layout(GridLayoutConstraints layoutConstra
     auto usedJustifyContent = gridStyle->justifyContent().resolve();
     auto usedAlignContent = gridStyle->alignContent().resolve();
 
-    GridLayoutState layoutState { layoutConstraints, gridDefinition, usedJustifyContent, usedAlignContent, usedGapValue(gridStyle->columnGap()), usedGapValue(gridStyle->rowGap()) };
+    GridLayoutState layoutState { layoutConstraints, gridDefinition, usedJustifyContent, usedAlignContent, usedGapValue(gridStyle->columnGap(), gridStyle), usedGapValue(gridStyle->rowGap(), gridStyle) };
 
     auto [ usedTrackSizes, gridItemRects ] = GridLayout { *this }.layout(unplacedGridItems, layoutState);
 
@@ -289,8 +289,8 @@ GridFormattingContext::IntrinsicWidths GridFormattingContext::computeIntrinsicWi
     auto usedJustifyContent = gridStyle->justifyContent().resolve();
     auto usedAlignContent = gridStyle->alignContent().resolve();
 
-    auto usedColumnGap = usedGapValue(gridStyle->columnGap());
-    auto usedRowGap = usedGapValue(gridStyle->rowGap());
+    auto usedColumnGap = usedGapValue(gridStyle->columnGap(), gridStyle);
+    auto usedRowGap = usedGapValue(gridStyle->rowGap(), gridStyle);
 
     // Compute min-content width by running the full grid sizing algorithm with MinContent scenario
     GridLayoutConstraints minContentConstraints {

--- a/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.h
@@ -101,14 +101,14 @@ public:
     // FIXME: This is only here because the integration code needs to know the
     // row gap to update RenderGrid. We should figure out a way to do that and remove
     // this from the public API.
-    static LayoutUnit usedGapValue(const Style::GapGutter& gap)
+    static LayoutUnit usedGapValue(const Style::GapGutter& gap, const Style::ComputedStyle& style)
     {
         if (gap.isNormal())
             return { };
 
         // Only handle fixed length gaps for now
         if (auto fixedGap = gap.tryFixed())
-            return Style::evaluate<LayoutUnit>(*fixedGap, 0_lu, Style::ZoomNeeded { });
+            return Style::evaluate<LayoutUnit>(*fixedGap, 0_lu, style.usedZoomForLength());
 
         ASSERT_NOT_REACHED();
         return { };

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLevelBoxInlines.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLevelBoxInlines.h
@@ -35,14 +35,14 @@
 namespace WebCore {
 namespace Layout {
 
-template<typename PreferredLineHeightFunctor> InlineLevelBox::VerticalAlignment toInlineBoxLevelVerticalAlign(const Style::VerticalAlign& verticalAlign, NOESCAPE PreferredLineHeightFunctor&& preferredLineHeightFunctor)
+template<typename PreferredLineHeightFunctor> InlineLevelBox::VerticalAlignment toInlineBoxLevelVerticalAlign(const Style::ComputedStyle& style, NOESCAPE PreferredLineHeightFunctor&& preferredLineHeightFunctor)
 {
-    return WTF::switchOn(verticalAlign,
+    return WTF::switchOn(style.verticalAlign(),
         [](CSS::SpecificKeyword auto const& keyword) -> InlineLevelBox::VerticalAlignment {
             return keyword;
         },
         [&](const Style::VerticalAlign::LengthPercentage& value) -> InlineLevelBox::VerticalAlignment {
-            return Style::evaluate<InlineLayoutUnit>(value, std::forward<PreferredLineHeightFunctor>(preferredLineHeightFunctor), Style::ZoomNeeded { });
+            return Style::evaluate<InlineLayoutUnit>(value, std::forward<PreferredLineHeightFunctor>(preferredLineHeightFunctor), style.usedZoomForLength());
         }
     );
 }
@@ -54,7 +54,7 @@ inline InlineLevelBox::InlineLevelBox(const Box& layoutBox, const WebCore::Style
     , m_isFirstWithinLayoutBox(positionWithinLayoutBox.contains(PositionWithinLayoutBox::First))
     , m_isLastWithinLayoutBox(positionWithinLayoutBox.contains(PositionWithinLayoutBox::Last))
     , m_type(type)
-    , m_style({ style.fontCascade().metricsOfPrimaryFont(), style.lineHeight(), style.textBoxTrim(), style.textBoxEdge(), style.lineFitEdge(), style.usedZoomForLength(), style.lineBoxContain(), InlineLayoutUnit(style.fontCascade().fontDescription().computedSize()), toInlineBoxLevelVerticalAlign(style.verticalAlign(), [this] { return preferredLineHeight(); }) })
+    , m_style({ style.fontCascade().metricsOfPrimaryFont(), style.lineHeight(), style.textBoxTrim(), style.textBoxEdge(), style.lineFitEdge(), style.usedZoomForLength(), style.lineBoxContain(), InlineLayoutUnit(style.fontCascade().fontDescription().computedSize()), toInlineBoxLevelVerticalAlign(style, [this] { return preferredLineHeight(); }) })
 {
 }
 

--- a/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
@@ -89,7 +89,7 @@ InlineLayoutUnit TextUtil::width(const InlineTextBox& inlineTextBox, const FontC
         auto directionalOverride = isOverride(style->unicodeBidi());
         auto run = WebCore::TextRun { StringView(text).substring(from, to - from), contentLogicalLeft, { }, ExpansionBehavior::defaultBehavior(), directionalOverride ? style->writingMode().bidiDirection() : TextDirection::LTR, directionalOverride };
         if (!style->collapseWhiteSpace() && !style->tabSize().isZero())
-            run.setTabSize(true, Style::toPlatform(style->tabSize()));
+            run.setTabSize(true, Style::toPlatform(style->tabSize(), style->usedZoomForLength()));
         // FIXME: consider moving this to TextRun ctor
         run.setTextSpacingState(spacingState);
         width = fontCascade.width(run, { }, glyphOverflow);

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.cpp
@@ -180,7 +180,7 @@ void GridLayout::updateFormattingContextRootRenderer(const Layout::GridLayoutCon
 
     if (layoutConstraints.blockAxis.scenario() != Layout::AxisConstraint::FreeSpaceScenario::Definite) {
         auto& rowSizes = usedTrackSizes.rowSizes;
-        auto usedRowGutter = Layout::GridFormattingContext::usedGapValue(renderGrid->style().rowGap());
+        auto usedRowGutter = Layout::GridFormattingContext::usedGapValue(renderGrid->style().rowGap(), renderGrid->style());
         auto blockContentSize = std::reduce(rowSizes.begin(), rowSizes.end()) + Layout::GridLayoutUtils::totalGuttersSize(rowSizes.size(), usedRowGutter);
         renderGrid->setBorderBoxHeight(blockContentSize + renderGrid->borderAndPaddingLogicalHeight());
     } else
@@ -243,7 +243,7 @@ void GridLayout::populateGridPositionsForOutOfFlowLayout(const Layout::UsedTrack
     auto populate = [&](Style::GridTrackSizingDirection direction) {
         bool isColumns = direction == Style::GridTrackSizingDirection::Columns;
         auto& trackSizes = isColumns ? usedTrackSizes.columnSizes : usedTrackSizes.rowSizes;
-        auto gap = Layout::GridFormattingContext::usedGapValue(isColumns ? renderGrid->style().columnGap() : renderGrid->style().rowGap());
+        auto gap = Layout::GridFormattingContext::usedGapValue(isColumns ? renderGrid->style().columnGap() : renderGrid->style().rowGap(), renderGrid->style());
         auto borderAndPadding = isColumns ? renderGrid->borderAndPaddingStart() : renderGrid->borderAndPaddingBefore();
         auto numberOfTracks = trackSizes.size();
         bool hasMultipleTracks = numberOfTracks > 1;

--- a/Source/WebCore/layout/integration/inline/InlineIteratorBoxModernPathInlines.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorBoxModernPathInlines.h
@@ -61,7 +61,7 @@ inline TextRun BoxModernPath::textRun(TextRunMode mode) const
     };
     auto characterScanForCodePath = isText() && !renderText().canUseSimpleFontCodePath();
     auto textRun = TextRun { mode == TextRunMode::Editing ? originalText() : box().text().renderedContent(), logicalLeft(), expansion.horizontalExpansion, expansion.behavior, direction(), style->rtlOrdering() == Order::Visual, characterScanForCodePath };
-    textRun.setTabSize(!style->collapseWhiteSpace(), Style::toPlatform(style->tabSize()));
+    textRun.setTabSize(!style->collapseWhiteSpace(), Style::toPlatform(style->tabSize(), style->usedZoomForLength()));
     return textRun;
 }
 

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -705,7 +705,7 @@ void LocalFrameView::applyPaginationToViewport()
         if (!columnGap.isNormal()) {
             CheckedPtr renderBox = dynamicDowncast<RenderBox>(documentOrBodyRenderer.get());
             if (CheckedPtr containerForPaginationGap = renderBox ? renderBox : documentOrBodyRenderer->containingBlock())
-                pagination.gap = Style::evaluate<LayoutUnit>(columnGap, containerForPaginationGap->contentBoxLogicalWidth(), Style::ZoomNeeded { }).toUnsigned();
+                pagination.gap = Style::evaluate<LayoutUnit>(columnGap, containerForPaginationGap->contentBoxLogicalWidth(), documentOrBodyRenderer->style().usedZoomForLength()).toUnsigned();
         }
     }
     setPagination(pagination);

--- a/Source/WebCore/page/PrintContext.cpp
+++ b/Source/WebCore/page/PrintContext.cpp
@@ -38,6 +38,7 @@
 #include "Settings.h"
 #include "StyleComputedStyle+GettersInlines.h"
 #include "StyleDocumentScope.h"
+#include "StylePrimitiveNumericTypes+Evaluation.h"
 #include "StyleResolver.h"
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
@@ -429,7 +430,11 @@ String PrintContext::pageProperty(LocalFrame* frame, const String& propertyName,
                 return "portrait"_s;
             },
             [&](const Style::PageSize::Lengths& lengths) {
-                return makeString(lengths.width().resolveZoom(Style::ZoomNeeded { }), ' ', lengths.height().resolveZoom(Style::ZoomNeeded { }));
+                return makeString(
+                    Style::evaluate<float>(lengths.width(), Style::ZoomFactor::none()),
+                    ' ',
+                    Style::evaluate<float>(lengths.height(), Style::ZoomFactor::none())
+                );
             }
         );
     }

--- a/Source/WebCore/rendering/BackgroundPainter.cpp
+++ b/Source/WebCore/rendering/BackgroundPainter.cpp
@@ -797,7 +797,7 @@ template<typename Layer> BackgroundImageGeometry BackgroundPainter::calculateFil
     return BackgroundImageGeometry(destinationRect, tileSizeWithoutPixelSnapping, tileSize, phase, spaceSize, fixedAttachment);
 }
 
-template<typename Layer> LayoutSize BackgroundPainter::calculateFillTileSize(const RenderBoxModelObject& renderer, const Layer& fillLayer, Style::ZoomFactor, const LayoutSize& positioningAreaSize)
+template<typename Layer> LayoutSize BackgroundPainter::calculateFillTileSize(const RenderBoxModelObject& renderer, const Layer& fillLayer, Style::ZoomFactor zoom, const LayoutSize& positioningAreaSize)
 {
     RefPtr image = fillLayer.image().tryStyleImage();
     auto devicePixelSize = LayoutUnit { 1.0 / protect(renderer)->document().deviceScaleFactor() };
@@ -838,17 +838,17 @@ template<typename Layer> LayoutSize BackgroundPainter::calculateFillTileSize(con
             auto& layerHeight = size.height();
 
             if (auto fixed = layerWidth.tryFixed())
-                tileSize.setWidth(Style::evaluate<LayoutUnit>(*fixed, Style::ZoomNeeded { }));
+                tileSize.setWidth(Style::evaluate<LayoutUnit>(*fixed, zoom));
             else if (layerWidth.isPercentOrCalculated()) {
-                auto resolvedWidth = Style::evaluate<LayoutUnit>(layerWidth, positioningAreaSize.width(), Style::ZoomNeeded { });
+                auto resolvedWidth = Style::evaluate<LayoutUnit>(layerWidth, positioningAreaSize.width(), zoom);
                 // Non-zero resolved value should always produce some content.
                 tileSize.setWidth(!resolvedWidth ? resolvedWidth : std::max(devicePixelSize, resolvedWidth));
             }
 
             if (auto fixed = layerHeight.tryFixed())
-                tileSize.setHeight(Style::evaluate<LayoutUnit>(*fixed, Style::ZoomNeeded { }));
+                tileSize.setHeight(Style::evaluate<LayoutUnit>(*fixed, zoom));
             else if (layerHeight.isPercentOrCalculated()) {
-                auto resolvedHeight = Style::evaluate<LayoutUnit>(layerHeight, positioningAreaSize.height(), Style::ZoomNeeded { });
+                auto resolvedHeight = Style::evaluate<LayoutUnit>(layerHeight, positioningAreaSize.height(), zoom);
                 // Non-zero resolved value should always produce some content.
                 tileSize.setHeight(!resolvedHeight ? resolvedHeight : std::max(devicePixelSize, resolvedHeight));
             }

--- a/Source/WebCore/rendering/LegacyInlineTextBox.cpp
+++ b/Source/WebCore/rendering/LegacyInlineTextBox.cpp
@@ -239,7 +239,7 @@ TextRun LegacyInlineTextBox::createTextRun() const
 {
     CheckedRef style = lineStyle();
     TextRun textRun { text(), textPos(), 0, ExpansionBehavior::forbidAll(), direction(), style->rtlOrdering() == Order::Visual, !renderer().canUseSimpleFontCodePath() };
-    textRun.setTabSize(!style->collapseWhiteSpace(), Style::toPlatform(style->tabSize()));
+    textRun.setTabSize(!style->collapseWhiteSpace(), Style::toPlatform(style->tabSize(), style->usedZoomForLength()));
     return textRun;
 }
 

--- a/Source/WebCore/rendering/NinePieceImagePainter.cpp
+++ b/Source/WebCore/rendering/NinePieceImagePainter.cpp
@@ -75,11 +75,11 @@ static bool NODELETE isVerticalPiece(ImagePiece piece)
 }
 
 template<typename WidthValue>
-static LayoutUnit computeSlice(const WidthValue& length, LayoutUnit width, LayoutUnit slice, LayoutUnit extent, const Style::ZoomFactor&)
+static LayoutUnit computeSlice(const WidthValue& length, LayoutUnit width, LayoutUnit slice, LayoutUnit extent, const Style::ZoomFactor& zoom)
 {
     return WTF::switchOn(length,
         [&](const typename WidthValue::LengthPercentage& value) {
-            return Style::evaluate<LayoutUnit>(value, extent, Style::ZoomNeeded { });
+            return Style::evaluate<LayoutUnit>(value, extent, zoom);
         },
         [&](const typename WidthValue::Number& value) {
             return LayoutUnit { value.value * width };

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -343,7 +343,7 @@ void RenderBlockFlow::adjustIntrinsicLogicalWidthsForColumns(LayoutUnit& minLogi
         LayoutUnit colGap = columnGap();
         LayoutUnit gapExtra = (columnCount - 1) * colGap;
         if (auto columnWidthLength = style().columnWidth().tryLength()) {
-            columnWidth = Style::evaluate<LayoutUnit>(*columnWidthLength, Style::ZoomNeeded { });
+            columnWidth = Style::evaluate<LayoutUnit>(*columnWidthLength, style().usedZoomForLength());
             minLogicalWidth = std::min(minLogicalWidth, columnWidth);
         } else
             minLogicalWidth = minLogicalWidth * columnCount + gapExtra;
@@ -413,7 +413,7 @@ LayoutUnit RenderBlockFlow::columnGap() const
 {
     if (style().columnGap().isNormal())
         return LayoutUnit(style().fontDescription().computedSize()); // "1em" is recommended as the normal gap setting. Matches <p> margins.
-    return Style::evaluate<LayoutUnit>(style().columnGap(), contentBoxLogicalWidth(), Style::ZoomNeeded { });
+    return Style::evaluate<LayoutUnit>(style().columnGap(), contentBoxLogicalWidth(), style().usedZoomForLength());
 }
 
 void RenderBlockFlow::computeColumnCountAndWidth()
@@ -431,7 +431,7 @@ void RenderBlockFlow::computeColumnCountAndWidth()
 
     LayoutUnit availWidth = desiredColumnWidth;
     LayoutUnit colGap = columnGap();
-    LayoutUnit colWidth = std::max(1_lu, Style::evaluate<LayoutUnit>(style().columnWidth().tryLength().value_or(0_css_px), Style::ZoomNeeded { }));
+    LayoutUnit colWidth = std::max(1_lu, Style::evaluate<LayoutUnit>(style().columnWidth().tryLength().value_or(0_css_px), style().usedZoomForLength()));
     unsigned colCount = std::max<unsigned>(1, style().columnCount().tryValue().value_or(1).value);
 
     if (style().columnWidth().isAuto() && !style().columnCount().isAuto()) {
@@ -1226,7 +1226,7 @@ void RenderBlockFlow::layoutBlockChild(RenderBox& child, MarginInfo& marginInfo,
 
     auto& childStyle = child.style();
     if (auto blockStepSizeForChild = childStyle.blockStepSize().tryLength(); blockStepSizeForChild && BlockStepSizing::childHasSupportedStyle(childStyle))
-        performBlockStepSizing(child, LayoutUnit(blockStepSizeForChild->resolveZoom(Style::ZoomNeeded { })));
+        performBlockStepSizing(child, Style::evaluate<LayoutUnit>(*blockStepSizeForChild, childStyle.usedZoomForLength()));
 
     // Cache if we are at the top of the block right now.
     bool atBeforeSideOfBlock = marginInfo.atBeforeSideOfBlock();

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -2362,7 +2362,7 @@ LayoutRect RenderBox::clipRect(const LayoutPoint& location) const
         },
         [&](const Style::ClipRect& rect) {
             if (auto clipLeft = rect.value->left().tryLength()) {
-                auto c = LayoutUnit { clipLeft->resolveZoom(Style::ZoomNeeded { }) };
+                auto c = LayoutUnit { clipLeft->resolveZoom(style().usedZoomForLength()) };
                 clipRect.move(c, 0_lu);
                 clipRect.contract(c, 0_lu);
             }
@@ -2371,16 +2371,16 @@ LayoutRect RenderBox::clipRect(const LayoutPoint& location) const
             // from the left and top edges. Therefore it's better to avoid constraining to smaller widths and heights.
 
             if (auto clipRight = rect.value->right().tryLength())
-                clipRect.contract(borderBoxWidth() - LayoutUnit { clipRight->resolveZoom(Style::ZoomNeeded { }) }, 0_lu);
+                clipRect.contract(borderBoxWidth() - LayoutUnit { clipRight->resolveZoom(style().usedZoomForLength()) }, 0_lu);
 
             if (auto clipTop = rect.value->top().tryLength()) {
-                auto c = LayoutUnit { clipTop->resolveZoom(Style::ZoomNeeded { }) };
+                auto c = LayoutUnit { clipTop->resolveZoom(style().usedZoomForLength()) };
                 clipRect.move(0_lu, c);
                 clipRect.contract(0_lu, c);
             }
 
             if (auto clipBottom = rect.value->bottom().tryLength())
-                clipRect.contract(0_lu, borderBoxHeight() - LayoutUnit { clipBottom->resolveZoom(Style::ZoomNeeded { }) });
+                clipRect.contract(0_lu, borderBoxHeight() - LayoutUnit { clipBottom->resolveZoom(style().usedZoomForLength()) });
 
             return clipRect;
         }

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -3164,7 +3164,7 @@ LayoutUnit RenderFlexibleBox::computeGap(RenderFlexibleBox::GapType gapType) con
         return { };
 
     auto availableSize = usesRowGap ? availableLogicalHeightForPercentageComputation().value_or(0_lu) : contentBoxLogicalWidth();
-    return Style::evaluateMinimum<LayoutUnit>(gap, availableSize, Style::ZoomNeeded { });
+    return Style::evaluateMinimum<LayoutUnit>(gap, availableSize, style().usedZoomForLength());
 }
 
 bool RenderFlexibleBox::layoutUsingFlexFormattingContext()

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -729,7 +729,7 @@ LayoutUnit RenderGrid::gridGap(Style::GridTrackSizingDirection direction, std::o
         return downcast<RenderGrid>(parent())->gridGap(parentDirection);
     }
 
-    return Style::evaluate<LayoutUnit>(gap, availableSize.value_or(0_lu), Style::ZoomNeeded { });
+    return Style::evaluate<LayoutUnit>(gap, availableSize.value_or(0_lu), style().usedZoomForLength());
 }
 
 LayoutUnit RenderGrid::gridGap(Style::GridTrackSizingDirection direction) const

--- a/Source/WebCore/rendering/RenderMarquee.cpp
+++ b/Source/WebCore/rendering/RenderMarquee.cpp
@@ -305,7 +305,7 @@ void RenderMarquee::timerFired()
         }
         bool positive = range > 0;
         int clientSize = (isHorizontal() ? roundToInt(renderBox->paddingBoxWidth()) : roundToInt(renderBox->paddingBoxHeight()));
-        int increment = std::abs(Style::evaluate<float>(layer->renderer().style().marqueeIncrement(), clientSize, Style::ZoomNeeded { }));
+        int increment = std::abs(Style::evaluate<float>(layer->renderer().style().marqueeIncrement(), clientSize, layer->renderer().style().usedZoomForLength()));
         int currentPos = (isHorizontal() ? scrollableArea->scrollOffset().x() : scrollableArea->scrollOffset().y());
         newPos =  currentPos + (addIncrement ? increment : -increment);
         if (positive)

--- a/Source/WebCore/rendering/RenderMultiColumnSet.cpp
+++ b/Source/WebCore/rendering/RenderMultiColumnSet.cpp
@@ -447,7 +447,7 @@ LayoutUnit RenderMultiColumnSet::columnGap() const
     auto& parentBlockGap = parentBlock.style().columnGap();
     if (parentBlockGap.isNormal())
         return LayoutUnit(parentBlock.style().fontDescription().computedSize()); // "1em" is recommended as the normal gap setting. Matches <p> margins.
-    return Style::evaluate<LayoutUnit>(parentBlockGap, parentBlock.contentBoxLogicalWidth(), Style::ZoomNeeded { });
+    return Style::evaluate<LayoutUnit>(parentBlockGap, parentBlock.contentBoxLogicalWidth(), parentBlock.style().usedZoomForLength());
 }
 
 unsigned RenderMultiColumnSet::columnCount() const

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -1037,7 +1037,7 @@ ALWAYS_INLINE float RenderText::widthFromCache(const FontCascade& fontCascade, u
 
     TextRun run = RenderBlock::constructTextRun(*this, start, length, style);
     run.setCharacterScanForCodePath(!canUseSimpleFontCodePath());
-    run.setTabSize(!style.collapseWhiteSpace(), Style::toPlatform(style.tabSize()));
+    run.setTabSize(!style.collapseWhiteSpace(), Style::toPlatform(style.tabSize(), style.usedZoomForLength()));
     run.setXPos(xPos);
     return fontCascade.width(run, fallbackFonts, glyphOverflow);
 }
@@ -1518,7 +1518,7 @@ void RenderText::computeMinMaxIntrinsicLogicalWidths(float leadingWidth, SingleT
                 currMaxWidth = 0;
             } else {
                 TextRun run = RenderBlock::constructTextRun(*this, i, 1, style);
-                run.setTabSize(!style.collapseWhiteSpace(), Style::toPlatform(style.tabSize()));
+                run.setTabSize(!style.collapseWhiteSpace(), Style::toPlatform(style.tabSize(), style.usedZoomForLength()));
                 run.setXPos(leadingWidth + currMaxWidth);
 
                 currMaxWidth += font.width(run, &fallbackFonts);
@@ -2011,7 +2011,7 @@ float RenderText::width(unsigned from, unsigned length, const FontCascade& fontC
     } else {
         TextRun run = RenderBlock::constructTextRun(*this, from, length, style);
         run.setCharacterScanForCodePath(!canUseSimpleFontCodePath());
-        run.setTabSize(!style.collapseWhiteSpace(), Style::toPlatform(style.tabSize()));
+        run.setTabSize(!style.collapseWhiteSpace(), Style::toPlatform(style.tabSize(), style.usedZoomForLength()));
         run.setXPos(xPos);
 
         width = fontCascade.width(run, fallbackFonts, glyphOverflow);

--- a/Source/WebCore/rendering/svg/RenderSVGEllipse.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGEllipse.cpp
@@ -84,12 +84,13 @@ void RenderSVGEllipse::updateShapeFromElement()
 void RenderSVGEllipse::calculateRadiiAndCenter()
 {
     Ref graphicsElement = this->graphicsElement();
+    auto usedZoom = style().usedZoomForLength();
     SVGLengthContext lengthContext(graphicsElement.ptr());
     m_center = FloatPoint(
-        lengthContext.valueForLength(style().cx(), Style::ZoomNeeded { }, SVGLengthMode::Width),
-        lengthContext.valueForLength(style().cy(), Style::ZoomNeeded { }, SVGLengthMode::Height));
+        lengthContext.valueForLength(style().cx(), usedZoom, SVGLengthMode::Width),
+        lengthContext.valueForLength(style().cy(), usedZoom, SVGLengthMode::Height));
     if (is<SVGCircleElement>(graphicsElement)) {
-        float radius = lengthContext.valueForLength(style().r(), Style::ZoomNeeded { });
+        float radius = lengthContext.valueForLength(style().r(), usedZoom);
         m_radii = FloatSize(radius, radius);
         return;
     }
@@ -99,8 +100,8 @@ void RenderSVGEllipse::calculateRadiiAndCenter()
     auto& rx = style().rx();
     auto& ry = style().ry();
     m_radii = FloatSize(
-        lengthContext.valueForLength(rx.isAuto() ? ry : rx, Style::ZoomNeeded { }, SVGLengthMode::Width),
-        lengthContext.valueForLength(ry.isAuto() ? rx : ry, Style::ZoomNeeded { }, SVGLengthMode::Height));
+        lengthContext.valueForLength(rx.isAuto() ? ry : rx, usedZoom, SVGLengthMode::Width),
+        lengthContext.valueForLength(ry.isAuto() ? rx : ry, usedZoom, SVGLengthMode::Height));
     if (rx.isAuto())
         m_radii.setWidth(m_radii.height());
     else if (ry.isAuto())

--- a/Source/WebCore/rendering/svg/RenderSVGForeignObject.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGForeignObject.cpp
@@ -101,8 +101,8 @@ void RenderSVGForeignObject::layout()
     auto usedZoom = usedStyle->usedZoomForLength();
 
     // Cache viewport boundaries
-    auto x = lengthContext.valueForLength(usedStyle->x(), Style::ZoomNeeded { }, SVGLengthMode::Width);
-    auto y = lengthContext.valueForLength(usedStyle->y(), Style::ZoomNeeded { }, SVGLengthMode::Height);
+    auto x = lengthContext.valueForLength(usedStyle->x(), usedZoom, SVGLengthMode::Width);
+    auto y = lengthContext.valueForLength(usedStyle->y(), usedZoom, SVGLengthMode::Height);
     auto width = std::max(0.0f, lengthContext.valueForLength(usedStyle->width(), usedZoom, SVGLengthMode::Width));
     auto height = std::max(0.0f, lengthContext.valueForLength(usedStyle->height(), usedZoom, SVGLengthMode::Height));
     m_viewport = { x, y, width, height };

--- a/Source/WebCore/rendering/svg/RenderSVGRect.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGRect.cpp
@@ -72,8 +72,8 @@ void RenderSVGRect::updateShapeFromElement()
     if (boundingBoxSize.isEmpty())
         return;
 
-    if (lengthContext.valueForLength(style->rx(), Style::ZoomNeeded { }, SVGLengthMode::Width) > 0
-        || lengthContext.valueForLength(style->ry(), Style::ZoomNeeded { }, SVGLengthMode::Height) > 0)
+    if (lengthContext.valueForLength(style->rx(), usedZoom, SVGLengthMode::Width) > 0
+        || lengthContext.valueForLength(style->ry(), usedZoom, SVGLengthMode::Height) > 0)
         m_shapeType = ShapeType::RoundedRectangle;
     else
         m_shapeType = ShapeType::Rectangle;
@@ -84,8 +84,8 @@ void RenderSVGRect::updateShapeFromElement()
         return;
     }
 
-    m_fillBoundingBox = FloatRect(FloatPoint(lengthContext.valueForLength(style->x(), Style::ZoomNeeded { }, SVGLengthMode::Width),
-        lengthContext.valueForLength(style->y(), Style::ZoomNeeded { }, SVGLengthMode::Height)), boundingBoxSize);
+    m_fillBoundingBox = FloatRect(FloatPoint(lengthContext.valueForLength(style->x(), usedZoom, SVGLengthMode::Width),
+        lengthContext.valueForLength(style->y(), usedZoom, SVGLengthMode::Height)), boundingBoxSize);
 
     auto strokeBoundingBox = m_fillBoundingBox;
     if (!style->stroke().isNone())

--- a/Source/WebCore/rendering/svg/SVGPathFromElement.cpp
+++ b/Source/WebCore/rendering/svg/SVGPathFromElement.cpp
@@ -51,11 +51,12 @@ static Path pathFromCircleElement(const SVGCircleElement& element)
 
     Path path;
     auto& style = renderer->style();
+    auto usedZoom = style.usedZoomForLength();
     SVGLengthContext lengthContext(&element);
-    float r = lengthContext.valueForLength(style.r(), Style::ZoomNeeded { });
+    float r = lengthContext.valueForLength(style.r(), usedZoom);
     if (r > 0) {
-        float cx = lengthContext.valueForLength(style.cx(), Style::ZoomNeeded { }, SVGLengthMode::Width);
-        float cy = lengthContext.valueForLength(style.cy(), Style::ZoomNeeded { }, SVGLengthMode::Height);
+        float cx = lengthContext.valueForLength(style.cx(), usedZoom, SVGLengthMode::Width);
+        float cy = lengthContext.valueForLength(style.cy(), usedZoom, SVGLengthMode::Height);
         path.addEllipseInRect(FloatRect(cx - r, cy - r, r * 2, r * 2));
     }
     return path;
@@ -77,22 +78,24 @@ static Path pathFromEllipseElement(const SVGEllipseElement& element)
     if (rxStyle.isAuto() && ryStyle.isAuto())
         return { };
 
+    auto usedZoom = style.usedZoomForLength();
+
     float rx, ry;
     if (rxStyle.isAuto())
-        rx = ry = lengthContext.valueForLength(ryStyle, Style::ZoomNeeded { }, SVGLengthMode::Height);
+        rx = ry = lengthContext.valueForLength(ryStyle, usedZoom, SVGLengthMode::Height);
     else if (ryStyle.isAuto())
-        ry = rx = lengthContext.valueForLength(rxStyle, Style::ZoomNeeded { }, SVGLengthMode::Width);
+        ry = rx = lengthContext.valueForLength(rxStyle, usedZoom, SVGLengthMode::Width);
     else {
-        rx = lengthContext.valueForLength(rxStyle, Style::ZoomNeeded { }, SVGLengthMode::Width);
-        ry = lengthContext.valueForLength(ryStyle, Style::ZoomNeeded { }, SVGLengthMode::Height);
+        rx = lengthContext.valueForLength(rxStyle, usedZoom, SVGLengthMode::Width);
+        ry = lengthContext.valueForLength(ryStyle, usedZoom, SVGLengthMode::Height);
     }
 
     if (rx <= 0 || ry <= 0)
         return { };
 
     Path path;
-    float cx = lengthContext.valueForLength(style.cx(), Style::ZoomNeeded { }, SVGLengthMode::Width);
-    float cy = lengthContext.valueForLength(style.cy(), Style::ZoomNeeded { }, SVGLengthMode::Height);
+    float cx = lengthContext.valueForLength(style.cx(), usedZoom, SVGLengthMode::Width);
+    float cy = lengthContext.valueForLength(style.cy(), usedZoom, SVGLengthMode::Height);
     path.addEllipseInRect(FloatRect(cx - rx, cy - ry, rx * 2, ry * 2));
     return path;
 }
@@ -161,13 +164,13 @@ static Path pathFromRectElement(const SVGRectElement& element)
         return { };
 
     auto location = FloatPoint {
-        lengthContext.valueForLength(style.x(), Style::ZoomNeeded { }, SVGLengthMode::Width),
-        lengthContext.valueForLength(style.y(), Style::ZoomNeeded { }, SVGLengthMode::Height)
+        lengthContext.valueForLength(style.x(), usedZoom, SVGLengthMode::Width),
+        lengthContext.valueForLength(style.y(), usedZoom, SVGLengthMode::Height)
     };
 
     auto radii = FloatSize {
-        lengthContext.valueForLength(style.rx(), Style::ZoomNeeded { }, SVGLengthMode::Width),
-        lengthContext.valueForLength(style.ry(), Style::ZoomNeeded { }, SVGLengthMode::Height)
+        lengthContext.valueForLength(style.rx(), usedZoom, SVGLengthMode::Width),
+        lengthContext.valueForLength(style.ry(), usedZoom, SVGLengthMode::Height)
     };
 
     // Per SVG spec: if one of radii.x() and radii.y() is auto or negative, then the other corner

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
@@ -524,8 +524,9 @@ void SVGRenderSupport::applyStrokeStyleToContext(GraphicsContext& context, const
         return;
     }
 
+    auto usedZoom = style.usedZoomForLength();
     SVGLengthContext lengthContext(element.get());
-    context.setStrokeThickness(lengthContext.valueForLength(style.strokeWidth(), style.usedZoomForLength()));
+    context.setStrokeThickness(lengthContext.valueForLength(style.strokeWidth(), usedZoom));
     context.setLineCap(style.capStyle());
     context.setLineJoin(style.joinStyle());
     if (style.joinStyle() == LineJoin::Miter)
@@ -555,15 +556,15 @@ void SVGRenderSupport::applyStrokeStyleToContext(GraphicsContext& context, const
         }
         
         bool canSetLineDash = false;
-        auto dashArray = DashArray::map(dashes, [&lengthContext, scaleFactor, &canSetLineDash](auto& dash) -> DashArrayElement {
-            auto value = lengthContext.valueForLength(dash, Style::ZoomNeeded { }) * scaleFactor;
+        auto dashArray = DashArray::map(dashes, [&lengthContext, usedZoom, scaleFactor, &canSetLineDash](auto& dash) -> DashArrayElement {
+            auto value = lengthContext.valueForLength(dash, usedZoom) * scaleFactor;
             if (value > 0)
                 canSetLineDash = true;
             return value;
         });
 
         if (canSetLineDash)
-            context.setLineDash(dashArray, lengthContext.valueForLength(style.strokeDashOffset(), Style::ZoomNeeded { }) * scaleFactor);
+            context.setLineDash(dashArray, lengthContext.valueForLength(style.strokeDashOffset(), usedZoom) * scaleFactor);
         else
             context.setStrokeStyle(StrokeStyle::SolidStroke);
     }

--- a/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
@@ -206,10 +206,11 @@ static void writeSVGStrokePaintingResource(TextStream& ts, const RenderElement& 
     auto& style = renderer.style();
 
     SVGLengthContext lengthContext(&shape);
-    double dashOffset = lengthContext.valueForLength(style.strokeDashOffset(), Style::ZoomNeeded { });
-    double strokeWidth = lengthContext.valueForLength(style.strokeWidth(), style.usedZoomForLength());
+    auto zoom = style.usedZoomForLength();
+    double dashOffset = lengthContext.valueForLength(style.strokeDashOffset(), zoom);
+    double strokeWidth = lengthContext.valueForLength(style.strokeWidth(), zoom);
     auto dashArray = DashArray::map(style.strokeDashArray(), [&](auto& length) -> DashArrayElement {
-        return lengthContext.valueForLength(length, Style::ZoomNeeded { });
+        return lengthContext.valueForLength(length, zoom);
     });
 
     writeIfNotDefault(ts, "opacity"_s, Style::evaluate<float>(style.strokeOpacity()), 1.0f);

--- a/Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.cpp
@@ -50,7 +50,7 @@ float SVGTextLayoutEngineBaseline::calculateBaselineShift(const Style::ComputedS
             return m_font->metricsOfPrimaryFont().height() / 2;
         },
         [&](const Style::SVGBaselineShift::LengthPercentage& value) -> float {
-            return Style::evaluate<float>(value, m_font->size(), Style::ZoomNeeded { });
+            return Style::evaluate<float>(value, m_font->size(), style.usedZoomForLength());
         }
     );
 }

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGEllipse.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGEllipse.cpp
@@ -84,11 +84,12 @@ void LegacyRenderSVGEllipse::calculateRadiiAndCenter()
 {
     Ref graphicsElement = this->graphicsElement();
     SVGLengthContext lengthContext(graphicsElement.ptr());
+    auto zoom = style().usedZoomForLength();
     m_center = FloatPoint(
-        lengthContext.valueForLength(style().cx(), Style::ZoomNeeded { }, SVGLengthMode::Width),
-        lengthContext.valueForLength(style().cy(), Style::ZoomNeeded { }, SVGLengthMode::Height));
+        lengthContext.valueForLength(style().cx(), zoom, SVGLengthMode::Width),
+        lengthContext.valueForLength(style().cy(), zoom, SVGLengthMode::Height));
     if (is<SVGCircleElement>(graphicsElement)) {
-        float radius = lengthContext.valueForLength(style().r(), Style::ZoomNeeded { });
+        float radius = lengthContext.valueForLength(style().r(), zoom);
         m_radii = FloatSize(radius, radius);
         return;
     }
@@ -98,8 +99,8 @@ void LegacyRenderSVGEllipse::calculateRadiiAndCenter()
     auto& rx = style().rx();
     auto& ry = style().ry();
     m_radii = FloatSize(
-        lengthContext.valueForLength(rx.isAuto() ? ry : rx, Style::ZoomNeeded { }, SVGLengthMode::Width),
-        lengthContext.valueForLength(ry.isAuto() ? rx : ry, Style::ZoomNeeded { }, SVGLengthMode::Height));
+        lengthContext.valueForLength(rx.isAuto() ? ry : rx, zoom, SVGLengthMode::Width),
+        lengthContext.valueForLength(ry.isAuto() ? rx : ry, zoom, SVGLengthMode::Height));
     if (rx.isAuto())
         m_radii.setWidth(m_radii.height());
     else if (ry.isAuto())

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGForeignObject.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGForeignObject.cpp
@@ -140,7 +140,7 @@ void LegacyRenderSVGForeignObject::layout()
     SVGLengthContext lengthContext(foreignObjectElement.ptr());
     CheckedRef usedStyle = style();
     auto usedZoom = usedStyle->usedZoomForLength();
-    FloatPoint viewportLocation(lengthContext.valueForLength(usedStyle->x(), Style::ZoomNeeded { }, SVGLengthMode::Width), lengthContext.valueForLength(usedStyle->y(), Style::ZoomNeeded { }, SVGLengthMode::Height));
+    FloatPoint viewportLocation(lengthContext.valueForLength(usedStyle->x(), usedZoom, SVGLengthMode::Width), lengthContext.valueForLength(usedStyle->y(), usedZoom, SVGLengthMode::Height));
     m_viewport = FloatRect(viewportLocation, FloatSize(std::max(0.0f, lengthContext.valueForLength(usedStyle->width(), usedZoom, SVGLengthMode::Width)), std::max(0.0f, lengthContext.valueForLength(usedStyle->height(), usedZoom, SVGLengthMode::Height))));
     if (!updateCachedBoundariesInParents)
         updateCachedBoundariesInParents = oldViewport != m_viewport;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRect.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRect.cpp
@@ -69,8 +69,8 @@ void LegacyRenderSVGRect::updateShapeFromElement()
     if (boundingBoxSize.isEmpty())
         return;
 
-    if (lengthContext.valueForLength(style->rx(), Style::ZoomNeeded { }, SVGLengthMode::Width) > 0
-        || lengthContext.valueForLength(style->ry(), Style::ZoomNeeded { }, SVGLengthMode::Height) > 0)
+    if (lengthContext.valueForLength(style->rx(), usedZoom, SVGLengthMode::Width) > 0
+        || lengthContext.valueForLength(style->ry(), usedZoom, SVGLengthMode::Height) > 0)
         m_shapeType = ShapeType::RoundedRectangle;
     else
         m_shapeType = ShapeType::Rectangle;
@@ -81,8 +81,8 @@ void LegacyRenderSVGRect::updateShapeFromElement()
         return;
     }
 
-    m_fillBoundingBox = FloatRect(FloatPoint(lengthContext.valueForLength(style->x(), Style::ZoomNeeded { }, SVGLengthMode::Width),
-        lengthContext.valueForLength(style->y(),  Style::ZoomNeeded { }, SVGLengthMode::Height)),
+    m_fillBoundingBox = FloatRect(FloatPoint(lengthContext.valueForLength(style->x(), usedZoom, SVGLengthMode::Width),
+        lengthContext.valueForLength(style->y(),  usedZoom, SVGLengthMode::Height)),
         boundingBoxSize);
 
     auto strokeBoundingBox = m_fillBoundingBox;

--- a/Source/WebCore/style/computed/StyleComputedStyle.cpp
+++ b/Source/WebCore/style/computed/StyleComputedStyle.cpp
@@ -627,7 +627,7 @@ static LayoutUnit computeOutset(const OutsetValue& outsetValue, const Style::Lin
             return LayoutUnit(Style::evaluate<LayoutUnit>(borderWidth, zoom, deviceScaleFactor) * number.value);
         },
         [&](const typename OutsetValue::Length& length) {
-            return Style::evaluate<LayoutUnit>(length, Style::ZoomNeeded { });
+            return Style::evaluate<LayoutUnit>(length, zoom);
         }
     );
 }

--- a/Source/WebCore/style/values/align/StyleGapGutter.h
+++ b/Source/WebCore/style/values/align/StyleGapGutter.h
@@ -31,7 +31,7 @@ namespace Style {
 
 // <'row-gap/column-gap'> = normal | <length-percentage [0,∞]>
 // https://drafts.csswg.org/css-align/#column-row-gap
-struct GapGutter : PrimitiveNumericOrKeyword<LengthPercentage<CSS::Nonnegative>, CSS::Keyword::Normal> {
+struct GapGutter : PrimitiveNumericOrKeyword<LengthPercentage<CSS::NonnegativeUnzoomed>, CSS::Keyword::Normal> {
     using Base::Base;
 
     ALWAYS_INLINE bool isNormal() const { return holdsAlternative<CSS::Keyword::Normal>(); }

--- a/Source/WebCore/style/values/backgrounds/StyleBackgroundSize.h
+++ b/Source/WebCore/style/values/backgrounds/StyleBackgroundSize.h
@@ -30,7 +30,7 @@
 namespace WebCore {
 namespace Style {
 
-struct BackgroundSizeLength : PrimitiveNumericOrKeyword<LengthPercentage<CSS::Nonnegative>, CSS::Keyword::Auto> {
+struct BackgroundSizeLength : PrimitiveNumericOrKeyword<LengthPercentage<CSS::NonnegativeUnzoomed>, CSS::Keyword::Auto> {
     using Base::Base;
 
     ALWAYS_INLINE bool isAuto() const { return holdsAlternative<CSS::Keyword::Auto>(); }

--- a/Source/WebCore/style/values/backgrounds/StyleBorderImageOutset.h
+++ b/Source/WebCore/style/values/backgrounds/StyleBorderImageOutset.h
@@ -37,7 +37,7 @@ namespace Style {
 
 // <border-image-outset-value> = <length [0,∞]> | <number [0,∞]>
 struct BorderImageOutsetValue {
-    using Length = Style::Length<CSS::Nonnegative, float>;
+    using Length = Style::Length<CSS::NonnegativeUnzoomed, float>;
     using Number = Style::Number<CSS::Nonnegative, float>;
 
     constexpr BorderImageOutsetValue(Length length) : m_value { length } { }

--- a/Source/WebCore/style/values/backgrounds/StyleBorderImageWidth.h
+++ b/Source/WebCore/style/values/backgrounds/StyleBorderImageWidth.h
@@ -37,7 +37,7 @@ namespace Style {
 
 // <border-image-width-value> = <length-percentage [0,∞]> | <number [0,∞]> | auto
 struct BorderImageWidthValue {
-    using LengthPercentage = Style::LengthPercentage<CSS::Nonnegative>;
+    using LengthPercentage = Style::LengthPercentage<CSS::NonnegativeUnzoomed>;
     using Number = Style::Number<CSS::Nonnegative, float>;
 
     BorderImageWidthValue(CSS::Keyword::Auto keyword)

--- a/Source/WebCore/style/values/filter-effects/StyleBlurFunction.cpp
+++ b/Source/WebCore/style/values/filter-effects/StyleBlurFunction.cpp
@@ -29,6 +29,7 @@
 #include "CSSFilterFunctionDescriptor.h"
 #include "FEGaussianBlur.h"
 #include "FilterOperation.h"
+#include "StyleComputedStyleBase+GettersInlines.h"
 #include "StylePrimitiveNumericTypes+Conversions.h"
 #include "StylePrimitiveNumericTypes+Evaluation.h"
 
@@ -40,9 +41,9 @@ Blur Blur::passthroughForInterpolation()
     return { .value = CSSFilterFunctionDescriptor<CSSValueBlur>::initialValueForInterpolation };
 }
 
-IntOutsets Blur::calculateOutsets(ZoomFactor) const
+IntOutsets Blur::calculateOutsets(ZoomFactor zoom) const
 {
-    auto stdDeviation = evaluate<float>(value, ZoomNeeded { });
+    auto stdDeviation = evaluate<float>(value, zoom);
     return FEGaussianBlur::calculateOutsets({ stdDeviation, stdDeviation });
 }
 
@@ -62,17 +63,17 @@ auto ToStyle<CSS::Blur>::operator()(const CSS::Blur& value, const BuilderState& 
 
 // MARK: - Evaluation
 
-auto Evaluation<Blur, Ref<FilterEffect>>::operator()(const Blur& value, const Style::ComputedStyle&) -> Ref<FilterEffect>
+auto Evaluation<Blur, Ref<FilterEffect>>::operator()(const Blur& value, const Style::ComputedStyle& style) -> Ref<FilterEffect>
 {
-    auto stdDeviation = evaluate<float>(value, ZoomNeeded { });
+    auto stdDeviation = evaluate<float>(value, style.usedZoomForLength());
     return FEGaussianBlur::create(stdDeviation, stdDeviation, EdgeModeType::None);
 }
 
 // MARK: - Platform
 
-auto ToPlatform<Blur>::operator()(const Blur& value, const Style::ComputedStyle&) -> Ref<FilterOperation>
+auto ToPlatform<Blur>::operator()(const Blur& value, const Style::ComputedStyle& style) -> Ref<FilterOperation>
 {
-    return BlurFilterOperation::create(Style::evaluate<float>(value, ZoomNeeded { }));
+    return BlurFilterOperation::create(Style::evaluate<float>(value, style.usedZoomForLength()));
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/filter-effects/StyleBlurFunction.h
+++ b/Source/WebCore/style/values/filter-effects/StyleBlurFunction.h
@@ -43,7 +43,7 @@ struct ZoomFactor;
 // blur() = blur( <length [0,∞]>?@(default=0px) )
 // https://drafts.fxtf.org/filter-effects/#funcdef-filter-blur
 struct Blur {
-    using Parameter = Length<CSS::Nonnegative>;
+    using Parameter = Length<CSS::NonnegativeUnzoomed>;
 
     Parameter value;
 

--- a/Source/WebCore/style/values/inline/StyleVerticalAlign.h
+++ b/Source/WebCore/style/values/inline/StyleVerticalAlign.h
@@ -36,7 +36,7 @@ namespace Style {
 // https://drafts.csswg.org/css-inline/#propdef-vertical-align
 
 struct VerticalAlign {
-    using LengthPercentage = Style::LengthPercentage<>;
+    using LengthPercentage = Style::LengthPercentage<CSS::AllUnzoomed>;
 
     VerticalAlign(CSS::Keyword::Baseline keyword) : m_value { keyword } { }
     VerticalAlign(CSS::Keyword::Sub keyword) : m_value { keyword } { }

--- a/Source/WebCore/style/values/masking/StyleClip.h
+++ b/Source/WebCore/style/values/masking/StyleClip.h
@@ -39,7 +39,7 @@ struct ClipRect;
 namespace Style {
 
 // <clip-edge> = <length> | auto
-struct ClipEdge : ValueOrKeyword<Length<>, CSS::Keyword::Auto> {
+struct ClipEdge : ValueOrKeyword<Length<CSS::AllUnzoomed>, CSS::Keyword::Auto> {
     using Base::Base;
     using Length = typename Base::Value;
 

--- a/Source/WebCore/style/values/masking/StyleMaskBorderOutset.h
+++ b/Source/WebCore/style/values/masking/StyleMaskBorderOutset.h
@@ -37,7 +37,7 @@ namespace Style {
 
 // <mask-border-outset-value> = <length [0,∞]> | <number [0,∞]>
 struct MaskBorderOutsetValue {
-    using Length = Style::Length<CSS::Nonnegative, float>;
+    using Length = Style::Length<CSS::NonnegativeUnzoomed, float>;
     using Number = Style::Number<CSS::Nonnegative, float>;
 
     constexpr MaskBorderOutsetValue(Length length)

--- a/Source/WebCore/style/values/masking/StyleMaskBorderWidth.h
+++ b/Source/WebCore/style/values/masking/StyleMaskBorderWidth.h
@@ -37,7 +37,7 @@ namespace Style {
 
 // <mask-border-width-value> = <length-percentage [0,∞]> | <number [0,∞]> | auto
 struct MaskBorderWidthValue {
-    using LengthPercentage = Style::LengthPercentage<CSS::Nonnegative>;
+    using LengthPercentage = Style::LengthPercentage<CSS::NonnegativeUnzoomed>;
     using Number = Style::Number<CSS::Nonnegative, float>;
 
     MaskBorderWidthValue(CSS::Keyword::Auto keyword)

--- a/Source/WebCore/style/values/multicol/StyleColumnWidth.h
+++ b/Source/WebCore/style/values/multicol/StyleColumnWidth.h
@@ -30,7 +30,7 @@ namespace WebCore::Style {
 
 // <'column-width'> = auto | <length [0,∞]>
 // https://www.w3.org/TR/css-multicol-1/#propdef-column-width
-struct ColumnWidth : ValueOrKeyword<Length<CSS::Nonnegative, float>, CSS::Keyword::Auto> {
+struct ColumnWidth : ValueOrKeyword<Length<CSS::NonnegativeUnzoomed, float>, CSS::Keyword::Auto> {
     using Base::Base;
     using Length = typename Base::Value;
 

--- a/Source/WebCore/style/values/non-standard/StyleWebKitMarqueeIncrement.h
+++ b/Source/WebCore/style/values/non-standard/StyleWebKitMarqueeIncrement.h
@@ -34,7 +34,7 @@ namespace Style {
 // NOTE: There is no standard associated with this property. It exists to model the "marquee scroll distance" concept derived from the <marquee> element's `scrollamount` attribute.
 // https://html.spec.whatwg.org/multipage/obsolete.html#marquee-scroll-distance
 // FIXME: Consider changing this type (and the associated internal property `-webkit-marquee-increment`) to be named after the spec term "marquee scroll distance".
-DEFINE_PRIMITIVE_NUMERIC_TYPE_WRAPPER(WebkitMarqueeIncrement, LengthPercentage<>);
+DEFINE_PRIMITIVE_NUMERIC_TYPE_WRAPPER(WebkitMarqueeIncrement, LengthPercentage<CSS::AllUnzoomed>);
 
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/values/overflow/StyleOverflowClipMargin.h
+++ b/Source/WebCore/style/values/overflow/StyleOverflowClipMargin.h
@@ -37,7 +37,7 @@ namespace Style {
 // <'overflow-clip-margin'> = <visual-box> || <length [0,∞]>
 // https://drafts.csswg.org/css-overflow/#overflow-clip-margin
 struct OverflowClipMargin {
-    using Length = Style::Length<CSS::Nonnegative, float>;
+    using Length = Style::Length<CSS::NonnegativeUnzoomed, float>;
 
     OverflowClipMargin(CSS::ValueLiteral<CSS::LengthUnit::Px> length)
         : m_value { length }

--- a/Source/WebCore/style/values/page/StylePageSize.cpp
+++ b/Source/WebCore/style/values/page/StylePageSize.cpp
@@ -36,36 +36,36 @@ namespace Style {
 static PageSize pageSizeFromName(BuilderState& state, const CSSKeywordValue& pageSizeName, RefPtr<const CSSKeywordValue> pageOrientation)
 {
     auto mmLength = [](double mm) {
-        return Length<CSS::Nonnegative>(CSS::pixelsPerMm * mm);
+        return Length<CSS::NonnegativeUnzoomed>(CSS::pixelsPerMm * mm);
     };
 
     auto inchLength = [](double inch) {
-        return Length<CSS::Nonnegative>(CSS::pixelsPerInch * inch);
+        return Length<CSS::NonnegativeUnzoomed>(CSS::pixelsPerInch * inch);
     };
 
-    static constexpr Length<CSS::Nonnegative> a5Width(mmLength(148));
-    static constexpr Length<CSS::Nonnegative> a5Height(mmLength(210));
-    static constexpr Length<CSS::Nonnegative> a4Width(mmLength(210));
-    static constexpr Length<CSS::Nonnegative> a4Height(mmLength(297));
-    static constexpr Length<CSS::Nonnegative> a3Width(mmLength(297));
-    static constexpr Length<CSS::Nonnegative> a3Height(mmLength(420));
-    static constexpr Length<CSS::Nonnegative> b5Width(mmLength(176));
-    static constexpr Length<CSS::Nonnegative> b5Height(mmLength(250));
-    static constexpr Length<CSS::Nonnegative> b4Width(mmLength(250));
-    static constexpr Length<CSS::Nonnegative> b4Height(mmLength(353));
-    static constexpr Length<CSS::Nonnegative> jisB5Width(mmLength(182));
-    static constexpr Length<CSS::Nonnegative> jisB5Height(mmLength(257));
-    static constexpr Length<CSS::Nonnegative> jisB4Width(mmLength(257));
-    static constexpr Length<CSS::Nonnegative> jisB4Height(mmLength(364));
-    static constexpr Length<CSS::Nonnegative> letterWidth(inchLength(8.5));
-    static constexpr Length<CSS::Nonnegative> letterHeight(inchLength(11));
-    static constexpr Length<CSS::Nonnegative> legalWidth(inchLength(8.5));
-    static constexpr Length<CSS::Nonnegative> legalHeight(inchLength(14));
-    static constexpr Length<CSS::Nonnegative> ledgerWidth(inchLength(11));
-    static constexpr Length<CSS::Nonnegative> ledgerHeight(inchLength(17));
+    static constexpr Length<CSS::NonnegativeUnzoomed> a5Width(mmLength(148));
+    static constexpr Length<CSS::NonnegativeUnzoomed> a5Height(mmLength(210));
+    static constexpr Length<CSS::NonnegativeUnzoomed> a4Width(mmLength(210));
+    static constexpr Length<CSS::NonnegativeUnzoomed> a4Height(mmLength(297));
+    static constexpr Length<CSS::NonnegativeUnzoomed> a3Width(mmLength(297));
+    static constexpr Length<CSS::NonnegativeUnzoomed> a3Height(mmLength(420));
+    static constexpr Length<CSS::NonnegativeUnzoomed> b5Width(mmLength(176));
+    static constexpr Length<CSS::NonnegativeUnzoomed> b5Height(mmLength(250));
+    static constexpr Length<CSS::NonnegativeUnzoomed> b4Width(mmLength(250));
+    static constexpr Length<CSS::NonnegativeUnzoomed> b4Height(mmLength(353));
+    static constexpr Length<CSS::NonnegativeUnzoomed> jisB5Width(mmLength(182));
+    static constexpr Length<CSS::NonnegativeUnzoomed> jisB5Height(mmLength(257));
+    static constexpr Length<CSS::NonnegativeUnzoomed> jisB4Width(mmLength(257));
+    static constexpr Length<CSS::NonnegativeUnzoomed> jisB4Height(mmLength(364));
+    static constexpr Length<CSS::NonnegativeUnzoomed> letterWidth(inchLength(8.5));
+    static constexpr Length<CSS::NonnegativeUnzoomed> letterHeight(inchLength(11));
+    static constexpr Length<CSS::NonnegativeUnzoomed> legalWidth(inchLength(8.5));
+    static constexpr Length<CSS::NonnegativeUnzoomed> legalHeight(inchLength(14));
+    static constexpr Length<CSS::NonnegativeUnzoomed> ledgerWidth(inchLength(11));
+    static constexpr Length<CSS::NonnegativeUnzoomed> ledgerHeight(inchLength(17));
 
-    Style::Length<CSS::Nonnegative> width { 0 };
-    Style::Length<CSS::Nonnegative> height { 0 };
+    Style::Length<CSS::NonnegativeUnzoomed> width { 0 };
+    Style::Length<CSS::NonnegativeUnzoomed> height { 0 };
 
     switch (pageSizeName.valueID()) {
     case CSSValueA5:
@@ -140,10 +140,9 @@ auto CSSValueConversion<PageSize>::operator()(BuilderState& state, const CSSValu
         RefPtr primitiveValueFirst = dynamicDowncast<CSSPrimitiveValue>(first);
         RefPtr primitiveValueSecond = dynamicDowncast<CSSPrimitiveValue>(second);
         if (primitiveValueFirst && primitiveValueSecond) {
-            auto conversionData = state.cssToLengthConversionData().copyWithAdjustedZoom(1.0f);
             return PageSize::Lengths {
-                toStyleFromCSSValue<Length<CSS::Nonnegative>>(conversionData, *primitiveValueFirst),
-                toStyleFromCSSValue<Length<CSS::Nonnegative>>(conversionData, *primitiveValueSecond),
+                toStyleFromCSSValue<Length<CSS::NonnegativeUnzoomed>>(state, *primitiveValueFirst),
+                toStyleFromCSSValue<Length<CSS::NonnegativeUnzoomed>>(state, *primitiveValueSecond),
             };
         }
 
@@ -162,8 +161,7 @@ auto CSSValueConversion<PageSize>::operator()(BuilderState& state, const CSSValu
     // <length [0,∞]> | auto | <page-size> | [ portrait | landscape]
     if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
         // <length [0,∞]>
-        auto conversionData = state.cssToLengthConversionData().copyWithAdjustedZoom(1.0f);
-        auto length = toStyleFromCSSValue<Length<CSS::Nonnegative>>(conversionData, *primitiveValue);
+        auto length = toStyleFromCSSValue<Length<CSS::NonnegativeUnzoomed>>(state, *primitiveValue);
         return PageSize::Lengths { length, length };
     }
 

--- a/Source/WebCore/style/values/page/StylePageSize.h
+++ b/Source/WebCore/style/values/page/StylePageSize.h
@@ -32,7 +32,7 @@ namespace Style {
 // <'size'> (for @page) = <length [0,∞]>{1,2} | auto | [ <page-size> || [ portrait | landscape ] ]
 // https://drafts.csswg.org/css-page-3/#descdef-page-size
 struct PageSize {
-    using Lengths = MinimallySerializingSpaceSeparatedSize<Length<CSS::Nonnegative>>;
+    using Lengths = MinimallySerializingSpaceSeparatedSize<Length<CSS::NonnegativeUnzoomed>>;
 
     PageSize(Lengths&& lengths) : m_value { WTF::move(lengths) } { }
     PageSize(CSS::Keyword::Auto keyword) : m_value { keyword } { }

--- a/Source/WebCore/style/values/rhythm/StyleBlockStepSize.h
+++ b/Source/WebCore/style/values/rhythm/StyleBlockStepSize.h
@@ -32,7 +32,7 @@ namespace Style {
 
 // <'block-step-size'> = none | <length [0,∞]>
 // https://www.w3.org/TR/css-rhythm-1/#propdef-block-step-size
-struct BlockStepSize : ValueOrKeyword<Length<CSS::Nonnegative, float>, CSS::Keyword::None> {
+struct BlockStepSize : ValueOrKeyword<Length<CSS::NonnegativeUnzoomed, float>, CSS::Keyword::None> {
     using Base::Base;
     using Length = typename Base::Value;
 

--- a/Source/WebCore/style/values/svg/StyleSVGBaselineShift.h
+++ b/Source/WebCore/style/values/svg/StyleSVGBaselineShift.h
@@ -31,7 +31,7 @@ namespace Style {
 
 // <'baseline-shift'> = baseline | sub | super | <length-percentage>
 struct SVGBaselineShift {
-    using LengthPercentage = Style::LengthPercentage<>;
+    using LengthPercentage = Style::LengthPercentage<CSS::AllUnzoomed>;
 
     SVGBaselineShift(CSS::Keyword::Baseline keyword)
         : m_value { keyword }

--- a/Source/WebCore/style/values/svg/StyleSVGCenterCoordinateComponent.h
+++ b/Source/WebCore/style/values/svg/StyleSVGCenterCoordinateComponent.h
@@ -32,7 +32,7 @@ namespace Style {
 // <'cx'/'cy'> = <length-percentage>
 // https://svgwg.org/svg2-draft/geometry.html#CX
 // https://svgwg.org/svg2-draft/geometry.html#CY
-DEFINE_PRIMITIVE_NUMERIC_TYPE_WRAPPER(SVGCenterCoordinateComponent, LengthPercentage<>);
+DEFINE_PRIMITIVE_NUMERIC_TYPE_WRAPPER(SVGCenterCoordinateComponent, LengthPercentage<CSS::AllUnzoomed>);
 
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/values/svg/StyleSVGCoordinateComponent.h
+++ b/Source/WebCore/style/values/svg/StyleSVGCoordinateComponent.h
@@ -32,7 +32,7 @@ namespace Style {
 // <'x'/'y'> = <length-percentage>
 // https://svgwg.org/svg2-draft/geometry.html#X
 // https://svgwg.org/svg2-draft/geometry.html#Y
-DEFINE_PRIMITIVE_NUMERIC_TYPE_WRAPPER(SVGCoordinateComponent, LengthPercentage<>);
+DEFINE_PRIMITIVE_NUMERIC_TYPE_WRAPPER(SVGCoordinateComponent, LengthPercentage<CSS::AllUnzoomed>);
 
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/values/svg/StyleSVGRadius.h
+++ b/Source/WebCore/style/values/svg/StyleSVGRadius.h
@@ -31,7 +31,7 @@ namespace Style {
 
 // <'r'> = <length-percentage [0,∞]>
 // https://svgwg.org/svg2-draft/geometry.html#R
-DEFINE_PRIMITIVE_NUMERIC_TYPE_WRAPPER(SVGRadius, LengthPercentage<CSS::Nonnegative>);
+DEFINE_PRIMITIVE_NUMERIC_TYPE_WRAPPER(SVGRadius, LengthPercentage<CSS::NonnegativeUnzoomed>);
 
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/values/svg/StyleSVGRadiusComponent.h
+++ b/Source/WebCore/style/values/svg/StyleSVGRadiusComponent.h
@@ -32,7 +32,7 @@ namespace Style {
 // <'rx'/'ry'> = <length-percentage [0,∞]> | auto
 // https://svgwg.org/svg2-draft/geometry.html#RX
 // https://svgwg.org/svg2-draft/geometry.html#RY
-struct SVGRadiusComponent : PrimitiveNumericOrKeyword<LengthPercentage<CSS::Nonnegative>, CSS::Keyword::Auto> {
+struct SVGRadiusComponent : PrimitiveNumericOrKeyword<LengthPercentage<CSS::NonnegativeUnzoomed>, CSS::Keyword::Auto> {
     using Base::Base;
 
     ALWAYS_INLINE bool isAuto() const { return holdsAlternative<CSS::Keyword::Auto>(); }

--- a/Source/WebCore/style/values/svg/StyleSVGStrokeDasharray.h
+++ b/Source/WebCore/style/values/svg/StyleSVGStrokeDasharray.h
@@ -31,7 +31,7 @@ namespace Style {
 
 // <dasharray-value> = [ <length-percentage [0,∞]> | <number [0,∞]>@(converted-to-px) ]
 struct SVGStrokeDasharrayValue {
-    using LengthPercentage = Style::LengthPercentage<CSS::Nonnegative>;
+    using LengthPercentage = Style::LengthPercentage<CSS::NonnegativeUnzoomed>;
     using Fixed = typename LengthPercentage::Fixed;
     using Percentage = typename LengthPercentage::Percentage;
     using Calc = typename LengthPercentage::Calc;

--- a/Source/WebCore/style/values/svg/StyleSVGStrokeDashoffset.h
+++ b/Source/WebCore/style/values/svg/StyleSVGStrokeDashoffset.h
@@ -32,7 +32,7 @@ namespace Style {
 // <'stroke-dashoffset'> = <length-percentage> | <number>@(converted-to-px)
 // https://svgwg.org/svg2-draft/painting.html#StrokeDashoffsetProperty
 struct SVGStrokeDashoffset {
-    using LengthPercentage = Style::LengthPercentage<>;
+    using LengthPercentage = Style::LengthPercentage<CSS::AllUnzoomed>;
     using Fixed = LengthPercentage::Fixed;
     using Percentage = LengthPercentage::Percentage;
     using Calc = LengthPercentage::Calc;

--- a/Source/WebCore/style/values/text/StyleTabSize.cpp
+++ b/Source/WebCore/style/values/text/StyleTabSize.cpp
@@ -74,14 +74,14 @@ auto Blending<TabSize>::blend(const TabSize& a, const TabSize& b, const Blending
 
 // MARK: - Platform
 
-auto ToPlatform<TabSize>::operator()(const TabSize& value) -> WebCore::TabSize
+auto ToPlatform<TabSize>::operator()(const TabSize& value, ZoomFactor zoom) -> WebCore::TabSize
 {
     return WTF::switchOn(value,
         [](const TabSize::Spaces& spaces) {
             return WebCore::TabSize { spaces.value, SpaceValueType };
         },
-        [](const TabSize::Length& length) {
-            return WebCore::TabSize { evaluate<float>(length, ZoomNeeded { }), LengthValueType };
+        [&](const TabSize::Length& length) {
+            return WebCore::TabSize { evaluate<float>(length, zoom), LengthValueType };
         }
     );
 }

--- a/Source/WebCore/style/values/text/StyleTabSize.h
+++ b/Source/WebCore/style/values/text/StyleTabSize.h
@@ -36,7 +36,7 @@ namespace Style {
 // https://drafts.csswg.org/css-text-3/#propdef-tab-size
 struct TabSize {
     using Spaces = Style::Number<CSS::Nonnegative, float>;
-    using Length = Style::Length<CSS::Nonnegative, float>;
+    using Length = Style::Length<CSS::NonnegativeUnzoomed, float>;
 
     constexpr TabSize(CSS::ValueLiteral<CSS::NumberUnit::Number> literal)
         : m_value { Spaces { literal } }
@@ -97,7 +97,7 @@ template<> struct Blending<TabSize> {
 
 // MARK: - Platform
 
-template<> struct ToPlatform<TabSize> { auto operator()(const TabSize&) -> WebCore::TabSize; };
+template<> struct ToPlatform<TabSize> { auto operator()(const TabSize&, ZoomFactor) -> WebCore::TabSize; };
 
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/values/transforms/StyleTransformFunction.cpp
+++ b/Source/WebCore/style/values/transforms/StyleTransformFunction.cpp
@@ -528,7 +528,7 @@ auto CSSValueCreation<TransformFunction>::operator()(CSSValuePool& pool, const S
 {
     auto translateLength = [&](const auto& length) -> Ref<CSSValue> {
         if (length.isKnownZero())
-            return createCSSValue(pool, style, Length<> { 0_css_px });
+            return createCSSValue(pool, style, Length<CSS::AllUnzoomed> { 0_css_px });
         else
             return createCSSValue(pool, style, length);
     };
@@ -688,7 +688,7 @@ void Serialize<TransformFunction>::operator()(StringBuilder& builder, const CSS:
 {
     auto translateLength = [&](const auto& length) {
         if (length.isKnownZero())
-            serializationForCSS(builder, context, style, Length<> { 0_css_px });
+            serializationForCSS(builder, context, style, Length<CSS::AllUnzoomed> { 0_css_px });
         else
             serializationForCSS(builder, context, style, length);
     };

--- a/Source/WebCore/svg/SVGLengthContext.cpp
+++ b/Source/WebCore/svg/SVGLengthContext.cpp
@@ -123,7 +123,6 @@ static inline float NODELETE dimensionForLengthMode(SVGLengthMode mode, FloatSiz
 }
 
 template<typename SizeType> float SVGLengthContext::valueForSizeType(const SizeType& size, Style::ZoomFactor usedZoom, SVGLengthMode lengthMode)
-    requires (SizeType::Fixed::zoomOptions == CSS::RangeZoomOptions::Unzoomed || SizeType::Calc::range.zoomOptions == CSS::RangeZoomOptions::Unzoomed)
 {
     return WTF::switchOn(size,
         [&](const typename SizeType::Fixed& fixed) -> float {
@@ -143,30 +142,6 @@ template<typename SizeType> float SVGLengthContext::valueForSizeType(const SizeT
             return 0;
         }
     );
-
-}
-
-template<typename SizeType> float SVGLengthContext::valueForSizeType(const SizeType& size, Style::ZoomNeeded zoomNeeded, SVGLengthMode lengthMode)
-{
-    return WTF::switchOn(size,
-        [&](const typename SizeType::Fixed& fixed) -> float {
-            return Style::evaluate<float>(fixed, zoomNeeded);
-        },
-        [&](const typename SizeType::Percentage& percentage) -> float {
-            auto result = convertValueFromPercentageToUserUnits(percentage.value / 100, lengthMode);
-            if (result.hasException())
-                return 0;
-            return clampTo<float>(result.releaseReturnValue());
-        },
-        [&](const typename SizeType::Calc& calc) -> float {
-            auto viewportSize = this->viewportSize().value_or(FloatSize { });
-            return Style::evaluate<float>(calc, dimensionForLengthMode(lengthMode, viewportSize), zoomNeeded);
-        },
-        [&](const auto&) -> float {
-            return 0;
-        }
-    );
-
 }
 
 float SVGLengthContext::valueForLength(const Style::PreferredSize& size, Style::ZoomFactor usedZoom, SVGLengthMode lengthMode)
@@ -174,34 +149,34 @@ float SVGLengthContext::valueForLength(const Style::PreferredSize& size, Style::
     return valueForSizeType(size, usedZoom, lengthMode);
 }
 
-float SVGLengthContext::valueForLength(const Style::SVGCenterCoordinateComponent& size, Style::ZoomNeeded zoomNeeded, SVGLengthMode lengthMode)
+float SVGLengthContext::valueForLength(const Style::SVGCenterCoordinateComponent& size, Style::ZoomFactor zoom, SVGLengthMode lengthMode)
 {
-    return valueForSizeType(size, zoomNeeded, lengthMode);
+    return valueForSizeType(size, zoom, lengthMode);
 }
 
-float SVGLengthContext::valueForLength(const Style::SVGCoordinateComponent& size, Style::ZoomNeeded zoomNeeded, SVGLengthMode lengthMode)
+float SVGLengthContext::valueForLength(const Style::SVGCoordinateComponent& size, Style::ZoomFactor zoom, SVGLengthMode lengthMode)
 {
-    return valueForSizeType(size, zoomNeeded, lengthMode);
+    return valueForSizeType(size, zoom, lengthMode);
 }
 
-float SVGLengthContext::valueForLength(const Style::SVGRadius& size, Style::ZoomNeeded zoomNeeded, SVGLengthMode lengthMode)
+float SVGLengthContext::valueForLength(const Style::SVGRadius& size, Style::ZoomFactor zoom, SVGLengthMode lengthMode)
 {
-    return valueForSizeType(size, zoomNeeded, lengthMode);
+    return valueForSizeType(size, zoom, lengthMode);
 }
 
-float SVGLengthContext::valueForLength(const Style::SVGRadiusComponent& size, Style::ZoomNeeded zoomNeeded, SVGLengthMode lengthMode)
+float SVGLengthContext::valueForLength(const Style::SVGRadiusComponent& size, Style::ZoomFactor zoom, SVGLengthMode lengthMode)
 {
-    return valueForSizeType(size, zoomNeeded, lengthMode);
+    return valueForSizeType(size, zoom, lengthMode);
 }
 
-float SVGLengthContext::valueForLength(const Style::SVGStrokeDasharrayValue& size, Style::ZoomNeeded zoomNeeded, SVGLengthMode lengthMode)
+float SVGLengthContext::valueForLength(const Style::SVGStrokeDasharrayValue& size, Style::ZoomFactor zoom, SVGLengthMode lengthMode)
 {
-    return valueForSizeType(size, zoomNeeded, lengthMode);
+    return valueForSizeType(size, zoom, lengthMode);
 }
 
-float SVGLengthContext::valueForLength(const Style::SVGStrokeDashoffset& size, Style::ZoomNeeded zoomNeeded, SVGLengthMode lengthMode)
+float SVGLengthContext::valueForLength(const Style::SVGStrokeDashoffset& size, Style::ZoomFactor zoom, SVGLengthMode lengthMode)
 {
-    return valueForSizeType(size, zoomNeeded, lengthMode);
+    return valueForSizeType(size, zoom, lengthMode);
 }
 
 float SVGLengthContext::valueForLength(const Style::StrokeWidth& size, Style::ZoomFactor usedZoom, SVGLengthMode lengthMode)
@@ -285,21 +260,21 @@ ExceptionOr<float> SVGLengthContext::resolveValueToUserUnits(float value, const 
     }
 }
 
-ExceptionOr<CSS::LengthPercentage<>> SVGLengthContext::resolveValueFromUserUnits(float value, const CSS::LengthPercentageUnit& targetUnit, SVGLengthMode lengthMode) const
+ExceptionOr<CSS::LengthPercentage<CSS::AllUnzoomed>> SVGLengthContext::resolveValueFromUserUnits(float value, const CSS::LengthPercentageUnit& targetUnit, SVGLengthMode lengthMode) const
 {
     switch (targetUnit) {
     case CSS::LengthPercentageUnit::Percentage: {
         auto percent = convertValueFromUserUnitsToPercentage(value, lengthMode);
         if (percent.hasException())
             return percent.releaseException();
-        return CSS::LengthPercentage<>(targetUnit, percent.releaseReturnValue());
+        return CSS::LengthPercentage<CSS::AllUnzoomed>(targetUnit, percent.releaseReturnValue());
     }
 
     case CSS::LengthPercentageUnit::Ex: {
         auto exVal = convertValueFromUserUnitsToEXS(value);
         if (exVal.hasException())
             return exVal.releaseException();
-        return CSS::LengthPercentage<>(targetUnit, exVal.releaseReturnValue());
+        return CSS::LengthPercentage<CSS::AllUnzoomed>(targetUnit, exVal.releaseReturnValue());
     }
 
     default: {
@@ -313,7 +288,7 @@ ExceptionOr<CSS::LengthPercentage<>> SVGLengthContext::resolveValueFromUserUnits
         if (!pxPerUnit)
             return Exception { ExceptionCode::NotSupportedError };
 
-        return CSS::LengthPercentage<>(targetUnit, value / pxPerUnit);
+        return CSS::LengthPercentage<CSS::AllUnzoomed>(targetUnit, value / pxPerUnit);
     }
     }
 }

--- a/Source/WebCore/svg/SVGLengthContext.h
+++ b/Source/WebCore/svg/SVGLengthContext.h
@@ -66,17 +66,17 @@ public:
     static FloatPoint resolvePoint(const SVGElement*, SVGUnitTypes::SVGUnitType, const SVGLengthValue& x, const SVGLengthValue& y);
     static float resolveLength(const SVGElement*, SVGUnitTypes::SVGUnitType, const SVGLengthValue&);
 
-    float valueForLength(const Style::PreferredSize&, Style::ZoomFactor usedZoom, SVGLengthMode = SVGLengthMode::Other);
-    float valueForLength(const Style::SVGCenterCoordinateComponent&, Style::ZoomNeeded, SVGLengthMode = SVGLengthMode::Other);
-    float valueForLength(const Style::SVGCoordinateComponent&, Style::ZoomNeeded, SVGLengthMode = SVGLengthMode::Other);
-    float valueForLength(const Style::SVGRadius&, Style::ZoomNeeded, SVGLengthMode = SVGLengthMode::Other);
-    float valueForLength(const Style::SVGRadiusComponent&, Style::ZoomNeeded, SVGLengthMode = SVGLengthMode::Other);
-    float valueForLength(const Style::SVGStrokeDasharrayValue&, Style::ZoomNeeded, SVGLengthMode = SVGLengthMode::Other);
-    float valueForLength(const Style::SVGStrokeDashoffset&, Style::ZoomNeeded, SVGLengthMode = SVGLengthMode::Other);
-    float valueForLength(const Style::StrokeWidth&, Style::ZoomFactor usedZoom, SVGLengthMode = SVGLengthMode::Other);
+    float valueForLength(const Style::PreferredSize&, Style::ZoomFactor, SVGLengthMode = SVGLengthMode::Other);
+    float valueForLength(const Style::SVGCenterCoordinateComponent&, Style::ZoomFactor, SVGLengthMode = SVGLengthMode::Other);
+    float valueForLength(const Style::SVGCoordinateComponent&, Style::ZoomFactor, SVGLengthMode = SVGLengthMode::Other);
+    float valueForLength(const Style::SVGRadius&, Style::ZoomFactor, SVGLengthMode = SVGLengthMode::Other);
+    float valueForLength(const Style::SVGRadiusComponent&, Style::ZoomFactor, SVGLengthMode = SVGLengthMode::Other);
+    float valueForLength(const Style::SVGStrokeDasharrayValue&, Style::ZoomFactor, SVGLengthMode = SVGLengthMode::Other);
+    float valueForLength(const Style::SVGStrokeDashoffset&, Style::ZoomFactor, SVGLengthMode = SVGLengthMode::Other);
+    float valueForLength(const Style::StrokeWidth&, Style::ZoomFactor, SVGLengthMode = SVGLengthMode::Other);
 
     ExceptionOr<float> resolveValueToUserUnits(float, const CSS::LengthPercentageUnit&, SVGLengthMode) const;
-    ExceptionOr<CSS::LengthPercentage<>> resolveValueFromUserUnits(float, const CSS::LengthPercentageUnit&, SVGLengthMode) const;
+    ExceptionOr<CSS::LengthPercentage<CSS::AllUnzoomed>> resolveValueFromUserUnits(float, const CSS::LengthPercentageUnit&, SVGLengthMode) const;
 
     std::optional<FloatSize> viewportSize() const;
 
@@ -94,8 +94,7 @@ private:
 
     std::optional<CSSToLengthConversionData> cssConversionData() const;
 
-    template<typename SizeType> float valueForSizeType(const SizeType&, Style::ZoomFactor usedZoom, SVGLengthMode = SVGLengthMode::Other) requires (SizeType::Fixed::zoomOptions == CSS::RangeZoomOptions::Unzoomed || SizeType::Calc::range.zoomOptions == CSS::RangeZoomOptions::Unzoomed);
-    template<typename SizeType> float valueForSizeType(const SizeType&, Style::ZoomNeeded, SVGLengthMode = SVGLengthMode::Other);
+    template<typename SizeType> float valueForSizeType(const SizeType&, Style::ZoomFactor, SVGLengthMode = SVGLengthMode::Other);
 
     WeakPtr<const SVGElement, WeakPtrImplWithEventTargetData> m_context;
     mutable std::optional<FloatSize> m_viewportSize;

--- a/Source/WebCore/svg/SVGLengthValue.cpp
+++ b/Source/WebCore/svg/SVGLengthValue.cpp
@@ -81,7 +81,7 @@ static inline CSS::LengthPercentageUnit NODELETE svgLengthTypeToCSSLengthUnit(SV
     }
 }
 
-static Variant<CSS::Number<>, CSS::LengthPercentage<>> createVariantForLengthType(float value, SVGLengthType lengthType)
+static Variant<CSS::Number<>, CSS::LengthPercentage<CSS::AllUnzoomed>> createVariantForLengthType(float value, SVGLengthType lengthType)
 {
     if (lengthType == SVGLengthType::Number)
         return CSS::Number<>(value);
@@ -92,7 +92,7 @@ static Variant<CSS::Number<>, CSS::LengthPercentage<>> createVariantForLengthTyp
         return CSS::Number<>(value);
     }
 
-    return CSS::LengthPercentage<>(svgLengthTypeToCSSLengthUnit(lengthType), value);
+    return CSS::LengthPercentage<CSS::AllUnzoomed>(svgLengthTypeToCSSLengthUnit(lengthType), value);
 }
 
 
@@ -153,7 +153,7 @@ SVGLengthType SVGLengthValue::lengthType() const
         [](const CSS::Number<>&) -> SVGLengthType {
             return SVGLengthType::Number;
         },
-        [](const CSS::LengthPercentage<>& length) -> SVGLengthType {
+        [](const CSS::LengthPercentage<CSS::AllUnzoomed>& length) -> SVGLengthType {
             if (auto raw = length.raw())
                 return cssLengthUnitToSVGLengthType(raw->unit);
 
@@ -177,7 +177,7 @@ bool SVGLengthValue::isRelative() const
         [](const CSS::Number<>&) {
             return false;
         },
-        [](const CSS::LengthPercentage<>& length) {
+        [](const CSS::LengthPercentage<CSS::AllUnzoomed>& length) {
             if (auto raw = length.raw()) {
                 using Unit = CSS::LengthPercentageUnit;
                 switch (raw->unit) {
@@ -243,7 +243,7 @@ float SVGLengthValue::valueAsPercentage() const
 
             return 0.0f;
         },
-        [](const CSS::LengthPercentage<>& length) -> float {
+        [](const CSS::LengthPercentage<CSS::AllUnzoomed>& length) -> float {
             if (auto raw = length.raw()) {
                 if (raw->unit == CSS::LengthPercentageUnit::Percentage)
                     return raw->value / 100.0f;
@@ -300,7 +300,7 @@ ExceptionOr<float> SVGLengthValue::valueForBindings(const SVGLengthContext& cont
 
             return Exception { ExceptionCode::NotFoundError };
         },
-        [&](const CSS::LengthPercentage<>& length) -> ExceptionOr<float> {
+        [&](const CSS::LengthPercentage<CSS::AllUnzoomed>& length) -> ExceptionOr<float> {
             if (auto raw = length.raw())
                 return context.resolveValueToUserUnits(raw->value, raw->unit, m_lengthMode);
 
@@ -315,9 +315,9 @@ void SVGLengthValue::setValueInSpecifiedUnits(float value)
         [&](const CSS::Number<>&) -> decltype(m_value) {
             return CSS::Number<>(value);
         },
-        [&](const CSS::LengthPercentage<>& current) -> decltype(m_value) {
+        [&](const CSS::LengthPercentage<CSS::AllUnzoomed>& current) -> decltype(m_value) {
             if (auto raw = current.raw())
-                return CSS::LengthPercentage<>(raw->unit, value);
+                return CSS::LengthPercentage<CSS::AllUnzoomed>(raw->unit, value);
 
             return CSS::Number<>(value);
         }
@@ -331,7 +331,7 @@ ExceptionOr<void> SVGLengthValue::setValue(const SVGLengthContext& context, floa
             m_value = CSS::Number<>(value);
             return { };
         },
-        [&](const CSS::LengthPercentage<>& current) -> ExceptionOr<void> {
+        [&](const CSS::LengthPercentage<CSS::AllUnzoomed>& current) -> ExceptionOr<void> {
             if (auto raw = current.raw()) {
                 auto resolvedValue = context.resolveValueFromUserUnits(value, raw->unit, m_lengthMode);
                 if (resolvedValue.hasException())
@@ -381,7 +381,7 @@ ExceptionOr<void> SVGLengthValue::setValueAsString(StringView string)
     CSSTokenizer tokenizer(trimmedString.toString());
     auto tokenRange = tokenizer.tokenRange();
 
-    auto parsedValue = CSSPropertyParserHelpers::MetaConsumer<CSS::Number<>, CSS::LengthPercentage<>>::consume(tokenRange, parserState, { });
+    auto parsedValue = CSSPropertyParserHelpers::MetaConsumer<CSS::Number<>, CSS::LengthPercentage<CSS::AllUnzoomed>>::consume(tokenRange, parserState, { });
     if (!parsedValue || !tokenRange.atEnd())
         return Exception { ExceptionCode::SyntaxError };
 
@@ -394,7 +394,7 @@ ExceptionOr<void> SVGLengthValue::setValueAsString(StringView string)
                 m_value = WTF::move(number);
             return { };
         },
-        [&](CSS::LengthPercentage<>&& length) -> ExceptionOr<void> {
+        [&](CSS::LengthPercentage<CSS::AllUnzoomed>&& length) -> ExceptionOr<void> {
             // FIXME: Add support for calculated lengths.
             if (length.isCalc())
                 return Exception { ExceptionCode::SyntaxError };

--- a/Source/WebCore/svg/SVGLengthValue.h
+++ b/Source/WebCore/svg/SVGLengthValue.h
@@ -95,7 +95,7 @@ public:
     friend bool operator==(SVGLengthValue, SVGLengthValue) = default;
 
 private:
-    Variant<CSS::Number<>, CSS::LengthPercentage<>> m_value;
+    Variant<CSS::Number<>, CSS::LengthPercentage<CSS::AllUnzoomed>> m_value;
     SVGLengthMode m_lengthMode { SVGLengthMode::Other };
 };
 


### PR DESCRIPTION
#### a233deebcceb6ac726b24b8cb560827c9b054b5b
<pre>
[EvaluationTimeZoom] Convert remaining trivial to convert properties to evaluation time zoom
<a href="https://bugs.webkit.org/show_bug.cgi?id=318786">https://bugs.webkit.org/show_bug.cgi?id=318786</a>

Reviewed by NOBODY (OOPS!).

WIP. More tests needed.

Converts `block-step-size`, `tab-size`,`row-gap`, `column-gap`, `background-size`,
`border-image-outset`,  `border-image-width`, `mask-border-outset`, `mask-border-width`,
`vertical-align`, `clip`, `column-width`, `-webkit-marquee-increment`, `overflow-clip-margin`,
`baseline-shift`,  `cx`, `cy`, `x`, `y`, `r`, `rx`, `ry`, `stroke-dasharray`,
`stroke-dashoffset`, `filter: blur()` and @page `size`.

Tests: imported/w3c/web-platform-tests/css/css-viewport/zoom/background-size.html
       imported/w3c/web-platform-tests/css/css-viewport/zoom/block-step-size.html
       imported/w3c/web-platform-tests/css/css-viewport/zoom/border-image-outset.html
       imported/w3c/web-platform-tests/css/css-viewport/zoom/column-gap.html
       imported/w3c/web-platform-tests/css/css-viewport/zoom/mask-border-outset.html
       imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/background-size-ref.html
       imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/block-step-size-ref.html
       imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/border-image-outset-ref.html
       imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/column-gap-ref.html
       imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/mask-border-outset-ref.html
       imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/row-gap-ref.html
       imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/tab-size-ref.html
       imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/vertical-align-ref.html
       imported/w3c/web-platform-tests/css/css-viewport/zoom/row-gap.html
       imported/w3c/web-platform-tests/css/css-viewport/zoom/tab-size.html
       imported/w3c/web-platform-tests/css/css-viewport/zoom/vertical-align.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/background-size-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/background-size.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/block-step-size-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/block-step-size.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/border-image-outset-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/border-image-outset.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/column-gap-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/column-gap.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/mask-border-outset-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/mask-border-outset.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/background-size-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/block-step-size-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/border-image-outset-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/column-gap-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/mask-border-outset-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/row-gap-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/tab-size-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/vertical-align-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/row-gap-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/row-gap.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/tab-size-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/tab-size.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/vertical-align-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/vertical-align.html: Added.
* Source/WebCore/css/deprecated-cssom/DeprecatedCSSOMRect.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Background.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Filter.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Overflow.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+SVG.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Timeline.cpp:
* Source/WebCore/css/parser/CSSPropertyParserCustom.h:
* Source/WebCore/css/values/backgrounds/CSSBorderImageOutset.h:
* Source/WebCore/css/values/backgrounds/CSSBorderImageWidth.h:
* Source/WebCore/css/values/borders/CSSBorderRadius.cpp:
* Source/WebCore/css/values/borders/CSSBorderRadius.h:
* Source/WebCore/css/values/filter-effects/CSSBlurFunction.h:
* Source/WebCore/css/values/masking/CSSClip.h:
* Source/WebCore/css/values/masking/CSSMaskBorderOutset.h:
* Source/WebCore/css/values/masking/CSSMaskBorderWidth.h:
* Source/WebCore/dom/Document.cpp:
* Source/WebCore/layout/formattingContexts/flex/FlexFormattingUtils.cpp:
* Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp:
* Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.h:
* Source/WebCore/layout/formattingContexts/inline/InlineLevelBoxInlines.h:
* Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp:
* Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.cpp:
* Source/WebCore/layout/integration/inline/InlineIteratorBoxModernPathInlines.h:
* Source/WebCore/page/LocalFrameView.cpp:
* Source/WebCore/page/PrintContext.cpp:
* Source/WebCore/rendering/BackgroundPainter.cpp:
* Source/WebCore/rendering/LegacyInlineTextBox.cpp:
* Source/WebCore/rendering/NinePieceImagePainter.cpp:
* Source/WebCore/rendering/RenderBlockFlow.cpp:
* Source/WebCore/rendering/RenderBox.cpp:
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
* Source/WebCore/rendering/RenderGrid.cpp:
* Source/WebCore/rendering/RenderMarquee.cpp:
* Source/WebCore/rendering/RenderMultiColumnSet.cpp:
* Source/WebCore/rendering/RenderText.cpp:
* Source/WebCore/rendering/svg/RenderSVGEllipse.cpp:
* Source/WebCore/rendering/svg/RenderSVGForeignObject.cpp:
* Source/WebCore/rendering/svg/RenderSVGRect.cpp:
* Source/WebCore/rendering/svg/SVGPathFromElement.cpp:
* Source/WebCore/rendering/svg/SVGRenderSupport.cpp:
* Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp:
* Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.cpp:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGEllipse.cpp:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGForeignObject.cpp:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRect.cpp:
* Source/WebCore/style/computed/StyleComputedStyle.cpp:
* Source/WebCore/style/values/align/StyleGapGutter.h:
* Source/WebCore/style/values/backgrounds/StyleBackgroundSize.h:
* Source/WebCore/style/values/backgrounds/StyleBorderImageOutset.h:
* Source/WebCore/style/values/backgrounds/StyleBorderImageWidth.h:
* Source/WebCore/style/values/filter-effects/StyleBlurFunction.cpp:
* Source/WebCore/style/values/filter-effects/StyleBlurFunction.h:
* Source/WebCore/style/values/inline/StyleVerticalAlign.h:
* Source/WebCore/style/values/masking/StyleClip.h:
* Source/WebCore/style/values/masking/StyleMaskBorderOutset.h:
* Source/WebCore/style/values/masking/StyleMaskBorderWidth.h:
* Source/WebCore/style/values/multicol/StyleColumnWidth.h:
* Source/WebCore/style/values/non-standard/StyleWebKitMarqueeIncrement.h:
* Source/WebCore/style/values/overflow/StyleOverflowClipMargin.h:
* Source/WebCore/style/values/page/StylePageSize.cpp:
* Source/WebCore/style/values/page/StylePageSize.h:
* Source/WebCore/style/values/rhythm/StyleBlockStepSize.h:
* Source/WebCore/style/values/svg/StyleSVGBaselineShift.h:
* Source/WebCore/style/values/svg/StyleSVGCenterCoordinateComponent.h:
* Source/WebCore/style/values/svg/StyleSVGCoordinateComponent.h:
* Source/WebCore/style/values/svg/StyleSVGRadius.h:
* Source/WebCore/style/values/svg/StyleSVGRadiusComponent.h:
* Source/WebCore/style/values/svg/StyleSVGStrokeDasharray.h:
* Source/WebCore/style/values/svg/StyleSVGStrokeDashoffset.h:
* Source/WebCore/style/values/text/StyleTabSize.cpp:
* Source/WebCore/style/values/text/StyleTabSize.h:
* Source/WebCore/style/values/transforms/StyleTransformFunction.cpp:
* Source/WebCore/svg/SVGLengthContext.cpp:
* Source/WebCore/svg/SVGLengthContext.h:
* Source/WebCore/svg/SVGLengthValue.cpp:
* Source/WebCore/svg/SVGLengthValue.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a233deebcceb6ac726b24b8cb560827c9b054b5b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173104 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47035 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40986 "Failed to checkout and rebase branch from PR 68837") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182677 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130660 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174969 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48329 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46718 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134613 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95036 "23 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176062 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38011 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155340 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115082 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36656 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34996 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31162 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147080 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34838 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185099 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37899 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39198 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143447 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46704 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154900 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143319 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47383 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31673 "Exiting early after 60 failures. 87024 tests run. 60 failures") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112456 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38278 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119132 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45889 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9784 "Passed tests") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45291 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45522 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45348 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->