### PR TITLE
Replace *_TBA API availability declarations with 27.0

### DIFF
--- a/Source/WebKit/Scripts/generate-swift-availability-macros
+++ b/Source/WebKit/Scripts/generate-swift-availability-macros
@@ -75,6 +75,7 @@ anyAppleOSAndDownlevels 17.0: $(macOS 14.0), $(iOS 17.0), $(visionOS 1.0)
 anyAppleOSAndDownlevels 18.4: $(macOS 15.4), $(iOS 18.4), $(visionOS 2.4)
 anyAppleOSAndDownlevels 26.0: $(macOS 26.0), $(iOS 26.0), $(visionOS 26.0)
 anyAppleOSAndDownlevels 26.4: $(macOS 26.4), $(iOS 26.4), $(visionOS 26.4)
+anyAppleOSAndDownlevels 27.0: $(macOS 27.0), $(iOS 27.0), $(visionOS 27.0)
 
 # Upcoming API, release version unspecified.
 TBA: macOS ${OSX_VERSION}, iOS ${IOS_VERSION}, visionOS ${XROS_VERSION}

--- a/Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.h
+++ b/Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.h
@@ -48,7 +48,7 @@ WK_CLASS_AVAILABLE(macos(10.12), ios(16.0))
 @property (nonatomic, readonly) BOOL hasLocalDataForLinkURL WK_API_DEPRECATED_WITH_REPLACEMENT("linkLocalResourceResponse", macos(15.0, 26.0), ios(18.0, 26.0), visionos(2.0, 26.0));
 @property (nonatomic, readonly, copy) NSString *linkLocalDataMIMEType WK_API_DEPRECATED_WITH_REPLACEMENT("linkLocalResourceResponse.MIMEType", macos(15.0, 26.0), ios(18.0, 26.0), visionos(2.0, 26.0));
 @property (nonatomic, readonly, copy) NSURL *absoluteMediaURL;
-@property (nonatomic, readonly, copy) NSURL *absoluteModelURL WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+@property (nonatomic, readonly, copy) NSURL *absoluteModelURL WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
 @property (nonatomic, readonly, copy) NSURLResponse *linkLocalResourceResponse WK_API_AVAILABLE(macos(26.0), ios(26.0), visionos(26.0));
 
 @property (nonatomic, readonly, copy) NSString *linkLabel;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListItemPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListItemPrivate.h
@@ -29,7 +29,7 @@
 
 // For testing only.
 - (CGImageRef)_copySnapshotForTesting WK_API_AVAILABLE(macos(10.12.3), ios(10.3));
-- (NSString *)_loggingStringForTesting WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+- (NSString *)_loggingStringForTesting WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
 
 @property (nonatomic) CGPoint _scrollPosition WK_API_AVAILABLE(macos(10.14.4), ios(12.2));
 @property (nonatomic, readonly) BOOL _wasCreatedByJSWithoutUserInteraction WK_API_AVAILABLE(macos(14.0), ios(17.0));

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentWorld.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentWorld.h
@@ -64,7 +64,7 @@ Repeated calls will retrieve the same WKContentWorld instance.
 @discussion Unlike all other worlds, worlds created with this factory method cannot be retrieved later.
 Clients therefore need to take care to reference them for as long as they are needed.
 */
-+ (WKContentWorld *)worldWithConfiguration:(WKContentWorldConfiguration *)configuration NS_SWIFT_NAME(init(configuration:)) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
++ (WKContentWorld *)worldWithConfiguration:(WKContentWorldConfiguration *)configuration NS_SWIFT_NAME(init(configuration:)) WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
 
 /*! @abstract Retrieves a named content world for API client use.
 @param name The name of the WKContentWorld to retrieve.

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentWorldConfiguration.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentWorldConfiguration.h
@@ -38,7 +38,7 @@ For example:
 WK_SWIFT_UI_ACTOR
 NS_SWIFT_SENDABLE
 NS_SWIFT_NAME(WKContentWorld.Configuration)
-WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
+WK_CLASS_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0))
 @interface WKContentWorldConfiguration : NSObject<NSCopying, NSSecureCoding>
 
 /*! @abstract A boolean value indicating whether every shadow root should be treated as open mode shadow root or not. */

--- a/Source/WebKit/UIProcess/API/Cocoa/WKFormInfo.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKFormInfo.h
@@ -35,7 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 
 NS_SWIFT_UI_ACTOR
-WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
+WK_CLASS_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0))
 @interface WKFormInfo : NSObject
 
 /*! @abstract The frame where the form is being submitted will cause a navigation.

--- a/Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.h
@@ -61,7 +61,7 @@ WK_SWIFT_UI_ACTOR
  @param url The URL to fetch the matching cookies for.
  @param completionHandler A block to invoke with the fetched cookies.
  */
-- (void)getCookiesForURL:(NSURL *)url completionHandler:(NS_SWIFT_UI_ACTOR void (^)(NSArray<NSHTTPCookie *> *))completionHandler NS_SWIFT_NAME(getCookies(for:completionHandler:)) WK_SWIFT_ASYNC_NAME(cookies(for:)) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+- (void)getCookiesForURL:(NSURL *)url completionHandler:(NS_SWIFT_UI_ACTOR void (^)(NSArray<NSHTTPCookie *> *))completionHandler NS_SWIFT_NAME(getCookies(for:completionHandler:)) WK_SWIFT_ASYNC_NAME(cookies(for:)) WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
 
 /*! @abstract Set a cookie.
  @param cookie The cookie to set.

--- a/Source/WebKit/UIProcess/API/Cocoa/WKImmersiveEnvironment.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKImmersiveEnvironment.h
@@ -34,7 +34,7 @@ NS_HEADER_AUDIT_BEGIN(nullability, sendability)
  */
 NS_SWIFT_UI_ACTOR
 NS_SWIFT_SENDABLE
-WK_CLASS_AVAILABLE(visionos(WK_XROS_TBA))
+WK_CLASS_AVAILABLE(visionos(27.0))
 WK_API_UNAVAILABLE(macos, ios)
 @interface WKImmersiveEnvironment : NSObject
 
@@ -43,7 +43,7 @@ WK_API_UNAVAILABLE(macos, ios)
 
 /*! @abstract The frame information of the website that provided this immersive environment.
  */
-@property (nonatomic, readonly) WKFrameInfo *sourceFrame WK_API_AVAILABLE(visionos(WK_XROS_TBA));
+@property (nonatomic, readonly) WKFrameInfo *sourceFrame WK_API_AVAILABLE(visionos(27.0));
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKImmersiveEnvironmentDelegate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKImmersiveEnvironmentDelegate.h
@@ -37,7 +37,7 @@ NS_HEADER_AUDIT_BEGIN(nullability, sendability)
  and dismissal of immersive environments requested by websites.
  */
 NS_SWIFT_UI_ACTOR
-WK_API_AVAILABLE(visionos(WK_XROS_TBA))
+WK_API_AVAILABLE(visionos(27.0))
 WK_API_UNAVAILABLE(macos, ios)
 @protocol WKImmersiveEnvironmentDelegate <NSObject>
 
@@ -47,7 +47,7 @@ WK_API_UNAVAILABLE(macos, ios)
  @param completionHandler The completion handler you must invoke with the request's answer. `YES` to allow
  the environment presentation, or `NO` to deny it.
  */
-- (void)webView:(WKWebView *)webView shouldAllowImmersiveEnvironmentFromFrame:(WKFrameInfo *)frame completionHandler:(void (^)(BOOL allow))completionHandler NS_SWIFT_ASYNC_NAME(webView(_:shouldAllowImmersiveEnvironmentFrom:)) WK_API_AVAILABLE(visionos(WK_XROS_TBA));
+- (void)webView:(WKWebView *)webView shouldAllowImmersiveEnvironmentFromFrame:(WKFrameInfo *)frame completionHandler:(void (^)(BOOL allow))completionHandler NS_SWIFT_ASYNC_NAME(webView(_:shouldAllowImmersiveEnvironmentFrom:)) WK_API_AVAILABLE(visionos(27.0));
 
 /*! @abstract Asks the delegate to present an immersive environment.
  @param webView The web view requesting presentation.
@@ -55,14 +55,14 @@ WK_API_UNAVAILABLE(macos, ios)
  @param completionHandler The completion handler you must invoke once the presentation transition has completed.
  The error argument should be used in case the presentation failed and the environment couldn't be presented.
  */
-- (void)webView:(WKWebView *)webView presentImmersiveEnvironment:(WKImmersiveEnvironment *)environment completionHandler:(void (^)(NSError * _Nullable error))completionHandler NS_SWIFT_ASYNC_NAME(webView(_:presentImmersiveEnvironment:)) WK_API_AVAILABLE(visionos(WK_XROS_TBA));
+- (void)webView:(WKWebView *)webView presentImmersiveEnvironment:(WKImmersiveEnvironment *)environment completionHandler:(void (^)(NSError * _Nullable error))completionHandler NS_SWIFT_ASYNC_NAME(webView(_:presentImmersiveEnvironment:)) WK_API_AVAILABLE(visionos(27.0));
 
 /*! @abstract Asks the delegate to dismiss an immersive environment.
  @param webView The web view requesting dismissal.
  @param environment The immersive environment to dismiss.
  @param completionHandler The completion handler you must invoke once the dismissal transition has completed.
  */
-- (void)webView:(WKWebView *)webView dismissImmersiveEnvironment:(WKImmersiveEnvironment *)environment completionHandler:(void (^)(void))completionHandler NS_SWIFT_ASYNC_NAME(webView(_:dismissImmersiveEnvironment:)) WK_API_AVAILABLE(visionos(WK_XROS_TBA));
+- (void)webView:(WKWebView *)webView dismissImmersiveEnvironment:(WKImmersiveEnvironment *)environment completionHandler:(void (^)(void))completionHandler NS_SWIFT_ASYNC_NAME(webView(_:dismissImmersiveEnvironment:)) WK_API_AVAILABLE(visionos(27.0));
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKJSHandle.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKJSHandle.h
@@ -49,7 +49,7 @@ NS_ASSUME_NONNULL_BEGIN
  Whatever JavaScript object the `WKJSHandle` represents, it will be protected from garbage collection for the lifetime of the `WKJSHandle`
  The `WKJSHandle` can also be used as an argument to future JavaScript run via `[WKWebView callAsyncJavaScript:...]`
  */
-WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
+WK_CLASS_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0))
 @interface WKJSHandle : NSObject<NSCopying>
 
 + (instancetype)new NS_UNAVAILABLE;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKJSSerializedNode.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKJSSerializedNode.h
@@ -47,7 +47,7 @@ NS_ASSUME_NONNULL_BEGIN
  to a live JavaScript object, and it can be used as an argument to a JavaScript program running in any context.
  e.g. In a different frame, or after a navigation.
  */
-WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
+WK_CLASS_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0))
 @interface WKJSSerializedNode : NSObject
 
 + (instancetype)new NS_UNAVAILABLE;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKMenuItemIdentifiersPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKMenuItemIdentifiersPrivate.h
@@ -78,10 +78,10 @@ WK_EXTERN NSString * const _WKMenuItemIdentifierPauseAllAnimations WK_API_AVAILA
 WK_EXTERN NSString * const _WKMenuItemIdentifierPlayAnimation  WK_API_AVAILABLE(macos(14.0), ios(17.0));
 WK_EXTERN NSString * const _WKMenuItemIdentifierPauseAnimation  WK_API_AVAILABLE(macos(14.0), ios(17.0));
 
-WK_EXTERN NSString * const _WKMenuItemIdentifierSubstitutionsMenu WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
-WK_EXTERN NSString * const _WKMenuItemIdentifierShowSubstitutions WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
-WK_EXTERN NSString * const _WKMenuItemIdentifierSmartCopyPaste WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
-WK_EXTERN NSString * const _WKMenuItemIdentifierSmartQuotes WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
-WK_EXTERN NSString * const _WKMenuItemIdentifierSmartDashes WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
-WK_EXTERN NSString * const _WKMenuItemIdentifierSmartLinks WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
-WK_EXTERN NSString * const _WKMenuItemIdentifierTextReplacement WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+WK_EXTERN NSString * const _WKMenuItemIdentifierSubstitutionsMenu WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
+WK_EXTERN NSString * const _WKMenuItemIdentifierShowSubstitutions WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
+WK_EXTERN NSString * const _WKMenuItemIdentifierSmartCopyPaste WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
+WK_EXTERN NSString * const _WKMenuItemIdentifierSmartQuotes WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
+WK_EXTERN NSString * const _WKMenuItemIdentifierSmartDashes WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
+WK_EXTERN NSString * const _WKMenuItemIdentifierSmartLinks WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
+WK_EXTERN NSString * const _WKMenuItemIdentifierTextReplacement WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.h
@@ -89,7 +89,7 @@ WK_CLASS_AVAILABLE(macos(10.10), ios(8.0))
 /*! @abstract The most recent main frame navigation that took place that encompasses this navigation action.
 @discussion If this WKNavigationAction represents a request to open a new WKWebView or it represents a frame load that is not in the main frame of an existing WKWebView, then mainFrameNavigation will be nil.
  */
-@property (nonatomic, readonly, nullable) WKNavigation *mainFrameNavigation WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+@property (nonatomic, readonly, nullable) WKNavigation *mainFrameNavigation WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
 
 #if TARGET_OS_IPHONE
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationDelegate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationDelegate.h
@@ -213,7 +213,7 @@ WK_SWIFT_UI_ACTOR
  @param formInfo Information about the form submission that will take place.
  @param submissionHandler A block to call once the application has done any asynchronous work it needs to for this form submission, indicating that the form submission can continue.
 */
-- (void)webView:(WKWebView *)webView willSubmitForm:(WKFormInfo *)formInfo submissionHandler:(NS_SWIFT_UI_ACTOR void (^)(void))submissionHandler WK_SWIFT_ASYNC(3) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+- (void)webView:(WKWebView *)webView willSubmitForm:(WKFormInfo *)formInfo submissionHandler:(NS_SWIFT_UI_ACTOR void (^)(void))submissionHandler WK_SWIFT_ASYNC(3) WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationResponse.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationResponse.h
@@ -53,7 +53,7 @@ WK_CLASS_AVAILABLE(macos(10.10), ios(8.0))
 
 /*! @abstract The most recent main frame navigation that took place that encompasses this navigation response.
  */
-@property (nonatomic, readonly, nullable) WKNavigation *mainFrameNavigation WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+@property (nonatomic, readonly, nullable) WKNavigation *mainFrameNavigation WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h
@@ -65,7 +65,7 @@ typedef NS_ENUM(NSInteger, _WKNavigatorWebDriverActivePolicy) {
     _WKNavigatorWebDriverActivePolicyAuto,
     _WKNavigatorWebDriverActivePolicyEnabled,
     _WKNavigatorWebDriverActivePolicyDisabled,
-} WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+} WK_API_AVAILABLE(macos(27.0), ios(27.0));
 
 @class _WKFeature;
 @class _WKExperimentalFeature;
@@ -93,7 +93,7 @@ typedef NS_ENUM(NSInteger, _WKNavigatorWebDriverActivePolicy) {
 @property (nonatomic, setter=_setAnimatedImageAsyncDecodingEnabled:) BOOL _animatedImageAsyncDecodingEnabled WK_API_AVAILABLE(macos(10.12.4), ios(10.3));
 @property (nonatomic, setter=_setTextAutosizingEnabled:) BOOL _textAutosizingEnabled WK_API_AVAILABLE(macos(10.12), ios(10.0));
 
-@property (nonatomic, setter=_setUseUIProcessForBackForwardItemLoading:) BOOL _useUIProcessForBackForwardItemLoading WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+@property (nonatomic, setter=_setUseUIProcessForBackForwardItemLoading:) BOOL _useUIProcessForBackForwardItemLoading WK_API_AVAILABLE(macos(27.0), ios(27.0));
 
 @property (nonatomic, setter=_setDeveloperExtrasEnabled:) BOOL _developerExtrasEnabled WK_API_AVAILABLE(macos(10.11), ios(9.0));
 
@@ -184,7 +184,7 @@ typedef NS_ENUM(NSInteger, _WKNavigatorWebDriverActivePolicy) {
 @property (nonatomic, setter=_setPrivateClickMeasurementDebugModeEnabled:) BOOL _privateClickMeasurementDebugModeEnabled WK_API_AVAILABLE(macos(14.0), ios(17.0));
 @property (nonatomic, setter=_setPitchCorrectionAlgorithm:) _WKPitchCorrectionAlgorithm _pitchCorrectionAlgorithm WK_API_AVAILABLE(macos(12.0), ios(15.0));
 @property (nonatomic, setter=_setMediaSessionEnabled:) BOOL _mediaSessionEnabled WK_API_AVAILABLE(macos(12.0), ios(15.0));
-@property (nonatomic, setter=_setNavigatorWebDriverActivePolicy:) _WKNavigatorWebDriverActivePolicy _navigatorWebDriverActivePolicy WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+@property (nonatomic, setter=_setNavigatorWebDriverActivePolicy:) _WKNavigatorWebDriverActivePolicy _navigatorWebDriverActivePolicy WK_API_AVAILABLE(macos(27.0), ios(27.0));
 @property (nonatomic, getter=_isExtensibleSSOEnabled, setter=_setExtensibleSSOEnabled:) BOOL _extensibleSSOEnabled WK_API_AVAILABLE(macos(12.0), ios(15.0));
 @property (nonatomic, setter=_setRequiresPageVisibilityToPlayAudio:) BOOL _requiresPageVisibilityToPlayAudio WK_API_AVAILABLE(macos(12.0), ios(15.0));
 @property (nonatomic, setter=_setFileSystemAccessEnabled:) BOOL _fileSystemAccessEnabled WK_API_AVAILABLE(macos(13.0), ios(16.0));
@@ -214,7 +214,7 @@ typedef NS_ENUM(NSInteger, _WKNavigatorWebDriverActivePolicy) {
 @property (nonatomic, setter=_setUpdateSceneGeometryEnabled:) BOOL _updateSceneGeometryEnabled WK_API_AVAILABLE(visionos(26.4));
 @property (nonatomic, setter=_setRequiresPageVisibilityForVideoToBeNowPlayingForTesting:) BOOL _requiresPageVisibilityForVideoToBeNowPlayingForTesting WK_API_AVAILABLE(macos(15.4), ios(18.4), visionos(2.4));
 @property (nonatomic, setter=_setSiteIsolationEnabled:) BOOL _siteIsolationEnabled WK_API_AVAILABLE(macos(26.0), ios(26.0), visionos(26.0));
-@property (nonatomic, setter=_setUsesPageCache:) BOOL _usesPageCache WK_API_AVAILABLE(macos(10.13.4), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+@property (nonatomic, setter=_setUsesPageCache:) BOOL _usesPageCache WK_API_AVAILABLE(macos(10.13.4), ios(27.0), visionos(27.0));
 
 #if !TARGET_OS_IPHONE
 @property (nonatomic, setter=_setWebGLEnabled:) BOOL _webGLEnabled WK_API_AVAILABLE(macos(10.13.4));

--- a/Source/WebKit/UIProcess/API/Cocoa/WKProcessPoolPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKProcessPoolPrivate.h
@@ -143,7 +143,7 @@ WK_CLASS_AVAILABLE(macos(14.5), ios(17.5), visionos(1.2))
 - (BOOL)_hasPrewarmedWebProcess WK_API_AVAILABLE(macos(10.14.4), ios(12.2));
 - (size_t)_webProcessCountIgnoringPrewarmed WK_API_AVAILABLE(macos(10.14), ios(12.0));
 - (size_t)_webProcessCountIgnoringPrewarmedAndCached WK_API_AVAILABLE(macos(10.14.4), ios(12.2));
-- (NSUInteger)_prewarmedProcessCountLimit WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+- (NSUInteger)_prewarmedProcessCountLimit WK_API_AVAILABLE(macos(27.0), ios(27.0));
 - (size_t)_pluginProcessCount WK_API_AVAILABLE(macos(10.13.4), ios(11.3));
 - (size_t)_serviceWorkerProcessCount WK_API_AVAILABLE(macos(10.14), ios(12.0));
 - (void)_isJITDisabledInAllRemoteWorkerProcesses:(void(^)(BOOL))completionHandler;
@@ -166,7 +166,7 @@ WK_CLASS_AVAILABLE(macos(14.5), ios(17.5), visionos(1.2))
 + (void)_forceGameControllerFramework WK_API_AVAILABLE(macos(10.13), ios(11.0));
 + (void)_setLinkedOnOrAfterEverythingForTesting WK_API_AVAILABLE(macos(12.0), ios(15.0));
 + (void)_crashOnMessageCheckFailureForTesting WK_API_AVAILABLE(macos(15.4), ios(18.4), visionos(2.4));
-+ (void)_forceUseSharedMemoryForSendingForTesting:(BOOL)force WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
++ (void)_forceUseSharedMemoryForSendingForTesting:(BOOL)force WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
 + (void)_setLinkedOnOrBeforeEverythingForTesting WK_API_AVAILABLE(macos(12.0), ios(15.0));
 + (void)_setCaptivePortalModeEnabledGloballyForTesting:(BOOL)isEnabled WK_API_AVAILABLE(macos(13.0), ios(16.0));
 + (void)_clearCaptivePortalModeEnabledGloballyForTesting WK_API_AVAILABLE(macos(13.0), ios(16.0));

--- a/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegate.h
@@ -299,7 +299,7 @@ WK_SWIFT_UI_ACTOR
  @param frame The frame that initiated the request.
  @param decisionHandler The decision handler to call once the app has made its decision.
  */
-- (void)webView:(WKWebView *)webView requestGeolocationPermissionForOrigin:(WKSecurityOrigin*)origin initiatedByFrame:(WKFrameInfo *)frame decisionHandler:(WK_SWIFT_UI_ACTOR void (^)(WKPermissionDecision decision))decisionHandler WK_SWIFT_ASYNC_NAME(webView(_:requestGeolocationPermissionFor:initiatedBy:)) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+- (void)webView:(WKWebView *)webView requestGeolocationPermissionForOrigin:(WKSecurityOrigin*)origin initiatedByFrame:(WKFrameInfo *)frame decisionHandler:(WK_SWIFT_UI_ACTOR void (^)(WKPermissionDecision decision))decisionHandler WK_SWIFT_ASYNC_NAME(webView(_:requestGeolocationPermissionFor:initiatedBy:)) WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
 
 #if TARGET_OS_IOS && !TARGET_OS_MACCATALYST && __IPHONE_OS_VERSION_MIN_REQUIRED >= 180400
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h
@@ -191,8 +191,8 @@ struct UIEdgeInsets;
 - (void)_webView:(WKWebView *)webView didChangeFontAttributes:(NSDictionary<NSString *, id> *)fontAttributes WK_API_AVAILABLE(macos(10.14.4), ios(12.2));
 
 - (void)_webView:(WKWebView *)webView takeFocus:(_WKFocusDirection)direction WK_API_AVAILABLE(macos(10.13.4), ios(12.2));
-- (void)_focusWebView:(WKWebView *)webView WK_API_AVAILABLE(macos(10.13.4), ios(WK_IOS_TBA));
-- (void)_unfocusWebView:(WKWebView *)webView WK_API_AVAILABLE(macos(10.13.4), ios(WK_IOS_TBA));
+- (void)_focusWebView:(WKWebView *)webView WK_API_AVAILABLE(macos(10.13.4), ios(27.0));
+- (void)_unfocusWebView:(WKWebView *)webView WK_API_AVAILABLE(macos(10.13.4), ios(27.0));
 
 - (void)_webView:(WKWebView *)webView requestWebAuthenticationConditionalMediationRegistrationForUser:(NSString *)user completionHandler:(void (^)(BOOL))completionHandler WK_API_AVAILABLE(macos(15.0), ios(18.0), visionos(2.0));
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.h
@@ -149,13 +149,13 @@ WK_CLASS_AVAILABLE(macos(10.10), ios(8.0))
  @param contentWorld The WKContentWorld to add the buffer to.
         The buffer will only be visible to JavaScript executing in that content world.
  */
-- (void)addBuffer:(NSData *)buffer name:(NSString *)name contentWorld:(WKContentWorld *)world WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+- (void)addBuffer:(NSData *)buffer name:(NSString *)name contentWorld:(WKContentWorld *)world WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
 
 /*! @abstract Removes a previously added data buffer from the given `WKContentWorld
  @param name The name of the buffer to remove.
  @param contentWorld The WKContentWorld from which to remove the buffer.
  */
-- (void)removeBufferWithName:(NSString *)name contentWorld:(WKContentWorld *)world WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+- (void)removeBufferWithName:(NSString *)name contentWorld:(WKContentWorld *)world WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMatchPatternPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMatchPatternPrivate.h
@@ -26,7 +26,7 @@
 #import <WebKit/WKFoundation.h>
 #import <WebKit/WKWebExtensionMatchPattern.h>
 
-static const WKWebExtensionMatchPatternOptions WKWebExtensionMatchPatternOptionsAllowFileScheme WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) = 1 << 3;
+static const WKWebExtensionMatchPatternOptions WKWebExtensionMatchPatternOptionsAllowFileScheme WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0)) = 1 << 3;
 
 @interface WKWebExtensionMatchPattern ()
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.h
@@ -136,7 +136,7 @@ typedef NS_ENUM(NSInteger, WKFullscreenState) {
  @param url The URL to which to navigate.
  @result A new navigation for the given request.
  */
-- (nullable WKNavigation *)loadURL:(NSURL *)url NS_SWIFT_NAME(load(_:)) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+- (nullable WKNavigation *)loadURL:(NSURL *)url NS_SWIFT_NAME(load(_:)) WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
 
 /*! @abstract Navigates to the requested file URL on the filesystem.
  @param URL The file URL to which to navigate.
@@ -735,11 +735,11 @@ typedef NS_OPTIONS(NSUInteger, WKWebViewDataType) {
 #if defined(TARGET_OS_VISION) && TARGET_OS_VISION
 /*! @abstract The delegate that manages immersive environment presentation.
  */
-@property (nullable, nonatomic, weak) id <WKImmersiveEnvironmentDelegate> immersiveEnvironmentDelegate WK_API_AVAILABLE(visionos(WK_XROS_TBA));
+@property (nullable, nonatomic, weak) id <WKImmersiveEnvironmentDelegate> immersiveEnvironmentDelegate WK_API_AVAILABLE(visionos(27.0));
 
 /*! @abstract Dismisses the currently presented immersive environment.
  */
-- (void)dismissImmersiveEnvironmentWithCompletionHandler:(NS_SWIFT_UI_ACTOR void (^)(void))completionHandler NS_SWIFT_ASYNC_NAME(dismissImmersiveEnvironment()) WK_API_AVAILABLE(visionos(WK_XROS_TBA));
+- (void)dismissImmersiveEnvironmentWithCompletionHandler:(NS_SWIFT_UI_ACTOR void (^)(void))completionHandler NS_SWIFT_ASYNC_NAME(dismissImmersiveEnvironment()) WK_API_AVAILABLE(visionos(27.0));
 #endif
 
 #if TARGET_OS_OSX && __MAC_OS_X_VERSION_MIN_REQUIRED >= 270000
@@ -747,7 +747,7 @@ typedef NS_OPTIONS(NSUInteger, WKWebViewDataType) {
  @discussion Setting this property adds the refresh controller above the web
  content when scrolling past the top of the page.
  */
-@property (strong, nullable) NSRefreshController *refreshController WK_API_AVAILABLE(macos(WK_MAC_TBA));
+@property (strong, nullable) NSRefreshController *refreshController WK_API_AVAILABLE(macos(27.0));
 #endif
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.h
@@ -255,7 +255,7 @@ on the system setting.
  If NO, requests to present immersive environments are ignored. If YES, requests are routed to your `WKImmersiveEnvironmentDelegate`.
  The default value is NO.
  */
-@property (nonatomic) BOOL allowsImmersiveEnvironments WK_API_AVAILABLE(visionos(WK_XROS_TBA));
+@property (nonatomic) BOOL allowsImmersiveEnvironments WK_API_AVAILABLE(visionos(27.0));
 #endif
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h
@@ -181,8 +181,8 @@ typedef NS_ENUM(NSUInteger, _WKContentSecurityPolicyModeForExtension) {
 @property (nonatomic, setter=_setCSSTransformStyleSeparatedEnabled:) BOOL _cssTransformStyleSeparatedEnabled WK_API_AVAILABLE(visionos(2.4));
 #endif
 
-@property (nonatomic, setter=_setSystemTextExtractionEnabled:) BOOL _systemTextExtractionEnabled WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
-@property (nonatomic, setter=_setBackgroundTextExtractionEnabled:) BOOL _backgroundTextExtractionEnabled WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+@property (nonatomic, setter=_setSystemTextExtractionEnabled:) BOOL _systemTextExtractionEnabled WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
+@property (nonatomic, setter=_setBackgroundTextExtractionEnabled:) BOOL _backgroundTextExtractionEnabled WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -203,7 +203,7 @@ typedef NS_ENUM(NSInteger, _WKImmediateActionType) {
 #endif
 - (void)_getInformationFromImageData:(NSData *)imageData completionHandler:(void (^)(NSString *typeIdentifier, NSArray<NSValue *> *availableSizes, NSError *error))completionHandler WK_API_AVAILABLE(macos(15.4), ios(18.4), visionos(2.4));
 
-- (void)_getImageMetadata:(NSData *)imageData completionHandler:(void (^)(NSDictionary<NSString *, id> *metadata, NSError *error))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+- (void)_getImageMetadata:(NSData *)imageData completionHandler:(void (^)(NSDictionary<NSString *, id> *metadata, NSError *error))completionHandler WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
 
 - (void)_createIconDataFromImageData:(NSData *)imageData withLengths:(NSArray<NSNumber *> *)lengths completionHandler:(void (^)(NSData *, NSError *))completionHandler WK_API_AVAILABLE(macos(15.4), ios(18.4), visionos(2.4));
 #if TARGET_OS_OSX
@@ -240,7 +240,7 @@ for this property.
 
 - (void)_frames:(void (^)(_WKFrameTreeNode *))completionHandler WK_API_AVAILABLE(macos(11.0), ios(14.0));
 - (void)_frameTrees:(void (^)(NSSet<_WKFrameTreeNode *> *))completionHandler WK_API_AVAILABLE(macos(14.0), ios(17.0));
-- (void)_frameTreesInBackForwardCacheAtIndex:(NSInteger)relativeIndex completionHandler:(void (^)(NSSet<_WKFrameTreeNode *> *))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+- (void)_frameTreesInBackForwardCacheAtIndex:(NSInteger)relativeIndex completionHandler:(void (^)(NSSet<_WKFrameTreeNode *> *))completionHandler WK_API_AVAILABLE(macos(27.0), ios(27.0));
 - (void)_frameInfoFromHandle:(_WKFrameHandle *)handle completionHandler:(void (^)(WKFrameInfo *))completionHandler WK_API_AVAILABLE(macos(15.4), ios(18.4));
 
 // FIXME: Remove these once nobody is using them.
@@ -284,7 +284,7 @@ for this property.
 - (void)_evaluateJavaScript:(NSString *)javaScriptString withSourceURL:(NSURL *)url inFrame:(WKFrameInfo *)frame inContentWorld:(WKContentWorld *)contentWorld withUserGesture:(BOOL)withUserGesture completionHandler:(void (^)(id, NSError *error))completionHandler WK_API_AVAILABLE(macos(15.0), ios(18.0), visionos(2.0));
 - (void)_callAsyncJavaScript:(NSString *)functionBody arguments:(NSDictionary<NSString *, id> *)arguments inFrame:(WKFrameInfo *)frame inContentWorld:(WKContentWorld *)contentWorld completionHandler:(void (^)(id, NSError *error))completionHandler WK_API_AVAILABLE(macos(11.0), ios(14.0));
 - (void)_callAsyncJavaScript:(NSString *)functionBody arguments:(NSDictionary<NSString *, id> *)arguments inFrame:(WKFrameInfo *)frame inContentWorld:(WKContentWorld *)contentWorld withUserGesture:(BOOL)withUserGesture completionHandler:(void (^)(id, NSError *error))completionHandler WK_API_AVAILABLE(macos(15.4), ios(18.4), visionos(2.4));
-- (void)_clearContentWorld:(WKContentWorld *)contentWorld completionHandler:(NS_SWIFT_UI_ACTOR void (^)(void))completionHandler NS_SWIFT_ASYNC_NAME(_clearContentWorld(_:)) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+- (void)_clearContentWorld:(WKContentWorld *)contentWorld completionHandler:(NS_SWIFT_UI_ACTOR void (^)(void))completionHandler NS_SWIFT_ASYNC_NAME(_clearContentWorld(_:)) WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
 
 - (BOOL)_allMediaPresentationsClosed WK_API_AVAILABLE(macos(12.0), ios(15.0));
 
@@ -636,14 +636,14 @@ typedef NS_OPTIONS(NSUInteger, _WKWebViewDataType) {
     _WKWebViewDataTypeSessionStorage = 1 << 0
 } WK_API_AVAILABLE(macos(15.4), ios(18.4), visionos(2.4));
 
-- (void)_fetchDataOfTypes:(_WKWebViewDataType)dataTypes completionHandler:(WK_SWIFT_UI_ACTOR void (^)(NSData *))completionHandler WK_API_DEPRECATED_WITH_REPLACEMENT("-fetchDataOfTypes:completionHandler:", macos(15.4, WK_MAC_TBA), ios(18.4, WK_IOS_TBA), visionos(2.4, WK_XROS_TBA));
-- (void)_restoreData:(NSData *)data completionHandler:(WK_SWIFT_UI_ACTOR void(^)(BOOL))completionHandler WK_API_DEPRECATED_WITH_REPLACEMENT("-restoreData:completionHandler:", macos(15.4, WK_MAC_TBA), ios(18.4, WK_IOS_TBA), visionos(2.4, WK_XROS_TBA));
+- (void)_fetchDataOfTypes:(_WKWebViewDataType)dataTypes completionHandler:(WK_SWIFT_UI_ACTOR void (^)(NSData *))completionHandler WK_API_DEPRECATED_WITH_REPLACEMENT("-fetchDataOfTypes:completionHandler:", macos(15.4, 27.0), ios(18.4, 27.0), visionos(2.4, 27.0));
+- (void)_restoreData:(NSData *)data completionHandler:(WK_SWIFT_UI_ACTOR void(^)(BOOL))completionHandler WK_API_DEPRECATED_WITH_REPLACEMENT("-restoreData:completionHandler:", macos(15.4, 27.0), ios(18.4, 27.0), visionos(2.4, 27.0));
 
 @property (nonatomic) audit_token_t presentingApplicationAuditToken WK_API_AVAILABLE(macos(15.4), ios(18.4), visionos(2.4));
 
 @property (nonatomic, setter=_setShouldSuppressTopColorExtensionView:) BOOL _shouldSuppressTopColorExtensionView WK_API_AVAILABLE(macos(26.0), ios(26.0));
 
-@property (nonatomic, setter=_setShouldSuppressFormValidationBubble:) BOOL _shouldSuppressFormValidationBubble WK_API_AVAILABLE(ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+@property (nonatomic, setter=_setShouldSuppressFormValidationBubble:) BOOL _shouldSuppressFormValidationBubble WK_API_AVAILABLE(ios(27.0), visionos(27.0));
 
 #if TARGET_OS_OSX
 - (NSUInteger)accessibilityRemoteChildTokenHash;
@@ -660,20 +660,20 @@ typedef NS_OPTIONS(NSUInteger, _WKWebViewDataType) {
 #endif
 
 - (void)_getSelectorPathDataForNode:(_WKJSHandle *)node completionHandler:(WK_SWIFT_UI_ACTOR void (^)(NSData *))completionHandler WK_SWIFT_ASYNC_NAME(_getSelectorPathDataForNode(_:)) WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4));
-- (void)_getSelectorPathData:(WKJSHandle *)node completionHandler:(WK_SWIFT_UI_ACTOR void (^)(NSData *))completionHandler WK_SWIFT_ASYNC_NAME(_getSelectorPathData(_:)) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+- (void)_getSelectorPathData:(WKJSHandle *)node completionHandler:(WK_SWIFT_UI_ACTOR void (^)(NSData *))completionHandler WK_SWIFT_ASYNC_NAME(_getSelectorPathData(_:)) WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
 - (void)_getNodeForSelectorPathData:(NSData *)data completionHandler:(WK_SWIFT_UI_ACTOR void (^)(_WKJSHandle *))completionHandler WK_SWIFT_ASYNC_NAME(_getNodeForSelectorPathData(_:)) WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4));
 
 - (void)_debugTextWithConfiguration:(_WKTextExtractionConfiguration *)configuration completionHandler:(WK_SWIFT_UI_ACTOR void(^)(NSString *))completionHandler WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4)) NS_SWIFT_NAME(_debugText(with:completionHandler:));
 - (void)_extractDebugTextWithConfiguration:(_WKTextExtractionConfiguration *)configuration completionHandler:(WK_SWIFT_UI_ACTOR void(^)(_WKTextExtractionResult *))completionHandler WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4)) NS_SWIFT_NAME(_extractDebugText(with:completionHandler:));
 - (void)_performInteraction:(_WKTextExtractionInteraction *)interaction completionHandler:(WK_SWIFT_UI_ACTOR void(^)(_WKTextExtractionInteractionResult *))completionHandler WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4)) NS_SWIFT_NAME(_performInteraction(_:completionHandler:));
 
-- (void)_addWritingToolsPreservedNodes:(NSArray<_WKJSHandle *> *)nodes WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+- (void)_addWritingToolsPreservedNodes:(NSArray<_WKJSHandle *> *)nodes WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
 
 #if !TARGET_OS_TV && !TARGET_OS_WATCH
-@property (nonatomic, strong, setter=_setPlatformRefreshControl:) id _platformRefreshControl WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+@property (nonatomic, strong, setter=_setPlatformRefreshControl:) id _platformRefreshControl WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
 #endif
 
-- (void)_filterExtractedString:(NSString *)string options:(_WKTextExtractionFilterOptions)options completionHandler:(void(^)(NSString *))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+- (void)_filterExtractedString:(NSString *)string options:(_WKTextExtractionFilterOptions)options completionHandler:(void(^)(NSString *))completionHandler WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.h
@@ -130,21 +130,21 @@ WK_CLASS_AVAILABLE(macos(10.15), ios(13.0))
 
 /* @abstract Used to make changes to the network request that will be used for this navigation's main resource load.
 */
-@property (nonatomic, copy, nullable) NSURLRequest *alternateRequest WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+@property (nonatomic, copy, nullable) NSURLRequest *alternateRequest WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
 
 /* @abstract Used to apply a custom `referer` header to all resource loads in the frame for this navigation.
 */
-@property (nonatomic, copy, nullable) NSString *overrideReferrer WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+@property (nonatomic, copy, nullable) NSString *overrideReferrer WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
 
 /*! @abstract A boolean indicating whether `window.webkit.createJSHandle` will be available in `[WKContentWorld pageWorld]`
  @discussion The default value is false.
  */
-@property (nonatomic) BOOL allowsJSHandleCreationInPageWorld WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+@property (nonatomic) BOOL allowsJSHandleCreationInPageWorld WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
 
 /*! @abstract Whether the Global Privacy Control (GPC) signal is enabled for the navigation.
  @discussion The default value is NO. When enabled, both navigator.globalPrivacyControl and the
  Sec-GPC: 1 request header are active for the main frame, its subframes, and their subresources.
  */
-@property (nonatomic) BOOL globalPrivacyControlStatus WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+@property (nonatomic) BOOL globalPrivacyControlStatus WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferencesPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferencesPrivate.h
@@ -131,12 +131,12 @@ typedef NS_OPTIONS(NSUInteger, _WKWebsiteNetworkConnectionIntegrityPolicy) {
 
 @property (nonatomic, setter=_setPushAndNotificationAPIEnabled:) BOOL _pushAndNotificationAPIEnabled;
 
-@property (nonatomic, setter=setAlternateRequest:) NSURLRequest *_alternateRequest WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+@property (nonatomic, setter=setAlternateRequest:) NSURLRequest *_alternateRequest WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
 
 @property (nonatomic, setter=_setAllowsJSHandleCreationInPageWorld:) BOOL _allowsJSHandleCreationInPageWorld WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4));
 
 @property (nonatomic, setter=_setEnhancedSecurityEnabled:) BOOL _enhancedSecurityEnabled WK_API_DEPRECATED_WITH_REPLACEMENT("securityRestrictionMode", macos(26.4, 26.4), ios(26.4, 26.4), visionos(26.4, 26.4));
 
-@property (nonatomic, setter=setOverrideReferrer:) NSString *_overrideReferrerForAllRequests WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+@property (nonatomic, setter=setOverrideReferrer:) NSString *_overrideReferrerForAllRequests WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h
@@ -109,7 +109,7 @@ typedef NS_ENUM(uint8_t, _WKRestrictedOpenerType) {
 
 @property (nullable, nonatomic, weak) id <_WKWebsiteDataStoreDelegate> _delegate WK_API_AVAILABLE(macos(10.15), ios(13.0));
 @property (nonatomic, readonly, copy) _WKWebsiteDataStoreConfiguration *_configuration;
-@property (readonly) NSString *_thirdPartyCookieBlockingModeForTesting WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+@property (readonly) NSString *_thirdPartyCookieBlockingModeForTesting WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
 
 + (WKNotificationManagerRef)_sharedServiceWorkerNotificationManager WK_API_AVAILABLE(macos(13.0), ios(16.0));
 
@@ -158,12 +158,12 @@ typedef NS_ENUM(uint8_t, _WKRestrictedOpenerType) {
 - (void)_runningOrTerminatingServiceWorkerCountForTesting:(void(^)(NSUInteger))completionHandler WK_API_AVAILABLE(macos(15.4), ios(18.4));
 
 // Supported data types are: WKWebsiteDataTypeLocalStorage.
-- (void)_fetchDataOfTypes:(NSSet<NSString *> *)dataTypes completionHandler:(WK_SWIFT_UI_ACTOR void(^)(NSData *))completionHandler WK_API_DEPRECATED_WITH_REPLACEMENT("-fetchDataOfTypes:completionHandler:", macos(15.4, WK_MAC_TBA), ios(18.4, WK_IOS_TBA), visionos(2.4, WK_XROS_TBA));
-- (void)_restoreData:(NSData *)data completionHandler:(WK_SWIFT_UI_ACTOR void(^)(BOOL))completionHandler WK_API_DEPRECATED_WITH_REPLACEMENT("-restoreData:completionHandler:", macos(15.4, WK_MAC_TBA), ios(18.4, WK_IOS_TBA), visionos(2.4, WK_XROS_TBA));
+- (void)_fetchDataOfTypes:(NSSet<NSString *> *)dataTypes completionHandler:(WK_SWIFT_UI_ACTOR void(^)(NSData *))completionHandler WK_API_DEPRECATED_WITH_REPLACEMENT("-fetchDataOfTypes:completionHandler:", macos(15.4, 27.0), ios(18.4, 27.0), visionos(2.4, 27.0));
+- (void)_restoreData:(NSData *)data completionHandler:(WK_SWIFT_UI_ACTOR void(^)(BOOL))completionHandler WK_API_DEPRECATED_WITH_REPLACEMENT("-restoreData:completionHandler:", macos(15.4, 27.0), ios(18.4, 27.0), visionos(2.4, 27.0));
 
 - (void)_isStorageSuspendedForTesting:(WK_SWIFT_UI_ACTOR void(^)(BOOL))completionHandler WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4));
 
-- (void)_installMockParentalControlsURLFilterForTestingWithBlockedURLs:(NSArray<NSURL *> *)blockedURLs completionHandler:(void(^)(void))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+- (void)_installMockParentalControlsURLFilterForTestingWithBlockedURLs:(NSArray<NSURL *> *)blockedURLs completionHandler:(void(^)(void))completionHandler WK_API_AVAILABLE(macos(27.0), ios(27.0));
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKActivatedElementInfo.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKActivatedElementInfo.h
@@ -43,7 +43,7 @@ WK_CLASS_AVAILABLE(macos(10.10), ios(8.0))
 
 @property (nonatomic, readonly) NSURL *URL;
 @property (nonatomic, readonly) NSURL *imageURL;
-@property (nonatomic, readonly) NSURL *modelURL WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+@property (nonatomic, readonly) NSURL *modelURL WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
 @property (nonatomic, readonly) NSString *title;
 @property (nonatomic, readonly) _WKActivatedElementType type;
 @property (nonatomic, readonly) CGRect boundingRect;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKAutomationSessionDelegate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKAutomationSessionDelegate.h
@@ -78,9 +78,9 @@ typedef NS_ENUM(NSInteger, _WKAutomationSessionWebExtensionResourceOptions) {
 - (void)_automationSession:(_WKAutomationSession *)automationSession loadWebExtensionWithOptions:(_WKAutomationSessionWebExtensionResourceOptions)options resource:(NSString *)resource completionHandler:(void(^)(NSString *))completionHandler WK_API_AVAILABLE(macos(15.4));
 - (void)_automationSession:(_WKAutomationSession *)automationSession unloadWebExtensionWithIdentifier:(NSString *)identifier completionHandler:(void(^)(BOOL))completionHandler WK_API_AVAILABLE(macos(15.4));
 
-- (void)_automationSession:(_WKAutomationSession *)automationSession performCommandForWebView:(WKWebView *)webView commandName:(NSString *)commandName arguments:(NSString *)arguments completionHandler:(void(^)(NSString * _Nullable))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+- (void)_automationSession:(_WKAutomationSession *)automationSession performCommandForWebView:(WKWebView *)webView commandName:(NSString *)commandName arguments:(NSString *)arguments completionHandler:(void(^)(NSString * _Nullable))completionHandler WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
 
-- (BOOL)_automationSessionShouldEnableInspectorTesting:(_WKAutomationSession *)automationSession WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+- (BOOL)_automationSessionShouldEnableInspectorTesting:(_WKAutomationSession *)automationSession WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
@@ -55,7 +55,7 @@ typedef NS_ENUM(NSInteger, _WKTextExtractionOutputFormat) {
     _WKTextExtractionOutputFormatHTML,
     _WKTextExtractionOutputFormatMarkdown,
     _WKTextExtractionOutputFormatJSON,
-    _WKTextExtractionOutputFormatPlainText WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)),
+    _WKTextExtractionOutputFormatPlainText WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0)),
 } WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4));
 
 #define WK_TEXT_EXTRACTION_HAS_EVENT_LISTENER_CATEGORIES 1
@@ -68,7 +68,7 @@ typedef NS_OPTIONS(NSUInteger, _WKTextExtractionEventListenerCategory) {
     _WKTextExtractionEventListenerCategoryWheel         = 1 << 3,
     _WKTextExtractionEventListenerCategoryKeyboard      = 1 << 4,
     _WKTextExtractionEventListenerCategoryAll           = NSUIntegerMax
-} WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+} WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
 
 #define WK_TEXT_EXTRACTION_HAS_DATA_DETECTOR_TYPES 1
 
@@ -79,17 +79,17 @@ typedef NS_OPTIONS(NSUInteger, _WKTextExtractionDataDetectorTypes) {
     _WKTextExtractionDataDetectorCalendarEvent      = 1 << 2,
     _WKTextExtractionDataDetectorTrackingNumber     = 1 << 3,
     _WKTextExtractionDataDetectorAll                = NSUIntegerMax,
-} WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+} WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
 
 typedef NS_ENUM(NSInteger, _WKTextExtractionWordLimitPolicy) {
     _WKTextExtractionWordLimitPolicyAlways,
     _WKTextExtractionWordLimitPolicyDiscretionary,
-} WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+} WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
 
 WK_CLASS_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4))
 @interface _WKTextExtractionConfiguration : NSObject
 
-@property (nonatomic, class, copy, readonly) _WKTextExtractionConfiguration *configurationForVisibleTextOnly WK_API_DEPRECATED_WITH_REPLACEMENT("_WKTextExtractionOutputFormatPlainText", macos(WK_MAC_TBA, WK_MAC_TBA), ios(WK_IOS_TBA, WK_IOS_TBA), visionos(WK_XROS_TBA, WK_XROS_TBA)) NS_SWIFT_NAME(visibleTextOnly);
+@property (nonatomic, class, copy, readonly) _WKTextExtractionConfiguration *configurationForVisibleTextOnly WK_API_DEPRECATED_WITH_REPLACEMENT("_WKTextExtractionOutputFormatPlainText", macos(27.0, 27.0), ios(27.0, 27.0), visionos(27.0, 27.0)) NS_SWIFT_NAME(visibleTextOnly);
 
 /*!
  Disables all optional metadata in the extraction output: URLs, bounding rects,
@@ -191,7 +191,7 @@ WK_CLASS_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4))
  The default value is `nil`.
  */
 @property (nonatomic, copy, nullable) _WKJSHandle *targetNode;
-@property (nonatomic, copy, nullable) WKJSHandle *targetNodeHandle WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+@property (nonatomic, copy, nullable) WKJSHandle *targetNodeHandle WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
 
 /*!
  If specified, these DOM nodes and their subtrees will be skipped during extraction.
@@ -272,7 +272,7 @@ WK_CLASS_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4))
  At least one of `nodeIdentifier` or `searchText` must be specified.
  */
 - (void)requestJSHandleForNodeIdentifier:(nullable NSString *)nodeIdentifier searchText:(nullable NSString *)searchText completionHandler:(void (^)(_WKJSHandle * _Nullable))completionHandler;
-- (void)requestHandleForNodeIdentifier:(nullable NSString *)nodeIdentifier searchText:(nullable NSString *)searchText completionHandler:(void (^)(WKJSHandle * _Nullable))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+- (void)requestHandleForNodeIdentifier:(nullable NSString *)nodeIdentifier searchText:(nullable NSString *)searchText completionHandler:(void (^)(WKJSHandle * _Nullable))completionHandler WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
 
 /*!
  Asynchronously map a node identifier string (corresponding to a `uid` in
@@ -285,7 +285,7 @@ WK_CLASS_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4))
  At least one of `nodeIdentifier` or `searchText` must be specified.
  */
 - (void)requestContainerJSHandleForNodeIdentifier:(nullable NSString *)nodeIdentifier searchText:(nullable NSString *)searchText completionHandler:(void (^)(_WKJSHandle * _Nullable))completionHandler;
-- (void)requestContainerHandleForNodeIdentifier:(nullable NSString *)nodeIdentifier searchText:(nullable NSString *)searchText completionHandler:(void (^)(WKJSHandle * _Nullable))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+- (void)requestContainerHandleForNodeIdentifier:(nullable NSString *)nodeIdentifier searchText:(nullable NSString *)searchText completionHandler:(void (^)(WKJSHandle * _Nullable))completionHandler WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
 
 /*!
  Asynchronously find the smallest appropriately-sized container element that
@@ -298,7 +298,7 @@ WK_CLASS_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4))
  At least one search text or a non-null node identifier must be specified.
  */
 - (void)requestContainerJSHandleForSearchTexts:(NSArray<NSString *> *)searchTexts nodeIdentifier:(nullable NSString *)nodeIdentifier completionHandler:(void (^)(_WKJSHandle * _Nullable))completionHandler;
-- (void)requestContainerHandleForSearchTexts:(NSArray<NSString *> *)searchTexts nodeIdentifier:(nullable NSString *)nodeIdentifier completionHandler:(void (^)(WKJSHandle * _Nullable))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+- (void)requestContainerHandleForSearchTexts:(NSArray<NSString *> *)searchTexts nodeIdentifier:(nullable NSString *)nodeIdentifier completionHandler:(void (^)(WKJSHandle * _Nullable))completionHandler WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
 
 @end
 
@@ -309,9 +309,9 @@ typedef NS_ENUM(NSInteger, _WKTextExtractionAction) {
     _WKTextExtractionActionTextInput,
     _WKTextExtractionActionKeyPress,
     _WKTextExtractionActionHighlightText,
-    _WKTextExtractionActionScroll WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)),
+    _WKTextExtractionActionScroll WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0)),
     _WKTextExtractionActionScrollBy = _WKTextExtractionActionScroll,
-    _WKTextExtractionActionHover WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)),
+    _WKTextExtractionActionHover WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0)),
 } WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4));
 
 WK_CLASS_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4))
@@ -344,8 +344,8 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 @interface _WKTextExtractionInteractionResult : NSObject
 
 @property (nonatomic, readonly, nullable) NSError *error;
-@property (nonatomic, readonly, nullable) NSString *summary WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
-@property (nonatomic, readonly) CGRect interactedElementBounds WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+@property (nonatomic, readonly, nullable) NSString *summary WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
+@property (nonatomic, readonly) CGRect interactedElementBounds WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.h
@@ -121,7 +121,7 @@ WK_CLASS_AVAILABLE(macos(10.13), ios(11.0))
 @property (nonatomic) BOOL allLoadsBlockedByDeviceManagementRestrictionsForTesting WK_API_AVAILABLE(macos(10.15), ios(13.0));
 
 @property (nonatomic, nullable, copy) NSString *additionalDomainsWithUserInteractionForTesting WK_API_AVAILABLE(macos(26.4), ios(26.4));
-@property (nonatomic) NSUInteger overridePersistentNotificationMinimumLifetimeForTesting WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+@property (nonatomic) NSUInteger overridePersistentNotificationMinimumLifetimeForTesting WK_API_AVAILABLE(macos(27.0), ios(27.0));
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+Configuration.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+Configuration.swift
@@ -107,7 +107,7 @@ extension WebPage {
         /// If `true`, requests are routed through the `onWebViewImmersiveEnvironmentRequest` view modifier callbacks.
         ///
         /// The default value is `false`.
-        @available(WK_XROS_TBA, *)
+        @available(visionOS 27.0, *)
         @available(iOS, unavailable)
         @available(macOS, unavailable)
         @available(watchOS, unavailable)

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+FormInfo.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+FormInfo.swift
@@ -28,7 +28,7 @@ public import Foundation
 extension WebPage {
     /// A type that contains information about a form submission from a webpage.
     @MainActor
-    @available(TBA, *)
+    @available(anyAppleOSAndDownlevels 27.0, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     public struct FormInfo {

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+ImmersiveEnvironment.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+ImmersiveEnvironment.swift
@@ -28,7 +28,7 @@ public import Foundation
 extension WebPage {
     /// An object representing a website-provided immersive environment that is ready for presentation.
     @MainActor
-    @available(TBA, *)
+    @available(anyAppleOSAndDownlevels 27.0, *)
     @available(iOS, unavailable)
     @available(macOS, unavailable)
     @available(watchOS, unavailable)

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+NavigationDeciding.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+NavigationDeciding.swift
@@ -149,7 +149,7 @@ extension WebPage {
         /// The form submission will not actually proceed until after this callback asynchronously resolves.
         ///
         /// - Parameter formInfo: The form values that will be submitted for this navigation
-        @available(TBA, *)
+        @available(anyAppleOSAndDownlevels 27.0, *)
         @MainActor
         mutating func willSubmit(formInfo: WebPage.FormInfo) async
     }
@@ -185,7 +185,7 @@ extension WebPage.NavigationDeciding {
     }
 
     /// By default, this method does nothing.
-    @available(TBA, *)
+    @available(anyAppleOSAndDownlevels 27.0, *)
     @MainActor
     public func willSubmit(formInfo: WebPage.FormInfo) async {
     }

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+NavigationPreferences.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+NavigationPreferences.swift
@@ -130,13 +130,13 @@ extension WebPage {
         }
 
         /// Used to make changes to the network request that will be used for this navigation's main resource load.
-        @available(TBA, *)
+        @available(anyAppleOSAndDownlevels 27.0, *)
         @available(watchOS, unavailable)
         @available(tvOS, unavailable)
         public var alternateRequest: URLRequest? = nil
 
         /// Used to apply a custom `referer` header to all resource loads in the frame of this navigation.
-        @available(TBA, *)
+        @available(anyAppleOSAndDownlevels 27.0, *)
         @available(watchOS, unavailable)
         @available(tvOS, unavailable)
         public var overrideReferrer: Swift.String? = nil
@@ -145,7 +145,7 @@ extension WebPage {
         ///
         /// The default value of this property is `false`. When enabled, both `navigator.globalPrivacyControl`
         /// and the `Sec-GPC: 1` request header are active for the main frame, its subframes, and their subresources.
-        @available(TBA, *)
+        @available(anyAppleOSAndDownlevels 27.0, *)
         @available(watchOS, unavailable)
         @available(tvOS, unavailable)
         public var globalPrivacyControlStatus: Bool = false

--- a/Source/WebKit/UIProcess/Cocoa/WKNavigationDelegateAdapter.swift
+++ b/Source/WebKit/UIProcess/Cocoa/WKNavigationDelegateAdapter.swift
@@ -126,7 +126,7 @@ final class WKNavigationDelegateAdapter: NSObject, WKNavigationDelegate {
         await navigationDecider.decideAuthenticationChallengeDisposition(for: challenge)
     }
 
-    @available(TBA, *)
+    @available(anyAppleOSAndDownlevels 27.0, *)
     func webView(
         _ webView: WKWebView,
         willSubmitForm formInfo: WKFormInfo

--- a/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInFramePrivate.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInFramePrivate.h
@@ -35,7 +35,7 @@
 + (instancetype)lookUpFrameFromHandle:(_WKFrameHandle *)handle;
 + (instancetype)lookUpFrameFromJSContext:(JSContext *)context;
 + (instancetype)lookUpContentFrameFromWindowOrFrameElement:(JSValue *)value;
-+ (_WKJSHandle *)jsHandleFromValue:(JSValue *)value withContext:(JSContext *)context WK_API_DEPRECATED("No longer supported", macos(WK_MAC_TBA, WK_MAC_TBA), ios(WK_IOS_TBA, WK_IOS_TBA), visionos(WK_XROS_TBA, WK_XROS_TBA));
++ (_WKJSHandle *)jsHandleFromValue:(JSValue *)value withContext:(JSContext *)context WK_API_DEPRECATED("No longer supported", macos(27.0, 27.0), ios(27.0, 27.0), visionos(27.0, 27.0));
 
 @property (nonatomic, readonly) WKWebProcessPlugInBrowserContextController *_browserContextController;
 

--- a/Source/WebKit/_WebKit_SwiftUI/API/View+WebViewModifiers.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/API/View+WebViewModifiers.swift
@@ -193,7 +193,7 @@ extension View {
     ///     the immersive environment. It receives the `WebPage.ImmersiveEnvironment` to dismiss.
     ///     This closure should return after the dismissal transition completes.
     /// - Returns: A modified view that manages immersive environment lifecycle.
-    @available(TBA, *)
+    @available(anyAppleOSAndDownlevels 27.0, *)
     @available(iOS, unavailable)
     @available(macOS, unavailable)
     @available(watchOS, unavailable)

--- a/Source/WebKit/_WebKit_SwiftUI/API/WebViewImmersiveEnvironmentView.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/API/WebViewImmersiveEnvironmentView.swift
@@ -33,7 +33,7 @@ import WebKit_Private
 /// `WebPage.ImmersiveEnvironment` received from the presentation callback to render
 /// that specific environment.
 @MainActor
-@available(TBA, *)
+@available(anyAppleOSAndDownlevels 27.0, *)
 @available(iOS, unavailable)
 @available(macOS, unavailable)
 @available(watchOS, unavailable)

--- a/Tools/Scripts/webkitpy/common/version_name_map.py
+++ b/Tools/Scripts/webkitpy/common/version_name_map.py
@@ -30,7 +30,7 @@ from webkitpy.common.memoized import memoized
 # class attribute; IOSPort/WatchPort/VisionOSPort inherit it. The constant lives here so
 # version_name_map can read it without importing the (heavy) port chain. If the WebKit
 # Darwin OSes ever diverge in version, split this into per-OS constants.
-DARWIN_CURRENT_VERSION = Version(26)
+DARWIN_CURRENT_VERSION = Version(27)
 
 
 PUBLIC_TABLE = 'public'
@@ -73,7 +73,8 @@ class VersionNameMap(object):
                 'Ventura': Version(13, 0),
                 'Sonoma': Version(14, 0),
                 'Sequoia': Version(15, 0),
-                'Tahoe': Version(26, 0)
+                'Tahoe': Version(26, 0),
+                'Golden Gate': Version(27, 0)
             },
             'ios': self._automap_to_major_version('iOS', minimum=Version(10), maximum=DARWIN_CURRENT_VERSION),
             'tvos': self._automap_to_major_version('tvOS', minimum=Version(10), maximum=DARWIN_CURRENT_VERSION),

--- a/Tools/Scripts/webkitpy/port/mac_unittest.py
+++ b/Tools/Scripts/webkitpy/port/mac_unittest.py
@@ -188,14 +188,14 @@ class MacTest(darwin_testcase.DarwinTest):
         self.assertEqual(search_path[5], '/mock-checkout/LayoutTests/platform/mac-mountainlion-wk2')
 
     def test_latest_baseline_search_path(self):
-        search_path = self.make_port(port_name='macos-tahoe').default_baseline_search_path()
+        search_path = self.make_port(port_name='macos-golden-gate').default_baseline_search_path()
         self.assertEqual(search_path[0], '/mock-checkout/LayoutTests/platform/mac-wk2')
         self.assertEqual(search_path[1], '/mock-checkout/LayoutTests/platform/mac')
 
     def test_downlevel_baseline_search_path(self):
-        search_path = self.make_port(port_name='macos-sequoia').default_baseline_search_path()
-        self.assertEqual(search_path[0], '/mock-checkout/LayoutTests/platform/mac-sequoia-wk2')
-        self.assertEqual(search_path[1], '/mock-checkout/LayoutTests/platform/mac-sequoia')
+        search_path = self.make_port(port_name='macos-tahoe').default_baseline_search_path()
+        self.assertEqual(search_path[0], '/mock-checkout/LayoutTests/platform/mac-tahoe-wk2')
+        self.assertEqual(search_path[1], '/mock-checkout/LayoutTests/platform/mac-tahoe')
         self.assertEqual(search_path[2], '/mock-checkout/LayoutTests/platform/mac-wk2')
         self.assertEqual(search_path[3], '/mock-checkout/LayoutTests/platform/mac')
 


### PR DESCRIPTION
#### a1549020ff9ffb3550817e0af6f41461f729b7b9
<pre>
Replace *_TBA API availability declarations with 27.0
<a href="https://bugs.webkit.org/show_bug.cgi?id=318788">https://bugs.webkit.org/show_bug.cgi?id=318788</a>
<a href="https://rdar.apple.com/181607201">rdar://181607201</a>

Reviewed by Abrar Rahman Protyasha.

Update all TBA API availability versions to *OS 27.0.

* Source/WebKit/Scripts/generate-swift-availability-macros:
* Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.h:
* Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListItemPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKContentWorld.h:
* Source/WebKit/UIProcess/API/Cocoa/WKContentWorldConfiguration.h:
* Source/WebKit/UIProcess/API/Cocoa/WKFormInfo.h:
* Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.h:
* Source/WebKit/UIProcess/API/Cocoa/WKImmersiveEnvironment.h:
* Source/WebKit/UIProcess/API/Cocoa/WKImmersiveEnvironmentDelegate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKJSHandle.h:
* Source/WebKit/UIProcess/API/Cocoa/WKJSSerializedNode.h:
* Source/WebKit/UIProcess/API/Cocoa/WKMenuItemIdentifiersPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.h:
* Source/WebKit/UIProcess/API/Cocoa/WKNavigationDelegate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKNavigationResponse.h:
* Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKProcessPoolPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKUIDelegate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMatchPatternPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferencesPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKActivatedElementInfo.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKAutomationSessionDelegate.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.h:
* Source/WebKit/UIProcess/API/Swift/WebPage+Configuration.swift:
* Source/WebKit/UIProcess/API/Swift/WebPage+FormInfo.swift:
* Source/WebKit/UIProcess/API/Swift/WebPage+ImmersiveEnvironment.swift:
* Source/WebKit/UIProcess/API/Swift/WebPage+NavigationDeciding.swift:
* Source/WebKit/UIProcess/API/Swift/WebPage+NavigationPreferences.swift:
* Source/WebKit/UIProcess/Cocoa/WKNavigationDelegateAdapter.swift:
* Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInFramePrivate.h:
* Source/WebKit/_WebKit_SwiftUI/API/View+WebViewModifiers.swift:
* Source/WebKit/_WebKit_SwiftUI/API/WebViewImmersiveEnvironmentView.swift:
* Tools/Scripts/webkitpy/common/version_name_map.py:
(VersionNameMap.__init__):
* Tools/Scripts/webkitpy/port/mac_unittest.py:
(MacTest.test_latest_baseline_search_path):
(MacTest.test_downlevel_baseline_search_path):

Canonical link: <a href="https://commits.webkit.org/316661@main">https://commits.webkit.org/316661@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26591d2c754b9ad1ac53b132a17a0e6dd503c611

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173046 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46977 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40457 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/182612 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130602 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174911 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48272 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46660 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/182612 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176004 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37986 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/155176 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/182612 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/172367 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36631 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31104 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147055 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34675 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185041 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37825 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39160 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143404 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46649 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143276 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38685 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47326 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31506 "Build is in progress. Recent messages:") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112397 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38256 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119074 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45831 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9618 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45233 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45464 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45290 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->