### PR TITLE
Web Inspector: [SI] wire the frontend cookie UI onto the UIProcess Storage domain https://bugs.webkit.org/show_bug.cgi?id=318789 rdar://181612724

### DIFF
--- a/LayoutTests/http/tests/site-isolation/inspector/storage/storage-frontend-gate-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/storage/storage-frontend-gate-expected.txt
@@ -1,0 +1,12 @@
+Tests that the frontend's WI.storageManager.shouldUseStorageDomain gate selects the Storage domain for cookie inspection only once a cross-origin iframe (a Frame Target) makes Site Isolation active.
+
+
+== Running test suite: SiteIsolation.Storage.FrontendGate
+-- Running test case: SiteIsolation.Storage.FrontendGate.RoutesToStorageDomainOnceFrameTargetExists
+PASS: The Storage domain should exist on the backend (multiplexing) target regardless of Site Isolation.
+PASS: Site Isolation should not be active before a cross-origin iframe loads.
+PASS: Frontend should not route cookies through the Storage domain before Site Isolation is active.
+PASS: Cross-origin iframe should be its own Frame Target (out-of-process).
+PASS: Site Isolation should be active once a Frame Target exists.
+PASS: Frontend should route cookies through the Storage domain once Site Isolation is active.
+

--- a/LayoutTests/http/tests/site-isolation/inspector/storage/storage-frontend-gate.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/storage/storage-frontend-gate.html
@@ -1,0 +1,61 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script>
+function addCrossOriginIframeThatSetsCookie() {
+    let crossOriginHost = location.hostname === "localhost" ? "127.0.0.1" : "localhost";
+    let iframe = document.createElement("iframe");
+    iframe.name = "cookie-frame";
+    // Cross-origin => separate WebContent process under Site Isolation, which spawns a Frame Target.
+    iframe.src = `http://${crossOriginHost}:8000/site-isolation/inspector/storage/resources/set-cookie-via-script.html`;
+    document.body.appendChild(iframe);
+}
+
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.Storage.FrontendGate");
+
+    suite.addTestCase({
+        name: "SiteIsolation.Storage.FrontendGate.RoutesToStorageDomainOnceFrameTargetExists",
+        description: "WI.storageManager.shouldUseStorageDomain gates the frontend's cookie source on Site Isolation. It must be false before any cross-origin iframe exists, and flip to true once the iframe's Frame Target is committed, so cookie inspection reads the authoritative Storage-domain store rather than the in-process Page path.",
+        async test() {
+            await InspectorTest.evaluateInPage(`if (window.testRunner) testRunner.setAlwaysAcceptCookies(true);`);
+
+            // The Storage domain lives on the backend (multiplexing) target and exists regardless of
+            // Site Isolation. WI.storageManager.enable() runs at startup, so it is already active.
+            InspectorTest.expectTrue(WI.storageManager.hasStorageDomain, "The Storage domain should exist on the backend (multiplexing) target regardless of Site Isolation.");
+
+            // Before any cross-origin frame, there is no Frame Target, so Site Isolation is not yet
+            // active from the frontend's point of view and the Storage-domain path is not selected.
+            InspectorTest.expectFalse(WI.isSiteIsolationEnabled(), "Site Isolation should not be active before a cross-origin iframe loads.");
+            InspectorTest.expectFalse(WI.storageManager.shouldUseStorageDomain, "Frontend should not route cookies through the Storage domain before Site Isolation is active.");
+
+            // Adding the cross-origin iframe spawns a Frame Target. TargetAdded is dispatched
+            // asynchronously, so await it as the reliable "Site Isolation is active" signal.
+            let targetAddedPromise = WI.targetManager.awaitEvent(WI.TargetManager.Event.TargetAdded);
+            InspectorTest.evaluateInPage("addCrossOriginIframeThatSetsCookie()");
+
+            let frameTarget = (await targetAddedPromise).data.target;
+            InspectorTest.expectThat(frameTarget instanceof WI.FrameTarget, "Cross-origin iframe should be its own Frame Target (out-of-process).");
+
+            if (frameTarget.isProvisional)
+                await WI.targetManager.awaitEvent(WI.TargetManager.Event.DidCommitProvisionalTarget);
+
+            // With a Frame Target present, the frontend gate flips: cookies now come from the
+            // authoritative Storage-domain store so cross-origin iframe cookies are visible.
+            InspectorTest.expectTrue(WI.isSiteIsolationEnabled(), "Site Isolation should be active once a Frame Target exists.");
+            InspectorTest.expectTrue(WI.storageManager.shouldUseStorageDomain, "Frontend should route cookies through the Storage domain once Site Isolation is active.");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Tests that the frontend's WI.storageManager.shouldUseStorageDomain gate selects the Storage domain for cookie inspection only once a cross-origin iframe (a Frame Target) makes Site Isolation active.</p>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/inspector/storage/storage-set-and-delete-cookies-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/storage/storage-set-and-delete-cookies-expected.txt
@@ -15,6 +15,11 @@ PASS: Cookie value should be 'PASS'.
 PASS: setCookie should return a partitionKey.
 PASS: Returned partitionKey should echo the explicit cookie partitionKey.
 
+-- Running test case: Storage.setCookie.SessionCookieRoundtrip
+PASS: A session cookie set with expires:0 should be readable, not silently dropped as epoch-expired.
+PASS: Session cookie value should be 'PASS'.
+PASS: Round-tripped cookie should still be a session cookie.
+
 -- Running test case: Storage.deleteCookies.ByFilter
 PASS: 'DeleteMe' should be gone.
 PASS: 'KeepMe' should remain.

--- a/LayoutTests/http/tests/site-isolation/inspector/storage/storage-set-and-delete-cookies.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/storage/storage-set-and-delete-cookies.html
@@ -57,6 +57,28 @@ function test()
     });
 
     suite.addTestCase({
+        name: "Storage.setCookie.SessionCookieRoundtrip",
+        description: "A session cookie (session:true) read back by getCookies serializes its required 'expires' field as 0. Echoing that object straight back into setCookie must NOT file an epoch-expired cookie: the agent honors 'session' and leaves the expiry unset, so the cookie survives the round-trip.",
+        async test() {
+            await WI.backendTarget.StorageAgent.setCookie({
+                name: "SessionCookie",
+                value: "PASS",
+                domain: "127.0.0.1",
+                path: "/",
+                session: true,
+                expires: 0,
+            });
+
+            let {cookies} = await WI.backendTarget.StorageAgent.getCookies({name: "SessionCookie"});
+            InspectorTest.expectEqual(cookies.length, 1, "A session cookie set with expires:0 should be readable, not silently dropped as epoch-expired.");
+            if (cookies.length) {
+                InspectorTest.expectEqual(cookies[0].value, "PASS", "Session cookie value should be 'PASS'.");
+                InspectorTest.expectEqual(cookies[0].session, true, "Round-tripped cookie should still be a session cookie.");
+            }
+        }
+    });
+
+    suite.addTestCase({
         name: "Storage.deleteCookies.ByFilter",
         description: "Deleting by filter should remove only the matching cookies.",
         async test() {

--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -58,6 +58,8 @@ http/tests/site-isolation/inspector/debugger/setBreakpoint-cross-origin-iframe.h
 http/tests/site-isolation/inspector/page/override-setting-cross-origin-iframe.html [ Pass Failure ]
 webkit.org/b/311836 http/tests/site-isolation/inspector/page/set-emulated-media-cross-origin-iframe.html [ Pass Failure ]
 http/tests/site-isolation/inspector/worker/worker-in-cross-origin-iframe.html [ Pass ]
+http/tests/site-isolation/inspector/storage/storage-get-cookies-cross-origin-iframe.html [ Pass ]
+http/tests/site-isolation/inspector/storage/storage-frontend-gate.html [ Pass ]
 http/tests/storageAccess/grant-storage-access-under-opener-at-popup-user-gesture-ephemeral.https.html [ Failure ]
 http/tests/storageAccess/grant-storage-access-under-opener-at-popup-user-gesture.https.html [ Failure ]
 http/tests/storageAccess/request-and-grant-access-cross-origin-sandboxed-iframe-from-prevalent-domain-with-user-interaction-and-access-from-right-frame.https.html [ Failure ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2187,6 +2187,10 @@ webkit.org/b/310302 imported/w3c/web-platform-tests/uievents/mouse/mouse_boundar
 http/tests/site-isolation/inspector/debugger/scriptParsed-frame-target.html [ Skip ]
 http/tests/site-isolation/inspector/debugger/pause-in-cross-origin-iframe.html [ Skip ]
 http/tests/site-isolation/inspector/debugger/setBreakpoint-cross-origin-iframe.html [ Skip ]
+# These await a cross-origin FrameTarget (TargetAdded) that never fires with Site Isolation off, so
+# they time out on this bot. They run (expected Pass) on platform/mac-site-isolation.
+http/tests/site-isolation/inspector/storage/storage-get-cookies-cross-origin-iframe.html [ Skip ]
+http/tests/site-isolation/inspector/storage/storage-frontend-gate.html [ Skip ]
 http/tests/site-isolation/inspector/page/override-setting-cross-origin-iframe.html [ Pass Failure ]
 webkit.org/b/311836 http/tests/site-isolation/inspector/page/set-emulated-media-cross-origin-iframe.html [ Pass Failure ]
 

--- a/Source/WebInspectorUI/UserInterface/Base/Main.js
+++ b/Source/WebInspectorUI/UserInterface/Base/Main.js
@@ -113,6 +113,7 @@ WI.loaded = function()
         WI.targetManager = new WI.TargetManager,
         WI.networkManager = new WI.NetworkManager,
         WI.domStorageManager = new WI.DOMStorageManager,
+        WI.storageManager = new WI.StorageManager,
         WI.indexedDBManager = new WI.IndexedDBManager,
         WI.domManager = new WI.DOMManager,
         WI.cssManager = new WI.CSSManager,
@@ -143,6 +144,7 @@ WI.loaded = function()
     WI.networkManager.addEventListener(WI.NetworkManager.Event.MainFrameDidChange, WI._mainFrameDidChange, WI);
     WI.networkManager.addEventListener(WI.NetworkManager.Event.FrameWasAdded, WI._frameWasAdded, WI);
     WI.browserManager.enable();
+    WI.storageManager.enable();
 
     WI.Frame.addEventListener(WI.Frame.Event.MainResourceDidChange, WI._mainResourceDidChange, WI);
 
@@ -3210,6 +3212,14 @@ Object.defineProperty(WI, "targets",
 WI.assumingMainTarget = function()
 {
     return WI.mainTarget;
+};
+
+// Site Isolation runs cross-origin iframes in separate WebContent processes, each surfaced to the
+// frontend as its own WI.FrameTarget (rather than a WI.Frame in the page tree). The presence of any
+// FrameTarget is therefore the signal that Site Isolation is active for this inspection.
+WI.isSiteIsolationEnabled = function()
+{
+    return WI.targets.some((target) => target instanceof WI.FrameTarget);
 };
 
 WI.reset = async function()

--- a/Source/WebInspectorUI/UserInterface/Controllers/StorageManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/StorageManager.js
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Manages the "Storage" protocol domain (cookies for now). Storage is a "web-page" domain that,
+// like "Browser", lives on the UIProcess (multiplexing) backend target -- it reads the authoritative
+// NetworkProcess cookie store, so it sees cookies across every WebContent process, including the
+// out-of-process cross-origin iframes created under Site Isolation.
+//
+// This manager owns only the enable/disable lifecycle and exposes shouldUseStorageDomain. The actual
+// cookie get/set/delete (and the choice of Storage-vs-Page path) lives on WI.CookieStorageObject, so
+// views never issue cookie commands or know which backend serves them.
+
+WI.StorageManager = class StorageManager extends WI.Object
+{
+    constructor()
+    {
+        super();
+
+        this._enabled = false;
+    }
+
+    // Agent
+
+    get domains() { return ["Storage"]; }
+
+    activateExtraDomain(domain)
+    {
+        // COMPATIBILITY (iOS 14.0): Inspector.activateExtraDomains was removed in favor of a declared debuggable type
+
+        console.assert(domain === "Storage");
+
+        for (let target of WI.targets)
+            this.initializeTarget(target);
+    }
+
+    // Target
+
+    initializeTarget(target)
+    {
+        if (!this._enabled)
+            return;
+
+        // COMPATIBILITY (macOS 26.2, iOS 26.2): The Storage domain did not exist yet. Like Browser,
+        // it lives on the UIProcess (multiplexing) target, exposed as WI.backendTarget.StorageAgent.
+        if (target.hasDomain("Storage"))
+            target.StorageAgent.enable();
+    }
+
+    // Public
+
+    // The Storage domain is the correct cookie source only when Site Isolation is actually active:
+    // that is when cross-origin iframes run out-of-process and the legacy in-process Page cookie
+    // commands cannot see their cookies. In a non-Site-Isolation session the old Page path is left
+    // unchanged. The domain must also be present on the backend target (older backends lack it).
+    get shouldUseStorageDomain()
+    {
+        return WI.isSiteIsolationEnabled() && this.hasStorageDomain;
+    }
+
+    get hasStorageDomain()
+    {
+        return !!WI.backendTarget && WI.backendTarget.hasDomain("Storage");
+    }
+
+    enable()
+    {
+        console.assert(!this._enabled);
+
+        this._enabled = true;
+
+        for (let target of WI.targets)
+            this.initializeTarget(target);
+    }
+
+    disable()
+    {
+        console.assert(this._enabled);
+
+        for (let target of WI.targets) {
+            // COMPATIBILITY (macOS 26.2, iOS 26.2): The Storage domain did not exist yet.
+            if (target.hasDomain("Storage"))
+                target.StorageAgent.disable();
+        }
+
+        this._enabled = false;
+    }
+};

--- a/Source/WebInspectorUI/UserInterface/Main.html
+++ b/Source/WebInspectorUI/UserInterface/Main.html
@@ -961,6 +961,7 @@
     <script src="Controllers/ResourceQueryController.js"></script>
     <script src="Controllers/RuntimeManager.js"></script>
     <script src="Controllers/StackTraceTreeController.js"></script>
+    <script src="Controllers/StorageManager.js"></script>
     <script src="Controllers/TargetManager.js"></script>
     <script src="Controllers/TimelineManager.js"></script>
     <script src="Controllers/TypeTokenAnnotator.js"></script>

--- a/Source/WebInspectorUI/UserInterface/Models/CookieStorageObject.js
+++ b/Source/WebInspectorUI/UserInterface/Models/CookieStorageObject.js
@@ -57,10 +57,89 @@ WI.CookieStorageObject = class CookieStorageObject
         return this._host;
     }
 
+    // Under Site Isolation cookies are read through the "Storage" domain, which reads the authoritative
+    // NetworkProcess store and so sees the out-of-process cross-origin iframe cookies the legacy in-process
+    // Page cookie commands cannot. Otherwise the legacy Page path is used, leaving non-Site-Isolation
+    // sessions unchanged. Callers use these accessors and methods and never touch a specific agent/target.
+
+    get canGetCookies()
+    {
+        if (this._useStorageDomain)
+            return WI.backendTarget.hasCommand("Storage.getCookies");
+        return InspectorBackend.hasCommand("Page.getCookies");
+    }
+
+    get canSetCookie()
+    {
+        if (this._useStorageDomain)
+            return WI.backendTarget.hasCommand("Storage.setCookie");
+        return InspectorBackend.hasCommand("Page.setCookie");
+    }
+
+    get canDeleteCookie()
+    {
+        if (this._useStorageDomain)
+            return WI.backendTarget.hasCommand("Storage.deleteCookies");
+        return InspectorBackend.hasCommand("Page.deleteCookie");
+    }
+
+    // True when cookies can arrive from targets that appear after the initial load. Under Site Isolation
+    // a cross-origin iframe becomes its own out-of-process target and its cookies then become readable,
+    // so the view should refresh on TargetAdded. The legacy in-process path has no such late arrivals.
+    get reloadsCookiesOnTargetAdded()
+    {
+        return this._useStorageDomain;
+    }
+
+    getCookies()
+    {
+        if (this._useStorageDomain) {
+            // No filter: fetch the full authoritative store; the view buckets by host. Partition
+            // "context" targets the inspected page's data store.
+            return WI.backendTarget.StorageAgent.getCookies.invoke({partition: {type: "context"}}).then((payload) => payload.cookies);
+        }
+
+        return WI.assumingMainTarget().PageAgent.getCookies().then((payload) => payload.cookies);
+    }
+
+    setCookie(cookie, cookieProtocolPayload)
+    {
+        if (this._useStorageDomain)
+            return WI.backendTarget.StorageAgent.setCookie.invoke({cookie: cookieProtocolPayload, partition: {type: "context"}});
+
+        // COMPATIBILITY (macOS 15.2, iOS 18.2): `Page.setCookie` did not have a `shouldPartition` parameter yet.
+        return WI.assumingMainTarget().PageAgent.setCookie.invoke({
+            cookie: cookieProtocolPayload,
+            shouldPartition: !cookie.partitionKey && !!cookie.partitioned,
+        });
+    }
+
+    deleteCookie(cookie)
+    {
+        if (this._useStorageDomain) {
+            // Storage.deleteCookies is filter-based; target this one cookie by its identity fields.
+            let filter = {name: cookie.name};
+            if (cookie.domain)
+                filter.domain = cookie.domain;
+            if (cookie.path)
+                filter.path = cookie.path;
+            return WI.backendTarget.StorageAgent.deleteCookies.invoke({filter, partition: {type: "context"}});
+        }
+
+        return WI.assumingMainTarget().PageAgent.deleteCookie(cookie.name, cookie.url);
+    }
+
     saveIdentityToCookie(cookie)
     {
         // FIXME <https://webkit.org/b/151413>: This class should actually store cookie data for this host.
         cookie[WI.CookieStorageObject.CookieHostCookieKey] = this.host;
+    }
+
+    // Private
+
+    get _useStorageDomain()
+    {
+        return WI.storageManager.shouldUseStorageDomain;
     }
 };
 

--- a/Source/WebInspectorUI/UserInterface/Protocol/MultiplexingBackendTarget.js
+++ b/Source/WebInspectorUI/UserInterface/Protocol/MultiplexingBackendTarget.js
@@ -46,6 +46,7 @@ WI.MultiplexingBackendTarget = class MultiplexingBackendTarget extends WI.Target
         // Site Isolation. NetworkManager initializes the multiplexing target's Network agent
         // lazily when the first FrameTarget is created (signaling SI is active).
         WI.browserManager.initializeTarget(this);
+        WI.storageManager.initializeTarget(this);
         WI.targetManager.initializeTarget(this);
     }
 

--- a/Source/WebInspectorUI/UserInterface/Test.html
+++ b/Source/WebInspectorUI/UserInterface/Test.html
@@ -288,6 +288,7 @@
     <script src="Controllers/MemoryManager.js"></script>
     <script src="Controllers/NetworkManager.js"></script>
     <script src="Controllers/RuntimeManager.js"></script>
+    <script src="Controllers/StorageManager.js"></script>
     <script src="Controllers/TargetManager.js"></script>
     <script src="Controllers/TimelineManager.js"></script>
     <script src="Controllers/WebInspectorExtensionController.js"></script>

--- a/Source/WebInspectorUI/UserInterface/Test/Test.js
+++ b/Source/WebInspectorUI/UserInterface/Test/Test.js
@@ -54,6 +54,7 @@ WI.loaded = function()
         WI.targetManager = new WI.TargetManager,
         WI.networkManager = new WI.NetworkManager,
         WI.domStorageManager = new WI.DOMStorageManager,
+        WI.storageManager = new WI.StorageManager,
         WI.indexedDBManager = new WI.IndexedDBManager,
         WI.domManager = new WI.DOMManager,
         WI.cssManager = new WI.CSSManager,
@@ -76,6 +77,7 @@ WI.loaded = function()
     // Register for events.
     document.addEventListener("DOMContentLoaded", WI.contentLoaded);
     WI.browserManager.enable();
+    WI.storageManager.enable();
 
     // Targets.
     WI.backendTarget = null;

--- a/Source/WebInspectorUI/UserInterface/Views/CookieStorageContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/CookieStorageContentView.js
@@ -42,21 +42,24 @@ WI.CookieStorageContentView = class CookieStorageContentView extends WI.ContentV
         this._filterBarNavigationItem = new WI.FilterBarNavigationItem;
         this._filterBarNavigationItem.filterBar.addEventListener(WI.FilterBar.Event.FilterDidChange, this._handleFilterBarFilterDidChange, this);
 
-        if (InspectorBackend.hasCommand("Page.setCookie")) {
+        if (this._canSetCookie) {
             this._setCookieButtonNavigationItem = new WI.ButtonNavigationItem("cookie-storage-set-cookie", WI.UIString("Add Cookie"), "Images/Plus15.svg", 15, 15);
             this._setCookieButtonNavigationItem.addEventListener(WI.ButtonNavigationItem.Event.Clicked, this._handleSetCookieButtonClick, this);
         }
 
-        if (InspectorBackend.hasCommand("Page.getCookies")) {
+        if (this._canGetCookies) {
             this._refreshButtonNavigationItem = new WI.ButtonNavigationItem("cookie-storage-refresh", WI.UIString("Refresh"), "Images/ReloadFull.svg", 13, 13);
             this._refreshButtonNavigationItem.addEventListener(WI.ButtonNavigationItem.Event.Clicked, this._refreshButtonClicked, this);
         }
 
-        if (InspectorBackend.hasCommand("Page.deleteCookie")) {
-            this._clearButtonNavigationItem = new WI.ButtonNavigationItem("cookie-storage-clear", WI.UIString("Clear Cookies"), "Images/NavigationItemTrash.svg", 15, 15);
+        if (this._canDeleteCookie) {            this._clearButtonNavigationItem = new WI.ButtonNavigationItem("cookie-storage-clear", WI.UIString("Clear Cookies"), "Images/NavigationItemTrash.svg", 15, 15);
             this._clearButtonNavigationItem.visibilityPriority = WI.NavigationItem.VisibilityPriority.Low;
             this._clearButtonNavigationItem.addEventListener(WI.ButtonNavigationItem.Event.Clicked, this._handleClearNavigationItemClicked, this);
         }
+
+        // Under Site Isolation the authoritative cookie store can gain cookies from a cross-origin
+        // iframe that only just became its own out-of-process target, so refresh when one appears.
+        WI.targetManager.addEventListener(WI.TargetManager.Event.TargetAdded, this._handleTargetAdded, this);
     }
 
     // Public
@@ -79,6 +82,13 @@ WI.CookieStorageContentView = class CookieStorageContentView extends WI.ContentV
     {
         cookie.type = WI.ContentViewCookieType.CookieStorage;
         cookie.host = this.representedObject.host;
+    }
+
+    closed()
+    {
+        WI.targetManager.removeEventListener(WI.TargetManager.Event.TargetAdded, this._handleTargetAdded, this);
+
+        super.closed();
     }
 
     get scrollableElements()
@@ -153,7 +163,7 @@ WI.CookieStorageContentView = class CookieStorageContentView extends WI.ContentV
 
         contextMenu.appendSeparator();
 
-        if (InspectorBackend.hasCommand("Page.setCookie") && column.identifier !== "size") {
+        if (this._canSetCookie && column.identifier !== "size") {
             contextMenu.appendItem(WI.UIString("Edit %s").format(column.name), () => {
                 this._showCookiePopover(cell, this._filteredCookies[rowIndex], column.identifier);
             });
@@ -170,7 +180,7 @@ WI.CookieStorageContentView = class CookieStorageContentView extends WI.ContentV
             InspectorFrontendHost.copyText(this._formatCookiesAsText(cookies));
         });
 
-        if (InspectorBackend.hasCommand("Page.deleteCookie")) {
+        if (this._canDeleteCookie) {
             contextMenu.appendItem(WI.UIString("Delete"), () => {
                 if (table.isRowSelected(rowIndex))
                     table.removeSelectedRows();
@@ -197,8 +207,7 @@ WI.CookieStorageContentView = class CookieStorageContentView extends WI.ContentV
             this._filteredCookies.splice(rowIndex, 1);
             this._cookies.remove(cookie);
 
-            let target = WI.assumingMainTarget();
-            target.PageAgent.deleteCookie(cookie.name, cookie.url);
+            this._deleteCookie(cookie);
         }
     }
 
@@ -335,6 +344,47 @@ WI.CookieStorageContentView = class CookieStorageContentView extends WI.ContentV
 
     // Private
 
+    // Cookie fetch/store lives on the represented object (WI.CookieStorageObject); the view only asks
+    // it for cookies and for what operations are available, and never knows which backend serves them.
+
+    get _canGetCookies()
+    {
+        return this.representedObject.canGetCookies;
+    }
+
+    get _canSetCookie()
+    {
+        return this.representedObject.canSetCookie;
+    }
+
+    get _canDeleteCookie()
+    {
+        return this.representedObject.canDeleteCookie;
+    }
+
+    _getCookies()
+    {
+        return this.representedObject.getCookies();
+    }
+
+    _setCookie(cookie, cookieProtocolPayload)
+    {
+        return this.representedObject.setCookie(cookie, cookieProtocolPayload);
+    }
+
+    _deleteCookie(cookie)
+    {
+        return this.representedObject.deleteCookie(cookie);
+    }
+
+    _handleTargetAdded(event)
+    {
+        // The represented object may serve cookies from targets that appear after the initial load
+        // (e.g. a cross-origin iframe becoming its own target under Site Isolation); refresh if so.
+        if (this.representedObject.reloadsCookiesOnTargetAdded)
+            this._reloadCookies();
+    }
+
     _getCookiesForHost(cookies, host)
     {
         let resourceMatchesStorageDomain = (resource) => {
@@ -460,17 +510,13 @@ WI.CookieStorageContentView = class CookieStorageContentView extends WI.ContentV
             return;
         }
 
-        let target = WI.assumingMainTarget();
-
         let promises = [];
-        if (editingCookie)
-            promises.push(target.PageAgent.deleteCookie(editingCookie.name, editingCookie.url));
 
-        // COMPATIBILITY (macOS 15.2, iOS 18.2): `Page.setCookie` did not have a `shouldPartition` parameter yet.
-        promises.push(target.PageAgent.setCookie.invoke({
-            cookie: cookieProtocolPayload,
-            shouldPartition: !cookieToSet.partitionKey && !!cookieToSet.partitioned,
-        }));
+        // Editing a cookie can change its identity (name/domain/path), so delete the original first.
+        if (editingCookie)
+            promises.push(this._deleteCookie(editingCookie));
+
+        promises.push(this._setCookie(cookieToSet, cookieProtocolPayload));
 
         promises.push(this._reloadCookies());
         await Promise.all(promises);
@@ -499,21 +545,24 @@ WI.CookieStorageContentView = class CookieStorageContentView extends WI.ContentV
 
     _handleClearNavigationItemClicked(event)
     {
-        let target = WI.assumingMainTarget();
         for (let cookie of this._cookies)
-            target.PageAgent.deleteCookie(cookie.name, cookie.url);
+            this._deleteCookie(cookie);
 
         this._reloadCookies();
     }
 
     _reloadCookies()
     {
-        let target = WI.assumingMainTarget();
-        if (!target.hasCommand("Page.getCookies"))
-            return;
+        // A refresh can be requested (e.g. by _handleTargetAdded) before initialLayout has created
+        // the table. There is nothing to populate yet; initialLayout does the first load itself.
+        if (!this._table)
+            return Promise.resolve();
 
-        target.PageAgent.getCookies().then((payload) => {
-            this._cookies = this._getCookiesForHost(payload.cookies.map(WI.Cookie.fromPayload), this.representedObject.host);
+        if (!this._canGetCookies)
+            return Promise.resolve();
+
+        return this._getCookies().then((cookies) => {
+            this._cookies = this._getCookiesForHost(cookies.map(WI.Cookie.fromPayload), this.representedObject.host);
             this._updateSort();
             this._updateFilteredCookies();
             this._updateEmptyFilterResultsMessage();
@@ -583,7 +632,7 @@ WI.CookieStorageContentView = class CookieStorageContentView extends WI.ContentV
     _handleTableKeyDown(event)
     {
         if (event.keyCode === WI.KeyboardShortcut.Key.Backspace.keyCode || event.keyCode === WI.KeyboardShortcut.Key.Delete.keyCode) {
-            if (InspectorBackend.hasCommand("Page.deleteCookie"))
+            if (this._canDeleteCookie)
                 this._table.removeSelectedRows();
             else
                 InspectorFrontendHost.beep();

--- a/Source/WebKit/UIProcess/Inspector/Agents/InspectorStorageAgent.cpp
+++ b/Source/WebKit/UIProcess/Inspector/Agents/InspectorStorageAgent.cpp
@@ -220,8 +220,14 @@ void InspectorStorageAgent::setCookie(Ref<JSON::Object>&& cookie, RefPtr<JSON::O
     webCoreCookie.secure = cookie->getBoolean("secure"_s).value_or(false);
     webCoreCookie.httpOnly = cookie->getBoolean("httpOnly"_s).value_or(false);
     webCoreCookie.session = cookie->getBoolean("session"_s).value_or(false);
-    if (auto expires = cookie->getDouble("expires"_s))
-        webCoreCookie.expires = *expires;
+    // A session cookie has no expiry, but getCookies must emit the required `expires` field, so it
+    // serializes a session cookie's absent expiry as 0. Echoing that back must not set expires to 0
+    // (the 1970 epoch, i.e. already expired). Treat session (and any non-positive timestamp) as "no
+    // expiry", matching WI.Cookie's own `(!session && expires)` rule.
+    if (!webCoreCookie.session) {
+        if (auto expires = cookie->getDouble("expires"_s); expires && *expires > 0)
+            webCoreCookie.expires = *expires;
+    }
     if (auto sameSite = cookie->getString("sameSite"_s); !sameSite.isEmpty())
         webCoreCookie.sameSite = fromProtocol(sameSite);
 


### PR DESCRIPTION
#### 0e40cc1ed3a51283798297dad6918ae54f132285
<pre>
Web Inspector: [SI] wire the frontend cookie UI onto the UIProcess Storage domain <a href="https://bugs.webkit.org/show_bug.cgi?id=318789">https://bugs.webkit.org/show_bug.cgi?id=318789</a> <a href="https://rdar.apple.com/181612724">rdar://181612724</a>

Reviewed by Qianlang Chen.

Wire the frontend onto the UIProcess Storage domain added in the previous
commit so cookie inspection sees cross-origin iframe cookies under Site
Isolation, which the in-process Page cookie commands cannot.

WI.StorageManager owns the domain&apos;s enable/disable lifecycle. Like
BrowserManager, the Storage domain lives on the UIProcess (multiplexing)
backend target, so MultiplexingBackendTarget.initialize() calls
storageManager.initializeTarget() directly -- that target is added without
dispatching TargetAdded and its initialize() does not iterate WI.managers,
so an explicit call is required for the enable to actually reach the backend
(the same reason browserManager is wired there). The manager exposes the gate
WI.storageManager.shouldUseStorageDomain: true only when Site Isolation is
active (a WI.FrameTarget exists) and the backend declares the Storage domain.
WI.isSiteIsolationEnabled is promoted from the test harness into Base/Main.js
(kept in Test.js, matching the other duplicated target utilities) so
production can read it.

WI.CookieStorageObject (the represented object) owns cookie get/set/delete
and the choice of backend: under Site Isolation it routes through
WI.backendTarget.StorageAgent (which reads the authoritative NetworkProcess
store and so sees out-of-process cross-origin iframe cookies), otherwise it
keeps the exact legacy Page path -- non-Site-Isolation sessions are unchanged.
The model also exposes canGetCookies / canSetCookie / canDeleteCookie in place
of the hardcoded Page.* command checks. Storage.deleteCookies is filter-based,
so a single-cookie delete targets it by (name, domain, path).
CookieStorageContentView only asks the represented object for cookies and for
which operations are available; it no longer knows which backend serves them.
The view refreshes on TargetAdded (gated by the model&apos;s
reloadsCookiesOnTargetAdded) so a cookie set by a cross-origin iframe appears
once that frame becomes its own target.

setCookie no longer files a session cookie as epoch-expired: getCookies
serializes a session cookie&apos;s absent expiry as 0 (Cookie::expires is
optional), and echoing that back set expires to the 1970 epoch. Honor
`session` (and reject a non-positive timestamp) so the set/get round-trip
preserves session cookies, matching WI.Cookie&apos;s own (!session &amp;&amp; expires)
rule.

The two tests that require an out-of-process frame target skip on the
Site-Isolation-off bot (they await a TargetAdded that never fires) and pass
on mac-site-isolation, matching the sibling frame-target tests.

Test: http/tests/site-isolation/inspector/storage/storage-frontend-gate.html

* LayoutTests/http/tests/site-isolation/inspector/storage/storage-frontend-gate-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/storage/storage-frontend-gate.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/storage/storage-set-and-delete-cookies-expected.txt:
* LayoutTests/http/tests/site-isolation/inspector/storage/storage-set-and-delete-cookies.html:
* LayoutTests/platform/mac-site-isolation/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebInspectorUI/UserInterface/Base/Main.js:
(WI.loaded):
* Source/WebInspectorUI/UserInterface/Controllers/StorageManager.js: Added.
(WI.StorageManager):
(WI.StorageManager.prototype.get domains):
(WI.StorageManager.prototype.activateExtraDomain):
(WI.StorageManager.prototype.initializeTarget):
(WI.StorageManager.prototype.get shouldUseStorageDomain):
(WI.StorageManager.prototype.get hasStorageDomain):
(WI.StorageManager.prototype.enable):
(WI.StorageManager.prototype.disable):
* Source/WebInspectorUI/UserInterface/Main.html:
* Source/WebInspectorUI/UserInterface/Models/CookieStorageObject.js:
(WI.CookieStorageObject.prototype.get canGetCookies):
(WI.CookieStorageObject.prototype.get canSetCookie):
(WI.CookieStorageObject.prototype.get canDeleteCookie):
(WI.CookieStorageObject.prototype.get reloadsCookiesOnTargetAdded):
(WI.CookieStorageObject.prototype.getCookies):
(WI.CookieStorageObject.prototype.setCookie):
(WI.CookieStorageObject.prototype.deleteCookie):
(WI.CookieStorageObject.prototype.get _useStorageDomain):
* Source/WebInspectorUI/UserInterface/Protocol/MultiplexingBackendTarget.js:
(WI.MultiplexingBackendTarget.prototype.initialize):
* Source/WebInspectorUI/UserInterface/Test.html:
* Source/WebInspectorUI/UserInterface/Test/Test.js:
(WI.loaded):
* Source/WebInspectorUI/UserInterface/Views/CookieStorageContentView.js:
(WI.CookieStorageContentView):
(WI.CookieStorageContentView.prototype.closed):
(WI.CookieStorageContentView.prototype.tableCellContextMenuClicked):
(WI.CookieStorageContentView.prototype.tableDidRemoveRows):
(WI.CookieStorageContentView.prototype.get _canGetCookies):
(WI.CookieStorageContentView.prototype.get _canSetCookie):
(WI.CookieStorageContentView.prototype.get _canDeleteCookie):
(WI.CookieStorageContentView.prototype._getCookies):
(WI.CookieStorageContentView.prototype._setCookie):
(WI.CookieStorageContentView.prototype._deleteCookie):
(WI.CookieStorageContentView.prototype._handleTargetAdded):
(WI.CookieStorageContentView.prototype.async _willDismissCookiePopover):
(WI.CookieStorageContentView.prototype._handleClearNavigationItemClicked):
(WI.CookieStorageContentView.prototype._reloadCookies):
(WI.CookieStorageContentView.prototype._handleTableKeyDown):
* Source/WebKit/UIProcess/Inspector/Agents/InspectorStorageAgent.cpp:
(WebKit::InspectorStorageAgent::setCookie):

Canonical link: <a href="https://commits.webkit.org/317130@main">https://commits.webkit.org/317130@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44d828f21eb48107f098fda0082217d6ccacbba8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174429 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48362 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/42143 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184006 "Failed to checkout and rebase branch from PR 68843") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/132297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49654 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48044 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/184006 "Failed to checkout and rebase branch from PR 68843") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/132297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177387 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/39128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/156488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/184006 "Failed to checkout and rebase branch from PR 68843") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/37769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32487 "Failed to checkout and rebase branch from PR 68843") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/148192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/35980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186432 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/39653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/144606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48029 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/156042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/144464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48708 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114266 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26508 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/39364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/120663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47215 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/10944 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/46617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46848 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46675 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->