### PR TITLE
Set Radar to Analyze/Fix for draft PRs when radar auto update

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
@@ -787,11 +787,12 @@ class PullRequest(Command):
         if radar_issue and update_issue and radar_issue.tracker.radarclient():
             if args.update_radar and radar_issue.state == 'Analyze' and radar_issue.substate in ['Investigate', 'Fix']:
                 try:
-                    radar_issue.set_state(state='Analyze', substate='Review')
-                    print('Updated {} to Analyze/Review'.format(radar_issue.link))
+                    new_state = 'Fix' if pr.draft else 'Review'
+                    radar_issue.set_state(state='Analyze', substate=new_state)
+                    print(f'Updated {radar_issue.link} to Analyze/{new_state}')
                 except radar_issue.tracker.radarclient().exceptions.UnsuccessfulResponseException as e:
-                    sys.stderr.write('Failed to update {}:\n'.format(radar_issue.link))
-                    sys.stderr.write('{}\n'.format(e))
+                    sys.stderr.write(f'Failed to update {radar_issue.link}:\n')
+                    sys.stderr.write(f'{e}\n')
 
         if issue and pr._metadata and pr._metadata.get('issue'):
             log.info('Syncing PR labels with issue component...')

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
@@ -1973,7 +1973,7 @@ No pre-PR checks to run""")
         )
 
     def test_update_radar(self):
-        def run(args, substate='Investigate', message=None):
+        def run(commands, substate='Investigate', message=None):
             issues = list(bmocks.ISSUES)
             issues[0] = dict(bmocks.ISSUES[0], substate=substate)
             if message is None:
@@ -2008,34 +2008,49 @@ No pre-PR checks to run""")
                     )
                 ]
 
+                result = None
                 repo.head = repo.commits['eng/pr-branch'][-1]
-                result = program.main(args=args, path=self.path)
+                for args in commands:
+                    result = program.main(args=args, path=self.path)
                 rdar_tracker = next(t for t in Tracker._trackers if isinstance(t, radar.Tracker))
                 return result, rdar_tracker.issue(1).substate
 
         # on by default: Investigate → Review
-        result, substate = run(('pull-request', '--no-history'))
+        result, substate = run([('pull-request', '--no-history')])
         self.assertEqual(0, result)
         self.assertEqual('Review', substate)
 
         # on by default: Fix → Review
-        result, substate = run(('pull-request', '--no-history'), substate='Fix')
+        result, substate = run([('pull-request', '--no-history')], substate='Fix')
         self.assertEqual(0, result)
         self.assertEqual('Review', substate)
 
+        # draft PR: Investigate → Fix
+        result, substate = run([('pull-request', '--no-history', '--draft')])
+        self.assertEqual(0, result)
+        self.assertEqual('Fix', substate)
+
+        # existing draft PR re-pushed without --draft: still → Fix
+        result, substate = run([
+            ('pull-request', '--no-history', '--draft'),
+            ('pull-request', '--no-history'),
+        ])
+        self.assertEqual(0, result)
+        self.assertEqual('Fix', substate)
+
         # --no-update-radar: no change
-        result, substate = run(('pull-request', '--no-history', '--no-update-radar'))
+        result, substate = run([('pull-request', '--no-history', '--no-update-radar')])
         self.assertEqual(0, result)
         self.assertEqual('Investigate', substate)
 
         # substate not Investigate or Fix: no change
-        result, substate = run(('pull-request', '--no-history'), substate='Screen')
+        result, substate = run([('pull-request', '--no-history')], substate='Screen')
         self.assertEqual(0, result)
         self.assertEqual('Screen', substate)
 
         # new radar: no change
         result, substate = run(
-            ('pull-request', '--no-history'),
+            [('pull-request', '--no-history')],
             substate='Screen',
             message='[Testing] Existing commit\nbugs.example.com/show_bug.cgi?id=1\n'
         )


### PR DESCRIPTION
#### a05c31a21f60bcb2cb207d41d56fe7fc8bfa2b91
<pre>
Set Radar to Analyze/Fix for draft PRs when radar auto update
<a href="https://bugs.webkit.org/show_bug.cgi?id=318795">https://bugs.webkit.org/show_bug.cgi?id=318795</a>
<a href="https://rdar.apple.com/XXXXXXX">rdar://181624906 </a>

Reviewed by Elliott Williams.

When auto-updating the associated Radar on a draft pull-request, move
it to Analyze/Fix rather than Analyze/Review, since the change is not
yet ready for review.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py:
(PullRequest.create_pull_request): Use Analyze/Fix for draft PRs,
Analyze/Review for non-draft PRs.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py:
(TestPullRequest.test_update_radar): Added draft PR case.

Canonical link: <a href="https://commits.webkit.org/317064@main">https://commits.webkit.org/317064@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a7b8bca87e19e033877db8d2b8bf0e8958f7beb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173088 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47019 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41324 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182661 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130644 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174953 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48313 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46702 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134603 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95030 "21 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176046 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38008 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155793 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115072 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/172409 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36653 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34986 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31146 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147077 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35287 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185083 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39188 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143435 "Found 1 new test failure: compositing/color-matching/image-color-matching.html (failure)") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/172488 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46688 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143307 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38891 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47367 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31902 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/112440 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38271 "Passed tests") | | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45873 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10241 "Passed tests") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45275 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45506 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45332 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->