### PR TITLE
add site-isolation to the api-test expectations parser

### DIFF
--- a/Tools/Scripts/webkitpy/api_tests/test_expectations.py
+++ b/Tools/Scripts/webkitpy/api_tests/test_expectations.py
@@ -78,7 +78,7 @@ class APITestExpectations:
         config = set()
         port_config = self._port.api_test_current_configuration()
 
-        for key in ('platform', 'version', 'style', 'architecture', 'hardware', 'hardware_type'):
+        for key in ('platform', 'version', 'style', 'architecture', 'hardware', 'hardware_type', 'flavor'):
             value = port_config.get(key)
             if value:
                 config.add(value.lower())

--- a/Tools/Scripts/webkitpy/port/base.py
+++ b/Tools/Scripts/webkitpy/port/base.py
@@ -1347,6 +1347,10 @@ class Port(object):
         if hasattr(self, 'architecture') and self.architecture():
             config['architecture'] = self.architecture()
 
+        if self.get_option('site_isolation_enabled_by_default'):
+            # No hyphen: an interior '-' would be parsed as a version specifier rather than a flavor.
+            config['flavor'] = 'siteisolation'
+
         return config
 
     def _api_test_platform_cascade(self):

--- a/Tools/Scripts/webkitpy/port/mac_unittest.py
+++ b/Tools/Scripts/webkitpy/port/mac_unittest.py
@@ -32,6 +32,7 @@ import logging
 from webkitcorepy import Version, OutputCapture
 
 from webkitpy.port.mac import MacPort
+from webkitpy.api_tests.test_expectations import APITestExpectations
 from webkitpy.port import darwin_testcase
 from webkitpy.port import port_testcase
 from webkitpy.tool.mocktool import MockOptions
@@ -271,6 +272,16 @@ class MacTest(darwin_testcase.DarwinTest):
             ),
             port.configuration_for_upload(),
         )
+
+    def test_api_test_current_configuration_omits_flavor_without_site_isolation(self):
+        port = self.make_port(options=MockOptions(configuration='Release'))
+        self.assertNotIn('flavor', port.api_test_current_configuration())
+        self.assertNotIn('siteisolation', APITestExpectations(port).get_current_configuration())
+
+    def test_api_test_current_configuration_adds_site_isolation_flavor(self):
+        port = self.make_port(options=MockOptions(configuration='Release', site_isolation_enabled_by_default=True))
+        self.assertEqual('siteisolation', port.api_test_current_configuration().get('flavor'))
+        self.assertIn('siteisolation', APITestExpectations(port).get_current_configuration())
 
     def test_rosetta_expectations(self):
         mock_host = MockSystemHost()


### PR DESCRIPTION
#### 1d17054cda86576aa0ca982e2d42df390612c4d3
<pre>
add site-isolation to the api-test expectations parser
<a href="https://bugs.webkit.org/show_bug.cgi?id=318797">https://bugs.webkit.org/show_bug.cgi?id=318797</a>
<a href="https://rdar.apple.com/181625009">rdar://181625009</a>

Reviewed by Jonathan Bedard.

api-tests don&apos;t currently have a way to mark site-isolation expectations, this adds that functionality.

* Tools/Scripts/webkitpy/api_tests/test_expectations.py:
(APITestExpectations.get_current_configuration):
* Tools/Scripts/webkitpy/port/base.py:
(Port.api_test_current_configuration):
* Tools/Scripts/webkitpy/port/mac_unittest.py:
(MacTest.test_api_test_current_configuration_omits_flavor_without_site_isolation):
(MacTest):
(MacTest.test_api_test_current_configuration_adds_site_isolation_flavor):

Canonical link: <a href="https://commits.webkit.org/316663@main">https://commits.webkit.org/316663@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3af707ffaebb870f3198e532259597c04245e366

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173117 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/47048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/40537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/182690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/130673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174982 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/48342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/46731 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/182690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/130673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176075 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/48342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/40537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/182690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/172438 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/48342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/46731 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/31175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/40537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/48342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/40537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/185112 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/46731 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/185112 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/46717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/40537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/185112 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/38695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/47396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/40537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/112469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26277 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/47396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/45902 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/40537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/45304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/45535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/45361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->