### PR TITLE
isUserVisibleURL() look-ahead tests fixed buffer indices instead of the current position

### DIFF
--- a/Source/WTF/wtf/cocoa/NSURLExtras.mm
+++ b/Source/WTF/wtf/cocoa/NSURLExtras.mm
@@ -334,15 +334,16 @@ BOOL isUserVisibleURL(NSString *string)
 
     // Check for control characters, %-escape sequences that are non-ASCII, and xn--: these
     // are the things that might lead the userVisibleString function to actually change the string.
-    for (auto character : characters) {
+    for (size_t i = 0; i < characters.size(); ++i) {
+        auto character = characters[i];
         // Control characters, including space, will be escaped by userVisibleString.
         if (character <= 0x20 || character == 0x7F)
             return NO;
         // Escape sequences that expand to non-ASCII characters may be converted to non-escaped UTF-8 sequences.
-        if (character == '%' && isASCIIHexDigit(characters[0]) && isASCIIHexDigit(characters[1]) && !isASCII(toASCIIHexValue(characters[0], characters[1])))
+        if (character == '%' && i + 2 < characters.size() && isASCIIHexDigit(characters[i + 1]) && isASCIIHexDigit(characters[i + 2]) && !isASCII(toASCIIHexValue(characters[i + 1], characters[i + 2])))
             return NO;
         // If "xn--" appears, then we might need to run the IDN algorithm if it's a host name.
-        if (isASCIIAlphaCaselessEqual(character, 'x') && isASCIIAlphaCaselessEqual(characters[0], 'n') && characters[1] == '-' && characters[2] == '-')
+        if (isASCIIAlphaCaselessEqual(character, 'x') && i + 3 < characters.size() && isASCIIAlphaCaselessEqual(characters[i + 1], 'n') && characters[i + 2] == '-' && characters[i + 3] == '-')
             return NO;
     }
 

--- a/Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm
@@ -324,6 +324,25 @@ TEST(URLExtras, URLExtras_InvalidACELabel)
     EXPECT_NULL([@"xn--8i7caa.example" _wk_decodeHostName]);
 }
 
+TEST(URLExtras, IsUserVisibleURL)
+{
+    // No escapes or "xn--": userVisibleString leaves these untouched, so the fast path returns YES.
+    EXPECT_TRUE(WTF::isUserVisibleURL(@"http://site.com/"));
+
+    // A %-escape that expands to a non-ASCII byte must be flagged, since userVisibleString decodes it
+    // (see the %C3%B7 case above). The look-ahead has to test the two hex digits *after* '%', not a
+    // fixed offset from the start of the buffer.
+    EXPECT_FALSE(WTF::isUserVisibleURL(@"http://site.com%C3%B7other.org"));
+
+    // An "xn--" label may require the IDN algorithm, so the fast path must conservatively return NO.
+    EXPECT_FALSE(WTF::isUserVisibleURL(@"http://xn--8i7caa.example/"));
+
+    // Short inputs whose '%'/'x' look-ahead would run past the string end must stay in bounds
+    // (regression coverage for the out-of-range read; benign result on a non-ASan build).
+    EXPECT_TRUE(WTF::isUserVisibleURL(@"x"));
+    EXPECT_TRUE(WTF::isUserVisibleURL(@"%"));
+}
+
 TEST(URLExtras, URLExtras_IPv6)
 {
     // IPv6 hosts pass through unchanged.


### PR DESCRIPTION
#### e11b9818d62b8682e6310420e3d31cd3f10ffc38
<pre>
isUserVisibleURL() look-ahead tests fixed buffer indices instead of the current position
<a href="https://bugs.webkit.org/show_bug.cgi?id=318799">https://bugs.webkit.org/show_bug.cgi?id=318799</a>

Reviewed by NOBODY (OOPS!).

isUserVisibleURL() is a fast path that returns YES when userVisibleString()
is guaranteed not to change the URL. It scans the string looking for a &apos;%&apos;
followed by two hex digits that decode to a non-ASCII byte, and for an
&quot;xn--&quot; label.

When the loop was converted from a post-incrementing pointer
(while (auto character = *characters++)) to a range-for over a span in
<a href="https://commits.webkit.org/283081@main">283081@main</a>, the look-ahead was left referring to the literal indices
characters[0], characters[1] and characters[2]. Those are absolute offsets
into the start of the buffer rather than the bytes following the current
character, so:

- The &apos;%&apos;-escape and &quot;xn--&quot; checks only fire when the sequence happens to
  sit at the very start of the buffer, so isUserVisibleURL() wrongly
  returns YES for URLs whose escapes decode to non-ASCII (e.g.
  &quot;<a href="http://site.com%C3%B7other.org&quot">http://site.com%C3%B7other.org&quot</a>;) and for &quot;xn--&quot; hosts.
- For a 1- or 2-character string the span has length 1 or 2, so reading
  characters[1]/characters[2] runs past the end of the span.

Track the current index and read the look-ahead relative to it
(characters[i + 1] .. characters[i + 3]), matching the original pointer
semantics, and bound each access against characters.size() before reading
so short strings stay in range.

Test: Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm

* Source/WTF/wtf/cocoa/NSURLExtras.mm:
(WTF::isUserVisibleURL):
* Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm:
(TestWebKitAPI::TEST(URLExtras, IsUserVisibleURL)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e11b9818d62b8682e6310420e3d31cd3f10ffc38

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173086 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47017 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41307 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182659 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130642 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174951 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48311 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46700 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134601 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95029 "21 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/07f95a04-dd9b-42ea-b633-f1b9072a1786) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176044 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37998 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155787 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115070 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c98e88c1-16d4-44f8-bf64-2215cffd273e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36643 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34982 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31144 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/4298 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147067 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35281 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185081 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/34348 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37878 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39184 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143434 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46686 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143306 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47365 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31896 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112438 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38274 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119114 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/210311 "Build was cancelled. Recent messages:Printed configuration") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45871 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10235 "Passed tests") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/210311 "Build was cancelled. Recent messages:Printed configuration") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45273 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45504 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45330 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->