### PR TITLE
[WTF] GenericTimeMixin-derived time classes fail to build with Swift C++ interoperability

### DIFF
--- a/Source/WTF/wtf/ApproximateTime.h
+++ b/Source/WTF/wtf/ApproximateTime.h
@@ -39,6 +39,10 @@ class ApproximateTime final : public GenericTimeMixin<ApproximateTime> {
 public:
     static constexpr ClockType clockType = ClockType::Approximate;
 
+    // Re-declare so Swift's C++ interop importer synthesizes a `bool`
+    // conversion; it mishandles the inherited operator (rdar://181622867).
+    using GenericTimeMixin<ApproximateTime>::operator bool;
+
     // This is the epoch. So, x.secondsSinceEpoch() should be the same as x - ApproximateTime().
     constexpr ApproximateTime() = default;
 

--- a/Source/WTF/wtf/ContinuousApproximateTime.h
+++ b/Source/WTF/wtf/ContinuousApproximateTime.h
@@ -40,6 +40,10 @@ class ContinuousApproximateTime final : public GenericTimeMixin<ContinuousApprox
 public:
     static constexpr ClockType clockType = ClockType::ContinuousApproximate;
 
+    // Re-declare so Swift's C++ interop importer synthesizes a `bool`
+    // conversion; it mishandles the inherited operator (rdar://181622867).
+    using GenericTimeMixin<ContinuousApproximateTime>::operator bool;
+
     // This is the epoch. So, x.secondsSinceEpoch() should be the same as x - ContinuousApproximateTime().
     constexpr ContinuousApproximateTime() = default;
 

--- a/Source/WTF/wtf/ContinuousTime.h
+++ b/Source/WTF/wtf/ContinuousTime.h
@@ -39,6 +39,10 @@ class ContinuousTime final : public GenericTimeMixin<ContinuousTime> {
 public:
     static constexpr ClockType clockType = ClockType::Continuous;
 
+    // Re-declare so Swift's C++ interop importer synthesizes a `bool`
+    // conversion; it mishandles the inherited operator (rdar://181622867).
+    using GenericTimeMixin<ContinuousTime>::operator bool;
+
     // This is the epoch. So, x.secondsSinceEpoch() should be the same as x - ContinuousTime().
     constexpr ContinuousTime() = default;
 

--- a/Source/WTF/wtf/GenericTimeMixin.h
+++ b/Source/WTF/wtf/GenericTimeMixin.h
@@ -49,6 +49,9 @@ public:
 
     constexpr Seconds secondsSinceEpoch() const { return Seconds(m_value); }
 
+    // Newer versions of Swift's C++ interop importer fail to synthesize a `bool`
+    // conversion for an `operator bool` inherited from a dependent template base,
+    // so each `DerivedTime` subclass re-declares this with `using` (rdar://181622867).
     explicit constexpr operator bool() const { return !!m_value; }
 
     constexpr DerivedTime operator+(Seconds other) const

--- a/Source/WTF/wtf/MonotonicTime.h
+++ b/Source/WTF/wtf/MonotonicTime.h
@@ -42,6 +42,10 @@ class PrintStream;
 class MonotonicTime final : public GenericTimeMixin<MonotonicTime> {
 public:
     static constexpr ClockType clockType = ClockType::Monotonic;
+
+    // Re-declare so Swift's C++ interop importer synthesizes a `bool`
+    // conversion; it mishandles the inherited operator (rdar://181622867).
+    using GenericTimeMixin<MonotonicTime>::operator bool;
     
     // This is the epoch. So, x.secondsSinceEpoch() should be the same as x - MonotonicTime().
     constexpr MonotonicTime() = default;

--- a/Source/WTF/wtf/ReducedResolutionSeconds.h
+++ b/Source/WTF/wtf/ReducedResolutionSeconds.h
@@ -40,6 +40,10 @@ class ReducedResolutionSeconds final : public GenericTimeMixin<ReducedResolution
 public:
     static constexpr ClockType clockType = ClockType::Monotonic;
 
+    // Re-declare so Swift's C++ interop importer synthesizes a `bool`
+    // conversion; it mishandles the inherited operator (rdar://181622867).
+    using GenericTimeMixin<ReducedResolutionSeconds>::operator bool;
+
     constexpr ReducedResolutionSeconds() = default;
 
     static constexpr ReducedResolutionSeconds fromSeconds(Seconds value)

--- a/Source/WTF/wtf/UnbarrieredMonotonicTime.h
+++ b/Source/WTF/wtf/UnbarrieredMonotonicTime.h
@@ -65,6 +65,10 @@ class UnbarrieredMonotonicTime final : public GenericTimeMixin<UnbarrieredMonoto
 public:
     static constexpr ClockType clockType = ClockType::UnbarrieredMonotonic;
 
+    // Re-declare so Swift's C++ interop importer synthesizes a `bool`
+    // conversion; it mishandles the inherited operator (rdar://181622867).
+    using GenericTimeMixin<UnbarrieredMonotonicTime>::operator bool;
+
     // This is the epoch. So, x.secondsSinceEpoch() should be the same as x - UnbarrieredMonotonicTime().
     constexpr UnbarrieredMonotonicTime() = default;
 

--- a/Source/WTF/wtf/WallTime.h
+++ b/Source/WTF/wtf/WallTime.h
@@ -42,6 +42,10 @@ class PrintStream;
 class WallTime final : public GenericTimeMixin<WallTime> {
 public:
     static constexpr ClockType clockType = ClockType::Wall;
+
+    // Re-declare so Swift's C++ interop importer synthesizes a `bool`
+    // conversion; it mishandles the inherited operator (rdar://181622867).
+    using GenericTimeMixin<WallTime>::operator bool;
     
     // This is the epoch. So, x.secondsSinceEpoch() should be the same as x - WallTime().
     constexpr WallTime() = default;


### PR DESCRIPTION
#### 323ae695da8c973e153d37b66e954a08898696ab
<pre>
[WTF] GenericTimeMixin-derived time classes fail to build with Swift C++ interoperability
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=318801">https://bugs.webkit.org/show_bug.cgi?id=318801</a>&gt;
&lt;<a href="https://rdar.apple.com/181623908">rdar://181623908</a>&gt;

Reviewed by Adrian Taylor.

A newer version of Apple&apos;s Swift C++ interoperability importer fails
to synthesize a `bool` conversion for a class that inherits
`explicit operator bool` from a dependent template base, so importing
a `GenericTimeMixin`-derived time class (`MonotonicTime`, `WallTime`,
and others) into a Swift module fails with &quot;cannot convert ... to
&apos;bool&apos; without a conversion operator&quot; (<a href="https://rdar.apple.com/181622867">rdar://181622867</a>).  The operator
cannot be hidden from the importer, because the synthesis is eager and
the same module compiles C++ callers such as `TimerBase::isActive()`
that need it.

Re-declare the operator with a `using` declaration in each derived
class.  The importer synthesizes the conversion correctly when the
operator is declared on the non-dependent derived class, while the base
keeps it for all C++ callers.

No new tests since this change is not directly testable.

* Source/WTF/wtf/ApproximateTime.h:
(WTF::ApproximateTime):
* Source/WTF/wtf/ContinuousApproximateTime.h:
(WTF::ContinuousApproximateTime):
* Source/WTF/wtf/ContinuousTime.h:
(WTF::ContinuousTime):
* Source/WTF/wtf/GenericTimeMixin.h:
(WTF::GenericTimeMixin::operator bool):
* Source/WTF/wtf/MonotonicTime.h:
(WTF::MonotonicTime):
* Source/WTF/wtf/ReducedResolutionSeconds.h:
(WTF::ReducedResolutionSeconds):
* Source/WTF/wtf/UnbarrieredMonotonicTime.h:
(WTF::UnbarrieredMonotonicTime):
* Source/WTF/wtf/WallTime.h:
(WTF::WallTime):

Canonical link: <a href="https://commits.webkit.org/316725@main">https://commits.webkit.org/316725@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/83ec7441795c28f6980af0d10814abce9675090f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173213 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47145 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40650 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182786 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130769 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c49e6130-1f67-4cfd-a1b1-39ac4da3a578) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48438 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46827 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134686 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/843362ff-751d-4aad-9d00-8c2eee3ee323) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176171 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38096 "Found 1 new test failure: fast/css/getComputedStyle-font-variant-shorthand-crash.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155308 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115157 "Found 1 new API test failure: WPE/TestWebKitWebView:/webkit/WebKitWebView/save (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/280387fb-6ef8-4e55-9803-20cd6a6f1eda) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36741 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35084 "Found 1 new API test failure: TestWebKitAPI.UnifiedPDF/PrintWithJSExecutionOptionTests.PDFWithNonPrintingOpenActionDoesNotPrint/allowsContentJavascript_is_true (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31271 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/3824 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147165 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34807 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185208 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/34475 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38066 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39286 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143528 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46813 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143399 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47492 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112575 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26307 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38358 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119241 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45998 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9753 "Passed tests") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45400 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45631 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45457 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->