### PR TITLE
[build.webkit.org] Add Igalia WebServers to CORS allowed origins

### DIFF
--- a/Tools/CISupport/build-webkit-org-webserver/master.cfg
+++ b/Tools/CISupport/build-webkit-org-webserver/master.cfg
@@ -60,7 +60,7 @@ if use_multi_master:
 
 c['change_source'] = PBChangeSource(port=16000)
 
-c['www'] = dict(port='tcp:8710:interface=127.0.0.1', plugins=dict(waterfall_view={}, console_view={}, grid_view={}), allowed_origins=['https://build.webkit*.org', 'https://*.apple.com'])
+c['www'] = dict(port='tcp:8710:interface=127.0.0.1', plugins=dict(waterfall_view={}, console_view={}, grid_view={}), allowed_origins=['https://build.webkit*.org', 'https://*.apple.com', 'https://people.igalia.com', 'https://teams.pages.igalia.com'])
 c['www']['ui_default_config'] = {
     'Builders.show_workers_name': True,
     'Builders.buildFetchLimit': 1000,

--- a/Tools/CISupport/ews-build-webserver/master.cfg
+++ b/Tools/CISupport/ews-build-webserver/master.cfg
@@ -40,7 +40,7 @@ if use_multi_master:
         'wamp_debug_level': 'info'
     }
 
-c['www'] = dict(port='tcp:8010:interface=127.0.0.1', allowed_origins=['https://ews-build.webkit*.org', 'https://*.apple.com'])
+c['www'] = dict(port='tcp:8010:interface=127.0.0.1', allowed_origins=['https://ews-build.webkit*.org', 'https://*.apple.com', 'https://people.igalia.com', 'https://teams.pages.igalia.com'])
 c['www']['custom_templates_dir'] = 'templates'
 c['www']['ui_default_config'] = {
     'Builders.show_workers_name': True,


### PR DESCRIPTION
#### 77408f68257f55c05c2051d7e122fff41954b004
<pre>
[build.webkit.org] Add Igalia WebServers to CORS allowed origins
<a href="https://bugs.webkit.org/show_bug.cgi?id=318809">https://bugs.webkit.org/show_bug.cgi?id=318809</a>

Reviewed by Aakash Jain.

This will allow pages on those servers to consume the buildbot API
directly.

* Tools/CISupport/build-webkit-org-webserver/master.cfg:
* Tools/CISupport/ews-build-webserver/master.cfg:

Canonical link: <a href="https://commits.webkit.org/316707@main">https://commits.webkit.org/316707@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a2ebeee121029841537e1522cc4d537020a59f0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173113 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47044 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/40533 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/182686 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/130669 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174978 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/48338 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46727 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/182686 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/130669 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176071 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/48338 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/40533 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/182686 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/48338 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/35002 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31171 "Built successfully") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/40533 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/48338 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/40533 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185108 "Built successfully") | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/39204 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/143451 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/172513 "Passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/46713 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/40533 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/143323 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/38696 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/47392 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/40533 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/112465 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26297 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/47392 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45898 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/40533 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/45300 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/45531 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/45357 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->