### PR TITLE
[Site Isolation] It should not be possible for the frame trees to be mismatched in the UI process and web processes

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -3242,7 +3242,8 @@ TEST(SiteIsolation, FindStringSelectionMultipleMatchesInChildFrame)
 TEST(SiteIsolation, FindStringSelectionSameOriginFrameBeforeWrap)
 {
     auto mainframeHTML = "<p>Hello world</p>"
-        "<iframe src='https://domain2.com/subframe'></iframe>"_s;
+        "<iframe src='https://domain2.com/subframe'></iframe>"
+        "<iframe src='https://domain1.com/subframe'></iframe>"_s;
     HTTPServer server({
         { "/mainframe"_s, { mainframeHTML } },
         { "/subframe"_s, { "<p>Hello world</p>"_s } }
@@ -3250,16 +3251,6 @@ TEST(SiteIsolation, FindStringSelectionSameOriginFrameBeforeWrap)
     auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(server);
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://domain1.com/mainframe"]]];
     [navigationDelegate waitForDidFinishNavigation];
-
-    // FIXME(267907): If the iframe is not added like this the UI process and web processes may have mismatched frame trees.
-    auto addFrameToBody = @"let frame = document.createElement('iframe');"
-    "frame.setAttribute('src', 'https://domain1.com/subframe');"
-    "document.body.appendChild(frame);";
-    __block bool done = false;
-    [webView evaluateJavaScript:addFrameToBody completionHandler:^(id _Nullable, NSError * _Nullable error) {
-        done = true;
-    }];
-    Util::run(&done);
 
     RetainPtr findConfiguration = adoptNS([[WKFindConfiguration alloc] init]);
     using SelectionOffsets = std::array<std::pair<int, int>, 3>;


### PR DESCRIPTION
#### f334d0bc02541c030ac8c24c8d6e6ae3278af4f1
<pre>
[Site Isolation] It should not be possible for the frame trees to be mismatched in the UI process and web processes
<a href="https://bugs.webkit.org/show_bug.cgi?id=267907">https://bugs.webkit.org/show_bug.cgi?id=267907</a>
<a href="https://rdar.apple.com/121411755">rdar://121411755</a>

Reviewed by Megan Gardner.

There was a FIXME comment from early 2024 when we were still working on the basics of iframe loading.
The issue has since been resolved.

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::TEST(SiteIsolation, FindStringSelectionSameOriginFrameBeforeWrap)):

Canonical link: <a href="https://commits.webkit.org/316693@main">https://commits.webkit.org/316693@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b26dbee0fc152ff185e80dc074922f95337e6c4d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173116 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47047 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40536 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182689 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130672 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174981 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48341 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46730 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134612 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176074 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38015 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155213 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115081 "Found 1 new API test failure: WPE/TestWebKitWebView:/webkit/WebKitWebView/save (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dff731e3-2637-40f4-a826-0078e2dd532d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36660 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35006 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31174 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147084 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34712 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185111 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39208 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143454 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46716 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143326 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47395 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112468 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26289 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38289 "Passed tests") | | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45901 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9655 "Passed tests") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45303 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45534 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45360 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->