### PR TITLE
Assertion failure under WebPageProxy::executeEditCommand() when NetworkProcess connection isn't established yet

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -4022,8 +4022,11 @@ void WebPageProxy::executeEditCommand(const String& commandName, const String& a
     };
 
     if (auto pasteAccessCategory = pasteAccessCategoryForCommand(commandName)) {
-        if (auto replyID = willPerformPasteCommand(*pasteAccessCategory, WTF::move(completionHandler), frameID))
-            protect(protect(protect(websiteDataStore())->networkProcess())->connection())->waitForAsyncReplyAndDispatchImmediately<Messages::NetworkProcess::AllowFilesAccessFromWebProcess>(*replyID, 100_ms);
+        if (auto replyID = willPerformPasteCommand(*pasteAccessCategory, WTF::move(completionHandler), frameID)) {
+            Ref networkProcess = protect(websiteDataStore())->networkProcess();
+            if (networkProcess->hasConnection())
+                protect(networkProcess->connection())->waitForAsyncReplyAndDispatchImmediately<Messages::NetworkProcess::AllowFilesAccessFromWebProcess>(*replyID, 100_ms);
+        }
     } else
         completionHandler();
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/PasteImage.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/PasteImage.mm
@@ -30,6 +30,7 @@
 #import "Helpers/PlatformUtilities.h"
 #import "Helpers/cocoa/TestWKWebView.h"
 #import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
+#import <WebKit/WKWebsiteDataStorePrivate.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/text/WTFString.h>
 
@@ -343,6 +344,30 @@ TEST(PasteImage, PasteTIFFImage)
     [webView waitForMessage:@"loaded" afterEvaluatingScript:@"insertFileAsImage(pngItem.file)"];
     EXPECT_WK_STREQ("blob:", [webView stringByEvaluatingJavaScript:@"url = new URL(imageElement.src); url.protocol"]);
     EXPECT_WK_STREQ("100", [webView stringByEvaluatingJavaScript:@"imageElement.width"]);
+}
+
+TEST(PasteImage, PasteFileWhileNetworkProcessIsLaunching)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    [webView synchronouslyLoadTestPageNamed:@"paste-image"];
+
+    NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"sunset-in-cupertino-200px" withExtension:@"png"];
+    writeBundleFileToPasteboard(url);
+
+    // Terminating existing network process, so network process will be relaunched for paste.
+    [[webView configuration].websiteDataStore _terminateNetworkProcess];
+
+    [webView paste:nil];
+
+    unsigned fileCount = 0;
+    bool receivedFile = TestWebKitAPI::Util::waitFor([&] {
+        fileCount = [webView stringByEvaluatingJavaScript:@"dataTransfer.files ? dataTransfer.files.length : 0"].integerValue;
+        return !!fileCount;
+    });
+
+    EXPECT_TRUE(receivedFile);
+    EXPECT_EQ(1U, fileCount);
+    EXPECT_WK_STREQ("image/png", [webView stringByEvaluatingJavaScript:@"dataTransfer.files[0].type"]);
 }
 #endif
 


### PR DESCRIPTION
#### 4aaf25fe9410814b6d80a71e5fca825af0742764
<pre>
Assertion failure under WebPageProxy::executeEditCommand() when NetworkProcess connection isn&apos;t established yet
<a href="https://bugs.webkit.org/show_bug.cgi?id=318812">https://bugs.webkit.org/show_bug.cgi?id=318812</a>
<a href="https://rdar.apple.com/181397513">rdar://181397513</a>

Reviewed by Abrar Rahman Protyasha.

executeEditCommand(commandName, argument) synchronously waits for the AllowFilesAccessFromWebProcess reply by calling
AuxiliaryProcessProxy::connection() on the NetworkProcess, which RELEASE_ASSERTs that m_connection is non-null.
willPerformPasteCommand() can return a valid AsyncReplyID (via grantAccessToCurrentPasteboardData -&gt;
WebPasteboardProxy::grantAccessToCurrentData) even while the NetworkProcess is still launching, since
sendWithAsyncReply() queues the message in m_pendingMessages and only establishes m_connection once the process
finishes launching. Pasting content that carries file paths (e.g. an attachment) before the NetworkProcess connection
exists therefore hits the RELEASE_ASSERT and crashes the UI process.

This is a follow-up to 99d7f658ab04 (bug 301321), which added a similar hasRunningProcess() guard to the callback-based
overload of executeEditCommand() but did not cover this synchronous overload&apos;s unconditional connection() call.

Guard the wait with hasConnection() instead. The AllowFilesAccessFromWebProcess message itself is unaffected: it is
already queued safely regardless of process launch state, and its completion handler will still run once the
NetworkProcess is up and the reply is dispatched normally. Skipping the synchronous wait only means the paste&apos;s
completion handler may run asynchronously later rather than being fast-pathed within this call.

API Test: PasteImage.PasteFileWhileNetworkProcessIsLaunching

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::executeEditCommand):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/PasteImage.mm:
(TEST(PasteImage, PasteFileWhileNetworkProcessIsLaunching)):

Canonical link: <a href="https://commits.webkit.org/316740@main">https://commits.webkit.org/316740@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d272dd5803dec5ce190596c26d9415c528cb4303

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173294 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47226 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40765 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182867 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130850 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cc17740a-a80e-4c35-89db-0d529153e757) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175159 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48519 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46908 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/134755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95149 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176252 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38163 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/155402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/115229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/664fbac6-89e2-4e29-9425-78305e3c186b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36807 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/35153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31352 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147231 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34900 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185290 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/38151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/39354 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143593 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46894 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143461 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38723 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47573 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112674 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38422 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/119322 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46079 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9846 "") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45481 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45712 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45538 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->