### PR TITLE
[WPE][GTK] Improvements to platform media queries (prefers reduced motion, high contrast, and dark theme)

### DIFF
--- a/Source/WebCore/css/query/MediaQueryFeatures.cpp
+++ b/Source/WebCore/css/query/MediaQueryFeatures.cpp
@@ -548,20 +548,28 @@ static const IdentifierSchema& prefersContrastFeatureSchema()
         FixedVector { CSSValueNoPreference, CSSValueMore, CSSValueLess, CSSValueCustom },
         MediaQueryDynamicDependency::Accessibility,
         [](auto& context) {
-            bool userPrefersContrast = [&] {
+            InterfaceContrastPreference userPreferredContrast = [&] {
                 Ref frame = *context.document->frame();
                 switch (frame->settings().forcedPrefersContrastAccessibilityValue()) {
                 case ForcedAccessibilityValue::On:
-                    return true;
+                    return InterfaceContrastPreference::MoreContrast;
                 case ForcedAccessibilityValue::Off:
-                    return false;
+                    return InterfaceContrastPreference::NoPreference;
                 case ForcedAccessibilityValue::System:
-                    return Theme::singleton().userPrefersContrast();
+                    return Theme::singleton().userPreferredContrast();
                 }
-                return false;
+                return InterfaceContrastPreference::NoPreference;
             }();
 
-            return MatchingIdentifiers { userPrefersContrast ? CSSValueMore : CSSValueNoPreference };
+            switch (userPreferredContrast) {
+            case InterfaceContrastPreference::NoPreference:
+                return MatchingIdentifiers { CSSValueNoPreference };
+            case InterfaceContrastPreference::MoreContrast:
+                return MatchingIdentifiers { CSSValueMore };
+            case InterfaceContrastPreference::LessContrast:
+                return MatchingIdentifiers { CSSValueLess };
+            }
+            RELEASE_ASSERT_NOT_REACHED();
         }
     };
     return schema;

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
@@ -740,7 +740,7 @@ void InspectorPageAgent::defaultUserPreferencesDidChange()
 
     defaultUserPreferences->addItem(WTF::move(prefersReducedMotionUserPreference));
 
-    bool prefersContrast = Theme::singleton().userPrefersContrast();
+    bool prefersContrast = Theme::singleton().userPreferredContrast() == InterfaceContrastPreference::MoreContrast;
 
     auto prefersContrastUserPreference = Inspector::Protocol::Page::UserPreference::create()
         .setName(Inspector::Protocol::Page::UserPreferenceName::PrefersContrast)

--- a/Source/WebCore/platform/Theme.h
+++ b/Source/WebCore/platform/Theme.h
@@ -32,13 +32,19 @@ namespace WebCore {
 class FloatSize;
 class GraphicsContext;
 
+enum class InterfaceContrastPreference : uint8_t {
+    NoPreference,
+    MoreContrast,
+    LessContrast
+};
+
 class Theme {
 public:
     static Theme& NODELETE singleton();
 
     virtual void drawNamedImage(const String&, GraphicsContext&, const FloatSize&) const;
 
-    virtual bool userPrefersContrast() const { return false; }
+    virtual InterfaceContrastPreference userPreferredContrast() const { return InterfaceContrastPreference::NoPreference; }
     virtual bool userPrefersReducedMotion() const { return false; }
     virtual bool userPrefersOnOffLabels() const { return false; }
     virtual bool userPrefersDifferentiationWithoutColor() const { return false; }

--- a/Source/WebCore/platform/adwaita/ThemeAdwaita.cpp
+++ b/Source/WebCore/platform/adwaita/ThemeAdwaita.cpp
@@ -54,7 +54,7 @@ ThemeAdwaita::ThemeAdwaita()
 
     // Note that Theme is NeverDestroy'd so the destructor will never be called to disconnect this.
     SystemSettings::singleton().addObserver([this](const SystemSettings::State& state) mutable {
-        if (state.enableAnimations || state.themeName)
+        if (state.reducedMotion || state.interfaceContrast)
             this->refreshSettings();
     }, this);
 #endif // PLATFORM(GTK) || PLATFORM(WPE)
@@ -64,16 +64,11 @@ ThemeAdwaita::ThemeAdwaita()
 
 void ThemeAdwaita::refreshSettings()
 {
-    if (auto enableAnimations = SystemSettings::singleton().enableAnimations())
-        m_prefersReducedMotion = !enableAnimations.value();
+    if (auto prefersReducedMotion = SystemSettings::singleton().reducedMotion())
+        m_prefersReducedMotion = prefersReducedMotion.value();
 
-    // For high contrast in GTK3 we can rely on the theme name and be accurate most of the time.
-    // However whether or not high-contrast is enabled is also stored in GSettings/xdg-desktop-portal.
-    // We could rely on libadwaita, dynamically, to re-use its logic.
-#if PLATFORM(GTK) && !USE(GTK4)
-    if (auto themeName = SystemSettings::singleton().themeName())
-        m_prefersContrast = themeName == "HighContrast"_s || themeName == "HighContrastInverse"_s;
-#endif // PLATFORM(GTK) && !USE(GTK4)
+    if (auto preferredContrast = SystemSettings::singleton().interfaceContrast())
+        m_preferredContrast = preferredContrast.value();
 }
 
 #endif // PLATFORM(GTK) || PLATFORM(WPE)
@@ -93,13 +88,9 @@ Color ThemeAdwaita::accentColor()
     return m_accentColor;
 }
 
-bool ThemeAdwaita::userPrefersContrast() const
+InterfaceContrastPreference ThemeAdwaita::userPreferredContrast() const
 {
-#if !USE(GTK4)
-    return m_prefersContrast;
-#else
-    return false;
-#endif
+    return m_preferredContrast;
 }
 
 bool ThemeAdwaita::userPrefersReducedMotion() const

--- a/Source/WebCore/platform/adwaita/ThemeAdwaita.h
+++ b/Source/WebCore/platform/adwaita/ThemeAdwaita.h
@@ -39,7 +39,7 @@ public:
 
     virtual void platformColorsDidChange() { };
 
-    bool userPrefersContrast() const final;
+    InterfaceContrastPreference userPreferredContrast() const final;
     bool userPrefersReducedMotion() const final;
 
     void setAccentColor(const Color&);
@@ -52,9 +52,7 @@ private:
     Color m_accentColor { SRGBA<uint8_t> { 52, 132, 228 } };
 
     bool m_prefersReducedMotion { false };
-#if !USE(GTK4)
-    bool m_prefersContrast { false };
-#endif
+    InterfaceContrastPreference m_preferredContrast { InterfaceContrastPreference::NoPreference };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/glib/SystemSettings.cpp
+++ b/Source/WebCore/platform/glib/SystemSettings.cpp
@@ -83,8 +83,11 @@ void SystemSettings::updateSettings(const SystemSettings::State& state)
     if (state.overlayScrolling)
         m_state.overlayScrolling = state.overlayScrolling;
 
-    if (state.enableAnimations)
-        m_state.enableAnimations = state.enableAnimations;
+    if (state.reducedMotion)
+        m_state.reducedMotion = state.reducedMotion;
+
+    if (state.interfaceContrast)
+        m_state.interfaceContrast = state.interfaceContrast;
 
     for (auto* context : copyToVector(m_observers.keys())) {
         const auto it = m_observers.find(context);

--- a/Source/WebCore/platform/glib/SystemSettings.h
+++ b/Source/WebCore/platform/glib/SystemSettings.h
@@ -35,6 +35,8 @@
 
 namespace WebCore {
 
+enum class InterfaceContrastPreference : uint8_t;
+
 struct SystemSettingsState {
     std::optional<String> themeName;
     std::optional<bool> darkMode;
@@ -52,7 +54,8 @@ struct SystemSettingsState {
     std::optional<int> cursorBlinkTime;
     std::optional<bool> primaryButtonWarpsSlider;
     std::optional<bool> overlayScrolling;
-    std::optional<bool> enableAnimations;
+    std::optional<bool> reducedMotion;
+    std::optional<InterfaceContrastPreference> interfaceContrast;
 };
 
 class SystemSettings {
@@ -82,7 +85,8 @@ public:
     std::optional<bool> followFontSystemSettings() const { return m_state.followFontSystemSettings; }
     std::optional<bool> overlayScrolling() const { return m_state.overlayScrolling; }
     std::optional<bool> primaryButtonWarpsSlider() const { return m_state.primaryButtonWarpsSlider; }
-    std::optional<bool> enableAnimations() const { return m_state.enableAnimations; }
+    std::optional<bool> reducedMotion() const { return m_state.reducedMotion; }
+    std::optional<InterfaceContrastPreference> interfaceContrast() const { return m_state.interfaceContrast; };
 
     std::optional<FontRenderOptions::Hinting> hintStyle() const;
     std::optional<FontRenderOptions::SubpixelOrder> subpixelOrder() const;

--- a/Source/WebCore/platform/ios/ThemeIOS.h
+++ b/Source/WebCore/platform/ios/ThemeIOS.h
@@ -33,7 +33,7 @@ namespace WebCore {
 
 class ThemeIOS final : public ThemeCocoa {
 private:
-    bool userPrefersContrast() const final;
+    InterfaceContrastPreference userPreferredContrast() const final;
     bool userPrefersReducedMotion() const final;
     bool userPrefersOnOffLabels() const final;
 };

--- a/Source/WebCore/platform/ios/ThemeIOS.mm
+++ b/Source/WebCore/platform/ios/ThemeIOS.mm
@@ -39,9 +39,11 @@ Theme& Theme::singleton()
     return theme;
 }
 
-bool ThemeIOS::userPrefersContrast() const
+InterfaceContrastPreference ThemeIOS::userPreferredContrast() const
 {
-    return PAL::softLink_UIKit_UIAccessibilityDarkerSystemColorsEnabled();
+    if (PAL::softLink_UIKit_UIAccessibilityDarkerSystemColorsEnabled())
+        return InterfaceContrastPreference::MoreContrast;
+    return InterfaceContrastPreference::NoPreference;
 }
 
 bool ThemeIOS::userPrefersReducedMotion() const

--- a/Source/WebCore/platform/mac/ThemeMac.h
+++ b/Source/WebCore/platform/mac/ThemeMac.h
@@ -37,7 +37,7 @@ private:
     friend NeverDestroyed<ThemeMac>;
     ThemeMac() = default;
 
-    bool userPrefersContrast() const final;
+    InterfaceContrastPreference userPreferredContrast() const final;
     bool userPrefersDifferentiationWithoutColor() const final;
     bool userPrefersReducedMotion() const final;
 };

--- a/Source/WebCore/platform/mac/ThemeMac.mm
+++ b/Source/WebCore/platform/mac/ThemeMac.mm
@@ -41,9 +41,11 @@ Theme& Theme::singleton()
 
 // Theme overrides
 
-bool ThemeMac::userPrefersContrast() const
+InterfaceContrastPreference ThemeMac::userPreferredContrast() const
 {
-    return [[NSWorkspace sharedWorkspace] accessibilityDisplayShouldIncreaseContrast];
+    if ([[NSWorkspace sharedWorkspace] accessibilityDisplayShouldIncreaseContrast])
+        return InterfaceContrastPreference::MoreContrast;
+    return InterfaceContrastPreference::NoPreference;
 }
 
 bool ThemeMac::userPrefersDifferentiationWithoutColor() const

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -261,7 +261,7 @@ static Color switchTrackColor(const RenderObject& renderer)
     Ref element = switchElement(renderer);
 
     auto isOn = element->isSwitchVisuallyOn();
-    auto isHighContrast = Theme::singleton().userPrefersContrast();
+    auto isHighContrast = Theme::singleton().userPreferredContrast() == InterfaceContrastPreference::MoreContrast;
     auto isDark = styleColorOptions.contains(StyleColorOptions::UseDarkAppearance);
     auto progress = easeInOut(element->switchAnimationVisuallyOnProgress());
 
@@ -350,7 +350,7 @@ static void paintSwitchTrackOnOffLabels(OptionSet<ControlStyle::State> states, c
     Ref element = switchElement(renderer);
 
     auto isOn = element->isSwitchVisuallyOn();
-    auto isHighContrast = Theme::singleton().userPrefersContrast();
+    auto isHighContrast = Theme::singleton().userPreferredContrast() == InterfaceContrastPreference::MoreContrast;
     auto isInlineFlipped = states.contains(ControlStyle::State::InlineFlippedWritingMode);
     auto isVertical = states.contains(ControlStyle::State::VerticalWritingMode);
     auto isEnabled = states.contains(ControlStyle::State::Enabled);
@@ -499,7 +499,7 @@ static void paintLiquidGlassSwitchTrackOnOffLabels(OptionSet<ControlStyle::State
     const auto zoomScale = style->usedZoom();
 
     auto isOn = element->isSwitchVisuallyOn();
-    auto isHighContrast = Theme::singleton().userPrefersContrast();
+    auto isHighContrast = Theme::singleton().userPreferredContrast() == InterfaceContrastPreference::MoreContrast;
     auto isInlineFlipped = states.contains(ControlStyle::State::InlineFlippedWritingMode);
     auto isVertical = states.contains(ControlStyle::State::VerticalWritingMode);
     auto isEnabled = states.contains(ControlStyle::State::Enabled);
@@ -664,7 +664,7 @@ static bool renderThemePaintLiquidGlassSwitchThumb(OptionSet<ControlStyle::State
 
     context.restore();
 
-    if (Theme::singleton().userPrefersContrast())
+    if (Theme::singleton().userPreferredContrast() == InterfaceContrastPreference::MoreContrast)
         drawHighContrastOutline(context, thumbPath, renderer.styleColorOptions());
 #else
     const auto shadowColor = SRGBA<uint8_t> { 0, 0, 0, static_cast<uint8_t>(30.63 * shadowOpacityMultiplier) }; // opacity 0.12f
@@ -719,7 +719,7 @@ static bool renderThemePaintLiquidGlassSwitchTrack(OptionSet<ControlStyle::State
         paintLiquidGlassSwitchTrackOnOffLabels(states, renderer, paintInfo, trackRect);
 
 #if PLATFORM(MAC)
-    if (Theme::singleton().userPrefersContrast())
+    if (Theme::singleton().userPreferredContrast() == InterfaceContrastPreference::MoreContrast)
         drawHighContrastOutline(context, trackPath, styleColorOptions);
 
     // On macOS, the track color in the on-state and the focus ring color are almost
@@ -2089,7 +2089,7 @@ bool RenderThemeCocoa::paintCheckboxForVectorBasedControls(const RenderElement& 
     context.fillPath(glyphPath);
 
 #if PLATFORM(MAC)
-    if (Theme::singleton().userPrefersContrast())
+    if (Theme::singleton().userPreferredContrast() == InterfaceContrastPreference::MoreContrast)
         drawHighContrastOutline(context, path, box.styleColorOptions());
 #endif
 
@@ -2158,7 +2158,7 @@ bool RenderThemeCocoa::paintRadioForVectorBasedControls(const RenderElement& box
         context.fillEllipse(innerCircleRect);
 
 #if PLATFORM(MAC)
-    if (Theme::singleton().userPrefersContrast())
+    if (Theme::singleton().userPreferredContrast() == InterfaceContrastPreference::MoreContrast)
         drawHighContrastOutline(context, boundingPath, box.styleColorOptions());
 #endif
     } else if (!isVision) {
@@ -2220,7 +2220,7 @@ bool RenderThemeCocoa::paintButtonForVectorBasedControls(const RenderElement& bo
     const auto boundingRect = buttonShape.boundingRect;
 
 #if PLATFORM(MAC)
-    const auto userPrefersContrast = Theme::singleton().userPrefersContrast();
+    const auto userPrefersContrast = Theme::singleton().userPreferredContrast() == InterfaceContrastPreference::MoreContrast;
     const auto borderColor = userPrefersContrast ? highContrastOutlineColor(styleColorOptions) : systemColor(CSSValueWebkitControlBackground, styleColorOptions);
 #else
     const auto borderColor = systemColor(CSSValueWebkitControlBackground, styleColorOptions);
@@ -2278,7 +2278,7 @@ bool RenderThemeCocoa::paintColorWellForVectorBasedControls(const RenderElement&
     context.fillRoundedRect(boundingRoundedRect, backgroundColor);
 
 #if PLATFORM(MAC)
-    if (Theme::singleton().userPrefersContrast()) {
+    if (Theme::singleton().userPreferredContrast() == InterfaceContrastPreference::MoreContrast) {
         Path path;
         path.addRoundedRect(boundingRoundedRect);
         drawHighContrastOutline(context, path, box.styleColorOptions());
@@ -2727,7 +2727,7 @@ bool RenderThemeCocoa::paintInnerSpinButtonForVectorBasedControls(const RenderEl
     context.fillPath(path);
 
 #if PLATFORM(MAC)
-    const auto userPrefersContrast = Theme::singleton().userPrefersContrast();
+    const auto userPrefersContrast = Theme::singleton().userPreferredContrast() == InterfaceContrastPreference::MoreContrast;
 
     if (userPrefersContrast)
         drawHighContrastOutline(context, path, styleColorOptions);
@@ -3091,7 +3091,7 @@ static bool paintTextAreaOrTextField(const RenderElement& box, const PaintInfo& 
     const auto styleColorOptions = box.styleColorOptions();
     auto backgroundColor = style->visitedDependentBackgroundColor();
 #if PLATFORM(MAC)
-    const auto prefersContrast = Theme::singleton().userPrefersContrast();
+    const auto prefersContrast = Theme::singleton().userPreferredContrast() == InterfaceContrastPreference::MoreContrast;
     auto borderColor = prefersContrast ? highContrastOutlineColor(styleColorOptions) : RenderTheme::singleton().systemColor(CSSValueAppleSystemContainerBorder, styleColorOptions);
 #else
     auto borderColor = RenderTheme::singleton().systemColor(CSSValueAppleSystemContainerBorder, styleColorOptions);
@@ -3536,7 +3536,7 @@ bool RenderThemeCocoa::paintMeterForVectorBasedControls(const RenderElement& ren
     auto isHorizontalWritingMode = renderer.writingMode().isHorizontal();
 
 #if PLATFORM(MAC)
-    const auto userPrefersContrast = Theme::singleton().userPrefersContrast();
+    const auto userPrefersContrast = Theme::singleton().userPreferredContrast() == InterfaceContrastPreference::MoreContrast;
     FloatRoundedRect boundingRoundedRect = roundedFillRect;
     if (userPrefersContrast)
         context.save();
@@ -3716,7 +3716,7 @@ bool RenderThemeCocoa::paintListButtonForVectorBasedControls(const RenderElement
     context.setFillColor(backgroundColor);
     context.fillPath(backgroundPath);
 
-    if (Theme::singleton().userPrefersContrast())
+    if (Theme::singleton().userPreferredContrast() == InterfaceContrastPreference::MoreContrast)
         drawHighContrastOutline(context, backgroundPath, styleColorOptions);
 #endif
 
@@ -4183,7 +4183,7 @@ bool RenderThemeCocoa::paintSliderThumbForVectorBasedControls(const RenderElemen
     context.fillPath(sliderThumbPath);
 
 #if PLATFORM(MAC)
-    if (Theme::singleton().userPrefersContrast()) {
+    if (Theme::singleton().userPreferredContrast() == InterfaceContrastPreference::MoreContrast) {
         drawHighContrastOutline(context, sliderThumbPath, styleColorOptions);
         return true;
     }
@@ -4226,7 +4226,7 @@ bool RenderThemeCocoa::paintSearchFieldForVectorBasedControls(const RenderElemen
     const auto isEnabled = states.contains(ControlStyle::State::Enabled);
 
 #if PLATFORM(MAC)
-    auto userPrefersContrast = Theme::singleton().userPrefersContrast();
+    auto userPrefersContrast = Theme::singleton().userPreferredContrast() == InterfaceContrastPreference::MoreContrast;
     auto isDarkMode = box.styleColorOptions().contains(StyleColorOptions::UseDarkAppearance);
     Color borderColor;
     if (userPrefersContrast)
@@ -4340,7 +4340,7 @@ bool RenderThemeCocoa::paintSearchFieldCancelButtonForVectorBasedControls(const 
     const auto isDarkMode = styleColorOptions.contains(StyleColorOptions::UseDarkAppearance);
 
     Color fillColor;
-    if (Theme::singleton().userPrefersContrast())
+    if (Theme::singleton().userPreferredContrast() == InterfaceContrastPreference::MoreContrast)
         fillColor = highContrastOutlineColor(styleColorOptions);
     else {
         fillColor = isDarkMode ? SRGBA<uint8_t> { 161, 161, 161 } : SRGBA<uint8_t> { 76, 76, 76, 216 };
@@ -4403,7 +4403,7 @@ bool RenderThemeCocoa::paintSearchFieldDecorationPartForVectorBasedControls(cons
     // In dark mode, the high contrast color is darker than white, which is what
     // we use if "Increase contrast" was off. To avoid decreasing contrast in this case,
     // only behave as if "Increase contrast" is enabled when not in dark mode.
-    auto userPrefersContrast = Theme::singleton().userPrefersContrast()  && !isDarkMode;
+    auto userPrefersContrast = Theme::singleton().userPreferredContrast() == InterfaceContrastPreference::MoreContrast && !isDarkMode;
     auto hasSearchResults = input && input->maxResults() > 0;
 
     auto color = userPrefersContrast ? highContrastOutlineColor(styleColorOptions) : (isDarkMode ? colorForDarkMode : colorForLightMode);
@@ -4568,7 +4568,7 @@ bool RenderThemeCocoa::paintPlatformResizerForVectorBasedControls(const RenderLa
     const auto styleColorOptions = renderer.styleColorOptions();
 
     Color resizerColor;
-    if (Theme::singleton().userPrefersContrast())
+    if (Theme::singleton().userPreferredContrast() == InterfaceContrastPreference::MoreContrast)
         resizerColor = highContrastOutlineColor(styleColorOptions);
     else
         resizerColor = systemColor(CSSValueAppleSystemSecondaryLabel, styleColorOptions);

--- a/Source/WebKit/Shared/glib/SystemSettings.serialization.in
+++ b/Source/WebKit/Shared/glib/SystemSettings.serialization.in
@@ -20,7 +20,13 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-headers: <WebCore/SystemSettings.h>
+enum class WebCore::InterfaceContrastPreference : uint8_t {
+    NoPreference,
+    MoreContrast,
+    LessContrast
+};
+
+headers: <WebCore/SystemSettings.h> <WebCore/Theme.h>
 [CustomHeader] struct WebCore::SystemSettingsState {
     std::optional<String> themeName;
     std::optional<bool> darkMode;
@@ -38,5 +44,6 @@ headers: <WebCore/SystemSettings.h>
     std::optional<int> cursorBlinkTime;
     std::optional<bool> primaryButtonWarpsSlider;
     std::optional<bool> overlayScrolling;
-    std::optional<bool> enableAnimations;
+    std::optional<bool> reducedMotion;
+    std::optional<WebCore::InterfaceContrastPreference> interfaceContrast;
 }

--- a/Source/WebKit/UIProcess/glib/SystemSettingsManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/glib/SystemSettingsManagerProxy.cpp
@@ -104,9 +104,14 @@ bool SystemSettingsManagerProxy::overlayScrolling() const
     return true;
 }
 
-bool SystemSettingsManagerProxy::enableAnimations() const
+bool SystemSettingsManagerProxy::reducedMotion() const
 {
-    return true;
+    return false;
+}
+
+WebCore::InterfaceContrastPreference SystemSettingsManagerProxy::interfaceContrast() const
+{
+    return WebCore::InterfaceContrastPreference::NoPreference;
 }
 
 #endif // !PLATFORM(GTK) && (!PLATFORM(WPE) || !ENABLE(WPE_PLATFORM))
@@ -180,9 +185,13 @@ void SystemSettingsManagerProxy::settingsDidChange()
     if (oldState.overlayScrolling != overlayScrolling)
         changedState.overlayScrolling = overlayScrolling;
 
-    auto enableAnimations = this->enableAnimations();
-    if (oldState.enableAnimations != enableAnimations)
-        changedState.enableAnimations = enableAnimations;
+    auto reducedMotion = this->reducedMotion();
+    if (oldState.reducedMotion != reducedMotion)
+        changedState.reducedMotion = reducedMotion;
+
+    auto interfaceContrast = this->interfaceContrast();
+    if (oldState.interfaceContrast != interfaceContrast)
+        changedState.interfaceContrast = interfaceContrast;
 
     for (auto& processPool : WebProcessPool::allProcessPools())
         processPool->sendToAllProcesses(Messages::SystemSettingsManager::DidChange(changedState));

--- a/Source/WebKit/UIProcess/glib/SystemSettingsManagerProxy.h
+++ b/Source/WebKit/UIProcess/glib/SystemSettingsManagerProxy.h
@@ -42,6 +42,7 @@ using PlatformSettings = void;
 
 namespace WebCore {
 struct SystemSettingsState;
+enum class InterfaceContrastPreference : uint8_t;
 }
 
 namespace WebKit {
@@ -72,7 +73,8 @@ private:
     int cursorBlinkTime() const;
     bool primaryButtonWarpsSlider() const;
     bool overlayScrolling() const;
-    bool enableAnimations() const;
+    bool reducedMotion() const;
+    WebCore::InterfaceContrastPreference interfaceContrast() const;
 
     PlatformSettings* m_settings { nullptr };
 };

--- a/Source/WebKit/UIProcess/gtk/SystemSettingsManagerProxyGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/SystemSettingsManagerProxyGtk.cpp
@@ -28,6 +28,7 @@
 
 #include <WebCore/PlatformScreen.h>
 #include <WebCore/SystemSettings.h>
+#include <WebCore/Theme.h>
 #include <gtk/gtk.h>
 #include <wtf/glib/GUniquePtr.h>
 
@@ -52,13 +53,26 @@ String SystemSettingsManagerProxy::themeName() const
 
 bool SystemSettingsManagerProxy::darkMode() const
 {
+#if GTK_CHECK_VERSION(4, 20, 0)
+    GtkInterfaceColorScheme gtkInterfaceColorScheme;
+    g_object_get(m_settings, "gtk-interface-color-scheme", &gtkInterfaceColorScheme, nullptr);
+    switch (gtkInterfaceColorScheme) {
+    case GTK_INTERFACE_COLOR_SCHEME_UNSUPPORTED:
+        return false;
+    case GTK_INTERFACE_COLOR_SCHEME_DEFAULT:
+        return false;
+    case GTK_INTERFACE_COLOR_SCHEME_DARK:
+        return true;
+    case GTK_INTERFACE_COLOR_SCHEME_LIGHT:
+        return false;
+    }
+    return false;
+#else
     gboolean preferDarkTheme;
     g_object_get(m_settings, "gtk-application-prefer-dark-theme", &preferDarkTheme, nullptr);
     if (preferDarkTheme)
         return true;
 
-    // FIXME: These are just heuristics, we should get the dark mode from libhandy/libadwaita, falling back to the settings portal.
-    // Or maybe just use the settings portal, because we don't want to depend on libhandy, and maybe don't want to depend on libadwaita?
     if (const char* themeNameEnv = g_getenv("GTK_THEME")) {
         String themeNameEnvString = String::fromUTF8(themeNameEnv);
         return themeNameEnvString.endsWith("-dark"_s) || themeNameEnvString.endsWith("-Dark"_s) || themeNameEnvString.endsWith(":dark"_s);
@@ -73,6 +87,7 @@ bool SystemSettingsManagerProxy::darkMode() const
     }
 
     return false;
+#endif
 }
 
 String SystemSettingsManagerProxy::fontName() const
@@ -169,11 +184,40 @@ bool SystemSettingsManagerProxy::overlayScrolling() const
     return !!overlayScrollingSetting;
 }
 
-bool SystemSettingsManagerProxy::enableAnimations() const
+bool SystemSettingsManagerProxy::reducedMotion() const
 {
-    gboolean enableAnimationsSetting;
-    g_object_get(m_settings, "gtk-enable-animations", &enableAnimationsSetting, nullptr);
-    return !!enableAnimationsSetting;
+#if GTK_CHECK_VERSION(4, 22, 0)
+    GtkReducedMotion prefersReducedMotion;
+    g_object_get(m_settings, "gtk-interface-reduced-motion", &prefersReducedMotion, nullptr);
+    return prefersReducedMotion == GTK_REDUCED_MOTION_REDUCE;
+#else
+    gboolean enableAnimations;
+    g_object_get(m_settings, "gtk-enable-animations", &enableAnimations, nullptr);
+    return !enableAnimations;
+#endif
+}
+
+WebCore::InterfaceContrastPreference SystemSettingsManagerProxy::interfaceContrast() const
+{
+#if GTK_CHECK_VERSION(4, 20, 0)
+    GtkInterfaceContrast gtkInterfaceContrast;
+    g_object_get(m_settings, "gtk-interface-contrast", &gtkInterfaceContrast, nullptr);
+    switch (gtkInterfaceContrast) {
+    case GTK_INTERFACE_CONTRAST_UNSUPPORTED:
+    case GTK_INTERFACE_CONTRAST_NO_PREFERENCE:
+        return WebCore::InterfaceContrastPreference::NoPreference;
+    case GTK_INTERFACE_CONTRAST_MORE:
+        return WebCore::InterfaceContrastPreference::MoreContrast;
+    case GTK_INTERFACE_CONTRAST_LESS:
+        return WebCore::InterfaceContrastPreference::LessContrast;
+    }
+    return WebCore::InterfaceContrastPreference::NoPreference;
+#else
+    auto name = themeName();
+    if (name == "HighContrast"_s || name == "HighContrastInverse"_s)
+        return WebCore::InterfaceContrastPreference::MoreContrast;
+    return WebCore::InterfaceContrastPreference::NoPreference;
+#endif
 }
 
 void SystemSettingsManagerProxy::updateFontProperties(const String& fontName, WebCore::SystemSettingsState& changedState)

--- a/Source/WebKit/UIProcess/wpe/SystemSettingsManagerProxyWPE.cpp
+++ b/Source/WebKit/UIProcess/wpe/SystemSettingsManagerProxyWPE.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(WPE_PLATFORM)
 
+#include <WebCore/Theme.h>
 #include <wpe/WPEDisplay.h>
 #include <wpe/WPESettings.h>
 #include <wtf/glib/GUniquePtr.h>
@@ -181,9 +182,23 @@ bool SystemSettingsManagerProxy::overlayScrolling() const
     return getBool(m_settings, WPE_SETTING_OVERLAY_SCROLLBARS, true);
 }
 
-bool SystemSettingsManagerProxy::enableAnimations() const
+bool SystemSettingsManagerProxy::reducedMotion() const
 {
-    return !getBool(m_settings, WPE_SETTING_DISABLE_ANIMATIONS, false);
+    return !getBool(m_settings, WPE_SETTING_REDUCED_MOTION, false);
+}
+
+WebCore::InterfaceContrastPreference SystemSettingsManagerProxy::interfaceContrast() const
+{
+    switch (getUint8(m_settings, WPE_SETTING_INTERFACE_CONTRAST, WPE_SETTINGS_INTERFACE_CONTRAST_NO_PREFERENCE)) {
+    case WPE_SETTINGS_INTERFACE_CONTRAST_NO_PREFERENCE:
+        return WebCore::InterfaceContrastPreference::NoPreference;
+    case WPE_SETTINGS_INTERFACE_CONTRAST_MORE:
+        return WebCore::InterfaceContrastPreference::MoreContrast;
+    case WPE_SETTINGS_INTERFACE_CONTRAST_LESS:
+        return WebCore::InterfaceContrastPreference::LessContrast;
+    }
+    ASSERT_NOT_REACHED();
+    return WebCore::InterfaceContrastPreference::NoPreference;
 }
 
 SystemSettingsManagerProxy::SystemSettingsManagerProxy()

--- a/Source/WebKit/WPEPlatform/wpe/WPESettings.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPESettings.cpp
@@ -91,7 +91,8 @@ struct _WPESettingsPrivate {
         static const std::vector<Setting> defaultSettings = {
             { WPE_SETTING_FONT_NAME, G_VARIANT_TYPE_STRING, g_variant_ref_sink(g_variant_new_string("Sans 10")) },
             { WPE_SETTING_DARK_MODE, G_VARIANT_TYPE_BOOLEAN, g_variant_ref_sink(g_variant_new_boolean(false)) },
-            { WPE_SETTING_DISABLE_ANIMATIONS, G_VARIANT_TYPE_BOOLEAN, g_variant_ref_sink(g_variant_new_boolean(false)) },
+            { WPE_SETTING_REDUCED_MOTION, G_VARIANT_TYPE_BOOLEAN, g_variant_ref_sink(g_variant_new_boolean(false)) },
+            { WPE_SETTING_INTERFACE_CONTRAST, G_VARIANT_TYPE_BYTE, g_variant_ref_sink(g_variant_new_byte(WPE_SETTINGS_INTERFACE_CONTRAST_NO_PREFERENCE)) },
             { WPE_SETTING_FONT_ANTIALIAS, G_VARIANT_TYPE_BOOLEAN, g_variant_ref_sink(g_variant_new_boolean(true)) },
             { WPE_SETTING_FONT_HINTING_STYLE, G_VARIANT_TYPE_BYTE, g_variant_ref_sink(g_variant_new_byte(WPE_SETTINGS_HINTING_STYLE_SLIGHT)) },
             { WPE_SETTING_FONT_SUBPIXEL_LAYOUT, G_VARIANT_TYPE_BYTE, g_variant_ref_sink(g_variant_new_byte(WPE_SETTINGS_SUBPIXEL_LAYOUT_RGB)) },

--- a/Source/WebKit/WPEPlatform/wpe/WPESettings.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPESettings.h
@@ -77,15 +77,40 @@ WPE_API GQuark wpe_settings_error_quark(void);
 #define WPE_SETTING_DARK_MODE "/wpe-platform/dark-mode"
 
 /**
- * WPE_SETTING_DISABLE_ANIMATIONS:
+ * WPE_SETTING_REDUCED_MOTION:
  *
- * Disables animations on websites.
+ * Whether the user prefers reduced animations.
  *
  * VariantType: boolean
  *
  * Default: false
  */
-#define WPE_SETTING_DISABLE_ANIMATIONS "/wpe-platform/disable-animations"
+#define WPE_SETTING_REDUCED_MOTION "/wpe-platform/reduced-motion"
+
+/**
+ * WPESettingsInterfaceContrast:
+ * @WPE_SETTINGS_INTERFACE_CONTRAST_NO_PREFERENCE: the user prefers normal contrast
+ * @WPE_SETTINGS_INTERFACE_CONTRAST_MORE: the user prefers high contrast
+ * @WPE_SETTINGS_INTERFACE_CONTRAST_LESS: the user prefers less contrast
+ *
+ * The user's preference for high contrast, low contrast, or normal contrast.
+ */
+typedef enum {
+    WPE_SETTINGS_INTERFACE_CONTRAST_NO_PREFERENCE,
+    WPE_SETTINGS_INTERFACE_CONTRAST_MORE,
+    WPE_SETTINGS_INTERFACE_CONTRAST_LESS
+} WPESettingsInterfaceContrast;
+
+/**
+ * WPE_SETTING_INTERFACE_CONTRAST:
+ *
+ * Whether the user prefers high contrast, low contrast, or normal contrast.
+ *
+ * VariantType: byte (WPESettingsInterfaceContrast)
+ *
+ * Default: WPE_SETTINGS_INTERFACE_CONTRAST_NO_PREFERENCE
+ */
+#define WPE_SETTING_INTERFACE_CONTRAST "/wpe-platform/interface-contrast"
 
 /**
  * WPE_SETTING_FONT_ANTIALIAS:


### PR DESCRIPTION
#### 446267f9f445d5be8fe4b59264af04c69bbbec00
<pre>
[WPE][GTK] Improvements to platform media queries (prefers reduced motion, high contrast, and dark theme)
<a href="https://bugs.webkit.org/show_bug.cgi?id=317488">https://bugs.webkit.org/show_bug.cgi?id=317488</a>

Reviewed by Carlos Garcia Campos.

GNOME 50 has a new reduced motion setting, separate from GTK&apos;s disable
animations setting. We currently have the disable animations setting
hooked up to the prefers-reduced-motion CSS media query. Let&apos;s stop
using that, and use the new reduced motion setting instead. For good
measure, I&apos;ve also created a new WPE API setting matching the new name,
and removed the older one (because the WPEPlatform API is not stable
yet).

I had been planning to stop there, but then I noticed that we have the
prefers-contrast media query implemented only for GTK 3. I have
implemented it for GTK 4 as well. This required some effort, because
WebKit has it implemented as a boolean value, but GNOME and CSS both use
a tri-state, so I had to change a bunch of places to expose it as a
tri-state. I&apos;ve also created a new WPE setting for this as well. I
considered updating Internals so that I could expose the tri-state to
layout tests as well, but it currently uses ForcedAccessibilityValue
which is a boolean, and I decided not to try changing this.

Finally, I&apos;ve improved the implementation of the prefers-color-scheme
media query for GTK 4. This is an especially significant change because
it previously did not respect the user&apos;s dark mode preference at all.
Now a bunch of websites will become dark.

This is my second attempt to land the change. The first attempt,
316627@main, was reverted because it broke the WPE build.

* Source/WebCore/css/query/MediaQueryFeatures.cpp:
(WebCore::MQ::Features::prefersContrastFeatureSchema):
* Source/WebCore/inspector/agents/InspectorPageAgent.cpp:
(WebCore::InspectorPageAgent::defaultUserPreferencesDidChange):
* Source/WebCore/platform/Theme.h:
(WebCore::Theme::userPreferredContrast const):
(WebCore::Theme::userPrefersContrast const): Deleted.
* Source/WebCore/platform/adwaita/ThemeAdwaita.cpp:
(WebCore::ThemeAdwaita::ThemeAdwaita):
(WebCore::ThemeAdwaita::refreshSettings):
(WebCore::ThemeAdwaita::userPreferredContrast const):
(WebCore::ThemeAdwaita::userPrefersContrast const): Deleted.
* Source/WebCore/platform/adwaita/ThemeAdwaita.h:
* Source/WebCore/platform/glib/SystemSettings.cpp:
(WebCore::SystemSettings::updateSettings):
* Source/WebCore/platform/glib/SystemSettings.h:
(WebCore::SystemSettings::reducedMotion const):
(WebCore::SystemSettings::interfaceContrast const):
(WebCore::SystemSettings::enableAnimations const): Deleted.
* Source/WebCore/platform/ios/ThemeIOS.h:
* Source/WebCore/platform/ios/ThemeIOS.mm:
(WebCore::ThemeIOS::userPreferredContrast const):
(WebCore::ThemeIOS::userPrefersContrast const): Deleted.
* Source/WebCore/platform/mac/ThemeMac.h:
* Source/WebCore/platform/mac/ThemeMac.mm:
(WebCore::ThemeMac::userPreferredContrast const):
(WebCore::ThemeMac::userPrefersContrast const): Deleted.
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
(WebCore::switchTrackColor):
(WebCore::paintSwitchTrackOnOffLabels):
(WebCore::paintLiquidGlassSwitchTrackOnOffLabels):
(WebCore::renderThemePaintLiquidGlassSwitchThumb):
(WebCore::renderThemePaintLiquidGlassSwitchTrack):
(WebCore::RenderThemeCocoa::paintCheckboxForVectorBasedControls):
(WebCore::RenderThemeCocoa::paintRadioForVectorBasedControls):
(WebCore::RenderThemeCocoa::paintButtonForVectorBasedControls):
(WebCore::RenderThemeCocoa::paintColorWellForVectorBasedControls):
(WebCore::RenderThemeCocoa::paintInnerSpinButtonForVectorBasedControls):
(WebCore::paintTextAreaOrTextField):
(WebCore::RenderThemeCocoa::paintMeterForVectorBasedControls):
(WebCore::RenderThemeCocoa::paintListButtonForVectorBasedControls):
(WebCore::RenderThemeCocoa::paintSliderThumbForVectorBasedControls):
(WebCore::RenderThemeCocoa::paintSearchFieldForVectorBasedControls):
(WebCore::RenderThemeCocoa::paintSearchFieldCancelButtonForVectorBasedControls):
(WebCore::RenderThemeCocoa::paintSearchFieldDecorationPartForVectorBasedControls):
(WebCore::RenderThemeCocoa::paintPlatformResizerForVectorBasedControls):
* Source/WebKit/Shared/glib/SystemSettings.serialization.in:
* Source/WebKit/UIProcess/glib/SystemSettingsManagerProxy.cpp:
(WebKit::SystemSettingsManagerProxy::reducedMotion const):
(WebKit::SystemSettingsManagerProxy::interfaceContrast const):
(WebKit::SystemSettingsManagerProxy::settingsDidChange):
(WebKit::SystemSettingsManagerProxy::enableAnimations const): Deleted.
* Source/WebKit/UIProcess/glib/SystemSettingsManagerProxy.h:
* Source/WebKit/UIProcess/gtk/SystemSettingsManagerProxyGtk.cpp:
(WebKit::SystemSettingsManagerProxy::darkMode const):
(WebKit::SystemSettingsManagerProxy::reducedMotion const):
(WebKit::SystemSettingsManagerProxy::interfaceContrast const):
(WebKit::SystemSettingsManagerProxy::enableAnimations const): Deleted.
* Source/WebKit/UIProcess/wpe/SystemSettingsManagerProxyWPE.cpp:
(WebKit::SystemSettingsManagerProxy::reducedMotion const):
(WebKit::SystemSettingsManagerProxy::interfaceContrast const):
(WebKit::SystemSettingsManagerProxy::enableAnimations const): Deleted.
* Source/WebKit/WPEPlatform/wpe/WPESettings.cpp:
(_WPESettingsPrivate::_WPESettingsPrivate):
* Source/WebKit/WPEPlatform/wpe/WPESettings.h:

Canonical link: <a href="https://commits.webkit.org/316709@main">https://commits.webkit.org/316709@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c00591b83b1e9d15ec80ec15aa939bd5fee36873

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173154 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47086 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40579 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182727 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130710 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175019 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48379 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46768 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134644 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176112 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38049 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155247 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115113 "Found 1 new API test failure: WPE/TestWebKitWebView:/webkit/WebKitWebView/save (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36694 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35038 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31212 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147118 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34746 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185149 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37961 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39240 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143486 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46754 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143358 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38714 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47433 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112507 "Built successfully") | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26298 "") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38316 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119182 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45939 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9689 "Passed tests") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45341 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45572 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45398 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->