### PR TITLE
PlaceholderModelPlayer camera and animation methods do not call their completion handlers

### DIFF
--- a/Source/WebCore/Modules/model-element/PlaceholderModelPlayer.cpp
+++ b/Source/WebCore/Modules/model-element/PlaceholderModelPlayer.cpp
@@ -229,40 +229,49 @@ void PlaceholderModelPlayer::handleMouseUp(const LayoutPoint&, MonotonicTime)
 {
 }
 
-void PlaceholderModelPlayer::getCamera(CompletionHandler<void(std::optional<WebCore::HTMLModelElementCamera>&&)>&&)
+void PlaceholderModelPlayer::getCamera(CompletionHandler<void(std::optional<WebCore::HTMLModelElementCamera>&&)>&& completionHandler)
 {
+    completionHandler(std::nullopt);
 }
 
-void PlaceholderModelPlayer::setCamera(WebCore::HTMLModelElementCamera, CompletionHandler<void(bool success)>&&)
+void PlaceholderModelPlayer::setCamera(WebCore::HTMLModelElementCamera, CompletionHandler<void(bool success)>&& completionHandler)
 {
+    completionHandler(false);
 }
 
-void PlaceholderModelPlayer::isPlayingAnimation(CompletionHandler<void(std::optional<bool>&&)>&&)
+void PlaceholderModelPlayer::isPlayingAnimation(CompletionHandler<void(std::optional<bool>&&)>&& completionHandler)
 {
+    completionHandler(std::nullopt);
 }
 
-void PlaceholderModelPlayer::setAnimationIsPlaying(bool, CompletionHandler<void(bool success)>&&)
+void PlaceholderModelPlayer::setAnimationIsPlaying(bool, CompletionHandler<void(bool success)>&& completionHandler)
 {
+    completionHandler(false);
 }
 
-void PlaceholderModelPlayer::isLoopingAnimation(CompletionHandler<void(std::optional<bool>&&)>&&)
+void PlaceholderModelPlayer::isLoopingAnimation(CompletionHandler<void(std::optional<bool>&&)>&& completionHandler)
 {
+    completionHandler(std::nullopt);
 }
 
-void PlaceholderModelPlayer::setIsLoopingAnimation(bool, CompletionHandler<void(bool success)>&&)
+void PlaceholderModelPlayer::setIsLoopingAnimation(bool, CompletionHandler<void(bool success)>&& completionHandler)
 {
+    completionHandler(false);
 }
 
-void PlaceholderModelPlayer::animationDuration(CompletionHandler<void(std::optional<Seconds>&&)>&&)
+void PlaceholderModelPlayer::animationDuration(CompletionHandler<void(std::optional<Seconds>&&)>&& completionHandler)
 {
+    completionHandler(std::nullopt);
 }
 
-void PlaceholderModelPlayer::animationCurrentTime(CompletionHandler<void(std::optional<Seconds>&&)>&&)
+void PlaceholderModelPlayer::animationCurrentTime(CompletionHandler<void(std::optional<Seconds>&&)>&& completionHandler)
 {
+    completionHandler(std::nullopt);
 }
 
-void PlaceholderModelPlayer::setAnimationCurrentTime(Seconds, CompletionHandler<void(bool success)>&&)
+void PlaceholderModelPlayer::setAnimationCurrentTime(Seconds, CompletionHandler<void(bool success)>&& completionHandler)
 {
+    completionHandler(false);
 }
 
 #if ENABLE(MODEL_ELEMENT_ACCESSIBILITY)

--- a/Source/WebCore/Modules/model-element/PlaceholderModelPlayer.h
+++ b/Source/WebCore/Modules/model-element/PlaceholderModelPlayer.h
@@ -89,15 +89,16 @@ private:
     void NODELETE handleMouseDown(const LayoutPoint&, MonotonicTime) final;
     void NODELETE handleMouseMove(const LayoutPoint&, MonotonicTime) final;
     void NODELETE handleMouseUp(const LayoutPoint&, MonotonicTime) final;
-    void NODELETE getCamera(CompletionHandler<void(std::optional<WebCore::HTMLModelElementCamera>&&)>&&) final;
-    void NODELETE setCamera(WebCore::HTMLModelElementCamera, CompletionHandler<void(bool success)>&&) final;
-    void NODELETE isPlayingAnimation(CompletionHandler<void(std::optional<bool>&&)>&&) final;
-    void NODELETE setAnimationIsPlaying(bool, CompletionHandler<void(bool success)>&&) final;
-    void NODELETE isLoopingAnimation(CompletionHandler<void(std::optional<bool>&&)>&&) final;
-    void NODELETE setIsLoopingAnimation(bool, CompletionHandler<void(bool success)>&&) final;
-    void NODELETE animationDuration(CompletionHandler<void(std::optional<Seconds>&&)>&&) final;
-    void NODELETE animationCurrentTime(CompletionHandler<void(std::optional<Seconds>&&)>&&) final;
-    void NODELETE setAnimationCurrentTime(Seconds, CompletionHandler<void(bool success)>&&) final;
+
+    void getCamera(CompletionHandler<void(std::optional<WebCore::HTMLModelElementCamera>&&)>&&) final;
+    void setCamera(WebCore::HTMLModelElementCamera, CompletionHandler<void(bool success)>&&) final;
+    void isPlayingAnimation(CompletionHandler<void(std::optional<bool>&&)>&&) final;
+    void setAnimationIsPlaying(bool, CompletionHandler<void(bool success)>&&) final;
+    void isLoopingAnimation(CompletionHandler<void(std::optional<bool>&&)>&&) final;
+    void setIsLoopingAnimation(bool, CompletionHandler<void(bool success)>&&) final;
+    void animationDuration(CompletionHandler<void(std::optional<Seconds>&&)>&&) final;
+    void animationCurrentTime(CompletionHandler<void(std::optional<Seconds>&&)>&&) final;
+    void setAnimationCurrentTime(Seconds, CompletionHandler<void(bool success)>&&) final;
 #if ENABLE(MODEL_ELEMENT_ACCESSIBILITY)
     ModelPlayerAccessibilityChildren accessibilityChildren() final;
 #endif


### PR DESCRIPTION
#### d8a467a3231239387021498e1dfda32e543a9c94
<pre>
PlaceholderModelPlayer camera and animation methods do not call their completion handlers

<a href="https://bugs.webkit.org/show_bug.cgi?id=318820">https://bugs.webkit.org/show_bug.cgi?id=318820</a>
<a href="https://rdar.apple.com/181635780">rdar://181635780</a>

Reviewed by Mike Wyrzykowski.

9 PlaceholderModelPlayer overrides (getCamera, setCamera, isPlayingAnimation,
setAnimationIsPlaying, isLoopingAnimation, setIsLoopingAnimation, animationDuration,
animationCurrentTime, and setAnimationCurrentTime) had empty bodies that returned
without invoking their CompletionHandler. A CompletionHandler must be called exactly
once: dropping it trips the assertion in ~CompletionHandler() in debug builds, and in
release leaves the corresponding JS promise unsettled.

Call each handler with the same unavailable value already used by
ModelProcessModelPlayerProxy: std::nullopt for the optional getters and false for the
boolean setters, so HTMLModelElement rejects the promise cleanly instead of hanging.

Drop the NODELETE annotation from those nine declarations: invoking a CompletionHandler
may run destructors and free memory (it destroys the wrapped callable), which NODELETE
asserts the function does not do, so the safer-cpp NoDeleteChecker flags it.

No new tests.

* Source/WebCore/Modules/model-element/PlaceholderModelPlayer.cpp:
(WebCore::PlaceholderModelPlayer::getCamera):
(WebCore::PlaceholderModelPlayer::setCamera):
(WebCore::PlaceholderModelPlayer::isPlayingAnimation):
(WebCore::PlaceholderModelPlayer::setAnimationIsPlaying):
(WebCore::PlaceholderModelPlayer::isLoopingAnimation):
(WebCore::PlaceholderModelPlayer::setIsLoopingAnimation):
(WebCore::PlaceholderModelPlayer::animationDuration):
(WebCore::PlaceholderModelPlayer::animationCurrentTime):
(WebCore::PlaceholderModelPlayer::setAnimationCurrentTime):
* Source/WebCore/Modules/model-element/PlaceholderModelPlayer.h:

Canonical link: <a href="https://commits.webkit.org/316827@main">https://commits.webkit.org/316827@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01e9e09614b7a61bff45ae37f519214ba8e0cda0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173317 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47249 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40792 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182890 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130873 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/45e78146-b2b9-4cec-ac04-3693a06d0bae) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175182 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48542 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46931 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134761 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95162 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176275 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38178 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155418 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115236 "Found 1 new API test failure: WPE/TestWebKitWebView:/webkit/WebKitWebView/save (failure)") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ca06883a-f2f2-4b72-96dc-6abfc0297204) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36821 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35170 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31375 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147245 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34915 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185314 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38175 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39371 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143615 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46917 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143484 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38768 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47596 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31751 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112697 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38435 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119345 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46102 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9862 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45504 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45735 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45561 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->