### PR TITLE
[JSC] Make sizeof(Air::Arg) 16

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirArg.cpp
+++ b/Source/JavaScriptCore/b3/air/AirArg.cpp
@@ -99,48 +99,50 @@ unsigned Arg::jsHash() const
     case SIMDInfo:
         break;
     case Tmp:
-        result += m_base.internalValue();
+        result += m_tmps.base.internalValue();
         break;
     case Imm:
     case BitImm:
     case FPImm32:
     case ZeroReg:
-    case CallArg:
     case RelCond:
     case ResCond:
     case DoubleCond:
     case StatusCond:
     case WidthArg:
+        result += static_cast<unsigned>(m_value);
+        break;
+    case CallArg:
         result += static_cast<unsigned>(m_offset);
         break;
     case BigImm:
     case BitImm64:
     case FPImm64:
     case FPImm128:
-        result += static_cast<unsigned>(m_offset);
-        result += static_cast<unsigned>(m_offset >> 32);
+        result += static_cast<unsigned>(m_value);
+        result += static_cast<unsigned>(m_value >> 32);
         break;
     case SimpleAddr:
-        result += m_base.internalValue();
+        result += m_tmps.base.internalValue();
         break;
     case Addr:
     case ExtendedOffsetAddr:
         result += m_offset;
-        result += m_base.internalValue();
+        result += m_tmps.base.internalValue();
         break;
     case Index:
         result += static_cast<unsigned>(m_offset);
-        result += m_scale;
-        result += m_base.internalValue();
-        result += m_index.internalValue();
+        result += m_logScale;
+        result += m_tmps.base.internalValue();
+        result += m_tmps.index.internalValue();
         break;
     case PreIndex:
     case PostIndex:
         result += m_offset;
-        result += m_base.internalValue();
+        result += m_tmps.base.internalValue();
         break;
     case Stack:
-        result += static_cast<unsigned>(m_scale);
+        result += static_cast<unsigned>(m_offset);
         result += stackSlot()->index();
         break;
     }
@@ -158,22 +160,22 @@ void Arg::dump(PrintStream& out) const
         out.print(tmp());
         return;
     case Imm:
-        out.print("$", m_offset);
+        out.print("$", m_value);
         return;
     case BigImm:
-        out.printf("$0x%llx", static_cast<long long unsigned>(m_offset));
+        out.printf("$0x%llx", static_cast<long long unsigned>(m_value));
         return;
     case BitImm:
-        out.print("$", m_offset);
+        out.print("$", m_value);
         return;
     case BitImm64:
-        out.printf("$0x%llx", static_cast<long long unsigned>(m_offset));
+        out.printf("$0x%llx", static_cast<long long unsigned>(m_value));
         return;
     case FPImm32:
-        out.print("$", m_offset);
+        out.print("$", m_value);
         return;
     case FPImm64:
-        out.printf("$0x%llx", static_cast<long long unsigned>(m_offset));
+        out.printf("$0x%llx", static_cast<long long unsigned>(m_value));
         return;
     case FPImm128:
         out.print(asV128());

--- a/Source/JavaScriptCore/b3/air/AirArg.h
+++ b/Source/JavaScriptCore/b3/air/AirArg.h
@@ -492,8 +492,8 @@ public:
 
     Arg(Air::Tmp tmp)
         : m_kind(Tmp)
-        , m_base(tmp)
     {
+        m_tmps.base = tmp;
     }
 
     Arg(Reg reg)
@@ -523,7 +523,7 @@ public:
             RELEASE_ASSERT((Fits<int64_t, Wide32>::check(value) || Fits<uint64_t, Wide32>::check(value)));
         Arg result;
         result.m_kind = Imm;
-        result.m_offset = value;
+        result.m_value = value;
         return result;
     }
 
@@ -533,7 +533,7 @@ public:
             RELEASE_ASSERT((Fits<int64_t, Wide32>::check(value) || Fits<uint64_t, Wide32>::check(value)));
         Arg result;
         result.m_kind = BigImm;
-        result.m_offset = value;
+        result.m_value = value;
         return result;
     }
 
@@ -553,7 +553,7 @@ public:
             RELEASE_ASSERT((Fits<int64_t, Wide32>::check(value)));
         Arg result;
         result.m_kind = BitImm;
-        result.m_offset = value;
+        result.m_value = value;
         return result;
     }
 
@@ -563,7 +563,7 @@ public:
             UNREACHABLE_FOR_PLATFORM();
         Arg result;
         result.m_kind = BitImm64;
-        result.m_offset = value;
+        result.m_value = value;
         return result;
     }
 
@@ -573,7 +573,7 @@ public:
             RELEASE_ASSERT((Fits<int64_t, Wide32>::check(value)));
         Arg result;
         result.m_kind = FPImm32;
-        result.m_offset = value;
+        result.m_value = value;
         return result;
     }
 
@@ -583,7 +583,7 @@ public:
             UNREACHABLE_FOR_PLATFORM();
         Arg result;
         result.m_kind = FPImm64;
-        result.m_offset = value;
+        result.m_value = value;
         return result;
     }
 
@@ -593,7 +593,7 @@ public:
             UNREACHABLE_FOR_PLATFORM();
         Arg result;
         result.m_kind = FPImm128;
-        result.m_offset = value.u64x2[0];
+        result.m_value = value.u64x2[0];
         ASSERT(bitEquals(value, result.asV128()));
         return result;
     }
@@ -608,7 +608,7 @@ public:
         ASSERT(ptr.isGP());
         Arg result;
         result.m_kind = SimpleAddr;
-        result.m_base = ptr;
+        result.m_tmps.base = ptr;
         return result;
     }
 
@@ -618,7 +618,7 @@ public:
         ASSERT(base.isGP());
         Arg result;
         result.m_kind = Addr;
-        result.m_base = base;
+        result.m_tmps.base = base;
         result.m_offset = offset;
         return result;
     }
@@ -628,7 +628,7 @@ public:
     {
         Arg result;
         result.m_kind = ExtendedOffsetAddr;
-        result.m_base = Air::Tmp(MacroAssembler::framePointerRegister);
+        result.m_tmps.base = Air::Tmp(MacroAssembler::framePointerRegister);
         result.m_offset = offsetFromFP;
         return result;
     }
@@ -643,8 +643,8 @@ public:
     {
         Arg result;
         result.m_kind = Stack;
-        result.m_offset = std::bit_cast<intptr_t>(value);
-        result.m_scale = offset; // I know, yuck.
+        result.m_value = std::bit_cast<intptr_t>(value);
+        result.m_offset = offset;
         return result;
     }
 
@@ -713,9 +713,9 @@ public:
         ASSERT(isValidScale(scale));
         Arg result;
         result.m_kind = Index;
-        result.m_base = base;
-        result.m_index = index;
-        result.m_scale = static_cast<int32_t>(scale);
+        result.m_tmps.base = base;
+        result.m_tmps.index = index;
+        result.m_logScale = static_cast<uint8_t>(logScale(scale));
         result.m_offset = offset;
         result.m_extend = extend;
         return result;
@@ -733,7 +733,7 @@ public:
         ASSERT(isInt9(index));
         Arg result;
         result.m_kind = PreIndex;
-        result.m_base = base;
+        result.m_tmps.base = base;
         result.m_offset = index;
         return result;
     }
@@ -745,7 +745,7 @@ public:
         ASSERT(isInt9(index));
         Arg result;
         result.m_kind = PostIndex;
-        result.m_base = base;
+        result.m_tmps.base = base;
         result.m_offset = index;
         return result;
     }
@@ -754,7 +754,7 @@ public:
     {
         Arg result;
         result.m_kind = RelCond;
-        result.m_offset = condition;
+        result.m_value = condition;
         return result;
     }
 
@@ -762,7 +762,7 @@ public:
     {
         Arg result;
         result.m_kind = ResCond;
-        result.m_offset = condition;
+        result.m_value = condition;
         return result;
     }
 
@@ -770,7 +770,7 @@ public:
     {
         Arg result;
         result.m_kind = DoubleCond;
-        result.m_offset = condition;
+        result.m_value = condition;
         return result;
     }
 
@@ -778,7 +778,7 @@ public:
     {
         Arg result;
         result.m_kind = StatusCond;
-        result.m_offset = condition;
+        result.m_value = condition;
         return result;
     }
 
@@ -786,7 +786,7 @@ public:
     {
         Arg result;
         result.m_kind = Special;
-        result.m_offset = std::bit_cast<intptr_t>(special);
+        result.m_value = std::bit_cast<intptr_t>(special);
         return result;
     }
 
@@ -794,7 +794,7 @@ public:
     {
         Arg result;
         result.m_kind = WidthArg;
-        result.m_offset = bytesForWidth(width);
+        result.m_value = bytesForWidth(width);
         return result;
     }
 
@@ -802,17 +802,19 @@ public:
     {
         Arg result;
         result.m_kind = ZeroReg;
-        result.m_offset = 0;
+        result.m_value = 0;
         return result;
     }
 
     bool operator==(const Arg& other) const
     {
-        return m_offset == other.m_offset
+        // m_value aliases the base+index Tmp pair, so comparing it covers both those and the
+        // 64-bit immediate/pointer payload.
+        return m_value == other.m_value
             && m_kind == other.m_kind
-            && m_base == other.m_base
-            && m_index == other.m_index
-            && m_scale == other.m_scale;
+            && m_offset == other.m_offset
+            && m_logScale == other.m_logScale
+            && m_extend == other.m_extend;
     }
 
     explicit operator bool() const { return *this != Arg(); }
@@ -1019,13 +1021,13 @@ public:
     Air::Tmp tmp() const
     {
         ASSERT(kind() == Tmp);
-        return m_base;
+        return m_tmps.base;
     }
 
     int64_t value() const
     {
         ASSERT(isSomeImm());
-        return m_offset;
+        return m_value;
     }
 
     template<typename T>
@@ -1113,52 +1115,51 @@ public:
     void* pointerValue() const
     {
         ASSERT(kind() == BigImm);
-        return std::bit_cast<void*>(static_cast<intptr_t>(m_offset));
+        return std::bit_cast<void*>(static_cast<intptr_t>(m_value));
     }
     
     Air::Tmp ptr() const
     {
         ASSERT(kind() == SimpleAddr);
-        return m_base;
+        return m_tmps.base;
     }
 
     Air::Tmp base() const
     {
         ASSERT(kind() == SimpleAddr || kind() == Addr || kind() == ExtendedOffsetAddr || kind() == Index || kind() == PreIndex || kind() == PostIndex);
-        return m_base;
+        return m_tmps.base;
     }
 
     bool hasOffset() const { return isMemory(); }
     
     Value::OffsetType offset() const
     {
-        if (kind() == Stack)
-            return static_cast<Value::OffsetType>(m_scale);
-        ASSERT(kind() == Addr || kind() == ExtendedOffsetAddr || kind() == CallArg || kind() == Index || kind() == PreIndex || kind() == PostIndex);
+        ASSERT(kind() == Stack || kind() == Addr || kind() == ExtendedOffsetAddr || kind() == CallArg || kind() == Index || kind() == PreIndex || kind() == PostIndex);
         return static_cast<Value::OffsetType>(m_offset);
     }
 
     StackSlot* stackSlot() const
     {
         ASSERT(kind() == Stack);
-        return std::bit_cast<StackSlot*>(static_cast<uintptr_t>(m_offset));
+        return std::bit_cast<StackSlot*>(static_cast<uintptr_t>(m_value));
     }
 
     Air::Tmp index() const
     {
         ASSERT(kind() == Index);
-        return m_index;
+        return m_tmps.index;
     }
 
     unsigned scale() const
     {
         ASSERT(kind() == Index);
-        return m_scale;
+        return 1u << m_logScale;
     }
 
     unsigned logScale() const
     {
-        return logScale(scale());
+        ASSERT(kind() == Index);
+        return m_logScale;
     }
 
     MacroAssembler::Extend extend() const
@@ -1169,13 +1170,13 @@ public:
     Air::Special* special() const
     {
         ASSERT(kind() == Special);
-        return std::bit_cast<Air::Special*>(static_cast<uintptr_t>(m_offset));
+        return std::bit_cast<Air::Special*>(static_cast<uintptr_t>(m_value));
     }
 
     Width width() const
     {
         ASSERT(kind() == WidthArg);
-        return widthForBytes(m_offset);
+        return widthForBytes(m_value);
     }
 
     bool isGPTmp() const
@@ -1654,11 +1655,11 @@ public:
         case ExtendedOffsetAddr:
         case PreIndex:
         case PostIndex:
-            functor(m_base);
+            functor(m_tmps.base);
             break;
         case Index:
-            functor(m_base);
-            functor(m_index);
+            functor(m_tmps.base);
+            functor(m_tmps.index);
             break;
         default:
             break;
@@ -1691,20 +1692,20 @@ public:
         switch (m_kind) {
         case Tmp:
             ASSERT(isAnyUse(argRole) || isAnyDef(argRole));
-            functor(m_base, argRole, argBank, argWidth);
+            functor(m_tmps.base, argRole, argBank, argWidth);
             break;
         case SimpleAddr:
         case Addr:
         case ExtendedOffsetAddr:
-            functor(m_base, Use, GP, argRole == UseAddr ? argWidth : pointerWidth());
+            functor(m_tmps.base, Use, GP, argRole == UseAddr ? argWidth : pointerWidth());
             break;
         case PreIndex:
         case PostIndex:
-            functor(m_base, UseDef, GP, argRole == UseAddr ? argWidth : pointerWidth());
+            functor(m_tmps.base, UseDef, GP, argRole == UseAddr ? argWidth : pointerWidth());
             break;
         case Index:
-            functor(m_base, Use, GP, argRole == UseAddr ? argWidth : pointerWidth());
-            functor(m_index, Use, GP, argRole == UseAddr ? argWidth : pointerWidth());
+            functor(m_tmps.base, Use, GP, argRole == UseAddr ? argWidth : pointerWidth());
+            functor(m_tmps.index, Use, GP, argRole == UseAddr ? argWidth : pointerWidth());
             break;
         default:
             break;
@@ -1714,7 +1715,7 @@ public:
     MacroAssembler::TrustedImm32 asTrustedImm32() const
     {
         ASSERT(isImm() || isBitImm() || isFPImm32());
-        return MacroAssembler::TrustedImm32(static_cast<Value::OffsetType>(m_offset));
+        return MacroAssembler::TrustedImm32(static_cast<Value::OffsetType>(m_value));
     }
 
     MacroAssembler::TrustedImm64 asTrustedImm64() const
@@ -1730,7 +1731,7 @@ public:
         if constexpr (is32Bit())
             UNREACHABLE_FOR_PLATFORM();
         ASSERT(isFPImm128());
-        return v128_t(m_offset, m_offset);
+        return v128_t(m_value, m_value);
     }
 
     decltype(auto) asTrustedBigImm() const
@@ -1761,53 +1762,53 @@ public:
     MacroAssembler::Address asAddress() const
     {
         if (isSimpleAddr())
-            return MacroAssembler::Address(m_base.gpr());
+            return MacroAssembler::Address(m_tmps.base.gpr());
         ASSERT(isAddr() || isExtendedOffsetAddr());
-        return MacroAssembler::Address(m_base.gpr(), static_cast<Value::OffsetType>(m_offset));
+        return MacroAssembler::Address(m_tmps.base.gpr(), static_cast<Value::OffsetType>(m_offset));
     }
 
     MacroAssembler::BaseIndex asBaseIndex() const
     {
         ASSERT(isIndex());
         return MacroAssembler::BaseIndex(
-            m_base.gpr(), m_index.gpr(), static_cast<MacroAssembler::Scale>(logScale()),
+            m_tmps.base.gpr(), m_tmps.index.gpr(), static_cast<MacroAssembler::Scale>(logScale()),
             static_cast<Value::OffsetType>(m_offset), m_extend);
     }
 
     MacroAssembler::PreIndexAddress asPreIndexAddress() const
     {
         ASSERT(isPreIndex());
-        return MacroAssembler::PreIndexAddress(m_base.gpr(), offset());
+        return MacroAssembler::PreIndexAddress(m_tmps.base.gpr(), offset());
     }
 
     MacroAssembler::PostIndexAddress asPostIndexAddress() const
     {
         ASSERT(isPostIndex());
-        return MacroAssembler::PostIndexAddress(m_base.gpr(), offset());
+        return MacroAssembler::PostIndexAddress(m_tmps.base.gpr(), offset());
     }
 
     MacroAssembler::RelationalCondition asRelationalCondition() const
     {
         ASSERT(isRelCond());
-        return static_cast<MacroAssembler::RelationalCondition>(m_offset);
+        return static_cast<MacroAssembler::RelationalCondition>(m_value);
     }
 
     MacroAssembler::ResultCondition asResultCondition() const
     {
         ASSERT(isResCond());
-        return static_cast<MacroAssembler::ResultCondition>(m_offset);
+        return static_cast<MacroAssembler::ResultCondition>(m_value);
     }
 
     MacroAssembler::DoubleCondition asDoubleCondition() const
     {
         ASSERT(isDoubleCond());
-        return static_cast<MacroAssembler::DoubleCondition>(m_offset);
+        return static_cast<MacroAssembler::DoubleCondition>(m_value);
     }
     
     MacroAssembler::StatusCondition asStatusCondition() const
     {
         ASSERT(isStatusCond());
-        return static_cast<MacroAssembler::StatusCondition>(m_offset);
+        return static_cast<MacroAssembler::StatusCondition>(m_value);
     }
     
     ::JSC::SIMDInfo simdInfo() const
@@ -1881,8 +1882,8 @@ public:
     void dump(PrintStream&) const;
 
     Arg(WTF::HashTableDeletedValueType)
-        : m_base(WTF::HashTableDeletedValue)
     {
+        m_tmps.base = Air::Tmp(WTF::HashTableDeletedValue);
     }
 
     bool isHashTableDeletedValue() const
@@ -1895,24 +1896,34 @@ public:
     unsigned hash() const
     {
         // This really doesn't have to be that great.
-        return WTF::IntHash<int64_t>::hash(m_offset) + m_kind + m_scale + m_base.hash() +
-            m_index.hash();
+        return WTF::IntHash<int64_t>::hash(m_value) + m_kind + static_cast<unsigned>(m_offset)
+            + m_logScale + static_cast<unsigned>(m_extend);
     }
 
 private:
-    int64_t m_offset { 0 };
+    union {
+        int64_t m_value { 0 };
+        struct {
+            Air::Tmp base;
+            Air::Tmp index;
+        } m_tmps;
+    };
+    union {
+        int32_t m_offset { 0 };
+        JSC::SIMDInfo m_simdInfo;
+    };
     Kind m_kind { Invalid };
+    uint8_t m_logScale { 0 }; // Only meaningful for Index: scale() == 1u << m_logScale.
     MacroAssembler::Extend m_extend { MacroAssembler::Extend::None };
-    JSC::SIMDInfo m_simdInfo;
-    int32_t m_scale { 1 };
-    Air::Tmp m_base;
-    Air::Tmp m_index;
 #if USE(JSVALUE32_64)
-    // XXX: stick in union with m_base?
     Air::Tmp m_baseHi;
     Air::Tmp m_baseLo;
 #endif
 };
+
+#if USE(JSVALUE64) && !OS(WINDOWS)
+static_assert(sizeof(Arg) == 16, "Arg is expected to stay 16 bytes on JSVALUE64.");
+#endif
 
 } } } // namespace JSC::B3::Air
 
@@ -1927,7 +1938,7 @@ JS_EXPORT_PRIVATE void printInternal(PrintStream&, JSC::B3::Air::Arg::Signedness
 
 template<typename T> struct HashTraits;
 template<> struct HashTraits<JSC::B3::Air::Arg> : SimpleClassHashTraits<JSC::B3::Air::Arg> {
-    // Because m_scale is 1 in the empty value.
+    // Because m_extend is None (== 2), not zero, in the empty value.
     static constexpr bool emptyValueIsZero = false;
 };
 

--- a/Source/JavaScriptCore/b3/air/AirKind.h
+++ b/Source/JavaScriptCore/b3/air/AirKind.h
@@ -40,32 +40,43 @@ namespace JSC { namespace B3 { namespace Air {
 // opcode-agnostic.
 
 struct Kind {
-    Kind(Opcode opcode)
+    constexpr Kind(Opcode opcode)
         : opcode(opcode)
     {
     }
-    
-    Kind()
-        : Kind(Nop)
-    {
-    }
-    
+
+    Kind() = default;
+
     friend bool operator==(const Kind&, const Kind&) = default;
-    
-    unsigned hash() const
+
+    constexpr unsigned hash() const
     {
-        return static_cast<unsigned>(opcode) + (static_cast<unsigned>(effects) << 16) + (static_cast<unsigned>(spill) << 17);
+        return raw();
     }
-    
+
     explicit operator bool() const
     {
         return *this != Kind();
     }
-    
+
     void dump(PrintStream&) const;
-    
-    Opcode opcode;
-    
+
+    constexpr uint16_t raw() const
+    {
+        return static_cast<uint16_t>(opcode) | (static_cast<uint16_t>(effects) << 14) | (static_cast<uint16_t>(spill) << 15);
+    }
+
+    static constexpr Kind fromRaw(uint16_t value)
+    {
+        Kind kind;
+        kind.opcode = static_cast<Opcode>(value & 0x3fff);
+        kind.effects = (value >> 14) & 1;
+        kind.spill = (value >> 15) & 1;
+        return kind;
+    }
+
+    Opcode opcode : 14 { Nop };
+
     // This is an opcode-agnostic flag that indicates that we expect that this instruction will do
     // any of the following:
     // - Trap.

--- a/Source/JavaScriptCore/b3/air/AirLowerStackArgs.cpp
+++ b/Source/JavaScriptCore/b3/air/AirLowerStackArgs.cpp
@@ -178,7 +178,7 @@ void lowerStackArgs(Code& code)
                     Arg scratch = inst.args[2];
                     ASSERT(scratch.isReg());
                     // Insert Mov src, scratchReg
-                    insertionSet.insert(instIndex, inst.kind.opcode, inst.origin, src, scratch);
+                    insertionSet.insert(instIndex, static_cast<Opcode>(inst.kind.opcode), inst.origin, src, scratch);
                     extendedOffsetAddrRegInUse = false; // Used by the inserted instruction; no longer needed.
                     // Modify inst to be 'Move scratch, dest'.
                     src = scratch;

--- a/Source/JavaScriptCore/b3/air/opcode_generator.rb
+++ b/Source/JavaScriptCore/b3/air/opcode_generator.rb
@@ -562,7 +562,7 @@ writeH("Opcode") {
     outp.puts "#undef MemoryFence"
     
     outp.puts "namespace JSC { namespace B3 { namespace Air {"
-    outp.puts "enum Opcode : int16_t {"
+    outp.puts "enum Opcode : uint16_t {"
     $opcodes.keys.each {
         | opcode |
         outp.puts "    #{opcode},"


### PR DESCRIPTION
#### d801f1e36011760cbbdf313c054c630f24c5e359
<pre>
[JSC] Make sizeof(Air::Arg) 16
<a href="https://bugs.webkit.org/show_bug.cgi?id=318822">https://bugs.webkit.org/show_bug.cgi?id=318822</a>
<a href="https://rdar.apple.com/181638333">rdar://181638333</a>

Reviewed by Yijia Huang.

This patch shrinks sizeof(Air::Arg) from 24 to 16. This is important to
shrink the sizeof(Air::Inst) as it includes 3 Air::Arg instances. We can
pack them since all the fields are not used at all time. Some of them
are mutually exclusively used so we do not need to keep all of them.
We also pack Air::Kind into uint16_t size.

* Source/JavaScriptCore/b3/air/AirArg.cpp:
(JSC::B3::Air::Arg::jsHash const):
(JSC::B3::Air::Arg::dump const):
* Source/JavaScriptCore/b3/air/AirArg.h:
(JSC::B3::Air::Arg::Arg):
(JSC::B3::Air::Arg::imm):
(JSC::B3::Air::Arg::bigImm):
(JSC::B3::Air::Arg::bitImm):
(JSC::B3::Air::Arg::bitImm64):
(JSC::B3::Air::Arg::fpImm32):
(JSC::B3::Air::Arg::fpImm64):
(JSC::B3::Air::Arg::fpImm128):
(JSC::B3::Air::Arg::simpleAddr):
(JSC::B3::Air::Arg::addr):
(JSC::B3::Air::Arg::extendedOffsetAddr):
(JSC::B3::Air::Arg::stack):
(JSC::B3::Air::Arg::index):
(JSC::B3::Air::Arg::preIndex):
(JSC::B3::Air::Arg::postIndex):
(JSC::B3::Air::Arg::relCond):
(JSC::B3::Air::Arg::resCond):
(JSC::B3::Air::Arg::doubleCond):
(JSC::B3::Air::Arg::statusCond):
(JSC::B3::Air::Arg::special):
(JSC::B3::Air::Arg::widthArg):
(JSC::B3::Air::Arg::zeroReg):
(JSC::B3::Air::Arg::operator== const):
(JSC::B3::Air::Arg::tmp const):
(JSC::B3::Air::Arg::value const):
(JSC::B3::Air::Arg::pointerValue const):
(JSC::B3::Air::Arg::ptr const):
(JSC::B3::Air::Arg::base const):
(JSC::B3::Air::Arg::offset const):
(JSC::B3::Air::Arg::stackSlot const):
(JSC::B3::Air::Arg::index const):
(JSC::B3::Air::Arg::scale const):
(JSC::B3::Air::Arg::logScale const):
(JSC::B3::Air::Arg::special const):
(JSC::B3::Air::Arg::width const):
(JSC::B3::Air::Arg::forEachTmpFast):
(JSC::B3::Air::Arg::forEachTmp):
(JSC::B3::Air::Arg::asTrustedImm32 const):
(JSC::B3::Air::Arg::asV128 const):
(JSC::B3::Air::Arg::asAddress const):
(JSC::B3::Air::Arg::asBaseIndex const):
(JSC::B3::Air::Arg::asPreIndexAddress const):
(JSC::B3::Air::Arg::asPostIndexAddress const):
(JSC::B3::Air::Arg::asRelationalCondition const):
(JSC::B3::Air::Arg::asResultCondition const):
(JSC::B3::Air::Arg::asDoubleCondition const):
(JSC::B3::Air::Arg::asStatusCondition const):
(JSC::B3::Air::Arg::hash const):
* Source/JavaScriptCore/b3/air/AirKind.h:
(JSC::B3::Air::Kind::Kind):
(JSC::B3::Air::Kind::hash const):
(JSC::B3::Air::Kind::raw const):
(JSC::B3::Air::Kind::fromRaw):
* Source/JavaScriptCore/b3/air/AirLowerStackArgs.cpp:
(JSC::B3::Air::lowerStackArgs):
* Source/JavaScriptCore/b3/air/opcode_generator.rb:

Canonical link: <a href="https://commits.webkit.org/316691@main">https://commits.webkit.org/316691@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8cc23dcc8d6b378051bf710470a19f7eab34f7a2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173152 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47084 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40576 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182725 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130708 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48377 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46766 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134641 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176110 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38048 "Found 1 new test failure: fast/css/getComputedStyle-font-variant-shorthand-crash.html (failure)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/155245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115110 "Found 1 new API test failure: WPE/TestWebKitWebView:/webkit/WebKitWebView/save (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/33131672-88ad-418a-b667-09a61fe2ceb3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36693 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/35037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31210 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/3761 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147117 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34744 "Found 1 new test failure: imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-corner-shape-change.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185147 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/34414 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37959 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39239 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143485 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46752 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143357 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47431 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112505 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26287 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38312 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/119180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45937 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9687 "Passed tests") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45339 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45570 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45396 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->