### PR TITLE
[iOS] Improve logging around AirPlay route selection

### DIFF
--- a/Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.mm
+++ b/Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.mm
@@ -263,7 +263,9 @@ void MediaSessionHelper::activeRoutesDidChange(MediaDeviceRouteController& route
 
     if (RefPtr mostRecentActiveRoute = routeController.mostRecentActiveRoute()) {
 #if HAVE(AVROUTING_FRAMEWORK)
-        if (!target->hasAirPlayDevice())
+        bool hasAirPlayDevice = target->hasAirPlayDevice();
+        RELEASE_LOG(Media, "MediaSessionHelper::activeRoutesDidChange: hasAirPlayDevice = %d", hasAirPlayDevice);
+        if (!hasAirPlayDevice)
             return;
 
         auto wirelessPlaybackTarget = dynamicDowncast<MediaPlaybackTargetWirelessPlayback>(m_playbackTarget.get());
@@ -604,7 +606,9 @@ void MediaSessionHelperIOS::externalOutputDeviceAvailableDidChange()
         Ref target = MediaPlaybackTargetCocoa::create();
 
 #if HAVE(AVROUTING_FRAMEWORK)
-        if (target->hasAirPlayDevice()) {
+        bool hasAirPlayDevice = target->hasAirPlayDevice();
+        RELEASE_LOG(Media, "-[WebMediaSessionHelper activeOutputDeviceDidChange:]: hasAirPlayDevice = %d", hasAirPlayDevice);
+        if (hasAirPlayDevice) {
             RefPtr mostRecentActiveRoute = MediaDeviceRouteController::singleton().mostRecentActiveRoute();
             auto wirelessPlaybackTarget = dynamicDowncast<MediaPlaybackTargetWirelessPlayback>(callback->playbackTarget());
             if (!wirelessPlaybackTarget || wirelessPlaybackTarget->route() != mostRecentActiveRoute.get())


### PR DESCRIPTION
#### 4bc078979343a91e6f06958ef1c9e9c91a31dfa7
<pre>
[iOS] Improve logging around AirPlay route selection
<a href="https://bugs.webkit.org/show_bug.cgi?id=318825">https://bugs.webkit.org/show_bug.cgi?id=318825</a>
<a href="https://rdar.apple.com/181639994">rdar://181639994</a>

Reviewed by Eric Carlson.

Added logging around call sites of MediaPlaybackTargetCocoa::hasAirPlayDevice().

* Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.mm:
(MediaSessionHelper::activeRoutesDidChange):
(-[WebMediaSessionHelper activeOutputDeviceDidChange:]):

Canonical link: <a href="https://commits.webkit.org/316728@main">https://commits.webkit.org/316728@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/99ce097f110c462885f90a1bf2c200a3012940f8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173150 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47082 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40747 "Hash 99ce097f for PR 68874 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182723 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130706 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3737f95b-2024-45cb-9428-718ec2d4bbbb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175015 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48375 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46764 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134640 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ec0836e4-a58d-4899-b921-46c5aa5321bb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176108 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38057 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155249 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115109 "Found 1 new API test failure: WPE/TestWebKitWebView:/webkit/WebKitWebView/save (failure)") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/26c475fc-c694-433e-a934-fa397483cd6e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36702 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35035 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31208 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147126 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34748 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185145 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37993 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39237 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143482 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46750 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143354 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38721 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47429 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31580 "Unable to confirm if test failures are introduced by change, retrying build") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112503 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38313 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119178 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45935 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9691 "Passed tests") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45337 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45568 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45394 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->