### PR TITLE
[Site Isolation] [intersection-observer] Update remote intersection observers in all frames, not just the main frame

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -10485,7 +10485,7 @@ void Document::updateIntersectionObservers()
     updateAndNotifyIntersectionObservers(m_localIntersectionObservers, *frame);
     updateRemoteIntersectionObservers();
 
-    if (frame->isMainFrame())
+    if (settings().siteIsolationEnabled())
         page->chrome().client().updateRemoteIntersectionObserversInOtherWebProcesses();
 }
 


### PR DESCRIPTION
#### e562a996c9cecf90a2d938878d51177265cc57ac
<pre>
[Site Isolation] [intersection-observer] Update remote intersection observers in all frames, not just the main frame
<a href="https://rdar.apple.com/181641524">rdar://181641524</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=318827">https://bugs.webkit.org/show_bug.cgi?id=318827</a>

Reviewed by Abrar Rahman Protyasha.

In a page with nested iframes (e.g main frame &lt;= iframe 1 &lt;= iframe 2),
and there&apos;s an implicit root intersection observer in iframe 2, when iframe
1 scrolls, the observer in iframe 2 should be updated too, as scrolling
may have scrolled the intersection target out of view.

In Site Isolation mode, Document::updateIntersectionObservers (called when
Page updates rendering) has code to trigger intersection observers in other
processes to update, but only when the Document is in the main frame. When
iframe 1 scrolls, the Page object in its process updates rendering, but
it&apos;s not the main frame, hence it doesn&apos;t update the observer in iframe 2.

Fix this by updating remote intersection observers when any frames update
its rendering. Since this is only needed in Site Isolation mode, don&apos;t
update if Site Isolation is not enabled.

No tests - I tried multiple ways to simulate scrolling, but they all
makes the main frame update its rendering, which would not reproduce
the issue.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::updateIntersectionObservers):

Canonical link: <a href="https://commits.webkit.org/317066@main">https://commits.webkit.org/317066@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/274ecd82475094f36922fb3603f5dfee9e700e0d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173164 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47096 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41217 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182737 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130720 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/26808a7b-6659-477c-b751-b59c81e1d7ef) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175029 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48389 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46778 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134651 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95065 "1 flakes 21 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/be7c7206-065d-4e20-b950-4a1517bcb0c9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176122 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38063 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155743 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115121 "Found 1 new API test failure: WPE/TestWebKitWebView:/webkit/WebKitWebView/save (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8742140c-5563-4216-8111-38d8db500c9b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36708 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35046 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31222 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147132 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35238 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185159 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37973 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39248 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143492 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46764 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143364 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38893 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47443 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31853 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112517 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38324 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119192 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45949 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10191 "Passed tests") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45351 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45582 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45408 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->