### PR TITLE
sf-saas.apple.com: Support copy/paste of SVG data

### DIFF
--- a/LayoutTests/editing/async-clipboard/sanitize-when-reading-and-writing-svg-expected.txt
+++ b/LayoutTests/editing/async-clipboard/sanitize-when-reading-and-writing-svg-expected.txt
@@ -1,0 +1,16 @@
+
+PASS HTML script elements are removed from pasted SVG
+PASS SVG script elements are removed from pasted SVG
+PASS foreignObject elements are removed from pasted SVG
+PASS style elements are removed from pasted SVG
+PASS base/link/meta/title elements are removed from pasted SVG
+PASS use elements are removed from pasted SVG
+PASS embed/frame/iframe/object elements are removed from pasted SVG
+PASS on* event handler attributes are removed from pasted SVG
+PASS attributes with javascript: URLs are removed from pasted SVG
+PASS SVG animation of a navigating attribute to a javascript: URL is neutralized
+PASS comment nodes are removed from pasted SVG
+PASS display:none content is removed from pasted SVG
+PASS display:none content from a style sheet is removed from pasted SVG
+PASS benign SVG content is preserved through a clipboard round-trip
+

--- a/LayoutTests/editing/async-clipboard/sanitize-when-reading-and-writing-svg.html
+++ b/LayoutTests/editing/async-clipboard/sanitize-when-reading-and-writing-svg.html
@@ -1,0 +1,245 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncClipboardAPIEnabled=true ] -->
+<meta charset="utf-8">
+<title>navigator.clipboard round-trips and sanitizes image/svg+xml</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../resources/ui-helper.js"></script>
+<script src="./resources/async-clipboard-helpers.js"></script>
+
+<body>
+    <script>
+        'use strict';
+
+        const SVG_NS = "http://www.w3.org/2000/svg";
+        const XLINK_NS = "http://www.w3.org/1999/xlink";
+        const XHTML_NS = "http://www.w3.org/1999/xhtml";
+
+        function svg(inner, extraRootAttributes = "") {
+            return `<svg xmlns="${SVG_NS}" xmlns:xlink="${XLINK_NS}" width="100" height="100" ${extraRootAttributes}>${inner}</svg>`;
+        }
+
+        async function pressButtonAndRun(action) {
+            const button = document.createElement("button");
+            document.body.appendChild(button);
+
+            await UIHelper.ensurePresentationUpdate();
+
+            const done = new Promise((resolve, reject) => {
+                button.addEventListener("click", () => {
+                    action().then(resolve, reject);
+                }, {once: true});
+            });
+
+            UIHelper.activateElement(button);
+            try {
+                return await done;
+            } finally {
+                button.remove();
+            }
+        }
+
+        async function copy(svg) {
+            await pressButtonAndRun(() => navigator.clipboard.write([
+                new ClipboardItem({"image/svg+xml": svg})
+            ]));
+        }
+
+        async function paste() {
+            return await pressButtonAndRun(async () => {
+                const [item] = await navigator.clipboard.read();
+                const blob = await item.getType("image/svg+xml");
+                return blob.text();
+            });
+        }
+
+        async function roundTripSVG(markup) {
+            await copy(new Blob([markup], {type: "image/svg+xml"}));
+            const pastedMarkup = await paste();
+            const doc = new DOMParser().parseFromString(pastedMarkup, "image/svg+xml");
+            assert_equals(doc.querySelector("parsererror"), null,
+                `sanitized SVG should still parse as well-formed XML (got: ${pastedMarkup})`);
+            return doc;
+        }
+
+        function elementsNamed(doc, localName) {
+            return doc.getElementsByTagNameNS("*", localName);
+        }
+
+        function allElements(doc) {
+            return [...doc.getElementsByTagName("*")];
+        }
+
+        function commentNodes(doc) {
+            const walker = doc.createTreeWalker(doc, NodeFilter.SHOW_COMMENT);
+            const comments = [];
+            while (walker.nextNode())
+                comments.push(walker.currentNode);
+            return comments;
+        }
+
+        promise_test(async t => {
+            const doc = await roundTripSVG(svg(
+                `<script xmlns="${XHTML_NS}">window.ranHTMLScript = true;<\/script>`
+                + `<rect width="10" height="10" fill="green"/>`));
+            assert_equals(elementsNamed(doc, "script").length, 0, "HTML <script> should be stripped");
+            assert_equals(elementsNamed(doc, "rect").length, 1, "benign sibling should survive");
+        }, "HTML script elements are removed from pasted SVG");
+
+        promise_test(async t => {
+            const doc = await roundTripSVG(svg(
+                `<script>window.ranSVGScript = true;<\/script>`
+                + `<rect width="10" height="10" fill="green"/>`));
+            assert_equals(elementsNamed(doc, "script").length, 0, "SVG <script> should be stripped");
+            assert_equals(elementsNamed(doc, "rect").length, 1, "benign sibling should survive");
+        }, "SVG script elements are removed from pasted SVG");
+
+        promise_test(async t => {
+            const doc = await roundTripSVG(svg(
+                `<foreignObject width="50" height="50">`
+                + `<div xmlns="${XHTML_NS}"><p>hello</p></div>`
+                + `</foreignObject>`
+                + `<rect width="10" height="10" fill="green"/>`));
+            assert_equals(elementsNamed(doc, "foreignObject").length, 0, "<foreignObject> should be stripped");
+            assert_equals(elementsNamed(doc, "rect").length, 1, "benign sibling should survive");
+        }, "foreignObject elements are removed from pasted SVG");
+
+        promise_test(async t => {
+            const doc = await roundTripSVG(svg(
+                `<style><a onclick="window.styleMutationXSS = true">x</a></style>`
+                + `<rect width="10" height="10" fill="green"/>`));
+            assert_equals(elementsNamed(doc, "style").length, 0, "<style> should be stripped");
+            assert_false(allElements(doc).some(element => element.hasAttribute("onclick")),
+                "no element smuggled inside <style> should retain an event handler");
+            assert_equals(elementsNamed(doc, "rect").length, 1, "benign sibling should survive");
+        }, "style elements are removed from pasted SVG");
+
+        promise_test(async t => {
+            const doc = await roundTripSVG(
+                `<base href="https://evil.example/"/>`
+                + `<link rel="stylesheet" href="https://evil.example/style.css"/>`
+                + `<meta http-equiv="refresh" content="0;url=https://evil.example/"/>`
+                + `<title>hijacked</title>`
+                + svg(`<rect width="10" height="10" fill="green"/>`));
+            for (const name of ["base", "link", "meta", "title"])
+                assert_equals(elementsNamed(doc, name).length, 0, `<${name}> should be stripped`);
+            assert_equals(elementsNamed(doc, "rect").length, 1, "benign sibling should survive");
+        }, "base/link/meta/title elements are removed from pasted SVG");
+
+        promise_test(async t => {
+            const doc = await roundTripSVG(svg(
+                `<defs><rect id="icon" width="10" height="10" fill="green"/></defs>`
+                + `<use href="#icon"/>`
+                + `<use xlink:href="#icon"/>`
+                + `<use href="https://evil.example/x.svg#icon"/>`
+                + `<use xlink:href="data:image/svg+xml,&lt;svg xmlns='${SVG_NS}'&gt;&lt;script/&gt;&lt;/svg&gt;#icon"/>`
+                + `<rect width="10" height="10" fill="green"/>`));
+            assert_equals(elementsNamed(doc, "use").length, 0, "<use> should be stripped (fragment, external, and data: refs alike)");
+            assert_equals(elementsNamed(doc, "rect").length, 2, "the referenced <defs> target and benign sibling should survive");
+        }, "use elements are removed from pasted SVG");
+
+        promise_test(async t => {
+            const doc = await roundTripSVG(
+                `<embed src="https://evil.example/x"/>`
+                + `<frame src="https://evil.example/x"/>`
+                + `<iframe src="https://evil.example/x"></iframe>`
+                + `<object data="https://evil.example/x"></object>`
+                + svg(`<rect width="10" height="10" fill="green"/>`));
+            for (const name of ["embed", "frame", "iframe", "object"])
+                assert_equals(elementsNamed(doc, name).length, 0, `<${name}> should be stripped`);
+            assert_equals(elementsNamed(doc, "rect").length, 1, "benign sibling should survive");
+        }, "embed/frame/iframe/object elements are removed from pasted SVG");
+
+        promise_test(async t => {
+            const doc = await roundTripSVG(svg(
+                `<rect width="10" height="10" fill="green" onload="window.x = 1" onclick="window.y = 1"/>`));
+            const rect = elementsNamed(doc, "rect")[0];
+            assert_not_equals(rect, undefined, "rect element should survive");
+            const onAttributes = allElements(doc).flatMap(element =>
+                [...element.attributes].filter(attribute => attribute.localName.toLowerCase().startsWith("on")));
+            assert_equals(onAttributes.length, 0, "on* event handler attributes should be removed");
+            assert_equals(rect.getAttribute("fill"), "green", "benign attributes should be preserved");
+        }, "on* event handler attributes are removed from pasted SVG");
+
+        promise_test(async t => {
+            const doc = await roundTripSVG(svg(
+                `<a xlink:href="javascript:window.x = 1"><rect width="10" height="10" fill="green"/></a>`
+                + `<image href="javascript:window.y = 1" width="10" height="10"/>`));
+            const hasJavaScriptURL = allElements(doc).some(element =>
+                [...element.attributes].some(attribute =>
+                    attribute.value.replace(/\s/g, "").toLowerCase().includes("javascript:")));
+            assert_false(hasJavaScriptURL, "attributes containing javascript: URLs should be removed");
+            assert_equals(elementsNamed(doc, "a").length, 1, "the anchor element itself should survive");
+        }, "attributes with javascript: URLs are removed from pasted SVG");
+
+        promise_test(async t => {
+            const doc = await roundTripSVG(svg(
+                `<a xlink:href="https://example.com/"><rect width="10" height="10" fill="green"/>`
+                + `<set attributeName="xlink:href" to="javascript:window.a = 1"/>`
+                + `<animate attributeName="xlink:href" values="0;javascript:window.b = 1" dur="1s"/>`
+                + `<animate attributeName="xlink:href" to="javascript:window.c = 1" dur="1s"/>`
+                + `</a>`));
+            const hasJavaScriptURL = allElements(doc).some(element =>
+                [...element.attributes].some(attribute =>
+                    attribute.value.replace(/\s/g, "").toLowerCase().includes("javascript:")));
+            assert_false(hasJavaScriptURL, "animation values that set a navigating attribute to a javascript: URL should be removed");
+            assert_equals(elementsNamed(doc, "a")[0].getAttributeNS(XLINK_NS, "href"), "https://example.com/", "the static safe href should survive");
+        }, "SVG animation of a navigating attribute to a javascript: URL is neutralized");
+
+        promise_test(async t => {
+            const doc = await roundTripSVG(svg(
+                `<!-- <script>window.commentXSS = true;<\/script> -->`
+                + `<rect width="10" height="10" fill="green"/>`));
+            assert_equals(commentNodes(doc).length, 0, "comment nodes should be stripped");
+            assert_equals(commentNodes(doc).length + elementsNamed(doc, "script").length, 0, "comment nodes should be stripped");
+        }, "comment nodes are removed from pasted SVG");
+
+        promise_test(async t => {
+            const doc = await roundTripSVG(svg(
+                `<g style="display:none">`
+                + `<script>window.hiddenScript = true;<\/script>`
+                + `<rect id="hidden" width="10" height="10" fill="red"/>`
+                + `</g>`
+                + `<rect display="none" width="10" height="10" fill="red"/>`
+                + `<rect width="10" height="10" fill="green"/>`));
+            assert_equals(elementsNamed(doc, "script").length, 0, "script inside display:none content should be stripped");
+            assert_equals(elementsNamed(doc, "g").length, 0, "the display:none container (inline style) and its subtree should be dropped");
+            const rects = [...elementsNamed(doc, "rect")];
+            assert_equals(rects.length, 1, "the hidden subtree rect and the display=\"none\" rect should be dropped");
+            assert_equals(rects[0].getAttribute("fill"), "green", "only the visible rect should survive");
+        }, "display:none content is removed from pasted SVG");
+
+        promise_test(async t => {
+            const doc = await roundTripSVG(svg(
+                `<style>.hidden { display: none; }</style>`
+                + `<g class="hidden">`
+                + `<script>window.styleSheetHiddenScript = true;<\/script>`
+                + `<rect id="hidden" width="10" height="10" fill="red"/>`
+                + `</g>`
+                + `<rect width="10" height="10" fill="green"/>`));
+            assert_equals(elementsNamed(doc, "script").length, 0, "script inside style-sheet-hidden content should be stripped");
+            assert_equals(elementsNamed(doc, "g").length, 0, "the display:none container (style sheet rule) and its subtree should be dropped");
+            const rects = [...elementsNamed(doc, "rect")];
+            assert_equals(rects.length, 1, "the style-sheet-hidden rect should be dropped");
+            assert_equals(rects[0].getAttribute("fill"), "green", "only the visible rect should survive");
+        }, "display:none content from a style sheet is removed from pasted SVG");
+
+        promise_test(async t => {
+            const doc = await roundTripSVG(svg(
+                `<g id="group" fill="green" transform="translate(5, 5)">`
+                + `<rect x="1" y="2" width="10" height="20" fill="blue" stroke="black"/>`
+                + `<circle cx="5" cy="5" r="3"/>`
+                + `<a xlink:href="https://example.com/"><text x="0" y="10">label</text></a>`
+                + `</g>`));
+            const group = elementsNamed(doc, "g")[0];
+            assert_equals(group.getAttribute("fill"), "green", "group fill should be preserved");
+            assert_equals(group.getAttribute("transform"), "translate(5, 5)", "group transform should be preserved");
+            const rect = elementsNamed(doc, "rect")[0];
+            assert_equals(rect.getAttribute("stroke"), "black", "rect stroke should be preserved");
+            assert_equals(rect.getAttribute("width"), "10", "rect width should be preserved");
+            assert_equals(elementsNamed(doc, "circle").length, 1, "circle should be preserved");
+            const anchor = elementsNamed(doc, "a")[0];
+            assert_equals(anchor.getAttributeNS(XLINK_NS, "href"), "https://example.com/", "safe xlink:href should be preserved");
+            assert_equals(elementsNamed(doc, "text").length, 1, "text should be preserved");
+        }, "benign SVG content is preserved through a clipboard round-trip");
+    </script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/clipboard-apis/clipboard-item.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/clipboard-apis/clipboard-item.https-expected.txt
@@ -15,7 +15,7 @@ PASS supports(text/plain) returns true
 PASS supports(text/html) returns true
 PASS supports(image/png) returns true
 PASS supports(text/uri-list) returns true
-FAIL supports(image/svg+xml) returns true assert_equals: expected true but got false
+PASS supports(image/svg+xml) returns true
 FAIL supports(web foo/bar) returns true assert_equals: expected true but got false
 FAIL supports(web text/html) returns true assert_equals: expected true but got false
 PASS supports(web ) returns false

--- a/Source/WebCore/Modules/async-clipboard/Clipboard.cpp
+++ b/Source/WebCore/Modules/async-clipboard/Clipboard.cpp
@@ -293,6 +293,17 @@ void Clipboard::getType(ClipboardItem& item, const String& type, Ref<DeferredPro
         resultAsString = markupReader.takeMarkup();
     }
 
+    if (type == imageSVGContentTypeAtom()) {
+        ClipboardImageReader imageReader { frame->document(), type };
+        activePasteboard().read(imageReader, itemIndex);
+        auto imageBlob = imageReader.takeResult();
+        if (updateSessionValidity() == SessionIsValid::Yes && imageBlob)
+            promise->resolve<IDLInterface<Blob>>(imageBlob.releaseNonNull());
+        else
+            promise->reject(ExceptionCode::NotAllowedError);
+        return;
+    }
+
     // FIXME: Support reading custom data.
     if (updateSessionValidity() == SessionIsValid::No || resultAsString.isNull()) {
         promise->reject(ExceptionCode::NotAllowedError);

--- a/Source/WebCore/Modules/async-clipboard/ClipboardImageReader.cpp
+++ b/Source/WebCore/Modules/async-clipboard/ClipboardImageReader.cpp
@@ -29,6 +29,7 @@
 #include "Document.h"
 #include "DocumentPage.h"
 #include "SharedBuffer.h"
+#include "markup.h"
 
 namespace WebCore {
 
@@ -38,9 +39,17 @@ void ClipboardImageReader::readBuffer(const String&, const String&, Ref<SharedBu
 {
     if (m_mimeType == "image/png"_s)
         m_result = Blob::create(m_document.get(), buffer->extractData(), m_mimeType);
+    else if (m_mimeType == "image/svg+xml"_s)
+        readSVG(buffer);
 }
 
 #endif // !PLATFORM(COCOA)
+
+void ClipboardImageReader::readSVG(const SharedBuffer& buffer)
+{
+    auto sanitizedMarkup = sanitizeSVG(String::fromUTF8(buffer.span()), m_document.get());
+    m_result = Blob::create(m_document.get(), Vector<uint8_t>(sanitizedMarkup.utf8().span()), m_mimeType);
+}
 
 bool ClipboardImageReader::shouldReadBuffer(const String& mimeType) const
 {

--- a/Source/WebCore/Modules/async-clipboard/ClipboardImageReader.h
+++ b/Source/WebCore/Modules/async-clipboard/ClipboardImageReader.h
@@ -49,6 +49,7 @@ private:
 
     bool shouldReadBuffer(const String&) const final;
     void readBuffer(const String& filename, const String& type, Ref<SharedBuffer>&&) final;
+    void readSVG(const SharedBuffer&);
 
     RefPtr<Document> m_document;
     String m_mimeType;

--- a/Source/WebCore/Modules/async-clipboard/ClipboardItem.cpp
+++ b/Source/WebCore/Modules/async-clipboard/ClipboardItem.cpp
@@ -106,15 +106,11 @@ bool ClipboardItem::supports(const String& type)
     // FIXME: Custom format starts with `"web "`("web" followed by U+0020 SPACE) prefix
     // and suffix (after stripping out `"web "`) passes the parsing a MIME type check.
     // https://webkit.org/b/280664
-    // FIXME: add type == "image/svg+xml"_s when we have sanitized copy/paste for SVG data
-    // https://webkit.org/b/280726
-    if (type == textPlainContentTypeAtom()
+    return type == textPlainContentTypeAtom()
         || type == textHTMLContentTypeAtom()
         || type == "image/png"_s
-        || type == "text/uri-list"_s) {
-        return true;
-        }
-    return false;
+        || type == "text/uri-list"_s
+        || type == "image/svg+xml"_s;
 }
 
 void ClipboardItem::collectDataForWriting(Clipboard& destination, CompletionHandler<void(std::optional<PasteboardCustomData>)>&& completion)

--- a/Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp
+++ b/Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp
@@ -45,6 +45,7 @@
 #include "JSDOMPromiseDeferred.h"
 #include "LocalFrame.h"
 #include "LocalFrameInlines.h"
+#include "NodeName.h"
 #include "Page.h"
 #include "PasteboardCustomData.h"
 #include "SharedBuffer.h"
@@ -315,6 +316,15 @@ void ClipboardItemBindingsDataSource::ClipboardItemTypeLoader::sanitizeDataIfNee
 
         RefPtr document = documentFromClipboard(m_writingDestination.get());
         m_data = { sanitizeMarkup(markupToSanitize, document.get()) };
+    }
+
+    if (m_type == imageSVGContentTypeAtom()) {
+        auto markupToSanitize = dataAsString();
+        if (markupToSanitize.isEmpty())
+            return;
+
+        RefPtr document = documentFromClipboard(m_writingDestination.get());
+        m_data = { sanitizeSVG(markupToSanitize, document.get()) };
     }
 
     if (m_type == "image/png"_s) {

--- a/Source/WebCore/Modules/async-clipboard/ios/ClipboardImageReaderIOS.mm
+++ b/Source/WebCore/Modules/async-clipboard/ios/ClipboardImageReaderIOS.mm
@@ -30,6 +30,7 @@
 
 #import "Document.h"
 #import "SharedBuffer.h"
+#import "markup.h"
 #import <wtf/cocoa/VectorCocoa.h>
 
 #import <pal/ios/UIKitSoftLink.h>
@@ -43,6 +44,8 @@ void ClipboardImageReader::readBuffer(const String&, const String&, Ref<SharedBu
         if (auto nsData = UIImagePNGRepresentation(image.get()))
             m_result = Blob::create(m_document.get(), makeVector(nsData), m_mimeType);
     }
+    if (m_mimeType == "image/svg+xml"_s)
+        readSVG(buffer);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/async-clipboard/mac/ClipboardImageReaderMac.mm
+++ b/Source/WebCore/Modules/async-clipboard/mac/ClipboardImageReaderMac.mm
@@ -30,6 +30,7 @@
 
 #import "Document.h"
 #import "SharedBuffer.h"
+#import "markup.h"
 #import <wtf/cocoa/VectorCocoa.h>
 
 namespace WebCore {
@@ -44,6 +45,8 @@ void ClipboardImageReader::readBuffer(const String&, const String&, Ref<SharedBu
             m_result = Blob::create(m_document.get(), makeVector(nsData.get()), m_mimeType);
         }
     }
+    if (m_mimeType == "image/svg+xml"_s)
+        readSVG(buffer);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2839,6 +2839,12 @@ bool Element::hasDisplayNone() const
     return style && style->display() == Style::DisplayType::None;
 }
 
+bool Element::computedStyleIsDisplayNone()
+{
+    CheckedPtr style = computedStyle();
+    return style && style->display() == Style::DisplayType::None;
+}
+
 void Element::storeDisplayContentsOrNoneStyle(std::unique_ptr<Style::ComputedStyle> style)
 {
     // This is used by RenderTreeUpdater to store the style for Elements with display:{contents|none}.

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -858,6 +858,7 @@ public:
 
     bool NODELETE hasDisplayContents() const;
     bool NODELETE hasDisplayNone() const;
+    bool computedStyleIsDisplayNone();
     void storeDisplayContentsOrNoneStyle(std::unique_ptr<Style::ComputedStyle>);
     void clearDisplayContentsOrNoneStyle();
 

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -45,6 +45,7 @@
 #include "ContainerNodeInlines.h"
 #include "CustomElementRegistry.h"
 #include "DeprecatedGlobalSettings.h"
+#include "Document.h"
 #include "DocumentFragment.h"
 #include "DocumentLoader.h"
 #include "DocumentPage.h"
@@ -56,6 +57,7 @@
 #include "EditorClient.h"
 #include "ElementChildIteratorInlines.h"
 #include "ElementRareData.h"
+#include "ElementTraversal.h"
 #include "EmptyClients.h"
 #include "File.h"
 #include "FrameLoader.h"
@@ -64,10 +66,16 @@
 #include "HTMLBaseElement.h"
 #include "HTMLBodyElement.h"
 #include "HTMLDivElement.h"
+#include "HTMLEmbedElement.h"
+#include "HTMLFrameElement.h"
 #include "HTMLHeadElement.h"
 #include "HTMLHtmlElement.h"
+#include "HTMLIFrameElement.h"
 #include "HTMLImageElement.h"
+#include "HTMLLinkElement.h"
+#include "HTMLMetaElement.h"
 #include "HTMLNames.h"
+#include "HTMLObjectElement.h"
 #include "HTMLPictureElement.h"
 #include "HTMLSourceElement.h"
 #include "HTMLStyleElement.h"
@@ -75,6 +83,7 @@
 #include "HTMLTemplateElement.h"
 #include "HTMLTextAreaElement.h"
 #include "HTMLTextFormControlElement.h"
+#include "HTMLTitleElement.h"
 #include "LocalFrameInlines.h"
 #include "MarkupAccumulator.h"
 #include "MutableStyleProperties.h"
@@ -87,11 +96,21 @@
 #include "RenderBlock.h"
 #include "RenderElementInlines.h"
 #include "RenderObjectStyle.h"
+#include "SVGAnimationElement.h"
+#include "SVGElementTypeHelpers.h"
+#include "SVGForeignObjectElement.h"
+#include "SVGNames.h"
+#include "SVGStyleElement.h"
+#include "SVGUseElement.h"
+#include "ScriptElement.h"
 #include "ScriptWrappableInlines.h"
 #include "Settings.h"
 #include "SocketProvider.h"
+#include "StylePropertiesInlines.h"
 #include "TextIterator.h"
 #include "TextManipulationController.h"
+#include "TrustedType.h"
+#include "TypedElementDescendantIterator.h"
 #include "TypedElementDescendantIteratorInlines.h"
 #include "UnicodeHelpers.h"
 #include "VisibleSelection.h"
@@ -261,7 +280,7 @@ Ref<Page> createPageForSanitizingWebContent(Document* destinationDocument, std::
     return page;
 }
 
-String sanitizeMarkup(const String& rawHTML, Document* destinationDocument, MSOListQuirks msoListQuirks, std::optional<Function<void(DocumentFragment&)>> fragmentSanitizer)
+String sanitizeMarkup(const String& rawHTML, Document* destinationDocument, MSOListQuirks msoListQuirks, NOESCAPE const Function<void(DocumentFragment&)>& fragmentSanitizer, NOESCAPE const Function<void(Element&)>& postLayoutSanitizer)
 {
     Ref page = createPageForSanitizingWebContent(destinationDocument);
     RefPtr stagingDocument = page->localTopDocument();
@@ -271,9 +290,70 @@ String sanitizeMarkup(const String& rawHTML, Document* destinationDocument, MSOL
     auto fragment = createFragmentFromMarkup(*stagingDocument, rawHTML, emptyString(), { });
 
     if (fragmentSanitizer)
-        (*fragmentSanitizer)(fragment);
+        fragmentSanitizer(fragment);
 
-    return sanitizedMarkupForFragmentInDocument(WTF::move(fragment), *stagingDocument, msoListQuirks, rawHTML);
+    return sanitizedMarkupForFragmentInDocument(WTF::move(fragment), *stagingDocument, msoListQuirks, rawHTML, postLayoutSanitizer);
+}
+
+String sanitizeSVG(const String& svg, Document* destinationDocument)
+{
+    auto removeMatchingElements = [](ContainerNode& root, NOESCAPE const Function<bool(Element&)>& shouldRemove) {
+        Vector<Ref<Element>> elementsToRemove;
+        RefPtr element = ElementTraversal::firstWithin(root);
+        while (element) {
+            if (shouldRemove(*element)) {
+                RefPtr next = ElementTraversal::nextSkippingChildren(*element, &root);
+                elementsToRemove.append(element.releaseNonNull());
+                element = WTF::move(next);
+                continue;
+            }
+
+            element = ElementTraversal::next(*element, &root);
+        }
+
+        for (auto& element : elementsToRemove)
+            element->remove();
+    };
+
+    auto sanitizeFragment = [&](DocumentFragment& fragment) {
+        removeMatchingElements(fragment, [](Element& element) {
+            return isScriptElement(element) || is<SVGForeignObjectElement>(element) || is<SVGUseElement>(element)
+                || isAnyOf<HTMLObjectElement, HTMLEmbedElement, HTMLIFrameElement, HTMLFrameElement, HTMLBaseElement, HTMLLinkElement, HTMLMetaElement, HTMLTitleElement>(element);
+        });
+
+        Vector<std::pair<Ref<Element>, QualifiedName>> attributesToRemove;
+        for (RefPtr element = ElementTraversal::firstWithin(fragment); element; element = ElementTraversal::next(*element, &fragment)) {
+            if (!element->hasAttributes())
+                continue;
+            RefPtr svgElement = dynamicDowncast<SVGElement>(*element);
+            bool isAnimationElement = svgElement && is<SVGAnimationElement>(*svgElement);
+            for (auto& attribute : element->attributes()) {
+                if (isEventHandlerAttribute(attribute.name()) || WTF::isValidJavaScriptURL(attribute.value())) {
+                    attributesToRemove.append({ *element, attribute.name() });
+                    continue;
+                }
+
+                if (isAnimationElement) {
+                    for (auto component : StringView(attribute.value()).split(';')) {
+                        if (WTF::isValidJavaScriptURL(component)) {
+                            attributesToRemove.append({ *element, attribute.name() });
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        for (auto& item : attributesToRemove)
+            item.first->removeAttribute(item.second);
+    };
+
+    auto sanitizeElements = [&](Element& stagingBody) {
+        removeMatchingElements(stagingBody, [](Element& element) {
+            return isAnyOf<HTMLStyleElement, SVGStyleElement>(element) || element.computedStyleIsDisplayNone();
+        });
+    };
+
+    return sanitizeMarkup(svg, destinationDocument, MSOListQuirks::Disabled, Function<void(DocumentFragment&)> { WTF::move(sanitizeFragment) }, Function<void(Element&)> { WTF::move(sanitizeElements) });
 }
 
 UserSelectNoneStateCache::UserSelectNoneStateCache(TreeType treeType)
@@ -1272,7 +1352,7 @@ static bool shouldPreserveMSOLists(StringView markup)
         && tag.contains("xmlns:w=\"urn:schemas-microsoft-com:office:word\""_s);
 }
 
-String sanitizedMarkupForFragmentInDocument(Ref<DocumentFragment>&& fragment, Document& document, MSOListQuirks msoListQuirks, const String& originalMarkup)
+String sanitizedMarkupForFragmentInDocument(Ref<DocumentFragment>&& fragment, Document& document, MSOListQuirks msoListQuirks, const String& originalMarkup, NOESCAPE const Function<void(Element&)>& postLayoutSanitizer)
 {
     MSOListMode msoListMode = msoListQuirks == MSOListQuirks::CheckIfNeeded && shouldPreserveMSOLists(originalMarkup)
         ? MSOListMode::Preserve : MSOListMode::DoNotPreserve;
@@ -1280,6 +1360,11 @@ String sanitizedMarkupForFragmentInDocument(Ref<DocumentFragment>&& fragment, Do
     RefPtr bodyElement { document.body() };
     ASSERT(bodyElement);
     bodyElement->appendChild(fragment.get());
+
+    if (postLayoutSanitizer) {
+        document.updateLayoutIgnorePendingStylesheets();
+        postLayoutSanitizer(*bodyElement);
+    }
 
     // SerializeComposedTree::No because there can't be a shadow tree in the pasted fragment.
     auto result = serializePreservingVisualAppearanceInternal(firstPositionInNode(*bodyElement), lastPositionInNode(*bodyElement), nullptr,

--- a/Source/WebCore/editing/markup.h
+++ b/Source/WebCore/editing/markup.h
@@ -62,8 +62,9 @@ void removeSubresourceURLAttributes(Ref<DocumentFragment>&&, Function<bool(const
 
 Ref<Page> createPageForSanitizingWebContent(Document* destinationDocument, std::optional<PageConfiguration>&& = { });
 enum class MSOListQuirks : bool { CheckIfNeeded, Disabled };
-String sanitizeMarkup(const String&, Document* destinationDocument, MSOListQuirks = MSOListQuirks::Disabled, std::optional<Function<void(DocumentFragment&)>> fragmentSanitizer = std::nullopt);
-String sanitizedMarkupForFragmentInDocument(Ref<DocumentFragment>&&, Document&, MSOListQuirks, const String& originalMarkup);
+String sanitizeMarkup(const String&, Document* destinationDocument, MSOListQuirks = MSOListQuirks::Disabled, NOESCAPE const Function<void(DocumentFragment&)>& fragmentSanitizer = nullptr, NOESCAPE const Function<void(Element& stagingBody)>& postLayoutSanitizer = nullptr);
+WEBCORE_EXPORT String sanitizeSVG(const String& svg, Document* destinationDocument);
+String sanitizedMarkupForFragmentInDocument(Ref<DocumentFragment>&&, Document&, MSOListQuirks, const String& originalMarkup, NOESCAPE const Function<void(Element& stagingBody)>& postLayoutSanitizer = nullptr);
 
 class UserSelectNoneStateCache {
 public:

--- a/Source/WebCore/platform/cocoa/PasteboardCocoa.mm
+++ b/Source/WebCore/platform/cocoa/PasteboardCocoa.mm
@@ -54,6 +54,7 @@ enum class ImageType {
     PNG,
     JPEG,
     GIF,
+    SVG,
 };
 
 static ImageType cocoaTypeToImageType(const String& cocoaType)
@@ -74,6 +75,8 @@ static ImageType cocoaTypeToImageType(const String& cocoaType)
         return ImageType::JPEG;
     if (cocoaType == String(UTTypeGIF.identifier))
         return ImageType::GIF;
+    if (cocoaType == String(UTTypeSVG.identifier))
+        return ImageType::SVG;
 
     return ImageType::Invalid;
 }
@@ -97,6 +100,8 @@ static ASCIILiteral imageTypeToMIMEType(ImageType type)
         return "image/jpeg"_s;
     case ImageType::GIF:
         return "image/gif"_s;
+    case ImageType::SVG:
+        return "image/svg+xml"_s;
     }
 }
 
@@ -119,6 +124,8 @@ static ASCIILiteral imageTypeToFakeFilename(ImageType type)
         return "image.jpeg"_s;
     case ImageType::GIF:
         return "image.gif"_s;
+    case ImageType::SVG:
+        return "image.svg"_s;
     }
 }
 

--- a/Source/WebCore/platform/glib/PasteboardGLib.cpp
+++ b/Source/WebCore/platform/glib/PasteboardGLib.cpp
@@ -365,6 +365,12 @@ void Pasteboard::read(PasteboardFileReader& reader, std::optional<size_t>)
             return;
         }
     }
+
+    static constexpr auto svgImageType = "image/svg+xml"_s;
+    if (reader.shouldReadBuffer(svgImageType)) {
+        if (auto buffer = readBuffer(0, svgImageType))
+            reader.readBuffer("image.svg"_s, svgImageType, buffer.releaseNonNull());
+    }
 }
 
 bool Pasteboard::hasData()

--- a/Source/WebCore/platform/ios/PlatformPasteboardIOS.mm
+++ b/Source/WebCore/platform/ios/PlatformPasteboardIOS.mm
@@ -176,6 +176,9 @@ static const char *safeTypeForDOMToReadAndWriteForPlatformType(NSString *platfor
     if (includeImageTypes == PlatformPasteboard::IncludeImageTypes::Yes && [utType conformsToType:UTTypePNG])
         return "image/png"_s;
 
+    if (includeImageTypes == PlatformPasteboard::IncludeImageTypes::Yes && [utType conformsToType:UTTypeSVG])
+        return "image/svg+xml"_s;
+
     return nullptr;
 }
 
@@ -387,6 +390,9 @@ String PlatformPasteboard::platformPasteboardTypeForSafeTypeForDOMToReadAndWrite
 
     if (includeImageTypes == IncludeImageTypes::Yes && domType == "image/png"_s)
         return UTTypePNG.identifier;
+
+    if (includeImageTypes == IncludeImageTypes::Yes && domType == "image/svg+xml"_s)
+        return UTTypeSVG.identifier;
 
     return { };
 }

--- a/Source/WebCore/platform/mac/PlatformPasteboardMac.mm
+++ b/Source/WebCore/platform/mac/PlatformPasteboardMac.mm
@@ -350,6 +350,9 @@ String PlatformPasteboard::platformPasteboardTypeForSafeTypeForDOMToReadAndWrite
     if (includeImageTypes == IncludeImageTypes::Yes && domType == "image/png"_s)
         return legacyPNGPasteboardTypeSingleton();
 
+    if (includeImageTypes == IncludeImageTypes::Yes && domType == "image/svg+xml"_s)
+        return UTTypeSVG.identifier;
+
     return { };
 }
 
@@ -495,6 +498,8 @@ static String webSafeMIMETypeForModernPasteboardType(NSPasteboardType platformTy
         return "text/uri-list"_s;
     if ([platformType isEqual:NSPasteboardTypePNG] || [platformType isEqual:NSPasteboardTypeTIFF])
         return "image/png"_s;
+    if ([platformType isEqual:UTTypeSVG.identifier])
+        return "image/svg+xml"_s;
     return { };
 }
 

--- a/Source/WebKit/UIProcess/gtk/WebPasteboardProxyGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/WebPasteboardProxyGtk.cpp
@@ -143,6 +143,8 @@ void WebPasteboardProxy::writeCustomData(IPC::Connection&, const Vector<Pasteboa
                 selectionData.setMarkup(std::get<String>(stringOrBuffer));
             else if (type == "text/uri-list"_s)
                 selectionData.setURIList(std::get<String>(stringOrBuffer));
+            else if (type == "image/svg+xml"_s)
+                selectionData.addBuffer(type, SharedBuffer::create(std::get<String>(stringOrBuffer).utf8().span()));
         }
     });
 
@@ -163,6 +165,8 @@ static WebCore::PasteboardItemInfo pasteboardItemInfoFromFormats(Vector<String>&
         info.webSafeTypesByFidelity.append("text/uri-list"_s);
     if (formats.contains("image/png"_s))
         info.webSafeTypesByFidelity.append("image/png"_s);
+    if (formats.contains("image/svg+xml"_s))
+        info.webSafeTypesByFidelity.append("image/svg+xml"_s);
     info.platformTypesByFidelity = WTF::move(formats);
     return info;
 }

--- a/Source/WebKit/UIProcess/wpe/WebPasteboardProxyWPE.cpp
+++ b/Source/WebKit/UIProcess/wpe/WebPasteboardProxyWPE.cpp
@@ -209,6 +209,8 @@ void WebPasteboardProxy::writeCustomData(IPC::Connection&, const Vector<Pasteboa
                     setClipboardContentFromSpan(content.get(), "text/html", std::get<String>(stringOrBuffer).utf8().span());
                 else if (type == "text/uri-list"_s)
                     setClipboardContentFromSpan(content.get(), "text/uri-list", std::get<String>(stringOrBuffer).utf8().span());
+                else if (type == "image/svg+xml"_s)
+                    setClipboardContentFromSpan(content.get(), "image/svg+xml", std::get<String>(stringOrBuffer).utf8().span());
             }
         });
 
@@ -239,6 +241,8 @@ static PasteboardItemInfo pasteboardItemInfoFromFormats(Vector<String>&& formats
         info.webSafeTypesByFidelity.append("text/html"_s);
     if (formats.contains("text/uri-list"_s))
         info.webSafeTypesByFidelity.append("text/uri-list"_s);
+    if (formats.contains("image/svg+xml"_s))
+        info.webSafeTypesByFidelity.append("image/svg+xml"_s);
     info.platformTypesByFidelity = WTF::move(formats);
     return info;
 }

--- a/Tools/WebKitTestRunner/PlatformMac.cmake
+++ b/Tools/WebKitTestRunner/PlatformMac.cmake
@@ -146,6 +146,8 @@ list(APPEND WebKitTestRunner_SOURCES
     ${WebKitTestRunner_DIR}/mac/WebKitTestRunnerWindow.mm
     ${WebKitTestRunner_DIR}/mac/main.mm
 
+    ${WebKitTestRunner_SHARED_DIR}/mac/NSPasteboardAdditions.mm
+
     ${WebKitTestRunner_SHARED_DIR}/cocoa/ClassMethodSwizzler.mm
     ${WebKitTestRunner_SHARED_DIR}/cocoa/InstanceMethodSwizzler.mm
     ${WebKitTestRunner_SHARED_DIR}/cocoa/LayoutTestSpellChecker.mm


### PR DESCRIPTION
#### f22a4386b7f213365c5cf30ef5597160e39b0b1f
<pre>
sf-saas.apple.com: Support copy/paste of SVG data
<a href="https://bugs.webkit.org/show_bug.cgi?id=318829">https://bugs.webkit.org/show_bug.cgi?id=318829</a>
<a href="https://rdar.apple.com/137553836">rdar://137553836</a>

Reviewed by Wenson Hsieh.

The clipboard (navigator.clipboard) did not support image/svg+xml.
SVG could not simply be allowed through like other image types because
it can carry scripts, event handlers, javascript: URLs, and external
references.

This patch adds image/svg+xml as a supported clipboard type and sanitizes
it on both the write and read paths, modeled on the sanitization baseline
in the Sanitizer API (<a href="https://wicg.github.io/sanitizer-api/).">https://wicg.github.io/sanitizer-api/).</a>

I also removed content hidden with display: none. To do this, I added a
new callback to sanitizeMarkup that get&apos;s run post-layout, so we have
access to the computed style of each element.

* LayoutTests/editing/async-clipboard/sanitize-when-reading-and-writing-svg-expected.txt: Added.
* LayoutTests/editing/async-clipboard/sanitize-when-reading-and-writing-svg.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/clipboard-apis/clipboard-item.https-expected.txt:
* Source/WebCore/Modules/async-clipboard/Clipboard.cpp:
(WebCore::Clipboard::getType):
* Source/WebCore/Modules/async-clipboard/ClipboardImageReader.cpp:
(WebCore::ClipboardImageReader::readBuffer):
(WebCore::ClipboardImageReader::readSVG):
* Source/WebCore/Modules/async-clipboard/ClipboardImageReader.h:
* Source/WebCore/Modules/async-clipboard/ClipboardItem.cpp:
(WebCore::ClipboardItem::supports):
* Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp:
(WebCore::ClipboardItemBindingsDataSource::ClipboardItemTypeLoader::sanitizeDataIfNeeded):
* Source/WebCore/Modules/async-clipboard/ios/ClipboardImageReaderIOS.mm:
(WebCore::ClipboardImageReader::readBuffer):
* Source/WebCore/Modules/async-clipboard/mac/ClipboardImageReaderMac.mm:
(WebCore::ClipboardImageReader::readBuffer):
* Source/WebCore/editing/markup.cpp:
(WebCore::sanitizeMarkup):
(WebCore::sanitizeSVG):
(WebCore::sanitizedMarkupForFragmentInDocument):
* Source/WebCore/editing/markup.h:
* Source/WebCore/platform/cocoa/PasteboardCocoa.mm:
(WebCore::cocoaTypeToImageType):
(WebCore::imageTypeToMIMEType):
(WebCore::imageTypeToFakeFilename):
* Source/WebCore/platform/glib/PasteboardGLib.cpp:
(WebCore::Pasteboard::read):
* Source/WebCore/platform/ios/PlatformPasteboardIOS.mm:
(WebCore::safeTypeForDOMToReadAndWriteForPlatformType):
(WebCore::PlatformPasteboard::platformPasteboardTypeForSafeTypeForDOMToReadAndWrite):
* Source/WebCore/platform/mac/PlatformPasteboardMac.mm:
(WebCore::PlatformPasteboard::platformPasteboardTypeForSafeTypeForDOMToReadAndWrite):
(WebCore::webSafeMIMETypeForModernPasteboardType):
* Source/WebKit/UIProcess/gtk/WebPasteboardProxyGtk.cpp:
(WebKit::WebPasteboardProxy::writeCustomData):
(WebKit::pasteboardItemInfoFromFormats):
* Source/WebKit/UIProcess/wpe/WebPasteboardProxyWPE.cpp:
(WebKit::WebPasteboardProxy::writeCustomData):
(WebKit::pasteboardItemInfoFromFormats):
* Tools/WebKitTestRunner/PlatformMac.cmake:

Canonical link: <a href="https://commits.webkit.org/317528@main">https://commits.webkit.org/317528@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bcc2bc92f88887d73df1f0707f119a1edb5c691d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175554 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49486 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43267 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185140 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177418 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50778 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49169 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/136695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6228f240-f63b-4076-a1ce-c630867b0417) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178511 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40118 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157456 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/117173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/145a4326-4ff0-46fb-a702-839bb7957494) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38759 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37144 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149181 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/36949 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33615 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41174 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41347 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187565 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49153 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/157012 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/145665 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39187 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49833 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33573 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145502 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40323 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122026 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115812 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48340 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11925 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47742 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47972 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47799 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->