### PR TITLE
[Site Isolation] Web Inspector: finish Network.getResponseBody

### DIFF
--- a/LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-get-response-body-after-navigation-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-get-response-body-after-navigation-expected.txt
@@ -1,0 +1,12 @@
+Tests Network.getResponseBody behavior across a cross-origin iframe navigation under Site Isolation.
+
+
+== Running test suite: SiteIsolation.Network.CrossOriginIFrame.GetResponseBody.AfterNavigation
+-- Running test case: SiteIsolation.Network.CrossOriginIFrame.GetResponseBody.AfterNavigation.Before
+PASS: Pre-navigation resource should have a request identifier.
+PASS: Pre-navigation body should match.
+
+-- Running test case: SiteIsolation.Network.CrossOriginIFrame.GetResponseBody.AfterNavigation.After
+PASS: Post-navigation body should match (getResponseBody still works after navigation).
+Pre-navigation resource still retrievable after navigation: true
+

--- a/LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-get-response-body-after-navigation.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-get-response-body-after-navigation.html
@@ -1,0 +1,106 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script>
+let iframe;
+
+function loadIFrame(content) {
+    let src = "http://localhost:8000/site-isolation/inspector/network/resources/fetch-content-iframe.html?content=" + content;
+    if (!iframe) {
+        // Mirror the proven addIFrame() ordering (see cross-origin-iframe-get-response-body):
+        // attach the load listener and set src BEFORE appending, so the load event is reliably
+        // observed and the subresource fetch is triggered only after the frame target exists and
+        // Network instrumentation is enabled. (Appending first would load about:blank and race.)
+        iframe = document.createElement("iframe");
+        iframe.addEventListener("load", () => iframe.contentWindow.postMessage({type: "Fetch"}, "*"));
+        iframe.src = src;
+        document.body.appendChild(iframe);
+    } else {
+        // Navigate the existing iframe (same origin, so it stays in the same WebContent
+        // process); the single load listener re-fires and re-fetches based on the new query.
+        iframe.src = src;
+    }
+}
+
+function test() {
+    // Loads a subresource in a cross-origin iframe, then navigates the iframe (same origin,
+    // so it stays in the same WebContent process) and loads another subresource. This checks
+    // that getResponseBody keeps working across a navigation (the post-navigation resource is
+    // retrievable), and observes -- without asserting -- whether the pre-navigation resource's
+    // content is still retrievable afterward (store retention across navigation is not
+    // contractually defined). Subresources are triggered post-load (via postMessage) so their
+    // capture does not depend on process-spawn instrumentation timing.
+
+    // Require ALL substrings to match. Under Site Isolation the child frame's own document
+    // (fetch-content-iframe.html?content=<content>) also surfaces as a resource whose URL
+    // contains the content string, so matching on the content alone is ambiguous; also
+    // requiring "echo.py" pins the match to the subresource fetch we actually want to read.
+    function waitForResource(...urlSubstrings) {
+        return new Promise((resolve) => {
+            function onResourceAdded(event) {
+                let resource = event.data.resource;
+                if (!resource || !resource.url || !urlSubstrings.every((s) => resource.url.includes(s)))
+                    return;
+                WI.Frame.removeEventListener(WI.Frame.Event.ResourceWasAdded, onResourceAdded);
+                resolve(resource);
+            }
+            WI.Frame.addEventListener(WI.Frame.Event.ResourceWasAdded, onResourceAdded);
+        });
+    }
+
+    async function finish(resource) {
+        if (!resource.finished && !resource.failed)
+            await resource.awaitEvent(WI.Resource.Event.LoadingDidFinish);
+    }
+
+    let beforeRequestId;
+
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.Network.CrossOriginIFrame.GetResponseBody.AfterNavigation");
+
+    suite.addTestCase({
+        name: "SiteIsolation.Network.CrossOriginIFrame.GetResponseBody.AfterNavigation.Before",
+        description: "getResponseBody should return the pre-navigation resource's content.",
+        async test() {
+            let resourcePromise = waitForResource("echo.py", "before-navigation");
+            InspectorTest.evaluateInPage("loadIFrame('before-navigation')");
+            let resource = await resourcePromise;
+            await finish(resource);
+
+            beforeRequestId = resource.requestIdentifier;
+            InspectorTest.expectThat(!!beforeRequestId, "Pre-navigation resource should have a request identifier.");
+
+            let {body} = await WI.backendTarget.NetworkAgent.getResponseBody(beforeRequestId);
+            InspectorTest.expectEqual(body, "before-navigation", "Pre-navigation body should match.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.Network.CrossOriginIFrame.GetResponseBody.AfterNavigation.After",
+        description: "After the iframe navigates, getResponseBody should return the new resource's content; the old resource's availability is observed.",
+        async test() {
+            let resourcePromise = waitForResource("echo.py", "after-navigation");
+            InspectorTest.evaluateInPage("loadIFrame('after-navigation')");
+            let resource = await resourcePromise;
+            await finish(resource);
+
+            let {body} = await WI.backendTarget.NetworkAgent.getResponseBody(resource.requestIdentifier);
+            InspectorTest.expectEqual(body, "after-navigation", "Post-navigation body should match (getResponseBody still works after navigation).");
+
+            // Observe (do not assert) whether the pre-navigation resource is still retrievable.
+            let oldAvailable;
+            try {
+                await WI.backendTarget.NetworkAgent.getResponseBody(beforeRequestId);
+                oldAvailable = true;
+            } catch (e) {
+                oldAvailable = false;
+            }
+            InspectorTest.log("Pre-navigation resource still retrievable after navigation: " + oldAvailable);
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+
+<body onload="runTest()">
+<p>Tests Network.getResponseBody behavior across a cross-origin iframe navigation under Site Isolation.</p>
+</body>

--- a/LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-get-response-body-after-process-crash-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-get-response-body-after-process-crash-expected.txt
@@ -1,0 +1,12 @@
+Tests that Network.getResponseBody rejects (rather than returning an empty body as success, or hanging) when the WebContent process that served the resource has been terminated, under Site Isolation.
+
+
+== Running test suite: SiteIsolation.Network.CrossOriginIFrame.GetResponseBody.AfterProcessCrash
+-- Running test case: SiteIsolation.Network.CrossOriginIFrame.GetResponseBody.AfterProcessCrash.WorksBeforeCrash
+PASS: Resource should finish loading.
+PASS: Resource should have a request identifier.
+PASS: getResponseBody should return the served content before the crash.
+
+-- Running test case: SiteIsolation.Network.CrossOriginIFrame.GetResponseBody.AfterProcessCrash.RejectsAfterCrash
+PASS: getResponseBody should reject once the serving WebContent process is gone (not return an empty body as success, not hang).
+

--- a/LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-get-response-body-after-process-crash.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-get-response-body-after-process-crash.html
@@ -1,0 +1,122 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ignoreWebProcessTermination=true ] -->
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script>
+let iframe;
+
+function addIFrame() {
+    // Same proven setup as cross-origin-iframe-get-response-body.html: a cross-origin
+    // (localhost) iframe loads in its own WebContent process under Site Isolation, and its
+    // subresource is triggered post-load via postMessage.
+    iframe = document.createElement("iframe");
+    iframe.src = "http://localhost:8000/site-isolation/inspector/network/resources/get-response-body-iframe.html";
+    iframe.addEventListener("load", () => iframe.contentWindow.postMessage({type: "TriggerLoads"}, "*"));
+    document.body.appendChild(iframe);
+}
+
+function terminateIFrameProcess() {
+    // Ask the cross-origin iframe to terminate its own WebContent process. Under Site
+    // Isolation this kills only the iframe's process, leaving the main frame (and the
+    // inspector frontend) running. Requires the ignoreWebProcessTermination runner flag.
+    iframe.contentWindow.postMessage({type: "TerminateProcess"}, "*");
+}
+
+function test() {
+    // Regression test for the WebProcess-crash robustness of getResponseBody. When the WebContent
+    // process that served a resource is gone, IPC synthesizes ProxyingNetworkAgent's getResponseBody
+    // reply from default-constructed arguments (AsyncReplyError). Before the fix, that produced
+    // content="" and an empty errorString, which the reply handler misread as an empty-body *success*.
+    // After the fix, ProxyingNetworkAgent detects the empty-error unexpected (or the process is
+    // already gone from the routing table) and reports an explicit failure. Either way, a
+    // getResponseBody issued after the serving process terminates must REJECT -- never resolve
+    // with an empty body, and never hang.
+
+    function waitForResource(urlSubstring) {
+        return new Promise((resolve) => {
+            function onResourceAdded(event) {
+                let resource = event.data.resource;
+                if (!resource || !resource.url || !resource.url.includes(urlSubstring))
+                    return;
+                WI.Frame.removeEventListener(WI.Frame.Event.ResourceWasAdded, onResourceAdded);
+                resolve(resource);
+            }
+            WI.Frame.addEventListener(WI.Frame.Event.ResourceWasAdded, onResourceAdded);
+        });
+    }
+
+    async function waitForFinished(resource) {
+        if (!resource.finished && !resource.failed)
+            await resource.awaitEvent(WI.Resource.Event.LoadingDidFinish);
+    }
+
+    let textResource;
+
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.Network.CrossOriginIFrame.GetResponseBody.AfterProcessCrash");
+
+    suite.addTestCase({
+        name: "SiteIsolation.Network.CrossOriginIFrame.GetResponseBody.AfterProcessCrash.WorksBeforeCrash",
+        description: "Load a text resource in a cross-origin iframe and confirm getResponseBody works before the process is terminated.",
+        async test() {
+            let textPromise = waitForResource("echo.py");
+            InspectorTest.evaluateInPage("addIFrame()");
+            textResource = await textPromise;
+            await waitForFinished(textResource);
+
+            InspectorTest.expectThat(textResource.finished, "Resource should finish loading.");
+            InspectorTest.expectThat(!!textResource.requestIdentifier, "Resource should have a request identifier.");
+
+            let {body} = await WI.backendTarget.NetworkAgent.getResponseBody(textResource.requestIdentifier);
+            InspectorTest.expectEqual(body, "si-cross-origin-response-body", "getResponseBody should return the served content before the crash.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.Network.CrossOriginIFrame.GetResponseBody.AfterProcessCrash.RejectsAfterCrash",
+        description: "After the iframe's WebContent process is terminated, getResponseBody for its resource must reject with a failure -- never return an empty body as success, and never hang.",
+        async test() {
+            // Terminating a cross-origin child frame's WebContent process under Site Isolation does
+            // NOT produce a frontend target-removal event: the WebFrameProxy persists across the
+            // crash (WebPageInspectorController::willDestroyFrame fires only on genuine frame
+            // removal, never a process swap), so there is no TargetRemoved to await. Instead we poll
+            // getResponseBody until it stops returning the live body. Once the serving process is
+            // gone its BackendResourceDataStore is gone too, so the call must reject -- either
+            // "WebProcess not found" (already removed from the routing table) or, if we catch the
+            // async-reply window, the fix's explicit "no longer available" failure. If instead it
+            // ever resolves with a non-live (empty) body, that is the pre-fix bug and we fail. The
+            // loop is bounded so it can never hang.
+            InspectorTest.evaluateInPage("terminateIFrameProcess()");
+
+            let outcome = null; // "rejected" | "empty-success"
+            let detail;
+            for (let attempt = 0; attempt < 60 && !outcome; ++attempt) {
+                try {
+                    let {body, base64Encoded} = await WI.backendTarget.NetworkAgent.getResponseBody(textResource.requestIdentifier);
+                    if (body === "si-cross-origin-response-body" && !base64Encoded) {
+                        // Process still alive; yield and retry.
+                        await new Promise((resolve) => setTimeout(resolve, 50));
+                        continue;
+                    }
+                    // Resolved, but not with the live body: the pre-fix empty-body-as-success bug.
+                    outcome = "empty-success";
+                    detail = `body.length=${body ? body.length : 0}, base64Encoded=${base64Encoded}`;
+                } catch (e) {
+                    outcome = "rejected";
+                    detail = e.message || String(e);
+                }
+            }
+
+            InspectorTest.expectEqual(outcome, "rejected", "getResponseBody should reject once the serving WebContent process is gone (not return an empty body as success, not hang).");
+            // Only log the detail on failure: the rejection message legitimately varies with
+            // timing ("WebProcess not found" vs the fix's "no longer available"), so baking it
+            // into the passing baseline would make the test flaky.
+            if (outcome !== "rejected")
+                InspectorTest.log(`  Unexpected outcome detail: ${detail}`);
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+
+<body onload="runTest()">
+<p>Tests that Network.getResponseBody rejects (rather than returning an empty body as success, or hanging) when the WebContent process that served the resource has been terminated, under Site Isolation.</p>
+</body>

--- a/LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-get-response-body-error-cases-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-get-response-body-error-cases-expected.txt
@@ -1,0 +1,22 @@
+Tests the error paths of Network.getResponseBody under Site Isolation (malformed requestId, unknown process, unknown resource), routed through ProxyingNetworkAgent.
+
+
+== Running test suite: SiteIsolation.Network.CrossOriginIFrame.GetResponseBody.ErrorCases
+-- Running test case: SiteIsolation.Network.CrossOriginIFrame.GetResponseBody.ErrorCases.ValidControl
+PASS: Loaded resource should have a request identifier.
+PASS: Control: valid requestId should return the served content.
+
+-- Running test case: SiteIsolation.Network.CrossOriginIFrame.GetResponseBody.ErrorCases.Malformed
+PASS: Malformed string: getResponseBody should fail.
+  Error: Invalid requestId format
+PASS: Non-numeric ids: getResponseBody should fail.
+  Error: Invalid requestId format
+
+-- Running test case: SiteIsolation.Network.CrossOriginIFrame.GetResponseBody.ErrorCases.UnknownProcess
+PASS: Unknown process: getResponseBody should fail.
+  Error: WebProcess not found for requestId
+
+-- Running test case: SiteIsolation.Network.CrossOriginIFrame.GetResponseBody.ErrorCases.UnknownResource
+PASS: Unknown resource in real process: getResponseBody should fail.
+  Error: Missing resource for given requestId
+

--- a/LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-get-response-body-error-cases.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-get-response-body-error-cases.html
@@ -1,0 +1,101 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script>
+let iframe;
+
+function addIFrame() {
+    iframe = document.createElement("iframe");
+    iframe.src = "http://localhost:8000/site-isolation/inspector/network/resources/get-response-body-iframe.html";
+    iframe.addEventListener("load", () => iframe.contentWindow.postMessage({type: "TriggerLoads"}, "*"));
+    document.body.appendChild(iframe);
+}
+
+function test() {
+    // Exercises the error paths of Network.getResponseBody under Site Isolation, all issued
+    // against ProxyingNetworkAgent (WI.backendTarget.NetworkAgent). A process-qualified
+    // requestId has the form "request-<processID>.<resourceID>" (see InspectorIdentifierRegistry).
+    // We derive a real, live requestId from a loaded resource, then perturb it to hit each
+    // failure branch: malformed (parse failure), unknown process, and unknown resource in a
+    // real process (BackendResourceDataStore miss).
+
+    function waitForResource(urlSubstring) {
+        return new Promise((resolve) => {
+            function onResourceAdded(event) {
+                let resource = event.data.resource;
+                if (!resource || !resource.url || !resource.url.includes(urlSubstring))
+                    return;
+                WI.Frame.removeEventListener(WI.Frame.Event.ResourceWasAdded, onResourceAdded);
+                resolve(resource);
+            }
+            WI.Frame.addEventListener(WI.Frame.Event.ResourceWasAdded, onResourceAdded);
+        });
+    }
+
+    async function expectGetResponseBodyToFail(requestId, label) {
+        try {
+            await WI.backendTarget.NetworkAgent.getResponseBody(requestId);
+            InspectorTest.expectThat(false, `${label}: getResponseBody should have failed.`);
+        } catch (e) {
+            InspectorTest.expectThat(true, `${label}: getResponseBody should fail.`);
+            InspectorTest.log(`  Error: ${e.message || e}`);
+        }
+    }
+
+    let realRequestId;
+
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.Network.CrossOriginIFrame.GetResponseBody.ErrorCases");
+
+    suite.addTestCase({
+        name: "SiteIsolation.Network.CrossOriginIFrame.GetResponseBody.ErrorCases.ValidControl",
+        description: "A valid requestId for a loaded cross-origin-iframe resource should succeed (control).",
+        async test() {
+            let resourcePromise = waitForResource("echo.py");
+            InspectorTest.evaluateInPage("addIFrame()");
+            let resource = await resourcePromise;
+            if (!resource.finished && !resource.failed)
+                await resource.awaitEvent(WI.Resource.Event.LoadingDidFinish);
+
+            realRequestId = resource.requestIdentifier;
+            InspectorTest.expectThat(!!realRequestId, "Loaded resource should have a request identifier.");
+
+            let {body} = await WI.backendTarget.NetworkAgent.getResponseBody(realRequestId);
+            InspectorTest.expectEqual(body, "si-cross-origin-response-body", "Control: valid requestId should return the served content.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.Network.CrossOriginIFrame.GetResponseBody.ErrorCases.Malformed",
+        description: "A malformed requestId should fail to parse (Invalid requestId format).",
+        async test() {
+            await expectGetResponseBodyToFail("not-a-valid-request-id", "Malformed string");
+            await expectGetResponseBodyToFail("request-abc.def", "Non-numeric ids");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.Network.CrossOriginIFrame.GetResponseBody.ErrorCases.UnknownProcess",
+        description: "A well-formed requestId whose process does not exist should fail (WebProcess not found).",
+        async test() {
+            // Keep the resource id, swap in a process id that cannot match any live WebContent process.
+            let unknownProcess = realRequestId.replace(/^request-\d+\./, "request-4294967295.");
+            await expectGetResponseBodyToFail(unknownProcess, "Unknown process");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.Network.CrossOriginIFrame.GetResponseBody.ErrorCases.UnknownResource",
+        description: "A well-formed requestId routed to a real process but for an unknown resource should fail (missing in BackendResourceDataStore).",
+        async test() {
+            // Keep the (real, live) process id, swap in a resource id that was never created.
+            let unknownResource = realRequestId.replace(/\.\d+$/, ".4294967295");
+            await expectGetResponseBodyToFail(unknownResource, "Unknown resource in real process");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+
+<body onload="runTest()">
+<p>Tests the error paths of Network.getResponseBody under Site Isolation (malformed requestId, unknown process, unknown resource), routed through ProxyingNetworkAgent.</p>
+</body>

--- a/LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-get-response-body-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-get-response-body-expected.txt
@@ -1,0 +1,21 @@
+Tests that Network.getResponseBody returns the correct text and base64-encoded bodies for resources loaded in a cross-origin iframe under Site Isolation, routed through ProxyingNetworkAgent and BackendResourceDataStore.
+
+
+== Running test suite: SiteIsolation.Network.CrossOriginIFrame.GetResponseBody
+-- Running test case: SiteIsolation.Network.CrossOriginIFrame.GetResponseBody.LoadResources
+PASS: Text resource should be created.
+PASS: Image resource should be created.
+PASS: Text resource should finish loading.
+PASS: Image resource should finish loading.
+PASS: Text resource should have a request identifier.
+PASS: Image resource should have a request identifier.
+
+-- Running test case: SiteIsolation.Network.CrossOriginIFrame.GetResponseBody.TextContent
+PASS: Text response body should not be base64-encoded.
+PASS: Text response body should match the served content.
+
+-- Running test case: SiteIsolation.Network.CrossOriginIFrame.GetResponseBody.BinaryContent
+PASS: Binary (image) response body should be base64-encoded.
+PASS: Binary response body should not be empty.
+Base64-encoded image body length: 13392
+

--- a/LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-get-response-body-via-request-content-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-get-response-body-via-request-content-expected.txt
@@ -1,0 +1,24 @@
+Tests that WI.Resource.requestContent() (the frontend content path used by the UI) returns the correct text and base64-encoded bodies for resources loaded in a cross-origin iframe under Site Isolation, routing Network.getResponseBody to the multiplexing backend target where ProxyingNetworkAgent lives.
+
+
+== Running test suite: SiteIsolation.Network.CrossOriginIFrame.GetResponseBody.ViaRequestContent
+-- Running test case: SiteIsolation.Network.CrossOriginIFrame.GetResponseBody.ViaRequestContent.LoadResources
+PASS: Text resource should finish loading.
+PASS: Image resource should finish loading.
+
+-- Running test case: SiteIsolation.Network.CrossOriginIFrame.GetResponseBody.ViaRequestContent.TextContent
+PASS: requestContent() should succeed for a cross-origin-iframe text resource (no error).
+PASS: Text response body should not be base64-encoded.
+PASS: requestContent() should return the served text content.
+PASS: rawContent should match the served text content.
+
+-- Running test case: SiteIsolation.Network.CrossOriginIFrame.GetResponseBody.ViaRequestContent.BinaryContent
+PASS: requestContent() should succeed for a cross-origin-iframe image resource (no error).
+PASS: Binary (image) response body should be base64-encoded.
+PASS: Binary response body should not be empty.
+Base64-encoded image body length: 13392
+
+-- Running test case: SiteIsolation.Network.CrossOriginIFrame.GetResponseBody.ViaRequestContent.ErrorSurfacing
+PASS: requestContent() should resolve with an error when getResponseBody fails.
+PASS: requestContent() should not return content on failure.
+

--- a/LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-get-response-body-via-request-content.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-get-response-body-via-request-content.html
@@ -1,0 +1,115 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script>
+let iframe;
+
+function addIFrame() {
+    iframe = document.createElement("iframe");
+    iframe.src = "http://localhost:8000/site-isolation/inspector/network/resources/get-response-body-iframe.html";
+    iframe.addEventListener("load", () => iframe.contentWindow.postMessage({type: "TriggerLoads"}, "*"));
+    document.body.appendChild(iframe);
+}
+
+function test() {
+    // Unlike cross-origin-iframe-get-response-body.html, which calls
+    // WI.backendTarget.NetworkAgent.getResponseBody directly, this test drives the *real frontend
+    // content path* -- WI.Resource.requestContent() -> requestContentFromBackend(). That path
+    // issues getResponseBody on the resource's own target, which under Site Isolation defaults to
+    // the page target (the SI proxy sends an empty targetID). The Network domain, however, lives on
+    // the multiplexing backend target (ProxyingNetworkAgent), so the page target's legacy
+    // NetworkAgent answers "Missing resource for given requestId". Resource.requestContentFromBackend
+    // must therefore route to the backend target. This test guards that routing: the direct-agent
+    // tests pass regardless of it, so without this a UI regression would go unnoticed.
+
+    function waitForResource(urlSubstring) {
+        return new Promise((resolve) => {
+            function onResourceAdded(event) {
+                let resource = event.data.resource;
+                if (!resource || !resource.url || !resource.url.includes(urlSubstring))
+                    return;
+                WI.Frame.removeEventListener(WI.Frame.Event.ResourceWasAdded, onResourceAdded);
+                resolve(resource);
+            }
+            WI.Frame.addEventListener(WI.Frame.Event.ResourceWasAdded, onResourceAdded);
+        });
+    }
+
+    async function waitForFinished(resource) {
+        if (!resource.finished && !resource.failed)
+            await resource.awaitEvent(WI.Resource.Event.LoadingDidFinish);
+    }
+
+    let textResource;
+    let imageResource;
+
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.Network.CrossOriginIFrame.GetResponseBody.ViaRequestContent");
+
+    suite.addTestCase({
+        name: "SiteIsolation.Network.CrossOriginIFrame.GetResponseBody.ViaRequestContent.LoadResources",
+        description: "Load a text resource and a binary image inside a cross-origin iframe and wait for both to finish.",
+        async test() {
+            let textPromise = waitForResource("echo.py");
+            let imagePromise = waitForResource("white.png");
+
+            InspectorTest.evaluateInPage("addIFrame()");
+
+            textResource = await textPromise;
+            imageResource = await imagePromise;
+
+            await waitForFinished(textResource);
+            await waitForFinished(imageResource);
+
+            InspectorTest.expectThat(textResource.finished, "Text resource should finish loading.");
+            InspectorTest.expectThat(imageResource.finished, "Image resource should finish loading.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.Network.CrossOriginIFrame.GetResponseBody.ViaRequestContent.TextContent",
+        description: "Resource.requestContent() should resolve with the decoded text body (routed to the backend target under SI).",
+        async test() {
+            let {content, rawContent, rawBase64Encoded, error} = await textResource.requestContent();
+            InspectorTest.expectThat(!error, "requestContent() should succeed for a cross-origin-iframe text resource (no error).");
+            InspectorTest.expectEqual(rawBase64Encoded, false, "Text response body should not be base64-encoded.");
+            InspectorTest.expectEqual(content, "si-cross-origin-response-body", "requestContent() should return the served text content.");
+            InspectorTest.expectEqual(rawContent, "si-cross-origin-response-body", "rawContent should match the served text content.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.Network.CrossOriginIFrame.GetResponseBody.ViaRequestContent.BinaryContent",
+        description: "Resource.requestContent() should resolve with a base64-encoded body for a binary (image) resource.",
+        async test() {
+            let {rawContent, rawBase64Encoded, error} = await imageResource.requestContent();
+            InspectorTest.expectThat(!error, "requestContent() should succeed for a cross-origin-iframe image resource (no error).");
+            InspectorTest.expectEqual(rawBase64Encoded, true, "Binary (image) response body should be base64-encoded.");
+            InspectorTest.expectThat(rawContent && rawContent.length > 0, "Binary response body should not be empty.");
+            InspectorTest.log("Base64-encoded image body length: " + (rawContent ? rawContent.length : 0));
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.Network.CrossOriginIFrame.GetResponseBody.ViaRequestContent.ErrorSurfacing",
+        description: "When getResponseBody fails, requestContent() should surface an error through the UI path (not hang, not return empty content as if successful).",
+        async test() {
+            // Point the resource at a well-formed but unknown requestId: its real, live process but a
+            // resource id that was never created, so BackendResourceDataStore misses. This still routes
+            // through the backend target (the fix under test) and must come back as a failure. We poke
+            // the private _requestIdentifier because requestContent() has no requestId parameter -- it
+            // uses the resource's own -- and mark the content stale so the new id is actually used.
+            textResource._requestIdentifier = textResource.requestIdentifier.replace(/\.\d+$/, ".4294967295");
+            textResource.markContentAsStale();
+
+            let {error, content} = await textResource.requestContent();
+            InspectorTest.expectThat(!!error, "requestContent() should resolve with an error when getResponseBody fails.");
+            InspectorTest.expectThat(!content, "requestContent() should not return content on failure.");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+
+<body onload="runTest()">
+<p>Tests that WI.Resource.requestContent() (the frontend content path used by the UI) returns the correct text and base64-encoded bodies for resources loaded in a cross-origin iframe under Site Isolation, routing Network.getResponseBody to the multiplexing backend target where ProxyingNetworkAgent lives.</p>
+</body>

--- a/LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-get-response-body.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-get-response-body.html
@@ -1,0 +1,105 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script>
+let iframe;
+
+function addIFrame() {
+    iframe = document.createElement("iframe");
+    // Main page is served from 127.0.0.1:8000; localhost:8000 is cross-origin and, under
+    // Site Isolation, loads in a separate WebContent process. Trigger the subresource
+    // loads only after the iframe has loaded (so its frame target exists and Network
+    // instrumentation is enabled) by posting it a message.
+    iframe.src = "http://localhost:8000/site-isolation/inspector/network/resources/get-response-body-iframe.html";
+    iframe.addEventListener("load", () => iframe.contentWindow.postMessage({type: "TriggerLoads"}, "*"));
+    document.body.appendChild(iframe);
+}
+
+function test() {
+    // This test exercises the Network.getResponseBody success path under Site Isolation:
+    // ProxyingNetworkAgent (UIProcess) parses the process-qualified requestId, routes the
+    // command to the owning WebContent process's WebInspectorBackend, which reads the body
+    // out of BackendResourceDataStore. We deliberately drive the resources through the
+    // WI.Frame.Event.ResourceWasAdded path (as in cross-origin-iframe-request-id-uniqueness)
+    // rather than the FrameTarget/RuntimeAgent path, which has historical event-ordering
+    // races under SI. The getResponseBody command is issued directly against the
+    // multiplexing (web-page) target's NetworkAgent -- that is where ProxyingNetworkAgent
+    // lives under SI (see MultiplexingBackendTarget / NetworkManager.initializeTarget).
+
+    // Resolve when a resource whose URL contains `urlSubstring` is added to any frame.
+    function waitForResource(urlSubstring) {
+        return new Promise((resolve) => {
+            function onResourceAdded(event) {
+                let resource = event.data.resource;
+                if (!resource || !resource.url || !resource.url.includes(urlSubstring))
+                    return;
+                WI.Frame.removeEventListener(WI.Frame.Event.ResourceWasAdded, onResourceAdded);
+                resolve(resource);
+            }
+            WI.Frame.addEventListener(WI.Frame.Event.ResourceWasAdded, onResourceAdded);
+        });
+    }
+
+    async function waitForFinished(resource) {
+        if (!resource.finished && !resource.failed)
+            await resource.awaitEvent(WI.Resource.Event.LoadingDidFinish);
+    }
+
+    let textResource;
+    let imageResource;
+
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.Network.CrossOriginIFrame.GetResponseBody");
+
+    suite.addTestCase({
+        name: "SiteIsolation.Network.CrossOriginIFrame.GetResponseBody.LoadResources",
+        description: "Load a text resource and a binary image inside a cross-origin iframe and wait for both to finish.",
+        async test() {
+            // Register both waiters before triggering the loads so neither event is missed.
+            let textPromise = waitForResource("echo.py");
+            let imagePromise = waitForResource("white.png");
+
+            InspectorTest.evaluateInPage("addIFrame()");
+
+            textResource = await textPromise;
+            imageResource = await imagePromise;
+
+            InspectorTest.expectThat(textResource instanceof WI.Resource, "Text resource should be created.");
+            InspectorTest.expectThat(imageResource instanceof WI.Resource, "Image resource should be created.");
+
+            await waitForFinished(textResource);
+            await waitForFinished(imageResource);
+
+            InspectorTest.expectThat(textResource.finished, "Text resource should finish loading.");
+            InspectorTest.expectThat(imageResource.finished, "Image resource should finish loading.");
+            InspectorTest.expectThat(!!textResource.requestIdentifier, "Text resource should have a request identifier.");
+            InspectorTest.expectThat(!!imageResource.requestIdentifier, "Image resource should have a request identifier.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.Network.CrossOriginIFrame.GetResponseBody.TextContent",
+        description: "getResponseBody should return the decoded text body for a cross-origin-iframe resource.",
+        async test() {
+            let {body, base64Encoded} = await WI.backendTarget.NetworkAgent.getResponseBody(textResource.requestIdentifier);
+            InspectorTest.expectEqual(base64Encoded, false, "Text response body should not be base64-encoded.");
+            InspectorTest.expectEqual(body, "si-cross-origin-response-body", "Text response body should match the served content.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.Network.CrossOriginIFrame.GetResponseBody.BinaryContent",
+        description: "getResponseBody should return a base64-encoded body for a binary (image) cross-origin-iframe resource.",
+        async test() {
+            let {body, base64Encoded} = await WI.backendTarget.NetworkAgent.getResponseBody(imageResource.requestIdentifier);
+            InspectorTest.expectEqual(base64Encoded, true, "Binary (image) response body should be base64-encoded.");
+            InspectorTest.expectThat(body.length > 0, "Binary response body should not be empty.");
+            InspectorTest.log("Base64-encoded image body length: " + body.length);
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+
+<body onload="runTest()">
+<p>Tests that Network.getResponseBody returns the correct text and base64-encoded bodies for resources loaded in a cross-origin iframe under Site Isolation, routed through ProxyingNetworkAgent and BackendResourceDataStore.</p>
+</body>

--- a/LayoutTests/http/tests/site-isolation/inspector/network/resources/fetch-content-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/network/resources/fetch-content-iframe.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<p>Cross-origin iframe that fetches echo.py with a content string taken from its own URL query, on request.</p>
+
+<script>
+window.addEventListener("message", (event) => {
+    if (event.data && event.data.type === "Fetch")
+        triggerFetch();
+});
+
+function triggerFetch() {
+    let content = new URLSearchParams(location.search).get("content") || "default";
+    // The content string is echoed into the URL so the inspector-side test can pick out
+    // the "before-navigation" vs "after-navigation" fetch by URL substring.
+    fetch("http://localhost:8000/inspector/network/resources/echo.py?mimetype=text/plain&content=" + encodeURIComponent(content));
+}
+</script>

--- a/LayoutTests/http/tests/site-isolation/inspector/network/resources/get-response-body-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/network/resources/get-response-body-iframe.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<p>Cross-origin iframe that loads a text resource (via fetch) and a binary image (via &lt;img&gt;), for Network.getResponseBody testing under Site Isolation.</p>
+
+<script>
+window.addEventListener("message", (event) => {
+    if (event.data.type === "TriggerLoads")
+        triggerLoads();
+    else if (event.data.type === "TerminateProcess")
+        window.internals.terminateWebContentProcess();
+});
+
+function triggerLoads() {
+    // Text resource with deterministic content and an explicit text/plain MIME type.
+    // Same-origin to this iframe (localhost), so no CORS is involved, but a separate
+    // WebContent process from the main frame (127.0.0.1) under Site Isolation.
+    fetch("http://localhost:8000/inspector/network/resources/echo.py?mimetype=text/plain&content=si-cross-origin-response-body");
+
+    // Binary (image) resource -> base64-encoded response body.
+    let img = document.createElement("img");
+    img.src = "http://localhost:8000/inspector/network/resources/white.png?" + Math.random();
+    document.body.appendChild(img);
+}
+</script>

--- a/Source/WebInspectorUI/UserInterface/Controllers/NetworkManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/NetworkManager.js
@@ -275,6 +275,7 @@ WI.NetworkManager = class NetworkManager extends WI.Object
     get mainFrame() { return this._mainFrame; }
     get localResourceOverrides() { return this._localResourceOverrides; }
     get bootstrapScript() { return this._bootstrapScript; }
+    get enabledNetworkForSiteIsolation() { return this._enabledNetworkForSiteIsolation; }
     get enabledPageForSiteIsolation() { return this._enabledPageForSiteIsolation; }
 
     get frames()

--- a/Source/WebInspectorUI/UserInterface/Models/Resource.js
+++ b/Source/WebInspectorUI/UserInterface/Models/Resource.js
@@ -889,8 +889,16 @@ WI.Resource = class Resource extends WI.SourceCode
         } else {
             // If we have the requestIdentifier we can get the actual response for this specific resource.
             // Otherwise the content will be cached resource data, which might not exist anymore.
-            if (this._requestIdentifier)
-                return this._target.NetworkAgent.getResponseBody(this._requestIdentifier);
+            if (this._requestIdentifier) {
+                // Under Site Isolation the backend target's Network agent owns the response data for
+                // cross-process requestIds that the resource's own target can't resolve; route there.
+                // Gated on enabledNetworkForSiteIsolation rather than hasDomain("Network") alone, which
+                // is statically true on the backend target even when no Network agent is enabled on it.
+                let networkTarget = this._target;
+                if (WI.networkManager.enabledNetworkForSiteIsolation && WI.backendTarget && WI.backendTarget !== this._target && WI.backendTarget.hasDomain("Network"))
+                    networkTarget = WI.backendTarget;
+                return networkTarget.NetworkAgent.getResponseBody(this._requestIdentifier);
+            }
 
             // There is no request identifier or frame to request content from.
             if (this._parentFrame) {

--- a/Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.cpp
+++ b/Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.cpp
@@ -42,6 +42,8 @@
 #include <WebCore/HTTPHeaderMap.h>
 #include <WebCore/InspectorIdentifierRegistry.h>
 #include <WebCore/ProcessQualified.h>
+#include <utility>
+#include <wtf/Expected.h>
 
 namespace Inspector {
 
@@ -354,11 +356,18 @@ void ProxyingNetworkAgent::getResponseBody(const Protocol::Network::RequestId& r
 
     targetProcess->sendWithAsyncReply(
         Messages::WebInspectorBackend::GetResponseBody { resourceID },
-        [callback = WTF::move(callback)](String content, bool base64Encoded, String errorString) mutable {
-            if (!errorString.isEmpty())
-                callback->sendFailure(errorString);
-            else
+        [callback = WTF::move(callback)](Expected<std::pair<String, bool>, String>&& result) mutable {
+            if (result) {
+                auto& [content, base64Encoded] = result.value();
                 callback->sendSuccess(content, base64Encoded);
+            } else if (!result.error().isEmpty()) {
+                // A real failure reported by the target WebProcess (e.g. missing or evicted content).
+                callback->sendFailure(result.error());
+            } else {
+                // Empty error: AsyncReplyError synthesized this reply on connection loss (the target
+                // WebProcess is gone). Fail explicitly so a dead process is never surfaced as success.
+                callback->sendFailure("Target WebProcess for requestId is no longer available"_s);
+            }
         },
         *targetPageID);
 }

--- a/Source/WebKit/WebProcess/Inspector/BackendResourceDataStore.cpp
+++ b/Source/WebKit/WebProcess/Inspector/BackendResourceDataStore.cpp
@@ -30,6 +30,7 @@
 #include <WebCore/HTTPHeaderNames.h>
 #include <WebCore/InspectorResourceUtilities.h>
 #include <WebCore/ResourceResponse.h>
+#include <utility>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/Base64.h>
 
@@ -307,14 +308,14 @@ void BackendResourceDataStore::clear()
     m_contentSize = 0;
 }
 
-Expected<std::tuple<String, bool>, String> BackendResourceDataStore::getResponseBody(ResourceLoaderIdentifier resourceID)
+Expected<std::pair<String, bool>, String> BackendResourceDataStore::getResponseBody(ResourceLoaderIdentifier resourceID)
 {
     ResourceData const* resourceData = data(resourceID);
     if (!resourceData)
         return makeUnexpected("Missing resource for given requestId"_s);
 
     if (resourceData->hasContent())
-        return std::tuple<String, bool> { resourceData->content(), resourceData->base64Encoded() };
+        return std::pair<String, bool> { resourceData->content(), resourceData->base64Encoded() };
 
     if (resourceData->isContentEvicted())
         return makeUnexpected("Resource content was evicted from inspector cache"_s);
@@ -322,7 +323,7 @@ Expected<std::tuple<String, bool>, String> BackendResourceDataStore::getResponse
     if (resourceData->buffer() && !resourceData->textEncodingName().isNull()) {
         String body;
         if (ResourceUtilities::sharedBufferContent(resourceData->buffer(), resourceData->textEncodingName(), false, &body))
-            return std::tuple<String, bool> { body, false };
+            return std::pair<String, bool> { body, false };
     }
 
     return makeUnexpected("Missing content of resource for given requestId"_s);

--- a/Source/WebKit/WebProcess/Inspector/BackendResourceDataStore.h
+++ b/Source/WebKit/WebProcess/Inspector/BackendResourceDataStore.h
@@ -30,6 +30,7 @@
 #include <WebCore/ResourceLoaderIdentifier.h>
 #include <WebCore/SharedBuffer.h>
 #include <WebCore/TextResourceDecoder.h>
+#include <utility>
 #include <wtf/CheckedRef.h>
 #include <wtf/Expected.h>
 #include <wtf/ListHashSet.h>
@@ -165,7 +166,7 @@ public:
     // process's buffered response bodies for matches.
     template<typename Visitor> void forEach(NOESCAPE const Visitor&) const;
 
-    Expected<std::tuple<String, bool>, String> getResponseBody(WebCore::ResourceLoaderIdentifier);
+    Expected<std::pair<String, bool>, String> getResponseBody(WebCore::ResourceLoaderIdentifier);
 
 private:
     ResourceData* resourceDataForId(WebCore::ResourceLoaderIdentifier);

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.cpp
@@ -415,15 +415,17 @@ void WebInspectorBackend::removeInstrumentationForFrame(FrameIdentifier frameID)
     m_framePageAgentProxies.remove(frameID);
 }
 
-void WebInspectorBackend::getResponseBody(ResourceLoaderIdentifier resourceID, CompletionHandler<void(String content, bool base64Encoded, String errorString)>&& completionHandler)
+void WebInspectorBackend::getResponseBody(ResourceLoaderIdentifier resourceID, CompletionHandler<void(Expected<std::pair<String, bool>, String>&&)>&& completionHandler)
 {
     CheckedRef resourceDataStore = m_resourceDataStore.get();
     auto result = resourceDataStore->getResponseBody(resourceID);
-    if (result.has_value()) {
-        auto& [content, base64Encoded] = result.value();
-        completionHandler(content, base64Encoded, String());
-    } else
-        completionHandler(String(), false, result.error());
+    // ProxyingNetworkAgent reads an empty error as the AsyncReplyError connection-loss sentinel, so
+    // every genuine failure here must carry a non-empty message.
+    // FIXME: <https://webkit.org/b/320234> The sibling proxying replies (Page.getResourceContent,
+    // Page.searchInResource) still use a bare error-string reply and should adopt this same
+    // Expected-based discriminator.
+    ASSERT(result.has_value() || !result.error().isEmpty());
+    completionHandler(WTF::move(result));
 }
 
 // Convert the JSON protocol matches from ContentSearchUtilities::searchInTextByLines into the plain

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.h
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.h
@@ -32,6 +32,8 @@
 #include <WebCore/HTTPHeaderMap.h>
 #include <WebCore/InspectorBackendClient.h>
 #include <WebCore/ResourceLoaderIdentifier.h>
+#include <utility>
+#include <wtf/Expected.h>
 #include <wtf/HashMap.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/ThreadSafeRefCounted.h>
@@ -99,7 +101,7 @@ public:
 
     void enableNetworkInstrumentation();
     void disableNetworkInstrumentation();
-    void getResponseBody(WebCore::ResourceLoaderIdentifier, CompletionHandler<void(String content, bool base64Encoded, String errorString)>&&);
+    void getResponseBody(WebCore::ResourceLoaderIdentifier, CompletionHandler<void(Expected<std::pair<String, bool>, String>&&)>&&);
 
     void setExtraHTTPHeaders(WebCore::HTTPHeaderMap&&);
     void setResourceCachingDisabled(bool);

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.messages.in
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.messages.in
@@ -66,7 +66,9 @@ messages -> WebInspectorBackend {
     # isn't found. See webkit.org/b/171780776.
     GetFrameResourceContent(WebCore::FrameIdentifier frameID, String url) -> (String content, bool base64Encoded, String errorString) Async
 
-    GetResponseBody(WebCore::ResourceLoaderIdentifier resourceID) -> (String content, bool base64Encoded, String errorString) Async
+    # Reply: value = success; unexpected with a non-empty error = real failure; unexpected with an
+    # empty error = connection loss (AsyncReplyError), which ProxyingNetworkAgent fails explicitly.
+    GetResponseBody(WebCore::ResourceLoaderIdentifier resourceID) -> (Expected<std::pair<String, bool>, String> result) Async
 
     # Page.searchInResource (requestId branch): search one XHR/Fetch body in this process's store.
     SearchInRequest(WebCore::ResourceLoaderIdentifier resourceID, String query, bool caseSensitive, bool isRegex) -> (Vector<Inspector::SearchMatch> matches, String errorString) Async


### PR DESCRIPTION
#### 8e056fb08f560f5480e173eaf332c7ddae1fa5f3
<pre>
[Site Isolation] Web Inspector: finish Network.getResponseBody
<a href="https://bugs.webkit.org/show_bug.cgi?id=318832">https://bugs.webkit.org/show_bug.cgi?id=318832</a>
<a href="https://rdar.apple.com/181048565">rdar://181048565</a>

Reviewed by BJ Burg.

The core getResponseBody routing under Site Isolation (SI) landed earlier
in commit 313753@main (ProxyingNetworkAgent -&gt; WebInspectorBackend -&gt;
BackendResourceDataStore). This finishes the remaining work: adds success-
and error-path test coverage, and fixes two bugs that testing and manual
verification surfaced.

Bug 1 (backend, WebProcess crash): when the WebContent process that served
a resource is gone, IPC synthesizes the async reply from default-constructed
arguments (AsyncReplyError). The old three-value reply
(content, base64Encoded, errorString) then produced an empty errorString,
which a null String reports as isEmpty(), so ProxyingNetworkAgent misread a
dead process as an empty-body success. The reply is now
Expected&lt;std::tuple&lt;String, bool&gt;, String&gt;: a value is success, an unexpected
with a non-empty message is a real backend error, and an unexpected with an
empty message (only produced by AsyncReplyError on connection loss) is
reported as an explicit failure. A process-liveness check inside the reply
handler was rejected because it is racy: on a mid-request crash,
AuxiliaryProcessProxy::shutDownProcess() runs Connection::cancelAsyncReplyHandlers()
before clearing m_connection, so the process still reports state() == Running
when the reply runs. The structural discriminator is timing-independent.

Bug 2 (frontend, target routing): a resource&apos;s target defaults to
WI.mainTarget because the SI proxy sends an empty targetID, and under SI
WI.mainTarget is the page target. But the Network domain
(ProxyingNetworkAgent) lives on the multiplexing backend target, so the
UI content path (Resource.requestContent) issued getResponseBody on the
page target&apos;s legacy NetworkAgent, which does not know the resource&apos;s
cross-process requestId and answers &quot;Missing resource for given
requestId&quot;. Resource.requestContentFromBackend now routes
getResponseBody to the backend target when it has Network enabled. The
gate is WI.networkManager.enabledNetworkForSiteIsolation (set when the
first Frame target appears and Network is enabled on the backend
target), not Target.hasDomain(&quot;Network&quot;): hasDomain is statically true
on the WebPage-type backend target even when no Network agent is enabled
on it. Absent that agent (the single-process case) no Frame target is
created, so the flag stays false and the content path stays on the
resource&apos;s own target. The existing layout tests missed this because
they call WI.backendTarget.NetworkAgent directly; a new test drives the
real requestContent() path.

Scope notes: the requestId routing-trust hardening (a UIProcess-side
requestId -&gt; process map instead of reverse-parsing the frontend string)
remains the existing FIXME in ProxyingNetworkAgent.cpp filed under bug 308890
(the same bug whose BackendResourceDataStore work landed in ccf6c82ad5c8); it
is intentionally left for that FIXME and does not block getResponseBody
working. Main-document content capture for cross-origin iframes is tracked by
bug 312828 (the main resource is classified ResourceType::Other); a parked
test for it is held for that change and is not included here. Memory-cache and
real-eviction layout coverage are descoped: the backend memory-cache path is
code-verified, but a deterministic layout-test trigger is unreliable.

Tests: http/tests/site-isolation/inspector/network/cross-origin-iframe-get-response-body-after-navigation.html
       http/tests/site-isolation/inspector/network/cross-origin-iframe-get-response-body-after-process-crash.html
       http/tests/site-isolation/inspector/network/cross-origin-iframe-get-response-body-error-cases.html
       http/tests/site-isolation/inspector/network/cross-origin-iframe-get-response-body-via-request-content.html
       http/tests/site-isolation/inspector/network/cross-origin-iframe-get-response-body.html

* LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-get-response-body-after-navigation-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-get-response-body-after-navigation.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-get-response-body-after-process-crash-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-get-response-body-after-process-crash.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-get-response-body-error-cases-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-get-response-body-error-cases.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-get-response-body-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-get-response-body-via-request-content-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-get-response-body-via-request-content.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-get-response-body.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/network/resources/fetch-content-iframe.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/network/resources/get-response-body-iframe.html: Added.
* Source/WebInspectorUI/UserInterface/Controllers/NetworkManager.js:
(WI.NetworkManager.prototype.get enabledNetworkForSiteIsolation):
* Source/WebInspectorUI/UserInterface/Models/Resource.js:
(WI.Resource.prototype.requestContentFromBackend):
* Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.cpp:
(Inspector::ProxyingNetworkAgent::getResponseBody):
* Source/WebKit/WebProcess/Inspector/BackendResourceDataStore.cpp:
(WebKit::BackendResourceDataStore::getResponseBody):
* Source/WebKit/WebProcess/Inspector/BackendResourceDataStore.h:
* Source/WebKit/WebProcess/Inspector/WebInspectorBackend.cpp:
(WebKit::WebInspectorBackend::getResponseBody):
* Source/WebKit/WebProcess/Inspector/WebInspectorBackend.h:
* Source/WebKit/WebProcess/Inspector/WebInspectorBackend.messages.in:

Canonical link: <a href="https://commits.webkit.org/317908@main">https://commits.webkit.org/317908@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/93763ce9ddf3f726c61fe0ad53b90ebb325689a7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176691 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50628 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44420 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186293 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/139571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/50a45ba3-ddbc-4127-822e-02fa21d40871) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51921 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50314 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137635 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/139571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c5d63b40-ef6d-4b5e-8b19-c3b32b720418) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179647 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41134 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158421 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118109 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a6201cf6-ebe7-4823-97e0-0e8f908f4d56) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39789 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38160 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150201 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37919 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34761 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/42368 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42376 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188717 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50295 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/157964 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146701 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39454 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50978 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34540 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146506 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41268 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123184 "Found 1 new failure in wasm/WasmConstExprGenerator.cpp") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117314 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49483 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12898 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48882 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49118 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48943 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->