### PR TITLE
[GARDENING][iOS DEBUG] 2x TestWebKitAPI.ContentRuleList.* (api-tests) are flaky timeouts.

### DIFF
--- a/TestExpectations/apitests
+++ b/TestExpectations/apitests
@@ -54,6 +54,10 @@
 
 TestWebKitAPI.WebPageTransferableTests/exportToImage(type:) [ Skip ]
 
+# webkit.org/b/318834 [ iOS DEBUG ] 2x TestWebKitAPI.ContentRuleList.* (api-tests) are flaky timeouts.
+[ iOS Debug ] TestWebKitAPI.ContentRuleList.RequestMethods [ Pass Timeout ]
+[ iOS Debug ] TestWebKitAPI.ContentRuleList.ResourceTypes [ Pass Timeout ]
+
 # webkit.org/b/318739 [iOS DEBUG] 9x TestWebKitAPI.WebKitLegacy.* (api-tests) are constant crashes.
 [ iOS Debug ] TestWebKitAPI.WebKitLegacy.DateInputAccessoryViewTest [ Crash ]
 [ iOS Debug ] TestWebKitAPI.WebKitLegacy.DateTimeLocalInputAccessoryViewTest [ Crash ]


### PR DESCRIPTION
#### a4748223ee49d4cb8de783555f0b48f5d96944c4
<pre>
[GARDENING][iOS DEBUG] 2x TestWebKitAPI.ContentRuleList.* (api-tests) are flaky timeouts.

<a href="https://bugs.webkit.org/show_bug.cgi?id=318834">https://bugs.webkit.org/show_bug.cgi?id=318834</a>
<a href="https://rdar.apple.com/181645582">rdar://181645582</a>

Unreviewed test gardening.

* TestExpectations/apitests:

Canonical link: <a href="https://commits.webkit.org/316727@main">https://commits.webkit.org/316727@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a7033451cf247576a6b86dfc1205a3b1272c688

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173191 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47123 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40622 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182764 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130747 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48416 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46805 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134666 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176149 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38076 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155279 "Found 2 new API test failures: TestWebKitAPI.WKWebExtensionContext.SyntaxErrorInBackground, TestWebKitAPI.WKWebExtensionContext.UncaughtScriptErrorInMainWorldContentScript (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115137 "Found 1 new API test failure: WPE/TestWebKitWebView:/webkit/WebKitWebView/save (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36721 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35067 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31249 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147145 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34778 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185186 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39269 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143509 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46791 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143380 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47470 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/112546 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26308 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38340 "Passed tests") | | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45976 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9721 "Passed tests") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45378 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45609 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45435 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->