### PR TITLE
Small updates to new JavaScript APIs

### DIFF
--- a/Source/WebKit/Modules/Internal/module.modulemap
+++ b/Source/WebKit/Modules/Internal/module.modulemap
@@ -386,6 +386,12 @@ module WebKit_Internal [system] {
         export *
     }
 
+    module WKUserContentControllerInternal {
+        requires cplusplus20,objc
+        header "../../UIProcess/API/Cocoa/WKUserContentControllerInternal.h"
+        export *
+    }
+
     // FIXME: These parts of the module map needs work as discussed in https://github.com/WebKit/WebKit/pull/54322
 
     module WebKit_Internal_Cxx {

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentWorldConfiguration.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentWorldConfiguration.h
@@ -58,10 +58,10 @@ WK_CLASS_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0))
  object for the application to use in future JavaScript programs.
  Refer to the `WKJSSerializedNode` documentation for more information.
  */
-@property (nonatomic) BOOL nodeSerializationEnabled;
+@property (nonatomic, getter=isNodeSerializationEnabled) BOOL nodeSerializationEnabled NS_SWIFT_NAME(nodeSerializationEnabled);
 
 /*! @abstract A boolean indicating whether or not `window.webkit.createJSHandle` is available. */
-@property (nonatomic, setter=setJSHandleCreationEnabled:) BOOL jsHandleCreationEnabled;
+@property (nonatomic, getter=isJSHandleCreationEnabled, setter=setJSHandleCreationEnabled:) BOOL jsHandleCreationEnabled NS_SWIFT_NAME(jsHandleCreationEnabled);
 
 /*! @abstract A boolean indicating whether the JavaScript in this world is visible to the Web Inspector. */
 @property (nonatomic, getter=isInspectable) BOOL inspectable NS_SWIFT_NAME(inspectable);

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentWorldConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentWorldConfiguration.mm
@@ -147,7 +147,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
     _worldConfiguration->setDisableLegacyBuiltinOverrides(!enabled);
 }
 
-- (BOOL)jsHandleCreationEnabled
+- (BOOL)isJSHandleCreationEnabled
 {
     return _worldConfiguration->allowJSHandleCreation();
 }
@@ -167,7 +167,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
     _worldConfiguration->setInspectable(inspectable);
 }
 
-- (BOOL)nodeSerializationEnabled
+- (BOOL)isNodeSerializationEnabled
 {
     return _worldConfiguration->allowNodeSerialization();
 }
@@ -253,7 +253,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (BOOL)allowNodeSerialization
 {
-    return [self nodeSerializationEnabled];
+    return [self isNodeSerializationEnabled];
 }
 
 - (void)setAllowNodeSerialization:(BOOL)allow

--- a/Source/WebKit/UIProcess/API/Cocoa/WKJSHandle.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKJSHandle.h
@@ -49,6 +49,8 @@ NS_ASSUME_NONNULL_BEGIN
  Whatever JavaScript object the `WKJSHandle` represents, it will be protected from garbage collection for the lifetime of the `WKJSHandle`
  The `WKJSHandle` can also be used as an argument to future JavaScript run via `[WKWebView callAsyncJavaScript:...]`
  */
+WK_SWIFT_UI_ACTOR
+NS_SWIFT_SENDABLE
 WK_CLASS_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0))
 @interface WKJSHandle : NSObject<NSCopying>
 
@@ -64,14 +66,14 @@ WK_CLASS_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0))
 /*! @abstract The world in which the `WKJSHandle` can be used.
  @discussion If the `WKJSHandle` is used in another world it will be interpreted as the JavaScript value `undefined`.
  */
-@property (nonatomic, readonly, weak) WKContentWorld *world;
+@property (nonatomic, readonly, weak) WKContentWorld *contentWorld;
 
 /*! @abstract The frame represented by the JavaScript value.
  @discussion If the `WKJSHandle` represents a JavaScript Window proxy object, the result of this method will be a snapshot of the
  frame represented by that Window object.
  Otherwise the result of this method will be `nil`
  */
-- (void)windowProxyFrameInfo:(void (^)(WKFrameInfo * _Nullable))completionHandler;
+- (void)getWindowProxyFrameWithCompletionHandler:(void (^)(WKFrameInfo * _Nullable))completionHandler WK_SWIFT_ASYNC_NAME(getter:windowProxyFrame());
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKJSHandle.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKJSHandle.mm
@@ -52,12 +52,12 @@
     return wrapper(API::FrameInfo::create(WebKit::FrameInfoData { _ref->info().frameInfo })).autorelease();
 }
 
-- (WKContentWorld *)world
+- (WKContentWorld *)contentWorld
 {
     return wrapper(API::ContentWorld::worldForIdentifier(_ref->info().worldIdentifier));
 }
 
-- (void)windowProxyFrameInfo:(void (^)(WKFrameInfo *))completionHandler
+- (void)getWindowProxyFrameWithCompletionHandler:(void (^)(WKFrameInfo *))completionHandler
 {
     RefPtr webFrame = WebKit::WebFrameProxy::webFrame(_ref->info().windowProxyFrameIdentifier);
     if (!webFrame)
@@ -100,9 +100,14 @@
 
 @implementation _WKJSHandle
 
+- (WKContentWorld *)world
+{
+    return [self contentWorld];
+}
+
 - (void)windowFrameInfo:(void (^)(WKFrameInfo * _Nullable))completionHandler
 {
-    [self windowProxyFrameInfo:completionHandler];
+    [self getWindowProxyFrameWithCompletionHandler:completionHandler];
 }
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.h
@@ -149,13 +149,13 @@ WK_CLASS_AVAILABLE(macos(10.10), ios(8.0))
  @param contentWorld The WKContentWorld to add the buffer to.
         The buffer will only be visible to JavaScript executing in that content world.
  */
-- (void)addBuffer:(NSData *)buffer name:(NSString *)name contentWorld:(WKContentWorld *)world WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
+- (void)addBuffer:(NSData *)buffer name:(NSString *)name contentWorld:(WKContentWorld *)world NS_REFINED_FOR_SWIFT WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
 
 /*! @abstract Removes a previously added data buffer from the given `WKContentWorld
  @param name The name of the buffer to remove.
  @param contentWorld The WKContentWorld from which to remove the buffer.
  */
-- (void)removeBufferWithName:(NSString *)name contentWorld:(WKContentWorld *)world WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
+- (void)removeBufferWithName:(NSString *)name contentWorld:(WKContentWorld *)world NS_REFINED_FOR_SWIFT WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.mm
@@ -232,7 +232,7 @@ private:
     protect(*_userContentControllerProxy)->removeAllUserMessageHandlers();
 }
 
-- (void)addBuffer:(NSData *)buffer name:(NSString *)name contentWorld:(WKContentWorld *)world
+- (void)_addBuffer:(NSData *)buffer dataSpan:(std::span<const uint8_t>)dataSpan name:(NSString *)name contentWorld:(WKContentWorld *)world
 {
     auto isInReadOnlyRegion = [] (std::span<const uint8_t> span) {
         if (span.empty())
@@ -259,17 +259,34 @@ private:
     };
 
     RefPtr<WebCore::SharedMemory> sharedMemory;
-    auto dataSpan = span(buffer);
     if (isInReadOnlyRegion(dataSpan))
         sharedMemory = WebCore::SharedMemory::wrapMap(dataSpan, WebCore::SharedMemoryProtection::ReadOnly);
-    if (!sharedMemory)
-        sharedMemory = WebCore::SharedMemory::copyBuffer(WebCore::SharedBuffer::create(buffer));
+
+    if (!sharedMemory) {
+        // If we have a Data, wrapping it can possibly give us a memory usage win.
+        // Otherwise, it's fine to fallback to the dataSpan version.
+        if (buffer)
+            sharedMemory = WebCore::SharedMemory::copyBuffer(WebCore::SharedBuffer::create(buffer));
+        else
+            sharedMemory = WebCore::SharedMemory::copyBuffer(WebCore::SharedBuffer::create(dataSpan));
+    }
+
     if (!sharedMemory) {
         ASSERT_NOT_REACHED();
         return;
     }
 
     protect(*_userContentControllerProxy)->addJSBuffer(sharedMemory.releaseNonNull(), Ref { *world->_contentWorld }, name);
+}
+
+- (void)addBuffer:(NSData *)buffer name:(NSString *)name contentWorld:(WKContentWorld *)world
+{
+    [self _addBuffer:buffer dataSpan:span(buffer) name:name contentWorld:world];
+}
+
+- (void)_addDataSpan:(std::span<const uint8_t>)dataSpan name:(NSString *)name contentWorld:(WKContentWorld *)world
+{
+    [self _addBuffer:nil dataSpan:dataSpan name:name contentWorld:world];
 }
 
 - (void)removeBufferWithName:(NSString *)name contentWorld:(WKContentWorld *)world

--- a/Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.swift
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.swift
@@ -1,0 +1,63 @@
+// Copyright (C) 2026 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#if compiler(>=6.4)
+
+import Foundation
+import WebKit_Internal
+
+@available(anyAppleOSAndDownlevels 27.0, *)
+@available(watchOS, unavailable)
+@available(tvOS, unavailable)
+extension WKUserContentController {
+    /// Adds a data buffer that will be available to JavaScript through the `window.webkit.buffers` object.
+    ///
+    /// - Parameters:
+    ///   - buffer: The buffer to add.
+    ///   - name: The name of the buffer to be referenced from JavaScript.
+    ///     e.g. with a `name` parameter of `"mybuffer"`, JavaScript can reference the buffer via `window.webkit.buffers.mybuffer`.
+    ///   - contentWorld: The `WKContentWorld` to add the buffer to.
+    ///     The buffer will only be visible to JavaScript executing in that content world.
+    ///
+    public func addBuffer(_ buffer: RawSpan, name: Swift.String, to contentWorld: WKContentWorld) {
+        let typedSpan = Span<UInt8>(viewing: buffer)
+        // This use of unsafe is necessary to wrap the RawSpan for immediate processing by WebKit,
+        // unknowledging that the safety of the RawSpan passed in by the client cannot be guaranteed.
+        // This is fine becuase WebKit is going to immediately make a copy of the passed-in bytes
+        // into a safely managed object.
+        // rdar://181746505
+        unsafe _addDataSpan(.init(typedSpan), name: name, contentWorld: contentWorld)
+    }
+
+    /// Removes a previously added data buffer from the given `WKContentWorld`.
+    ///
+    /// - Parameters:
+    ///   - name: The name of the buffer to remove.
+    ///   - contentWorld: The `WKContentWorld` from which to remove the buffer.
+    ///
+    public func removeBuffer(named name: Swift.String, from contentWorld: WKContentWorld) {
+        __removeBuffer(withName: name, contentWorld: contentWorld)
+    }
+}
+
+#endif // compiler(>=6.4)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKUserContentControllerInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUserContentControllerInternal.h
@@ -27,6 +27,8 @@
 
 #import "WKObject.h"
 #import "WebUserContentControllerProxy.h"
+#import <cstdint>
+#import <span>
 #import <wtf/AlignedStorage.h>
 
 namespace WebKit {
@@ -43,5 +45,6 @@ class WebScriptMessageHandler;
 }
 
 - (void)_addScriptMessageHandler:(WebKit::WebScriptMessageHandler&)scriptMessageHandler;
+- (void)_addDataSpan:(std::span<const uint8_t>)dataSpan name:(NSString *)name contentWorld:(WKContentWorld *)world;
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKJSHandle.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKJSHandle.h
@@ -29,6 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 WK_CLASS_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4))
 @interface _WKJSHandle : WKJSHandle
+@property (nonatomic, readonly, weak) WKContentWorld *world;
 - (void)windowFrameInfo:(void (^)(WKFrameInfo * _Nullable))completionHandler;
 @end
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -645,6 +645,7 @@
 		1CF0C94E2AC380C400EC82F2 /* WebExtensionAction.h in Headers */ = {isa = PBXBuildFile; fileRef = 1CF0C94D2AC380C400EC82F2 /* WebExtensionAction.h */; };
 		1CF35F482B3607960079C02C /* WebExtensionCookieParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = 1CF35F472B3607960079C02C /* WebExtensionCookieParameters.h */; };
 		1CF7FFA62AA7AD66003609F0 /* WebExtensionTabQueryParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = 1CF7FFA52AA7AD66003609F0 /* WebExtensionTabQueryParameters.h */; };
+		1D3F2E8A99B47C6E5F7A2D11 /* PreconnectRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 1D3F2E8A99B47C6E5F7A2D12 /* PreconnectRequest.h */; };
 		1DB01943211CF002009FB3E8 /* WKShareSheet.h in Headers */ = {isa = PBXBuildFile; fileRef = 1DE0D095211CC21300439B5F /* WKShareSheet.h */; };
 		1DB01944211CF005009FB3E8 /* WKShareSheet.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1DBBB061211CC3CB00502ECC /* WKShareSheet.mm */; };
 		1F335BC0185B84F0001A201A /* WKWebProcessPlugInLoadDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F335BBF185B84D8001A201A /* WKWebProcessPlugInLoadDelegate.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -668,6 +669,7 @@
 		26F9A83B18A3468100AEB88A /* WKWebViewPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 26F9A83A18A3463F00AEB88A /* WKWebViewPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2749F6442146561B008380BF /* InjectedBundleNodeHandle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC4BEEAA120A0A5F00FBA0C7 /* InjectedBundleNodeHandle.cpp */; };
 		2749F6452146561E008380BF /* InjectedBundleRangeHandle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC33E0D012408E8600360F3F /* InjectedBundleRangeHandle.cpp */; };
+		2790DB2B37644A61AA0AD21E /* BidiDigitalCredentialsAgent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 277A87492B55413CB027FECA /* BidiDigitalCredentialsAgent.cpp */; };
 		2794980522E80B7D0082E68C /* WKPageStateClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 2794980022E800BF0082E68C /* WKPageStateClient.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		27A2BDFC28932C4200758E99 /* WKFeature.h in Headers */ = {isa = PBXBuildFile; fileRef = 27A2BDFA28932C4200758E99 /* WKFeature.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		290F4272172A0C7400939FF0 /* AuxiliaryProcessSupplement.h in Headers */ = {isa = PBXBuildFile; fileRef = 290F4271172A0C7400939FF0 /* AuxiliaryProcessSupplement.h */; };
@@ -1281,6 +1283,7 @@
 		518198902B7585EB0084E292 /* CoreIPCDateComponents.h in Headers */ = {isa = PBXBuildFile; fileRef = 5181988E2B7585E30084E292 /* CoreIPCDateComponents.h */; };
 		518198912B7585F80084E292 /* CoreIPCDateComponents.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5181988F2B7585E30084E292 /* CoreIPCDateComponents.mm */; };
 		5183722223CE97410003CF83 /* APIContentWorld.h in Headers */ = {isa = PBXBuildFile; fileRef = 5183722023CE973A0003CF83 /* APIContentWorld.h */; };
+		5185FA5E2FFDF84500C98F45 /* WKUserContentController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5185FA5D2FFDF84500C98F45 /* WKUserContentController.swift */; };
 		51871B5C127CB89D00F76232 /* WebContextMenu.h in Headers */ = {isa = PBXBuildFile; fileRef = 51871B5A127CB89D00F76232 /* WebContextMenu.h */; };
 		5187BDEA2AFF5419008A6EE5 /* CoreIPCArray.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5187BDE82AFF4A3A008A6EE5 /* CoreIPCArray.mm */; };
 		5187BDEE2B005E16008A6EE5 /* CoreIPCDictionary.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5187BDED2B005DEE008A6EE5 /* CoreIPCDictionary.mm */; };
@@ -1515,7 +1518,6 @@
 		5C1426ED1C23F80900D41183 /* NetworkProcessCreationParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C1426E31C23F80500D41183 /* NetworkProcessCreationParameters.h */; };
 		5C1426EE1C23F80900D41183 /* NetworkProcessSupplement.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C1426E41C23F80500D41183 /* NetworkProcessSupplement.h */; };
 		5C1426F01C23F80900D41183 /* NetworkResourceLoadParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C1426E61C23F80500D41183 /* NetworkResourceLoadParameters.h */; };
-		1D3F2E8A99B47C6E5F7A2D11 /* PreconnectRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 1D3F2E8A99B47C6E5F7A2D12 /* PreconnectRequest.h */; };
 		5C1427021C23F84C00D41183 /* Download.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C1426F41C23F84300D41183 /* Download.h */; };
 		5C1427051C23F84C00D41183 /* DownloadID.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C1426F71C23F84300D41183 /* DownloadID.h */; };
 		5C1427071C23F84C00D41183 /* DownloadManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C1426F91C23F84300D41183 /* DownloadManager.h */; };
@@ -1940,6 +1942,7 @@
 		9955A6F51C7986E000EB6A93 /* AutomationBackendDispatchers.h in Headers */ = {isa = PBXBuildFile; fileRef = 9955A6F11C79866400EB6A93 /* AutomationBackendDispatchers.h */; };
 		9955A6F61C7986E300EB6A93 /* AutomationProtocolObjects.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9955A6F21C79866400EB6A93 /* AutomationProtocolObjects.cpp */; };
 		9955A6F71C7986E500EB6A93 /* AutomationProtocolObjects.h in Headers */ = {isa = PBXBuildFile; fileRef = 9955A6F31C79866400EB6A93 /* AutomationProtocolObjects.h */; };
+		99657F74FE484682A7055097 /* BidiDigitalCredentialsAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = BA0937229E9E469B9278ED67 /* BidiDigitalCredentialsAgent.h */; };
 		996B2B9925E2448200719379 /* WebInspectorUIExtensionControllerProxyMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 996B2B9625E2448200719379 /* WebInspectorUIExtensionControllerProxyMessages.h */; };
 		996B2B9D25E257FF00719379 /* InspectorExtensionDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 996B2B9C25E257EE00719379 /* InspectorExtensionDelegate.h */; };
 		996B2BA125E2591100719379 /* _WKInspectorExtensionDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 996B2BA025E2591100719379 /* _WKInspectorExtensionDelegate.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1947,8 +1950,6 @@
 		9979659E25310A4900B31AE3 /* WebInspectorUIExtensionControllerMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 9979659A25310A4800B31AE3 /* WebInspectorUIExtensionControllerMessages.h */; };
 		997965A3253128C700B31AE3 /* _WKInspectorExtensionHost.h in Headers */ = {isa = PBXBuildFile; fileRef = 997965A2253128C700B31AE3 /* _WKInspectorExtensionHost.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		9979CA58237F49F10039EC05 /* _WKInspectorPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 9979CA57237F49F00039EC05 /* _WKInspectorPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		99657F74FE484682A7055097 /* BidiDigitalCredentialsAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = BA0937229E9E469B9278ED67 /* BidiDigitalCredentialsAgent.h */; };
-		2790DB2B37644A61AA0AD21E /* BidiDigitalCredentialsAgent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 277A87492B55413CB027FECA /* BidiDigitalCredentialsAgent.cpp */; };
 		997EB9DA2E5544FC002CFED7 /* BidiPermissionsAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = 997EB9D82E5544FC002CFED7 /* BidiPermissionsAgent.h */; };
 		997EB9DB2E5544FC002CFED7 /* BidiPermissionsAgent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 997EB9D92E5544FC002CFED7 /* BidiPermissionsAgent.cpp */; };
 		99996A9F25004BCC004F7559 /* _WKInspectorPrivateForTesting.h in Headers */ = {isa = PBXBuildFile; fileRef = 99996A9D25004BCB004F7559 /* _WKInspectorPrivateForTesting.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -4794,6 +4795,8 @@
 		1D32F89D23A84C5B00B1EA6A /* RemoteMediaResourceProxy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteMediaResourceProxy.cpp; sourceTree = "<group>"; };
 		1D3AB04D23AB0072005C1FF0 /* RemoteMediaResourceLoader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteMediaResourceLoader.h; sourceTree = "<group>"; };
 		1D3AB04E23AB009B005C1FF0 /* RemoteMediaResourceLoader.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteMediaResourceLoader.cpp; sourceTree = "<group>"; };
+		1D3F2E8A99B47C6E5F7A2D12 /* PreconnectRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PreconnectRequest.h; sourceTree = "<group>"; };
+		1D3F2E8A99B47C6E5F7A2D13 /* PreconnectRequest.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = PreconnectRequest.serialization.in; sourceTree = "<group>"; };
 		1D47657825CB3AF6007AF312 /* RemoteImageDecoderAVF.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteImageDecoderAVF.h; sourceTree = "<group>"; };
 		1D47657925CB3AF6007AF312 /* RemoteImageDecoderAVF.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteImageDecoderAVF.cpp; sourceTree = "<group>"; };
 		1D47658425CCA416007AF312 /* RemoteImageDecoderAVFProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteImageDecoderAVFProxy.h; sourceTree = "<group>"; };
@@ -4851,6 +4854,7 @@
 		26F10BE619187E2E001D0E68 /* WKSyntheticTapGestureRecognizer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKSyntheticTapGestureRecognizer.h; sourceTree = "<group>"; };
 		26F10BE719187E2E001D0E68 /* WKSyntheticTapGestureRecognizer.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKSyntheticTapGestureRecognizer.mm; sourceTree = "<group>"; };
 		26F9A83A18A3463F00AEB88A /* WKWebViewPrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKWebViewPrivate.h; sourceTree = "<group>"; };
+		277A87492B55413CB027FECA /* BidiDigitalCredentialsAgent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = BidiDigitalCredentialsAgent.cpp; sourceTree = "<group>"; };
 		2794980022E800BF0082E68C /* WKPageStateClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKPageStateClient.h; sourceTree = "<group>"; };
 		27A2BDF928932C4100758E99 /* WKFeature.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WKFeature.cpp; sourceTree = "<group>"; };
 		27A2BDFA28932C4200758E99 /* WKFeature.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKFeature.h; sourceTree = "<group>"; };
@@ -6136,6 +6140,7 @@
 		5183722023CE973A0003CF83 /* APIContentWorld.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APIContentWorld.h; sourceTree = "<group>"; };
 		5183722123CE973A0003CF83 /* APIContentWorld.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = APIContentWorld.cpp; sourceTree = "<group>"; };
 		518405282A9E861F00630A12 /* com.apple.webkit.webpushd.relocatable.mac.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = com.apple.webkit.webpushd.relocatable.mac.plist; sourceTree = "<group>"; };
+		5185FA5D2FFDF84500C98F45 /* WKUserContentController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKUserContentController.swift; sourceTree = "<group>"; };
 		51867B652E74623700F956CB /* RemoteAudioVideoRendererProxyManager.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = RemoteAudioVideoRendererProxyManager.messages.in; sourceTree = "<group>"; };
 		51867B692E759FE600F956CB /* RemoteAudioVideoRendererIdentifier.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteAudioVideoRendererIdentifier.h; sourceTree = "<group>"; };
 		51871B59127CB89D00F76232 /* WebContextMenu.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebContextMenu.cpp; sourceTree = "<group>"; };
@@ -6886,6 +6891,8 @@
 		5CFECB031E1ED1C800F88504 /* LegacyCustomProtocolManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LegacyCustomProtocolManager.cpp; sourceTree = "<group>"; };
 		5CFFD8472DEF511B00C421F5 /* SwiftDemoLogo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDemoLogo.swift; sourceTree = "<group>"; };
 		5DAD73F1116FF90C00EE5396 /* BaseTarget.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = BaseTarget.xcconfig; sourceTree = "<group>"; };
+		5E55104100000000000A0001 /* SessionHistoryTraversalQueue.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = SessionHistoryTraversalQueue.cpp; sourceTree = "<group>"; };
+		5E55104100000000000A0002 /* SessionHistoryTraversalQueue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SessionHistoryTraversalQueue.h; sourceTree = "<group>"; };
 		5EB592AB2DC2049A0058664B /* BidiStorage.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = BidiStorage.json; sourceTree = "<group>"; };
 		5EEC724B2DC1B30700D012DD /* BidiStorageAgent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = BidiStorageAgent.cpp; sourceTree = "<group>"; };
 		5EEC724D2DC1B31300D012DD /* BidiStorageAgent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BidiStorageAgent.h; sourceTree = "<group>"; };
@@ -7304,8 +7311,6 @@
 		8623B1282ACE1DE4002BA9EA /* ResourceLoadInfo.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = ResourceLoadInfo.serialization.in; sourceTree = "<group>"; };
 		862C44DE2E856922000DB57E /* WebCoreFont.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebCoreFont.serialization.in; sourceTree = "<group>"; };
 		863551D229647AB400C2BE98 /* NetworkResourceLoadParameters.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = NetworkResourceLoadParameters.serialization.in; sourceTree = "<group>"; };
-		1D3F2E8A99B47C6E5F7A2D12 /* PreconnectRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PreconnectRequest.h; sourceTree = "<group>"; };
-		1D3F2E8A99B47C6E5F7A2D13 /* PreconnectRequest.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = PreconnectRequest.serialization.in; sourceTree = "<group>"; };
 		8644890A27B47020007A1C66 /* _WKSystemPreferences.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKSystemPreferences.h; sourceTree = "<group>"; };
 		8644890C27B47045007A1C66 /* _WKSystemPreferences.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKSystemPreferences.mm; sourceTree = "<group>"; };
 		8644890E27B5CB43007A1C66 /* _WKSystemPreferencesInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKSystemPreferencesInternal.h; sourceTree = "<group>"; };
@@ -7622,8 +7627,6 @@
 		9979659B25310A4800B31AE3 /* WebInspectorUIExtensionControllerMessageReceiver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebInspectorUIExtensionControllerMessageReceiver.cpp; sourceTree = "<group>"; };
 		997965A2253128C700B31AE3 /* _WKInspectorExtensionHost.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKInspectorExtensionHost.h; sourceTree = "<group>"; };
 		9979CA57237F49F00039EC05 /* _WKInspectorPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKInspectorPrivate.h; sourceTree = "<group>"; };
-		BA0937229E9E469B9278ED67 /* BidiDigitalCredentialsAgent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BidiDigitalCredentialsAgent.h; sourceTree = "<group>"; };
-		277A87492B55413CB027FECA /* BidiDigitalCredentialsAgent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = BidiDigitalCredentialsAgent.cpp; sourceTree = "<group>"; };
 		997EB9D82E5544FC002CFED7 /* BidiPermissionsAgent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BidiPermissionsAgent.h; sourceTree = "<group>"; };
 		997EB9D92E5544FC002CFED7 /* BidiPermissionsAgent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = BidiPermissionsAgent.cpp; sourceTree = "<group>"; };
 		997EB9DC2E554524002CFED7 /* BidiPermissions.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = BidiPermissions.json; sourceTree = "<group>"; };
@@ -7947,6 +7950,7 @@
 		B6F6CA162AA91EC200DC14B5 /* WebExtensionAPIScriptingCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionAPIScriptingCocoa.mm; sourceTree = "<group>"; };
 		B878B613133428DC006888E9 /* CorrectionPanel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CorrectionPanel.h; sourceTree = "<group>"; };
 		B878B614133428DC006888E9 /* CorrectionPanel.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CorrectionPanel.mm; sourceTree = "<group>"; };
+		BA0937229E9E469B9278ED67 /* BidiDigitalCredentialsAgent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BidiDigitalCredentialsAgent.h; sourceTree = "<group>"; };
 		BC017CFF16260FF4007054F5 /* WKDOMDocument.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKDOMDocument.h; sourceTree = "<group>"; };
 		BC017D0016260FF4007054F5 /* WKDOMDocument.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKDOMDocument.mm; sourceTree = "<group>"; };
 		BC017D0116260FF4007054F5 /* WKDOMElement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKDOMElement.h; sourceTree = "<group>"; };
@@ -13134,6 +13138,7 @@
 				5C62FDF81EFC263C00CE072E /* WKURLSchemeTaskPrivate.h */,
 				1AFA3AC718E61C61003CCBAE /* WKUserContentController.h */,
 				1AFA3AC618E61C61003CCBAE /* WKUserContentController.mm */,
+				5185FA5D2FFDF84500C98F45 /* WKUserContentController.swift */,
 				1AAF08A3192682DA00B6390C /* WKUserContentControllerInternal.h */,
 				7C89D2B51A6B0DD9003A5FDE /* WKUserContentControllerPrivate.h */,
 				1AAF089919267EE500B6390C /* WKUserScript.h */,
@@ -22505,6 +22510,7 @@
 				076897F02D07B330006F9FA7 /* WKUIDelegateAdapter.swift in Sources */,
 				079A4DB02D73EA4A00CA387F /* WKURLSchemeHandlerAdapter.swift in Sources */,
 				8BFE6BF82F3C2F1300E82291 /* WKUSDStageConverter.swift in Sources */,
+				5185FA5E2FFDF84500C98F45 /* WKUserContentController.swift in Sources */,
 				079A4DA52D72CE3F00CA387F /* WKWebpagePreferences+Extras.swift in Sources */,
 				07642AEF2DEABBA100561888 /* WKWebsiteDataStore+SwiftOverlay.swift in Sources */,
 				2A5CE0E92FDC931D00BA4244 /* WKWebView+RefreshControl.swift in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/JSHandle.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/JSHandle.mm
@@ -46,7 +46,7 @@ static WKFrameInfo *getWindowFrameInfo(RetainPtr<WKJSHandle> node)
     EXPECT_TRUE([node isKindOfClass:WKJSHandle.class]);
     __block RetainPtr<WKFrameInfo> frame;
     __block bool done { false };
-    [node windowProxyFrameInfo:^(WKFrameInfo *info) {
+    [node getWindowProxyFrameWithCompletionHandler:^(WKFrameInfo *info) {
         frame = info;
         done = true;
     }];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewSwiftOverlayTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewSwiftOverlayTests.swift
@@ -41,4 +41,55 @@ struct WKWebViewSwiftOverlayTests {
         let response: Any? = try await webView.evaluateJavaScript("console.log('hello')")
         #expect(response == nil)
     }
+
+#if os(macOS) || os(iOS) || os(visionOS)
+#if compiler(>=6.4)
+    @Test
+    func wkUserContentControllerRefinements() async throws {
+        let controller = WKUserContentController()
+        let testData: [UInt8] = [0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x1A, 0x00, 0x00]
+        controller.addBuffer(testData.span, name: "Test", to: WKContentWorld.defaultClient)
+        controller.removeBuffer(named:"Test", from: WKContentWorld.defaultClient)
+    }
+#endif // #if compiler(>=6.4)
+
+    @Test
+    func wkJSHandleRefinements() async throws {
+        let webView = WKWebView()
+        let configuration = WKContentWorld.Configuration()
+        configuration.nodeSerializationEnabled = true
+        configuration.jsHandleCreationEnabled = true
+        let contentWorld = WKContentWorld.init(configuration:configuration)
+
+        // Make a JSHandle to the window object, which also lets us exercise the windowProxyFrame property
+        let jsHandle = try await webView.callAsyncJavaScript(
+            "return webkit.createJSHandle(window)",
+            arguments: [:],
+            in: nil,
+            contentWorld: contentWorld
+        ) as? WKJSHandle
+        #expect(jsHandle != nil)
+
+        let frame = await jsHandle?.windowProxyFrame
+        #expect(frame != nil)
+
+        // Make a DOM node and add some standard custom properties to it.
+        let node = try await webView.callAsyncJavaScript(
+            "let node = document.createElement('div'); node.setAttribute('data-foo', '42'); return webkit.serializeNode(node)",
+            arguments: [:],
+            in: nil,
+            contentWorld: contentWorld
+        ) as? WKJSSerializedNode
+        #expect(node != nil)
+
+        // That serialized node should round trip back into JS.
+        let result = try await webView.callAsyncJavaScript(
+            "return parseInt(theNode.getAttribute('data-foo'))",
+            arguments: ["theNode": node!],
+            in: nil,
+            contentWorld: contentWorld
+        ) as! Int
+        #expect(result == 42)
+    }
+#endif // #if os(macOS) || os(iOS) || os(visionOS)
 }


### PR DESCRIPTION
#### c31a1d0a8671eff3023cf2610b3599b59117e286
<pre>
Small updates to new JavaScript APIs
<a href="https://rdar.apple.com/181659133">rdar://181659133</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=318839">https://bugs.webkit.org/show_bug.cgi?id=318839</a>

Reviewed by Richard Robinson.

Feedback-based tweaks to these APIs to make them better for the platforms going forward.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/JSHandle.mm

* Source/WebKit/Modules/Internal/module.modulemap:
* Source/WebKit/UIProcess/API/Cocoa/WKContentWorldConfiguration.h:
* Source/WebKit/UIProcess/API/Cocoa/WKContentWorldConfiguration.mm:
(-[WKContentWorldConfiguration isJSHandleCreationEnabled]):
(-[WKContentWorldConfiguration isNodeSerializationEnabled]):
(-[_WKContentWorldConfiguration allowNodeSerialization]):
(-[WKContentWorldConfiguration jsHandleCreationEnabled]): Deleted.
(-[WKContentWorldConfiguration nodeSerializationEnabled]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKJSHandle.h:
* Source/WebKit/UIProcess/API/Cocoa/WKJSHandle.mm:
(-[WKJSHandle contentWorld]):
(-[WKJSHandle getWindowProxyFrame:]):
(-[_WKJSHandle world]):
(-[_WKJSHandle windowFrameInfo:]):
(-[WKJSHandle world]): Deleted.
(-[WKJSHandle windowProxyFrameInfo:]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.h:
* Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.mm:
(-[WKUserContentController _addBuffer:dataSpan:name:contentWorld:]):
(-[WKUserContentController addBuffer:name:contentWorld:]):
(-[WKUserContentController _addDataSpan:name:contentWorld:]):
* Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.swift: Added.
(WKUserContentController.addBuffer(_:name:to:)):
(WKUserContentController.removeBuffer(named:from:)):
* Source/WebKit/UIProcess/API/Cocoa/WKUserContentControllerInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKJSHandle.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/JSHandle.mm:
(TestWebKitAPI::getWindowFrameInfo):

Canonical link: <a href="https://commits.webkit.org/316796@main">https://commits.webkit.org/316796@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5360bda9eb04c5535284474bfee02dee3f5c06f1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173466 "25 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47398 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/41308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183039 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/131334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7ffbdbda-453b-41c4-aac0-158694572a4c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175331 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48691 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47080 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134882 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/131334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b4081547-dc88-4e39-9e20-a6fc1e80ba5d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176424 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38310 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/155562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115358 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/70c3cbcf-d527-486a-82d0-53fc1bce8d2c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36951 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/35304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31524 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147375 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35057 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185464 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/38335 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/39505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/143750 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47066 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143615 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38755 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47745 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/41308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112863 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38553 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/119497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46251 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10005 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45653 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45884 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45710 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->