### PR TITLE
[JSC] `Array#join` should write rope elements directly into the result buffer

### DIFF
--- a/JSTests/microbenchmarks/join-template-literal-parts.js
+++ b/JSTests/microbenchmarks/join-template-literal-parts.js
@@ -1,0 +1,19 @@
+var keys = ['utm_source', 'utm_medium', 'campaign_id', 'session_token', 'user_locale', 'page_number', 'sort_order', 'filter_state'];
+var vals = [];
+for (var j = 0; j < 16; ++j)
+    vals.push('value_' + (j * 7919) + '_abcdefgh');
+
+function build(i) {
+    var parts = [];
+    for (var j = 0; j < 8; ++j)
+        parts.push(`${keys[j]}=${vals[(i + j) & 15]}`);
+    return parts.join('&');
+}
+noInline(build);
+
+var sum = 0;
+for (var i = 0; i < 200000; ++i)
+    sum += build(i).length;
+
+if (sum !== 52400000)
+    throw new Error("bad sum: " + sum);

--- a/JSTests/stress/array-join-rope-elements.js
+++ b/JSTests/stress/array-join-rope-elements.js
@@ -1,0 +1,49 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}, expected: ${expected}`);
+}
+
+function makeRope(a, b) {
+    return a + b;
+}
+noInline(makeRope);
+
+function test() {
+    // 8-bit ropes with empty, 1-char, and multi-char separators.
+    var arr = [makeRope("foo", "bar"), makeRope("baz", "qux"), "plain"];
+    shouldBe(arr.join(''), "foobarbazquxplain");
+    shouldBe(arr.join('&'), "foobar&bazqux&plain");
+    shouldBe(arr.join('--'), "foobar--bazqux--plain");
+
+    // 16-bit ropes.
+    var arr16 = [makeRope("あい", "うえ"), makeRope("かき", "くけ")];
+    shouldBe(arr16.join(''), "あいうえかきくけ");
+    shouldBe(arr16.join('&'), "あいうえ&かきくけ");
+    shouldBe(arr16.join('ー'), "あいうえーかきくけ");
+
+    // Mixed 8-bit and 16-bit elements.
+    shouldBe([makeRope("abc", "def"), makeRope("あ", "ん")].join('&'), "abcdef&あん");
+
+    // Int32 elements interleaved with ropes.
+    var mixed = [1, makeRope("a", "b"), 42, makeRope("c", "d"), -7];
+    shouldBe(mixed.join(''), "1ab42cd-7");
+    shouldBe(mixed.join('&'), "1&ab&42&cd&-7");
+
+    // Substring ropes.
+    var sub = makeRope("0123456789", "abcdefghij").substring(3, 15);
+    shouldBe([sub, makeRope("X", "Y")].join('&'), "3456789abcde&XY");
+
+    // Deep rope.
+    var deep = "";
+    for (var i = 0; i < 100; ++i)
+        deep = makeRope(deep, "x" + i);
+    shouldBe([deep, deep].join('|'), deep + "|" + deep);
+
+    // Single element and empty strings.
+    shouldBe([makeRope("solo", "!")].join('&'), "solo!");
+    shouldBe(["", makeRope("", ""), ""].join('&'), "&&");
+}
+noInline(test);
+
+for (var i = 0; i < testLoopCount; ++i)
+    test();

--- a/Source/JavaScriptCore/runtime/JSStringJoiner.cpp
+++ b/Source/JavaScriptCore/runtime/JSStringJoiner.cpp
@@ -196,15 +196,19 @@ static inline String joinStrings(JSGlobalObject* globalObject, const WriteBarrie
         return { };
     }
 
+    auto appendString = [&](JSString* string) {
+        unsigned length = string->length();
+        string->resolveToBuffer(data.first(length));
+        data = data.subspan(length);
+    };
+
     switch (separator.size()) {
     case 0: {
         for (unsigned i = 0; i < size; ++i) {
             JSValue value = strings[i].get();
-            if (value.isString()) {
-                auto view = asString(value)->view(globalObject);
-                RETURN_IF_EXCEPTION(scope, String());
-                appendStringToData(data, view);
-            } else {
+            if (value.isString())
+                appendString(asString(value));
+            else {
                 ASSERT(value.isInt32());
                 appendStringToData(data, value.asInt32());
             }
@@ -213,25 +217,20 @@ static inline String joinStrings(JSGlobalObject* globalObject, const WriteBarrie
     }
     default: {
         JSValue value = strings[0].get();
-        if (value.isString()) {
-            auto view = asString(value)->view(globalObject);
-            RETURN_IF_EXCEPTION(scope, String());
-            appendStringToData(data, view);
-        } else {
+        if (value.isString())
+            appendString(asString(value));
+        else {
             ASSERT(value.isInt32());
             appendStringToData(data, value.asInt32());
         }
 
         for (unsigned i = 1; i < size; ++i) {
             JSValue value = strings[i].get();
-            if (value.isString()) {
-                auto view = asString(value)->view(globalObject);
-                RETURN_IF_EXCEPTION(scope, String());
-                appendStringToData(data, separator);
-                appendStringToData(data, view);
-            } else {
+            appendStringToData(data, separator);
+            if (value.isString())
+                appendString(asString(value));
+            else {
                 ASSERT(value.isInt32());
-                appendStringToData(data, separator);
                 appendStringToData(data, value.asInt32());
             }
         }


### PR DESCRIPTION
#### 4e93b58dfd8e91ebdb3159fd872d98382cf8c563
<pre>
[JSC] `Array#join` should write rope elements directly into the result buffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=318840">https://bugs.webkit.org/show_bug.cgi?id=318840</a>

Reviewed by Keith Miller.

Array#join&apos;s fast path resolves each rope element via view(), allocating a
throwaway flat StringImpl per element and copying the characters twice.
This patch makes the write loop use JSString::resolveToBuffer instead, which
walks rope fibers and writes into the preallocated result buffer without
allocating. Since resolveToBuffer cannot throw, the per-element exception
checks are also gone.

                                      baseline                  patched

join-template-literal-parts       64.6259+-0.7114     ^     41.6549+-0.8681        ^ definitely 1.5515x faster

Tests: JSTests/microbenchmarks/join-template-literal-parts.js
       JSTests/stress/array-join-rope-elements.js

* JSTests/microbenchmarks/join-template-literal-parts.js: Added.
(build):
* JSTests/stress/array-join-rope-elements.js: Added.
(shouldBe):
(test):
* Source/JavaScriptCore/runtime/JSStringJoiner.cpp:
(JSC::joinStrings):

Canonical link: <a href="https://commits.webkit.org/316791@main">https://commits.webkit.org/316791@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b3bcc003cf75dd44e7c1fe353bb402e8db7ace0c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173455 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47387 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/41326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183028 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/131323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48680 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47069 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134871 "3 flakes 2 failures") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/131323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176413 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/38299 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155543 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115347 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/36940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/35293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31513 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/4055 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/147364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/35038 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185453 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/34717 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/38324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/39494 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143738 "16 flakes 5 failures") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47055 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/155100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143604 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38750 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47734 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/41326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112846 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38542 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/119486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/210488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46240 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9986 "Passed tests") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/210488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45642 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45873 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45699 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->