### PR TITLE
[list-marker] List Markers are overlapping on each other when position is set to relative

### DIFF
--- a/LayoutTests/fast/lists/outside-marker-with-relpos-block-content-expected.html
+++ b/LayoutTests/fast/lists/outside-marker-with-relpos-block-content-expected.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.list {
+    margin: 0;
+    padding-inline-start: 20px;
+    font: 16px/1.4 monospace;
+}
+
+.itemContent {
+    margin: 0;
+}
+</style>
+</head>
+<body>
+<ol class="list">
+    <li class="item"><p class="itemContent">Item A</p></li>
+    <li class="item"><p class="itemContent">Item B</p></li>
+    <li class="item"><p class="itemContent">Item C</p></li>
+</ol>
+</body>
+</html>

--- a/LayoutTests/fast/lists/outside-marker-with-relpos-block-content.html
+++ b/LayoutTests/fast/lists/outside-marker-with-relpos-block-content.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="match" href="outside-marker-with-relpos-block-content-expected.html">
+<meta name="assert" content="Outside list markers must not overlap when the list and its block-level item content are relatively positioned.">
+<style>
+.list {
+    position: relative;
+    margin: 0;
+    padding-inline-start: 20px;
+    font: 16px/1.4 monospace;
+}
+
+.itemContent {
+    position: relative;
+    margin: 0;
+}
+</style>
+</head>
+<body>
+<ol class="list">
+    <li class="item"><p class="itemContent">Item A</p></li>
+    <li class="item"><p class="itemContent">Item B</p></li>
+    <li class="item"><p class="itemContent">Item C</p></li>
+</ol>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderListItem.cpp
+++ b/Source/WebCore/rendering/RenderListItem.cpp
@@ -95,14 +95,16 @@ bool isHTMLListElement(const Node& node)
 
 static LayoutPoint NODELETE paintOffsetForMarkerFromAssociatedListItem(const RenderListMarker& marker, const RenderListItem& listItem, const LayoutPoint& listItemPaintOffset)
 {
-    auto markerParentPaintOffset = listItemPaintOffset;
+    // listItemPaintOffset is the list item's containing block origin, so add the list item's own
+    // location() to reach its border box, mirroring RenderBlock::paint (auto adjustedPaintOffset = paintOffset + location();).
+    auto adjustedPaintOffset = listItemPaintOffset + listItem.location();
     for (auto* ancestor = marker.parent(); ancestor && ancestor != &listItem; ancestor = ancestor->parent()) {
         auto* box = dynamicDowncast<RenderBox>(*ancestor);
         if (!box)
             break;
-        markerParentPaintOffset.moveBy(box->location());
+        adjustedPaintOffset.moveBy(box->location());
     }
-    return markerParentPaintOffset;
+    return adjustedPaintOffset;
 }
 
 // Returns the enclosing list with respect to the DOM order.


### PR DESCRIPTION
#### 6e1a06c27ccbef3b349be00ed26abc9b8187a840
<pre>
[list-marker] List Markers are overlapping on each other when position is set to relative
<a href="https://bugs.webkit.org/show_bug.cgi?id=318844">https://bugs.webkit.org/show_bug.cgi?id=318844</a>
&lt;<a href="https://rdar.apple.com/181615895">rdar://181615895</a>&gt;

Reviewed by NOBODY (OOPS!).

This fixes a bug when painting outside list markers with a different layer than its
associated RenderListItem would overlap each other. The list marker paint offset did not
account for the list item&apos;s location() within its containing block, causing markers to
collapse onto the same point.

This PR updates the RenderlistItem to handle this offset the same way RenderBlock::paint()
does, by applying &quot;adjustedPaintOffset = paintOffset + location();&quot;

* LayoutTests/fast/lists/outside-marker-with-relpos-block-content-expected.html: Added.
* LayoutTests/fast/lists/outside-marker-with-relpos-block-content.html: Added.
* Source/WebCore/rendering/RenderListItem.cpp:
(WebCore::paintOffsetForMarkerFromAssociatedListItem):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e1a06c27ccbef3b349be00ed26abc9b8187a840

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173225 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47157 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/41318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182798 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130781 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/12842e89-85ae-49b0-b902-6b9cad1a962a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175090 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48450 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46839 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134692 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-011.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95100 "2 flakes 26 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0ac2b71e-4289-492b-9017-b26a144777fc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176183 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38108 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155551 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115163 "Found 1 new API test failure: WPE/TestWebKitWebView:/webkit/WebKitWebView/save (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f88be6d0-53a7-4218-b862-52c4f2bf1444) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36753 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-011.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35093 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31283 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147177 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35046 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-011.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185220 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38050 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39295 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-011.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143536 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46825 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155108 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143407 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47504 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31652 "Unable to confirm if test failures are introduced by change, retrying build") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112590 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38367 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119253 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46010 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9994 "Passed tests") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45412 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45643 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45469 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->