### PR TITLE
[JSC] Use a polymorphic cache for microtask calls

### DIFF
--- a/JSTests/microbenchmarks/await-async-function-call-chain.js
+++ b/JSTests/microbenchmarks/await-async-function-call-chain.js
@@ -1,0 +1,18 @@
+// Awaiting a chain of distinct async functions makes each microtask resume a
+// different function, stressing the microtask call cache in the drain loop.
+
+async function d5() { return 42; }
+async function d4() { return await d5(); }
+async function d3() { return await d4(); }
+async function d2() { return await d3(); }
+async function d1() { return await d2(); }
+
+async function run() {
+    let acc = 0;
+    for (let i = 0; i < 1e5; i++)
+        acc += await d1();
+    return acc;
+}
+
+run();
+drainMicrotasks();

--- a/JSTests/microbenchmarks/promise-then-chain-distinct-functions.js
+++ b/JSTests/microbenchmarks/promise-then-chain-distinct-functions.js
@@ -1,0 +1,16 @@
+// A then-chain over distinct handler functions interleaves several functions
+// in the microtask stream, stressing the microtask call cache in the drain loop.
+
+const f1 = (x) => x + 1;
+const f2 = (x) => x + 2;
+const f3 = (x) => x + 3;
+
+async function run() {
+    let acc = 0;
+    for (let i = 0; i < 2e5; i++)
+        acc += await Promise.resolve(i).then(f1).then(f2).then(f3);
+    return acc;
+}
+
+run();
+drainMicrotasks();

--- a/JSTests/stress/microtask-call-cache.js
+++ b/JSTests/stress/microtask-call-cache.js
@@ -1,0 +1,53 @@
+// Exercises the microtask call cache in the drain loop: more distinct callees
+// than cache entries, closures sharing one executable, and a handler whose
+// arity exceeds the fast path limit.
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}, expected ${expected}`);
+}
+
+async function a1() { return 1; }
+async function a2() { return await a1() + 1; }
+async function a3() { return await a2() + 1; }
+async function a4() { return await a3() + 1; }
+async function a5() { return await a4() + 1; }
+async function a6() { return await a5() + 1; }
+async function a7() { return await a6() + 1; }
+async function a8() { return await a7() + 1; }
+async function a9() { return await a8() + 1; }
+async function a10() { return await a9() + 1; }
+async function a11() { return await a10() + 1; }
+async function a12() { return await a11() + 1; }
+
+function makeAdder(n) {
+    return async function adder() { return n + await a1(); };
+}
+const add10 = makeAdder(10);
+const add20 = makeAdder(20);
+const add30 = makeAdder(30);
+
+const wideArity = (a, b, c, d, e, f, g, h) => a + 100;
+
+async function test() {
+    shouldBe(await a12(), 12);
+    shouldBe(await add10(), 11);
+    shouldBe(await add20(), 21);
+    shouldBe(await add30(), 31);
+    shouldBe(await Promise.resolve(1).then(wideArity), 101);
+    shouldBe(await Promise.resolve(2).then(wideArity).then(add10), 11);
+}
+
+async function run() {
+    for (let i = 0; i < testLoopCount; i++)
+        await test();
+}
+
+let finished = false;
+let error;
+run().then(() => { finished = true; }, (e) => { error = e; });
+drainMicrotasks();
+if (error)
+    throw error;
+if (!finished)
+    throw new Error("did not finish");

--- a/Source/JavaScriptCore/interpreter/MicrotaskCall.h
+++ b/Source/JavaScriptCore/interpreter/MicrotaskCall.h
@@ -30,6 +30,7 @@
 #include <JavaScriptCore/FunctionExecutable.h>
 #include <JavaScriptCore/JSFunction.h>
 #include <wtf/ForbidHeapAllocation.h>
+#include <wtf/MathExtras.h>
 
 namespace JSC {
 
@@ -42,7 +43,7 @@ class MicrotaskCall final : public CallLinkInfoBase {
 public:
     static constexpr unsigned maxCallArguments = 6;
 
-    explicit MicrotaskCall(VM&)
+    MicrotaskCall()
         : CallLinkInfoBase(CallSiteType::MicrotaskCall)
     { }
 
@@ -56,19 +57,7 @@ public:
     template<typename... Args> requires (std::is_convertible_v<Args, JSValue> && ...)
     JSValue tryCallWithArguments(VM&, JSFunction*, JSValue thisValue, JSCell* context, Args...);
 
-    ALWAYS_INLINE bool canUseCall(JSValue functionObject) const
-    {
-        if (!m_functionExecutable) [[unlikely]]
-            return false;
-        if (!functionObject.isCell()) [[unlikely]]
-            return false;
-        auto* cell = functionObject.asCell();
-        if (cell->type() != JSFunctionType) [[unlikely]]
-            return false;
-        return m_functionExecutable == uncheckedDowncast<JSFunction>(cell)->executable();
-    }
-
-    bool isInitializedFor(FunctionExecutable* executable) const
+    bool isInitializedFor(ExecutableBase* executable) const
     {
         return m_functionExecutable == executable;
     }
@@ -84,6 +73,42 @@ private:
     void* m_addressForCall { nullptr };
     unsigned m_numParameters { 0 };
     friend class Interpreter;
+};
+
+class MicrotaskCallCache final {
+    WTF_MAKE_NONCOPYABLE(MicrotaskCallCache);
+    WTF_FORBID_HEAP_ALLOCATION;
+public:
+    static constexpr unsigned cacheSize = 8;
+    static_assert(hasOneBitSet(cacheSize));
+
+    MicrotaskCallCache() = default;
+
+    ALWAYS_INLINE MicrotaskCall* find(JSValue functionObject)
+    {
+        if (!functionObject.isCell()) [[unlikely]]
+            return nullptr;
+        auto* cell = functionObject.asCell();
+        if (cell->type() != JSFunctionType) [[unlikely]]
+            return nullptr;
+        auto* executable = uncheckedDowncast<JSFunction>(cell)->executable();
+        for (auto& entry : m_entries) {
+            if (entry.isInitializedFor(executable))
+                return &entry;
+        }
+        return nullptr;
+    }
+
+    ALWAYS_INLINE MicrotaskCall* nextEntryToReplace()
+    {
+        auto* result = &m_entries[m_nextEntryIndex];
+        m_nextEntryIndex = (m_nextEntryIndex + 1) & (cacheSize - 1);
+        return result;
+    }
+
+private:
+    std::array<MicrotaskCall, cacheSize> m_entries { };
+    unsigned m_nextEntryIndex { 0 };
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -345,8 +345,6 @@ namespace JSC {
 
 static StringImpl::StaticStringImpl intlLegacyConstructedSymbolDescription { "IntlLegacyConstructedSymbol" };
 
-MicrotaskQueue& JSGlobalObject::microtaskQueue() const { return m_microtaskQueue.get(); }
-
 #define CHECK_FEATURE_FLAG_TYPE(capitalName, lowerName, properName, instanceType, jsName, prototypeBase, featureFlag) \
 static_assert(std::is_same_v<std::remove_cv_t<decltype(featureFlag)>, bool> || std::is_same_v<std::remove_cv_t<decltype(featureFlag)>, bool&>);
 
@@ -3715,20 +3713,6 @@ static bool incumbentRealmIs(VM& vm, JSGlobalObject* target)
         return IterationStatus::Continue;
     });
     return result;
-}
-
-void JSGlobalObject::queueMicrotask(VM& vm, QueuedTask&& task)
-{
-    if (!m_canFastQueueMicrotask || vm.crossTaskToken()) [[unlikely]] {
-        queueMicrotaskSlow(vm, WTF::move(task));
-        return;
-    }
-    microtaskQueue().enqueue(WTF::move(task));
-}
-
-void JSGlobalObject::queueMicrotask(VM& vm, InternalMicrotask job, uint8_t payload, JSValue argument0, JSValue argument1, JSValue argument2)
-{
-    queueMicrotask(vm, QueuedTask { nullptr, job, payload, this, argument0, argument1, argument2 });
 }
 
 void JSGlobalObject::queueMicrotaskSlow(VM& vm, QueuedTask&& task)

--- a/Source/JavaScriptCore/runtime/JSMicrotask.cpp
+++ b/Source/JavaScriptCore/runtime/JSMicrotask.cpp
@@ -81,7 +81,7 @@ static ALWAYS_INLINE JSCell* NODELETE dynamicCastToCell(JSValue value)
 }
 
 template<typename... Args> requires (std::is_convertible_v<Args, JSValue> && ...)
-static JSValue callMicrotask(JSGlobalObject* globalObject, JSValue functionObject, JSValue thisValue, JSCell* context, ASCIILiteral message, MicrotaskCall* microtaskCall, Args... args)
+static JSValue callMicrotask(JSGlobalObject* globalObject, JSValue functionObject, JSValue thisValue, JSCell* context, ASCIILiteral message, MicrotaskCallCache* microtaskCallCache, Args... args)
 {
     NO_TAIL_CALLS();
 
@@ -89,15 +89,17 @@ static JSValue callMicrotask(JSGlobalObject* globalObject, JSValue functionObjec
     auto scope = DECLARE_THROW_SCOPE(vm);
     static_assert(sizeof...(args) <= MicrotaskCall::maxCallArguments);
 
-    if (microtaskCall && microtaskCall->canUseCall(functionObject)) [[likely]] {
-        if (!vm.isSafeToRecurseSoft()) [[unlikely]]
-            return throwStackOverflowError(globalObject, scope);
-        auto* jsFunction = uncheckedDowncast<JSFunction>(functionObject.asCell());
-        if (auto result = microtaskCall->tryCallWithArguments(vm, jsFunction, thisValue, context, args...)) [[likely]] {
-            scope.release();
-            return result;
+    if (microtaskCallCache) [[likely]] {
+        if (auto* microtaskCall = microtaskCallCache->find(functionObject)) [[likely]] {
+            if (!vm.isSafeToRecurseSoft()) [[unlikely]]
+                return throwStackOverflowError(globalObject, scope);
+            auto* jsFunction = uncheckedDowncast<JSFunction>(functionObject.asCell());
+            if (auto result = microtaskCall->tryCallWithArguments(vm, jsFunction, thisValue, context, args...)) [[likely]] {
+                scope.release();
+                return result;
+            }
+            RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, scope.exception());
         }
-        RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, scope.exception());
     }
 
     auto callData = JSC::getCallDataInline(functionObject);
@@ -135,8 +137,11 @@ static JSValue callMicrotask(JSGlobalObject* globalObject, JSValue functionObjec
             newCodeBlock->m_shouldAlwaysBeInlined = false;
         }
 
-        if (microtaskCall) {
+        if (microtaskCallCache) {
             auto* jsFunction = uncheckedDowncast<JSFunction>(functionObject.asCell());
+            auto* microtaskCall = microtaskCallCache->find(functionObject);
+            if (!microtaskCall)
+                microtaskCall = microtaskCallCache->nextEntryToReplace();
             microtaskCall->initialize(vm, jsFunction);
             RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, scope.exception());
 
@@ -1559,7 +1564,7 @@ static void webAssemblyInstantiateStreaming(JSGlobalObject* globalObject, VM& vm
 }
 #endif
 
-void runInternalMicrotask(JSGlobalObject* globalObject, VM& vm, InternalMicrotask task, uint8_t payload, std::span<const JSValue, maxMicrotaskArguments> arguments, MicrotaskCall* microtaskCall)
+void runInternalMicrotask(JSGlobalObject* globalObject, VM& vm, InternalMicrotask task, uint8_t payload, std::span<const JSValue, maxMicrotaskArguments> arguments, MicrotaskCallCache* microtaskCallCache)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
 
@@ -1664,7 +1669,7 @@ void runInternalMicrotask(JSGlobalObject* globalObject, VM& vm, InternalMicrotas
         JSValue error;
         {
             auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-            result = callMicrotask(globalObject, handler, jsUndefined(), dynamicCastToCell(handler), "handler is not a function"_s, microtaskCall, arguments[2]);
+            result = callMicrotask(globalObject, handler, jsUndefined(), dynamicCastToCell(handler), "handler is not a function"_s, microtaskCallCache, arguments[2]);
             if (catchScope.exception()) {
                 if (promiseOrCapability.isUndefinedOrNull()) {
                     scope.release();
@@ -1717,7 +1722,7 @@ void runInternalMicrotask(JSGlobalObject* globalObject, VM& vm, InternalMicrotas
     case InternalMicrotask::InvokeFunctionJob: {
         JSValue handler = arguments[0];
         scope.release();
-        callMicrotask(globalObject, handler, jsUndefined(), nullptr, "handler is not a function"_s, microtaskCall);
+        callMicrotask(globalObject, handler, jsUndefined(), nullptr, "handler is not a function"_s, microtaskCallCache);
         return;
     }
 
@@ -1750,7 +1755,7 @@ void runInternalMicrotask(JSGlobalObject* globalObject, VM& vm, InternalMicrotas
         JSValue error;
         {
             auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-            value = callMicrotask(generatorGlobalObject, next, thisValue, generator, "handler is not a function"_s, microtaskCall,
+            value = callMicrotask(generatorGlobalObject, next, thisValue, generator, "handler is not a function"_s, microtaskCallCache,
                 generator, jsNumber(state), resolution, jsNumber(static_cast<int32_t>(resumeMode)), frame);
             if (catchScope.exception()) {
                 error = catchScope.exception()->value();

--- a/Source/JavaScriptCore/runtime/JSMicrotask.h
+++ b/Source/JavaScriptCore/runtime/JSMicrotask.h
@@ -31,10 +31,10 @@
 
 namespace JSC {
 
-class MicrotaskCall;
+class MicrotaskCallCache;
 class JSAsyncGenerator;
 
-void runInternalMicrotask(JSGlobalObject*, VM&, InternalMicrotask, uint8_t, std::span<const JSValue, maxMicrotaskArguments>, MicrotaskCall* = nullptr);
+void runInternalMicrotask(JSGlobalObject*, VM&, InternalMicrotask, uint8_t, std::span<const JSValue, maxMicrotaskArguments>, MicrotaskCallCache* = nullptr);
 
 // https://tc39.es/ecma262/#sec-asyncgeneratorresume and #sec-asyncgeneratorawaitreturn — used by the C++
 // %AsyncGeneratorPrototype%.return / .throw host functions to drive a non-busy generator.

--- a/Source/JavaScriptCore/runtime/JSPromise.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromise.cpp
@@ -39,6 +39,7 @@
 #include "JSPromisePrototype.h"
 #include "JSPromiseReaction.h"
 #include "Microtask.h"
+#include "MicrotaskQueueInlines.h"
 #include "ObjectConstructor.h"
 #include "TopExceptionScope.h"
 #include "VMInlines.h"

--- a/Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp
@@ -41,6 +41,7 @@
 #include "JSPromiseCombinatorsGlobalContext.h"
 #include "JSPromisePrototype.h"
 #include "Microtask.h"
+#include "MicrotaskQueueInlines.h"
 #include "ObjectConstructor.h"
 #include "VMInlines.h"
 

--- a/Source/JavaScriptCore/runtime/MicrotaskQueue.cpp
+++ b/Source/JavaScriptCore/runtime/MicrotaskQueue.cpp
@@ -55,9 +55,9 @@ bool QueuedTask::isRunnable() const
     return uncheckedDowncast<JSGlobalObject>(dispatcher())->microtaskRunnability() == QueuedTaskResult::Executed;
 }
 
-static bool runMicrotask(JSGlobalObject* globalObject, TopExceptionScope& catchScope, VM& vm, QueuedTask& task, MicrotaskCall* microtaskCall)
+static bool runMicrotask(JSGlobalObject* globalObject, TopExceptionScope& catchScope, VM& vm, QueuedTask& task, MicrotaskCallCache* microtaskCallCache)
 {
-    runInternalMicrotask(globalObject, vm, task.job(), task.payload(), task.arguments(), microtaskCall);
+    runInternalMicrotask(globalObject, vm, task.job(), task.payload(), task.arguments(), microtaskCallCache);
     if (auto* exception = catchScope.exception()) [[unlikely]] {
         if (!catchScope.clearExceptionExceptTermination()) [[unlikely]]
             return false;
@@ -170,7 +170,7 @@ DEFINE_VISIT_AGGREGATE(MarkedMicrotaskDeque);
 template<bool useCallOnEachMicrotask>
 ALWAYS_INLINE std::pair<JSGlobalObject*, bool> MicrotaskQueue::drainImpl(JSGlobalObject* currentGlobalObject, VM& vm, TopExceptionScope& catchScope)
 {
-    MicrotaskCall microtaskCall(vm);
+    MicrotaskCallCache microtaskCallCache;
 
     while (!m_queue.isEmpty()) {
         auto& front = m_queue.front();
@@ -189,7 +189,7 @@ ALWAYS_INLINE std::pair<JSGlobalObject*, bool> MicrotaskQueue::drainImpl(JSGloba
                 return { globalObject, false };
 
             auto task = m_queue.dequeue();
-            if (!runMicrotask(globalObject, catchScope, vm, task, &microtaskCall)) [[unlikely]] {
+            if (!runMicrotask(globalObject, catchScope, vm, task, &microtaskCallCache)) [[unlikely]] {
                 clear();
                 return { nullptr, true };
             }

--- a/Source/JavaScriptCore/runtime/MicrotaskQueueInlines.h
+++ b/Source/JavaScriptCore/runtime/MicrotaskQueueInlines.h
@@ -27,6 +27,7 @@
 
 #include <JavaScriptCore/Debugger.h>
 #include <JavaScriptCore/JSCellInlines.h>
+#include <JavaScriptCore/JSGlobalObject.h>
 #include <JavaScriptCore/JSMicrotaskDispatcher.h>
 #include <JavaScriptCore/MicrotaskQueue.h>
 #include <JavaScriptCore/TopExceptionScope.h>
@@ -71,6 +72,25 @@ inline void MicrotaskQueue::enqueue(QueuedTask&& task)
     m_queue.enqueue(WTF::move(task));
     if (!m_isScheduledToRun) [[unlikely]]
         scheduleToRunIfNeeded();
+}
+
+inline MicrotaskQueue& JSGlobalObject::microtaskQueue() const
+{
+    return m_microtaskQueue.get();
+}
+
+inline void JSGlobalObject::queueMicrotask(VM& vm, QueuedTask&& task)
+{
+    if (!m_canFastQueueMicrotask || vm.crossTaskToken()) [[unlikely]] {
+        queueMicrotaskSlow(vm, WTF::move(task));
+        return;
+    }
+    SUPPRESS_UNCOUNTED_ARG m_microtaskQueue->enqueue(WTF::move(task));
+}
+
+inline void JSGlobalObject::queueMicrotask(VM& vm, InternalMicrotask job, uint8_t payload, JSValue argument0, JSValue argument1, JSValue argument2)
+{
+    queueMicrotask(vm, QueuedTask { nullptr, job, payload, this, argument0, argument1, argument2 });
 }
 
 template<bool useCallOnEachMicrotask>


### PR DESCRIPTION
#### d11c8c7ba675067079fe261af351c44e5fd3278b
<pre>
[JSC] Use a polymorphic cache for microtask calls
<a href="https://bugs.webkit.org/show_bug.cgi?id=318847">https://bugs.webkit.org/show_bug.cgi?id=318847</a>

Reviewed by Yusuke Suzuki.

The microtask drain loop has a call cache with a single entry. It
remembers the last callee (executable, CodeBlock, and entry address), and
a hit skips getCallData / prepareForExecution / incoming-call relinking.

But one entry misses whenever an async function awaits another async
function: the callee&apos;s completion wakes the caller, so their resumes are
always adjacent in the microtask stream, and the cache never sees the
same callee twice in a row. This is the common shape of async code, and
the miss path took ~14% of drain time in an await-chain profile.

This change widens the cache to 8 entries with round-robin replacement,
so all callees of a typical await/then chain stay cached.

It also inlines JSGlobalObject::queueMicrotask and microtaskQueue(),
which were out-of-line and copied a QueuedTask on every enqueue. This
part alone is worth about 5-8% on promise-heavy microbenchmarks.

                                                Baseline                  Patched

promise-then-chain-distinct-functions       16.9122+-0.1662     ^     10.7162+-0.1512        ^ definitely 1.5782x faster
await-async-function-call-chain             16.0482+-0.1623     ^     12.5936+-0.2134        ^ definitely 1.2743x faster

Tests: JSTests/microbenchmarks/await-async-function-call-chain.js
       JSTests/microbenchmarks/promise-then-chain-distinct-functions.js

* JSTests/microbenchmarks/await-async-function-call-chain.js: Added.
(async d5):
(async d4):
(async d3):
(async d2):
(async d1):
(async run):
* JSTests/microbenchmarks/promise-then-chain-distinct-functions.js: Added.
(async run):
* JSTests/stress/microtask-call-cache.js: Added.
(shouldBe):
(async a1):
(async a2):
(async a3):
(async a4):
(async a5):
(async a6):
(async a7):
(async a8):
(async a9):
(async a10):
(async a11):
(async a12):
(makeAdder.return.async adder):
(makeAdder):
(async test):
(async run):
* Source/JavaScriptCore/interpreter/MicrotaskCall.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::microtaskQueue const): Deleted.
(JSC::JSGlobalObject::queueMicrotask): Deleted.
* Source/JavaScriptCore/runtime/JSMicrotask.cpp:
(JSC::callMicrotask):
(JSC::runInternalMicrotask):
* Source/JavaScriptCore/runtime/JSMicrotask.h:
* Source/JavaScriptCore/runtime/JSPromise.cpp:
* Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp:
* Source/JavaScriptCore/runtime/MicrotaskQueue.cpp:
(JSC::runMicrotask):
(JSC::MicrotaskQueue::drainImpl):
* Source/JavaScriptCore/runtime/MicrotaskQueueInlines.h:
(JSC::JSGlobalObject::microtaskQueue const):
(JSC::JSGlobalObject::queueMicrotask):

Canonical link: <a href="https://commits.webkit.org/316864@main">https://commits.webkit.org/316864@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9bf08a50671940f3b8131162b6e3196a8d5b78f2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173499 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47432 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41258 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183072 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/131367 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48724 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47113 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134911 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/131367 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176457 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38343 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/155767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115388 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36984 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35337 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31557 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/4278 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147408 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35261 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185498 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/34761 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/38528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39537 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143787 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47099 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143645 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38784 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47778 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112927 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38583 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119640 "Found 119 new failures in b3/B3Value.h, b3/testb3_7.cpp, WebProcess/Network/WebResourceLoader.cpp, UIProcess/WebProcessPool.cpp, Shared/Cocoa/WKNSArray.mm, Shared/SessionState.cpp, NetworkProcess/NetworkResourceLoadParameters.cpp, WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm, WebProcess/WebPage/WebPage.cpp, WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm ...") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/210532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46284 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10214 "Passed tests") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/210532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45686 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45917 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45743 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->