### PR TITLE
[GLIB] REGRESSION(316670@main): /webkit/WebKitWebView/save is crashing

### DIFF
--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
@@ -224,8 +224,7 @@ Awaitable<bool> WebFullScreenManagerProxy::enterFullScreen(IPC::Connection& conn
 #endif // ENABLE(QUICKLOOK_FULLSCREEN)
 #endif // PLATFORM(IOS_FAMILY)
 
-    CheckedPtr client = m_client;
-    if (!client)
+    if (!m_client)
         co_return false;
 
     RefPtr page = m_page.get();
@@ -238,6 +237,10 @@ Awaitable<bool> WebFullScreenManagerProxy::enterFullScreen(IPC::Connection& conn
 
     if (auto coordinates = co_await page->convertPointToMainFrameCoordinates({ 0, 0 }, webFrame->rootFrame()->frameID()))
         m_rootFrameOriginInMainFrameCoordinates = IntPoint(*coordinates);
+
+    CheckedPtr client = m_client;
+    if (!client)
+        co_return false;
 
     bool success = co_await AwaitableFromCompletionHandler<bool> { [=] (auto completionHandler) {
         client->enterFullScreen(mediaDetails.mediaDimensions, WTF::move(completionHandler));
@@ -412,8 +415,7 @@ Awaitable<bool> WebFullScreenManagerProxy::beganEnterFullScreen(FrameIdentifier 
     if (!page)
         co_return false;
 
-    CheckedPtr client = m_client;
-    if (!client)
+    if (!m_client)
         co_return false;
 
     auto rectsInScreenCoordinates = convertFromRootViewToScreenCoordinates({ initialFrameInRootViewCoordinates, finalFrameInRootViewCoordinates });
@@ -422,6 +424,10 @@ Awaitable<bool> WebFullScreenManagerProxy::beganEnterFullScreen(FrameIdentifier 
     auto [initialFrameInScreenCoordinates, finalFrameInScreenCoordinates] = *rectsInScreenCoordinates;
 
     co_await page->nextPresentationUpdate();
+
+    CheckedPtr client = m_client;
+    if (!client)
+        co_return false;
 
     bool success = co_await AwaitableFromCompletionHandler<bool> { [=] (auto completionHandler) {
         client->beganEnterFullScreen(initialFrameInScreenCoordinates, finalFrameInScreenCoordinates, WTF::move(completionHandler));


### PR DESCRIPTION
#### 2a23510ee04deec7614748a0da4976f13ef66d5d
<pre>
[GLIB] REGRESSION(<a href="https://commits.webkit.org/316670@main">316670@main</a>): /webkit/WebKitWebView/save is crashing
<a href="https://bugs.webkit.org/show_bug.cgi?id=318848">https://bugs.webkit.org/show_bug.cgi?id=318848</a>

Reviewed by NOBODY (OOPS!).

<a href="https://commits.webkit.org/316670@main">316670@main</a> took a CheckedPtr to m_client before a co_await in enterFullScreen
(convertPointToMainFrameCoordinates) and beganEnterFullScreen
(nextPresentationUpdate) and used it after resuming. WebFullScreenManagerProxyClient
is a non-owning CanMakeCheckedPtr, so carrying a CheckedPtr across a suspension
point is unsafe: when the coroutine is instead resumed during teardown
(WebPageProxy::close() -&gt; WebProcessProxy::shutDown() -&gt; Connection::invalidate()
-&gt; cancelAsyncReplyHandlers()), the client is already gone, and touching the
dangling CheckedPtr reads freed memory, tripping the SingleThreadIntegralWrapper
m_creationThread assertion. Only WPE hit it because it leaves the
DispatchAfterEnsuringDrawing reply outstanding until teardown cancels it.

Probe m_client before the await and fetch the CheckedPtr fresh, with a null
check, after the await and immediately before use, so no CheckedPtr is carried
across those suspension points.

* Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp:
(WebKit::WebFullScreenManagerProxy::enterFullScreen):
(WebKit::WebFullScreenManagerProxy::beganEnterFullScreen):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a23510ee04deec7614748a0da4976f13ef66d5d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173245 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47177 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/41281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182818 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130801 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48470 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46859 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134711 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95116 "2 flakes 23 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176203 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38127 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155592 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115181 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36772 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35115 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31303 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147196 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35087 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185240 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38078 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39315 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143554 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46845 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143425 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47524 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31688 "Unable to confirm if test failures are introduced by change, retrying build") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112616 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38385 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119273 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46030 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10036 "Passed tests") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45432 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45663 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45489 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->