### PR TITLE
Null-deref of documentElement() when resolving root-font-relative SVG lengths

### DIFF
--- a/Source/WebCore/svg/SVGLengthContext.cpp
+++ b/Source/WebCore/svg/SVGLengthContext.cpp
@@ -226,8 +226,9 @@ float SVGLengthContext::removeZoomFromFontOrRootFontRelativeLength(float value, 
     if (CSS::isFontRelativeLength(unit))
         usedZoom = svgElement->renderer()->style().usedZoom();
     else if (CSS::isRootFontRelativeLength(unit)) {
-        if (auto* rootRenderer = svgElement->document().documentElement()->renderer())
-            usedZoom = rootRenderer->style().usedZoom();
+        auto* rootElement = svgElement->document().documentElement();
+        if (rootElement && rootElement->renderer())
+            usedZoom = rootElement->renderer()->style().usedZoom();
     }
 
     return (usedZoom != 1.0f) ? value / usedZoom : value;


### PR DESCRIPTION
#### 8256a3cb6c19ae63a9cb946a7179450883e1d04b
<pre>
Null-deref of documentElement() when resolving root-font-relative SVG lengths
<a href="https://bugs.webkit.org/show_bug.cgi?id=318852">https://bugs.webkit.org/show_bug.cgi?id=318852</a>
<a href="https://rdar.apple.com/181677854">rdar://181677854</a>

Reviewed by Taher Ali.

SVGLengthContext::removeZoomFromFontOrRootFontRelativeLength() dereferenced
Document::documentElement() without a null check when resolving a
root-font-relative unit (e.g. rem/rlh). documentElement() can return null
(document without a root element, or one being torn down), so this could
crash during length/style resolution.

The sibling helper rootRenderStyleForLengthResolving() already guards this
exact access with `if (!rootElement || !rootElement-&gt;renderer())`. Guard
documentElement() before reading its renderer, mirroring the sibling helper.

* Source/WebCore/svg/SVGLengthContext.cpp:
(WebCore::SVGLengthContext::removeZoomFromFontOrRootFontRelativeLength const):

Canonical link: <a href="https://commits.webkit.org/317004@main">https://commits.webkit.org/317004@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a6ddb49d37e63fad7c5e19f1ec43c6085043920

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173991 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47924 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41705 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183565 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131859 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9ca7f674-fb8b-4937-a798-e5c456541f7e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175856 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49216 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47606 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135312 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95415 "2 flakes 6 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/eb5426dd-8708-40be-86bf-9c5719e1dc79) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176949 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38744 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156105 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115790 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/04d30088-9316-40e8-8eda-d4880b046821) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37385 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35750 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32049 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147809 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35598 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185991 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39067 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39948 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144213 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47591 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144072 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38852 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48270 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32215 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113659 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38981 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120154 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46776 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10558 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46179 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46410 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46237 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->