### PR TITLE
[GTK] Filter buffer formats using GdkDisplay DMABUF formats when using GdkDmabufTextureBuilder

### DIFF
--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStore.cpp
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStore.cpp
@@ -178,12 +178,29 @@ Vector<RendererBufferFormat> AcceleratedBackingStore::preferredBufferFormats()
 
     RELEASE_ASSERT(display.glDisplay());
 
+    const auto& glDisplayFormats = display.glDisplay()->bufferFormats();
+    Vector<RendererBufferFormat::Format> formats;
+#if GTK_CHECK_VERSION(4, 13, 4)
+    auto* gdkFormats = gdk_display_get_dmabuf_formats(display.gdkDisplay());
+    for (const auto& format : glDisplayFormats) {
+        Vector<uint64_t, 1> modifiers;
+        for (auto modifier : format.modifiers) {
+            if (gdk_dmabuf_formats_contains(gdkFormats, format.fourcc.value, modifier))
+                modifiers.append(modifier);
+        }
+        if (!modifiers.isEmpty())
+            formats.append({ format.fourcc.value, WTF::move(modifiers) });
+    }
+#else
+    formats = glDisplayFormats.map([](const auto& format) -> RendererBufferFormat::Format {
+        return { format.fourcc.value, format.modifiers };
+    });
+#endif
+
     RendererBufferFormat format;
     format.usage = RendererBufferFormat::Usage::Rendering;
     format.drmDevice = drmMainDevice();
-    format.formats = display.glDisplay()->bufferFormats().map([](const auto& format) -> RendererBufferFormat::Format {
-        return { format.fourcc.value, format.modifiers };
-    });
+    format.formats = WTF::move(formats);
     return { WTF::move(format) };
 }
 #endif

--- a/Source/WebKit/UIProcess/gtk/Display.h
+++ b/Source/WebKit/UIProcess/gtk/Display.h
@@ -45,6 +45,7 @@ public:
     static Display& singleton();
     ~Display();
 
+    GdkDisplay* gdkDisplay() const { return m_gdkDisplay.get(); }
     WebCore::GLDisplay* glDisplay() const;
     bool glDisplayIsSharedWithGtk() const { return glDisplay() && !m_glDisplayOwned; }
 


### PR DESCRIPTION
#### d0e0b4f40d0ce607afc5d134228492a1a8478a31
<pre>
[GTK] Filter buffer formats using GdkDisplay DMABUF formats when using GdkDmabufTextureBuilder
<a href="https://bugs.webkit.org/show_bug.cgi?id=318853">https://bugs.webkit.org/show_bug.cgi?id=318853</a>

Reviewed by Nikolas Zimmermann.

Otherwise we might end up using a format that is not supported by GdkDmabufTextureBuilder.

* Source/WebKit/UIProcess/gtk/AcceleratedBackingStore.cpp:
(WebKit::AcceleratedBackingStore::preferredBufferFormats):
* Source/WebKit/UIProcess/gtk/Display.h:
(WebKit::Display::gdkDisplay const):

Canonical link: <a href="https://commits.webkit.org/316799@main">https://commits.webkit.org/316799@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48a2e0c881191bf2794f4a67afaa0f8e27e935f2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173239 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47171 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/41287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182812 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130795 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48464 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46853 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134704 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95111 "22 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176197 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38117 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/155583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115175 "Found 1 new API test failure: WPE/TestWebKitWebView:/webkit/WebKitWebView/save (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36762 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35108 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31297 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147186 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35078 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185234 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38068 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39309 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143547 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46839 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143419 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47518 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31674 "Unable to confirm if test failures are introduced by change, retrying build") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112608 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26352 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38380 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119267 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46024 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10027 "Passed tests") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45426 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45657 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45483 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->