### PR TITLE
[animation-triggers] update WPT snapshot for `scroll-animations/animation-trigger`

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/animation-trigger-addAnimation.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/animation-trigger-addAnimation.tentative.html
@@ -49,6 +49,12 @@
                                     COVER_START_OFFSET + TRIGGER_END_PX,
                                     scroller);
       const ANIMATION_DURATION_MS = 1;
+
+      const enter = () => {
+        return runAndWaitForFrameUpdate(() => {
+          rangeBoundaries.enterTriggerRange();
+        })
+      }
       const view_timeline = new ViewTimeline({ subject: subject });
       function setupAnimation() {
         const animation = new Animation(
@@ -112,7 +118,7 @@
         assert_times_equal(animation.currentTime, 0, "currentTime is 0");
 
         // Entering the trigger range should play the animation.
-        rangeBoundaries.enterTriggerRange();
+        await enter();
         await animation.finished;
 
         assert_equals(animation.playState, "finished",

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/animation-trigger-disarmed-by-apis.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/animation-trigger-disarmed-by-apis.tentative.html
@@ -122,6 +122,7 @@
 
         // First, verify that the trigger is indeed active.
         await rangeBoundaries.enterTriggerRange();
+        await waitForCompositorCommit();
         await animation.finished;
 
         assert_times_equal(animation.currentTime, ANIMATION_DURATION_MS,

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/animation-trigger-fill-mode-both-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/animation-trigger-fill-mode-both-ref.html
@@ -16,7 +16,7 @@
       .target {
         height: 100px;
         width: 100%;
-        background-color: blue;
+        background-color: green;
         position: absolute;
         left: -50px;
       }

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/animation-trigger-fill-mode-both.tentative-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/animation-trigger-fill-mode-both.tentative-expected.html
@@ -16,7 +16,7 @@
       .target {
         height: 100px;
         width: 100%;
-        background-color: blue;
+        background-color: green;
         position: absolute;
         left: -50px;
       }

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/animation-trigger-fill-mode-both.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/animation-trigger-fill-mode-both.tentative.html
@@ -17,6 +17,7 @@
       @keyframes slide-in {
         from {
           transform: translateX(-50px);
+          background-color: green;
         }
       }
       .target {

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/animation-trigger-fill-mode-none.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/animation-trigger-fill-mode-none.tentative.html
@@ -16,6 +16,7 @@
       @keyframes slide-in {
         from {
           transform: translateX(-50px);
+          background-color: red;
         }
       }
       .target {

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/animation-trigger-multiple-triggers.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/animation-trigger-multiple-triggers.tentative.html
@@ -58,8 +58,33 @@
       }
       const rangeBoundaries1 = getRangeBoundariesForSubject(subject1,
           scroller);
-      const rangeBoundaries2 = getRangeBoundariesForSubject(subject2,
-          scroller);
+
+      // TODO(crbug.com/451238244): Move these to support.js.
+      // Helper function for tests using timeline-trigger[1].
+      // This function scrolls into the activation range as configured by
+      // getRangeBoundariesForTest above.
+      //
+      // [1] https://drafts.csswg.org/css-animations-2/#timeline-triggers
+      const enter = (rangeBoundaries) => {
+        return runAndWaitForFrameUpdate(() => {
+          rangeBoundaries.enterTriggerRange();
+        }).then(waitForCompositorCommit);
+      }
+
+      // Helper function for tests using timeline-trigger[1].
+      // This function scrolls outside the active range as configured by
+      // getRangeBoundariesForTest above.
+      //
+      // [1] https://drafts.csswg.org/css-animations-2/#timeline-triggers
+      const exit = (rangeBoundaries, exitAbove = true) => {
+        return runAndWaitForFrameUpdate(() => {
+          if (exitAbove) {
+            rangeBoundaries.exitExitRangeAbove();
+          } else {
+            rangeBoundaries.exitExitRangeBelow();
+          }
+        }).then(waitForCompositorCommit);
+      }
 
       const ANIMATION_DURATION_MS = 1;
       const view_timeline1 = new ViewTimeline({ subject: subject1 });
@@ -111,15 +136,14 @@
         assert_array_equals(trigger1.getAnimations(), [animation],
           "trigger1 has animation attached");
 
-        await rangeBoundaries1.enterTriggerRange();
+        await enter(rangeBoundaries1);
         await animation.finished;
         assert_equals(animation.playState, "finished",
           "animation is played by trigger1");
         assert_times_equal(animation.currentTime, ANIMATION_DURATION_MS,
           `currentTime is ${ANIMATION_DURATION_MS}`);
 
-        await rangeBoundaries1.exitExitRangeBelow();
-        await waitForNextFrame();
+        await exit(rangeBoundaries1, /*exitAbove=*/false);
         assert_equals(animation.playState, "paused",
           "animation should be reset by trigger1");
         assert_times_equal(animation.currentTime, 0, "currentTime is 0");

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/animation-trigger-play.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/animation-trigger-play.tentative-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL play behavior resumes a paused animation assert_equals: expected "paused" but got "running"
-FAIL play behavior restarts a finished animation assert_equals: expected "running" but got "paused"
+FAIL play behavior resumes a paused animation assert_equals: initial state expected "paused" but got "running"
+FAIL play behavior restarts a finished animation assert_equals: triggered after enter expected "running" but got "paused"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/animation-trigger-play.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/animation-trigger-play.tentative.html
@@ -61,12 +61,16 @@
         return runAndWaitForFrameUpdate(async () => {
           scroller.scrollTop =
               (ACTIVATION_RANGE_START_PX + ACTIVATION_RANGE_END_PX) / 2;
+        }).then(() => {
+          return waitForCompositorCommit();
         });
       }
 
       const exit = () => {
         return runAndWaitForFrameUpdate(async () => {
           scroller.scrollTop = ACTIVATION_RANGE_END_PX + 100;
+        }).then(() => {
+          return waitForCompositorCommit();
         });
       }
 
@@ -79,27 +83,29 @@
 
       promise_test(async (test) => {
         const animation = target.getAnimations()[0];
-        assert_equals(animation.playState, "paused");
+        assert_equals(animation.playState, "paused", "initial state");
 
         // Entering the activation range should result in playing.
         await enter();
-        assert_equals(animation.playState, "running");
+
+        assert_equals(animation.playState, "running", "triggered after enter");
 
         animation.pause();
         animation.currentTime = CSS_ANIMATION_DURATION / 2;
         assert_times_equal(animation.currentTime, CSS_ANIMATION_DURATION / 2);
-        assert_equals(animation.playState, "paused");
+        assert_equals(animation.playState, "paused", "paused after pause()");
 
         // Exiting the active range should have no effect.
         await exit();
-        assert_equals(animation.playState, "paused");
+        assert_equals(animation.playState, "paused", "still paused after exit");
         assert_times_equal(animation.currentTime, CSS_ANIMATION_DURATION / 2);
 
         // Re-entering the activation range should resume playing from where it
         // left off.
         await enter();
         await waitForAnimationFrames(2);
-        assert_equals(animation.playState, "running");
+        assert_equals(animation.playState, "running",
+            "triggered after re-enter");
         assert_greater_than(animation.currentTime,
                                  CSS_ANIMATION_DURATION / 2);
       }, "play behavior resumes a paused animation");
@@ -107,25 +113,28 @@
       promise_test(async (test) => {
         reset();
         const animation = target.getAnimations()[0];
-        assert_equals(animation.playState, "paused");
+        assert_equals(animation.playState, "paused", "initial state");
 
         // Entering the activation range should result in playing.
         await enter();
-        assert_equals(animation.playState, "running");
+        assert_equals(animation.playState, "running", "triggered after enter");
 
         animation.finish();
         assert_times_equal(animation.currentTime, CSS_ANIMATION_DURATION);
-        assert_equals(animation.playState, "finished");
+        assert_equals(animation.playState, "finished",
+            "finished after finish()");
 
         // Exiting the active range should have no effect.
         await exit();
-        assert_equals(animation.playState, "finished");
+        assert_equals(animation.playState, "finished",
+            "still finished after exit");
         assert_times_equal(animation.currentTime, CSS_ANIMATION_DURATION);
 
         // Re-entering the activation range should restart the animation.
         await enter();
         await waitForAnimationFrames(2);
-        assert_equals(animation.playState, "running");
+        assert_equals(animation.playState, "running",
+            "triggered after re-enter");
         assert_greater_than(animation.currentTime, 0);
       }, "play behavior restarts a finished animation");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/animation-trigger-replay.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/animation-trigger-replay.tentative.html
@@ -57,17 +57,19 @@
       const ACTIVATION_RANGE_START_PX = COVER_START_OFFSET + CSS_TRIGGER_START_PX;
       const ACTIVATION_RANGE_END_PX = COVER_START_OFFSET + CSS_TRIGGER_END_PX;
 
+      // TODO(crbug.com/451238244): Replace these with common methods in
+      // support.js.
       const enter = () => {
-        return runAndWaitForFrameUpdate(async () => {
+        return runAndWaitForFrameUpdate(() => {
           scroller.scrollTop =
               (ACTIVATION_RANGE_START_PX + ACTIVATION_RANGE_END_PX) / 2;
-        });
+        }).then(waitForCompositorCommit);
       }
 
       const exit = () => {
-        return runAndWaitForFrameUpdate(async () => {
+        return runAndWaitForFrameUpdate(() => {
           scroller.scrollTop = ACTIVATION_RANGE_END_PX + 100;
-        });
+        }).then(waitForCompositorCommit);
       }
 
       const reset = () => {
@@ -84,7 +86,6 @@
         // Entering the activation range should result in playing.
         await enter();
         assert_equals(animation.playState, "running");
-
         animation.pause();
         animation.currentTime = CSS_ANIMATION_DURATION / 2;
         assert_times_equal(animation.currentTime, CSS_ANIMATION_DURATION / 2);

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/trigger-scope-add.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/trigger-scope-add.tentative.html
@@ -80,7 +80,7 @@
       async function scrollToTrigger() {
         return runAndWaitForFrameUpdate(() => {
           source.scrollIntoView({block: "center"});
-        });
+        }).then(waitForCompositorCommit);
       }
 
       async function resetScrollPositionAndElements(test) {
@@ -96,7 +96,7 @@
           assert_element_animation_state(inner_target, "paused");
           assert_element_animation_state(outer_target, "paused");
           assert_equals(current_scroller.scrollTop, 0, "scroll position reset");
-        });
+        }).then(waitForCompositorCommit);
       }
 
       async function scrollAndAssert(inner_play_state, outer_play_state) {


### PR DESCRIPTION
#### 0fc5f2bc6c8496b9b128a557037d2879ad37236f
<pre>
[animation-triggers] update WPT snapshot for `scroll-animations/animation-trigger`
<a href="https://bugs.webkit.org/show_bug.cgi?id=318857">https://bugs.webkit.org/show_bug.cgi?id=318857</a>
<a href="https://rdar.apple.com/181691667">rdar://181691667</a>

Reviewed by Anne van Kesteren.

Before we start work on the properties in the animation-triggers [0] spec, we need to
update our WPT snapshot to establish a baseline.

Upstream commit: web-platform-tests/wpt@48fb658

[0] <a href="https://drafts.csswg.org/animation-triggers-1">https://drafts.csswg.org/animation-triggers-1</a>

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/animation-trigger-addAnimation.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/animation-trigger-disarmed-by-apis.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/animation-trigger-fill-mode-both-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/animation-trigger-fill-mode-both.tentative-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/animation-trigger-fill-mode-both.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/animation-trigger-fill-mode-none.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/animation-trigger-multiple-triggers.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/animation-trigger-play.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/animation-trigger-play.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/animation-trigger-replay.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/trigger-scope-add.tentative.html:

Canonical link: <a href="https://commits.webkit.org/316717@main">https://commits.webkit.org/316717@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a2212bad88d26a612243d9e16e9a258c3124b63

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173248 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47180 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40707 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182821 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130804 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/26bbb262-ff85-4383-96db-064aec9fb1be) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48473 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46862 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134713 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5bd23659-fe53-42ef-ad88-8a92a800e2d3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176206 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38125 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/155357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115183 "Found 1 new API test failure: WPE/TestWebKitWebView:/webkit/WebKitWebView/save (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b1196882-63c2-45e3-a6ca-57c270168522) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36770 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/35117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31306 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147194 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34855 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185243 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39317 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143556 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46848 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154917 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143427 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47527 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112622 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26302 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38390 "Passed tests") | | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46033 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9801 "Passed tests") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45435 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45666 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45492 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->