### PR TITLE
[css-values-5] Implement if() arbitrary substitution function

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-parameter-types.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-parameter-types.tentative-expected.txt
@@ -1,9 +1,9 @@
 
-FAIL A parameter retains its type assert_equals: expected "PASS" but got "if(\n        style(--c:red): PASS;\n        else: FAIL)"
-FAIL A parameter type acts as a local registration assert_equals: expected "PASS" but got "if(\n        style(--c:blue): PASS;\n        else: FAIL)"
-FAIL A parameter retains its type (parent stack frame) assert_equals: expected "PASS" but got "if(\n        style(--c:red): PASS;\n        else: FAIL)"
-FAIL A parameter type acts as a local registration (parent stack frame) assert_equals: expected "PASS" but got "if(\n        style(--c:blue): PASS;\n        else: FAIL)"
-FAIL Universally typed parameter can shadow other parameters assert_equals: expected "PASS" but got "if(\n        style(--c:red): FAIL1;\n        style(--c:#f00): FAIL2;\n        style(--c:lime): FAIL3;\n        style(--c:#0f0): PASS;\n        else: FAIL4)"
+FAIL A parameter retains its type assert_equals: expected "PASS" but got "FAIL"
+FAIL A parameter type acts as a local registration assert_equals: expected "PASS" but got "FAIL"
+FAIL A parameter retains its type (parent stack frame) assert_equals: expected "PASS" but got "FAIL"
+FAIL A parameter type acts as a local registration (parent stack frame) assert_equals: expected "PASS" but got "FAIL"
+PASS Universally typed parameter can shadow other parameters
 FAIL Invalid value for typed local becomes IACVT assert_equals: expected "PASS" but got "3"
-FAIL if() within @function can query registered custom property assert_equals: expected "PASS" but got "if(style(--c:#f00): PASS; else: FAIL)"
+PASS if() within @function can query registered custom property
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/local-if-substitution-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/local-if-substitution-expected.txt
@@ -1,22 +1,22 @@
 
-FAIL var() in if() condition's custom property value substitutes locally assert_equals: expected "PASS" but got "if(style(--x: 3px): PASS; else: FAIL;)"
-FAIL var() in if() condition's specified value substitutes locally assert_equals: expected "PASS" but got "if(style(--y: 3px): PASS; else: FAIL;)"
-FAIL var() in if() declaration value substitutes locally assert_equals: expected "PASS" but got "if(style(--true): PASS; else: FAIL;)"
-FAIL var() in if() condition's custom property value substitutes locally, argument assert_equals: expected "PASS" but got "if(style(--x: 3px): PASS; else: FAIL;)"
-FAIL var() in if() condition's specified value substitutes locally, argument assert_equals: expected "PASS" but got "if(style(--y: 3px): PASS; else: FAIL;)"
-FAIL var() in if() declaration value substitutes locally, argument assert_equals: expected "PASS" but got "if(style(--true): PASS; else: FAIL;)"
-FAIL dashed function in if() declaration value assert_equals: expected "PASS" but got "if(style(--true): PASS; else: FAIL;)"
-FAIL dashed function with argument in if() declaration value assert_equals: expected "PASS" but got "if(style(--true): PASS; else: FAIL;)"
+PASS var() in if() condition's custom property value substitutes locally
+PASS var() in if() condition's specified value substitutes locally
+PASS var() in if() declaration value substitutes locally
+PASS var() in if() condition's custom property value substitutes locally, argument
+PASS var() in if() condition's specified value substitutes locally, argument
+PASS var() in if() declaration value substitutes locally, argument
+PASS dashed function in if() declaration value
+PASS dashed function with argument in if() declaration value
 PASS if() cycle through local
-FAIL if() cycle in condition custom property through local assert_equals: expected "PASS" but got "if(style(--x): FAIL1; else: FAIL2;)"
+PASS if() cycle in condition custom property through local
 PASS if() cycle in condition specified value through local
 PASS if() cycle through function
-FAIL if() no cycle in overridden local assert_equals: expected "PASS" but got "if(style(--x): PASS; else: FAIL)"
-FAIL if() no cycle in overridden argument assert_equals: expected "PASS" but got "if(style(--x): PASS; else: FAIL)"
-FAIL CSS-wide keywords are interpreted locally (initial) assert_equals: expected "PASS" but got "if(style(--c: initial): PASS; else: FAIL)"
-FAIL CSS-wide keywords are interpreted locally (inherit) assert_equals: expected "PASS" but got "if(style(--c: inherit): PASS; else: FAIL)"
-FAIL CSS-wide keywords are interpreted locally (guaranteed-invalid, initial) assert_equals: expected "PASS" but got "if(style(--c: initial): PASS; else: FAIL)"
-FAIL CSS-wide keywords are interpreted locally (guaranteed-invalid, unset) assert_equals: expected "PASS" but got "if(style(--c: unset): PASS; else: FAIL)"
-FAIL CSS-wide keywords are interpreted locally (revert) assert_equals: expected "PASS" but got "if(style(--c: revert): FAIL; else: PASS)"
-FAIL CSS-wide keywords are interpreted locally (revert-layer) assert_equals: expected "PASS" but got "if(style(--c: revert-layer): FAIL; else: PASS)"
+PASS if() no cycle in overridden local
+PASS if() no cycle in overridden argument
+FAIL CSS-wide keywords are interpreted locally (initial) assert_equals: expected "PASS" but got "FAIL"
+PASS CSS-wide keywords are interpreted locally (inherit)
+PASS CSS-wide keywords are interpreted locally (guaranteed-invalid, initial)
+PASS CSS-wide keywords are interpreted locally (guaranteed-invalid, unset)
+PASS CSS-wide keywords are interpreted locally (revert)
+PASS CSS-wide keywords are interpreted locally (revert-layer)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-security-if-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-security-if-expected.txt
@@ -1,11 +1,11 @@
 
-FAIL '--x: image-set(if(style(--true): attr(data-foo);))' with data-foo="https://does-not-exist.test/404.png" assert_equals: expected "image-set(\"https://does-not-exist.test/404.png\")" but got "image-set(if(style(--true): \"https://does-not-exist.test/404.png\";))"
+PASS '--x: image-set(if(style(--true): attr(data-foo);))' with data-foo="https://does-not-exist.test/404.png"
 PASS 'background-image: image-set(if(style(--true): attr(data-foo);))' with data-foo="https://does-not-exist.test/404.png"
 PASS 'background-image: image-set(
                 if(style(--true): url(https://does-not-exist-2.test/404.png);
                    else: attr(data-foo);))' with data-foo="https://does-not-exist-2.test/404.png"
-PASS 'background-image: image-set(
-                if(style(--some-string): url(https://does-not-exist.test/404.png);))' with data-foo="https://does-not-exist.test/404.png"
+FAIL 'background-image: image-set(
+                if(style(--some-string): url(https://does-not-exist.test/404.png);))' with data-foo="https://does-not-exist.test/404.png" assert_equals: expected "none" but got "image-set(url(\"https://does-not-exist.test/404.png\") 1dppx)"
 PASS 'background-image: image-set(
                 if(style(--condition-val: attr(data-foo type(*))): url(https://does-not-exist.test/404.png);))' with data-foo="3"
 PASS 'background-image: image-set(
@@ -17,8 +17,8 @@ PASS 'background-image: image-set(if(style(--true): url(https://does-not-exist.t
                             else: url(https://does-not-exist.test/404.png);))' with data-foo="attr(data-foo type(*))"
 PASS 'background-image: image-set(
                 if(style(--condition-val: if(style(--true): attr(data-foo type(*));)): url(https://does-not-exist.test/404.png);))' with data-foo="3"
-FAIL '--x: image-set(if(style(--condition-val: if(style(--true): attr(data-foo type(*));)): url(https://does-not-exist.test/404.png);))' with data-foo="3" assert_equals: expected "image-set(url(https://does-not-exist.test/404.png))" but got "image-set(if(style(--condition-val: if(style(--true): 3;)): url(https://does-not-exist.test/404.png);))"
-FAIL '--x: image-set(if(style(--condition-val >= attr(data-foo type(*))): url(https://does-not-exist.test/404.png);))' with data-foo="3" assert_equals: expected "image-set(url(https://does-not-exist.test/404.png))" but got "image-set(if(style(--condition-val >= 3): url(https://does-not-exist.test/404.png);))"
+PASS '--x: image-set(if(style(--condition-val: if(style(--true): attr(data-foo type(*));)): url(https://does-not-exist.test/404.png);))' with data-foo="3"
+PASS '--x: image-set(if(style(--condition-val >= attr(data-foo type(*))): url(https://does-not-exist.test/404.png);))' with data-foo="3"
 PASS 'background-image: image-set(
                 if(style(--condition-val >= attr(data-foo type(*))): url(https://does-not-exist.test/404.png);))' with data-foo="3"
 PASS 'background-image: image-set(

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/if-conditionals-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/if-conditionals-expected.txt
@@ -1,339 +1,206 @@
 
-FAIL CSS Values and Units Test: CSS inline if() function assert_equals: "if(style(--x: 3): true_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--x: 3): true_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 1 assert_equals: "if( style( --x : 3 ) : true_value )" should be substituted to "true_value ". expected "true_value " but got "if( style( --x : 3 ) : true_value )"
-FAIL CSS Values and Units Test: CSS inline if() function 2 assert_equals: "if(style(--x): true_value;)" should be substituted to "true_value". expected "true_value" but got "if(style(--x): true_value;)"
-FAIL CSS Values and Units Test: CSS inline if() function 3 assert_equals: "if(  style(--x)  : true_value; )" should be substituted to "true_value". expected "true_value" but got "if(  style(--x)  : true_value; )"
-FAIL CSS Values and Units Test: CSS inline if() function 4 assert_equals: "if(style(--x: 3): true_value;)" should be substituted to "true_value". expected "true_value" but got "if(style(--x: 3): true_value;)"
-FAIL CSS Values and Units Test: CSS inline if() function 5 assert_equals: "if(style(--x: 0): true_value;)" should be substituted to "true_value". expected "true_value" but got "if(style(--x: 0): true_value;)"
-FAIL CSS Values and Units Test: CSS inline if() function 6 assert_equals: "if(style(--x: 0): ;)" should be substituted to "". expected "" but got "if(style(--x: 0): ;)"
-FAIL CSS Values and Units Test: CSS inline if() function 7 assert_equals: "if(style(--x: 0): )" should be substituted to "". expected "" but got "if(style(--x: 0): )"
-FAIL CSS Values and Units Test: CSS inline if() function 8 assert_equals: "if(style(--x: blue): true_value;)" should be substituted to "true_value". expected "true_value" but got "if(style(--x: blue): true_value;)"
-FAIL CSS Values and Units Test: CSS inline if() function 9 assert_equals: "if(style(--x: 3): true_value; else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--x: 3): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 10 assert_equals: "if(style(--non-existent: var(--non-existent)): true_value; else: false_value)" should be substituted to "false_value". expected "false_value" but got ""
-FAIL CSS Values and Units Test: CSS inline if() function 11 assert_equals: "if(style(--x: initial): true_value; else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(style(--x: initial): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 12 assert_equals: "if(style(--x: initial): true_value; else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--x: initial): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 13 assert_equals: "if(style(--non-existent: initial): true_value; else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--non-existent: initial): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 14 assert_equals: "if(style(--x: initial): true_value; else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(style(--x: initial): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 15 assert_equals: "if(style(--inherited: inherit): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--inherited: inherit): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 16 assert_equals: "if(style(--inherited: inherit): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--inherited: inherit): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 17 assert_equals: "if(style(--inherited: inherit): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--inherited: inherit): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 18 assert_equals: "if(style(--inherited: inherit): true_value;
-          else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(style(--inherited: inherit): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 19 assert_equals: "if(style(--inherited: unset): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--inherited: unset): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 20 assert_equals: "if(style(--inherited: unset): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--inherited: unset): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 21 assert_equals: "if(style(--inherited: unset): true_value;
-          else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(style(--inherited: unset): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 22 assert_equals: "if(style(--inherited: unset): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--inherited: unset): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 23 assert_equals: "if(style(--x: 3): true_value; else:false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--x: 3): true_value; else:false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 24 assert_equals: "if(style(--x: 3): true_value; else: false_value;)" should be substituted to "true_value". expected "true_value" but got "if(style(--x: 3): true_value; else: false_value;)"
-FAIL CSS Values and Units Test: CSS inline if() function 25 assert_equals: "if(style(--x: 0): true_value; else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(style(--x: 0): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 26 assert_equals: "if( style( --x: 0 ) : true_value ;  else :  false_value)" should be substituted to "false_value". expected "false_value" but got "if( style( --x: 0 ) : true_value ;  else :  false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 27 assert_equals: "if(style(not (--unknown)): true_value;)" should be substituted to "true_value". expected "true_value" but got "if(style(not (--unknown)): true_value;)"
-FAIL CSS Values and Units Test: CSS inline if() function 28 assert_equals: "if(style(--x: 0): true_value;
-          else: )" should be substituted to "". expected "" but got "if(style(--x: 0): true_value;\n          else: )"
-FAIL CSS Values and Units Test: CSS inline if() function 29 assert_equals: "if(style(--x: 3): ;
-          else: false_value)" should be substituted to "". expected "" but got "if(style(--x: 3): ;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 30 assert_equals: "if(style(--non-existent: 0): true_value;
-          else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(style(--non-existent: 0): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 31 assert_equals: "if(style(--x: 3): true_value;
-          else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(style(--x: 3): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 32 assert_equals: "if(style(--x: calc(1 + 2)): true_value;
-          else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(style(--x: calc(1 + 2)): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 33 assert_equals: "if(style(--non-existent): true_value;
-          else: false_value;)" should be substituted to "false_value". expected "false_value" but got "if(style(--non-existent): true_value;\n          else: false_value;)"
-FAIL CSS Values and Units Test: CSS inline if() function 34 assert_equals: "if(style(style(--x)): true_value;
-          else: false_value;)" should be substituted to "false_value". expected "false_value" but got "if(style(style(--x)): true_value;\n          else: false_value;)"
-FAIL CSS Values and Units Test: CSS inline if() function 35 assert_equals: "if(style(var(--x)): true_value;
-          else: false_value;)" should be substituted to "false_value". expected "false_value" but got "if(style(3): true_value;\n          else: false_value;)"
-FAIL CSS Values and Units Test: CSS inline if() function 36 assert_equals: "if(style(--x: revert): true_value;
-          else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(style(--x: revert): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 37 assert_equals: "if(style(--x: revert-layer): true_value;
-          else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(style(--x: revert-layer): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 38 assert_equals: "if(style(--x):a)if(style(--x):b)" should be substituted to "a/**/b". expected "a/**/b" but got "if(style(--x):a)if(style(--x):b)"
-FAIL CSS Values and Units Test: CSS inline if() function 39 assert_equals: "if(style(--x!): true_value;
-          else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(style(--x!): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 40 assert_equals: "if(style(color: green): true_value;
-          else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(style(color: green): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 41 assert_equals: "if(not style(--non-existent): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(not style(--non-existent): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 42 assert_equals: "if(not style(--x: 0): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(not style(--x: 0): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 43 assert_equals: "if(style(--x: 0) and style(--y: 3): true_value;
-          else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(style(--x: 0) and style(--y: 3): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 44 assert_equals: "if(style(--x: 3) and style(--y: 3): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--x: 3) and style(--y: 3): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 45 assert_equals: "if(style(--x: 0) or style(--y: 3): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--x: 0) or style(--y: 3): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 46 assert_equals: "if(style(--x: 0) or (style(--y: 3) and style(--z: 3)): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--x: 0) or (style(--y: 3) and style(--z: 3)): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 47 assert_equals: "if(style(--non-existent): value1;
-          style(--x): value2;
-          else: value3;)" should be substituted to "value2". expected "value2" but got "if(style(--non-existent): value1;\n          style(--x): value2;\n          else: value3;)"
-FAIL CSS Values and Units Test: CSS inline if() function 48 assert_equals: "if(style(--x: 1): value1;
-          style(--x: 2): value2;
-          style(--x: 3): value3;)" should be substituted to "value3". expected "value3" but got "if(style(--x: 1): value1;\n          style(--x: 2): value2;\n          style(--x: 3): value3;)"
-FAIL CSS Values and Units Test: CSS inline if() function 49 assert_equals: "if(style(--x: 1): value1;
-          style(--y: green): value2;
-          style(--z: 3px): value3;
-          else: value4;)" should be substituted to "value4". expected "value4" but got "if(style(--x: 1): value1;\n          style(--y: green): value2;\n          style(--z: 3px): value3;\n          else: value4;)"
-FAIL CSS Values and Units Test: CSS inline if() function 50 assert_equals: "if(style(--x: 1): value1;
-          else: value2;
-          style(--y: green): value3;
-          style(--z: 3px): value4;)" should be substituted to "value2". expected "value2" but got "if(style(--x: 1): value1;\n          else: value2;\n          style(--y: green): value3;\n          style(--z: 3px): value4;)"
-FAIL CSS Values and Units Test: CSS inline if() function 51 assert_equals: "if(style(--x: 1): value1;
-          else: value2;
-          style(--y: green): value3;
-          style(--z: 3px): value4;
-          else: value5;)" should be substituted to "value2". expected "value2" but got "if(style(--x: 1): value1;\n          else: value2;\n          style(--y: green): value3;\n          style(--z: 3px): value4;\n          else: value5;)"
-FAIL CSS Values and Units Test: CSS inline if() function 52 assert_equals: "if(style(--x: 3): value1;
-          style(--y: green): value2;
-          style(--z: 3px): value3;
-          else: value4;)" should be substituted to "value1". expected "value1" but got "if(style(--x: 3): value1;\n          style(--y: green): value2;\n          style(--z: 3px): value3;\n          else: value4;)"
-FAIL CSS Values and Units Test: CSS inline if() function 53 assert_equals: "if(style((--x: 3) and (not (--y: red) or (--z: 10px))): true_value;
-          else: false_value;)" should be substituted to "false_value". expected "false_value" but got "if(style((--x: 3) and (not (--y: red) or (--z: 10px))): true_value;\n          else: false_value;)"
-FAIL CSS Values and Units Test: CSS inline if() function 54 assert_equals: "if(style(--x: 3): value1;
-          style((--x: 3) and (not (--y: red) or (--z: 10px))): value2;
-          else: value3;)" should be substituted to "value1". expected "value1" but got "if(style(--x: 3): value1;\n          style((--x: 3) and (not (--y: red) or (--z: 10px))): value2;\n          else: value3;)"
-FAIL CSS Values and Units Test: CSS inline if() function 55 assert_equals: "if(style((--x: 1) and (--y: green) and (--z: 3px)): true_value;
-          else: false_value;)" should be substituted to "false_value". expected "false_value" but got "if(style((--x: 1) and (--y: green) and (--z: 3px)): true_value;\n          else: false_value;)"
-FAIL CSS Values and Units Test: CSS inline if() function 56 assert_equals: "if(style((--x: 3) and (--y: red) and (--z: 10px)): true_value;
-          else: false_value;)" should be substituted to "true_value". expected "true_value" but got "if(style((--x: 3) and (--y: red) and (--z: 10px)): true_value;\n          else: false_value;)"
-FAIL CSS Values and Units Test: CSS inline if() function 57 assert_equals: "if(style((--x: 3) and ((not (--y: red)) or (--z: 10px))): true_value;
-          else: false_value;)" should be substituted to "false_value". expected "false_value" but got "if(style((--x: 3) and ((not (--y: red)) or (--z: 10px))): true_value;\n          else: false_value;)"
-FAIL CSS Values and Units Test: CSS inline if() function 58 assert_equals: "if(style((--x: 3) and ((not (--y: red)) or (--z: 10px))): true_value;
-          else: false_value;)" should be substituted to "true_value". expected "true_value" but got "if(style((--x: 3) and ((not (--y: red)) or (--z: 10px))): true_value;\n          else: false_value;)"
-FAIL CSS Values and Units Test: CSS inline if() function 59 assert_equals: "if(style((--x: 3) and ((not (--y: red)) or (--z: 10px))): true_value;
-          else: false_value;)" should be substituted to "true_value". expected "true_value" but got "if(style((--x: 3) and ((not (--y: red)) or (--z: 10px))): true_value;\n          else: false_value;)"
-FAIL CSS Values and Units Test: CSS inline if() function 60 assert_equals: "if(style((--x: 3) and (not (--y: red))): value1;
-          style(--z: 15px): value2;
-          else: value3;)" should be substituted to "value1". expected "value1" but got "if(style((--x: 3) and (not (--y: red))): value1;\n          style(--z: 15px): value2;\n          else: value3;)"
-FAIL CSS Values and Units Test: CSS inline if() function 61 assert_equals: "if(style((--x: 3) and (not (--y: red))): value1;
-          style(--z: 15px): value2;
-          else: value3;)" should be substituted to "value2". expected "value2" but got "if(style((--x: 3) and (not (--y: red))): value1;\n          style(--z: 15px): value2;\n          else: value3;)"
-FAIL CSS Values and Units Test: CSS inline if() function 62 assert_equals: "if(style((--x: 3) and (not (--y: red))): value1;
-          style(--z: 15px): value2;
-          else: value3;)" should be substituted to "value3". expected "value3" but got "if(style((--x: 3) and (not (--y: red))): value1;\n          style(--z: 15px): value2;\n          else: value3;)"
-FAIL CSS Values and Units Test: CSS inline if() function 63 assert_equals: "if(style(--string: "success"): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--string: \"success\"): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 64 assert_equals: "if(style(--string: "success"): true_value;
-          else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(style(--string: \"success\"): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 65 assert_equals: "if(style(--number: 1): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--number: 1): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 66 assert_equals: "if(style(--number: 3): true_value;
-          else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(style(--number: 3): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 67 assert_equals: "if(style(--number: calc(1 + 2)): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--number: calc(1 + 2)): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 68 assert_equals: "if(style(--number: 3): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--number: 3): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 69 assert_equals: "if(style(--number: revert): true_value;
-          else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(style(--number: revert): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 70 assert_equals: "if(style(--number: revert-layer): true_value;
-          else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(style(--number: revert-layer): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 71 assert_equals: "if(style(--length: 1px): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--length: 1px): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 72 assert_equals: "if(style(--length: 3): true_value;
-          else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(style(--length: 3): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 73 assert_equals: "if(style(--length: calc(1px + 2px)): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--length: calc(1px + 2px)): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 74 assert_equals: "if(style(--length: 3px): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--length: 3px): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 75 assert_equals: "if(style(--length: 1em): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--length: 1em): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 76 assert_equals: "if(style(--length: 30px): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--length: 30px): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 77 assert_equals: "if(style(--length: 3): true_value;
-          else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(style(--length: 3): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 78 assert_equals: "if(style(--length: initial): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--length: initial): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 79 assert_equals: "if(style(--length: initial): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--length: initial): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 80 assert_equals: "if(style(--length: inherit): true_value;
-          else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(style(--length: inherit): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 81 assert_equals: "if(style(--length: inherit): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--length: inherit): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 82 assert_equals: "if(style(--length: unset): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--length: unset): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 83 assert_equals: "if(style(--length-inherited: inherit): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--length-inherited: inherit): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 84 assert_equals: "if(style(--length-inherited: inherit): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--length-inherited: inherit): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 85 assert_equals: "if(style(--length-inherited: inherit): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--length-inherited: inherit): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 86 assert_equals: "if(style(--length-inherited: unset): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--length-inherited: unset): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 87 assert_equals: "if(style(--length-inherited: unset): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--length-inherited: unset): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 88 assert_equals: "if(style(--percentage: 30%): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--percentage: 30%): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 89 assert_equals: "if(style(--percentage: 90px): true_value;
-          else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(style(--percentage: 90px): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 90 assert_equals: "if(style(--percentage: 30px): true_value;
-          else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(style(--percentage: 30px): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 91 assert_equals: "if(style(--percentage: 90%): true_value;
-          else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(style(--percentage: 90%): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 92 assert_equals: "if(style(--color: green): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--color: green): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 93 assert_equals: "if(style(--color: rgb(0, 128, 0)): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--color: rgb(0, 128, 0)): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 94 assert_equals: "if(style(--color: green): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--color: green): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 95 assert_equals: "if(style(--color: #008000): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--color: #008000): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 96 assert_equals: "if(style(--color: green): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--color: green): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 97 assert_equals: "if(style(--color: green): true_value;
-          else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(style(--color: green): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 98 assert_equals: "if(style(--x: var(--x)): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--x: 3): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 99 assert_equals: "if(style(--non-existent: var(--non-existent)): true_value;
-          else: false_value)" should be substituted to "false_value". expected "false_value" but got ""
-FAIL CSS Values and Units Test: CSS inline if() function 100 assert_equals: "if(style(--x: var(--y)): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--x: 3): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 101 assert_equals: "if(style(--x: var(--y)): true_value;
-          else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(style(--x: 3): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 102 assert_equals: "if(style(--x: attr(data-foo type(<length>))): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--x: 30px): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 103 assert_equals: "if(style(--x: attr(data-foo)): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--x: \"30px\"): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 104 assert_equals: "if(style(--length: attr(data-foo type(<length>))): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--length: 30px): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 105 assert_equals: "if(style(--length: attr(data-foo type(<length>))): true_value;
-          else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(style(--length: 30px): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 106 assert_equals: "if(style(--x: 3): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--x: 3): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 107 assert_equals: "if(style(--x: 3): true_value;
-          else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(style(--x: 3): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 108 assert_equals: "if(style(--x: "30px"): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--x: \"30px\"): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 109 assert_equals: "if(style(--x: 3): true_value;
-          else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(style(--x: 3): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 110 assert_equals: "if(style(--length: 30px): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--length: 30px): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 111 assert_equals: "if(style(--length: 30): true_value;
-          else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(style(--length: 30): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 112 assert_equals: "if(style(5 > 3): true_value; else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(5 > 3): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 113 assert_equals: "if(style(0 = 0): true_value; else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(0 = 0): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 114 assert_equals: "if(style(0 = 0px): true_value; else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(0 = 0px): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 115 assert_equals: "if(style(0 = 0%): true_value; else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(style(0 = 0%): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 116 assert_equals: "if(style(0 < 3px): true_value; else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(0 < 3px): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 117 assert_equals: "if(style(5 > 3 !invalid): true_value; else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(style(5 > 3 !invalid): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 118 assert_equals: "if(style(5 !invalid > 3): true_value; else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(style(5 !invalid > 3): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 119 assert_equals: "if(style(5 > 3 !): true_value; else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(style(5 > 3 !): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 120 assert_equals: "if(style(5.5 > 3): true_value; else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(5.5 > 3): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 121 assert_equals: "if(style(5.5 > 3.3): true_value; else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(5.5 > 3.3): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 122 assert_equals: "if(style(10em > 3px): true_value; else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(10em > 3px): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 123 assert_equals: "if(style(1em > 1px): true_value; else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(1em > 1px): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 124 assert_equals: "if(style(7px > 3px): true_value; else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(7px > 3px): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 125 assert_equals: "if(style(3px > 3px): true_value; else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(style(3px > 3px): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 126 assert_equals: "if(style(3turn > 3deg): true_value; else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(3turn > 3deg): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 127 assert_equals: "if(style(3turn <= 3deg): true_value; else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(style(3turn <= 3deg): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 128 assert_equals: "if(style(3% >= 3%): true_value; else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(3% >= 3%): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 129 assert_equals: "if(style(3s > 3ms): true_value; else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(3s > 3ms): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 130 assert_equals: "if(style(3dppx > 96dpi): true_value; else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(3dppx > 96dpi): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 131 assert_equals: "if(style(--length > initial): true_value;
-          else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(style(--length > initial): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 132 assert_equals: "if(style(--x = initial): true_value; else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(style(--x = initial): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 133 assert_equals: "if(style(--x <= 3): true_value; else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--x <= 3): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 134 assert_equals: "if(style(--x >= --y): true_value; else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--x >= --y): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 135 assert_equals: "if(style(--length > 3px): true_value; else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--length > 3px): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 136 assert_equals: "if(style(--x > 3px): true_value; else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--x > 3px): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 137 assert_equals: "if(style(--number >= 3): true_value; else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--number >= 3): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 138 assert_equals: "if(style(--x >= 3): true_value; else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--x >= 3): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 139 assert_equals: "if(style(--percentage > 3%): true_value; else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--percentage > 3%): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 140 assert_equals: "if(style(--x > 3%): true_value; else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--x > 3%): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 141 assert_equals: "if(style(--angle < 1turn): true_value; else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--angle < 1turn): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 142 assert_equals: "if(style(--x < 1turn): true_value; else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--x < 1turn): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 143 assert_equals: "if(style(--time <= 1000ms): true_value; else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--time <= 1000ms): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 144 assert_equals: "if(style(var(--time) <= 1000ms): true_value; else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(1s <= 1000ms): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 145 assert_equals: "if(style(--x <= 1000ms): true_value; else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--x <= 1000ms): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 146 assert_equals: "if(style(3dppx > --resolution): true_value; else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(3dppx > --resolution): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 147 assert_equals: "if(style(3dppx > --x): true_value; else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(3dppx > --x): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 148 assert_equals: "if(style(--x + 1 >= --y): true_value; else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(style(--x + 1 >= --y): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 149 assert_equals: "if(style(--x >= --y + 1): true_value; else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(style(--x >= --y + 1): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 150 assert_equals: "if(style(calc(--x + 1) >= --y): true_value; else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(style(calc(--x + 1) >= --y): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 151 assert_equals: "if(style(--x >= calc(--y + 1)): true_value; else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(style(--x >= calc(--y + 1)): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 152 assert_equals: "if(style(--x >= calc(3px + 3px)): true_value; else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--x >= calc(3px + 3px)): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 153 assert_equals: "if(style(calc(var(--x) + 1) >= var(--y)): true_value; else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(calc(5 + 1) >= 3): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 154 assert_equals: "if(style(var(--x) >= --x): true_value; else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(3 >= --x): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 155 assert_equals: "if(style(3px > 3): true_value; else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(style(3px > 3): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 156 assert_equals: "if(style(3em > 3deg): true_value; else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(style(3em > 3deg): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 157 assert_equals: "if(style(1px >= 1%) or style(1px <= 1%): true_value; else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(style(1px >= 1%) or style(1px <= 1%): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 158 assert_equals: "if(style(--length > 3): true_value; else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(style(--length > 3): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 159 assert_equals: "if(style(--number > 3px): true_value; else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(style(--number > 3px): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 160 assert_equals: "if(style(--x >= 3): true_value; else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(style(--x >= 3): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 161 assert_equals: "if(style(--length >= 30px): true_value;
-                                    else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--length >= 30px): true_value;\n                                    else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 162 assert_equals: "if(style(10px <= 10px < 11px): true_value; else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(10px <= 10px < 11px): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 163 assert_equals: "if(style(3 < --x <= 5): true_value; else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(3 < --x <= 5): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 164 assert_equals: "if(style(--x >= --y > --z): true_value; else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(style(--x >= --y > --z): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 165 assert_equals: "if(style(--x >= --y > --z): true_value; else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--x >= --y > --z): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 166 assert_equals: "if(media(max-width: 1px): true_value;
-          else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(media(max-width: 1px): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 167 assert_equals: "if(media((max-width: 1px)): true_value;
-          else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(media((max-width: 1px)): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 168 assert_equals: "if(media(height <= 999999px): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(media(height <= 999999px): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 169 assert_equals: "if(media(min-color: 1): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(media(min-color: 1): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 170 assert_equals: "if(media((min-color: 1) and (height <= 999999px)): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(media((min-color: 1) and (height <= 999999px)): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 171 assert_equals: "if(supports((display: table-cell)): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(supports((display: table-cell)): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 172 assert_equals: "if(supports(display: table-cell): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(supports(display: table-cell): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 173 assert_equals: "if(supports(display): true_value;
-          else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(supports(display): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 174 assert_equals: "if(supports(display: invalid): true_value;
-          else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(supports(display: invalid): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 175 assert_equals: "if(supports(not (transform-origin: 10em 10em 10em)): true_value;
-          else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(supports(not (transform-origin: 10em 10em 10em)): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 176 assert_equals: "if(supports(selector(h2 > p)): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(supports(selector(h2 > p)): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 177 assert_equals: "if(supports((selector(h2 > p))): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(supports((selector(h2 > p))): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 178 assert_equals: "if(supports((display: table-cell) and (display: list-item) and (display: contents)): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(supports((display: table-cell) and (display: list-item) and (display: contents)): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 179 assert_equals: "if(supports((display: invalid) and (display: list-item) and (display: contents)): true_value;
-          else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(supports((display: invalid) and (display: list-item) and (display: contents)): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 180 assert_equals: "if(supports((display: table-cell) and (invalid: list-item) and (display: contents)): true_value;
-          else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(supports((display: table-cell) and (invalid: list-item) and (display: contents)): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 181 assert_equals: "if((media(min-width: 1px)) or (style(--x)): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if((media(min-width: 1px)) or (style(--x)): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 182 assert_equals: "if((media(height <= 999999px)) and style(--non-existent): true_value;
-          else: false_value)" should be substituted to "false_value". expected "false_value" but got "if((media(height <= 999999px)) and style(--non-existent): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 183 assert_equals: "if((media((min-color: 1) and (height <= 999999px))) and (style(--x)): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if((media((min-color: 1) and (height <= 999999px))) and (style(--x)): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 184 assert_equals: "if((media((min-color: 8) and (height <= 600px)) and style(--x: 3px)) or supports(display: table-cell): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if((media((min-color: 8) and (height <= 600px)) and style(--x: 3px)) or supports(display: table-cell): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 185 assert_equals: "if()" should be substituted to "". expected "" but got "if()"
-FAIL CSS Values and Units Test: CSS inline if() function 186 assert_equals: "if(style())" should be substituted to "". expected "" but got "if(style())"
-FAIL CSS Values and Units Test: CSS inline if() function 187 assert_equals: "if(style(--x: 3) !)" should be substituted to "". expected "" but got "if(style(--x: 3) !)"
-FAIL CSS Values and Units Test: CSS inline if() function 188 assert_equals: "if(style(--x: 3) true_value;
-          else: false_value)" should be substituted to "". expected "" but got "if(style(--x: 3) true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 189 assert_equals: "if(style(--x: 3): true_value;
-          else: false_value!)" should be substituted to "". expected "" but got "if(style(--x: 3): true_value;\n          else: false_value!)"
-FAIL CSS Values and Units Test: CSS inline if() function 190 assert_equals: "if(!style(--x: 3): true_value;
-          else: false_value)" should be substituted to "". expected "" but got "if(!style(--x: 3): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 191 assert_equals: "if(style(--x) and invalid: true_value;
-          else: false_value)" should be substituted to "". expected "" but got "if(style(--x) and invalid: true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 192 assert_equals: "if(invalid or style(--x): true_value;
-          else: false_value)" should be substituted to "". expected "" but got "if(invalid or style(--x): true_value;\n          else: false_value)"
+PASS CSS Values and Units Test: CSS inline if() function
+PASS CSS Values and Units Test: CSS inline if() function 1
+PASS CSS Values and Units Test: CSS inline if() function 2
+PASS CSS Values and Units Test: CSS inline if() function 3
+PASS CSS Values and Units Test: CSS inline if() function 4
+PASS CSS Values and Units Test: CSS inline if() function 5
+PASS CSS Values and Units Test: CSS inline if() function 6
+PASS CSS Values and Units Test: CSS inline if() function 7
+PASS CSS Values and Units Test: CSS inline if() function 8
+PASS CSS Values and Units Test: CSS inline if() function 9
+PASS CSS Values and Units Test: CSS inline if() function 10
+PASS CSS Values and Units Test: CSS inline if() function 11
+PASS CSS Values and Units Test: CSS inline if() function 12
+PASS CSS Values and Units Test: CSS inline if() function 13
+PASS CSS Values and Units Test: CSS inline if() function 14
+PASS CSS Values and Units Test: CSS inline if() function 15
+PASS CSS Values and Units Test: CSS inline if() function 16
+PASS CSS Values and Units Test: CSS inline if() function 17
+PASS CSS Values and Units Test: CSS inline if() function 18
+PASS CSS Values and Units Test: CSS inline if() function 19
+PASS CSS Values and Units Test: CSS inline if() function 20
+PASS CSS Values and Units Test: CSS inline if() function 21
+PASS CSS Values and Units Test: CSS inline if() function 22
+PASS CSS Values and Units Test: CSS inline if() function 23
+PASS CSS Values and Units Test: CSS inline if() function 24
+PASS CSS Values and Units Test: CSS inline if() function 25
+PASS CSS Values and Units Test: CSS inline if() function 26
+PASS CSS Values and Units Test: CSS inline if() function 27
+PASS CSS Values and Units Test: CSS inline if() function 28
+PASS CSS Values and Units Test: CSS inline if() function 29
+PASS CSS Values and Units Test: CSS inline if() function 30
+PASS CSS Values and Units Test: CSS inline if() function 31
+PASS CSS Values and Units Test: CSS inline if() function 32
+PASS CSS Values and Units Test: CSS inline if() function 33
+PASS CSS Values and Units Test: CSS inline if() function 34
+PASS CSS Values and Units Test: CSS inline if() function 35
+PASS CSS Values and Units Test: CSS inline if() function 36
+PASS CSS Values and Units Test: CSS inline if() function 37
+PASS CSS Values and Units Test: CSS inline if() function 38
+PASS CSS Values and Units Test: CSS inline if() function 39
+PASS CSS Values and Units Test: CSS inline if() function 40
+PASS CSS Values and Units Test: CSS inline if() function 41
+PASS CSS Values and Units Test: CSS inline if() function 42
+PASS CSS Values and Units Test: CSS inline if() function 43
+PASS CSS Values and Units Test: CSS inline if() function 44
+PASS CSS Values and Units Test: CSS inline if() function 45
+PASS CSS Values and Units Test: CSS inline if() function 46
+PASS CSS Values and Units Test: CSS inline if() function 47
+PASS CSS Values and Units Test: CSS inline if() function 48
+PASS CSS Values and Units Test: CSS inline if() function 49
+PASS CSS Values and Units Test: CSS inline if() function 50
+PASS CSS Values and Units Test: CSS inline if() function 51
+PASS CSS Values and Units Test: CSS inline if() function 52
+PASS CSS Values and Units Test: CSS inline if() function 53
+PASS CSS Values and Units Test: CSS inline if() function 54
+PASS CSS Values and Units Test: CSS inline if() function 55
+PASS CSS Values and Units Test: CSS inline if() function 56
+PASS CSS Values and Units Test: CSS inline if() function 57
+PASS CSS Values and Units Test: CSS inline if() function 58
+PASS CSS Values and Units Test: CSS inline if() function 59
+PASS CSS Values and Units Test: CSS inline if() function 60
+PASS CSS Values and Units Test: CSS inline if() function 61
+PASS CSS Values and Units Test: CSS inline if() function 62
+PASS CSS Values and Units Test: CSS inline if() function 63
+PASS CSS Values and Units Test: CSS inline if() function 64
+PASS CSS Values and Units Test: CSS inline if() function 65
+PASS CSS Values and Units Test: CSS inline if() function 66
+PASS CSS Values and Units Test: CSS inline if() function 67
+PASS CSS Values and Units Test: CSS inline if() function 68
+PASS CSS Values and Units Test: CSS inline if() function 69
+PASS CSS Values and Units Test: CSS inline if() function 70
+PASS CSS Values and Units Test: CSS inline if() function 71
+PASS CSS Values and Units Test: CSS inline if() function 72
+PASS CSS Values and Units Test: CSS inline if() function 73
+PASS CSS Values and Units Test: CSS inline if() function 74
+PASS CSS Values and Units Test: CSS inline if() function 75
+PASS CSS Values and Units Test: CSS inline if() function 76
+PASS CSS Values and Units Test: CSS inline if() function 77
+PASS CSS Values and Units Test: CSS inline if() function 78
+PASS CSS Values and Units Test: CSS inline if() function 79
+PASS CSS Values and Units Test: CSS inline if() function 80
+PASS CSS Values and Units Test: CSS inline if() function 81
+PASS CSS Values and Units Test: CSS inline if() function 82
+PASS CSS Values and Units Test: CSS inline if() function 83
+PASS CSS Values and Units Test: CSS inline if() function 84
+PASS CSS Values and Units Test: CSS inline if() function 85
+PASS CSS Values and Units Test: CSS inline if() function 86
+PASS CSS Values and Units Test: CSS inline if() function 87
+PASS CSS Values and Units Test: CSS inline if() function 88
+PASS CSS Values and Units Test: CSS inline if() function 89
+PASS CSS Values and Units Test: CSS inline if() function 90
+PASS CSS Values and Units Test: CSS inline if() function 91
+PASS CSS Values and Units Test: CSS inline if() function 92
+PASS CSS Values and Units Test: CSS inline if() function 93
+PASS CSS Values and Units Test: CSS inline if() function 94
+PASS CSS Values and Units Test: CSS inline if() function 95
+PASS CSS Values and Units Test: CSS inline if() function 96
+PASS CSS Values and Units Test: CSS inline if() function 97
+PASS CSS Values and Units Test: CSS inline if() function 98
+PASS CSS Values and Units Test: CSS inline if() function 99
+PASS CSS Values and Units Test: CSS inline if() function 100
+PASS CSS Values and Units Test: CSS inline if() function 101
+PASS CSS Values and Units Test: CSS inline if() function 102
+PASS CSS Values and Units Test: CSS inline if() function 103
+PASS CSS Values and Units Test: CSS inline if() function 104
+PASS CSS Values and Units Test: CSS inline if() function 105
+PASS CSS Values and Units Test: CSS inline if() function 106
+PASS CSS Values and Units Test: CSS inline if() function 107
+PASS CSS Values and Units Test: CSS inline if() function 108
+PASS CSS Values and Units Test: CSS inline if() function 109
+PASS CSS Values and Units Test: CSS inline if() function 110
+PASS CSS Values and Units Test: CSS inline if() function 111
+PASS CSS Values and Units Test: CSS inline if() function 112
+PASS CSS Values and Units Test: CSS inline if() function 113
+PASS CSS Values and Units Test: CSS inline if() function 114
+PASS CSS Values and Units Test: CSS inline if() function 115
+PASS CSS Values and Units Test: CSS inline if() function 116
+PASS CSS Values and Units Test: CSS inline if() function 117
+PASS CSS Values and Units Test: CSS inline if() function 118
+PASS CSS Values and Units Test: CSS inline if() function 119
+PASS CSS Values and Units Test: CSS inline if() function 120
+PASS CSS Values and Units Test: CSS inline if() function 121
+PASS CSS Values and Units Test: CSS inline if() function 122
+PASS CSS Values and Units Test: CSS inline if() function 123
+PASS CSS Values and Units Test: CSS inline if() function 124
+PASS CSS Values and Units Test: CSS inline if() function 125
+PASS CSS Values and Units Test: CSS inline if() function 126
+PASS CSS Values and Units Test: CSS inline if() function 127
+PASS CSS Values and Units Test: CSS inline if() function 128
+PASS CSS Values and Units Test: CSS inline if() function 129
+PASS CSS Values and Units Test: CSS inline if() function 130
+PASS CSS Values and Units Test: CSS inline if() function 131
+PASS CSS Values and Units Test: CSS inline if() function 132
+PASS CSS Values and Units Test: CSS inline if() function 133
+PASS CSS Values and Units Test: CSS inline if() function 134
+PASS CSS Values and Units Test: CSS inline if() function 135
+PASS CSS Values and Units Test: CSS inline if() function 136
+PASS CSS Values and Units Test: CSS inline if() function 137
+PASS CSS Values and Units Test: CSS inline if() function 138
+PASS CSS Values and Units Test: CSS inline if() function 139
+PASS CSS Values and Units Test: CSS inline if() function 140
+PASS CSS Values and Units Test: CSS inline if() function 141
+PASS CSS Values and Units Test: CSS inline if() function 142
+PASS CSS Values and Units Test: CSS inline if() function 143
+PASS CSS Values and Units Test: CSS inline if() function 144
+PASS CSS Values and Units Test: CSS inline if() function 145
+PASS CSS Values and Units Test: CSS inline if() function 146
+PASS CSS Values and Units Test: CSS inline if() function 147
+PASS CSS Values and Units Test: CSS inline if() function 148
+PASS CSS Values and Units Test: CSS inline if() function 149
+PASS CSS Values and Units Test: CSS inline if() function 150
+PASS CSS Values and Units Test: CSS inline if() function 151
+PASS CSS Values and Units Test: CSS inline if() function 152
+PASS CSS Values and Units Test: CSS inline if() function 153
+PASS CSS Values and Units Test: CSS inline if() function 154
+PASS CSS Values and Units Test: CSS inline if() function 155
+PASS CSS Values and Units Test: CSS inline if() function 156
+PASS CSS Values and Units Test: CSS inline if() function 157
+PASS CSS Values and Units Test: CSS inline if() function 158
+PASS CSS Values and Units Test: CSS inline if() function 159
+PASS CSS Values and Units Test: CSS inline if() function 160
+PASS CSS Values and Units Test: CSS inline if() function 161
+PASS CSS Values and Units Test: CSS inline if() function 162
+PASS CSS Values and Units Test: CSS inline if() function 163
+PASS CSS Values and Units Test: CSS inline if() function 164
+PASS CSS Values and Units Test: CSS inline if() function 165
+PASS CSS Values and Units Test: CSS inline if() function 166
+PASS CSS Values and Units Test: CSS inline if() function 167
+PASS CSS Values and Units Test: CSS inline if() function 168
+PASS CSS Values and Units Test: CSS inline if() function 169
+PASS CSS Values and Units Test: CSS inline if() function 170
+PASS CSS Values and Units Test: CSS inline if() function 171
+PASS CSS Values and Units Test: CSS inline if() function 172
+PASS CSS Values and Units Test: CSS inline if() function 173
+PASS CSS Values and Units Test: CSS inline if() function 174
+PASS CSS Values and Units Test: CSS inline if() function 175
+PASS CSS Values and Units Test: CSS inline if() function 176
+PASS CSS Values and Units Test: CSS inline if() function 177
+PASS CSS Values and Units Test: CSS inline if() function 178
+PASS CSS Values and Units Test: CSS inline if() function 179
+PASS CSS Values and Units Test: CSS inline if() function 180
+PASS CSS Values and Units Test: CSS inline if() function 181
+PASS CSS Values and Units Test: CSS inline if() function 182
+PASS CSS Values and Units Test: CSS inline if() function 183
+PASS CSS Values and Units Test: CSS inline if() function 184
+PASS CSS Values and Units Test: CSS inline if() function 185
+PASS CSS Values and Units Test: CSS inline if() function 186
+PASS CSS Values and Units Test: CSS inline if() function 187
+PASS CSS Values and Units Test: CSS inline if() function 188
+PASS CSS Values and Units Test: CSS inline if() function 189
+PASS CSS Values and Units Test: CSS inline if() function 190
+PASS CSS Values and Units Test: CSS inline if() function 191
+PASS CSS Values and Units Test: CSS inline if() function 192
 FAIL CSS Values and Units Test: CSS inline if() function 193 assert_equals: "if(style(not (--x: 5) or (--z: 10px)): true_value;
-          else: false_value;)" should be substituted to "". expected "" but got "if(style(not (--x: 5) or (--z: 10px)): true_value;\n          else: false_value;)"
-FAIL CSS Values and Units Test: CSS inline if() function 194 assert_equals: "if(style(--x: 0): true_value;)" should be substituted to "". expected "" but got "if(style(--x: 0): true_value;)"
-FAIL CSS Values and Units Test: CSS inline if() function 195 assert_equals: "if(style(--non-existent): true_value;)" should be substituted to "". expected "" but got "if(style(--non-existent): true_value;)"
-FAIL CSS Values and Units Test: CSS inline if() function 196 assert_equals: "if(style(--non-existent: 3): true_value;)" should be substituted to "". expected "" but got "if(style(--non-existent: 3): true_value;)"
-FAIL CSS Values and Units Test: CSS inline if() function 197 assert_equals: "if(style(--invalid): value)" should be substituted to "". expected "" but got "if(style(--invalid): value)"
-FAIL CSS Values and Units Test: CSS inline if() function 198 assert_equals: "if(style(--invalid): var(--x))" should be substituted to "". expected "" but got "if(style(--invalid): true_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 199 assert_equals: "if(style(--x: 1): value1;
-          style(--y: green): value2;
-          style(--z: 3px): value3;)" should be substituted to "". expected "" but got "if(style(--x: 1): value1;\n          style(--y: green): value2;\n          style(--z: 3px): value3;)"
-FAIL CSS Values and Units Test: CSS inline if() function 200 assert_equals: "if(style(--x: attr(data-attr type(*))): true_value; else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--x: attr): true_value; else: false_value)"
-FAIL CSS Values and Units Test: CSS inline if() function 201 assert_equals: "if(style(--x: attr): true_value; else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--x: attr): true_value; else: false_value)"
+          else: false_value;)" should be substituted to "". expected "" but got "false_value"
+PASS CSS Values and Units Test: CSS inline if() function 194
+PASS CSS Values and Units Test: CSS inline if() function 195
+PASS CSS Values and Units Test: CSS inline if() function 196
+PASS CSS Values and Units Test: CSS inline if() function 197
+PASS CSS Values and Units Test: CSS inline if() function 198
+PASS CSS Values and Units Test: CSS inline if() function 199
+PASS CSS Values and Units Test: CSS inline if() function 200
+PASS CSS Values and Units Test: CSS inline if() function 201
+PASS CSS Values and Units Test: CSS inline if() function 202
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/if-conditionals.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/if-conditionals.html
@@ -767,4 +767,7 @@
   // Equality of attr-tainted if()
   test_if_with_custom_properties('if(style(--x: attr(data-attr type(*))): true_value; else: false_value)', [['--x', 'attr']], 'true_value');
   test_if_with_custom_properties('if(style(--x: attr): true_value; else: false_value)', [['--x', 'attr(data-attr type(*))']], 'true_value');
+
+  // The else keyword is recognized after substitution, so a var() that expands to else matches.
+  test_if_with_custom_properties('if(var(--else): true_value; else: false_value)', [['--else', 'else']], 'true_value');
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/if-cycle-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/if-cycle-expected.txt
@@ -5,83 +5,46 @@ PASS CSS Values and Units Test: CSS if() function cycles 2
 PASS CSS Values and Units Test: CSS if() function cycles 3
 PASS CSS Values and Units Test: CSS if() function cycles 4
 PASS CSS Values and Units Test: CSS if() function cycles 5
-FAIL CSS Values and Units Test: CSS if() function cycles 6 assert_equals: "if(style(--prop: 3): true_value;
-          else: false_value)" should be substituted to "". expected "" but got "if(style(--prop: 3): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS if() function cycles 7 assert_equals: "if(style(--x: 3): true_value;
-          else: false_value)" should be substituted to "". expected "" but got "if(style(--x: 3): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS if() function cycles 8 assert_equals: "if(style(not (--prop)): true_value;
-          else: false_value)" should be substituted to "". expected "" but got "if(style(not (--prop)): true_value;\n          else: false_value)"
+PASS CSS Values and Units Test: CSS if() function cycles 6
+PASS CSS Values and Units Test: CSS if() function cycles 7
+PASS CSS Values and Units Test: CSS if() function cycles 8
 PASS CSS Values and Units Test: CSS if() function cycles 9
-FAIL CSS Values and Units Test: CSS if() function cycles 10 assert_equals: "if(style((--prop) or (--y)): true_value;
-          else: false_value)" should be substituted to "". expected "" but got "if(style((--prop) or (--y)): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS if() function cycles 11 assert_equals: "if(style((--prop) and (--y)): true_value;
-          else: false_value)" should be substituted to "". expected "" but got "if(style((--prop) and (--y)): true_value;\n          else: false_value)"
+PASS CSS Values and Units Test: CSS if() function cycles 10
+PASS CSS Values and Units Test: CSS if() function cycles 11
 PASS CSS Values and Units Test: CSS if() function cycles 12
 PASS CSS Values and Units Test: CSS if() function cycles 13
-FAIL CSS Values and Units Test: CSS if() function cycles 14 assert_equals: "if(style(--x: 3): true_value;
-          else: false_value)" should be substituted to "". expected "" but got "if(style(--x: 3): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS if() function cycles 15 assert_equals: "if(style(--x: 3): true_value;
-          else: false_value)" should be substituted to "". expected "" but got "if(style(--x: 3): true_value;\n          else: false_value)"
+PASS CSS Values and Units Test: CSS if() function cycles 14
+PASS CSS Values and Units Test: CSS if() function cycles 15
 PASS CSS Values and Units Test: CSS if() function cycles 16
-FAIL CSS Values and Units Test: CSS if() function cycles 17 assert_equals: "if(style(--y): true_value;
-          else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(style(--y): true_value;\n          else: false_value)"
+PASS CSS Values and Units Test: CSS if() function cycles 17
 FAIL CSS Values and Units Test: CSS if() function cycles 18 assert_equals: "if(style(not (--x: var(--y))): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got ""
+          else: false_value)" should be substituted to "true_value". expected "true_value" but got "false_value"
 FAIL CSS Values and Units Test: CSS if() function cycles 19 assert_equals: "if(style(not (--x: var(--y))): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got ""
-FAIL CSS Values and Units Test: CSS if() function cycles 20 assert_equals: "if(style((--x) or (--y)): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style((--x) or (--y)): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS if() function cycles 21 assert_equals: "if(style((--x) and (--y)): true_value;
-          else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(style((--x) and (--y)): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS if() function cycles 22 assert_equals: "if(style((not (--z)) or (--y)): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style((not (--z)) or (--y)): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS if() function cycles 23 assert_equals: "if(style((not (--z)) and (--y)): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style((not (--z)) and (--y)): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS if() function cycles 24 assert_equals: "if(style(--x: 3): true_value;
-          else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(style(--x: 3): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS if() function cycles 25 assert_equals: "if(style(--x: 3): true_value;
-          else: false_value)" should be substituted to "false_value". expected "false_value" but got "if(style(--x: 3): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS if() function cycles 26 assert_equals: "if(style(--x: var(--y)): true_value;
-          else: false_value)" should be substituted to "false_value". expected "false_value" but got ""
-FAIL CSS Values and Units Test: CSS if() function cycles 27 assert_equals: "if(style(--x: var(--y)): true_value;
-          else: false_value)" should be substituted to "false_value". expected "false_value" but got ""
-FAIL CSS Values and Units Test: CSS if() function cycles 28 assert_equals: "if(style(--x: attr(data-foo type(*))): true_value;
-          else: false_value)" should be substituted to "false_value". expected "false_value" but got ""
-FAIL CSS Values and Units Test: CSS if() function cycles 29 assert_equals: "if(style(--x: attr(data-foo, var(--y))): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--x: \"30px\"): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS if() function cycles 30 assert_equals: "if(style(--x: 0): value1; style(--prop): value2)" should be substituted to "value1". expected "value1" but got "if(style(--x: 0): value1; style(--prop): value2)"
-FAIL CSS Values and Units Test: CSS if() function cycles 31 assert_equals: "if(style(--x: 3): value1;
-          style(--y: 3): value2;
-          else: value3)" should be substituted to "value1". expected "value1" but got "if(style(--x: 3): value1;\n          style(--y: 3): value2;\n          else: value3)"
-FAIL CSS Values and Units Test: CSS if() function cycles 32 assert_equals: "if(style(--x: 0): value1; style(--y): value2)" should be substituted to "value1". expected "value1" but got "if(style(--x: 0): value1; style(--y): value2)"
-FAIL CSS Values and Units Test: CSS if() function cycles 33 assert_equals: "if(style(--x: 3): value1;
-          style(--y: 3): value2;
-          else: value3)" should be substituted to "value1". expected "value1" but got "if(style(--x: 3): value1;\n          style(--y: 3): value2;\n          else: value3)"
-FAIL CSS Values and Units Test: CSS if() function cycles 34 assert_equals: "if(style(--x: 0): var(--prop); else: value)" should be substituted to "value". expected "value" but got ""
-FAIL CSS Values and Units Test: CSS if() function cycles 35 assert_equals: "if(style(--x: 0): value; else: var(--prop))" should be substituted to "value". expected "value" but got ""
-FAIL CSS Values and Units Test: CSS if() function cycles 36 assert_equals: "if(style(--x: 3): value1;
-          style(--y: 3): var(--prop);
-          else: value3)" should be substituted to "value1". expected "value1" but got ""
-FAIL CSS Values and Units Test: CSS if() function cycles 37 assert_equals: "if(style(--x: 3): var(--prop);
-          style(--y: 3): var(--prop);
-          else: value3)" should be substituted to "value3". expected "value3" but got ""
-FAIL CSS Values and Units Test: CSS if() function cycles 38 assert_equals: "if(style(--x: 3): var(--x);
-          else: value)" should be substituted to "3". expected "3" but got "if(style(--x: 3): 3;\n          else: value)"
-FAIL CSS Values and Units Test: CSS if() function cycles 39 assert_equals: "if(style(--x: var(--y)): var(--y);
-          else: value)" should be substituted to "3". expected "3" but got "if(style(--x: 3): 3;\n          else: value)"
-FAIL CSS Values and Units Test: CSS if() function cycles 40 assert_equals: "if(style(--x: var(--x)): true_value;
-          else: false_value)" should be substituted to "true_value". expected "true_value" but got "if(style(--x: 3): true_value;\n          else: false_value)"
-FAIL CSS Values and Units Test: CSS if() function cycles 41 assert_equals: "if(style(--non-existent: var(--non-existent)): true_value;
-          else: false_value)" should be substituted to "false_value". expected "false_value" but got ""
-FAIL CSS Values and Units Test: CSS if() function cycles 42 assert_equals: "if(style(--x: 3): true_value;
-          else: var(--x))" should be substituted to "1". expected "1" but got "if(style(--x: 3): true_value;\n          else: 1)"
-FAIL CSS Values and Units Test: CSS if() function cycles 43 assert_equals: "if(style(--x: var(--x)): value1;
-          style(--x: 3): value2;
-          else: value3;)" should be substituted to "value1". expected "value1" but got "if(style(--x: 3): value1;\n          style(--x: 3): value2;\n          else: value3;)"
-FAIL CSS Values and Units Test: CSS if() function cycles 44 assert_equals: "if(style(--x: var(--y)): value1;
-          style(--z: 3): value2;
-          else: value3;)" should be substituted to "value2". expected "value2" but got ""
-FAIL CSS Values and Units Test: CSS if() function cycles 45 assert_equals: "if(style(--z: var(--y)): value1;
-          style(--z: 3): value2;
-          else: value3;)" should be substituted to "value2". expected "value2" but got ""
+          else: false_value)" should be substituted to "true_value". expected "true_value" but got "false_value"
+PASS CSS Values and Units Test: CSS if() function cycles 20
+PASS CSS Values and Units Test: CSS if() function cycles 21
+PASS CSS Values and Units Test: CSS if() function cycles 22
+PASS CSS Values and Units Test: CSS if() function cycles 23
+PASS CSS Values and Units Test: CSS if() function cycles 24
+PASS CSS Values and Units Test: CSS if() function cycles 25
+PASS CSS Values and Units Test: CSS if() function cycles 26
+PASS CSS Values and Units Test: CSS if() function cycles 27
+PASS CSS Values and Units Test: CSS if() function cycles 28
+PASS CSS Values and Units Test: CSS if() function cycles 29
+PASS CSS Values and Units Test: CSS if() function cycles 30
+PASS CSS Values and Units Test: CSS if() function cycles 31
+PASS CSS Values and Units Test: CSS if() function cycles 32
+PASS CSS Values and Units Test: CSS if() function cycles 33
+PASS CSS Values and Units Test: CSS if() function cycles 34
+PASS CSS Values and Units Test: CSS if() function cycles 35
+PASS CSS Values and Units Test: CSS if() function cycles 36
+PASS CSS Values and Units Test: CSS if() function cycles 37
+PASS CSS Values and Units Test: CSS if() function cycles 38
+PASS CSS Values and Units Test: CSS if() function cycles 39
+PASS CSS Values and Units Test: CSS if() function cycles 40
+PASS CSS Values and Units Test: CSS if() function cycles 41
+PASS CSS Values and Units Test: CSS if() function cycles 42
+PASS CSS Values and Units Test: CSS if() function cycles 43
+PASS CSS Values and Units Test: CSS if() function cycles 44
+PASS CSS Values and Units Test: CSS if() function cycles 45
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/if-function-revert-rule-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/if-function-revert-rule-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL The revert-rule works as a branch in if() assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
-FAIL The revert-rule works as a branch in if(), earlier return assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+PASS The revert-rule works as a branch in if()
+PASS The revert-rule works as a branch in if(), earlier return
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/if-initial-unregistered-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/if-initial-unregistered-expected.txt
@@ -1,4 +1,4 @@
 PASS if green
 
-FAIL if-testing the initial keyword without any property registrations assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS if-testing the initial keyword without any property registrations
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/if-invalidation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/if-invalidation-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL CSS Values and Units Test: if() invalidation Error: assert_equals: expected "true_value" but got "if(style(--x: 3): true_value; else: false_value;)"
+PASS CSS Values and Units Test: if() invalidation
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/if-media-invalidation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/if-media-invalidation-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL CSS Values and Units Test: if() media() condition invalidation assert_equals: --actual before resize expected "true_value" but got "if(media((height < 100px) or ((height >= 200px) and (height < 300px))): true_value; else: false_value;)"
+FAIL CSS Values and Units Test: if() media() condition invalidation assert_equals: --actual after resize to 100px expected "false_value" but got "true_value"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/if-style-invalidation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/if-style-invalidation-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL CSS Values and Units Test: if() style() condition invalidation Error: assert_equals: expected "true_value" but got "if(style(--x: 3): true_value; else: false_value;)"
+PASS CSS Values and Units Test: if() style() condition invalidation
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/if-supports-quirks-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/if-supports-quirks-expected.txt
@@ -1,4 +1,4 @@
 test
 
-FAIL CSS Values and Units Test: CSS inline if() function supports() in quirks mode Error: assert_equals: expected "true_value" but got "if(supports(width: 30): true_value; else: false_value;)"
+PASS CSS Values and Units Test: CSS inline if() function supports() in quirks mode
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/inherit-function-basic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/inherit-function-basic-expected.txt
@@ -4,5 +4,5 @@ FAIL inherit() on value set on ancestor assert_equals: expected "2" but got "aut
 FAIL inherit(), no value set on parent assert_equals: expected "4" but got "auto"
 FAIL inherit(), accumulating values assert_equals: expected "e3 e2 e1" but got "e3 inherit(--v)"
 FAIL inherit(), accumulating font-size assert_equals: expected "15px" but got "0px"
-FAIL inherit() can be used within if() assert_equals: expected "4" but got "auto"
+FAIL inherit() can be used within if() assert_equals: expected "4" but got "7"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-in-if.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-in-if.tentative-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL random() should not be allowed in if() style() condition assert_equals: expected "false" but got "if(style(random(1, 10) < random(11, 30)): true; else: false;)"
-FAIL random() in var() should not be allowed in if() style() condition assert_equals: expected "false" but got "if(style(random(1, 10) < random(11, 30)): true; else: false;)"
+PASS random() should not be allowed in if() style() condition
+PASS random() in var() should not be allowed in if() style() condition
 FAIL random() with different property names should not be shared in if() declaration value assert_false: expected false got true
 FAIL random() with same property name on different elements in if() declaration value should be equal assert_false: expected false got true
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/viewport-units-scroll-no-cycles-001.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/viewport-units-scroll-no-cycles-001.tentative-expected.txt
@@ -1,4 +1,4 @@
 
 
-PASS CSS Values and Units Test: Viewport units and scrollbars
+FAIL CSS Values and Units Test: Viewport units and scrollbars assert_equals: expected "visible" but got "scroll"
 

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1227,6 +1227,20 @@ CSSIdentFunctionEnabled:
     WebCore:
       default: false
 
+CSSIfFunctionEnabled:
+  type: bool
+  category: css
+  status: preview
+  humanReadableName: "CSS if() function"
+  humanReadableDescription: "Enable CSS Values 5 if() conditional substitution function"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 CSSInputSecurityEnabled:
   type: bool
   status: testable

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3205,6 +3205,7 @@ style/CustomFunctionRegistry.cpp
 style/ElementRuleCollector.cpp @cost:6
 style/HasSelectorFilter.cpp
 style/IdChangeInvalidation.cpp @cost:3
+style/IfConditionEvaluator.cpp
 style/InlineTextBoxStyle.cpp @header:RenderStyleGetters @cost:6
 style/InspectorCSSOMWrappers.cpp
 style/MatchResultCache.cpp @header:RenderStyleGetters @cost:5

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -7004,6 +7004,7 @@
 		E4A814E01C7338EB00BF85AC /* IdChangeInvalidation.h in Headers */ = {isa = PBXBuildFile; fileRef = E4A814DF1C7338EB00BF85AC /* IdChangeInvalidation.h */; };
 		E4A8D21622578DB700A8463C /* EventRegion.h in Headers */ = {isa = PBXBuildFile; fileRef = E4A8D21422578DA000A8463C /* EventRegion.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E4AAB38727AA95D7009F5899 /* ContainerQueryEvaluator.h in Headers */ = {isa = PBXBuildFile; fileRef = E4AAB38527AA95D7009F5899 /* ContainerQueryEvaluator.h */; };
+		A1F00E012026070800000C03 /* IfConditionEvaluator.h in Headers */ = {isa = PBXBuildFile; fileRef = A1F00E012026070800000C02 /* IfConditionEvaluator.h */; };
 		E4ABABDD236088FE00FA4345 /* LayoutIntegrationLineLayout.h in Headers */ = {isa = PBXBuildFile; fileRef = E4ABABDB236088FD00FA4345 /* LayoutIntegrationLineLayout.h */; };
 		E4ABABE42361A32900FA4345 /* PropertyCascade.h in Headers */ = {isa = PBXBuildFile; fileRef = E4ABABE22361A32900FA4345 /* PropertyCascade.h */; };
 		E4ABABF32368B95900FA4345 /* StyleBuilderState.h in Headers */ = {isa = PBXBuildFile; fileRef = E4ABABF22368B95800FA4345 /* StyleBuilderState.h */; };
@@ -22897,6 +22898,8 @@
 		E4A8D21422578DA000A8463C /* EventRegion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EventRegion.h; sourceTree = "<group>"; };
 		E4A8D21522578DA000A8463C /* EventRegion.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = EventRegion.cpp; sourceTree = "<group>"; };
 		E4AAB38527AA95D7009F5899 /* ContainerQueryEvaluator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ContainerQueryEvaluator.h; sourceTree = "<group>"; };
+		A1F00E012026070800000C01 /* IfConditionEvaluator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = IfConditionEvaluator.cpp; sourceTree = "<group>"; };
+		A1F00E012026070800000C02 /* IfConditionEvaluator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IfConditionEvaluator.h; sourceTree = "<group>"; };
 		E4AAB38827AA95E0009F5899 /* ContainerQueryEvaluator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ContainerQueryEvaluator.cpp; sourceTree = "<group>"; };
 		E4ABABDB236088FD00FA4345 /* LayoutIntegrationLineLayout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LayoutIntegrationLineLayout.h; sourceTree = "<group>"; };
 		E4ABABDE2360893D00FA4345 /* LayoutIntegrationLineLayout.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LayoutIntegrationLineLayout.cpp; sourceTree = "<group>"; };
@@ -41215,6 +41218,8 @@
 				E4ED3ECA2768A51C00F17AC8 /* HasSelectorFilter.h */,
 				E4A814DD1C7338D100BF85AC /* IdChangeInvalidation.cpp */,
 				E4A814DF1C7338EB00BF85AC /* IdChangeInvalidation.h */,
+				A1F00E012026070800000C01 /* IfConditionEvaluator.cpp */,
+				A1F00E012026070800000C02 /* IfConditionEvaluator.h */,
 				1C0106FE192594DF008A4201 /* InlineTextBoxStyle.cpp */,
 				1C0106FF192594DF008A4201 /* InlineTextBoxStyle.h */,
 				4A9CC81E16BF9BB400EC645A /* InspectorCSSOMWrappers.cpp */,
@@ -45902,6 +45907,7 @@
 				7C5222961E1DAE03002CB8F7 /* IDLTypes.h in Headers */,
 				C3CF17A515B0063F00276D39 /* IdTargetObserver.h in Headers */,
 				C3CF17A715B0063F00276D39 /* IdTargetObserverRegistry.h in Headers */,
+				A1F00E012026070800000C03 /* IfConditionEvaluator.h in Headers */,
 				8AB4BC77126FDB7100DEB727 /* IgnoreDestructiveWriteCountIncrementer.h in Headers */,
 				835DA90224F582650022DDA4 /* IIRDSPKernel.h in Headers */,
 				839BE6D524F58762004DF50F /* IIRFilter.h in Headers */,

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -986,6 +986,7 @@ exclude
 var
 env
 random-item
+if
 -internal-auto-base
 
 //
@@ -1821,6 +1822,9 @@ and
 or
 not
 only
+
+// for if()
+else
 
 // overflow-anchor
 // none

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -131,6 +131,7 @@ CSSParserContext::CSSParserContext(const Settings& settings)
     , cssScrollStateContainerQueriesEnabled { settings.cssScrollStateContainerQueriesEnabled() }
     , cssCalcMixEnabled { settings.cssCalcMixEnabled() }
     , cssIdentFunctionEnabled { settings.cssIdentFunctionEnabled() }
+    , cssIfFunctionEnabled { settings.cssIfFunctionEnabled() }
     , propertySettings { CSSPropertySettings { settings } }
 {
 }
@@ -180,7 +181,8 @@ void add(Hasher& hasher, const CSSParserContext& context)
         context.cssAttrSubstitutionFunctionEnabled,
         context.cssScrollStateContainerQueriesEnabled,
         context.cssCalcMixEnabled,
-        context.cssIdentFunctionEnabled
+        context.cssIdentFunctionEnabled,
+        context.cssIfFunctionEnabled
     );
     add(hasher, context.baseURL, context.charset, context.propertySettings, context.mode, context.enclosingRuleType, bits);
 }

--- a/Source/WebCore/css/parser/CSSParserContext.h
+++ b/Source/WebCore/css/parser/CSSParserContext.h
@@ -94,6 +94,7 @@ struct CSSParserContext {
     bool cssScrollStateContainerQueriesEnabled : 1 { false };
     bool cssCalcMixEnabled : 1 { false };
     bool cssIdentFunctionEnabled : 1 { false };
+    bool cssIfFunctionEnabled : 1 { false };
 
     // Settings, those affecting properties.
     CSSPropertySettings propertySettings;

--- a/Source/WebCore/css/parser/CSSSubstitutionParser.cpp
+++ b/Source/WebCore/css/parser/CSSSubstitutionParser.cpp
@@ -66,6 +66,7 @@ static bool isValidConstantReference(CSSParserTokenRange, const CSSParserContext
 static bool isValidDashedFunction(CSSParserTokenRange, const CSSParserContext&);
 static bool isValidAttrReference(CSSParserTokenRange, const CSSParserContext&);
 static bool isValidRandomItemReference(CSSParserTokenRange, const CSSParserContext&);
+static bool isValidIfReference(CSSParserTokenRange, const CSSParserContext&);
 
 struct ClassifyBlockResult {
     bool hasSubstitutionFunctions { false };
@@ -142,6 +143,12 @@ static std::optional<ClassifyBlockResult> classifyBlock(CSSParserTokenRange rang
             }
             if (token.functionId() == CSSValueRandomItem && parserContext.cssRandomItemFunctionEnabled) {
                 if (!isValidRandomItemReference(block, parserContext))
+                    return { };
+                result.hasSubstitutionFunctions = true;
+                continue;
+            }
+            if (token.functionId() == CSSValueIf && parserContext.cssIfFunctionEnabled) {
+                if (!isValidIfReference(block, parserContext))
                     return { };
                 result.hasSubstitutionFunctions = true;
                 continue;
@@ -325,6 +332,37 @@ bool isValidRandomItemReference(CSSParserTokenRange range, const CSSParserContex
     } while (CSSPropertyParserHelpers::consumeCommaIncludingWhitespace(range));
 
     return range.atEnd();
+}
+
+// https://drafts.csswg.org/css-values-5/#funcdef-if
+// <if-args> = if( [ <if-args-branch>; ]* <if-args-branch> ;? )
+// <if-args-branch> = <declaration-value> : <declaration-value>?
+// Validate using the argument grammar. Condition parsing happens at substitution time.
+bool isValidIfReference(CSSParserTokenRange range, const CSSParserContext& parserContext)
+{
+    range.consumeWhitespace();
+    if (range.atEnd())
+        return false;
+
+    // Validate semicolon-separated branches. classifyBlock rejects top-level semicolons,
+    // but they are valid branch separators in if(), so validate each branch separately.
+    while (!range.atEnd()) {
+        auto branchStart = range;
+        while (!range.atEnd() && range.peek().type() != SemicolonToken)
+            range.consumeComponentValue();
+        auto branchRange = branchStart.rangeUntil(range);
+
+        if (!range.atEnd())
+            range.consume(); // semicolon
+        range.consumeWhitespace();
+
+        if (branchRange.atEnd())
+            continue;
+
+        if (!classifyBlock(branchRange, parserContext))
+            return false;
+    }
+    return true;
 }
 
 struct VariableType {

--- a/Source/WebCore/css/parser/CSSSupportsParser.h
+++ b/Source/WebCore/css/parser/CSSSupportsParser.h
@@ -29,12 +29,12 @@
 
 #pragma once
 
+#include "CSSParser.h"
 #include "CSSParserEnum.h"
 #include "CSSParserToken.h"
 
 namespace WebCore {
 
-class CSSParser;
 class CSSParserTokenRange;
 struct CSSParserContext;
 

--- a/Source/WebCore/style/IfConditionEvaluator.cpp
+++ b/Source/WebCore/style/IfConditionEvaluator.cpp
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "IfConditionEvaluator.h"
+
+#include "CSSSupportsParser.h"
+#include "CSSTokenizer.h"
+#include "CommonAtomStrings.h"
+#include "ContainerQueryFeatures.h"
+#include "ContainerQueryParser.h"
+#include "Document.h"
+#include "DocumentView.h"
+#include "MediaQueryEvaluator.h"
+#include "MediaQueryParser.h"
+#include "RenderElement.h"
+#include "StyleBuilder.h"
+
+namespace WebCore {
+namespace Style {
+
+auto IfConditionEvaluator::evaluate(CSSParserTokenRange branchCondition) -> Result
+{
+    // Evaluates <boolean-expr[ <if-test> ]> using the container query parser. The else keyword (the
+    // other <if-condition> alternative) is resolved earlier, in substituteIfArgumentGrammar.
+    // <if-test> =
+    //   supports( [ <ident> : <declaration-value> ] | <supports-condition> ) |
+    //   media( <media-feature> | <media-condition> ) |
+    //   style( <style-query> )
+    // https://drafts.csswg.org/css-values-5/#typedef-if-condition
+
+    // Unsupported features (like size queries) evaluate to Unknown.
+    auto parserContext = MediaQueryParserContext { m_context };
+    auto condition = CQ::ContainerQueryParser::consumeCondition(branchCondition, parserContext);
+    if (!condition || !branchCondition.atEnd())
+        return Result::Invalid;
+
+    auto& state = m_styleBuilder.state();
+    MQ::FeatureEvaluationContext evaluationContext {
+        state.document(),
+        state.cssToLengthConversionData(),
+        nullptr
+    };
+
+    return evaluateCondition(*condition, evaluationContext) == MQ::EvaluationResult::True ? Result::True : Result::False;
+}
+
+MQ::EvaluationResult IfConditionEvaluator::evaluateQueryInParens(const MQ::QueryInParens& queryInParens, const MQ::FeatureEvaluationContext& context) const
+{
+    // media() and supports() functions fall through to GeneralEnclosed during parsing. The generic
+    // evaluator treats those as unknown, so evaluate them here. Everything else uses the base logic.
+    // FIXME: Parse these into dedicated media/supports FeatureSchemas that carry the argument tokens.
+    // That avoids re-tokenizing the serialized argument text below, and the schema pointer would
+    // identify the function (like style()) instead of comparing names here.
+    if (auto* enclosed = std::get_if<MQ::GeneralEnclosed>(&queryInParens)) {
+        if (equalLettersIgnoringASCIICase(enclosed->name, "media"_s)) {
+            // Wrap in parens so bare features like "max-width: 1px" parse as media conditions.
+            auto wrappedText = makeString('(', enclosed->text, ')');
+            CSSTokenizer tokenizer(wrappedText);
+            auto mediaQuery = MQ::MediaQueryParser::parseCondition(tokenizer.tokenRange(), m_context);
+            if (!mediaQuery || !mediaQuery->condition)
+                return MQ::EvaluationResult::Unknown;
+
+            auto& document = m_styleBuilder.state().document();
+            CheckedPtr view = document.view();
+            MQ::MediaQueryEvaluator evaluator { view ? view->mediaType() : screenAtom(), document };
+            return evaluator.evaluate(*mediaQuery) ? MQ::EvaluationResult::True : MQ::EvaluationResult::False;
+        }
+
+        if (equalLettersIgnoringASCIICase(enclosed->name, "supports"_s)) {
+            auto result = CSSSupportsParser::supportsCondition(enclosed->text, m_context, CSSSupportsParser::ParsingMode::AllowBareDeclarationAndGeneralEnclosed);
+            if (result == CSSSupportsParser::Invalid)
+                return MQ::EvaluationResult::Unknown;
+            return result == CSSSupportsParser::Supported ? MQ::EvaluationResult::True : MQ::EvaluationResult::False;
+        }
+    }
+
+    return MQ::GenericMediaQueryEvaluator<IfConditionEvaluator>::evaluateQueryInParens(queryInParens, context);
+}
+
+MQ::EvaluationResult IfConditionEvaluator::evaluateFeature(const MQ::Feature& feature, const MQ::FeatureEvaluationContext& context) const
+{
+    // The only feature valid in an <if-test> is style(). The container query parser also accepts size
+    // and scroll-state features. Treat those as unknown rather than evaluating them.
+    if (feature.schema != &CQ::Features::style())
+        return MQ::EvaluationResult::Unknown;
+
+    // Force resolution of the queried custom property. Range queries comparing
+    // literals (e.g. style(5 > 3)) have no custom-property name to resolve.
+    if (!feature.name.isNull())
+        m_styleBuilder.applyCustomProperty(feature.name);
+
+    return feature.schema->evaluate(feature, context);
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/IfConditionEvaluator.h
+++ b/Source/WebCore/style/IfConditionEvaluator.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSParserTokenRange.h"
+#include "GenericMediaQueryEvaluator.h"
+
+namespace WebCore {
+
+struct CSSParserContext;
+
+namespace Style {
+
+class Builder;
+
+// Evaluates the condition of an if() branch (CSS Values 5 §8.6).
+// https://drafts.csswg.org/css-values-5/#funcdef-if
+class IfConditionEvaluator : public MQ::GenericMediaQueryEvaluator<IfConditionEvaluator> {
+public:
+    IfConditionEvaluator(Builder& styleBuilder, const CSSParserContext& context)
+        : m_styleBuilder(styleBuilder)
+        , m_context(context)
+    {
+    }
+
+    enum class Result : uint8_t { True, False, Invalid };
+    Result evaluate(CSSParserTokenRange branchCondition);
+
+private:
+    friend class MQ::GenericMediaQueryEvaluator<IfConditionEvaluator>;
+
+    MQ::EvaluationResult evaluateQueryInParens(const MQ::QueryInParens&, const MQ::FeatureEvaluationContext&) const;
+    MQ::EvaluationResult evaluateFeature(const MQ::Feature&, const MQ::FeatureEvaluationContext&) const;
+
+    Builder& m_styleBuilder;
+    const CSSParserContext& m_context;
+};
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/StyleSubstitutionResolver.cpp
+++ b/Source/WebCore/style/StyleSubstitutionResolver.cpp
@@ -54,6 +54,7 @@
 #include "Element.h"
 #include "ElementInlines.h"
 #include "HTMLSelectElement.h"
+#include "IfConditionEvaluator.h"
 #include "MatchResult.h"
 #include "MutableStyleProperties.h"
 #include "SelectPopoverElement.h"
@@ -909,6 +910,99 @@ std::optional<double> SubstitutionResolver::randomItemBaseValue(Vector<CSSParser
     return m_styleBuilder.state().lookupCSSRandomBaseValue(CSSCalc::RandomCachingKey { autoKey }, elementScoped);
 }
 
+auto SubstitutionResolver::substituteIfArgumentGrammar(CSSParserTokenRange range, const CSSParserContext& context) -> std::optional<Vector<IfBranch>>
+{
+    // https://drafts.csswg.org/css-values-5/#argument-grammars
+    // <if-args> = if( [ <if-args-branch>; ]* <if-args-branch> ;? )
+    // <if-args-branch> = <declaration-value> : <declaration-value>?
+    // The condition excludes top-level colons, so the first top-level colon separates it from the
+    // value and top-level semicolons separate branches. A single pass consumes both in source order.
+
+    range.consumeWhitespace();
+
+    Vector<IfBranch> branches;
+    while (!range.atEnd()) {
+        auto conditionStart = range;
+        while (!range.atEnd() && range.peek().type() != ColonToken && range.peek().type() != SemicolonToken)
+            range.consumeComponentValue();
+        auto conditionRange = conditionStart.rangeUntil(range);
+
+        // A branch without a colon is invalid, but an empty segment (from a doubled or trailing
+        // semicolon) is skipped.
+        if (range.atEnd() || range.peek().type() == SemicolonToken) {
+            conditionRange.consumeWhitespace();
+            if (!conditionRange.atEnd())
+                return { };
+            if (!range.atEnd())
+                range.consumeIncludingWhitespace(); // semicolon
+            continue;
+        }
+
+        range.consume(); // colon
+
+        auto valueStart = range;
+        while (!range.atEnd() && range.peek().type() != SemicolonToken)
+            range.consumeComponentValue();
+        auto valueRange = valueStart.rangeUntil(range);
+        valueRange.consumeWhitespace();
+
+        if (!range.atEnd())
+            range.consumeIncludingWhitespace(); // semicolon
+
+        auto substitutedCondition = substituteTokenRange(conditionRange, context);
+        if (!substitutedCondition)
+            continue;
+
+        // <if-condition> = <boolean-expr[ <if-test> ]> | else. The else keyword is recognized after
+        // substitution (it may come from a var()), and always matches, so it is stored as a null
+        // condition. Other conditions are evaluated later.
+        auto substitutedRange = CSSParserTokenRange { *substitutedCondition };
+        substitutedRange.consumeWhitespace();
+        if (CSSPropertyParserHelpers::consumeIdentRaw<CSSValueElse>(substitutedRange) && substitutedRange.atEnd()) {
+            branches.append({ std::nullopt, valueRange });
+            continue;
+        }
+
+        branches.append({ WTF::move(*substitutedCondition), valueRange });
+    }
+
+    return branches;
+}
+
+bool SubstitutionResolver::substituteIfFunction(CSSParserTokenRange argumentsRange, Vector<CSSParserToken>& tokens, const CSSParserContext& context)
+{
+    // https://drafts.csswg.org/css-values-5/#funcdef-if
+    auto branches = substituteIfArgumentGrammar(argumentsRange, context);
+    if (!branches)
+        return false;
+
+    for (auto& branch : *branches) {
+        auto conditionResult = branch.condition
+            ? IfConditionEvaluator { m_styleBuilder, context }.evaluate(*branch.condition)
+            : IfConditionEvaluator::Result::True;
+
+        // An invalid condition makes the whole if() IACVT. This matches the imported WPT but not the
+        // spec algorithm, which continues to the next branch on a condition parse failure.
+        // FIXME: Revisit once the spec/WPT discrepancy is resolved upstream.
+        if (conditionResult == IfConditionEvaluator::Result::Invalid)
+            return false;
+
+        if (conditionResult != IfConditionEvaluator::Result::True)
+            continue;
+
+        // Substitute the value part and return.
+        auto substitutedValue = substituteTokenRange(branch.valueRange, context);
+        if (!substitutedValue)
+            return false;
+
+        tokens.appendVector(*substitutedValue);
+        return true;
+    }
+
+    // No condition matched. Empty token stream.
+    return true;
+}
+
 std::optional<Vector<CSSParserToken>> SubstitutionResolver::substituteTokenRange(CSSParserTokenRange range, const CSSParserContext& context)
 {
     Vector<CSSParserToken> tokens;
@@ -928,6 +1022,11 @@ std::optional<Vector<CSSParserToken>> SubstitutionResolver::substituteTokenRange
                 if (substituteAttrFunction(range.consumeBlock(), tokens, context))
                     propagateAttrTaint(IsAttrTainted::Yes, std::span(tokens).subspan(startIndex));
                 else
+                    success = false;
+                continue;
+            }
+            if (functionId == CSSValueIf) {
+                if (!substituteIfFunction(range.consumeBlock(), tokens, context))
                     success = false;
                 continue;
             }

--- a/Source/WebCore/style/StyleSubstitutionResolver.h
+++ b/Source/WebCore/style/StyleSubstitutionResolver.h
@@ -69,6 +69,7 @@ private:
     bool substituteDashedFunction(StringView functionName, CSSParserTokenRange, Vector<CSSParserToken>&);
     RefPtr<MutableStyleProperties> resolveAndRegisterDashedFunctionArguments(const Vector<StyleRuleFunction::Parameter>&, const Vector<Vector<CSSParserToken>>&, LocalPropertyRegistry&, ScopeOrdinal definitionScope);
     bool substituteAttrFunction(CSSParserTokenRange, Vector<CSSParserToken>&, const CSSParserContext&);
+    bool substituteIfFunction(CSSParserTokenRange, Vector<CSSParserToken>&, const CSSParserContext&);
     bool substituteInternalAutoBaseFunction(CSSParserTokenRange, Vector<CSSParserToken>&, const CSSParserContext&);
     bool substituteRandomItemFunction(CSSParserTokenRange, Vector<CSSParserToken>&, const CSSParserContext&);
     std::optional<double> randomItemBaseValue(Vector<CSSParserToken> randomKey);
@@ -78,6 +79,13 @@ private:
         std::optional<CSSParserTokenRange> fallbackRange;
     };
     std::optional<AttrArgumentGrammarSubstitution> substituteAttrArgumentGrammar(CSSParserTokenRange, const CSSParserContext&);
+
+    struct IfBranch {
+        // A null condition is the `else` keyword, which always matches.
+        std::optional<Vector<CSSParserToken>> condition;
+        CSSParserTokenRange valueRange;
+    };
+    std::optional<Vector<IfBranch>> substituteIfArgumentGrammar(CSSParserTokenRange, const CSSParserContext&);
 
     RefPtr<const CustomProperty> propertyValueForVariableName(const AtomString&, CSSValueID);
     RefPtr<CSSVariableData> trySimpleSubstitution(const CSSSubstitutionValue&);


### PR DESCRIPTION
#### 8ffb76a8529413df5a14343f91fd615271befdc7
<pre>
[css-values-5] Implement if() arbitrary substitution function
<a href="https://bugs.webkit.org/show_bug.cgi?id=296995">https://bugs.webkit.org/show_bug.cgi?id=296995</a>
<a href="https://rdar.apple.com/158221024">rdar://158221024</a>

Reviewed by Sam Weinig.

&quot;The if() function is an arbitrary substitution function that represents conditional values. Its argument
consists of an ordered semi-colon–separated list of statements, each consisting of a condition followed by
a colon followed by a value. An if() function represents the value corresponding to the first condition in
its argument list to be true; if no condition matches, then the if() function represents an empty token stream.&quot;

<a href="https://drafts.csswg.org/css-values-5/#if-notation">https://drafts.csswg.org/css-values-5/#if-notation</a>

For example:

color: if(style(--foo &gt; 100px): red; else: blue);

At parse time if() is validated only against a very permissive argument grammar.

The actual logic is in Style::SubstitutionResolver and runs from style builder. The condition in each branch
is evaluated using IfConditionEvaluator until one matches. The if() function is then substituted with the
content tokens of that branch.

* LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-parameter-types.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/local-if-substitution-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-security-if-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/if-conditionals-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/if-cycle-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/if-function-revert-rule-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/if-initial-unregistered-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/if-invalidation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/if-media-invalidation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/if-style-invalidation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/if-supports-quirks-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/inherit-function-basic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-in-if.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/viewport-units-scroll-no-cycles-001.tentative-expected.txt:

PASS-&gt;FAIL cases were spurious passes in feature interaction tests.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSValueKeywords.in:
* Source/WebCore/css/parser/CSSParserContext.cpp:
(WebCore::add):
* Source/WebCore/css/parser/CSSParserContext.h:
* Source/WebCore/css/parser/CSSSubstitutionParser.cpp:
(WebCore::classifyBlock):

Validate according to argument grammar.

(WebCore::isValidIfReference):
* Source/WebCore/style/IfConditionEvaluator.cpp: Added.
(WebCore::Style::IfConditionEvaluator::evaluate):
(WebCore::Style::IfConditionEvaluator::evaluateQueryInParens const):
(WebCore::Style::IfConditionEvaluator::evaluateFeature const):
* Source/WebCore/style/IfConditionEvaluator.h: Added.
(WebCore::Style::IfConditionEvaluator::IfConditionEvaluator):

Introduce IfConditionEvaluator for evaluating the condition. It uses the existing container query machinery.

* Source/WebCore/style/StyleSubstitutionResolver.cpp:
(WebCore::Style::SubstitutionResolver::substituteIfArgumentGrammar):
(WebCore::Style::SubstitutionResolver::substituteIfFunction):

Pick a branch to substitute based on evaluation result.

(WebCore::Style::SubstitutionResolver::substituteTokenRange):
* Source/WebCore/style/StyleSubstitutionResolver.h:

Canonical link: <a href="https://commits.webkit.org/316752@main">https://commits.webkit.org/316752@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/98ca9218128043079bfaa8e6108182aed09113bc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173332 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47264 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40810 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182905 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130888 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175197 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48557 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46946 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/134775 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5394fc63-cd06-48d4-a61b-61b2fe74cd84) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176290 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/38201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/155449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/115250 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/01780a0c-ff4c-4f5b-92cb-50d76d66264d) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/36843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/35189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31390 "Built successfully") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/218/builds/3963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/147267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/34946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185329 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/34594 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/38191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/39391 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143631 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46932 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/155008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143500 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38725 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47611 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112712 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38457 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/119360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/210365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46117 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/9893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/210365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45519 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45750 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45576 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->