### PR TITLE
moveBefore() isn't updating web inspector

### DIFF
--- a/LayoutTests/inspector/dom/moveBefore-expected.txt
+++ b/LayoutTests/inspector/dom/moveBefore-expected.txt
@@ -1,0 +1,32 @@
+Tests that moveBefore() correctly updates the Web Inspector's DOM tree.
+
+
+== Running test suite: moveBefore
+-- Running test case: DOM.moveBefore.SiblingBecomesChild
+Before moveBefore():
+Children of #container:
+  div#sibling-a (parent: div#container)
+  div#sibling-b (parent: div#container)
+Children of #sibling-a:
+Moving #sibling-b to be a child of #sibling-a via moveBefore()...
+Move complete.
+After moveBefore():
+Children of #container:
+  div#sibling-a (parent: div#container)
+Children of #sibling-a:
+  div#sibling-b (parent: div#sibling-a)
+
+-- Running test case: DOM.moveBefore.ChildMovedBackToBeSibling
+Before moveBefore():
+Children of #container:
+  div#sibling-a (parent: div#container)
+Children of #sibling-a:
+  div#sibling-b (parent: div#sibling-a)
+Moving #sibling-b back out to be a child of #container via moveBefore()...
+Move complete.
+After moveBefore():
+Children of #container:
+  div#sibling-a (parent: div#container)
+  div#sibling-b (parent: div#container)
+Children of #sibling-a:
+

--- a/LayoutTests/inspector/dom/moveBefore-protocol-expected.txt
+++ b/LayoutTests/inspector/dom/moveBefore-protocol-expected.txt
@@ -1,0 +1,6 @@
+Testing that moveBefore() correctly triggers DOM.childNodeRemoved and DOM.childNodeInserted.
+
+PASS: onChildNodeRemoved called for #sibling-b
+PASS: onChildNodeInserted called for parent node #sibling-a
+PASS: onChildNodeInserted called for child node #sibling-b
+

--- a/LayoutTests/inspector/dom/moveBefore-protocol.html
+++ b/LayoutTests/inspector/dom/moveBefore-protocol.html
@@ -1,0 +1,95 @@
+<!-- webkit-test-runner [ MoveBeforeEnabled=true ] -->
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/protocol-test.js"></script>
+<script>
+function moveSiblingIntoOther()
+{
+    var siblingA = document.getElementById("sibling-a");
+    var siblingB = document.getElementById("sibling-b");
+    siblingA.moveBefore(siblingB, null);
+}
+
+function test()
+{
+    var nodesById = {};
+
+    InspectorProtocol.eventHandler["DOM.setChildNodes"] = onSetChildNodes;
+    InspectorProtocol.eventHandler["DOM.childNodeRemoved"] = onChildNodeRemoved;
+    InspectorProtocol.eventHandler["DOM.childNodeInserted"] = onChildNodeInserted;
+
+    function createNodeAttributesMap(node)
+    {
+        var attributes = {};
+        if (!node.attributes)
+            return attributes;
+        for (var i = 0; i < node.attributes.length; i += 2)
+            attributes[node.attributes[i]] = node.attributes[i + 1];
+        return attributes;
+    }
+
+    function collectNode(node)
+    {
+        nodesById[node.nodeId] = createNodeAttributesMap(node);
+        if (node.children)
+            node.children.forEach(collectNode);
+    }
+
+    function getNodeIdentifier(nodeId)
+    {
+        var node = nodesById[nodeId];
+        return node ? node.id : "<unknown node>";
+    }
+
+    function onSetChildNodes(response)
+    {
+        response.params.nodes.forEach(collectNode);
+    }
+
+    function onChildNodeRemoved(response)
+    {
+        var nodeId = response.params.nodeId;
+        ProtocolTest.expectThat(getNodeIdentifier(nodeId) === "sibling-b", "onChildNodeRemoved called for #sibling-b");
+        delete nodesById[nodeId];
+    }
+
+    function onChildNodeInserted(response)
+    {
+        collectNode(response.params.node);
+        ProtocolTest.expectThat(getNodeIdentifier(response.params.parentNodeId) === "sibling-a", "onChildNodeInserted called for parent node #sibling-a");
+        ProtocolTest.expectThat(getNodeIdentifier(response.params.node.nodeId) === "sibling-b", "onChildNodeInserted called for child node #sibling-b");
+    }
+
+    InspectorProtocol.sendCommand("DOM.getDocument", {}, onGotDocument);
+
+    function onGotDocument(msg)
+    {
+        InspectorProtocol.checkForError(msg);
+        InspectorProtocol.sendCommand("DOM.querySelector", {"nodeId": msg.result.root.nodeId, "selector": "#container"}, onQuerySelector);
+    }
+
+    function onQuerySelector(response)
+    {
+        // Make sure we receive the children of "#container" and "#sibling-a" as they change.
+        InspectorProtocol.sendCommand("DOM.requestChildNodes", {nodeId: response.result.nodeId, depth: -1});
+        InspectorProtocol.sendCommand("Runtime.evaluate", {"expression": "moveSiblingIntoOther()"}, function() {
+            delete InspectorProtocol.eventHandler["DOM.setChildNodes"];
+            delete InspectorProtocol.eventHandler["DOM.childNodeRemoved"];
+            delete InspectorProtocol.eventHandler["DOM.childNodeInserted"];
+            ProtocolTest.completeTest();
+        });
+    }
+}
+</script>
+</head>
+<body onload="runTest()">
+
+<p>Testing that moveBefore() correctly triggers DOM.childNodeRemoved and DOM.childNodeInserted.</p>
+
+<div id="container">
+    <div id="sibling-a"></div>
+    <div id="sibling-b"></div>
+</div>
+
+</body>
+</html>

--- a/LayoutTests/inspector/dom/moveBefore.html
+++ b/LayoutTests/inspector/dom/moveBefore.html
@@ -1,0 +1,108 @@
+<!-- webkit-test-runner [ MoveBeforeEnabled=true ] -->
+<!doctype html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+function moveSiblingIntoOther()
+{
+    let siblingA = document.getElementById("sibling-a");
+    let siblingB = document.getElementById("sibling-b");
+    siblingA.moveBefore(siblingB, null);
+}
+
+function moveChildBackToBeSibling()
+{
+    let container = document.getElementById("container");
+    let siblingB = document.getElementById("sibling-b");
+    container.moveBefore(siblingB, null);
+}
+
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("moveBefore");
+
+    async function ensureDocumentSubtree() {
+        let documentNode = await WI.domManager.requestDocument();
+
+        const entireSubtreeDepth = -1;
+        await WI.assumingMainTarget().DOMAgent.requestChildNodes(documentNode.id, entireSubtreeDepth);
+
+        return documentNode;
+    }
+
+    function logNode(node) {
+        let parent = node.parentNode;
+        InspectorTest.log("  " + node.unescapedSelector + " (parent: " + (parent ? parent.unescapedSelector : "none") + ")");
+    }
+
+    function logChildren(label, node) {
+        InspectorTest.log(label);
+        for (let child of (node.children || []))
+            logNode(child);
+    }
+
+    suite.addTestCase({
+        name: "DOM.moveBefore.SiblingBecomesChild",
+        description: "Ensure that moveBefore() updates the Web Inspector's DOM tree when moving a sibling element to become a child of another element.",
+        async test() {
+            let documentNode = await ensureDocumentSubtree();
+
+            let containerNode = WI.domManager.nodeForId(await documentNode.querySelector("#container"));
+            let siblingANode = WI.domManager.nodeForId(await documentNode.querySelector("#sibling-a"));
+
+            InspectorTest.log("Before moveBefore():");
+            logChildren("Children of #container:", containerNode);
+            logChildren("Children of #sibling-a:", siblingANode);
+
+            InspectorTest.log("Moving #sibling-b to be a child of #sibling-a via moveBefore()...");
+            await Promise.all([
+                WI.domManager.awaitEvent(WI.DOMManager.Event.NodeInserted),
+                InspectorTest.evaluateInPage(`moveSiblingIntoOther()`),
+            ]);
+            InspectorTest.log("Move complete.");
+
+            InspectorTest.log("After moveBefore():");
+            logChildren("Children of #container:", containerNode);
+            logChildren("Children of #sibling-a:", siblingANode);
+        }
+    });
+
+    suite.addTestCase({
+        name: "DOM.moveBefore.ChildMovedBackToBeSibling",
+        description: "Ensure that moveBefore() updates the Web Inspector's DOM tree when moving a child element back out to be a sibling of its former parent.",
+        async test() {
+            let documentNode = await ensureDocumentSubtree();
+
+            let containerNode = WI.domManager.nodeForId(await documentNode.querySelector("#container"));
+            let siblingANode = WI.domManager.nodeForId(await documentNode.querySelector("#sibling-a"));
+
+            InspectorTest.log("Before moveBefore():");
+            logChildren("Children of #container:", containerNode);
+            logChildren("Children of #sibling-a:", siblingANode);
+
+            InspectorTest.log("Moving #sibling-b back out to be a child of #container via moveBefore()...");
+            await Promise.all([
+                WI.domManager.awaitEvent(WI.DOMManager.Event.NodeInserted),
+                InspectorTest.evaluateInPage(`moveChildBackToBeSibling()`),
+            ]);
+            InspectorTest.log("Move complete.");
+
+            InspectorTest.log("After moveBefore():");
+            logChildren("Children of #container:", containerNode);
+            logChildren("Children of #sibling-a:", siblingANode);
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p id="test-description">Tests that moveBefore() correctly updates the Web Inspector's DOM tree.</p>
+<div id="container">
+    <div id="sibling-a"></div>
+    <div id="sibling-b"></div>
+</div>
+</body>
+</html>

--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -1518,6 +1518,8 @@ ExceptionOr<void> ContainerNode::moveBefore(Node& node, RefPtr<Node>&& refChild)
         }
 
         node.updateAncestorConnectedSubframeCountForRemoval();
+        // FIXME(319588): Handle inspector DOM breakpoints (e.g. InspectorInstrumentation::willRemoveDOMNode)
+        InspectorInstrumentation::didRemoveDOMNode(nodeDocument, node);
         node.setParentNode(nullptr);
 
         // FIXME(281223): Handle slot assignments and live ranges.
@@ -1526,6 +1528,8 @@ ExceptionOr<void> ContainerNode::moveBefore(Node& node, RefPtr<Node>&& refChild)
             insertBeforeCommon(*refChild, node);
         else
             appendChildCommon(node);
+        // FIXME(319588): Handle inspector DOM breakpoints (e.g. InspectorInstrumentation::willInsertDOMNode)
+        InspectorInstrumentation::didInsertDOMNode(protect(document()), node);
 
         node.setTreeScopeRecursively(treeScope());
         node.updateAncestorConnectedSubframeCountForInsertion();


### PR DESCRIPTION
#### f3f3dfe8ce76fa73883a2e4d8bfdfa6688aea27c
<pre>
moveBefore() isn&apos;t updating web inspector
<a href="https://bugs.webkit.org/show_bug.cgi?id=318861">https://bugs.webkit.org/show_bug.cgi?id=318861</a>

Reviewed by Devin Rousso.

Adds InspectorInstrumentation calls to ContainerNode::moveBefore(),
this ensures that the web inspector is kept up-to-date when elements move within the DOM.

This doesn&apos;t, however, support DOM breakpoints yet.

Also adds some tests to ensure this works as expected.

Tests: inspector/dom/moveBefore-protocol.html
       inspector/dom/moveBefore.html

* LayoutTests/inspector/dom/moveBefore-expected.txt: Added.
* LayoutTests/inspector/dom/moveBefore-protocol-expected.txt: Added.
* LayoutTests/inspector/dom/moveBefore-protocol.html: Added.
* LayoutTests/inspector/dom/moveBefore.html: Added.
* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::ContainerNode::moveBefore):

Canonical link: <a href="https://commits.webkit.org/318724@main">https://commits.webkit.org/318724@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c11ae768b9f4ffa47c4e9417da18d79d85a4021

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179148 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53087 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46882 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188979 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181011 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54380 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52797 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139701 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182105 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43296 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160456 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120148 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/41967 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40311 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; 6 api tests failed or timed out") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152367 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39960 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/285 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45693 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/44557 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191197 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52757 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159973 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148940 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39963 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53437 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148686 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43366 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125708 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120549 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51955 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14939 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51340 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51581 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51401 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->