### PR TITLE
Navigating back to page with previously active web env leaves UI stuck showing active state

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -7617,6 +7617,11 @@ void Document::setBackForwardCacheState(BackForwardCacheState state)
         exitPointerLock();
 #endif
 
+#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
+        if (RefPtr immersive = immersiveIfExists())
+            immersive->clearForBackForwardCache();
+#endif
+
         styleScope().clearResolver();
         m_styleRecalcTimer.stop();
 

--- a/Source/WebCore/dom/DocumentImmersive.cpp
+++ b/Source/WebCore/dom/DocumentImmersive.cpp
@@ -468,6 +468,18 @@ void DocumentImmersive::clear()
     clearPendingEvents();
 }
 
+void DocumentImmersive::clearForBackForwardCache()
+{
+    RefPtr previouslyImmersiveElement = m_immersiveElement;
+
+    clear();
+
+    if (previouslyImmersiveElement) {
+        previouslyImmersiveElement->exitImmersivePresentation([] { });
+        updateElementIsImmersive(previouslyImmersiveElement.get(), false);
+    }
+}
+
 }
 
 #endif

--- a/Source/WebCore/dom/DocumentImmersive.h
+++ b/Source/WebCore/dom/DocumentImmersive.h
@@ -66,6 +66,7 @@ public:
     void dispatchPendingEvents();
     void queueImmersiveEventForElement(EventType, Element&);
     void clear();
+    void clearForBackForwardCache();
 
 protected:
     friend class Document;


### PR DESCRIPTION
#### 2c84f4f3c4eafb71100f721c4e7e0318f0250f99
<pre>
Navigating back to page with previously active web env leaves UI stuck showing active state
<a href="https://bugs.webkit.org/show_bug.cgi?id=318860">https://bugs.webkit.org/show_bug.cgi?id=318860</a>
<a href="https://rdar.apple.com/180966321">rdar://180966321</a>

Reviewed by Etienne Segonzac.

Trigger the state exit of the old immersive element and queue the immersivechange notification when the document is about to
enter the back/forward cache, mirroring how pointer lock is torn down at the same call site.
Since the Immersive environment cannot survive navigation, it is safe to clear the immersive document state at this point,
to get back from a clean slate if the user navigates back to this page.
Sending the event to the page ensures that it updates its UI and doesn&apos;t stay in a stale state thinking that the
immersive environment is still up.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::setBackForwardCacheState):
* Source/WebCore/dom/DocumentImmersive.cpp:
(WebCore::DocumentImmersive::clearForBackForwardCache):
* Source/WebCore/dom/DocumentImmersive.h:

Canonical link: <a href="https://commits.webkit.org/316891@main">https://commits.webkit.org/316891@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/24e43423aa28034c37e56df8569ec234e6aabb16

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173257 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47189 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41264 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182830 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130813 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175122 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48482 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46871 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134721 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95128 "23 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176215 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38137 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155768 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115192 "1 api test failed or timed out") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36781 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35126 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31315 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147205 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35262 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185253 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38093 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39326 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143573 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46857 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143438 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38798 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47536 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112633 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38396 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119285 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46042 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10215 "Passed tests") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45444 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45675 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45501 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->