### PR TITLE
[GStreamer][WebRTC] Data race on stats GstStructure crashes webrtc/video-stats.html

### DIFF
--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
@@ -570,7 +570,17 @@ public:
     void updateFirstVideoSampleSeenFlag();
     bool receivedAudioSampleBeforeVideo();
 
-    const GstStructure* stats() const { return m_stats.get(); }
+    bool mergeStatsInto(GstStructure* destination) const
+    {
+        Locker locker { m_statsLock };
+        if (!m_stats)
+            return false;
+        gstStructureForeach(m_stats.get(), [&](auto id, const auto* value) {
+            gstStructureIdSetValue(destination, id, value);
+            return true;
+        });
+        return true;
+    }
 
 private:
     InternalSource(GstElement* parent, MediaStreamTrackPrivate& track, const String& padName, bool consumerIsVideoPlayer)
@@ -660,14 +670,8 @@ private:
             case GST_QUERY_CUSTOM: {
                 auto structure = gst_query_writable_structure(query);
                 if (gst_structure_has_name(structure, "webkit-media-source-stats")) {
-                    const auto stats = self->stats();
-                    if (!stats)
+                    if (!self->mergeStatsInto(structure))
                         return GST_PAD_PROBE_OK;
-
-                    gstStructureForeach(stats, [&](auto id, const auto* value) {
-                        gstStructureIdSetValue(structure, id, value);
-                        return true;
-                    });
                     return GST_PAD_PROBE_HANDLED;
                 }
                 break;
@@ -786,6 +790,7 @@ private:
         if (!m_trackSource)
             return;
 
+        Locker locker { m_statsLock };
         if (m_isVideoTrack) {
             if (!m_stats)
                 m_stats.reset(gst_structure_new_empty("video-stats"));
@@ -875,6 +880,7 @@ private:
     double m_totalAudioSamplesDuration { 0 };
     double m_totalAudioEnergy { 0 };
     unsigned m_audioSamplesCountSinceLastTotalEnergyCalculation { 0 };
+    mutable Lock m_statsLock;
     GUniquePtr<GstStructure> m_stats;
 #if USE(GSTREAMER_WEBRTC)
     RefPtr<PadProbeHandle<RealtimeIncomingSourceGStreamer>> m_incomingPadProbeHandle;

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerRTPPacketizer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerRTPPacketizer.cpp
@@ -242,19 +242,22 @@ int GStreamerRTPPacketizer::findLastExtensionId(const GstCaps* caps)
     return result;
 }
 
-std::optional<std::pair<unsigned, GstStructure*>> GStreamerRTPPacketizer::stats() const
+bool GStreamerRTPPacketizer::appendStatsTo(GstStructure* destination) const
 {
     GRefPtr<GstCaps> caps;
     g_object_get(m_capsFilter.get(), "caps", &caps.outPtr(), nullptr);
     if (!caps || gst_caps_is_empty(caps.get()) || gst_caps_is_any(caps.get()))
-        return std::nullopt;
+        return false;
 
     auto structure = gst_caps_get_structure(caps.get(), 0);
     auto ssrc = gstStructureGet<unsigned>(structure, "ssrc"_s);
     if (!ssrc)
-        return std::nullopt;
+        return false;
 
-    return { { *ssrc, m_stats.get() } };
+    auto ssrcString = makeString(*ssrc);
+    Locker locker { m_statsLock };
+    gst_structure_set(destination, ssrcString.ascii().data(), GST_TYPE_STRUCTURE, m_stats.get(), nullptr);
+    return true;
 }
 
 struct RTPPacketizerHolder {
@@ -270,6 +273,7 @@ void GStreamerRTPPacketizer::startUpdatingStats()
     GRefPtr pad = adoptGRef(gst_element_get_static_pad(m_encoder.get(), "src"));
     m_statsPadProbeId = gst_pad_add_probe(pad.get(), GST_PAD_PROBE_TYPE_BUFFER, [](GstPad*, GstPadProbeInfo*, gpointer userData) -> GstPadProbeReturn {
         auto packetizer = static_cast<RTPPacketizerHolder*>(userData)->packetizer;
+        Locker locker { packetizer->m_statsLock };
         packetizer->updateStats();
         packetizer->updateStatsFromRTPExtensions();
         return GST_PAD_PROBE_OK;

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerRTPPacketizer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerRTPPacketizer.h
@@ -23,6 +23,7 @@
 
 #include "GRefPtrGStreamer.h"
 #include "GUniquePtrGStreamer.h"
+#include <wtf/Lock.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/text/WTFString.h>
 
@@ -48,7 +49,7 @@ public:
     unsigned currentSequenceNumberOffset() const;
     void setSequenceNumberOffset(unsigned);
 
-    std::optional<std::pair<unsigned, GstStructure*>> stats() const;
+    bool appendStatsTo(GstStructure*) const;
     void startUpdatingStats();
     void stopUpdatingStats();
 
@@ -68,6 +69,7 @@ protected:
     GRefPtr<GstElement> m_valve;
 
     GUniquePtr<GstStructure> m_encodingParameters;
+    mutable Lock m_statsLock;
     GUniquePtr<GstStructure> m_stats;
 
 private:

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp
@@ -687,15 +687,8 @@ RealtimeOutgoingMediaSourceGStreamer::ExtensionLookupResults RealtimeOutgoingMed
 GUniquePtr<GstStructure> RealtimeOutgoingMediaSourceGStreamer::stats()
 {
     GUniquePtr<GstStructure> stats(gst_structure_new_empty("outgoing-media-stats"));
-    for (auto& packetizer : m_packetizers) {
-        auto packetizerStats = packetizer->stats();
-        if (!packetizerStats)
-            continue;
-
-        auto [ssrc, structure] = *packetizerStats;
-        auto ssrcString = makeString(ssrc);
-        gst_structure_set(stats.get(), ssrcString.ascii().data(), GST_TYPE_STRUCTURE, structure, nullptr);
-    }
+    for (auto& packetizer : m_packetizers)
+        packetizer->appendStatsTo(stats.get());
     return stats;
 }
 


### PR DESCRIPTION
#### 7790294d707ec5e549ceb41cf2cf5649949cab84
<pre>
[GStreamer][WebRTC] Data race on stats GstStructure crashes webrtc/video-stats.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=318863">https://bugs.webkit.org/show_bug.cgi?id=318863</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

No new tests (OOPS!).

* Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerRTPPacketizer.cpp:
(WebCore::GStreamerRTPPacketizer::appendStatsTo const):
(WebCore::GStreamerRTPPacketizer::startUpdatingStats):
(WebCore::GStreamerRTPPacketizer::stats const):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerRTPPacketizer.h:
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp:
(WebCore::RealtimeOutgoingMediaSourceGStreamer::stats):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7790294d707ec5e549ceb41cf2cf5649949cab84

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173279 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47211 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41239 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182852 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130835 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175144 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48504 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46893 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134735 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95142 "2 flakes 3 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176237 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38151 "Found 1 new test failure: fast/css/getComputedStyle-font-variant-shorthand-crash.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155757 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115207 "Found 1 new API test failure: WPE/TestWebKitWebView:/webkit/WebKitWebView/save (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36795 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35143 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31337 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147219 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35251 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185275 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38123 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39344 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143588 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46879 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143453 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47558 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31866 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112658 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38410 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119307 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46064 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10204 "Passed tests") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45466 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45697 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45523 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->