### PR TITLE
[animation-triggers] add parsing support for the `trigger-scope` CSS property

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -384,6 +384,7 @@ PASS transition-duration
 PASS transition-property
 PASS transition-timing-function
 PASS translate
+PASS trigger-scope
 PASS unicode-bidi
 PASS vector-effect
 PASS vertical-align

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/shadow-dom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/shadow-dom-expected.txt
@@ -1,9 +1,9 @@
 
 
-FAIL <video controls=""></video> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 442
-FAIL <video></video> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 442
-FAIL <audio></audio> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 442
-FAIL <audio controls=""></audio> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 443
+FAIL <video controls=""></video> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 443
+FAIL <video></video> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 443
+FAIL <audio></audio> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 443
+FAIL <audio controls=""></audio> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 444
 PASS <select></select> has a shadow tree with slot
 PASS <select multiple=""></select> has a shadow tree with slot
 PASS <select size="4"></select> has a shadow tree with slot

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/parsing/trigger-scope.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/parsing/trigger-scope.tentative-expected.txt
@@ -1,23 +1,23 @@
 
-FAIL e.style['trigger-scope'] = "initial" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['trigger-scope'] = "inherit" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['trigger-scope'] = "unset" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['trigger-scope'] = "revert" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['trigger-scope'] = "none" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['trigger-scope'] = "all" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['trigger-scope'] = "--a" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['trigger-scope'] = "--a, --b" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['trigger-scope'] = "--a, --b, --c" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['trigger-scope'] = "--foo, --bar" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['trigger-scope'] = "--bar, --foo" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL Property trigger-scope value 'initial' assert_true: trigger-scope doesn't seem to be supported in the computed style expected true got false
-FAIL Property trigger-scope value 'none' assert_true: trigger-scope doesn't seem to be supported in the computed style expected true got false
-FAIL Property trigger-scope value 'all' assert_true: trigger-scope doesn't seem to be supported in the computed style expected true got false
-FAIL Property trigger-scope value '--a' assert_true: trigger-scope doesn't seem to be supported in the computed style expected true got false
-FAIL Property trigger-scope value '--a, --b' assert_true: trigger-scope doesn't seem to be supported in the computed style expected true got false
-FAIL Property trigger-scope value '--a, --b, --c' assert_true: trigger-scope doesn't seem to be supported in the computed style expected true got false
-FAIL Property trigger-scope value '--foo, --bar' assert_true: trigger-scope doesn't seem to be supported in the computed style expected true got false
-FAIL Property trigger-scope value '--bar, --foo' assert_true: trigger-scope doesn't seem to be supported in the computed style expected true got false
+PASS e.style['trigger-scope'] = "initial" should set the property value
+PASS e.style['trigger-scope'] = "inherit" should set the property value
+PASS e.style['trigger-scope'] = "unset" should set the property value
+PASS e.style['trigger-scope'] = "revert" should set the property value
+PASS e.style['trigger-scope'] = "none" should set the property value
+PASS e.style['trigger-scope'] = "all" should set the property value
+PASS e.style['trigger-scope'] = "--a" should set the property value
+PASS e.style['trigger-scope'] = "--a, --b" should set the property value
+PASS e.style['trigger-scope'] = "--a, --b, --c" should set the property value
+PASS e.style['trigger-scope'] = "--foo, --bar" should set the property value
+PASS e.style['trigger-scope'] = "--bar, --foo" should set the property value
+PASS Property trigger-scope value 'initial'
+PASS Property trigger-scope value 'none'
+PASS Property trigger-scope value 'all'
+PASS Property trigger-scope value '--a'
+PASS Property trigger-scope value '--a, --b'
+PASS Property trigger-scope value '--a, --b, --c'
+PASS Property trigger-scope value '--foo, --bar'
+PASS Property trigger-scope value '--bar, --foo'
 PASS e.style['trigger-scope'] = "--a none" should not set the property value
 PASS e.style['trigger-scope'] = "none --a" should not set the property value
 PASS e.style['trigger-scope'] = "none all" should not set the property value

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/trigger-scope-add.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/trigger-scope-add.tentative-expected.txt
@@ -2,6 +2,6 @@ In-scope Target
 SOURCE
 Out-of-scope Target
 
-FAIL Added scope prevents subtree from searching for external trigger assert_equals: expected (string) "none" but got (undefined) undefined
+FAIL Added scope prevents subtree from searching for external trigger assert_equals: animation on inner_target has playState paused. expected "paused" but got "running"
 FAIL Added scope prevents external references from finding trigger within scope. assert_equals: animation on inner_target has playState running. expected "running" but got "paused"
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -384,6 +384,7 @@ PASS transition-duration
 PASS transition-property
 PASS transition-timing-function
 PASS translate
+PASS trigger-scope
 PASS unicode-bidi
 PASS vector-effect
 PASS vertical-align

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -13167,6 +13167,25 @@
                 "url": "https://drafts.csswg.org/scroll-animations-1/#view-timeline-name"
             }
         },
+        "trigger-scope": {
+            "animation-type": "not animatable",
+            "initial": "none",
+            "values": [
+                "none",
+                "all"
+            ],
+            "codegen-properties": {
+                "settings-flag": "animationTriggersEnabled",
+                "computed-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "computed-style-storage-kind": "reference",
+                "computed-style-type": "Style::NameScope",
+                "parser-grammar": "none | all | <dashed-ident>#"
+            },
+            "specification": {
+                "category": "animation-triggers",
+                "url": "https://drafts.csswg.org/animation-triggers-1/#trigger-scope"
+            }
+        },
         "view-transition-class": {
             "animation-type": "discrete",
             "initial": "none",
@@ -13961,6 +13980,11 @@
         }
     },
     "categories": {
+        "animation-triggers": {
+            "shortname": "Animation Triggers",
+            "longname": "Animation Triggers",
+            "url": "https://drafts.csswg.org/animation-triggers-1"
+        },
         "css-22": {
             "shortname": "CSS 2.2",
             "longname": "CSS 2.2",

--- a/Source/WebCore/style/computed/data/StyleNonInheritedRareData.cpp
+++ b/Source/WebCore/style/computed/data/StyleNonInheritedRareData.cpp
@@ -83,6 +83,7 @@ NonInheritedRareData::NonInheritedRareData()
     , scrollTimelines { CSS::Keyword::None { } }
     , viewTimelines { CSS::Keyword::None { } }
     , timelineScope(ComputedStyle::initialTimelineScope())
+    , triggerScope(ComputedStyle::initialTriggerScope())
     , scrollbarGutter(ComputedStyle::initialScrollbarGutter())
     , containerType(ComputedStyle::initialContainerType())
     , scrollSnapType(ComputedStyle::initialScrollSnapType())
@@ -189,6 +190,7 @@ inline NonInheritedRareData::NonInheritedRareData(const NonInheritedRareData& o)
     , scrollTimelines(o.scrollTimelines)
     , viewTimelines(o.viewTimelines)
     , timelineScope(o.timelineScope)
+    , triggerScope(o.triggerScope)
     , scrollbarGutter(o.scrollbarGutter)
     , containerType(o.containerType)
     , scrollSnapType(o.scrollSnapType)
@@ -300,6 +302,7 @@ bool NonInheritedRareData::operator==(const NonInheritedRareData& o) const
         && scrollTimelines == o.scrollTimelines
         && viewTimelines == o.viewTimelines
         && timelineScope == o.timelineScope
+        && triggerScope == o.triggerScope
         && scrollbarGutter == o.scrollbarGutter
         && containerType == o.containerType
         && scrollSnapType == o.scrollSnapType
@@ -443,6 +446,7 @@ void NonInheritedRareData::dumpDifferences(TextStream& ts, const NonInheritedRar
     LOG_IF_DIFFERENT(viewTimelines);
 
     LOG_IF_DIFFERENT(timelineScope);
+    LOG_IF_DIFFERENT(triggerScope);
 
     LOG_IF_DIFFERENT(scrollbarGutter);
     LOG_IF_DIFFERENT(containerType);

--- a/Source/WebCore/style/computed/data/StyleNonInheritedRareData.h
+++ b/Source/WebCore/style/computed/data/StyleNonInheritedRareData.h
@@ -188,6 +188,8 @@ public:
 
     NameScope timelineScope;
 
+    NameScope triggerScope;
+
     ScrollbarGutter scrollbarGutter;
     Style::ContainerType containerType;
 


### PR DESCRIPTION
#### 41e8bd103a1fc947375ceeb4dff84d768c244970
<pre>
[animation-triggers] add parsing support for the `trigger-scope` CSS property
<a href="https://bugs.webkit.org/show_bug.cgi?id=318864">https://bugs.webkit.org/show_bug.cgi?id=318864</a>
<a href="https://rdar.apple.com/181703481">rdar://181703481</a>

Reviewed by Sam Weinig and Antti Koivisto.

Add parsing support for the `trigger-scope` property as specified by <a href="https://drafts.csswg.org/animation-triggers-1/#trigger-scope.">https://drafts.csswg.org/animation-triggers-1/#trigger-scope.</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/shadow-dom-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/parsing/trigger-scope.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/trigger-scope-add.tentative-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/style/computed/data/StyleNonInheritedRareData.cpp:
(WebCore::Style::NonInheritedRareData::NonInheritedRareData):
(WebCore::Style::NonInheritedRareData::operator== const):
(WebCore::Style::NonInheritedRareData::dumpDifferences const):
* Source/WebCore/style/computed/data/StyleNonInheritedRareData.h:

Canonical link: <a href="https://commits.webkit.org/316757@main">https://commits.webkit.org/316757@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb701d1d870042d751931b69f0e8896fc0d3d606

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173360 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47292 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/40843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182933 "Failed to checkout and rebase branch from PR 68912") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/130916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175225 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48585 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46974 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/182933 "Failed to checkout and rebase branch from PR 68912") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/130916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176318 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/38218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/40843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/182933 "Failed to checkout and rebase branch from PR 68912") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/36860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/35209 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/31418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/40843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/147284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/40843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/185357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/38225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/39411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/185357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46960 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/40843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/185357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47639 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/40843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/112742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26328 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/38471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/119388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46145 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/40843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/45547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/45778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45604 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->