### PR TITLE
[preview-only] REGRESSION(304956@main): wpt /css/css-overflow/line-clamp/line-clamp-015.html

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4173,7 +4173,6 @@ imported/w3c/web-platform-tests/css/css-display/display-flow-root-002.html [ Ima
 imported/w3c/web-platform-tests/css/mediaqueries/viewport-script-dynamic.html [ ImageOnlyFailure ]
 
 # Initial failures on the initial import of css-overflow
-imported/w3c/web-platform-tests/css/css-overflow/line-clamp/line-clamp-015.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-overflow/line-clamp/line-clamp-024.tentative.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-overflow/line-clamp/line-clamp-025.tentative.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-overflow/line-clamp/line-clamp-auto-002.tentative.html [ ImageOnlyFailure ]

--- a/Source/WebCore/rendering/LineClampUpdater.h
+++ b/Source/WebCore/rendering/LineClampUpdater.h
@@ -53,7 +53,8 @@ inline LineClampUpdater::LineClampUpdater(const RenderBlock& blockContainer)
         return;
 
     m_previousLineClamp = layoutState->lineClamp();
-    if (blockContainer.isFieldset() || blockContainer.isNonReplacedAtomicInlineLevelBox() || blockContainer.isFloatingOrOutOfFlowPositioned()) {
+    if (blockContainer.isFieldset() || (layoutState->legacyLineClamp() && blockContainer.isNonReplacedAtomicInlineLevelBox()) || blockContainer.isFloatingOrOutOfFlowPositioned()) {
+        // Legacy line clamp does not cross into the interior of an atomic inline-level box.
         layoutState->setLineClamp({ });
 
         m_skippedLegacyLineClampToRestore = layoutState->legacyLineClamp();


### PR DESCRIPTION
#### f186fcf4e2e1b0a56de87a8edc97628b45b19558
<pre>
[preview-only] REGRESSION(304956@main): wpt /css/css-overflow/line-clamp/line-clamp-015.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=305869">https://bugs.webkit.org/show_bug.cgi?id=305869</a>
<a href="https://rdar.apple.com/problem/168534323">rdar://problem/168534323</a>

Reviewed by Alan Baradlay.

Line-clamp affects block containers, which includes inline blocks [1].

For legacy line clamp we keep the existing behaviour.

[1] <a href="https://drafts.csswg.org/css-overflow-4/#line-clamp">https://drafts.csswg.org/css-overflow-4/#line-clamp</a>

* LayoutTests/TestExpectations:
* Source/WebCore/rendering/LineClampUpdater.h:
(WebCore::LineClampUpdater::LineClampUpdater):

Canonical link: <a href="https://commits.webkit.org/319848@main">https://commits.webkit.org/319848@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d1e970ab6f0df4157caf692bc3a080f7d9aae30

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182791 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56714 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50523 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193008 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147079 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184653 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58056 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56449 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142663 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185746 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46379 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163425 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123092 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45071 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43323 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155467 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42954 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4180 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49361 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47586 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194949 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56383 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162919 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152116 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40797 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57088 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39566 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151813 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46378 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129357 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125411 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55596 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17958 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54967 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55204 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55034 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->