### PR TITLE
Complex text path should retain the system fallback fonts it uses

### DIFF
--- a/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
@@ -398,7 +398,7 @@ GlyphData FontCascadeFonts::glyphDataForSystemFallback(char32_t character, const
 
     // Keep the system fallback fonts we use alive.
     if (fallbackGlyphData.isValid())
-        m_systemFallbackFontSet.add(systemFallbackFont.releaseNonNull());
+        addSystemFallbackFont(systemFallbackFont.releaseNonNull());
 
     return fallbackGlyphData;
 }
@@ -573,6 +573,11 @@ void FontCascadeFonts::pruneSystemFallbacks()
     }
     m_systemFallbackFontSet.clear();
     m_shapedTextCache.clear();
+}
+
+void FontCascadeFonts::addSystemFallbackFont(Ref<Font>&& font)
+{
+    m_systemFallbackFontSet.add(WTF::move(font));
 }
 
 TextShapingResultAndDisplayList* FontCascadeFonts::getOrCreateCachedShapedText(const TextRun& run, const FontCascade& fontCascade, unsigned from, std::optional<unsigned> to, ForTextEmphasis forTextEmphasis)

--- a/Source/WebCore/platform/graphics/FontCascadeFonts.h
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.h
@@ -155,6 +155,8 @@ public:
 
     void pruneSystemFallbacks();
 
+    void addSystemFallbackFont(Ref<Font>&&);
+
 private:
     FontCascadeFonts();
     FontCascadeFonts(const FontPlatformData&);

--- a/Source/WebCore/platform/graphics/coretext/ComplexTextControllerCoreText.mm
+++ b/Source/WebCore/platform/graphics/coretext/ComplexTextControllerCoreText.mm
@@ -275,7 +275,11 @@ void ComplexTextController::collectComplexTextRunsForCharacters(std::span<const 
                         continue;
                     }
                     FontPlatformData runFontPlatformData(runCTFont.get(), CTFontGetSize(runCTFont.get()));
-                    runFont = protect(FontCache::forCurrentThread())->fontForPlatformData(runFontPlatformData).ptr();
+                    Ref systemFallbackFont = protect(FontCache::forCurrentThread())->fontForPlatformData(runFontPlatformData);
+                    // Keep this system fallback alive. The cached shaped buffer references it only weakly (mirrors glyphDataForSystemFallback()).
+                    RefPtr fonts = m_fontCascade->fonts();
+                    fonts->addSystemFallbackFont(systemFallbackFont.copyRef());
+                    runFont = systemFallbackFont.ptr();
                 }
                 if (m_fallbackFonts && runFont != &m_fontCascade->primaryFont())
                     m_fallbackFonts->add(*runFont);

--- a/Tools/TestWebKitAPI/Tests/WebCore/FontCascade.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/FontCascade.cpp
@@ -25,10 +25,13 @@
  */
 
 #include "config.h"
+#include <WebCore/Font.h>
 #include <WebCore/FontCache.h>
 #include <WebCore/FontCascade.h>
 #include <WebCore/FontCascadeFonts.h>
+#include <WebCore/TextRun.h>
 #include <WebCore/TextShapingResultAndDisplayList.h>
+#include <wtf/WeakHashSet.h>
 
 namespace TestWebKitAPI {
 
@@ -178,5 +181,33 @@ TEST(FontCascadeTest, PurgeInactiveFontDataClearsShapedTextCache)
     FontCache::forCurrentThread().purgeInactiveFontData();
 
     EXPECT_TRUE(fonts->shapedTextCache().isEmpty());
+}
+
+// The complex text path must retain the system fallback fonts it uses (like the simple path), otherwise a
+// cached shaped run's weak Font reference dangles once FontCache::purgeInactiveFontData reclaims the font.
+TEST(FontCascadeTest, ComplexTextRetainsSystemFallbackFonts)
+{
+    FontCascadeDescription description;
+    description.setOneFamily("Times"_s);
+    description.setComputedSize(16);
+    FontCascade fontCascade(WTF::move(description));
+    fontCascade.update();
+
+    // Complex-script characters Times cannot render, forcing Core Text system fallbacks.
+    static constexpr std::array<char16_t, 8> characters { 0x06D8, 0x092D, 0x0B40, 0x0F96, 0x0DBD, 0x0EAF, 0xA86C, 0x0ACF };
+    String text { std::span<const char16_t> { characters } };
+    TextRun run { text };
+
+    // Shaping the run collects the system fallback fonts Core Text used.
+    SingleThreadWeakHashSet<const Font> fallbackFonts;
+    fontCascade.width(run, &fallbackFonts);
+
+    // Each fallback font must be retained beyond FontCache's own reference, so a purge cannot reclaim it.
+    bool hasUsedFallbackFont = false;
+    for (auto& font : fallbackFonts) {
+        hasUsedFallbackFont = true;
+        EXPECT_FALSE(font.hasOneRef());
+    }
+    ASSERT_TRUE(hasUsedFallbackFont);
 }
 }


### PR DESCRIPTION
#### 0082e68a004c11e97081c9dd39d6fe7df23ddd07
<pre>
Complex text path should retain the system fallback fonts it uses
<a href="https://bugs.webkit.org/show_bug.cgi?id=318842">https://bugs.webkit.org/show_bug.cgi?id=318842</a>
<a href="https://rdar.apple.com/181117694">rdar://181117694</a>

Reviewed by Brent Fulgham.

A GlyphBuffer cached in a FontCascadeFonts shaped text cache references its Fonts
through weak pointers (308842@main). The simple text path keeps the system
fallbacks it uses alive in FontCascadeFonts::glyphDataForSystemFallback, but the
complex text path did not, so a Core Text fallback used only there had a single
reference and FontCache::purgeInactiveFontData could destroy it while a cached
shaped run still referenced it. Painting that run then dereferenced an expired
weak pointer in FontCascade::drawGlyphBuffer. Therefore, retain those fallbacks
on the FontCascadeFonts the same way the simple path does.

* Source/WebCore/platform/graphics/FontCascadeFonts.cpp:
(WebCore::FontCascadeFonts::addSystemFallbackFont):
* Source/WebCore/platform/graphics/FontCascadeFonts.h:
* Source/WebCore/platform/graphics/coretext/ComplexTextControllerCoreText.mm:
(WebCore::ComplexTextController::collectComplexTextRunsForCharacters):
* Tools/TestWebKitAPI/Tests/WebCore/FontCascade.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/316795@main">https://commits.webkit.org/316795@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e9a323d59f2c1b8f26ab4821aa42afe02e526639

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173403 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47335 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40892 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182976 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130959 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8c53aa17-0fde-4501-a767-290023a10956) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175268 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48628 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47017 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134824 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1b509e91-e806-4de1-b879-e016b34c0c8f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176361 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38252 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155494 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115300 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36893 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35246 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31461 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147317 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34990 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185401 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38271 "Found 1026 new failures in b3/testb3_7.cpp, b3/B3Value.h, WebProcess/Network/WebResourceLoader.cpp, jit/OperationResult.h, UIProcess/WebProcessPool.cpp, Shared/Cocoa/WKNSArray.mm, heap/WeakSet.h, API/tests/Regress141275.mm, Shared/SessionState.cpp, NetworkProcess/NetworkResourceLoadParameters.cpp ...") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39448 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143694 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47003 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143558 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38756 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47682 "Built successfully") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112785 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38500 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119431 "Found 1059 new failures in b3/B3Value.h, b3/testb3_7.cpp, WebProcess/Network/WebResourceLoader.cpp, jit/OperationResult.h, UIProcess/WebProcessPool.cpp, testing/MockMediaSessionCoordinator.cpp, Shared/Cocoa/WKNSArray.mm, heap/WeakSet.h, API/tests/Regress141275.mm, Shared/SessionState.cpp ...") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46188 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9938 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45590 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45821 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45647 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->