### PR TITLE
[Site Isolation] remove storage access on commit

### DIFF
--- a/LayoutTests/http/tests/storageAccess/resources/deferred-storage-access-revocation-test.js
+++ b/LayoutTests/http/tests/storageAccess/resources/deferred-storage-access-revocation-test.js
@@ -1,0 +1,127 @@
+// Shared driver for the "deferred storage-access revocation" tests. Each test grants a
+// cross-site iframe storage access, then has the cross-site top frame initiate a
+// navigation of that iframe and checks that storage access is retained.
+//
+// This testing code is very similar to the code from request-and-grant-access-cross-origin-sandboxed-iframe-*
+//
+// Because revocation should happen at commit time, an iframe that is has a navigation that is 
+// in-flight or never commits should not have its storage access removed.
+//
+// Before including this script, each test need to define:
+//   navigationTarget      - Path (everything after the origin) of where the top frame navigates the iframe to in step 4
+//   navigationDescription - debug() line logged when that navigation is initiated.
+
+jsTestIsAsync = true;
+
+// The cross-site iframe that is granted, then expected to retain, storage access. Everything
+// below is derived from this one origin; the top frame is this test page's own origin.
+const thirdPartyOrigin = "https://localhost:8443";
+const thirdPartyResourcesUrl = thirdPartyOrigin + "/storageAccess/resources";
+
+// Identifies the third-party host to the tracking-prevention (ITP) APIs. These key on the
+// registrable domain, so the "/temp" path is an unused placeholder.
+const statisticsUrl = thirdPartyOrigin + "/temp";
+const firstPartyCookieName = "firstPartyCookie";
+const subPathToSetFirstPartyCookie = "/set-cookie.py?name=" + firstPartyCookieName + "&value=value";
+const returnUrl = document.location.href.split("#")[0];
+
+function activateElement(elementId) {
+    let element = document.getElementById(elementId);
+    let centerX = element.offsetLeft + element.offsetWidth / 2;
+    let centerY = element.offsetTop + element.offsetHeight / 2;
+    UIHelper.activateAt(centerX, centerY).then(
+        function () {
+            if (window.eventSender)
+                eventSender.keyDown("escape");
+            else {
+                testFailed("No eventSender.");
+                setEnableFeature(false, finishJSTest);
+            }
+        },
+        function () {
+            testFailed("Promise rejected.");
+            setEnableFeature(false, finishJSTest);
+        }
+    );
+}
+
+function relayMessage(data) {
+    if (data.indexOf("PASS") === 0)
+        testPassed(data.replace(/^PASS[.]? ?/, ""));
+    else
+        testFailed(data);
+}
+
+function receiveMessage(event) {
+    if (event.origin === thirdPartyOrigin)
+        relayMessage(event.data);
+    else
+        testFailed("Received a message from an unexpected origin: " + event.origin);
+    runTest();
+}
+
+async function runTest() {
+    switch (document.location.hash) {
+        case "#step1":
+            if (testRunner.isStatisticsPrevalentResource(statisticsUrl))
+                testFailed("Host prematurely set as prevalent resource.");
+            // Set first-party cookie for localhost.
+            document.location.href = thirdPartyResourcesUrl + subPathToSetFirstPartyCookie + "#" + returnUrl + "#step2";
+            break;
+        case "#step2":
+            document.location.hash = "step3";
+            // Set localhost as prevalent with user interaction so its cookies are blocked in a third-party context.
+            testRunner.setStatisticsHasHadUserInteraction(statisticsUrl, true, function() {
+                testRunner.setStatisticsPrevalentResource(statisticsUrl, true, function() {
+                    testRunner.statisticsUpdateCookieBlocking(runTest);
+                });
+            });
+            break;
+        case "#step3":
+            document.location.hash = "step4";
+            // Per-frame access is required for clearing access on navigation of the iframe.
+            await testRunner.setStorageAccessAPIPerPageScopeEnabled(false);
+            // Create a sandboxed iframe that will request and be granted storage access.
+            let iframeElement = document.createElement("iframe");
+            iframeElement.setAttribute("sandbox", "allow-storage-access-by-user-activation allow-scripts allow-same-origin allow-modals");
+            iframeElement.onload = function() {
+                testRunner.statisticsUpdateCookieBlocking(function() {
+                    activateElement("TheIframeThatRequestsStorageAccess");
+                });
+            };
+            iframeElement.id = "TheIframeThatRequestsStorageAccess";
+            iframeElement.src = thirdPartyResourcesUrl + "/request-storage-access-and-report-client-side-cookies-iframe.html";
+            document.body.appendChild(iframeElement);
+            break;
+        case "#step4":
+            document.location.hash = "step5";
+            // The cross-site top frame initiates a navigation of the iframe. 
+            // The iframe's JavaScript will check if it retain storage 
+            // access after a failed load commit.
+            let iframe = document.getElementById("TheIframeThatRequestsStorageAccess");
+            iframe.src = thirdPartyOrigin + navigationTarget;
+            debug(navigationDescription);
+            setTimeout(function() {
+                iframe.contentWindow.postMessage("reportBackCookies", thirdPartyOrigin);
+            }, 0);
+            break;
+        case "#step5":
+            // Remove the iframe to cancel the pending navigation so the page finishes loading
+            // before notifyDone.
+            document.getElementById("TheIframeThatRequestsStorageAccess").remove();
+            // Reset access scope.
+            await testRunner.setStorageAccessAPIPerPageScopeEnabled(true);
+            setEnableFeature(false, finishJSTest);
+            break;
+    }
+}
+
+if (document.location.hash === "") {
+    setEnableFeature(true, function() {
+        document.location.hash = "step1";
+    });
+}
+
+window.addEventListener("message", receiveMessage, false);
+
+runTest();

--- a/LayoutTests/http/tests/storageAccess/resources/request-storage-access-and-report-client-side-cookies-iframe.html
+++ b/LayoutTests/http/tests/storageAccess/resources/request-storage-access-and-report-client-side-cookies-iframe.html
@@ -1,0 +1,64 @@
+<html>
+<head>
+    <script>
+        // Grants storage access on user activation like request-storage-access-iframe.html, but reports
+        // whether cookies are accessible by reading document.cookie client-side (which doesn't require a 
+        // fetch over the network).
+        // This lets the parent check the iframe's storage-access state even while the frame has an in-flight or
+        // non-committing navigation, without a fetch that would be cancelled or fail access-control checks.
+        const topOrigin = "https://127.0.0.1:8443";
+
+        var requestStorageAccessResolved;
+
+        function messageToTop(message) {
+            top.postMessage(message, topOrigin);
+        }
+
+        function receiveMessage(event) {
+            if (event.origin !== topOrigin) {
+                messageToTop("FAIL Received a message from an unexpected origin: " + event.origin);
+                return;
+            }
+            if (event.data.indexOf("reportBackCookies") !== -1) {
+                if (document.cookie.indexOf("firstPartyCookie=value") !== -1)
+                    messageToTop("PASS The iframe retained storage access. document.cookie == " + document.cookie);
+                else
+                    messageToTop("FAIL The iframe lost storage access. document.cookie == " + document.cookie);
+            } else {
+                messageToTop("FAIL Unknown request.");
+            }
+        }
+
+        window.addEventListener("message", receiveMessage, false);
+
+        function makeRequestWithUserGesture() {
+            document.requestStorageAccess().then(
+                function () {
+                    requestStorageAccessResolved = true;
+                    continueAfterRequestWithUserGesture();
+                },
+                function () {
+                    requestStorageAccessResolved = false;
+                    continueAfterRequestWithUserGesture();
+                }
+            );
+        }
+
+        function continueAfterRequestWithUserGesture() {
+            document.hasStorageAccess().then(
+                function (hasAccess) {
+                    if (requestStorageAccessResolved && hasAccess)
+                        messageToTop("PASS Storage access was granted. document.cookie == " + document.cookie);
+                    else
+                        messageToTop("FAIL Storage access was not granted. document.cookie == " + document.cookie);
+                },
+                function (reason) {
+                    messageToTop("FAIL document.hasStorageAccess() was rejected. Reason: " + reason);
+                }
+            );
+        }
+    </script>
+</head>
+<body onclick="makeRequestWithUserGesture()">
+</body>
+</html>

--- a/LayoutTests/http/tests/storageAccess/revoke-storage-access-deferred-until-failed-navigation.https-expected.txt
+++ b/LayoutTests/http/tests/storageAccess/revoke-storage-access-deferred-until-failed-navigation.https-expected.txt
@@ -1,0 +1,12 @@
+Tests that a cross-site-initiated navigation of an iframe does not revoke the iframe's storage access when the navigation never commits (a 204 No Content response). Storage access should only be revoked when a navigation commits.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Storage access was granted. document.cookie == firstPartyCookie=value
+Initiated a cross-site navigation of the iframe that does not commit. The original document should retain storage access.
+PASS The iframe retained storage access. document.cookie == firstPartyCookie=value
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/storageAccess/revoke-storage-access-deferred-until-failed-navigation.https.html
+++ b/LayoutTests/http/tests/storageAccess/revoke-storage-access-deferred-until-failed-navigation.https.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="/js-test-resources/js-test.js"></script>
+    <script src="/js-test-resources/ui-helper.js"></script>
+    <script src="/resourceLoadStatistics/resources/util.js"></script>
+</head>
+<body>
+    <script>
+        description("Tests that a cross-site-initiated navigation of an iframe does not revoke the iframe's storage access when the navigation never commits (a 204 No Content response). Storage access should only be revoked when a navigation commits.");
+        const navigationTarget = "/navigation/resources/response204.pl";
+        const navigationDescription = "Initiated a cross-site navigation of the iframe that does not commit. The original document should retain storage access.";
+    </script>
+    <script src="resources/deferred-storage-access-revocation-test.js"></script>
+</body>
+</html>

--- a/LayoutTests/http/tests/storageAccess/revoke-storage-access-deferred-until-slow-navigation.https-expected.txt
+++ b/LayoutTests/http/tests/storageAccess/revoke-storage-access-deferred-until-slow-navigation.https-expected.txt
@@ -1,0 +1,12 @@
+Tests that a cross-site-initiated navigation of an iframe does not revoke the iframe's storage access while the navigation is still in flight. Storage access should only be revoked when the navigation commits.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Storage access was granted. document.cookie == firstPartyCookie=value
+Started a cross-site-initiated navigation of the iframe that stays in flight. The in-flight document should still have storage access because revocation only happens at commit.
+PASS The iframe retained storage access. document.cookie == firstPartyCookie=value
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/storageAccess/revoke-storage-access-deferred-until-slow-navigation.https.html
+++ b/LayoutTests/http/tests/storageAccess/revoke-storage-access-deferred-until-slow-navigation.https.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="/js-test-resources/js-test.js"></script>
+    <script src="/js-test-resources/ui-helper.js"></script>
+    <script src="/resourceLoadStatistics/resources/util.js"></script>
+</head>
+<body>
+    <script>
+        description("Tests that a cross-site-initiated navigation of an iframe does not revoke the iframe's storage access while the navigation is still in flight. Storage access should only be revoked when the navigation commits.");
+        // never-respond.py never commits and can represent a slow
+        // Before the load commits, the document and its storage access look the same whether the navigation is slow or never completes.
+        const navigationTarget = "/navigation/resources/never-respond.py";
+        const navigationDescription = "Started a cross-site-initiated navigation of the iframe that stays in flight. The in-flight document should still have storage access because revocation only happens at commit.";
+    </script>
+    <script src="resources/deferred-storage-access-revocation-test.js"></script>
+</body>
+</html>

--- a/LayoutTests/ipc/loadping-firstpartyforcookies-message-check.html
+++ b/LayoutTests/ipc/loadping-firstpartyforcookies-message-check.html
@@ -58,6 +58,7 @@ promise_test(async (t) => {
         shouldClearReferrerOnHTTPSToHTTPRedirect: true,
         needsCertificateInfo: false,
         isMainFrameNavigation: false,
+        navigationLosesFrameSpecificStorageAccess: false,
         mainResourceNavigationDataForAnyFrame: {},
         shouldPreconnectOnly: 0,
         isNavigatingToAppBoundDomain: {},

--- a/LayoutTests/platform/ios-site-isolation/TestExpectations
+++ b/LayoutTests/platform/ios-site-isolation/TestExpectations
@@ -278,7 +278,6 @@ imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-
 imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-bfcache.html [ Failure ]
 imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-after-bfcache.html [ Failure ]
 imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-ABA.sub.https.window.html [ Failure ]
-imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-origin-iframe-navigation.sub.https.window.html [ Failure ]
 imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-site-iframe.sub.https.window.html [ Failure ]
 imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-nested-cross-site-iframe.sub.https.window.html [ Failure ]
 imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-sandboxed-iframe-allow-storage-access.sub.https.window.html [ Failure ]

--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -62,7 +62,6 @@ http/tests/site-isolation/inspector/storage/storage-get-cookies-cross-origin-ifr
 http/tests/site-isolation/inspector/storage/storage-frontend-gate.html [ Pass ]
 http/tests/storageAccess/grant-storage-access-under-opener-at-popup-user-gesture-ephemeral.https.html [ Failure ]
 http/tests/storageAccess/grant-storage-access-under-opener-at-popup-user-gesture.https.html [ Failure ]
-http/tests/storageAccess/request-and-grant-access-cross-origin-sandboxed-iframe-from-prevalent-domain-with-user-interaction-and-access-from-right-frame.https.html [ Failure ]
 http/wpt/webrtc/third-party-frame-ice-candidate-filtering.html [ Failure ]
 http/wpt/css/css-view-transitions/navigation/old_vt_promises_bfcache.html [ Failure ]
 imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies.tentative.https.html [ Failure ]
@@ -78,7 +77,6 @@ imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-loading-lazy-in-cross-origin-iframe-002.sub.html [ Failure ]
 imported/w3c/web-platform-tests/html/semantics/forms/customizable-combobox/customizable-combobox-appearance.html [ Skip ] # Flaky Failure
 imported/w3c/web-platform-tests/mediasession/playbackstate.html [ Failure ]
-imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-origin-iframe-navigation.sub.https.window.html [ Failure ]
 imported/w3c/web-platform-tests/webaudio/the-audio-api/the-analysernode-interface/test-analyser-minimum.html [ Failure ]
 imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiocontext-interface/audiocontext-getoutputtimestamp-cross-realm.html [ Failure ]
 imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiocontext-interface/audiocontext-state-change-after-close.http.window.html [ Failure ]

--- a/Source/WebCore/loader/NavigationRequester.cpp
+++ b/Source/WebCore/loader/NavigationRequester.cpp
@@ -30,8 +30,25 @@
 #include "FrameDestructionObserverInlines.h"
 #include "LocalFrame.h"
 #include "ProcessIdentifier.h"
+#include "SecurityOrigin.h"
+#include "Site.h"
 
 namespace WebCore {
+
+bool shouldNavigationLoseFrameSpecificStorageAccess(const NavigationRequester& requester, FrameIdentifier navigatedFrame, const URL& fromURL, const URL& toURL)
+{
+    if (!requester.frameID)
+        return false;
+
+    // A different, cross-site frame initiating the navigation drops access. A self-navigation
+    // drops access only when it crosses origins.
+    // https://privacycg.github.io/storage-access/#navigation
+    // FIXME: The algorithm also drops access when the navigation went through a cross-origin
+    // redirect; that needs redirect information not available here and is not implemented.
+    if (*requester.frameID != navigatedFrame)
+        return Site(requester.url) != Site(fromURL);
+    return !SecurityOrigin::create(fromURL)->isSameOriginAs(SecurityOrigin::create(toURL));
+}
 
 NavigationRequester NavigationRequester::from(Document& document)
 {

--- a/Source/WebCore/loader/NavigationRequester.h
+++ b/Source/WebCore/loader/NavigationRequester.h
@@ -56,4 +56,6 @@ struct NavigationRequester {
     std::optional<ProcessIdentifier> processIdentifier;
 };
 
+WEBCORE_EXPORT bool shouldNavigationLoseFrameSpecificStorageAccess(const NavigationRequester&, FrameIdentifier navigatedFrame, const URL& fromURL, const URL& toURL);
+
 } // namespace WebCore

--- a/Source/WebCore/platform/network/NetworkStorageSession.cpp
+++ b/Source/WebCore/platform/network/NetworkStorageSession.cpp
@@ -146,12 +146,12 @@ bool NetworkStorageSession::hasHadUserInteractionAsFirstParty(const RegistrableD
     return m_registrableDomainsWithUserInteractionAsFirstParty.contains(registrableDomain);
 }
 
-ThirdPartyCookieBlockingDecision NetworkStorageSession::thirdPartyCookieBlockingDecisionForRequest(const ResourceRequest& request, std::optional<FrameIdentifier> frameID, std::optional<PageIdentifier> pageID, ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking, IsKnownCrossSiteTracker isKnownCrossSiteTracker, bool isInitiatedByDedicatedWorker) const
+ThirdPartyCookieBlockingDecision NetworkStorageSession::thirdPartyCookieBlockingDecisionForRequest(const ResourceRequest& request, std::optional<FrameIdentifier> frameID, std::optional<PageIdentifier> pageID, ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking, IsKnownCrossSiteTracker isKnownCrossSiteTracker, bool isInitiatedByDedicatedWorker, bool navigationLosesFrameSpecificStorageAccess) const
 {
-    return thirdPartyCookieBlockingDecisionForRequest(request.firstPartyForCookies(), request.url(), frameID, pageID, shouldRelaxThirdPartyCookieBlocking, isKnownCrossSiteTracker, isInitiatedByDedicatedWorker);
+    return thirdPartyCookieBlockingDecisionForRequest(request.firstPartyForCookies(), request.url(), frameID, pageID, shouldRelaxThirdPartyCookieBlocking, isKnownCrossSiteTracker, isInitiatedByDedicatedWorker, navigationLosesFrameSpecificStorageAccess);
 }
-    
-ThirdPartyCookieBlockingDecision NetworkStorageSession::thirdPartyCookieBlockingDecisionForRequest(const URL& firstPartyForCookies, const URL& resource, std::optional<FrameIdentifier> frameID, std::optional<PageIdentifier> pageID, ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking, IsKnownCrossSiteTracker isKnownCrossSiteTracker, bool isInitiatedByDedicatedWorker) const
+
+ThirdPartyCookieBlockingDecision NetworkStorageSession::thirdPartyCookieBlockingDecisionForRequest(const URL& firstPartyForCookies, const URL& resource, std::optional<FrameIdentifier> frameID, std::optional<PageIdentifier> pageID, ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking, IsKnownCrossSiteTracker isKnownCrossSiteTracker, bool isInitiatedByDedicatedWorker, bool navigationLosesFrameSpecificStorageAccess) const
 {
     if (shouldRelaxThirdPartyCookieBlocking == ShouldRelaxThirdPartyCookieBlocking::Yes)
         return ThirdPartyCookieBlockingDecision::None;
@@ -176,7 +176,10 @@ ThirdPartyCookieBlockingDecision NetworkStorageSession::thirdPartyCookieBlocking
     if (firstPartyDomain == resourceDomain)
         return ThirdPartyCookieBlockingDecision::None;
 
-    if (hasStorageAccess(resourceDomain, firstPartyDomain, frameID, pageID) && !isInitiatedByDedicatedWorker)
+    // A navigation that loses its frame-specific storage access grant must not attach first-party
+    // cookies to its network request.
+    std::optional<FrameIdentifier> grantFrameID = navigationLosesFrameSpecificStorageAccess ? std::nullopt : frameID;
+    if (hasStorageAccess(resourceDomain, firstPartyDomain, grantFrameID, pageID) && !isInitiatedByDedicatedWorker)
         return ThirdPartyCookieBlockingDecision::None;
 
 #if ENABLE(OPT_IN_PARTITIONED_COOKIES)

--- a/Source/WebCore/platform/network/NetworkStorageSession.h
+++ b/Source/WebCore/platform/network/NetworkStorageSession.h
@@ -242,8 +242,8 @@ public:
     WEBCORE_EXPORT bool NODELETE trackingPreventionEnabled() const;
     WEBCORE_EXPORT void NODELETE setTrackingPreventionDebugLoggingEnabled(bool);
     bool trackingPreventionDebugLoggingEnabled() const { return m_isTrackingPreventionDebugLoggingEnabled; }
-    WEBCORE_EXPORT ThirdPartyCookieBlockingDecision thirdPartyCookieBlockingDecisionForRequest(const ResourceRequest&, std::optional<FrameIdentifier>, std::optional<PageIdentifier>, ShouldRelaxThirdPartyCookieBlocking, IsKnownCrossSiteTracker, bool isInitiatedByDedicatedWorker = false) const;
-    ThirdPartyCookieBlockingDecision thirdPartyCookieBlockingDecisionForRequest(const URL& firstPartyForCookies, const URL& resource, std::optional<FrameIdentifier>, std::optional<PageIdentifier>, ShouldRelaxThirdPartyCookieBlocking, IsKnownCrossSiteTracker, bool isInitiatedByDedicatedWorker = false) const;
+    WEBCORE_EXPORT ThirdPartyCookieBlockingDecision thirdPartyCookieBlockingDecisionForRequest(const ResourceRequest&, std::optional<FrameIdentifier>, std::optional<PageIdentifier>, ShouldRelaxThirdPartyCookieBlocking, IsKnownCrossSiteTracker, bool isInitiatedByDedicatedWorker = false, bool navigationLosesFrameSpecificStorageAccess = false) const;
+    ThirdPartyCookieBlockingDecision thirdPartyCookieBlockingDecisionForRequest(const URL& firstPartyForCookies, const URL& resource, std::optional<FrameIdentifier>, std::optional<PageIdentifier>, ShouldRelaxThirdPartyCookieBlocking, IsKnownCrossSiteTracker, bool isInitiatedByDedicatedWorker = false, bool navigationLosesFrameSpecificStorageAccess = false) const;
     WEBCORE_EXPORT bool shouldBlockCookies(const ResourceRequest&, std::optional<FrameIdentifier>, std::optional<PageIdentifier>, ShouldRelaxThirdPartyCookieBlocking, IsKnownCrossSiteTracker) const;
     WEBCORE_EXPORT bool shouldBlockCookies(const URL& firstPartyForCookies, const URL& resource, std::optional<FrameIdentifier>, std::optional<PageIdentifier>, ShouldRelaxThirdPartyCookieBlocking, IsKnownCrossSiteTracker) const;
     WEBCORE_EXPORT bool shouldBlockThirdPartyCookies(const RegistrableDomain&) const;

--- a/Source/WebKit/NetworkProcess/NetworkLoadParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkLoadParameters.h
@@ -67,6 +67,11 @@ struct NetworkLoadParameters {
     bool isInitiatedByDedicatedWorker { false };
 
     uint64_t requiredCookiesVersion { 0 };
+
+    // The navigation initiator lost the navigated frame's Storage Access API grant (computed in
+    // the WebProcess). We should block storage access cookies on this load's network requests without
+    // revoking the frame's storage from JS until the navigation load commits.
+    bool navigationLosesFrameSpecificStorageAccess { false };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.cpp
@@ -93,7 +93,8 @@ NetworkLoadParameters NetworkResourceLoadParameters::networkLoadParameters() con
         allowPrivacyProxy,
         advancedPrivacyProtections,
         isInitiatedByDedicatedWorker,
-        requiredCookiesVersion
+        requiredCookiesVersion,
+        navigationLosesFrameSpecificStorageAccess
     };
 }
 

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.h
@@ -70,6 +70,7 @@ struct NetworkResourceLoadParameters {
     bool shouldClearReferrerOnHTTPSToHTTPRedirect { true };
     bool needsCertificateInfo { false };
     bool isMainFrameNavigation { false };
+    bool navigationLosesFrameSpecificStorageAccess { false };
     std::optional<NavigationActionData> mainResourceNavigationDataForAnyFrame { };
     PreconnectOnly shouldPreconnectOnly { PreconnectOnly::No };
     std::optional<NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain { NavigatingToAppBoundDomain::No };

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.serialization.in
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.serialization.in
@@ -43,6 +43,7 @@ enum class WebKit::NavigatingToAppBoundDomain : bool;
     bool shouldClearReferrerOnHTTPSToHTTPRedirect;
     bool needsCertificateInfo;
     bool isMainFrameNavigation;
+    bool navigationLosesFrameSpecificStorageAccess;
     std::optional<WebKit::NavigationActionData> mainResourceNavigationDataForAnyFrame;
     WebKit::PreconnectOnly shouldPreconnectOnly;
     std::optional<WebKit::NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain;

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.h
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.h
@@ -86,6 +86,8 @@ public:
 
     bool isInitiatedByDedicatedWorker() const final { return m_isInitiatedByDedicatedWorker; }
 
+    bool navigationLosesFrameSpecificStorageAccess() const final { return m_navigationLosesFrameSpecificStorageAccess; }
+
     String description() const override;
 
     void setH2PingCallback(const URL&, CompletionHandler<void(Expected<WTF::Seconds, WebCore::ResourceError>&&)>&&) override;
@@ -118,6 +120,7 @@ private:
     Markable<WebPageProxyIdentifier> m_webPageProxyID;
 
     bool m_isForMainResourceNavigationForAnyFrame { false };
+    bool m_navigationLosesFrameSpecificStorageAccess { false };
     RefPtr<WebCore::SecurityOrigin> m_sourceOrigin;
     uint64_t m_requiredCookiesVersion { 0 };
 };

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
@@ -195,6 +195,7 @@ NetworkDataTaskCocoa::NetworkDataTaskCocoa(NetworkSession& session, NetworkDataT
     , m_pageID(parameters.webPageID)
     , m_webPageProxyID(parameters.webPageProxyID)
     , m_isForMainResourceNavigationForAnyFrame(!!parameters.mainResourceNavigationDataForAnyFrame)
+    , m_navigationLosesFrameSpecificStorageAccess(parameters.navigationLosesFrameSpecificStorageAccess)
     , m_sourceOrigin(parameters.sourceOrigin)
     , m_requiredCookiesVersion(parameters.requiredCookiesVersion)
 {

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.h
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.h
@@ -57,6 +57,8 @@ public:
 
     virtual bool isInitiatedByDedicatedWorker() const { return false; }
 
+    virtual bool navigationLosesFrameSpecificStorageAccess() const { return false; }
+
 protected:
     NetworkTaskCocoa(NetworkSession&);
 

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.mm
@@ -315,7 +315,7 @@ WebCore::ThirdPartyCookieBlockingDecision NetworkTaskCocoa::requestThirdPartyCoo
     auto thirdPartyCookieBlockingDecision = storedCredentialsPolicy() == WebCore::StoredCredentialsPolicy::EphemeralStateless ? WebCore::ThirdPartyCookieBlockingDecision::All : WebCore::ThirdPartyCookieBlockingDecision::None;
     if (CheckedPtr networkStorageSession = protect(m_networkSession)->networkStorageSession()) {
         if (!NetworkStorageSession::shouldBlockCookies(thirdPartyCookieBlockingDecision))
-            thirdPartyCookieBlockingDecision = networkStorageSession->thirdPartyCookieBlockingDecisionForRequest(request, frameID(), pageID(), shouldRelaxThirdPartyCookieBlocking(), NetworkSession::isRequestToKnownCrossSiteTracker(request), isInitiatedByDedicatedWorker());
+            thirdPartyCookieBlockingDecision = networkStorageSession->thirdPartyCookieBlockingDecisionForRequest(request, frameID(), pageID(), shouldRelaxThirdPartyCookieBlocking(), NetworkSession::isRequestToKnownCrossSiteTracker(request), isInitiatedByDedicatedWorker(), navigationLosesFrameSpecificStorageAccess());
     }
 
     return thirdPartyCookieBlockingDecision;

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -600,6 +600,8 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
         if (RefPtr documentLoader = resourceLoader.documentLoader()) {
             loadParameters.navigationID = documentLoader->navigationID();
             loadParameters.navigationRequester = documentLoader->triggeringAction().requester();
+            if (auto& requester = loadParameters.navigationRequester; requester && frame && !frame->isMainFrame() && frame->document())
+                loadParameters.navigationLosesFrameSpecificStorageAccess = shouldNavigationLoseFrameSpecificStorageAccess(*requester, frame->frameID(), frame->document()->url(), request.url());
             if (loadParameters.navigationRequester && (!loadParameters.sourceOrigin || loadParameters.sourceOrigin->isOpaque()))
                 loadParameters.sourceOrigin = loadParameters.navigationRequester->securityOrigin.ptr();
         }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -106,7 +106,6 @@
 #include <WebCore/ScriptController.h>
 #include <WebCore/SecurityOriginData.h>
 #include <WebCore/Settings.h>
-#include <WebCore/Site.h>
 #include <WebCore/SubresourceLoader.h>
 #include <WebCore/UIEventWithKeyState.h>
 #include <WebCore/Widget.h>
@@ -652,6 +651,8 @@ void WebLocalFrameLoaderClient::dispatchDidCommitLoad(std::optional<HasInsecureC
 
     frame->commitProvisionalFrame();
 
+    removeStorageAccessOnCommit(documentLoader.get());
+
     // Notify the bundle client.
     webPage->injectedBundleLoaderClient().didCommitLoadForFrame(*webPage, m_frame, userData);
 
@@ -1080,20 +1081,22 @@ WebCore::AllowsContentJavaScript WebLocalFrameLoaderClient::allowsContentJavaScr
     return webPage ? webPage->allowsContentJavaScriptFromMostRecentNavigation() : WebCore::AllowsContentJavaScript::No;
 }
 
+void WebLocalFrameLoaderClient::removeStorageAccessOnCommit(WebCore::DocumentLoader& documentLoader)
+{
+    if (m_frame->isMainFrame())
+        return;
+
+    auto& requester = documentLoader.triggeringAction().requester();
+    if (!requester)
+        return;
+
+    if (shouldNavigationLoseFrameSpecificStorageAccess(*requester, m_frame->frameID(), m_localFrame->loader().previousURL(), documentLoader.originalURL()))
+        removeStorageAccess();
+}
+
 void WebLocalFrameLoaderClient::dispatchDecidePolicyForNavigationAction(const NavigationAction& navigationAction, const ResourceRequest& request, const ResourceResponse& redirectResponse,
     FormState* formState, const String& clientRedirectSourceForHistory, std::optional<WebCore::NavigationIdentifier> navigationID, std::optional<WebCore::HitTestResult>&& hitTestResult, bool hasOpener, NavigationUpgradeToHTTPSBehavior navigationUpgradeToHTTPSBehavior, WebCore::SandboxFlags sandboxFlags, PolicyDecisionMode policyDecisionMode, FramePolicyFunction&& function)
 {
-    if (auto requestor = navigationAction.requester(); requestor && requestor->frameID) {
-        // another frame initiated navigation
-        if (*requestor->frameID != m_frame->frameID() && Site(requestor->url) != Site(m_frame->url()))
-            removeStorageAccess();
-        // this frame navigated itself
-        else if (*requestor->frameID == m_frame->frameID()) {
-            if (redirectResponse.isNull() && !SecurityOrigin::create(m_frame->url())->isSameOriginAs(SecurityOrigin::create(request.url())))
-                removeStorageAccess();
-        }
-    }
-
     WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction(navigationAction, request, redirectResponse, formState, clientRedirectSourceForHistory, navigationID, WTF::move(hitTestResult), hasOpener, navigationUpgradeToHTTPSBehavior, sandboxFlags, policyDecisionMode, WTF::move(function));
 }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h
@@ -70,6 +70,7 @@ public:
     WebCore::AllowsContentJavaScript allowsContentJavaScriptFromMostRecentNavigation() const final;
 
     void removeStorageAccess();
+    void removeStorageAccessOnCommit(WebCore::DocumentLoader&);
 
 private:
     bool hasHTMLView() const final;


### PR DESCRIPTION
#### b02d6f0d8dbbb2b69e2a742d32e59beefbb371f4
<pre>
[Site Isolation] remove storage access on commit
<a href="https://bugs.webkit.org/show_bug.cgi?id=317934">https://bugs.webkit.org/show_bug.cgi?id=317934</a>
<a href="https://rdar.apple.com/180735236">rdar://180735236</a>

Reviewed by Alex Christensen.

When a navigation of an iframe is initiated by a different, cross-site
frame, that iframe should lose its frame-specific storage access. This is
described by the navigation algorithm of the Storage Access API spec:
<a href="https://privacycg.github.io/storage-access/#navigation">https://privacycg.github.io/storage-access/#navigation</a>

WebKit implemented this for the same-process case in
WebLocalFrameLoaderClient::dispatchDecidePolicyForNavigationAction, but it
did not fire when the initiator and target frames were in different
processes under Site Isolation.

Rather than implement this check for the other frame is in another process
(WebRemoteFrameLoaderClient::dispatchDecidePolicyForNavigationAction),
this patch performs the storage access removal at commit time in
WebLocalFrameLoaderClient::dispatchDidCommitLoad. The committing frame is
always a local frame in its own process, where it owns
m_frameSpecificStorageAccessIdentifier and can remove access directly.
This way, the same code path covers both the same-process and cross-process
cases. The navigation initiator is available at commit via DocumentLoader::triggeringAction()&apos;s
requester, which is carried into the target process on the load.

Evaluating at commit time (instead of when a navigation is decided)
also means storage access is preserved while a navigation is in flight and
is not revoked at all for a navigation that never commits.

However, this doesn&apos;t cover a scenario where cookies should not be attached
to network requests that are made before the navigation load commits.
For example, if an iframe is navigated by a cross-site initiator it should
lose storage access. However, if you revoke the iframe&apos;s storage access
too-late (at commit-time), then it&apos;s possible for the main-resource load of the navigation
to have cookies attached when it shouldn&apos;t. To solve this issue,
I modified NetworkStorageSession::thirdPartyCookieBlockingDecisionForRequest
to not attach cookies on network requests when it had a navigation which
certainly drops storage access.

This patch fixes
http/tests/storageAccess/request-and-grant-access-cross-origin-sandboxed-iframe-from-prevalent-domain-with-user-interaction-and-access-from-right-frame.https.html
and
imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-origin-iframe-navigation.sub.https.window.html
with site isolation enabled.

* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::dispatchDidCommitLoad):
    Remove storage access when navigation commits.
(WebKit::WebLocalFrameLoaderClient::removeStorageAccessOnCommit):
(WebKit::WebLocalFrameLoaderClient::dispatchDecidePolicyForNavigationAction):
    Helper which performs the removal if the navigation meets
    the requirements.
* LayoutTests/http/tests/storageAccess/revoke-storage-access-deferred-until-failed-navigation.https.html: Added.
    Test that storage access is not revoked when a navigation fails to
    commit.
* LayoutTests/http/tests/storageAccess/revoke-storage-access-deferred-until-slow-navigation.https.html: Added.
    Test that storage access is not revoked when a navigation is still
    in-flight (in this test, the navigation never commits which is
    observably the same)
    HTML of iframe which requests storage access and reports if it still
    has it.
* LayoutTests/http/tests/storageAccess/resources/deferred-storage-access-revocation-test.js: Added.
(activateElement):
(relayMessage):
(receiveMessage):
(async runTest.switch.iframeElement.onload):
(async runTest):
    Shared driver for the two tests above. Each test only sets the navigation
    target and its description. The non-committing / in-flight navigation targets
    reuse the existing navigation/resources/response204.pl and never-respond.py.
* LayoutTests/http/tests/storageAccess/resources/request-storage-access-and-report-client-side-cookies-iframe.html: Added.
* LayoutTests/http/tests/storageAccess/revoke-storage-access-deferred-until-failed-navigation.https-expected.txt: Added.
* LayoutTests/http/tests/storageAccess/revoke-storage-access-deferred-until-slow-navigation.https-expected.txt: Added.
* Source/WebCore/loader/NavigationRequester.cpp:
(WebCore::shouldNavigationLoseFrameSpecificStorageAccess):
    Helper which makes the policy decision on removing storage access
    depending on if the navigation met the criteria from the Storage Access API
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::WebLoaderStrategy::scheduleLoadFromNetworkProcess):
    Populate new field in loadParameters to track if a navigation should
    cause a frame to lose storage access.
* LayoutTests/ipc/loadping-firstpartyforcookies-message-check.html:
* LayoutTests/platform/ios-site-isolation/TestExpectations:
* LayoutTests/platform/mac-site-isolation/TestExpectations:
* Source/WebCore/loader/NavigationRequester.h:
* Source/WebCore/platform/network/NetworkStorageSession.cpp:
(WebCore::NetworkStorageSession::thirdPartyCookieBlockingDecisionForRequest const):
* Source/WebCore/platform/network/NetworkStorageSession.h:
* Source/WebKit/NetworkProcess/NetworkLoadParameters.h:
* Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.cpp:
(WebKit::NetworkResourceLoadParameters::networkLoadParameters const):
* Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.h:
* Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.serialization.in:
* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm:
(WebKit::NetworkDataTaskCocoa::NetworkDataTaskCocoa):
* Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.h:
(WebKit::NetworkTaskCocoa::navigationLosesFrameSpecificStorageAccess const):
* Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.mm:
(WebKit::NetworkTaskCocoa::requestThirdPartyCookieBlockingDecision const):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h:

Canonical link: <a href="https://commits.webkit.org/317642@main">https://commits.webkit.org/317642@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c22acb62a34c35c5475497d73831b94fec15931f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174504 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48437 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42218 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184081 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132372 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/80f50592-872d-4739-b588-45e18084bd6e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176369 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49729 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48120 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135769 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95809 "1 flakes 2 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/38f9c14f-3419-40f7-8da1-dd43bae16cb8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177462 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39201 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156561 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116247 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/65156005-b378-4e40-8615-9de00be75e3a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37842 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36211 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32562 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148265 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36053 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186507 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39747 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40663 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144676 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48104 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156116 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144544 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48783 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32673 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114624 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26724 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39439 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120756 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47290 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11017 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46692 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46923 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46750 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->