### PR TITLE
[EvaluationTimeZoom] Convert more properties to evaluation time zoom

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/background-size-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/background-size-expected.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  background-size: 50px;
+  display: inline-block;
+}
+.container {
+  background-image: url("/images/pattern.png");
+  width: 40px;
+  height: 40px;
+}
+.container-zoom {
+  background-image: url("/images/pattern.png");
+  width: 80px;
+  height: 80px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="background-size: 50px;">
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="background-size: 50px;">
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container-zoom" style="background-size: 100px;">
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container-zoom" style="background-size: 100px;">
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/background-size.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/background-size.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Zoom applies to background-size</title>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+<link rel="match" href="reference/background-size-ref.html">
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  background-size: 50px;
+  display: inline-block;
+}
+.container {
+  background-image: url("/images/pattern.png");
+  width: 40px;
+  height: 40px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="background-size: 50px; zoom: 1;">
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="background-size: inherit; zoom: 1;">
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="background-size: 50px; zoom: 2;">
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="background-size: inherit; zoom: 2;">
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/block-step-size-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/block-step-size-expected.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  block-step-size: 50px;
+  display: inline-block;
+  width: 100px;
+  border: solid black 1px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="height: 100px;">
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="height: 100px;">
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="height: 200px;">
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="height: 200px;">
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/block-step-size.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/block-step-size.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Zoom applies to block-step-size</title>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+<link rel="match" href="reference/block-step-size-ref.html">
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  block-step-size: 50px;
+  display: inline-block;
+  width: 100px;
+  border: solid black 1px;
+}
+.container {
+  block-step-size: 50px;
+  height: 51px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="block-step-size: 50px; zoom: 1;">
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="block-step-size: inherit; zoom: 1;">
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="block-step-size: 50px; zoom: 2;">
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="block-step-size: inherit; zoom: 2;">
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/border-image-outset-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/border-image-outset-expected.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Zoom applies to border-image-outset</title>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+<link rel="match" href="reference/border-image-outset-ref.html">
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  border-image-outset: 5px;
+  display: inline-block;
+  padding: 10px;
+}
+.container {
+  border: 10px solid red;
+  border-image: url("/images/green.png") 2;
+}
+.container-zoom {
+  border: 20px solid red;
+  border-image: url("/images/green.png") 2;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="border-image-outset: 5px;">
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="border-image-outset: 5px;">
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container-zoom" style="border-image-outset: 10px;">
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container-zoom" style="border-image-outset: 10px;">
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/border-image-outset.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/border-image-outset.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Zoom applies to border-image-outset</title>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+<link rel="match" href="reference/border-image-outset-ref.html">
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  border-image-outset: 5px;
+  display: inline-block;
+  padding: 10px;
+}
+.container {
+  border: 10px solid red;
+  border-image: url("/images/green.png") 2;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="border-image-outset: 5px; zoom: 1;">
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="border-image-outset: inherit; zoom: 1;">
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="border-image-outset: 5px; zoom: 2;">
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="border-image-outset: inherit; zoom: 2;">
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/column-gap-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/column-gap-expected.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  display: block;
+  border: 1px solid black;
+  padding: 10px;
+  column-gap: 20px;
+}
+.container {
+  display: flex;
+  flex-direction: row;
+  width: 100px;
+}
+.container-zoom {
+  display: flex;
+  flex-direction: row;
+  width: 200px;
+}
+.container > div {
+  background-color: black;
+  width: 40px;
+  height: 10px;
+}
+.container-zoom > div {
+  background-color: black;
+  width: 80px;
+  height: 20px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="column-gap: 20px;">
+      <div></div>
+      <div></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="column-gap: 20px;">
+      <div></div>
+      <div></div>
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container-zoom" style="column-gap: 40px;">
+      <div></div>
+      <div></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container-zoom" style="column-gap: 40px;">
+      <div></div>
+      <div></div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/column-gap.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/column-gap.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Zoom applies to column-gap</title>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+<link rel="match" href="reference/column-gap-ref.html">
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  display: block;
+  border: 1px solid black;
+  padding: 10px;
+  column-gap: 20px;
+}
+.container {
+  display: flex;
+  flex-direction: row;
+  column-gap: 24px;
+  width: 100px;
+}
+.container > div {
+  background-color: black;
+  width: 40px;
+  height: 10px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="column-gap: 20px; zoom: 1;">
+      <div></div>
+      <div></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="column-gap: inherit; zoom: 1;">
+      <div></div>
+      <div></div>
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="column-gap: 20px; zoom: 2;">
+      <div></div>
+      <div></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="column-gap: inherit; zoom: 2;">
+      <div></div>
+      <div></div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/column-width-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/column-width-expected.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  display: block;
+  border: 1px solid black;
+  padding: 10px;
+  column-width: 100px;
+}
+.container {
+  height: 200px;
+  width: 300px;
+}
+.container-zoom {
+  height: 400px;
+  width: 600px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="column-width: 100px; font-size: 16px;">
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="column-width: 100px; font-size: 16px;">
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container-zoom" style="column-width: 200px; font-size: 16px;">
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container-zoom" style="column-width: 200px; font-size: 16px;">
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/column-width.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/column-width.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Zoom applies to column-width</title>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+<link rel="match" href="reference/column-width-ref.html">
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  display: block;
+  border: 1px solid black;
+  padding: 10px;
+  column-width: 100px;
+}
+.container {
+  height: 200px;
+  width: 300px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="column-width: 100px; zoom: 1; font-size: 16px;">
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="column-width: inherit; zoom: 1; font-size: 16px;">
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="column-width: 100px; zoom: 2; font-size: 8px;">
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="column-width: inherit; zoom: 2; font-size: 8px;">
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/filters-blur-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/filters-blur-expected.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  display: inline-block;
+  border: 1px solid black;
+  filter: blur(1px); 
+}
+.container {
+  padding: 10px;
+  width: 25px;
+  height: 50px;
+}
+.container-zoom {
+  padding: 30px;
+  width: 75px;
+  height: 150px;
+}
+.swatch {
+  width: 25px;
+  height: 25px;
+}
+.swatch-zoom {
+  width: 75px;
+  height: 75px;
+}
+.red { 
+  background-color: red;
+}
+.blue { 
+  background-color: blue;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="filter: blur(1px);">
+       <div class="swatch red"></div>
+       <div class="swatch blue"></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="filter: blur(1px);">
+       <div class="swatch red"></div>
+       <div class="swatch blue"></div>
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container-zoom" style="filter: blur(3px);">
+       <div class="swatch-zoom red"></div>
+       <div class="swatch-zoom blue"></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container-zoom" style="filter: blur(3px);">
+       <div class="swatch-zoom red"></div>
+       <div class="swatch-zoom blue"></div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/filters-blur.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/filters-blur.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Zoom applies to filter: blur()</title>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+<link rel="match" href="reference/filters-blur-ref.html">
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  display: inline-block;
+  border: 1px solid black;
+  filter: blur(1px);
+}
+.container {
+  padding: 10px;
+  width: 25px;
+  height: 50px;
+}
+.swatch {
+  width: 25px;
+  height: 25px;
+}
+.red {
+  background-color: red;
+}
+.blue {
+  background-color: blue;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="filter: blur(1px); zoom: 1;">
+       <div class="swatch red"></div>
+       <div class="swatch blue"></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="filter: inherit; zoom: 1;">
+       <div class="swatch red"></div>
+       <div class="swatch blue"></div>
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="filter: blur(1px); zoom: 3;">
+       <div class="swatch red"></div>
+       <div class="swatch blue"></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="filter: inherit; zoom: 3;">
+       <div class="swatch red"></div>
+       <div class="swatch blue"></div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/mask-border-outset-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/mask-border-outset-expected.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  mask-border-outset: 5px;
+  display: inline-block;
+}
+.container {
+  mask-border-source: url("/images/green.png");
+  mask-border-slice: 20;
+  background-color: black;
+  width: 50px;
+  height: 50px;
+}
+.container-zoom {
+  mask-border-source: url("/images/green.png");
+  mask-border-slice: 20;
+  background-color: black;
+  width: 100px;
+  height: 100px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="mask-border-outset: 5px;">
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="mask-border-outset: inherit;">
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container-zoom" style="mask-border-outset: 10px;">
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container-zoom" style="mask-border-outset: 10px;">
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/mask-border-outset.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/mask-border-outset.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Zoom applies to mask-border-outset</title>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+<link rel="match" href="reference/mask-border-outset-ref.html">
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  mask-border-outset: 5px;
+  display: inline-block;
+}
+.container {
+  mask-border-source: url("/images/green.png");
+  mask-border-slice: 20;
+  background-color: black;
+  width: 50px;
+  height: 50px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="mask-border-outset: 5px; zoom: 1;">
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="mask-border-outset: inherit; zoom: 1;">
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="mask-border-outset: 5px; zoom: 2;">
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="mask-border-outset: inherit; zoom: 2;">
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/background-size-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/background-size-ref.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  background-size: 50px;
+  display: inline-block;
+}
+.container {
+  background-image: url("/images/pattern.png");
+  width: 40px;
+  height: 40px;
+}
+.container-zoom {
+  background-image: url("/images/pattern.png");
+  width: 80px;
+  height: 80px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="background-size: 50px;">
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="background-size: 50px;">
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container-zoom" style="background-size: 100px;">
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container-zoom" style="background-size: 100px;">
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/block-step-size-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/block-step-size-ref.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  block-step-size: 50px;
+  display: inline-block;
+  width: 100px;
+  border: solid black 1px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="height: 100px;">
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="height: 100px;">
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="height: 200px;">
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="height: 200px;">
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/border-image-outset-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/border-image-outset-ref.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  border-image-outset: 5px;
+  display: inline-block;
+  padding: 10px;
+}
+.container {
+  border: 10px solid red;
+  border-image: url("/images/green.png") 2;
+}
+.container-zoom {
+  border: 20px solid red;
+  border-image: url("/images/green.png") 2;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="border-image-outset: 5px;">
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="border-image-outset: 5px;">
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container-zoom" style="border-image-outset: 10px;">
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container-zoom" style="border-image-outset: 10px;">
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/column-gap-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/column-gap-ref.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  display: block;
+  border: 1px solid black;
+  padding: 10px;
+  column-gap: 20px;
+}
+.container {
+  display: flex;
+  flex-direction: row;
+  width: 100px;
+}
+.container-zoom {
+  display: flex;
+  flex-direction: row;
+  width: 200px;
+}
+.container > div {
+  background-color: black;
+  width: 40px;
+  height: 10px;
+}
+.container-zoom > div {
+  background-color: black;
+  width: 80px;
+  height: 20px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="column-gap: 20px;">
+      <div></div>
+      <div></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="column-gap: 20px;">
+      <div></div>
+      <div></div>
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container-zoom" style="column-gap: 40px;">
+      <div></div>
+      <div></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container-zoom" style="column-gap: 40px;">
+      <div></div>
+      <div></div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/column-width-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/column-width-ref.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  display: block;
+  border: 1px solid black;
+  padding: 10px;
+  column-width: 100px;
+}
+.container {
+  height: 200px;
+  width: 300px;
+}
+.container-zoom {
+  height: 400px;
+  width: 600px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="column-width: 100px; font-size: 16px;">
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="column-width: 100px; font-size: 16px;">
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container-zoom" style="column-width: 200px; font-size: 16px;">
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container-zoom" style="column-width: 200px; font-size: 16px;">
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/filters-blur-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/filters-blur-ref.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  display: inline-block;
+  border: 1px solid black;
+  filter: blur(1px);
+}
+.container {
+  padding: 10px;
+  width: 25px;
+  height: 50px;
+}
+.container-zoom {
+  padding: 30px;
+  width: 75px;
+  height: 150px;
+}
+.swatch {
+  width: 25px;
+  height: 25px;
+}
+.swatch-zoom {
+  width: 75px;
+  height: 75px;
+}
+.red {
+  background-color: red;
+}
+.blue {
+  background-color: blue;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="filter: blur(1px);">
+       <div class="swatch red"></div>
+       <div class="swatch blue"></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="filter: blur(1px);">
+       <div class="swatch red"></div>
+       <div class="swatch blue"></div>
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container-zoom" style="filter: blur(3px);">
+       <div class="swatch-zoom red"></div>
+       <div class="swatch-zoom blue"></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container-zoom" style="filter: blur(3px);">
+       <div class="swatch-zoom red"></div>
+       <div class="swatch-zoom blue"></div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/mask-border-outset-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/mask-border-outset-ref.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  mask-border-outset: 5px;
+  display: inline-block;
+}
+.container {
+  mask-border-source: url("/images/green.png");
+  mask-border-slice: 20;
+  background-color: black;
+  width: 50px;
+  height: 50px;
+}
+.container-zoom {
+  mask-border-source: url("/images/green.png");
+  mask-border-slice: 20;
+  background-color: black;
+  width: 100px;
+  height: 100px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="mask-border-outset: 5px;">
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="mask-border-outset: inherit;">
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container-zoom" style="mask-border-outset: 10px;">
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container-zoom" style="mask-border-outset: 10px;">
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/row-gap-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/row-gap-ref.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  display: inline-block;
+  border: 1px solid black;
+  padding: 10px;
+  row-gap: 20px;
+}
+.container {
+  display: flex;
+  flex-wrap: wrap;
+  width: 150px;
+}
+.container-zoom {
+  display: flex;
+  flex-wrap: wrap;
+  width: 300px;
+}
+.container > div {
+  background-color: black;
+  flex: 1 1 auto;
+  width: 100px;
+  height: 20px;
+}
+.container-zoom > div {
+  background-color: black;
+  flex: 1 1 auto;
+  width: 200px;
+  height: 40px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="row-gap: 20px;">
+      <div></div>
+      <div></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="row-gap: 20px;">
+      <div></div>
+      <div></div>
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container-zoom" style="row-gap: 40px;">
+      <div></div>
+      <div></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container-zoom" style="row-gap: 40px;">
+      <div></div>
+      <div></div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/tab-size-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/tab-size-ref.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  display: inline-block;
+  tab-size: 40px;
+  border: solid black 1px;
+}
+.container {
+  display: inline-block;
+  font-size: 16px;
+}
+.container-zoom {
+  display: inline-block;
+  font-size: 32px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <pre class="container" style="tab-size: 40px;">	hello</pre>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <pre class="container" style="tab-size: 40px;">	hello</pre>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <pre class="container-zoom" style="tab-size: 80px;">	hello</pre>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <pre class="container-zoom" style="tab-size: 80px;">	hello</pre>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/vertical-align-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/vertical-align-ref.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  vertical-align: 20px;
+  display: inline-block;
+}
+.container {
+  width: 20px;
+  height: 20px;
+}
+.container-zoom {
+  width: 40px;
+  height: 40px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <img class="container" src="/images/green.png" style="vertical-align: 20px;">
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <img class="container" src="/images/green.png" style="vertical-align: 20px;">
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <img class="container-zoom" src="/images/green.png" style="vertical-align: 40px;">
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <img class="container-zoom" src="/images/green.png" style="vertical-align: 40px;">
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/row-gap-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/row-gap-expected.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  display: inline-block;
+  border: 1px solid black;
+  padding: 10px;
+  row-gap: 20px; 
+}
+.container {
+  display: flex;
+  flex-wrap: wrap;
+  width: 150px;
+}
+.container-zoom {
+  display: flex;
+  flex-wrap: wrap;
+  width: 300px;
+}
+.container > div {
+  background-color: black;
+  flex: 1 1 auto;
+  width: 100px;
+  height: 20px;
+}
+.container-zoom > div {
+  background-color: black;
+  flex: 1 1 auto;
+  width: 200px;
+  height: 40px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="row-gap: 20px;">
+      <div></div>
+      <div></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="row-gap: 20px;">
+      <div></div>
+      <div></div>
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container-zoom" style="row-gap: 40px;">
+      <div></div>
+      <div></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container-zoom" style="row-gap: 40px;">
+      <div></div>
+      <div></div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/row-gap.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/row-gap.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Zoom applies to row-gap</title>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+<link rel="match" href="reference/row-gap-ref.html">
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  display: inline-block;
+  border: 1px solid black;
+  padding: 10px;
+  row-gap: 20px;
+}
+.container {
+  display: flex;
+  flex-wrap: wrap;
+  width: 150px;
+}
+.container > div {
+  background-color: black;
+  flex: 1 1 auto;
+  width: 100px;
+  height: 20px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="row-gap: 20px; zoom: 1;">
+      <div></div>
+      <div></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="row-gap: inherit; zoom: 1;">
+      <div></div>
+      <div></div>
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="row-gap: 20px; zoom: 2;">
+      <div></div>
+      <div></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="row-gap: inherit; zoom: 2;">
+      <div></div>
+      <div></div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/tab-size-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/tab-size-expected.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  display: inline-block;
+  tab-size: 40px;
+  border: solid black 1px;
+}
+.container {
+  display: inline-block;
+  font-size: 16px;
+}
+.container-zoom {
+  display: inline-block;
+  font-size: 32px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p> 
+<div class="group">
+  <div class="outer">
+    <pre class="container" style="tab-size: 40px;">	hello</pre>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <pre class="container" style="tab-size: 40px;">	hello</pre>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <pre class="container-zoom" style="tab-size: 80px;">	hello</pre>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <pre class="container-zoom" style="tab-size: 80px;">	hello</pre>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/tab-size.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/tab-size.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Zoom applies to tab-size</title>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+<link rel="match" href="reference/tab-size-ref.html">
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  display: inline-block;
+  tab-size: 40px;
+  border: solid black 1px;
+}
+.container {
+  display: inline-block;
+  font-size: 16px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <pre class="container" style="tab-size: 40px; zoom: 1;">	hello</pre>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <pre class="container" style="tab-size: inherit; zoom: 1;">	hello</pre>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <pre class="container" style="tab-size: 40px; zoom: 2;">	hello</pre>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <pre class="container" style="tab-size: inherit; zoom: 2;">	hello</pre>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/vertical-align-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/vertical-align-expected.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  vertical-align: 20px;
+  display: inline-block;
+}
+.container {
+  width: 20px;
+  height: 20px;
+}
+.container-zoom {
+  width: 40px;
+  height: 40px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <img class="container" src="/images/green.png" style="vertical-align: 20px;">
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <img class="container" src="/images/green.png" style="vertical-align: 20px;">
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <img class="container-zoom" src="/images/green.png" style="vertical-align: 40px;">
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <img class="container-zoom" src="/images/green.png" style="vertical-align: 40px;">
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/vertical-align.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/vertical-align.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Zoom applies to vertical-align</title>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+<link rel="match" href="reference/vertical-align-ref.html">
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  vertical-align: 20px;
+  display: inline-block;
+}
+.container {
+  width: 20px;
+  height: 20px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <img class="container" src="/images/green.png" style="vertical-align: 20px; zoom: 1;">
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <img class="container" src="/images/green.png" style="vertical-align: inherit; zoom: 1;">
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <img class="container" src="/images/green.png" style="vertical-align: 20px; zoom: 2;">
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <img class="container" src="/images/green.png" style="vertical-align: inherit; zoom: 2;">
+  </div>
+</div>
+</body>
+</html>

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Background.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Background.cpp
@@ -299,10 +299,10 @@ std::optional<CSS::BorderImageWidth> consumeUnresolvedBorderImageWidth(CSSParser
 
         if (auto lengthPercentage = MetaConsumer<CSS::BorderImageWidth::Value::LengthPercentage>::consume(range, state, { .overrideParserMode = HTMLStandardMode })) {
             hasLength = WTF::switchOn(*lengthPercentage,
-                [](const CSS::LengthPercentage<CSS::Nonnegative>::Calc& calc) {
+                [](const CSS::BorderImageWidth::Value::LengthPercentage::Calc& calc) {
                     return calc.primitiveType() == CSSUnitType::CSS_PX;
                 },
-                [](const CSS::LengthPercentage<CSS::Nonnegative>::Raw& raw) {
+                [](const CSS::BorderImageWidth::Value::LengthPercentage::Raw& raw) {
                     return raw.unit != CSS::PercentageUnit::Percentage;
                 }
             );
@@ -402,7 +402,7 @@ template<CSSPropertyID property> static RefPtr<CSSValue> consumeBackgroundSize(C
     bool shouldCoalesce = true;
     RefPtr<CSSValue> horizontal = consumeIdent<CSSValueAuto>(range);
     if (!horizontal) {
-        horizontal = CSSPrimitiveValueResolver<CSS::LengthPercentage<CSS::Nonnegative>>::consumeAndResolve(range, state);
+        horizontal = CSSPrimitiveValueResolver<CSS::LengthPercentage<CSS::NonnegativeUnzoomed>>::consumeAndResolve(range, state);
         if (!horizontal)
             return nullptr;
         shouldCoalesce = false;
@@ -412,7 +412,7 @@ template<CSSPropertyID property> static RefPtr<CSSValue> consumeBackgroundSize(C
     if (!range.atEnd()) {
         vertical = consumeIdent<CSSValueAuto>(range);
         if (!vertical)
-            vertical = CSSPrimitiveValueResolver<CSS::LengthPercentage<CSS::Nonnegative>>::consumeAndResolve(range, state);
+            vertical = CSSPrimitiveValueResolver<CSS::LengthPercentage<CSS::NonnegativeUnzoomed>>::consumeAndResolve(range, state);
     }
     if (!vertical) {
         if constexpr (property == CSSPropertyWebkitBackgroundSize) {

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Filter.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Filter.cpp
@@ -90,7 +90,7 @@ static std::optional<CSS::BlurFunction> consumeFilterBlur(CSSParserTokenRange& r
     if (args.atEnd())
         return { CSS::BlurFunction { .parameters = { } } };
 
-    auto parsedValue = MetaConsumer<CSS::Length<CSS::Nonnegative>>::consume(args, state);
+    auto parsedValue = MetaConsumer<CSS::Length<CSS::NonnegativeUnzoomed>>::consume(args, state);
     if (!parsedValue || !args.atEnd())
         return { };
 

--- a/Source/WebCore/css/values/backgrounds/CSSBorderImageOutset.h
+++ b/Source/WebCore/css/values/backgrounds/CSSBorderImageOutset.h
@@ -32,7 +32,7 @@ namespace CSS {
 
 // <border-image-outset-value> = <length [0,∞]> | <number [0,∞]>
 struct BorderImageOutsetValue {
-    using Length = CSS::Length<CSS::Nonnegative, float>;
+    using Length = CSS::Length<CSS::NonnegativeUnzoomed, float>;
     using Number = CSS::Number<CSS::Nonnegative, float>;
 
     BorderImageOutsetValue(Length length) : m_value { length } { }

--- a/Source/WebCore/css/values/backgrounds/CSSBorderImageWidth.h
+++ b/Source/WebCore/css/values/backgrounds/CSSBorderImageWidth.h
@@ -30,8 +30,8 @@ namespace WebCore {
 namespace CSS {
 
 struct BorderImageWidthValue {
-    using LengthPercentage = CSS::LengthPercentage<CSS::Nonnegative, float>;
-    using Number = CSS::Number<CSS::Nonnegative, float>;
+    using LengthPercentage = CSS::LengthPercentage<NonnegativeUnzoomed, float>;
+    using Number = CSS::Number<Nonnegative, float>;
 
     BorderImageWidthValue(Keyword::Auto value) : m_value { value } { }
     BorderImageWidthValue(LengthPercentage&& value) : m_value { WTF::move(value) } { }

--- a/Source/WebCore/css/values/filter-effects/CSSBlurFunction.h
+++ b/Source/WebCore/css/values/filter-effects/CSSBlurFunction.h
@@ -32,7 +32,7 @@ namespace CSS {
 // blur() = blur( <length [0,∞]>? )
 // https://drafts.fxtf.org/filter-effects/#funcdef-filter-blur
 struct Blur {
-    using Parameter = Length<Nonnegative>;
+    using Parameter = Length<NonnegativeUnzoomed>;
 
     Markable<Parameter> value;
 

--- a/Source/WebCore/css/values/masking/CSSMaskBorderOutset.h
+++ b/Source/WebCore/css/values/masking/CSSMaskBorderOutset.h
@@ -32,7 +32,7 @@ namespace CSS {
 
 // <mask-border-outset-value> = <length [0,∞]> | <number [0,∞]>
 struct MaskBorderOutsetValue {
-    using Length = CSS::Length<CSS::Nonnegative, float>;
+    using Length = CSS::Length<CSS::NonnegativeUnzoomed, float>;
     using Number = CSS::Number<CSS::Nonnegative, float>;
 
     MaskBorderOutsetValue(Length length) : m_value { length } { }

--- a/Source/WebCore/css/values/masking/CSSMaskBorderWidth.h
+++ b/Source/WebCore/css/values/masking/CSSMaskBorderWidth.h
@@ -32,7 +32,7 @@ namespace CSS {
 
 // <mask-border-width-value> = <length-percentage [0,∞]> | <number [0,∞]> | auto
 struct MaskBorderWidthValue {
-    using LengthPercentage = CSS::LengthPercentage<CSS::Nonnegative, float>;
+    using LengthPercentage = CSS::LengthPercentage<CSS::NonnegativeUnzoomed, float>;
     using Number = CSS::Number<CSS::Nonnegative, float>;
 
     MaskBorderWidthValue(Keyword::Auto value) : m_value { value } { }

--- a/Source/WebCore/layout/formattingContexts/flex/FlexFormattingUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/flex/FlexFormattingUtils.cpp
@@ -95,7 +95,7 @@ LayoutUnit FlexFormattingUtils::mainAxisGapValue(const ElementBox& flexContainer
     auto flexDirection = flexContainer.style().flexDirection();
     auto isMainAxisInlineAxis = flexDirection == FlexDirection::Row || flexDirection == FlexDirection::RowReverse;
     auto& gap = isMainAxisInlineAxis ? flexContainer.style().columnGap() : flexContainer.style().rowGap();
-    return Style::evaluateMinimum<LayoutUnit>(gap, flexContainerContentBoxWidth, Style::ZoomNeeded { });
+    return Style::evaluateMinimum<LayoutUnit>(gap, flexContainerContentBoxWidth, flexContainer.style().usedZoomForLength());
 }
 
 LayoutUnit FlexFormattingUtils::crossAxisGapValue(const ElementBox& flexContainer, LayoutUnit flexContainerContentBoxHeight)
@@ -104,7 +104,7 @@ LayoutUnit FlexFormattingUtils::crossAxisGapValue(const ElementBox& flexContaine
     auto flexDirection = flexContainer.style().flexDirection();
     auto isMainAxisInlineAxis = flexDirection == FlexDirection::Row || flexDirection == FlexDirection::RowReverse;
     auto& gap = isMainAxisInlineAxis ? flexContainer.style().rowGap() : flexContainer.style().columnGap();
-    return Style::evaluateMinimum<LayoutUnit>(gap, flexContainerContentBoxHeight, Style::ZoomNeeded { });
+    return Style::evaluateMinimum<LayoutUnit>(gap, flexContainerContentBoxHeight, flexContainer.style().usedZoomForLength());
 }
 
 // flex container  direction  flex item    main axis size

--- a/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
@@ -194,7 +194,7 @@ UsedTrackSizes GridFormattingContext::layout(GridLayoutConstraints layoutConstra
     auto usedJustifyContent = gridStyle->justifyContent().resolve();
     auto usedAlignContent = gridStyle->alignContent().resolve();
 
-    GridLayoutState layoutState { layoutConstraints, gridDefinition, usedJustifyContent, usedAlignContent, usedGapValue(gridStyle->columnGap()), usedGapValue(gridStyle->rowGap()) };
+    GridLayoutState layoutState { layoutConstraints, gridDefinition, usedJustifyContent, usedAlignContent, usedGapValue(gridStyle->columnGap(), gridStyle), usedGapValue(gridStyle->rowGap(), gridStyle) };
 
     auto [ usedTrackSizes, gridItemRects ] = GridLayout { *this }.layout(unplacedGridItems, layoutState);
 
@@ -289,8 +289,8 @@ GridFormattingContext::IntrinsicWidths GridFormattingContext::computeIntrinsicWi
     auto usedJustifyContent = gridStyle->justifyContent().resolve();
     auto usedAlignContent = gridStyle->alignContent().resolve();
 
-    auto usedColumnGap = usedGapValue(gridStyle->columnGap());
-    auto usedRowGap = usedGapValue(gridStyle->rowGap());
+    auto usedColumnGap = usedGapValue(gridStyle->columnGap(), gridStyle);
+    auto usedRowGap = usedGapValue(gridStyle->rowGap(), gridStyle);
 
     // Compute min-content width by running the full grid sizing algorithm with MinContent scenario
     GridLayoutConstraints minContentConstraints {

--- a/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.h
@@ -101,14 +101,14 @@ public:
     // FIXME: This is only here because the integration code needs to know the
     // row gap to update RenderGrid. We should figure out a way to do that and remove
     // this from the public API.
-    static LayoutUnit usedGapValue(const Style::GapGutter& gap)
+    static LayoutUnit usedGapValue(const Style::GapGutter& gap, const Style::ComputedStyle& style)
     {
         if (gap.isNormal())
             return { };
 
         // Only handle fixed length gaps for now
         if (auto fixedGap = gap.tryFixed())
-            return Style::evaluate<LayoutUnit>(*fixedGap, 0_lu, Style::ZoomNeeded { });
+            return Style::evaluate<LayoutUnit>(*fixedGap, 0_lu, style.usedZoomForLength());
 
         ASSERT_NOT_REACHED();
         return { };

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLevelBoxInlines.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLevelBoxInlines.h
@@ -35,14 +35,14 @@
 namespace WebCore {
 namespace Layout {
 
-template<typename PreferredLineHeightFunctor> InlineLevelBox::VerticalAlignment toInlineBoxLevelVerticalAlign(const Style::VerticalAlign& verticalAlign, NOESCAPE PreferredLineHeightFunctor&& preferredLineHeightFunctor)
+template<typename PreferredLineHeightFunctor> InlineLevelBox::VerticalAlignment toInlineBoxLevelVerticalAlign(const Style::ComputedStyle& style, NOESCAPE PreferredLineHeightFunctor&& preferredLineHeightFunctor)
 {
-    return WTF::switchOn(verticalAlign,
+    return WTF::switchOn(style.verticalAlign(),
         [](CSS::SpecificKeyword auto const& keyword) -> InlineLevelBox::VerticalAlignment {
             return keyword;
         },
         [&](const Style::VerticalAlign::LengthPercentage& value) -> InlineLevelBox::VerticalAlignment {
-            return Style::evaluate<InlineLayoutUnit>(value, std::forward<PreferredLineHeightFunctor>(preferredLineHeightFunctor), Style::ZoomNeeded { });
+            return Style::evaluate<InlineLayoutUnit>(value, std::forward<PreferredLineHeightFunctor>(preferredLineHeightFunctor), style.usedZoomForLength());
         }
     );
 }
@@ -54,7 +54,7 @@ inline InlineLevelBox::InlineLevelBox(const Box& layoutBox, const WebCore::Style
     , m_isFirstWithinLayoutBox(positionWithinLayoutBox.contains(PositionWithinLayoutBox::First))
     , m_isLastWithinLayoutBox(positionWithinLayoutBox.contains(PositionWithinLayoutBox::Last))
     , m_type(type)
-    , m_style({ style.fontCascade().metricsOfPrimaryFont(), style.lineHeight(), style.textBoxTrim(), style.textBoxEdge(), style.lineFitEdge(), style.usedZoomForLength(), style.lineBoxContain(), InlineLayoutUnit(style.fontCascade().fontDescription().computedSize()), toInlineBoxLevelVerticalAlign(style.verticalAlign(), [this] { return preferredLineHeight(); }) })
+    , m_style({ style.fontCascade().metricsOfPrimaryFont(), style.lineHeight(), style.textBoxTrim(), style.textBoxEdge(), style.lineFitEdge(), style.usedZoomForLength(), style.lineBoxContain(), InlineLayoutUnit(style.fontCascade().fontDescription().computedSize()), toInlineBoxLevelVerticalAlign(style, [this] { return preferredLineHeight(); }) })
 {
 }
 

--- a/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
@@ -89,7 +89,7 @@ InlineLayoutUnit TextUtil::width(const InlineTextBox& inlineTextBox, const FontC
         auto directionalOverride = isOverride(style->unicodeBidi());
         auto run = WebCore::TextRun { StringView(text).substring(from, to - from), contentLogicalLeft, { }, ExpansionBehavior::defaultBehavior(), directionalOverride ? style->writingMode().bidiDirection() : TextDirection::LTR, directionalOverride };
         if (!style->collapseWhiteSpace() && !style->tabSize().isZero())
-            run.setTabSize(true, Style::toPlatform(style->tabSize()));
+            run.setTabSize(true, Style::toPlatform(style->tabSize(), style->usedZoomForLength()));
         // FIXME: consider moving this to TextRun ctor
         run.setTextSpacingState(spacingState);
         width = fontCascade.width(run, { }, glyphOverflow);

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.cpp
@@ -180,7 +180,7 @@ void GridLayout::updateFormattingContextRootRenderer(const Layout::GridLayoutCon
 
     if (layoutConstraints.blockAxis.scenario() != Layout::AxisConstraint::FreeSpaceScenario::Definite) {
         auto& rowSizes = usedTrackSizes.rowSizes;
-        auto usedRowGutter = Layout::GridFormattingContext::usedGapValue(renderGrid->style().rowGap());
+        auto usedRowGutter = Layout::GridFormattingContext::usedGapValue(renderGrid->style().rowGap(), renderGrid->style());
         auto blockContentSize = std::reduce(rowSizes.begin(), rowSizes.end()) + Layout::GridLayoutUtils::totalGuttersSize(rowSizes.size(), usedRowGutter);
         renderGrid->setBorderBoxHeight(blockContentSize + renderGrid->borderAndPaddingLogicalHeight());
     } else
@@ -267,7 +267,7 @@ void GridLayout::populateGridPositionsForOutOfFlowLayout(const Layout::UsedTrack
     auto populate = [&](Style::GridTrackSizingDirection direction) {
         bool isColumns = direction == Style::GridTrackSizingDirection::Columns;
         auto& trackSizes = isColumns ? usedTrackSizes.columnSizes : usedTrackSizes.rowSizes;
-        auto gap = Layout::GridFormattingContext::usedGapValue(isColumns ? renderGrid->style().columnGap() : renderGrid->style().rowGap());
+        auto gap = Layout::GridFormattingContext::usedGapValue(isColumns ? renderGrid->style().columnGap() : renderGrid->style().rowGap(), renderGrid->style());
         auto borderAndPadding = isColumns ? renderGrid->borderAndPaddingStart() : renderGrid->borderAndPaddingBefore();
         auto numberOfTracks = trackSizes.size();
         bool hasMultipleTracks = numberOfTracks > 1;

--- a/Source/WebCore/layout/integration/inline/InlineIteratorBoxModernPathInlines.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorBoxModernPathInlines.h
@@ -61,7 +61,7 @@ inline TextRun BoxModernPath::textRun(TextRunMode mode) const
     };
     auto characterScanForCodePath = isText() && !renderText().canUseSimpleFontCodePath();
     auto textRun = TextRun { mode == TextRunMode::Editing ? originalText() : box().text().renderedContent(), logicalLeft(), expansion.horizontalExpansion, expansion.behavior, direction(), style->rtlOrdering() == Order::Visual, characterScanForCodePath };
-    textRun.setTabSize(!style->collapseWhiteSpace(), Style::toPlatform(style->tabSize()));
+    textRun.setTabSize(!style->collapseWhiteSpace(), Style::toPlatform(style->tabSize(), style->usedZoomForLength()));
     return textRun;
 }
 

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -705,7 +705,7 @@ void LocalFrameView::applyPaginationToViewport()
         if (!columnGap.isNormal()) {
             CheckedPtr renderBox = dynamicDowncast<RenderBox>(documentOrBodyRenderer.get());
             if (CheckedPtr containerForPaginationGap = renderBox ? renderBox : documentOrBodyRenderer->containingBlock())
-                pagination.gap = Style::evaluate<LayoutUnit>(columnGap, containerForPaginationGap->contentBoxLogicalWidth(), Style::ZoomNeeded { }).toUnsigned();
+                pagination.gap = Style::evaluate<LayoutUnit>(columnGap, containerForPaginationGap->contentBoxLogicalWidth(), documentOrBodyRenderer->style().usedZoomForLength()).toUnsigned();
         }
     }
     setPagination(pagination);

--- a/Source/WebCore/rendering/BackgroundPainter.cpp
+++ b/Source/WebCore/rendering/BackgroundPainter.cpp
@@ -797,7 +797,7 @@ template<typename Layer> BackgroundImageGeometry BackgroundPainter::calculateFil
     return BackgroundImageGeometry(destinationRect, tileSizeWithoutPixelSnapping, tileSize, phase, spaceSize, fixedAttachment);
 }
 
-template<typename Layer> LayoutSize BackgroundPainter::calculateFillTileSize(const RenderBoxModelObject& renderer, const Layer& fillLayer, Style::ZoomFactor, const LayoutSize& positioningAreaSize)
+template<typename Layer> LayoutSize BackgroundPainter::calculateFillTileSize(const RenderBoxModelObject& renderer, const Layer& fillLayer, Style::ZoomFactor zoom, const LayoutSize& positioningAreaSize)
 {
     RefPtr image = fillLayer.image().tryStyleImage();
     auto devicePixelSize = LayoutUnit { 1.0 / protect(renderer)->document().deviceScaleFactor() };
@@ -838,17 +838,17 @@ template<typename Layer> LayoutSize BackgroundPainter::calculateFillTileSize(con
             auto& layerHeight = size.height();
 
             if (auto fixed = layerWidth.tryFixed())
-                tileSize.setWidth(Style::evaluate<LayoutUnit>(*fixed, Style::ZoomNeeded { }));
+                tileSize.setWidth(Style::evaluate<LayoutUnit>(*fixed, zoom));
             else if (layerWidth.isPercentOrCalculated()) {
-                auto resolvedWidth = Style::evaluate<LayoutUnit>(layerWidth, positioningAreaSize.width(), Style::ZoomNeeded { });
+                auto resolvedWidth = Style::evaluate<LayoutUnit>(layerWidth, positioningAreaSize.width(), zoom);
                 // Non-zero resolved value should always produce some content.
                 tileSize.setWidth(!resolvedWidth ? resolvedWidth : std::max(devicePixelSize, resolvedWidth));
             }
 
             if (auto fixed = layerHeight.tryFixed())
-                tileSize.setHeight(Style::evaluate<LayoutUnit>(*fixed, Style::ZoomNeeded { }));
+                tileSize.setHeight(Style::evaluate<LayoutUnit>(*fixed, zoom));
             else if (layerHeight.isPercentOrCalculated()) {
-                auto resolvedHeight = Style::evaluate<LayoutUnit>(layerHeight, positioningAreaSize.height(), Style::ZoomNeeded { });
+                auto resolvedHeight = Style::evaluate<LayoutUnit>(layerHeight, positioningAreaSize.height(), zoom);
                 // Non-zero resolved value should always produce some content.
                 tileSize.setHeight(!resolvedHeight ? resolvedHeight : std::max(devicePixelSize, resolvedHeight));
             }

--- a/Source/WebCore/rendering/LegacyInlineTextBox.cpp
+++ b/Source/WebCore/rendering/LegacyInlineTextBox.cpp
@@ -239,7 +239,7 @@ TextRun LegacyInlineTextBox::createTextRun() const
 {
     CheckedRef style = lineStyle();
     TextRun textRun { text(), textPos(), 0, ExpansionBehavior::forbidAll(), direction(), style->rtlOrdering() == Order::Visual, !renderer().canUseSimpleFontCodePath() };
-    textRun.setTabSize(!style->collapseWhiteSpace(), Style::toPlatform(style->tabSize()));
+    textRun.setTabSize(!style->collapseWhiteSpace(), Style::toPlatform(style->tabSize(), style->usedZoomForLength()));
     return textRun;
 }
 

--- a/Source/WebCore/rendering/NinePieceImagePainter.cpp
+++ b/Source/WebCore/rendering/NinePieceImagePainter.cpp
@@ -75,11 +75,11 @@ static bool NODELETE isVerticalPiece(ImagePiece piece)
 }
 
 template<typename WidthValue>
-static LayoutUnit computeSlice(const WidthValue& length, LayoutUnit width, LayoutUnit slice, LayoutUnit extent, const Style::ZoomFactor&)
+static LayoutUnit computeSlice(const WidthValue& length, LayoutUnit width, LayoutUnit slice, LayoutUnit extent, const Style::ZoomFactor& zoom)
 {
     return WTF::switchOn(length,
         [&](const typename WidthValue::LengthPercentage& value) {
-            return Style::evaluate<LayoutUnit>(value, extent, Style::ZoomNeeded { });
+            return Style::evaluate<LayoutUnit>(value, extent, zoom);
         },
         [&](const typename WidthValue::Number& value) {
             return LayoutUnit { value.value * width };

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -343,7 +343,7 @@ void RenderBlockFlow::adjustIntrinsicLogicalWidthsForColumns(LayoutUnit& minLogi
         LayoutUnit colGap = columnGap();
         LayoutUnit gapExtra = (columnCount - 1) * colGap;
         if (auto columnWidthLength = style().columnWidth().tryLength()) {
-            columnWidth = Style::evaluate<LayoutUnit>(*columnWidthLength, Style::ZoomNeeded { });
+            columnWidth = Style::evaluate<LayoutUnit>(*columnWidthLength, style().usedZoomForLength());
             minLogicalWidth = std::min(minLogicalWidth, columnWidth);
         } else
             minLogicalWidth = minLogicalWidth * columnCount + gapExtra;
@@ -413,7 +413,7 @@ LayoutUnit RenderBlockFlow::columnGap() const
 {
     if (style().columnGap().isNormal())
         return LayoutUnit(style().fontDescription().computedSize()); // "1em" is recommended as the normal gap setting. Matches <p> margins.
-    return Style::evaluate<LayoutUnit>(style().columnGap(), contentBoxLogicalWidth(), Style::ZoomNeeded { });
+    return Style::evaluate<LayoutUnit>(style().columnGap(), contentBoxLogicalWidth(), style().usedZoomForLength());
 }
 
 void RenderBlockFlow::computeColumnCountAndWidth()
@@ -431,7 +431,7 @@ void RenderBlockFlow::computeColumnCountAndWidth()
 
     LayoutUnit availWidth = desiredColumnWidth;
     LayoutUnit colGap = columnGap();
-    LayoutUnit colWidth = std::max(1_lu, Style::evaluate<LayoutUnit>(style().columnWidth().tryLength().value_or(0_css_px), Style::ZoomNeeded { }));
+    LayoutUnit colWidth = std::max(1_lu, Style::evaluate<LayoutUnit>(style().columnWidth().tryLength().value_or(0_css_px), style().usedZoomForLength()));
     unsigned colCount = std::max<unsigned>(1, style().columnCount().tryValue().value_or(1).value);
 
     if (style().columnWidth().isAuto() && !style().columnCount().isAuto()) {
@@ -1226,7 +1226,7 @@ void RenderBlockFlow::layoutBlockChild(RenderBox& child, MarginInfo& marginInfo,
 
     auto& childStyle = child.style();
     if (auto blockStepSizeForChild = childStyle.blockStepSize().tryLength(); blockStepSizeForChild && BlockStepSizing::childHasSupportedStyle(childStyle))
-        performBlockStepSizing(child, LayoutUnit(blockStepSizeForChild->resolveZoom(Style::ZoomNeeded { })));
+        performBlockStepSizing(child, Style::evaluate<LayoutUnit>(*blockStepSizeForChild, childStyle.usedZoomForLength()));
 
     // Cache if we are at the top of the block right now.
     bool atBeforeSideOfBlock = marginInfo.atBeforeSideOfBlock();

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -3223,7 +3223,7 @@ LayoutUnit RenderFlexibleBox::computeGap(RenderFlexibleBox::GapType gapType) con
         return { };
 
     auto availableSize = usesRowGap ? availableLogicalHeightForPercentageComputation().value_or(0_lu) : contentBoxLogicalWidth();
-    return Style::evaluateMinimum<LayoutUnit>(gap, availableSize, Style::ZoomNeeded { });
+    return Style::evaluateMinimum<LayoutUnit>(gap, availableSize, style().usedZoomForLength());
 }
 
 bool RenderFlexibleBox::layoutUsingFlexFormattingContext()

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -728,7 +728,7 @@ LayoutUnit RenderGrid::gridGap(Style::GridTrackSizingDirection direction, std::o
         return downcast<RenderGrid>(parent())->gridGap(parentDirection);
     }
 
-    return Style::evaluate<LayoutUnit>(gap, availableSize.value_or(0_lu), Style::ZoomNeeded { });
+    return Style::evaluate<LayoutUnit>(gap, availableSize.value_or(0_lu), style().usedZoomForLength());
 }
 
 LayoutUnit RenderGrid::gridGap(Style::GridTrackSizingDirection direction) const

--- a/Source/WebCore/rendering/RenderMultiColumnSet.cpp
+++ b/Source/WebCore/rendering/RenderMultiColumnSet.cpp
@@ -447,7 +447,7 @@ LayoutUnit RenderMultiColumnSet::columnGap() const
     auto& parentBlockGap = parentBlock.style().columnGap();
     if (parentBlockGap.isNormal())
         return LayoutUnit(parentBlock.style().fontDescription().computedSize()); // "1em" is recommended as the normal gap setting. Matches <p> margins.
-    return Style::evaluate<LayoutUnit>(parentBlockGap, parentBlock.contentBoxLogicalWidth(), Style::ZoomNeeded { });
+    return Style::evaluate<LayoutUnit>(parentBlockGap, parentBlock.contentBoxLogicalWidth(), parentBlock.style().usedZoomForLength());
 }
 
 unsigned RenderMultiColumnSet::columnCount() const

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -1037,7 +1037,7 @@ ALWAYS_INLINE float RenderText::widthFromCache(const FontCascade& fontCascade, u
 
     TextRun run = RenderBlock::constructTextRun(*this, start, length, style);
     run.setCharacterScanForCodePath(!canUseSimpleFontCodePath());
-    run.setTabSize(!style.collapseWhiteSpace(), Style::toPlatform(style.tabSize()));
+    run.setTabSize(!style.collapseWhiteSpace(), Style::toPlatform(style.tabSize(), style.usedZoomForLength()));
     run.setXPos(xPos);
     return fontCascade.width(run, fallbackFonts, glyphOverflow);
 }
@@ -1518,7 +1518,7 @@ void RenderText::computeMinMaxIntrinsicLogicalWidths(float leadingWidth, SingleT
                 currMaxWidth = 0;
             } else {
                 TextRun run = RenderBlock::constructTextRun(*this, i, 1, style);
-                run.setTabSize(!style.collapseWhiteSpace(), Style::toPlatform(style.tabSize()));
+                run.setTabSize(!style.collapseWhiteSpace(), Style::toPlatform(style.tabSize(), style.usedZoomForLength()));
                 run.setXPos(leadingWidth + currMaxWidth);
 
                 currMaxWidth += font.width(run, &fallbackFonts);
@@ -2011,7 +2011,7 @@ float RenderText::width(unsigned from, unsigned length, const FontCascade& fontC
     } else {
         TextRun run = RenderBlock::constructTextRun(*this, from, length, style);
         run.setCharacterScanForCodePath(!canUseSimpleFontCodePath());
-        run.setTabSize(!style.collapseWhiteSpace(), Style::toPlatform(style.tabSize()));
+        run.setTabSize(!style.collapseWhiteSpace(), Style::toPlatform(style.tabSize(), style.usedZoomForLength()));
         run.setXPos(xPos);
 
         width = fontCascade.width(run, fallbackFonts, glyphOverflow);

--- a/Source/WebCore/style/computed/StyleComputedStyle.cpp
+++ b/Source/WebCore/style/computed/StyleComputedStyle.cpp
@@ -627,7 +627,7 @@ static LayoutUnit computeOutset(const OutsetValue& outsetValue, const Style::Lin
             return LayoutUnit(Style::evaluate<LayoutUnit>(borderWidth, zoom, deviceScaleFactor) * number.value);
         },
         [&](const typename OutsetValue::Length& length) {
-            return Style::evaluate<LayoutUnit>(length, Style::ZoomNeeded { });
+            return Style::evaluate<LayoutUnit>(length, zoom);
         }
     );
 }

--- a/Source/WebCore/style/values/align/StyleGapGutter.h
+++ b/Source/WebCore/style/values/align/StyleGapGutter.h
@@ -31,7 +31,7 @@ namespace Style {
 
 // <'row-gap/column-gap'> = normal | <length-percentage [0,∞]>
 // https://drafts.csswg.org/css-align/#column-row-gap
-struct GapGutter : PrimitiveNumericOrKeyword<LengthPercentage<CSS::Nonnegative>, CSS::Keyword::Normal> {
+struct GapGutter : PrimitiveNumericOrKeyword<LengthPercentage<CSS::NonnegativeUnzoomed>, CSS::Keyword::Normal> {
     using Base::Base;
 
     ALWAYS_INLINE bool isNormal() const { return holdsAlternative<CSS::Keyword::Normal>(); }

--- a/Source/WebCore/style/values/backgrounds/StyleBackgroundSize.h
+++ b/Source/WebCore/style/values/backgrounds/StyleBackgroundSize.h
@@ -30,7 +30,7 @@
 namespace WebCore {
 namespace Style {
 
-struct BackgroundSizeLength : PrimitiveNumericOrKeyword<LengthPercentage<CSS::Nonnegative>, CSS::Keyword::Auto> {
+struct BackgroundSizeLength : PrimitiveNumericOrKeyword<LengthPercentage<CSS::NonnegativeUnzoomed>, CSS::Keyword::Auto> {
     using Base::Base;
 
     ALWAYS_INLINE bool isAuto() const { return holdsAlternative<CSS::Keyword::Auto>(); }

--- a/Source/WebCore/style/values/backgrounds/StyleBorderImageOutset.h
+++ b/Source/WebCore/style/values/backgrounds/StyleBorderImageOutset.h
@@ -37,7 +37,7 @@ namespace Style {
 
 // <border-image-outset-value> = <length [0,∞]> | <number [0,∞]>
 struct BorderImageOutsetValue {
-    using Length = Style::Length<CSS::Nonnegative, float>;
+    using Length = Style::Length<CSS::NonnegativeUnzoomed, float>;
     using Number = Style::Number<CSS::Nonnegative, float>;
 
     constexpr BorderImageOutsetValue(Length length) : m_value { length } { }

--- a/Source/WebCore/style/values/backgrounds/StyleBorderImageWidth.h
+++ b/Source/WebCore/style/values/backgrounds/StyleBorderImageWidth.h
@@ -37,7 +37,7 @@ namespace Style {
 
 // <border-image-width-value> = <length-percentage [0,∞]> | <number [0,∞]> | auto
 struct BorderImageWidthValue {
-    using LengthPercentage = Style::LengthPercentage<CSS::Nonnegative>;
+    using LengthPercentage = Style::LengthPercentage<CSS::NonnegativeUnzoomed>;
     using Number = Style::Number<CSS::Nonnegative, float>;
 
     BorderImageWidthValue(CSS::Keyword::Auto keyword)

--- a/Source/WebCore/style/values/filter-effects/StyleBlurFunction.cpp
+++ b/Source/WebCore/style/values/filter-effects/StyleBlurFunction.cpp
@@ -29,6 +29,7 @@
 #include "CSSFilterFunctionDescriptor.h"
 #include "FEGaussianBlur.h"
 #include "FilterOperation.h"
+#include "StyleComputedStyleBase+GettersInlines.h"
 #include "StylePrimitiveNumericTypes+Conversions.h"
 #include "StylePrimitiveNumericTypes+Evaluation.h"
 
@@ -40,9 +41,9 @@ Blur Blur::passthroughForInterpolation()
     return { .value = CSSFilterFunctionDescriptor<CSSValueBlur>::initialValueForInterpolation };
 }
 
-IntOutsets Blur::calculateOutsets(ZoomFactor) const
+IntOutsets Blur::calculateOutsets(ZoomFactor zoom) const
 {
-    auto stdDeviation = evaluate<float>(value, ZoomNeeded { });
+    auto stdDeviation = evaluate<float>(value, zoom);
     return FEGaussianBlur::calculateOutsets({ stdDeviation, stdDeviation });
 }
 
@@ -62,17 +63,17 @@ auto ToStyle<CSS::Blur>::operator()(const CSS::Blur& value, const BuilderState& 
 
 // MARK: - Evaluation
 
-auto Evaluation<Blur, Ref<FilterEffect>>::operator()(const Blur& value, const Style::ComputedStyle&) -> Ref<FilterEffect>
+auto Evaluation<Blur, Ref<FilterEffect>>::operator()(const Blur& value, const Style::ComputedStyle& style) -> Ref<FilterEffect>
 {
-    auto stdDeviation = evaluate<float>(value, ZoomNeeded { });
+    auto stdDeviation = evaluate<float>(value, style.usedZoomForLength());
     return FEGaussianBlur::create(stdDeviation, stdDeviation, EdgeModeType::None);
 }
 
 // MARK: - Platform
 
-auto ToPlatform<Blur>::operator()(const Blur& value, const Style::ComputedStyle&) -> Ref<FilterOperation>
+auto ToPlatform<Blur>::operator()(const Blur& value, const Style::ComputedStyle& style) -> Ref<FilterOperation>
 {
-    return BlurFilterOperation::create(Style::evaluate<float>(value, ZoomNeeded { }));
+    return BlurFilterOperation::create(Style::evaluate<float>(value, style.usedZoomForLength()));
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/filter-effects/StyleBlurFunction.h
+++ b/Source/WebCore/style/values/filter-effects/StyleBlurFunction.h
@@ -43,7 +43,7 @@ struct ZoomFactor;
 // blur() = blur( <length [0,∞]>?@(default=0px) )
 // https://drafts.fxtf.org/filter-effects/#funcdef-filter-blur
 struct Blur {
-    using Parameter = Length<CSS::Nonnegative>;
+    using Parameter = Length<CSS::NonnegativeUnzoomed>;
 
     Parameter value;
 

--- a/Source/WebCore/style/values/inline/StyleVerticalAlign.h
+++ b/Source/WebCore/style/values/inline/StyleVerticalAlign.h
@@ -36,7 +36,7 @@ namespace Style {
 // https://drafts.csswg.org/css-inline/#propdef-vertical-align
 
 struct VerticalAlign {
-    using LengthPercentage = Style::LengthPercentage<>;
+    using LengthPercentage = Style::LengthPercentage<CSS::AllUnzoomed>;
 
     VerticalAlign(CSS::Keyword::Baseline keyword) : m_value { keyword } { }
     VerticalAlign(CSS::Keyword::Sub keyword) : m_value { keyword } { }

--- a/Source/WebCore/style/values/masking/StyleMaskBorderOutset.h
+++ b/Source/WebCore/style/values/masking/StyleMaskBorderOutset.h
@@ -37,7 +37,7 @@ namespace Style {
 
 // <mask-border-outset-value> = <length [0,∞]> | <number [0,∞]>
 struct MaskBorderOutsetValue {
-    using Length = Style::Length<CSS::Nonnegative, float>;
+    using Length = Style::Length<CSS::NonnegativeUnzoomed, float>;
     using Number = Style::Number<CSS::Nonnegative, float>;
 
     constexpr MaskBorderOutsetValue(Length length)

--- a/Source/WebCore/style/values/masking/StyleMaskBorderWidth.h
+++ b/Source/WebCore/style/values/masking/StyleMaskBorderWidth.h
@@ -37,7 +37,7 @@ namespace Style {
 
 // <mask-border-width-value> = <length-percentage [0,∞]> | <number [0,∞]> | auto
 struct MaskBorderWidthValue {
-    using LengthPercentage = Style::LengthPercentage<CSS::Nonnegative>;
+    using LengthPercentage = Style::LengthPercentage<CSS::NonnegativeUnzoomed>;
     using Number = Style::Number<CSS::Nonnegative, float>;
 
     MaskBorderWidthValue(CSS::Keyword::Auto keyword)

--- a/Source/WebCore/style/values/multicol/StyleColumnWidth.h
+++ b/Source/WebCore/style/values/multicol/StyleColumnWidth.h
@@ -30,7 +30,7 @@ namespace WebCore::Style {
 
 // <'column-width'> = auto | <length [0,∞]>
 // https://www.w3.org/TR/css-multicol-1/#propdef-column-width
-struct ColumnWidth : ValueOrKeyword<Length<CSS::Nonnegative, float>, CSS::Keyword::Auto> {
+struct ColumnWidth : ValueOrKeyword<Length<CSS::NonnegativeUnzoomed, float>, CSS::Keyword::Auto> {
     using Base::Base;
     using Length = typename Base::Value;
 

--- a/Source/WebCore/style/values/rhythm/StyleBlockStepSize.h
+++ b/Source/WebCore/style/values/rhythm/StyleBlockStepSize.h
@@ -32,7 +32,7 @@ namespace Style {
 
 // <'block-step-size'> = none | <length [0,∞]>
 // https://www.w3.org/TR/css-rhythm-1/#propdef-block-step-size
-struct BlockStepSize : ValueOrKeyword<Length<CSS::Nonnegative, float>, CSS::Keyword::None> {
+struct BlockStepSize : ValueOrKeyword<Length<CSS::NonnegativeUnzoomed, float>, CSS::Keyword::None> {
     using Base::Base;
     using Length = typename Base::Value;
 

--- a/Source/WebCore/style/values/text/StyleTabSize.cpp
+++ b/Source/WebCore/style/values/text/StyleTabSize.cpp
@@ -74,14 +74,14 @@ auto Blending<TabSize>::blend(const TabSize& a, const TabSize& b, const Blending
 
 // MARK: - Platform
 
-auto ToPlatform<TabSize>::operator()(const TabSize& value) -> WebCore::TabSize
+auto ToPlatform<TabSize>::operator()(const TabSize& value, ZoomFactor zoom) -> WebCore::TabSize
 {
     return WTF::switchOn(value,
         [](const TabSize::Spaces& spaces) {
             return WebCore::TabSize { spaces.value, SpaceValueType };
         },
-        [](const TabSize::Length& length) {
-            return WebCore::TabSize { evaluate<float>(length, ZoomNeeded { }), LengthValueType };
+        [&](const TabSize::Length& length) {
+            return WebCore::TabSize { evaluate<float>(length, zoom), LengthValueType };
         }
     );
 }

--- a/Source/WebCore/style/values/text/StyleTabSize.h
+++ b/Source/WebCore/style/values/text/StyleTabSize.h
@@ -36,7 +36,7 @@ namespace Style {
 // https://drafts.csswg.org/css-text-3/#propdef-tab-size
 struct TabSize {
     using Spaces = Style::Number<CSS::Nonnegative, float>;
-    using Length = Style::Length<CSS::Nonnegative, float>;
+    using Length = Style::Length<CSS::NonnegativeUnzoomed, float>;
 
     constexpr TabSize(CSS::ValueLiteral<CSS::NumberUnit::Number> literal)
         : m_value { Spaces { literal } }
@@ -97,7 +97,7 @@ template<> struct Blending<TabSize> {
 
 // MARK: - Platform
 
-template<> struct ToPlatform<TabSize> { auto operator()(const TabSize&) -> WebCore::TabSize; };
+template<> struct ToPlatform<TabSize> { auto operator()(const TabSize&, ZoomFactor) -> WebCore::TabSize; };
 
 } // namespace Style
 } // namespace WebCore


### PR DESCRIPTION
#### 0715e8181b2f7117182d87de865acb7d9c746ca8
<pre>
[EvaluationTimeZoom] Convert more properties to evaluation time zoom
<a href="https://bugs.webkit.org/show_bug.cgi?id=318870">https://bugs.webkit.org/show_bug.cgi?id=318870</a>

Reviewed by Antti Koivisto.

Converts `block-step-size`, `tab-size`,`row-gap`, `column-gap`, `background-size`,
`border-image-outset`,  `border-image-width`, `mask-border-outset`, `mask-border-width`,
`vertical-align`, `column-width` and `filter: blur()`.

Tests: imported/w3c/web-platform-tests/css/css-viewport/zoom/background-size.html
       imported/w3c/web-platform-tests/css/css-viewport/zoom/block-step-size.html
       imported/w3c/web-platform-tests/css/css-viewport/zoom/border-image-outset.html
       imported/w3c/web-platform-tests/css/css-viewport/zoom/column-gap.html
       imported/w3c/web-platform-tests/css/css-viewport/zoom/column-width.html
       imported/w3c/web-platform-tests/css/css-viewport/zoom/filters-blur.html
       imported/w3c/web-platform-tests/css/css-viewport/zoom/mask-border-outset.html
       imported/w3c/web-platform-tests/css/css-viewport/zoom/row-gap.html
       imported/w3c/web-platform-tests/css/css-viewport/zoom/tab-size.html
       imported/w3c/web-platform-tests/css/css-viewport/zoom/vertical-align.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/background-size-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/background-size.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/block-step-size-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/block-step-size.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/border-image-outset-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/border-image-outset.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/column-gap-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/column-gap.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/column-width-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/column-width.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/filters-blur-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/filters-blur.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/mask-border-outset-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/mask-border-outset.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/background-size-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/block-step-size-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/border-image-outset-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/column-gap-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/column-width-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/filters-blur-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/mask-border-outset-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/row-gap-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/tab-size-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/vertical-align-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/row-gap-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/row-gap.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/tab-size-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/tab-size.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/vertical-align-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/vertical-align.html: Added.
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Background.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Filter.cpp:
* Source/WebCore/css/values/backgrounds/CSSBorderImageOutset.h:
* Source/WebCore/css/values/backgrounds/CSSBorderImageWidth.h:
* Source/WebCore/css/values/filter-effects/CSSBlurFunction.h:
* Source/WebCore/css/values/masking/CSSMaskBorderOutset.h:
* Source/WebCore/css/values/masking/CSSMaskBorderWidth.h:
* Source/WebCore/layout/formattingContexts/flex/FlexFormattingUtils.cpp:
* Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp:
* Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.h:
* Source/WebCore/layout/formattingContexts/inline/InlineLevelBoxInlines.h:
* Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp:
* Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.cpp:
* Source/WebCore/layout/integration/inline/InlineIteratorBoxModernPathInlines.h:
* Source/WebCore/page/LocalFrameView.cpp:
* Source/WebCore/rendering/BackgroundPainter.cpp:
* Source/WebCore/rendering/LegacyInlineTextBox.cpp:
* Source/WebCore/rendering/NinePieceImagePainter.cpp:
* Source/WebCore/rendering/RenderBlockFlow.cpp:
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
* Source/WebCore/rendering/RenderGrid.cpp:
* Source/WebCore/rendering/RenderMultiColumnSet.cpp:
* Source/WebCore/rendering/RenderText.cpp:
* Source/WebCore/style/computed/StyleComputedStyle.cpp:
* Source/WebCore/style/values/align/StyleGapGutter.h:
* Source/WebCore/style/values/backgrounds/StyleBackgroundSize.h:
* Source/WebCore/style/values/backgrounds/StyleBorderImageOutset.h:
* Source/WebCore/style/values/backgrounds/StyleBorderImageWidth.h:
* Source/WebCore/style/values/filter-effects/StyleBlurFunction.cpp:
* Source/WebCore/style/values/filter-effects/StyleBlurFunction.h:
* Source/WebCore/style/values/inline/StyleVerticalAlign.h:
* Source/WebCore/style/values/masking/StyleMaskBorderOutset.h:
* Source/WebCore/style/values/masking/StyleMaskBorderWidth.h:
* Source/WebCore/style/values/multicol/StyleColumnWidth.h:
* Source/WebCore/style/values/rhythm/StyleBlockStepSize.h:
* Source/WebCore/style/values/text/StyleTabSize.cpp:
* Source/WebCore/style/values/text/StyleTabSize.h:

Canonical link: <a href="https://commits.webkit.org/316785@main">https://commits.webkit.org/316785@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b8ffb6020b6de629b02b60c5e9ddcc5735e60af

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173297 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47229 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40768 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182870 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130853 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175162 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48522 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46911 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134750 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176255 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38166 "Found 1 new test failure: fast/css/getComputedStyle-font-variant-shorthand-crash.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155401 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115223 "Found 1 new API test failure: WPE/TestWebKitWebView:/webkit/WebKitWebView/save (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36810 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35157 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31355 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147234 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34899 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185293 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38147 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39358 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143602 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46897 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154961 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143470 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38747 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47576 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112677 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38425 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119325 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46082 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9845 "Passed tests") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45484 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45715 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45541 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->