### PR TITLE
[scroll-animations] calling play() for a finite timeline should reset the start time to the current time

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/play-animation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/play-animation-expected.txt
@@ -3,14 +3,14 @@ PASS Playing an animations aligns the start time with the start of the active ra
 PASS Playing an animations with a negative playback rate aligns the start time with the end of the active range
 PASS Start time set while play pending is preserved.
 PASS Current time set while play pending is preserved.
-FAIL Playing a running animation resets a sticky start time assert_approx_equals: values do not match for "undefined" expected 0 +/- 0.125 but got 10
-FAIL Playing a finished animation restarts the animation aligned at the start assert_approx_equals: values do not match for "undefined" expected 0 +/- 0.125 but got 100
-FAIL Playing a finished and reversed animation restarts the animation aligned at the end assert_approx_equals: values do not match for "undefined" expected 100 +/- 0.125 but got 0
-FAIL Playing a pause-pending but previously finished animation realigns with the scroll position assert_approx_equals: values do not match for "After aborting a pause when finished, the start time should no longer be sticky" expected 0 +/- 0.125 but got -50
-FAIL Playing a finished animation clears the start time assert_approx_equals: values do not match for "start time is zero" expected 0 +/- 0.125 but got -100
+PASS Playing a running animation resets a sticky start time
+PASS Playing a finished animation restarts the animation aligned at the start
+PASS Playing a finished and reversed animation restarts the animation aligned at the end
+PASS Playing a pause-pending but previously finished animation realigns with the scroll position
+PASS Playing a finished animation clears the start time
 PASS The ready promise should be replaced if the animation is not already pending
 PASS A pending ready promise should be resolved and not replaced when the animation enters the running state
-FAIL Resuming an animation from paused realigns with scroll position. assert_approx_equals: values do not match for "undefined" expected 0 +/- 0.125 but got -50
+PASS Resuming an animation from paused realigns with scroll position.
 PASS If a pause operation is interrupted, the ready promise is reused
 FAIL A pending playback rate is used when determining timeline range alignment assert_approx_equals: values do not match for "undefined" expected 100 +/- 0.125 but got -100
 PASS Playing a canceled animation sets the start time

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/reverse-animation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/reverse-animation-expected.txt
@@ -1,11 +1,11 @@
 
 PASS Setting current time while reverse-pending preserves currentTime
 PASS Reversing an animation inverts the playback rate
-FAIL Reversing an animation resets a sticky start time. assert_approx_equals: values do not match for "undefined" expected 100 +/- 0.125 but got 40
+FAIL Reversing an animation resets a sticky start time. assert_approx_equals: values do not match for "undefined" expected 100 +/- 0.125 but got -100
 PASS Reversing an animation does not cause it to leave the pending state
 PASS Reversing an animation does not cause it to resolve the ready promise
 PASS Reversing an animation with a negative playback rate should cause the animation to play in a forward direction
-FAIL Reversing when when playbackRate == 0 should preserve the playback rate assert_approx_equals: values do not match for "Anchors to range start boundary when playback rate is zero" expected 0 +/- 0.125 but got 50
+PASS Reversing when when playbackRate == 0 should preserve the playback rate
 FAIL Reversing an idle animation aligns startTime with the rangeEnd boundary assert_approx_equals: values do not match for "animation.startTime should be at its effect end" expected 100 +/- 0.125 but got -100
 PASS Reversing an animation without an active timeline throws an InvalidStateError
 PASS Reversing an animation plays a pausing animation

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -1236,10 +1236,13 @@ ExceptionOr<void> WebAnimation::play(AutoRewind autoRewind)
         m_holdTime = zeroTime();
     }
 
-    // 7. If has finite timeline and previous current time is unresolved:
+    // 7. If has finite timeline and auto-rewind is true:
     // Set the flag auto align start time to true.
-    if (hasFiniteTimeline && !previousCurrentTime)
+    // Set hold time to previous current time.
+    if (hasFiniteTimeline && autoRewind == AutoRewind::Yes) {
         m_autoAlignStartTime = true;
+        m_holdTime = previousCurrentTime;
+    }
 
     // 8. If animation’s hold time is resolved, let its start time be unresolved.
     if (m_holdTime)


### PR DESCRIPTION
#### 08b880d9b139ec5d7883bb481e555d6116d571d9
<pre>
[scroll-animations] calling play() for a finite timeline should reset the start time to the current time
<a href="https://bugs.webkit.org/show_bug.cgi?id=318875">https://bugs.webkit.org/show_bug.cgi?id=318875</a>
<a href="https://rdar.apple.com/181712713">rdar://181712713</a>

Reviewed by Tim Nguyen.

The Web Animations spec is changing [0] to reset the start time of a Scroll-driven Animation to the
current time when calling `play()` for a finite (ie. progress-based) timeline.

[0] <a href="https://github.com/w3c/csswg-drafts/issues/11469">https://github.com/w3c/csswg-drafts/issues/11469</a>

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/play-animation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/reverse-animation-expected.txt:
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::play):

Canonical link: <a href="https://commits.webkit.org/316745@main">https://commits.webkit.org/316745@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b170b6f1d02ad60b2f14cffcdbb3b015e80bd1bf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173299 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47231 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40770 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182872 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130855 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/06d0e5df-dd74-45ea-bb4a-b571fb6ebb0d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175164 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48524 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46913 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134752 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e4cefefe-5239-4906-af61-5e15bb01d3f4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176257 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38165 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/155405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115225 "Found 1 new API test failure: WPE/TestWebKitWebView:/webkit/WebKitWebView/save (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fb3431b7-2b21-409a-9bec-c1c5ba186739) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36809 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/35156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31357 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147233 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34902 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185295 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/38149 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39357 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143601 "Found 1 new test failure: fast/parser/entity-comment-in-style.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46899 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143469 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47578 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112679 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26322 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38428 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119327 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46084 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9849 "Passed tests") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45486 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45717 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45543 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->