### PR TITLE
[EWS] Support safe-merge-queue for webkitglib stable branches

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -2315,6 +2315,7 @@ class DetermineLabelOwner(buildstep.BuildStep, GitHubMixin, AddToLogMixin):
             self.setProperty('list_of_prs', list_of_prs)
             self.setProperty('github.title', pr_title)
             self.setProperty('github.head.sha', commit_hash)
+            self.setProperty('github.base.ref', pr_data['node']['baseRefName'])
 
         if not pr_number:
             yield self._addToLog('stdio', 'Unable to fetch PR number.\n')
@@ -2531,6 +2532,8 @@ class RemoveAndAddLabels(buildstep.BuildStep, GitHubMixin, AddToLogMixin):
     def run(self):
         if self.label_to_add == GitHub.MERGE_QUEUE_LABEL:
             pr_status = 'passed_status_check'
+        elif self.label_to_add == GitHub.UNSAFE_MERGE_QUEUE_LABEL:
+            pr_status = 'unsafe_passed_status_check'
         elif self.label_to_add == GitHub.BLOCKED_LABEL:
             pr_status = 'failed_status_check'
         else:
@@ -2609,6 +2612,7 @@ class RetrievePRDataFromLabel(buildstep.BuildStep, GitHubMixin, AddToLogMixin):
             return defer.returnValue(FAILURE)
 
         self.setProperty('passed_status_check', [])
+        self.setProperty('unsafe_passed_status_check', [])
         self.setProperty('failed_status_check', [])
         self.setProperty('pending_prs', [])
 
@@ -2628,7 +2632,7 @@ class RetrievePRDataFromLabel(buildstep.BuildStep, GitHubMixin, AddToLogMixin):
     @defer.inlineCallbacks
     def getAllPRData(self, limit, label, retry=0):
         project = self.getProperty('project') or CANONICAL_GITHUB_PROJECT
-        query_body = '{search(query: "repo:%s is:pr label:%s", type: ISSUE, last: %s) { edges { node { ... on PullRequest { title number commits(last: 3) { nodes { commit { commitUrl status { state contexts { context state } } } } } } } } } }' % (project, label, limit)
+        query_body = '{search(query: "repo:%s is:pr label:%s", type: ISSUE, last: %s) { edges { node { ... on PullRequest { title number baseRefName commits(last: 3) { nodes { commit { commitUrl status { state contexts { context state } } } } } } } } } }' % (project, label, limit)
         query = {'query': query_body}
 
         yield self._addToLog('stdio', f"Fetching all PRs with label {label}...\n")
@@ -2671,6 +2675,7 @@ class CheckStatusOfPR(buildstep.BuildStep, GitHubMixin, AddToLogMixin):
     EMBEDDED_CHECKS = ['ios', 'ios-safer-cpp', 'ios-sim', 'ios-wk2', 'ios-wk2-wpt', 'api-ios', 'vision', 'vision-sim', 'vision-wk2', 'tv', 'tv-sim', 'watch', 'watch-sim']
     MACOS_CHECKS = ['mac', 'mac-AS-debug', 'api-mac', 'api-mac-debug', 'mac-wk2', 'mac-AS-debug-wk2', 'mac-wk2-stress', 'mac-safer-cpp', 'jsc-x86-64', 'jsc-debug-arm64']
     LINUX_CHECKS = ['gtk', 'gtk-wk2', 'api-gtk', 'wpe', 'gtk3-libwebrtc', 'wpe-wk2', 'api-wpe']
+    EXTRA_LINUX_CHECKS = ['jsc-armv7', 'jsc-armv7-tests']
     WINDOWS_CHECKS = ['win']
     EWS_WEBKIT_FAILED = 0
     EWS_WEBKIT_PASSED = 1
@@ -2758,10 +2763,15 @@ class CheckStatusOfPR(buildstep.BuildStep, GitHubMixin, AddToLogMixin):
                     break
 
         # FIXME: safe-merge-queue should obtain skipped status from EWS instead of hardcoding
-        queues_for_safe_merge = self.EMBEDDED_CHECKS + self.MACOS_CHECKS
-        if self.getProperty('project') == CANONICAL_GITHUB_PROJECT:
-            queues_for_safe_merge += self.LINUX_CHECKS
-            queues_for_safe_merge += self.WINDOWS_CHECKS
+        branch = self.getProperty('github.base.ref', DEFAULT_BRANCH)
+        is_glib_stable_branch = bool(re.match(r'webkitglib/\d+\.\d+', branch))
+        if is_glib_stable_branch:
+            queues_for_safe_merge = self.LINUX_CHECKS + self.EXTRA_LINUX_CHECKS
+        else:
+            queues_for_safe_merge = self.EMBEDDED_CHECKS + self.MACOS_CHECKS
+            if self.getProperty('project') == CANONICAL_GITHUB_PROJECT:
+                queues_for_safe_merge += self.LINUX_CHECKS
+                queues_for_safe_merge += self.WINDOWS_CHECKS
 
         for queue in queues_for_safe_merge:
             queue_data = response.json().get(queue, None)
@@ -2807,8 +2817,13 @@ class CheckStatusOfPR(buildstep.BuildStep, GitHubMixin, AddToLogMixin):
             self.steps_to_add += [LeaveComment()]
             defer.returnValue(self.EWS_WEBKIT_FAILED)
         else:
-            passed_status_check.append(pr_number)
-            self.setProperty('passed_status_check', passed_status_check)
+            if is_glib_stable_branch:
+                unsafe_passed_status_check = self.getProperty('unsafe_passed_status_check')
+                unsafe_passed_status_check.append(pr_number)
+                self.setProperty('unsafe_passed_status_check', unsafe_passed_status_check)
+            else:
+                passed_status_check.append(pr_number)
+                self.setProperty('passed_status_check', passed_status_check)
             yield self._addToLog('stdio', 'Passed status check.\n')
             defer.returnValue(self.EWS_WEBKIT_PASSED)
 
@@ -2823,6 +2838,8 @@ class AddMergeLabelsToPRs(buildstep.BuildStep, GitHubMixin, AddToLogMixin):
         steps_to_add = []
         label_as_safe = self.getProperty('passed_status_check', '')
         yield self._addToLog('stdio', f'PRs to merge: {label_as_safe}.\n')
+        label_as_unsafe = self.getProperty('unsafe_passed_status_check', '')
+        yield self._addToLog('stdio', f'PRs to add to unsafe-merge-queue: {label_as_unsafe}.\n')
         label_as_blocked = self.getProperty('failed_status_check', '')
         yield self._addToLog('stdio', f'PRs to block: {label_as_blocked}.\n')
         pending_prs = self.getProperty('pending_prs', '')
@@ -2830,6 +2847,8 @@ class AddMergeLabelsToPRs(buildstep.BuildStep, GitHubMixin, AddToLogMixin):
 
         if len(label_as_safe):
             steps_to_add.append(RemoveAndAddLabels(label_to_add=GitHub.MERGE_QUEUE_LABEL, labels_to_remove=[GitHub.SAFE_MERGE_QUEUE_LABEL]))
+        if len(label_as_unsafe):
+            steps_to_add.append(RemoveAndAddLabels(label_to_add=GitHub.UNSAFE_MERGE_QUEUE_LABEL, labels_to_remove=[GitHub.SAFE_MERGE_QUEUE_LABEL]))
         if len(label_as_blocked):
             steps_to_add.append(RemoveAndAddLabels(label_to_add=GitHub.BLOCKED_LABEL, labels_to_remove=[GitHub.SAFE_MERGE_QUEUE_LABEL]))
         self.build.addStepsAfterCurrentStep(steps_to_add)

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -7363,6 +7363,37 @@ class TestCheckStatusOfPR(BuildStepMixinAdditions, unittest.TestCase):
         rc = self.run_step()
         return rc
 
+    def test_glib_branch_checks_only_linux(self):
+        self.setup_step(CheckStatusOfPR())
+        self.setProperty('github.number', 12345)
+        self.setProperty('repository', 'https://github.com/WebKit/WebKit')
+        self.setProperty('github.base.ref', 'webkitglib/2.46')
+        self.setProperty('project', 'WebKit/WebKit')
+        self.setProperty('list_of_prs', [])
+        self.setProperty('passed_status_check', [])
+        self.setProperty('unsafe_passed_status_check', [])
+        self.setProperty('failed_status_check', [])
+        self.setProperty('pending_prs', [])
+
+        CheckStatusOfPR.query_graph_ql = lambda self, query: {
+            'data': {'repository': {'pullRequest': {'commits': {'edges': [
+                {'node': {'commit': {'oid': '7496f8ecc4cc8011f19c8cc1bc7b18fe4a88ad5c'}}}
+            ]}}}}
+        }
+
+        # All Linux checks pass; Apple and Windows checks fail to prove they are not required for glib branches
+        queue_statuses = {queue: {'state': 0} for queue in CheckStatusOfPR.LINUX_CHECKS + CheckStatusOfPR.EXTRA_LINUX_CHECKS}
+        for queue in CheckStatusOfPR.MACOS_CHECKS + CheckStatusOfPR.EMBEDDED_CHECKS + CheckStatusOfPR.WINDOWS_CHECKS:
+            queue_statuses[queue] = {'state': 2}
+
+        TwistedAdditions.request = lambda *args, **kwargs: TwistedAdditions.Response(
+            status_code=200,
+            content=json.dumps(queue_statuses).encode('utf-8'),
+        )
+
+        self.expect_outcome(result=SUCCESS, state_string='PR 12345 marked safe for merge-queue')
+        return self.run_step()
+
 
 class TestAddMergeLabelsToPRs(BuildStepMixinAdditions, unittest.TestCase):
     def setUp(self):
@@ -7378,6 +7409,14 @@ class TestAddMergeLabelsToPRs(BuildStepMixinAdditions, unittest.TestCase):
         self.expect_outcome(result=SUCCESS, state_string="Started PR labelling process successfully")
         rc = self.run_step()
         return rc
+
+    def test_glib_stable_branch(self):
+        self.setup_step(AddMergeLabelsToPRs())
+        self.setProperty('passed_status_check', [])
+        self.setProperty('failed_status_check', [])
+        self.setProperty('unsafe_passed_status_check', [12345])
+        self.expect_outcome(result=SUCCESS, state_string='Started PR labelling process successfully')
+        return self.run_step()
 
 
 class TestRemoveAndAddLabels(BuildStepMixinAdditions, unittest.TestCase):
@@ -7429,6 +7468,27 @@ class TestRemoveAndAddLabels(BuildStepMixinAdditions, unittest.TestCase):
         self.expect_outcome(result=FAILURE, state_string='Failed to label PR  with merge-queue')
         rc = self.run_step()
         self.expect_property('passed_status_check', [])
+        return rc
+
+    def test_success_unsafe_merge_queue(self):
+        self.setup_step(RemoveAndAddLabels(label_to_add='unsafe-merge-queue'))
+        self.setProperty('buildername', 'Safe-Merge-Queue')
+        self.setProperty('repository', 'https://github.com/WebKit/WebKit')
+        self.setProperty('unsafe_passed_status_check', [17451])
+        RemoveAndAddLabels.update_labels = lambda self, pr_number: SUCCESS
+        self.expect_outcome(result=SUCCESS, state_string='Labelled PR 17451 with unsafe-merge-queue')
+        rc = self.run_step()
+        self.expect_property('unsafe_passed_status_check', [])
+        return rc
+
+    def test_failure_unsafe_merge_queue(self):
+        self.setup_step(RemoveAndAddLabels(label_to_add='unsafe-merge-queue'))
+        self.setProperty('buildername', 'Safe-Merge-Queue')
+        self.setProperty('repository', 'https://github.com/WebKit/WebKit')
+        self.setProperty('unsafe_passed_status_check', [])
+        self.expect_outcome(result=FAILURE, state_string='Failed to label PR  with unsafe-merge-queue')
+        rc = self.run_step()
+        self.expect_property('unsafe_passed_status_check', [])
         return rc
 
 
@@ -7916,6 +7976,29 @@ class TestDetermineLabelOwner(BuildStepMixinAdditions, unittest.TestCase):
             self.expect_outcome(result=FAILURE, state_string='Unable to determine owner of PR 17518\n')
             yield self.run_step()
             self.assertTrue(any(isinstance(step, RemoveLabelsFromPullRequest) for step in next_steps))
+
+    def test_safe_merge_queue_sets_base_ref(self):
+        self.setup_step(DetermineLabelOwner())
+        self.setProperty('buildername', 'Safe-Merge-Queue')
+        self.setProperty('list_of_prs', [17519])
+        self.setProperty('all_pr_data', [{'node': {
+            'number': 17519,
+            'title': 'Fix a bug in WPE',
+            'baseRefName': 'webkitglib/2.46',
+            'commits': {'nodes': [{'commit': {
+                'commitUrl': 'https://github.com/WebKit/WebKit/commit/7496f8ecc4cc8011f19c8cc1bc7b18fe4a88ad5c'
+            }}]},
+        }}])
+        response = {'data': {'repository': {'pullRequest': {'timelineItems': {'nodes': [{
+            'actor': {'login': 'csaavedra'},
+            'label': {'name': 'safe-merge-queue'},
+            'createdAt': '2024-01-01T00:00:00Z',
+        }]}}}}}
+        GitHubMixin.query_graph_ql = lambda self, query: response
+        Contributors.load = lambda *args, **kwargs: ({}, [])
+        self.expect_outcome(result=SUCCESS, state_string='Owner of PR 17519 determined to be csaavedra\n')
+        self.run_step()
+        self.expect_property('github.base.ref', 'webkitglib/2.46')
 
 
 class TestDetermineLandedIdentifier(BuildStepMixinAdditions, unittest.TestCase):


### PR DESCRIPTION
#### 6555a8fff78c4e1b3d20a22d42260cd15b571bcf
<pre>
[EWS] Support safe-merge-queue for webkitglib stable branches
<a href="https://bugs.webkit.org/show_bug.cgi?id=318877">https://bugs.webkit.org/show_bug.cgi?id=318877</a>

Reviewed by Ryan Haddad.

Make safe-merge-queue usable on the webkitglib/x.yy stable branches. This
is two-fold:

1) For these branches safe-merge-queue should only require a subset of
   Linux-related bots to be green. The Mac, iOS and Windows bots are
   irrelevant here and are skipped.

2) merge-queue does not work with the stable webkitglib branches: it
   builds for Mac, and these branches are not meant to be built on Mac,
   so they would likely fail to build. For webkitglib branches
   safe-merge-queue should therefore flip the PR to unsafe-merge-queue
   instead of merge-queue.

To do this, propagate the PR base branch through the safe-merge-queue
flow by fetching baseRefName in the GraphQL query and storing it as
github.base.ref in DetermineLabelOwner. When the target branch is a
webkitglib/x.yy stable branch, check only the Linux queues (GTK, WPE,
and JSC ARMv7), and once the PR passes, label it unsafe-merge-queue
rather than merge-queue.

* Tools/CISupport/ews-build/steps.py:
(DetermineLabelOwner.run):
(RemoveAndAddLabels.run):
(RetrievePRDataFromLabel.run):
(RetrievePRDataFromLabel.getAllPRData):
(CheckStatusOfPR):
(CheckStatusOfPR.getQueueStatusFromList):
(AddMergeLabelsToPRs.run):
* Tools/CISupport/ews-build/steps_unittest.py:

Canonical link: <a href="https://commits.webkit.org/317455@main">https://commits.webkit.org/317455@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a233cc4b71718b4393019af85f716e152eb199cd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175400 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49332 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43113 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184986 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177264 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50624 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49015 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/136552 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178357 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39971 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/157309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117030 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38613 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/149035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36802 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33461 "Built successfully") | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187411 "Built successfully") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/174804 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48999 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/145518 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49679 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/145359 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26657 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40176 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115574 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48185 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11775 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47588 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47818 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47645 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->