### PR TITLE
[CMake] Add --asan support to run-webkit-tests for ASan builds

### DIFF
--- a/Tools/Scripts/webkit-build-directory
+++ b/Tools/Scripts/webkit-build-directory
@@ -51,6 +51,7 @@ Usage: $programName [options]
   -h|--help             Show this help message
   --top-level           Show the top-level build directory
 
+  --asan                Select the ASan (AddressSanitizer) build tree (with --cmake: WebKitBuild/cmake-mac/ASan)
   --gtk                 Find the build directory for the GTK+ port
   --win                 Find the build directory for Windows port
 

--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -718,14 +718,15 @@ sub determineASanIsEnabled
 {
     return if defined $asanIsEnabled;
     determineBaseProductDir();
-    $asanIsEnabled = readSanitizerConfiguration("ASan");
+    # Honor an explicit --asan (like --cmake) in addition to the marker file.
+    $asanIsEnabled = checkForArgumentAndRemoveFromARGV("--asan") || readSanitizerConfiguration("ASan");
 }
 
 sub determineTSanIsEnabled
 {
     return if defined $tsanIsEnabled;
     determineBaseProductDir();
-    $tsanIsEnabled = readSanitizerConfiguration("TSan");
+    $tsanIsEnabled = checkForArgumentAndRemoveFromARGV("--tsan") || readSanitizerConfiguration("TSan");
 }
 
 sub determineUBSanIsEnabled
@@ -1195,7 +1196,11 @@ sub determineConfigurationProductDir
             if (isGtk() or isWPE() or isJSCOnly() or shouldBuildForCrossTarget() or inCrossTargetEnvironment()) {
                 $configurationProductDir = "$baseProductDir/$portName/$configuration";
             } elsif (isAppleCocoaWebKit() && isCMakeBuild()) {
-                $configurationProductDir = "$baseProductDir/cmake-mac/$configuration";
+                # Sanitizer presets build into a dedicated dir, e.g. cmake-mac/ASan.
+                my $cmakeConfiguration = $configuration;
+                $cmakeConfiguration = "ASan" if asanIsEnabled();
+                $cmakeConfiguration = "TSan" if tsanIsEnabled();
+                $configurationProductDir = "$baseProductDir/cmake-mac/$cmakeConfiguration";
             } else {
                 $configurationProductDir = "$baseProductDir/$configuration";
             }

--- a/Tools/Scripts/webkitpy/port/base.py
+++ b/Tools/Scripts/webkitpy/port/base.py
@@ -183,6 +183,7 @@ class Port(object):
             self._filesystem,
             self.port_name,
             use_cmake=bool(getattr(self._options, 'use_cmake', False)),
+            asan=bool(getattr(self._options, 'asan', False)),
         )
         self.pretty_patch = PrettyPatch(self._executive, self.path_from_webkit_base(), self._filesystem)
 

--- a/Tools/Scripts/webkitpy/port/config.py
+++ b/Tools/Scripts/webkitpy/port/config.py
@@ -58,13 +58,14 @@ class Config(object):
     # perl invocation whose result is invariant for given inputs within a run.
     _build_directories = {}
 
-    def __init__(self, executive, filesystem, port_implementation=None, use_cmake=False):
+    def __init__(self, executive, filesystem, port_implementation=None, use_cmake=False, asan=False):
         self._executive = executive
         self._filesystem = filesystem
         self._webkit_finder = webkit_finder.WebKitFinder(self._filesystem)
         self._default_configuration = None
         self._port_implementation = port_implementation
         self._use_cmake = use_cmake
+        self._asan = asan
 
     @classmethod
     def _clear_cache_for_testing(cls):
@@ -73,7 +74,7 @@ class Config(object):
     def build_directory(self, configuration, for_host=False):
         """Returns the path to the build directory for the configuration."""
         port_impl = self._port_implementation if not for_host else None
-        cache_key = (port_impl, configuration or "", for_host, self._use_cmake)
+        cache_key = (port_impl, configuration or "", for_host, self._use_cmake, self._asan)
         if self._build_directories.get(cache_key):
             return self._build_directories[cache_key]
 
@@ -85,6 +86,8 @@ class Config(object):
             flags.append('--' + port_impl)
         if self._use_cmake:
             flags.append('--cmake')
+        if self._asan:
+            flags.append('--asan')
 
         args = ["perl", self._webkit_finder.path_to_script("webkit-build-directory")] + flags
         output = self._executive.run_command(args, cwd=self._webkit_finder.webkit_base(), return_stderr=False).rstrip()
@@ -97,7 +100,7 @@ class Config(object):
             default_configuration = parts[1][len(parts[0]):]
             if default_configuration.startswith("/"):
                 default_configuration = default_configuration[1:]
-            self._build_directories[(port_impl, default_configuration, for_host, self._use_cmake)] = parts[1]
+            self._build_directories[(port_impl, default_configuration, for_host, self._use_cmake, self._asan)] = parts[1]
 
         return self._build_directories[cache_key]
 
@@ -145,6 +148,9 @@ class Config(object):
     @property
     @memoized
     def asan(self):
+        # --asan forces asan on; otherwise fall back to the marker file.
+        if self._asan:
+            return True
         try:
             return self._filesystem.exists(self._filesystem.join(self.build_directory(None), "ASan"))
         except:

--- a/Tools/Scripts/webkitpy/port/config_unittest.py
+++ b/Tools/Scripts/webkitpy/port/config_unittest.py
@@ -45,10 +45,10 @@ class ConfigTest(unittest.TestCase):
     def setUp(self):
         config.Config._clear_cache_for_testing()
 
-    def make_config(self, output='', files=None, exit_code=0, exception=None, run_command_fn=None, stderr='', port_implementation=None, use_cmake=False):
+    def make_config(self, output='', files=None, exit_code=0, exception=None, run_command_fn=None, stderr='', port_implementation=None, use_cmake=False, asan=False):
         e = MockExecutive2(output=output, exit_code=exit_code, exception=exception, run_command_fn=run_command_fn, stderr=stderr)
         fs = MockFileSystem(files)
-        return config.Config(e, fs, port_implementation=port_implementation, use_cmake=use_cmake)
+        return config.Config(e, fs, port_implementation=port_implementation, use_cmake=use_cmake, asan=asan)
 
     def assert_configuration(self, contents, expected):
         # This tests that a configuration file containing
@@ -118,6 +118,44 @@ class ConfigTest(unittest.TestCase):
         c_cmake.build_directory('Release')
         self.assertIn('--cmake', seen[-1])
 
+    def test_build_directory_passes_asan_flag(self):
+        seen = []
+
+        def mock_run_command(arg_list):
+            seen.append(list(arg_list))
+            if '--asan' in arg_list:
+                return '/WebKitBuild/cmake-mac/ASan'
+            return '/WebKitBuild/cmake-mac/Release'
+
+        # --asan selects the sanitizer tree regardless of Debug/Release.
+        c_asan = self.make_config(run_command_fn=mock_run_command, port_implementation='mac', use_cmake=True, asan=True)
+        self.assertEqual(c_asan.build_directory('Release'), '/WebKitBuild/cmake-mac/ASan')
+        self.assertIn('--asan', seen[-1])
+        self.assertIn('--cmake', seen[-1])
+
+        c_plain = self.make_config(run_command_fn=mock_run_command, port_implementation='mac', use_cmake=True, asan=False)
+        self.assertEqual(c_plain.build_directory('Release'), '/WebKitBuild/cmake-mac/Release')
+        self.assertNotIn('--asan', seen[-1])
+
+        # --asan is forwarded independently of --cmake; don't invent --cmake.
+        c_asan_no_cmake = self.make_config(run_command_fn=mock_run_command, port_implementation='mac', use_cmake=False, asan=True)
+        c_asan_no_cmake.build_directory('Release')
+        self.assertIn('--asan', seen[-1])
+        self.assertNotIn('--cmake', seen[-1])
+
+    def test_asan_marker_without_flag_is_unchanged(self):
+        # Regression: Xcode users enable ASan via the marker file, not --asan.
+        seen = []
+
+        def mock_run_command(arg_list):
+            seen.append(list(arg_list))
+            return 'foo\nfoo/Release'
+
+        c = self.make_config(run_command_fn=mock_run_command, files={'foo/ASan': 'YES'})
+        self.assertTrue(c.asan)
+        self.assertNotIn('--asan', seen[-1])
+        self.assertNotIn('--cmake', seen[-1])
+
     def test_default_configuration__release(self):
         self.assert_configuration('Release', 'Release')
 
@@ -179,3 +217,6 @@ class ConfigTest(unittest.TestCase):
         self.assertEqual(config.asan, True)
         config = self.make_config(output='foo\nfoo/Release', files={'foo/Configuration': 'Release'})
         self.assertEqual(config.asan, False)
+        # An explicit --asan forces asan on even without the marker file.
+        config = self.make_config(output='foo\nfoo/cmake-mac/ASan', files={}, asan=True)
+        self.assertEqual(config.asan, True)

--- a/Tools/Scripts/webkitpy/port/factory.py
+++ b/Tools/Scripts/webkitpy/port/factory.py
@@ -86,6 +86,8 @@ def configuration_options():
                              help='Set the configuration to Release'),
         optparse.make_option('--cmake', action='store_true', default=False, dest='use_cmake',
                              help='Use the CMake build tree (e.g. WebKitBuild/cmake-mac/<configuration>) instead of the default Xcode/Make tree'),
+        optparse.make_option('--asan', action='store_true', default=False, dest='asan',
+                             help='Use the ASan (AddressSanitizer) build tree (with --cmake: WebKitBuild/cmake-mac/ASan). Does not require --debug/--release.'),
         optparse.make_option('--64-bit', action='store_const', const='x86_64', default=None, dest="architecture",
                              help='use 64-bit binaries by default (x86_64 instead of x86)'),
         optparse.make_option('--32-bit', action='store_const', const='x86', default=None, dest="architecture",


### PR DESCRIPTION
#### 8dbdbd31a3a708148947b21f68e2f72c2dd5e12e
<pre>
[CMake] Add --asan support to run-webkit-tests for ASan builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=318769">https://bugs.webkit.org/show_bug.cgi?id=318769</a>
<a href="https://rdar.apple.com/181625104">rdar://181625104</a>

Reviewed by Pascoe.

Previously there was no way to point run-webkit-tests at the mac-asan
CMake preset build (WebKitBuild/cmake-mac/ASan): the build-directory
logic only understood Debug/Release, so `--cmake` could never resolve
the sanitizer tree.

Add a standalone `--asan` option (usable with `--cmake`, and independent
of --debug/--release) that resolves the build directory to
cmake-mac/ASan and reports the test configuration as ASan so the right
expectations apply. The webkitdirs sanitizer state now also honors an
`--asan`/`--tsan` argument, mirroring how `--cmake` is handled, in
addition to the existing set-webkit-configuration marker file.

Xcode marker-file users are unaffected: the ASan directory redirect is
scoped to the CMake branch, and marker detection is unchanged.

* Tools/Scripts/webkit-build-directory:
* Tools/Scripts/webkitdirs.pm:
(determineASanIsEnabled):
(determineTSanIsEnabled):
(determineConfigurationProductDir):
* Tools/Scripts/webkitpy/port/base.py:
(Port.__init__):
* Tools/Scripts/webkitpy/port/config.py:
(Config.__init__):
(Config.build_directory):
(Config.asan):
* Tools/Scripts/webkitpy/port/config_unittest.py:
(ConfigTest.make_config):
(ConfigTest.test_build_directory_passes_asan_flag):
(ConfigTest.test_build_directory_passes_asan_flag.mock_run_command):
(ConfigTest):
(ConfigTest.test_asan_marker_without_flag_is_unchanged):
(ConfigTest.test_asan_marker_without_flag_is_unchanged.mock_run_command):
(ConfigTest.test_asan):
* Tools/Scripts/webkitpy/port/factory.py:
(configuration_options):

Canonical link: <a href="https://commits.webkit.org/316761@main">https://commits.webkit.org/316761@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e0d21632e5a1408967f6850b2596ee46a442076

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173330 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47262 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40808 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182903 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130886 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e2666ae5-4a5f-46ba-aee7-5dd50add7c00) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175195 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48555 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46944 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134767 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7e5df71f-7f3a-4605-836b-7d7141986b2f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176288 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/38189 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/155439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115242 "Found 1 new API test failure: WPE/TestWebKitWebView:/webkit/WebKitWebView/save (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7d703687-cf52-4d2f-ac5b-34f864b3ddbf) 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/172651 "Found 1 webkitpy test failure: webkitcorepy.tests.file_lock_unittest.FileLockTestCase.test_race") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36831 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/35186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31388 "Built successfully") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/218/builds/3953 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147255 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34936 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185327 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/34592 "Built successfully and passed tests") | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/39388 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/143659 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46930 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143498 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38734 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47609 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112710 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38445 "Passed tests") | | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/210363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46115 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9883 "Passed tests") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/210363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45517 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45748 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45574 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->