### PR TITLE
[Site Isolation] Web Inspector: Page.setEmulatedMedia should apply to cross-origin frames

### DIFF
--- a/LayoutTests/http/tests/site-isolation/inspector/page/set-emulated-media-cross-origin-iframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/page/set-emulated-media-cross-origin-iframe-expected.txt
@@ -7,6 +7,13 @@ PASS: Added target should have Frame type.
 PASS: Main page should have screen styles (blue).
 PASS: Cross-origin iframe should have screen styles (blue).
 
+-- Running test case: SiteIsolation.Page.SetEmulatedMedia.EmulateExistingFrame
+PASS: Existing cross-origin iframe should start with screen styles (blue).
+Setting emulated media to print (no reload)...
+PASS: Existing cross-origin iframe should switch to print styles (green).
+Resetting emulated media...
+PASS: Existing cross-origin iframe should return to screen styles (blue).
+
 -- Running test case: SiteIsolation.Page.SetEmulatedMedia.EmulateAndReload
 Setting emulated media to print...
 Reloading...

--- a/LayoutTests/http/tests/site-isolation/inspector/page/set-emulated-media-cross-origin-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/page/set-emulated-media-cross-origin-iframe.html
@@ -18,10 +18,16 @@ function addCrossOriginIFrame() {
 
 function test() {
     async function addIFrameAndGetTarget() {
-        let targetAddedPromise = WI.targetManager.awaitEvent(WI.TargetManager.Event.TargetAdded);
+        // Under Site Isolation, TargetAdded fires for the iframe's provisional about:blank target
+        // before the cross-origin document commits; evaluating then hits the empty realm. Await the
+        // committed target + its execution context, mirroring executionContextCreated-frame-target.html.
+        let committedPromise = WI.targetManager.awaitEvent(WI.TargetManager.Event.DidCommitProvisionalTarget);
         InspectorTest.evaluateInPage("addCrossOriginIFrame()");
-        let event = await targetAddedPromise;
-        return event.data.target;
+        let event = await committedPromise;
+        let target = event.data.target;
+        if (!target.executionContext)
+            await target.awaitEvent(WI.FrameTarget.Event.ExecutionContextAdded);
+        return target;
     }
 
     async function getComputedColorInTarget(target) {
@@ -36,6 +42,26 @@ function test() {
         let response = await target.RuntimeAgent.evaluate.invoke({expression: "window.getComputedStyle(document.body).getPropertyValue('color')", objectGroup: "test", returnByValue: true});
         InspectorTest.assert(response.result.value, "Should be able to evaluate computed style in cross-origin target.");
         return response.result.value;
+    }
+
+    // Page.setEmulatedMedia under Site Isolation is hosted by the UIProcess ProxyingPageAgent on the
+    // web-page (backend) target -- invoked via WI.backendTarget, not the bare (page sub-target) PageAgent,
+    // which would relay only to the main frame's WebContent process. The proxy broadcasts to every hosting
+    // process, so the override reaches cross-origin iframe processes too. The broadcast is not ordered
+    // against the cross-origin target's own RuntimeAgent channel, so the computed style may not reflect the
+    // override on the very first read. Poll silently until it settles (or give up) so the assertion stays
+    // deterministic without logging retry noise.
+    async function awaitComputedColorInTarget(target, expectedColor) {
+        let color = await getComputedColorInTarget(target);
+        for (let attempt = 0; attempt < 20 && color !== expectedColor; ++attempt) {
+            await target.RuntimeAgent.evaluate.invoke({
+                expression: "new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)))",
+                objectGroup: "test",
+                awaitPromise: true,
+            });
+            color = await getComputedColorInTarget(target);
+        }
+        return color;
     }
 
     let suite = InspectorTest.createAsyncSuite("SiteIsolation.Page.SetEmulatedMediaCrossOriginIFrame");
@@ -56,11 +82,33 @@ function test() {
     });
 
     suite.addTestCase({
+        name: "SiteIsolation.Page.SetEmulatedMedia.EmulateExistingFrame",
+        description: "Emulating print media should propagate to a cross-origin iframe that already exists, without reloading.",
+        async test() {
+            let target = await addIFrameAndGetTarget();
+
+            let iframeColorBefore = await getComputedColorInTarget(target);
+            InspectorTest.expectEqual(iframeColorBefore, "rgb(0, 0, 255)", "Existing cross-origin iframe should start with screen styles (blue).");
+
+            InspectorTest.log("Setting emulated media to print (no reload)...");
+            await WI.backendTarget.PageAgent.setEmulatedMedia("print");
+
+            let iframeColorAfter = await awaitComputedColorInTarget(target, "rgb(0, 128, 0)");
+            InspectorTest.expectEqual(iframeColorAfter, "rgb(0, 128, 0)", "Existing cross-origin iframe should switch to print styles (green).");
+
+            InspectorTest.log("Resetting emulated media...");
+            await WI.backendTarget.PageAgent.setEmulatedMedia("");
+            let iframeColorReset = await awaitComputedColorInTarget(target, "rgb(0, 0, 255)");
+            InspectorTest.expectEqual(iframeColorReset, "rgb(0, 0, 255)", "Existing cross-origin iframe should return to screen styles (blue).");
+        }
+    });
+
+    suite.addTestCase({
         name: "SiteIsolation.Page.SetEmulatedMedia.EmulateAndReload",
         description: "Emulating print media and reloading should apply print styles in the cross-origin iframe.",
         async test() {
             InspectorTest.log("Setting emulated media to print...");
-            await PageAgent.setEmulatedMedia("print");
+            await WI.backendTarget.PageAgent.setEmulatedMedia("print");
 
             InspectorTest.log("Reloading...");
             await InspectorTest.reloadPage();
@@ -88,7 +136,7 @@ function test() {
         description: "Resetting emulated media and reloading should restore screen styles in both frames.",
         async test() {
             InspectorTest.log("Resetting emulated media...");
-            await PageAgent.setEmulatedMedia("");
+            await WI.backendTarget.PageAgent.setEmulatedMedia("");
 
             InspectorTest.log("Reloading...");
             await InspectorTest.reloadPage();

--- a/LayoutTests/http/tests/site-isolation/inspector/page/set-emulated-media-disable-restore-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/page/set-emulated-media-disable-restore-expected.txt
@@ -1,0 +1,12 @@
+Test that disabling Page instrumentation reverts a cross-origin iframe from an emulated-media override back to its real platform media under site isolation.
+
+
+== Running test suite: SiteIsolation.Page.SetEmulatedMediaDisableRestore
+-- Running test case: SiteIsolation.Page.SetEmulatedMedia.DisableRestoresRealMedia
+PASS: Added target should have Frame type.
+PASS: Cross-origin iframe should start with screen styles (blue).
+Emulating print media...
+PASS: Cross-origin iframe should switch to print styles (green).
+Disabling Page instrumentation on the backend target...
+PASS: Cross-origin iframe should revert to real screen media (blue) after Page instrumentation is disabled.
+

--- a/LayoutTests/http/tests/site-isolation/inspector/page/set-emulated-media-disable-restore.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/page/set-emulated-media-disable-restore.html
@@ -1,0 +1,104 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<style>
+body { color: blue; }
+@media print {
+    body { color: green; }
+}
+</style>
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script>
+let iframe;
+
+function addCrossOriginIFrame() {
+    let crossOriginHost = location.hostname === "localhost" ? "127.0.0.1" : "localhost";
+    iframe = document.createElement("iframe");
+    iframe.src = `http://${crossOriginHost}:8000/site-isolation/inspector/page/resources/emulated-media-frame.html`;
+    document.body.appendChild(iframe);
+}
+
+function test() {
+    async function addIFrameAndGetTarget() {
+        // Under Site Isolation, TargetAdded fires for the iframe's provisional about:blank target
+        // before the cross-origin document commits; evaluating then hits the empty realm. Await the
+        // committed target + its execution context, mirroring set-emulated-media-cross-origin-iframe.html.
+        let committedPromise = WI.targetManager.awaitEvent(WI.TargetManager.Event.DidCommitProvisionalTarget);
+        InspectorTest.evaluateInPage("addCrossOriginIFrame()");
+        let event = await committedPromise;
+        let target = event.data.target;
+        if (!target.executionContext)
+            await target.awaitEvent(WI.FrameTarget.Event.ExecutionContextAdded);
+        return target;
+    }
+
+    async function getComputedColorInTarget(target) {
+        // Wait for the iframe document to fully load before checking computed styles.
+        // TargetAdded fires when the JS context is created, before DOM and CSS are ready.
+        await target.RuntimeAgent.evaluate.invoke({
+            expression: "new Promise(resolve => { if (document.readyState === 'complete') resolve(); else window.addEventListener('load', resolve); })",
+            objectGroup: "test",
+            awaitPromise: true,
+        });
+
+        let response = await target.RuntimeAgent.evaluate.invoke({expression: "window.getComputedStyle(document.body).getPropertyValue('color')", objectGroup: "test", returnByValue: true});
+        InspectorTest.assert(response.result.value, "Should be able to evaluate computed style in cross-origin target.");
+        return response.result.value;
+    }
+
+    // The emulated-media override reaches the cross-origin iframe process via the UIProcess
+    // ProxyingPageAgent broadcast, which is not ordered against the cross-origin target's own
+    // RuntimeAgent channel, so the computed style may not reflect the change on the very first read.
+    // Poll silently until it settles (or give up) so the assertion stays deterministic without
+    // logging retry noise.
+    async function awaitComputedColorInTarget(target, expectedColor) {
+        let color = await getComputedColorInTarget(target);
+        for (let attempt = 0; attempt < 20 && color !== expectedColor; ++attempt) {
+            await target.RuntimeAgent.evaluate.invoke({
+                expression: "new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)))",
+                objectGroup: "test",
+                awaitPromise: true,
+            });
+            color = await getComputedColorInTarget(target);
+        }
+        return color;
+    }
+
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.Page.SetEmulatedMediaDisableRestore");
+
+    suite.addTestCase({
+        name: "SiteIsolation.Page.SetEmulatedMedia.DisableRestoresRealMedia",
+        description: "Disabling Page instrumentation should revert a cross-origin iframe from an emulated-media override back to its real platform media, without a reload.",
+        async test() {
+            // (a) The OOPIF starts on its real (screen) media -- blue.
+            let target = await addIFrameAndGetTarget();
+            InspectorTest.expectEqual(target.type, WI.TargetType.Frame, "Added target should have Frame type.");
+
+            let iframeColorBefore = await getComputedColorInTarget(target);
+            InspectorTest.expectEqual(iframeColorBefore, "rgb(0, 0, 255)", "Cross-origin iframe should start with screen styles (blue).");
+
+            // (b) Emulate print -- the OOPIF switches to print media (green).
+            InspectorTest.log("Emulating print media...");
+            await WI.backendTarget.PageAgent.setEmulatedMedia("print");
+            let iframeColorPrint = await awaitComputedColorInTarget(target, "rgb(0, 128, 0)");
+            InspectorTest.expectEqual(iframeColorPrint, "rgb(0, 128, 0)", "Cross-origin iframe should switch to print styles (green).");
+
+            // (c) Disable the Page domain on the backend target. This unwinds through the UIProcess
+            // ProxyingPageAgent::disable(), which sends DisablePageInstrumentation to every hosting
+            // process -- i.e. the WebInspectorBackend::disablePageInstrumentation() teardown path,
+            // NOT the setEmulatedMedia("") set path (which already re-evaluates). See webkit.org/b/308898.
+            InspectorTest.log("Disabling Page instrumentation on the backend target...");
+            await WI.backendTarget.PageAgent.disable();
+
+            // (d) The OOPIF reverts to its real platform media (blue). The override is gone; restore is
+            // a re-evaluation against real media, not a replay of a prior override.
+            let iframeColorRestored = await awaitComputedColorInTarget(target, "rgb(0, 0, 255)");
+            InspectorTest.expectEqual(iframeColorRestored, "rgb(0, 0, 255)", "Cross-origin iframe should revert to real screen media (blue) after Page instrumentation is disabled.");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+
+<body onload="runTest()">
+<p>Test that disabling Page instrumentation reverts a cross-origin iframe from an emulated-media override back to its real platform media under site isolation.</p>
+</body>

--- a/LayoutTests/http/tests/site-isolation/inspector/page/set-emulated-media-late-oopif-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/page/set-emulated-media-late-oopif-expected.txt
@@ -1,0 +1,10 @@
+Test that a Page.setEmulatedMedia override set before a cross-origin iframe is created is replayed to the iframe's late-joining process under site isolation.
+
+
+== Running test suite: SiteIsolation.Page.SetEmulatedMediaLateOOPIF
+-- Running test case: SiteIsolation.Page.SetEmulatedMedia.LateJoiningProcessInheritsOverride
+Setting emulated media to print before the cross-origin iframe exists...
+Adding cross-origin iframe into a new process...
+PASS: Added target should have Frame type.
+PASS: Late-joining cross-origin iframe process should observe the print media override.
+

--- a/LayoutTests/http/tests/site-isolation/inspector/page/set-emulated-media-late-oopif.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/page/set-emulated-media-late-oopif.html
@@ -1,0 +1,58 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script>
+let iframe;
+
+function addCrossOriginIFrame() {
+    let crossOriginHost = location.hostname === "localhost" ? "127.0.0.1" : "localhost";
+    iframe = document.createElement("iframe");
+    iframe.src = `http://${crossOriginHost}:8000/site-isolation/inspector/page/resources/emulated-media-frame.html`;
+    document.body.appendChild(iframe);
+}
+
+function test() {
+    async function addIFrameAndGetTarget() {
+        let targetAddedPromise = WI.targetManager.awaitEvent(WI.TargetManager.Event.TargetAdded);
+        InspectorTest.evaluateInPage("addCrossOriginIFrame()");
+        let event = await targetAddedPromise;
+        return event.data.target;
+    }
+
+    async function matchesPrintInTarget(target) {
+        // Wait for the iframe document to finish loading: TargetAdded fires when the JS context is
+        // created, before the document has committed and instrumentation is in place.
+        await target.RuntimeAgent.evaluate.invoke({
+            expression: "new Promise(resolve => { if (document.readyState === 'complete') resolve(); else window.addEventListener('load', resolve); })",
+            objectGroup: "test",
+            awaitPromise: true,
+        });
+
+        let response = await target.RuntimeAgent.evaluate.invoke({expression: `matchMedia("print").matches`, objectGroup: "test", returnByValue: true});
+        return response.result.value;
+    }
+
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.Page.SetEmulatedMediaLateOOPIF");
+
+    suite.addTestCase({
+        name: "SiteIsolation.Page.SetEmulatedMedia.LateJoiningProcessInheritsOverride",
+        description: "An emulated media override set before a cross-origin iframe is created should be replayed to its newly-spawned process, so it observes the override without a reload.",
+        async test() {
+            InspectorTest.log("Setting emulated media to print before the cross-origin iframe exists...");
+            await PageAgent.setEmulatedMedia("print");
+
+            InspectorTest.log("Adding cross-origin iframe into a new process...");
+            let target = await addIFrameAndGetTarget();
+            InspectorTest.expectEqual(target.type, WI.TargetType.Frame, "Added target should have Frame type.");
+
+            let matchesPrint = await matchesPrintInTarget(target);
+            InspectorTest.expectTrue(matchesPrint, "Late-joining cross-origin iframe process should observe the print media override.");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+
+<body onload="runTest()">
+<p>Test that a Page.setEmulatedMedia override set before a cross-origin iframe is created is replayed to the iframe's late-joining process under site isolation.</p>
+</body>

--- a/LayoutTests/http/tests/site-isolation/inspector/page/set-emulated-media-process-swap-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/page/set-emulated-media-process-swap-expected.txt
@@ -1,0 +1,9 @@
+Test that a Page.setEmulatedMedia override set before a cross-origin main-frame navigation is serialized to the swapped-in process under site isolation.
+
+
+== Running test suite: SiteIsolation.Page.SetEmulatedMediaProcessSwap
+-- Running test case: SiteIsolation.Page.SetEmulatedMedia.ProcessSwapInheritsOverride
+Setting emulated media to print before the cross-origin main-frame navigation...
+Navigating the main frame cross-origin to force a process swap...
+PASS: Swapped-in main-frame process should observe the print media override.
+

--- a/LayoutTests/http/tests/site-isolation/inspector/page/set-emulated-media-process-swap.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/page/set-emulated-media-process-swap.html
@@ -1,0 +1,88 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script>
+function navigateCrossOrigin() {
+    // Toggle the host so the same test page reloads at a cross-origin host, forcing a main-frame
+    // process swap under Site Isolation while keeping the frontend test harness alive.
+    location.hostname = location.hostname === "127.0.0.1" ? "localhost" : "127.0.0.1";
+}
+
+function test() {
+    async function navigateAndGetSwappedMainFrameTarget() {
+        // A cross-origin MAIN-frame navigation swaps the page into a new WebContent process under
+        // Site Isolation; the frontend observes the swapped-in main-frame target when its
+        // provisional page commits.
+        let committedPromise = new Promise((resolve) => {
+            function handle(event) {
+                let { target } = event.data;
+                if (target.type === WI.TargetType.Frame) {
+                    WI.targetManager.removeEventListener(WI.TargetManager.Event.DidCommitProvisionalTarget, handle);
+                    resolve(target);
+                }
+            }
+            WI.targetManager.addEventListener(WI.TargetManager.Event.DidCommitProvisionalTarget, handle);
+        });
+
+        InspectorTest.deferOutputUntilTestPageIsReloaded();
+        InspectorTest.evaluateInPage("navigateCrossOrigin()");
+
+        let target = await committedPromise;
+        if (!target.executionContext)
+            await target.awaitEvent(WI.FrameTarget.Event.ExecutionContextAdded);
+        return target;
+    }
+
+    async function matchesPrintInTarget(target) {
+        // The target commits before its document has finished loading and instrumentation is in
+        // place; wait for load before reading the media state.
+        await target.RuntimeAgent.evaluate.invoke({
+            expression: "new Promise(resolve => { if (document.readyState === 'complete') resolve(); else window.addEventListener('load', resolve); })",
+            objectGroup: "test",
+            awaitPromise: true,
+        });
+
+        let response = await target.RuntimeAgent.evaluate.invoke({expression: `matchMedia("print").matches`, objectGroup: "test", returnByValue: true});
+        return response.result.value;
+    }
+
+    // The override is serialized to the swapped-in process as it joins, which is not ordered against
+    // the target's own RuntimeAgent channel, so matchMedia may not reflect the override on the very
+    // first read. Poll silently until it settles (or give up) so the assertion stays deterministic
+    // without logging retry noise.
+    async function awaitMatchesPrintInTarget(target) {
+        let matches = await matchesPrintInTarget(target);
+        for (let attempt = 0; attempt < 20 && !matches; ++attempt) {
+            await target.RuntimeAgent.evaluate.invoke({
+                expression: "new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)))",
+                objectGroup: "test",
+                awaitPromise: true,
+            });
+            matches = await matchesPrintInTarget(target);
+        }
+        return matches;
+    }
+
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.Page.SetEmulatedMediaProcessSwap");
+
+    suite.addTestCase({
+        name: "SiteIsolation.Page.SetEmulatedMedia.ProcessSwapInheritsOverride",
+        description: "An emulated media override set before a cross-origin main-frame navigation should be serialized to the swapped-in process, so it observes the override without a reload.",
+        async test() {
+            InspectorTest.log("Setting emulated media to print before the cross-origin main-frame navigation...");
+            await WI.backendTarget.PageAgent.setEmulatedMedia("print");
+
+            InspectorTest.log("Navigating the main frame cross-origin to force a process swap...");
+            let target = await navigateAndGetSwappedMainFrameTarget();
+
+            let matchesPrint = await awaitMatchesPrintInTarget(target);
+            InspectorTest.expectTrue(matchesPrint, "Swapped-in main-frame process should observe the print media override.");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+
+<body onload="runTest()">
+<p>Test that a Page.setEmulatedMedia override set before a cross-origin main-frame navigation is serialized to the swapped-in process under site isolation.</p>
+</body>

--- a/LayoutTests/inspector/page/setEmulatedMedia.html
+++ b/LayoutTests/inspector/page/setEmulatedMedia.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=false ] -->
 <!DOCTYPE html>
 <html>
 <head>

--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -57,7 +57,7 @@ http/tests/site-isolation/inspector/debugger/pause-in-cross-origin-iframe.html [
 http/tests/site-isolation/inspector/debugger/scriptParsed-frame-target.html [ Pass ]
 http/tests/site-isolation/inspector/debugger/setBreakpoint-cross-origin-iframe.html [ Pass ]
 http/tests/site-isolation/inspector/page/override-setting-cross-origin-iframe.html [ Pass Failure ]
-webkit.org/b/311836 http/tests/site-isolation/inspector/page/set-emulated-media-cross-origin-iframe.html [ Pass Failure ]
+webkit.org/b/311836 http/tests/site-isolation/inspector/page/set-emulated-media-process-swap.html [ Pass Failure ]
 http/tests/site-isolation/inspector/worker/worker-in-cross-origin-iframe.html [ Pass ]
 http/tests/site-isolation/inspector/storage/storage-get-cookies-cross-origin-iframe.html [ Pass ]
 http/tests/site-isolation/inspector/storage/storage-frontend-gate.html [ Pass ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2206,7 +2206,7 @@ http/tests/site-isolation/inspector/debugger/setBreakpoint-cross-origin-iframe.h
 http/tests/site-isolation/inspector/storage/storage-get-cookies-cross-origin-iframe.html [ Skip ]
 http/tests/site-isolation/inspector/storage/storage-frontend-gate.html [ Skip ]
 http/tests/site-isolation/inspector/page/override-setting-cross-origin-iframe.html [ Pass Failure ]
-webkit.org/b/311836 http/tests/site-isolation/inspector/page/set-emulated-media-cross-origin-iframe.html [ Pass Failure ]
+webkit.org/b/311836 http/tests/site-isolation/inspector/page/set-emulated-media-process-swap.html [ Pass Failure ]
 
 webkit.org/b/314356 imported/w3c/web-platform-tests/websockets/constructor/013.html?default [ Pass Failure ]
 

--- a/Source/JavaScriptCore/inspector/protocol/Page.json
+++ b/Source/JavaScriptCore/inspector/protocol/Page.json
@@ -283,7 +283,7 @@
         {
             "name": "setEmulatedMedia",
             "description": "Emulates the given media for CSS media queries.",
-            "targetTypes": ["page"],
+            "targetTypes": ["page", "web-page"],
             "parameters": [
                 { "name": "media", "type": "string", "description": "Media type to emulate. Empty string disables the override." }
             ]

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1721,6 +1721,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     html/track/VideoTrackClient.h
 
     inspector/CommandLineAPIHost.h
+    inspector/EmulationOverrides.h
     inspector/FrameInspectorController.h
     inspector/InspectorBackendClient.h
     inspector/InspectorDebuggableType.h

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -749,6 +749,7 @@
 		1C7A6EB526F5D8F50096D8C7 /* FontPalette.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C4674FD26F4843600B61273 /* FontPalette.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1C81B95A0E97330800266E07 /* PageInspectorController.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C81B9560E97330800266E07 /* PageInspectorController.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1C81B95C0E97330800266E07 /* InspectorBackendClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C81B9580E97330800266E07 /* InspectorBackendClient.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		54F00963E1F6579DC877D0DD /* EmulationOverrides.h in Headers */ = {isa = PBXBuildFile; fileRef = 6D4379A62F149F2981EB980D /* EmulationOverrides.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1C9F4C1429E529660015819E /* DetectedFaceInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C38F28329E3B2BC008795CC /* DetectedFaceInterface.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1C9F4C1529E529660015819E /* BarcodeDetectorInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C38F27F29E3B27C008795CC /* BarcodeDetectorInterface.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1C9F4C1629E529660015819E /* BarcodeDetectorOptionsInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C38F28029E3B28A008795CC /* BarcodeDetectorOptionsInterface.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -9581,6 +9582,7 @@
 		1C81B9560E97330800266E07 /* PageInspectorController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PageInspectorController.h; sourceTree = "<group>"; };
 		1C81B9570E97330800266E07 /* PageInspectorController.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PageInspectorController.cpp; sourceTree = "<group>"; };
 		1C81B9580E97330800266E07 /* InspectorBackendClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InspectorBackendClient.h; sourceTree = "<group>"; };
+		6D4379A62F149F2981EB980D /* EmulationOverrides.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EmulationOverrides.h; sourceTree = "<group>"; };
 		1C84BE4126D3939F002D61FC /* ComposedCharacterClusterTextIterator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ComposedCharacterClusterTextIterator.h; sourceTree = "<group>"; };
 		1C8D26D022C09CDE00D125F3 /* libcompression.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libcompression.tbd; path = usr/lib/libcompression.tbd; sourceTree = SDKROOT; };
 		1C9067B6299CB44500A2B076 /* FontInterrogation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FontInterrogation.h; sourceTree = "<group>"; };
@@ -26353,6 +26355,7 @@
 				9109E9C5222CABC800BB6264 /* InspectorAuditResourcesObject.h */,
 				BCD8F9E02F27D80B00B42872 /* InspectorAuditResourcesObject.idl */,
 				1C81B9580E97330800266E07 /* InspectorBackendClient.h */,
+				6D4379A62F149F2981EB980D /* EmulationOverrides.h */,
 				6A22E8721F1042C400F546C3 /* InspectorCanvas.cpp */,
 				6A22E86F1F10418600F546C3 /* InspectorCanvas.h */,
 				BC08A72E2E889885005C4CD1 /* InspectorCanvasArguments.cpp */,
@@ -46275,6 +46278,7 @@
 				9175CE5C21E281ED00DF2C27 /* InspectorAuditDOMObject.h in Headers */,
 				9109E9C8222CABCA00BB6264 /* InspectorAuditResourcesObject.h in Headers */,
 				1C81B95C0E97330800266E07 /* InspectorBackendClient.h in Headers */,
+				54F00963E1F6579DC877D0DD /* EmulationOverrides.h in Headers */,
 				6A22E8701F10418600F546C3 /* InspectorCanvas.h in Headers */,
 				A5B81CA81FAA44620037D1E6 /* InspectorCanvasAgent.h in Headers */,
 				95AA571025EEED32004E9283 /* InspectorCanvasCallTracer.h in Headers */,

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -742,7 +742,7 @@ public:
     void setGotoAnchorNeededAfterStylesheetsLoad(bool b) { m_gotoAnchorNeededAfterStylesheetsLoad = b; }
 
     void updateElementsAffectedByMediaQueries();
-    void evaluateMediaQueriesAndReportChanges();
+    WEBCORE_EXPORT void evaluateMediaQueriesAndReportChanges();
 
     WEBCORE_EXPORT FormController& formController();
     Vector<AtomString> formElementsState() const;

--- a/Source/WebCore/inspector/EmulationOverrides.h
+++ b/Source/WebCore/inspector/EmulationOverrides.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <optional>
+#include <wtf/text/WTFString.h>
+
+namespace Inspector {
+
+// The emulation overrides applied to a page, in WebCore-native representations (not BiDi wire
+// JSON). Only emulatedMedia exists today; the rest of the BiDi emulation vocabulary (locale,
+// timezone, geolocation, userAgent, screenOrientation, touch, scriptingEnabled) is added per
+// implementation. network_conditions is excluded (it belongs to the Network domain). See
+// webkit.org/b/308897.
+struct EmulationOverrides {
+    std::optional<String> emulatedMedia;
+};
+
+} // namespace Inspector

--- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -716,6 +716,12 @@ void InspectorInstrumentation::applyEmulatedMediaImpl(InstrumentingAgents& instr
 {
     if (CheckedPtr pageAgent = instrumentingAgents.enabledPageAgent())
         pageAgent->applyEmulatedMedia(media);
+
+    // Under Site Isolation a cross-origin frame's process has no page-level InspectorPageAgent; its
+    // PageAgentProxy carries the emulated-media override forwarded from the UIProcess ProxyingPageAgent,
+    // so its media queries evaluate under the override too. See webkit.org/b/308898.
+    if (CheckedPtr pageProxy = instrumentingAgents.enabledPageProxy())
+        pageProxy->applyEmulatedMedia(media);
 }
 
 void InspectorInstrumentation::flexibleBoxRendererBeganLayoutImpl(InstrumentingAgents& instrumentingAgents, const RenderObject& renderer)

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -1138,6 +1138,7 @@ def headers_for_type(type, for_implementation_file=False):
         'CVPixelBufferRef': ['<WebCore/CVUtilities.h>'],
         'GCGLint': ['<WebCore/GraphicsTypesGL.h>'],
         'GenericPromise::Result': ['<wtf/NativePromise.h>'],
+        'Inspector::EmulationOverrides': ['<WebCore/EmulationOverrides.h>'],
         'Inspector::ExtensionAppearance': ['"InspectorExtensionTypes.h"'],
         'Inspector::ExtensionError': ['"InspectorExtensionTypes.h"'],
         'Inspector::ExtensionTabID': ['"InspectorExtensionTypes.h"'],

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -282,6 +282,11 @@ struct WebCore::CharacterRange {
     [Validator='!(CheckedUint64 { *location } + *length).hasOverflowed()'] uint64_t length
 }
 
+header: <WebCore/EmulationOverrides.h>
+[CustomHeader] struct Inspector::EmulationOverrides {
+    std::optional<String> emulatedMedia;
+}
+
 [AdditionalEncoder=StreamConnectionEncoder] class WebCore::AffineTransform {
     std::span<const double, 6> span();
 }

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -641,6 +641,7 @@ UIProcess/Inspector/WebInspectorUtilities.cpp
 UIProcess/Inspector/WebPageDebuggable.cpp
 UIProcess/Inspector/WebPageInspectorController.cpp
 
+UIProcess/Inspector/Agents/InspectorBackendSyncState.cpp
 UIProcess/Inspector/Agents/InspectorBrowserAgent.cpp
 UIProcess/Inspector/Agents/InspectorStorageAgent.cpp
 UIProcess/Inspector/Agents/ProxyingNetworkAgent.cpp
@@ -944,6 +945,7 @@ WebProcess/WebCoreSupport/WebStorageConnection.cpp
 WebProcess/WebCoreSupport/WebWorkerClient.cpp
 
 WebProcess/WebPage/DrawingArea.cpp @cost:3
+WebProcess/WebPage/EmulationManager.cpp
 WebProcess/WebPage/EventDispatcher.cpp @cost:3
 WebProcess/WebPage/FindIndicator.cpp
 WebProcess/WebPage/FindController.cpp @cost:3

--- a/Source/WebKit/UIProcess/Inspector/Agents/InspectorBackendSyncState.cpp
+++ b/Source/WebKit/UIProcess/Inspector/Agents/InspectorBackendSyncState.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "InspectorBackendSyncState.h"
+
+#include "WebInspectorBackendMessages.h"
+#include "WebProcessProxy.h"
+
+namespace Inspector {
+
+void InspectorBackendSyncState::sendTo(WebKit::WebProcessProxy& process, WebCore::PageIdentifier pageID) const
+{
+    process.send(Messages::WebInspectorBackend::SetEmulationOverrides(m_overrides), pageID);
+}
+
+} // namespace Inspector

--- a/Source/WebKit/UIProcess/Inspector/Agents/InspectorBackendSyncState.h
+++ b/Source/WebKit/UIProcess/Inspector/Agents/InspectorBackendSyncState.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/EmulationOverrides.h>
+#include <WebCore/PageIdentifier.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebKit {
+class WebProcessProxy;
+}
+
+namespace Inspector {
+
+// The typed, source-side (UIProcess) counterpart to the WebProcess-side EmulationManager sink.
+// Holds the inspector emulation overrides for the inspected page as a strongly-typed
+// Inspector::EmulationOverrides, and serializes them to every WebContent process that joins the
+// inspected page under Site Isolation -- whether by a cross-origin frame spawn or a process swap --
+// so a late-joining process inherits the same emulation config as the existing ones. Only
+// emulatedMedia is materialized today. See webkit.org/b/308897.
+class InspectorBackendSyncState {
+public:
+    // Update the emulated media type. An empty string clears the override, matching
+    // Page.setEmulatedMedia("").
+    void setEmulatedMedia(const String& media)
+    {
+        if (media.isEmpty())
+            m_overrides.emulatedMedia = std::nullopt;
+        else
+            m_overrides.emulatedMedia = media;
+    }
+
+    void clear() { m_overrides = { }; }
+
+    // Send the current typed overrides to a process that has just begun instrumentation.
+    void sendTo(WebKit::WebProcessProxy&, WebCore::PageIdentifier) const;
+
+private:
+    Inspector::EmulationOverrides m_overrides;
+};
+
+} // namespace Inspector

--- a/Source/WebKit/UIProcess/Inspector/Agents/ProxyingPageAgent.cpp
+++ b/Source/WebKit/UIProcess/Inspector/Agents/ProxyingPageAgent.cpp
@@ -80,6 +80,21 @@ void ProxyingPageAgent::removeAllRegisteredReceivers()
     m_pinnedInstrumentedProcesses.clear();
 }
 
+void ProxyingPageAgent::forEachInstrumentedProcess(NOESCAPE const Function<void(WebProcessProxy&, PageIdentifier)>& callback)
+{
+    // Iterate the registration map rather than forEachWebContentProcess(): under Site Isolation a
+    // process may have swapped out while still holding our receiver, so it would no longer be
+    // enumerated. The pinned refs keep each WebProcessProxy alive for the send.
+    for (auto& [key, count] : m_instrumentedProcessPageCounts) {
+        auto [processID, pageID] = key;
+        auto it = m_pinnedInstrumentedProcesses.find(processID);
+        ASSERT(it != m_pinnedInstrumentedProcesses.end());
+        if (it == m_pinnedInstrumentedProcesses.end())
+            continue;
+        callback(it->value.get(), pageID);
+    }
+}
+
 // MARK: - IPC event handlers
 
 // Resolve a frame's protocol ID from the authoritative UIProcess frame tree so the
@@ -191,6 +206,10 @@ void ProxyingPageAgent::enableInstrumentationForProcess(WebProcessProxy& webProc
     // exactly once per (process, page) registration, guarded above.
     if (m_showPaintRects)
         webProcess.send(Messages::WebInspectorBackend::SetShowPaintRects { true }, pageID);
+
+    // Serialize the active emulation overrides to this newly-joined process so a cross-origin frame
+    // spawn or process swap inherits the same config as the existing processes. See webkit.org/b/308897.
+    m_syncState.sendTo(webProcess, pageID);
 }
 
 void ProxyingPageAgent::disableInstrumentationForProcess(WebProcessProxy& webProcess, PageIdentifier pageID)
@@ -244,6 +263,7 @@ CommandResult<void> ProxyingPageAgent::disable()
 
     m_enabled = false;
     m_cachedFrameDocumentInfo.clear();
+    m_syncState.clear();
 
     // Reset so a later frontend reconnect doesn't replay a stale "on" toggle via
     // enableInstrumentationForProcess. The processes are torn down below, so no "off" send is needed.
@@ -696,8 +716,21 @@ CommandResult<void> ProxyingPageAgent::setShowPaintRects(bool show)
     return { };
 }
 
-CommandResult<void> ProxyingPageAgent::setEmulatedMedia(const String&)
+CommandResult<void> ProxyingPageAgent::setEmulatedMedia(const String& media)
 {
+    if (!m_enabled)
+        return { };
+
+    // Store the override so a late-joining process inherits it at the shared join seam, then
+    // broadcast it to every process already hosting a frame of the inspected page via the same
+    // SetEmulationOverrides message the join path sends. The WebContent WebInspectorBackend applies
+    // it to its local frames' media queries. See webkit.org/b/308898.
+    m_syncState.setEmulatedMedia(media);
+
+    forEachInstrumentedProcess([&](WebProcessProxy& process, PageIdentifier pageID) {
+        m_syncState.sendTo(process, pageID);
+    });
+
     return { };
 }
 

--- a/Source/WebKit/UIProcess/Inspector/Agents/ProxyingPageAgent.h
+++ b/Source/WebKit/UIProcess/Inspector/Agents/ProxyingPageAgent.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "InspectorBackendSyncState.h"
 #include "MessageReceiver.h"
 #include "WebPageInspectorAgentBase.h"
 #include <JavaScriptCore/InspectorBackendDispatchers.h>
@@ -114,6 +115,11 @@ private:
 
     void removeAllRegisteredReceivers();
 
+    // Invoke a callback for each WebContent process currently under page instrumentation, with the
+    // per-process page identifier. Used to broadcast a newly-set override (e.g. setEmulatedMedia) to
+    // every existing process; late-joining processes instead inherit it via m_syncState.
+    void forEachInstrumentedProcess(NOESCAPE const Function<void(WebKit::WebProcessProxy&, WebCore::PageIdentifier)>&);
+
     Ref<Protocol::Page::FrameResourceTree> buildFrameTree(const WebKit::WebFrameProxy&, const String* parentProtocolId, const HashMap<WebCore::FrameIdentifier, FrameResourceData>& resourcesByFrame) const;
 
     const UniqueRef<PageFrontendDispatcher> m_frontendDispatcher;
@@ -126,6 +132,10 @@ private:
     // Latest paint-rects toggle, fanned out to every WebContent process and replayed to any
     // process that registers later (e.g. a cross-origin navigation spawns a new one).
     bool m_showPaintRects { false };
+
+    // Source-side counterpart to the WebProcess EmulationManager sink; sends the typed overrides to
+    // late-joining processes at the shared join seam. See webkit.org/b/308897.
+    InspectorBackendSyncState m_syncState;
 
     // Pin each instrumented WebProcessProxy alive while we hold an IPC message
     // receiver registration on it. Without this, the process can be destructed

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -397,6 +397,7 @@
 		1A8E7D3D18C15149005A702A /* VisitedLinkTableControllerMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A8E7D3B18C15149005A702A /* VisitedLinkTableControllerMessages.h */; };
 		1A90C1EE1264FD50003E44D4 /* WebFindOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A90C1ED1264FD50003E44D4 /* WebFindOptions.h */; };
 		1A90C1F41264FD71003E44D4 /* FindController.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A90C1F21264FD71003E44D4 /* FindController.h */; };
+		B30F930A64E768A23B853C1A /* EmulationManager.h in Headers */ = {isa = PBXBuildFile; fileRef = FB02A447B24852317767595B /* EmulationManager.h */; };
 		1A92DC1112F8BA460017AF65 /* LayerTreeContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A92DC1012F8BA460017AF65 /* LayerTreeContext.h */; };
 		1A9E32891821636900F5D04C /* _WKRemoteObjectRegistry.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A9E32871821636900F5D04C /* _WKRemoteObjectRegistry.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1A9E328D182165A900F5D04C /* _WKRemoteObjectInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A9E328B182165A900F5D04C /* _WKRemoteObjectInterface.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -2341,6 +2342,7 @@
 		C1E123BA20A11573002646F4 /* PDFContextMenu.h in Headers */ = {isa = PBXBuildFile; fileRef = C1E123B920A11572002646F4 /* PDFContextMenu.h */; };
 		C3EE0FDA0234F84002CAF7FB /* ProxyingNetworkAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = EB43329193327F9D842EE004 /* ProxyingNetworkAgent.h */; };
 		C3EE0FDA0234F84002CAF7FC /* ProxyingPageAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = EB43329193327F9D842EE005 /* ProxyingPageAgent.h */; };
+		C3EE0FDA0234F84002CAF7FD /* InspectorBackendSyncState.h in Headers */ = {isa = PBXBuildFile; fileRef = EB43329193327F9D842EE006 /* InspectorBackendSyncState.h */; };
 		C4450D54570C4383A25745E6 /* _WKAutomationSessionPrivateForTesting.h in Headers */ = {isa = PBXBuildFile; fileRef = BC35BB81026B48A6A3BDAA80 /* _WKAutomationSessionPrivateForTesting.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		C517388112DF8F4F00EE3F47 /* DragControllerAction.h in Headers */ = {isa = PBXBuildFile; fileRef = C517388012DF8F4F00EE3F47 /* DragControllerAction.h */; };
 		C54256B518BEC18C00DE4179 /* WKDateTimeInputControl.h in Headers */ = {isa = PBXBuildFile; fileRef = C54256AF18BEC18B00DE4179 /* WKDateTimeInputControl.h */; };
@@ -3977,6 +3979,7 @@
 		1A8E7D3B18C15149005A702A /* VisitedLinkTableControllerMessages.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VisitedLinkTableControllerMessages.h; sourceTree = "<group>"; };
 		1A90C1ED1264FD50003E44D4 /* WebFindOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebFindOptions.h; sourceTree = "<group>"; };
 		1A90C1F21264FD71003E44D4 /* FindController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FindController.h; sourceTree = "<group>"; };
+		FB02A447B24852317767595B /* EmulationManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EmulationManager.h; sourceTree = "<group>"; };
 		1A90C1F31264FD71003E44D4 /* FindController.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FindController.cpp; sourceTree = "<group>"; };
 		1A92DC1012F8BA460017AF65 /* LayerTreeContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LayerTreeContext.h; sourceTree = "<group>"; };
 		1A9E32871821636900F5D04C /* _WKRemoteObjectRegistry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKRemoteObjectRegistry.h; sourceTree = "<group>"; };
@@ -8626,6 +8629,7 @@
 		D246E13B2C61292700B41DE2 /* HTTPSBrowsingWarning.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = HTTPSBrowsingWarning.xcassets; sourceTree = "<group>"; };
 		D2CB01DAB4428B76CDA8AECC /* ProxyingNetworkAgent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ProxyingNetworkAgent.cpp; sourceTree = "<group>"; };
 		D2CB01DAB4428B76CDA8AEDD /* ProxyingPageAgent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ProxyingPageAgent.cpp; sourceTree = "<group>"; };
+		D2CB01DAB4428B76CDA8AEDE /* InspectorBackendSyncState.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = InspectorBackendSyncState.cpp; sourceTree = "<group>"; };
 		D2E2FE6D29C8C30D00023E6B /* NetworkTaskCocoa.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NetworkTaskCocoa.h; sourceTree = "<group>"; };
 		D2E2FE6F29C8C4F900023E6B /* NetworkTaskCocoa.mm */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp; path = NetworkTaskCocoa.mm; sourceTree = "<group>"; };
 		D2FB53952E13020F00AF9D5C /* PageClient.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PageClient.cpp; sourceTree = "<group>"; };
@@ -8885,6 +8889,7 @@
 		EB36B16727A7B4500050E00D /* PushService.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = PushService.mm; sourceTree = "<group>"; };
 		EB43329193327F9D842EE004 /* ProxyingNetworkAgent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ProxyingNetworkAgent.h; sourceTree = "<group>"; };
 		EB43329193327F9D842EE005 /* ProxyingPageAgent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ProxyingPageAgent.h; sourceTree = "<group>"; };
+		EB43329193327F9D842EE006 /* InspectorBackendSyncState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = InspectorBackendSyncState.h; sourceTree = "<group>"; };
 		EB44A6992C8A4F6E006595BF /* WebClipCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebClipCache.h; sourceTree = "<group>"; };
 		EB44A69A2C8A4F6E006595BF /* WebClipCache.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WebClipCache.mm; sourceTree = "<group>"; };
 		EB450E0D2996C7A1009724B1 /* WKWebsiteDataStoreRefPrivateMac.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WKWebsiteDataStoreRefPrivateMac.h; path = mac/WKWebsiteDataStoreRefPrivateMac.h; sourceTree = "<group>"; };
@@ -15325,6 +15330,8 @@
 			isa = PBXGroup;
 			children = (
 				9197940423DBC4BB00257892 /* InspectorBrowserAgent.cpp */,
+				D2CB01DAB4428B76CDA8AEDE /* InspectorBackendSyncState.cpp */,
+				EB43329193327F9D842EE006 /* InspectorBackendSyncState.h */,
 				9197940323DBC4BB00257892 /* InspectorBrowserAgent.h */,
 				AA1057000000000000000001 /* InspectorStorageAgent.cpp */,
 				AA1057000000000000000002 /* InspectorStorageAgent.h */,
@@ -16058,6 +16065,7 @@
 				0214701B2995D3860077AFD6 /* DrawingArea.cpp */,
 				BC8452A61162C80900CAB9B5 /* DrawingArea.h */,
 				1A64228A12DD024700CAAE2C /* DrawingArea.messages.in */,
+				FB02A447B24852317767595B /* EmulationManager.h */,
 				1AA575F81496B52600A4EE06 /* EventDispatcher.cpp */,
 				1AA575F91496B52600A4EE06 /* EventDispatcher.h */,
 				1AA575FD1496B6F300A4EE06 /* EventDispatcher.messages.in */,
@@ -18430,6 +18438,7 @@
 				93B42F2F29834B2600DF1D45 /* FileSystemSyncAccessHandleInfo.h in Headers */,
 				00B9661A18E25AE100CE1F88 /* FindClient.h in Headers */,
 				1A90C1F41264FD71003E44D4 /* FindController.h in Headers */,
+				B30F930A64E768A23B853C1A /* EmulationManager.h in Headers */,
 				D6F6CDF82F60DB30007B93C6 /* FindIndicator.h in Headers */,
 				DD4DB789280F9471001700D4 /* FindNodes.js in Headers */,
 				0250C2512B5DCB2000D05C0B /* FindStringCallbackAggregator.h in Headers */,
@@ -18758,6 +18767,7 @@
 				1ADC268E29E89FDA005990CA /* ProvisionalFrameCreationParameters.h in Headers */,
 				C3EE0FDA0234F84002CAF7FB /* ProxyingNetworkAgent.h in Headers */,
 				C3EE0FDA0234F84002CAF7FC /* ProxyingPageAgent.h in Headers */,
+				C3EE0FDA0234F84002CAF7FD /* InspectorBackendSyncState.h in Headers */,
 				517B5F7D275E97B6002DC22D /* PushClientConnection.h in Headers */,
 				51EE7B5B2A95B5820016FF78 /* PushClientConnectionMessages.h in Headers */,
 				517B5F95275EBA63002DC22D /* PushMessageForTesting.h in Headers */,

--- a/Source/WebKit/WebProcess/Inspector/PageAgentProxy.cpp
+++ b/Source/WebKit/WebProcess/Inspector/PageAgentProxy.cpp
@@ -32,7 +32,9 @@
 #include "config.h"
 #include "PageAgentProxy.h"
 
+#include "EmulationManager.h"
 #include "ProxyingPageAgentMessages.h"
+#include "WebInspectorBackend.h"
 #include "WebPage.h"
 #include "WebProcess.h"
 #include <WebCore/Document.h>
@@ -204,8 +206,22 @@ void PageAgentProxy::applyUserAgentOverride(String&)
 {
 }
 
-void PageAgentProxy::applyEmulatedMedia(AtomString&)
+void PageAgentProxy::applyEmulatedMedia(AtomString& media)
 {
+    // Surface the emulated media type forwarded from the UIProcess so this process's media query
+    // evaluation matches the non-Site-Isolation InspectorPageAgent. Read the override straight from
+    // the WebProcess-side EmulationManager the backend owns, rather than caching a per-proxy copy.
+    // See webkit.org/b/308898.
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+
+    RefPtr backend = page->inspector(WebPage::LazyCreationPolicy::UseExistingOnly);
+    if (!backend)
+        return;
+
+    if (const auto& emulatedMedia = backend->emulationManager().overrides().emulatedMedia)
+        media = AtomString { *emulatedMedia };
 }
 
 void PageAgentProxy::didClearWindowObjectInWorld(LocalFrame&, DOMWrapperWorld&)

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "WebInspectorBackend.h"
 
+#include "EmulationManager.h"
 #include "FrameNetworkAgentProxy.h"
 #include "PageAgentProxy.h"
 #include "WebFrame.h"
@@ -80,6 +81,7 @@ Ref<WebInspectorBackend> WebInspectorBackend::create(WebPage& page)
 
 WebInspectorBackend::WebInspectorBackend(WebPage& page)
     : m_page(page)
+    , m_emulationManager(Inspector::EmulationManager::create(*this))
     , m_resourceDataStore(makeUniqueRef<BackendResourceDataStore>(BackendResourceDataStore::Settings { }))
 {
 }
@@ -87,6 +89,7 @@ WebInspectorBackend::WebInspectorBackend(WebPage& page)
 WebInspectorBackend::~WebInspectorBackend()
 {
     disableNetworkInstrumentation();
+    disablePageInstrumentation();
 
     if (RefPtr frontendConnection = m_frontendConnection)
         frontendConnection->invalidate();
@@ -374,6 +377,29 @@ void WebInspectorBackend::ensureNetworkInstrumentationForFrame(LocalFrame& frame
     m_frameNetworkAgentProxies.add(frameID, WTF::move(proxy));
 }
 
+void WebInspectorBackend::connectRemoteInstrumentationIfNeeded()
+{
+    // Connect on the first enabled domain only. Both bools have already been flipped to true by
+    // the caller, so exactly one of them being true means this is the first domain to enable.
+    if (m_networkInstrumentationEnabled && m_pageInstrumentationEnabled)
+        return;
+
+    if (RefPtr corePage = m_page ? m_page->corePage() : nullptr)
+        corePage->inspectorController().connectRemoteInstrumentation();
+}
+
+void WebInspectorBackend::disconnectRemoteInstrumentationIfNeeded()
+{
+    // Disconnect on the last enabled domain only. Both bools have already been flipped to false by
+    // the caller, so this disconnects exactly once, keeping the frontend counter balanced against
+    // the single connectRemoteInstrumentation() from connectRemoteInstrumentationIfNeeded().
+    if (m_networkInstrumentationEnabled || m_pageInstrumentationEnabled)
+        return;
+
+    if (RefPtr corePage = m_page ? m_page->corePage() : nullptr)
+        corePage->inspectorController().disconnectRemoteInstrumentation();
+}
+
 void WebInspectorBackend::enableNetworkInstrumentation()
 {
     if (!m_page)
@@ -386,7 +412,7 @@ void WebInspectorBackend::enableNetworkInstrumentation()
     if (!m_networkInstrumentationEnabled) {
         m_networkInstrumentationEnabled = true;
         corePage->settings().setDeveloperExtrasEnabled(true);
-        corePage->inspectorController().connectRemoteInstrumentation();
+        connectRemoteInstrumentationIfNeeded();
 
         // Buffer certificates only when the page opts in, matching PageNetworkAgent.
         CheckedRef { m_resourceDataStore.get() }->setSupportsShowingCertificate(corePage->settings().inspectorSupportsShowingCertificate());
@@ -414,10 +440,10 @@ void WebInspectorBackend::disableNetworkInstrumentation()
     if (!m_page)
         return;
 
-    if (RefPtr corePage = m_page->corePage()) {
+    if (RefPtr corePage = m_page->corePage())
         corePage->setResourceCachingDisabledByWebInspector(false);
-        corePage->inspectorController().disconnectRemoteInstrumentation();
-    }
+
+    disconnectRemoteInstrumentationIfNeeded();
 }
 
 void WebInspectorBackend::removeInstrumentationForFrame(FrameIdentifier frameID)
@@ -703,6 +729,13 @@ void WebInspectorBackend::ensurePageInstrumentationForFrame(LocalFrame& frame)
     proxy->setShowPaintRects(m_showPaintRects);
 
     m_framePageAgentProxies.add(frameID, WTF::move(proxy));
+
+    // The frame's document already committed before this proxy was installed, so nothing has
+    // recalculated its author styles against the now-instrumented frame. Recalc them (and
+    // re-evaluate its media queries, honoring any active emulated-media override) so an
+    // already-present cross-origin frame reflects its author stylesheet instead of the default
+    // UA style. See webkit.org/b/308896.
+    m_emulationManager->applyLocally(frame);
 }
 
 void WebInspectorBackend::enablePageInstrumentation()
@@ -717,6 +750,15 @@ void WebInspectorBackend::enablePageInstrumentation()
 
     RefPtr corePage = m_page->corePage();
     corePage->settings().setDeveloperExtrasEnabled(true);
+
+    // A process spawned instrumented (shouldEnablePageInstrumentation on creation) enables page
+    // instrumentation without ever receiving a SetFrontendConnection -- that message is delivered only
+    // to the main-frame process. Connect the page's remote instrumentation here so the per-process
+    // frontend counter is bumped and InspectorInstrumentation's FAST_RETURN_IF_NO_FRONTENDS fast path
+    // treats this process as instrumented; otherwise a cross-origin frame reports hasFrontends() == false
+    // and silently drops emulated-media (and other) overrides. Shared with network instrumentation so the
+    // counter is bumped exactly once regardless of enable order. See webkit.org/b/308896.
+    connectRemoteInstrumentationIfNeeded();
 
     corePage->forEachLocalFrame([&](LocalFrame& frame) {
         ensurePageInstrumentationForFrame(frame);
@@ -739,6 +781,14 @@ void WebInspectorBackend::disablePageInstrumentation()
     // Reset so a later re-enable seeds fresh proxies as off; the UIProcess ProxyingPageAgent also
     // resets on disable().
     m_showPaintRects = false;
+
+    // Balance the connect from enablePageInstrumentation() -- disconnects (and drops the frontend
+    // counter) only once the last instrumentation domain is disabled, so the counter can never
+    // underflow or leak across enable -> disable -> re-enable.
+    disconnectRemoteInstrumentationIfNeeded();
+
+    m_emulationManager->setEmulatedMedia(emptyString());
+    m_emulationManager->applyLocally(); // Restore real platform media on disable, mirroring setEmulationOverrides.
 }
 
 void WebInspectorBackend::setShowPaintRects(bool show)
@@ -748,6 +798,17 @@ void WebInspectorBackend::setShowPaintRects(bool show)
     m_showPaintRects = show;
     for (auto& proxy : m_framePageAgentProxies.values())
         proxy->setShowPaintRects(show);
+}
+
+void WebInspectorBackend::setEmulationOverrides(Inspector::EmulationOverrides&& overrides)
+{
+    // Apply each materialized emulation override forwarded from the UIProcess. Only emulatedMedia
+    // exists today; an absent value clears the override. The per-frame PageAgentProxies read the
+    // applied override back through the EmulationManager in applyEmulatedMedia, so there is nothing
+    // to push to them here. See webkit.org/b/308897.
+    Ref emulationManager = m_emulationManager;
+    emulationManager->setEmulatedMedia(overrides.emulatedMedia.value_or(emptyString()));
+    emulationManager->applyLocally();
 }
 
 void WebInspectorBackend::getFrameResourceData(Vector<WebCore::FrameIdentifier>&& frameIDs, CompletionHandler<void(Vector<std::pair<WebCore::FrameIdentifier, Inspector::FrameResourceData>>&&)>&& completionHandler)

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.h
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.h
@@ -37,9 +37,12 @@
 #include <wtf/HashMap.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/text/AtomString.h>
 #include <wtf/text/WTFString.h>
 
 namespace Inspector {
+class EmulationManager;
+struct EmulationOverrides;
 struct FrameResourceData;
 struct SearchMatch;
 struct SearchResult;
@@ -51,7 +54,11 @@ class FrameNetworkAgentProxy;
 class PageAgentProxy;
 class WebPage;
 
-class WebInspectorBackend : public ThreadSafeRefCounted<WebInspectorBackend>, private IPC::Connection::Client {
+// IPC::Connection::Client publicly derives CanMakeThreadSafeCheckedPtr, which is the
+// checked-pointer capability this class exposes. The base must be public so the
+// CheckedRef<WebInspectorBackend> member in EmulationManager can reach
+// increment/decrementCheckedPtrCount(); private inheritance hides them and fails to compile.
+class WebInspectorBackend : public ThreadSafeRefCounted<WebInspectorBackend>, public IPC::Connection::Client {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(WebInspectorBackend);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebInspectorBackend);
 public:
@@ -121,6 +128,13 @@ public:
     // Fan the paint-rects toggle out to every per-frame PageAgentProxy this process hosts.
     void setShowPaintRects(bool);
 
+    // Apply the typed emulation overrides forwarded from the UIProcess InspectorBackendSyncState.
+    // Only emulatedMedia is materialized today; it is applied through the EmulationManager so a
+    // process joining under Site Isolation inherits the config. See webkit.org/b/308897.
+    void setEmulationOverrides(Inspector::EmulationOverrides&&);
+
+    Inspector::EmulationManager& emulationManager() { return m_emulationManager.get(); }
+
     // Set up / tear down every per-frame instrumentation agent for a frame. Callers
     // don't need to know which agents are frame-scoped; each helper no-ops unless its
     // domain is enabled.
@@ -149,7 +163,17 @@ private:
     void ensureNetworkInstrumentationForFrame(WebCore::LocalFrame&);
     void ensurePageInstrumentationForFrame(WebCore::LocalFrame&);
 
+    // Connect the page's remote instrumentation (bumping the per-process frontend counter and
+    // registering the page's instrumenting agents) on the first enabled domain, and disconnect on
+    // the last. Network and page instrumentation share one connection so the counter stays balanced.
+    void connectRemoteInstrumentationIfNeeded();
+    void disconnectRemoteInstrumentationIfNeeded();
+
     WeakPtr<WebPage> m_page;
+
+    // Owned eagerly (created in the ctor): the backend's lifetime is the manager's lifetime, and the
+    // manager reaches the page back through this backend. See webkit.org/b/308897.
+    const Ref<Inspector::EmulationManager> m_emulationManager;
 
     RefPtr<IPC::Connection> m_frontendConnection;
     Vector<Function<void(IPC::Connection&)>> m_frontendConnectionActions;

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.messages.in
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.messages.in
@@ -58,6 +58,11 @@ messages -> WebInspectorBackend {
     # process instead draws in its own frame's coordinate space.
     SetShowPaintRects(bool show)
 
+    # Forward the typed emulation overrides from the UIProcess as a single struct so a process
+    # joining the inspected page under Site Isolation (cross-origin frame spawn or process swap)
+    # inherits the same emulation config. See webkit.org/b/308897.
+    SetEmulationOverrides(struct Inspector::EmulationOverrides overrides)
+
     # Returns, for each requested frame that is local to this process, its committed document's
     # loaderId and cached subresources as typed data, for the UIProcess ProxyingPageAgent to build
     # Page.getResourceTree cross-process under Site Isolation. The proxy walks the frame tree and

--- a/Source/WebKit/WebProcess/WebPage/EmulationManager.cpp
+++ b/Source/WebKit/WebProcess/WebPage/EmulationManager.cpp
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "EmulationManager.h"
+
+#include "WebInspectorBackend.h"
+#include "WebPage.h"
+#include <WebCore/Document.h>
+#include <WebCore/LocalFrame.h>
+#include <WebCore/LocalFrameInlines.h>
+#include <WebCore/Page.h>
+
+namespace Inspector {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(EmulationManager);
+
+Ref<EmulationManager> EmulationManager::create(WebKit::WebInspectorBackend& backend)
+{
+    return adoptRef(*new EmulationManager(backend));
+}
+
+EmulationManager::EmulationManager(WebKit::WebInspectorBackend& backend)
+    : m_backend(backend)
+{
+}
+
+EmulationManager::~EmulationManager() = default;
+
+void EmulationManager::setEmulatedMedia(const String& media)
+{
+    if (media.isEmpty())
+        m_overrides.emulatedMedia = std::nullopt;
+    else
+        m_overrides.emulatedMedia = media;
+}
+
+void EmulationManager::applyLocally()
+{
+    RefPtr page = m_backend->page();
+    if (!page)
+        return;
+
+    RefPtr corePage = page->corePage();
+    if (!corePage)
+        return;
+
+    // Mirrors InspectorPageAgent::setEmulatedMedia's layout kick. See webkit.org/b/308898.
+    // FIXME: Schedule a rendering update instead of synchronously updating the layout (bugs.webkit.org/b/308898).
+    // Intentionally distinct from the frame-scoped applyLocally(LocalFrame&) below: this set-time path
+    // is page-wide (updateStyleAfterChangeInEnvironment()), whereas the per-frame join path forces a
+    // scheduleFullStyleRebuild() on a single freshly-instrumented document. Do not merge them -- a
+    // page-wide full style rebuild on every emulation set would be a perf regression.
+    corePage->updateStyleAfterChangeInEnvironment();
+    corePage->forEachLocalFrame([](WebCore::LocalFrame& frame) {
+        if (RefPtr document = frame.document()) {
+            document->updateLayout();
+            document->evaluateMediaQueriesAndReportChanges();
+        }
+    });
+}
+
+void EmulationManager::applyLocally(WebCore::LocalFrame& frame)
+{
+    RefPtr document = frame.document();
+    if (!document)
+        return;
+
+    // Frame-scoped, synchronous sibling of the page-wide applyLocally() above. A cross-origin iframe
+    // that is already present when page instrumentation is enabled under Site Isolation had its
+    // PageAgentProxy installed after its document committed, so nothing recalculated its author
+    // styles against the now-instrumented frame; without this it reports the default UA color
+    // instead of its author stylesheet. Force a full style rebuild + synchronous layout on just this
+    // document, then re-evaluate its media queries so any active emulated-media override the proxy
+    // inherited takes effect. Scoped to one frame (not corePage->updateStyleAfterChangeInEnvironment(),
+    // which is page-wide) and synchronous to match the set-time path. See webkit.org/b/308896.
+    document->scheduleFullStyleRebuild();
+
+    // Only force a synchronous layout + media-query re-evaluation when an emulated-media override
+    // is actually set. The scheduleFullStyleRebuild() above unconditionally recalcs the freshly
+    // committed cross-origin iframe's author styles; but when no override is active there is nothing
+    // to re-evaluate, and forcing updateLayout() on every newly-instrumented frame is a perf regression.
+    if (m_overrides.emulatedMedia) {
+        document->updateLayout();
+        document->evaluateMediaQueriesAndReportChanges();
+    }
+}
+
+} // namespace Inspector

--- a/Source/WebKit/WebProcess/WebPage/EmulationManager.h
+++ b/Source/WebKit/WebProcess/WebPage/EmulationManager.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "WebInspectorBackend.h"
+#include <WebCore/EmulationOverrides.h>
+#include <wtf/CheckedRef.h>
+#include <wtf/Ref.h>
+#include <wtf/RefCounted.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/WeakPtr.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+class LocalFrame;
+}
+
+namespace Inspector {
+
+// WebProcess-side holder for a page's emulation overrides. Owned by the WebInspectorBackend that
+// created it and reaches the page through the backend. See webkit.org/b/308897.
+class EmulationManager : public RefCounted<EmulationManager> {
+    WTF_MAKE_TZONE_ALLOCATED(EmulationManager);
+public:
+    static Ref<EmulationManager> create(WebKit::WebInspectorBackend&);
+    ~EmulationManager();
+
+    // An empty string clears the override, matching Page.setEmulatedMedia("").
+    void setEmulatedMedia(const String&);
+
+    const EmulationOverrides& overrides() const { return m_overrides; }
+
+    // Re-evaluate media queries on the owning page against the current overrides. The values reach
+    // a frame via its PageAgentProxy::applyEmulatedMedia hook; this just forces the re-evaluation.
+    void applyLocally();
+
+    // Frame-scoped, synchronous sibling of applyLocally(): recalc author styles + re-evaluate media
+    // queries for a single frame that just had page instrumentation installed under Site Isolation,
+    // honoring the current overrides. See webkit.org/b/308896.
+    void applyLocally(WebCore::LocalFrame&);
+
+private:
+    explicit EmulationManager(WebKit::WebInspectorBackend&);
+
+    const CheckedRef<WebKit::WebInspectorBackend> m_backend;
+    EmulationOverrides m_overrides;
+};
+
+} // namespace Inspector

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -726,6 +726,7 @@ public:
 
     WebInspectorBackend* inspector(LazyCreationPolicy = LazyCreationPolicy::CreateIfNeeded);
     WebInspectorUI* inspectorUI();
+
     RemoteWebInspectorUI* remoteInspectorUI();
     bool isInspectorPage() { return !!m_inspectorUI || !!m_remoteInspectorUI; }
 


### PR DESCRIPTION
#### 00dda02b223f1b70e7dd6d48961c618409acdfe6
<pre>
[Site Isolation] Web Inspector: Page.setEmulatedMedia should apply to cross-origin frames
<a href="https://bugs.webkit.org/show_bug.cgi?id=308898">https://bugs.webkit.org/show_bug.cgi?id=308898</a>

Reviewed by NOBODY (OOPS!).

Under Site Isolation, Page.setEmulatedMedia only reached the main frame&apos;s
WebContent process, so a cross-origin iframe hosted in another process kept
evaluating its media queries against the un-emulated media type. Emulating
&quot;print&quot; on a page containing a cross-origin iframe left that iframe rendering
its screen styles instead of its @media print styles.

Route the command through the UIProcess ProxyingPageAgent, which owns the
authoritative emulated-media override and broadcasts it to every WebContent
process hosting a frame of the inspected page. Each WebContent process applies
the override to its local frames&apos; media query evaluation through a per-process
Inspector::EmulationManager, owned by the WebInspectorBackend.

A process that joins after the override was set -- a process swap or a newly
added cross-origin iframe -- must inherit the current value. The late-joiner
replay state is held by InspectorBackendSyncState, the strongly-typed source-side
counterpart to the per-process EmulationManager sink: it stores the overrides as
an Inspector::EmulationOverrides and sends them to each joining process.
Both the set-time broadcast and the late-join replay use the same IPC message.
The per-frame PageAgentProxy reads the applied media back through its page&apos;s
EmulationManager instead of keeping a duplicate copy.

Disabling Page-domain instrumentation must symmetrically restore the page. The
disable path clears the emulated-media override. Re-apply the
(now empty) override on disable through the same EmulationManager, mirroring the
set path: once the override is empty each frame re-evaluates its styles.

* LayoutTests/http/tests/site-isolation/inspector/page/set-emulated-media-cross-origin-iframe-expected.txt:
* LayoutTests/http/tests/site-isolation/inspector/page/set-emulated-media-cross-origin-iframe.html:
* LayoutTests/http/tests/site-isolation/inspector/page/set-emulated-media-disable-restore-expected.txt: Added.

* LayoutTests/http/tests/site-isolation/inspector/page/set-emulated-media-disable-restore.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/page/set-emulated-media-late-oopif-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/page/set-emulated-media-late-oopif.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/page/set-emulated-media-process-swap-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/page/set-emulated-media-process-swap.html: Added.
* LayoutTests/inspector/page/setEmulatedMedia.html:
* LayoutTests/platform/mac-site-isolation/TestExpectations: Unmark the cross-origin-iframe test (stable at 10 iterations).
* LayoutTests/platform/mac-wk2/TestExpectations: Don&apos;t run the legacy Page target test if SI is enabled.
* Source/JavaScriptCore/inspector/protocol/Page.json:

* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/Document.h:
* Source/WebCore/inspector/EmulationOverrides.h: Added.
* Source/WebCore/inspector/InspectorInstrumentation.cpp:
(WebCore::InspectorInstrumentation::applyEmulatedMediaImpl):
* Source/WebKit/Scripts/webkit/messages.py:
(headers_for_type):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/Sources.txt:
* Source/WebKit/UIProcess/Inspector/Agents/InspectorBackendSyncState.cpp: Added.
Typed source-side sync-state that sends the emulation overrides to a WebContent
process.

(Inspector::InspectorBackendSyncState::sendTo const):
* Source/WebKit/UIProcess/Inspector/Agents/InspectorBackendSyncState.h: Added.
(Inspector::InspectorBackendSyncState::setEmulatedMedia):
(Inspector::InspectorBackendSyncState::clear):
* Source/WebKit/UIProcess/Inspector/Agents/ProxyingPageAgent.cpp: Latch the
emulated-media override in the typed sync-state and send it -- at set time to
every hosting process and at the instrumentation seam to each late joiner --
over the one SetEmulationOverrides message.

(Inspector::ProxyingPageAgent::forEachInstrumentedProcess):
(Inspector::ProxyingPageAgent::enableInstrumentationForProcess):
(Inspector::ProxyingPageAgent::disable):
(Inspector::ProxyingPageAgent::setEmulatedMedia):
* Source/WebKit/UIProcess/Inspector/Agents/ProxyingPageAgent.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Tests:

* Source/WebKit/WebProcess/Inspector/PageAgentProxy.cpp:
(WebKit::PageAgentProxy::applyEmulatedMedia):
* Source/WebKit/WebProcess/Inspector/WebInspectorBackend.cpp: Receive
SetEmulationOverrides and apply it to local frames through the backend-owned
EmulationManager; on the disable path, re-apply the cleared override so
cross-origin frames revert to their real media.

(WebKit::WebInspectorBackend::WebInspectorBackend):
(WebKit::WebInspectorBackend::~WebInspectorBackend):
(WebKit::WebInspectorBackend::connectRemoteInstrumentationIfNeeded):
(WebKit::WebInspectorBackend::disconnectRemoteInstrumentationIfNeeded):
(WebKit::WebInspectorBackend::enableNetworkInstrumentation):
(WebKit::WebInspectorBackend::disableNetworkInstrumentation):
(WebKit::WebInspectorBackend::ensurePageInstrumentationForFrame):
(WebKit::WebInspectorBackend::enablePageInstrumentation):
(WebKit::WebInspectorBackend::disablePageInstrumentation):
(WebKit::WebInspectorBackend::setEmulationOverrides):
* Source/WebKit/WebProcess/Inspector/WebInspectorBackend.h:
(WebKit::WebInspectorBackend::emulationManager):
* Source/WebKit/WebProcess/Inspector/WebInspectorBackend.messages.in:
* Source/WebKit/WebProcess/WebPage/EmulationManager.cpp: Added. Per-process sink
that applies emulated-media overrides to its local frames; include
LocalFrameInlines.h for the inline LocalFrame::document() (WPE build).

(Inspector::EmulationManager::create):
(Inspector::EmulationManager::EmulationManager):
(Inspector::EmulationManager::setEmulatedMedia):
(Inspector::EmulationManager::applyLocally):
* Source/WebKit/WebProcess/WebPage/EmulationManager.h: Added.
(Inspector::EmulationManager::overrides const):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a0b57541e6b0021bcf86af43bcedbbc78c6d9edc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180774 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54719 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48517 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190987 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145097 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ecbb0d2d-f924-4727-a673-5a02728240cd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182636 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56017 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54435 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141024 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97725 "2 flakes 7 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/83c26971-8bf6-4383-bd7f-64396a9fe9b4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183729 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44681 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161772 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121476 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/da5dd67e-b693-440f-b70d-aaf5c678cca2) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/180098 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43354 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41631 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3443 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10257 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153758 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41301 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2148 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/42048 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47331 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45886 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192922 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54385 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161290 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150399 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55073 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37919 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150116 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44712 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127339 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122625 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53590 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16294 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52972 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53209 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53037 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->