### PR TITLE
[git-webkit] conflict command fails on radars with multiple source changes

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/conflict.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/conflict.py
@@ -32,6 +32,7 @@ class Conflict(Command):
     name = 'conflict'
     help = "Given the representative Radar ID of a conflicting merge, checkout the branch with conflict markers in place."
     INTEGRATION_BRANCH_PREFIX = 'integration'
+    INTEGRATION_BRANCH_TYPES = ('conflict', 'ci')
 
     @classmethod
     def parser(cls, parser, loggers=None):
@@ -41,12 +42,30 @@ class Conflict(Command):
             help='Radar ID that caused a merge conflict. Ex. rdar://problem/123, rdar://123, 123',
         )
 
+    @staticmethod
+    def parse_source_change(entry):
+        """
+        Parse a single source change entry of the form 'repo, action, sha'.
+
+        The sourceChanges field on a radar is free-form text, so not every line
+        is guaranteed to match this format. Returns a (repo, action, sha) tuple
+        for well-formed entries, or None for anything that doesn't parse.
+        """
+        parts = entry.split(', ')
+        return tuple(parts) if len(parts) == 3 else None
+
     @classmethod
     def find_conflict_pr(cls, remote, radar_id):
         """
-        Because we don't know what the target branch was just given the radar id,
-        we need to search for PRs with branches that start with the integration prefix
-        and have the first and last sha.
+        Given only the radar id, reconstruct the integration branch name from the
+        radar's source changes and search open integration PRs for a matching head.
+
+        A branch is named integration/<conflict|ci>/<first_sha>_<last_sha>/<target>
+        (shas truncated to Commit.HASH_LABEL_SIZE), matched via startswith since we
+        don't know the target branch. The source changes may form a range or, more
+        commonly, one branch per change (<sha>_<sha>), and we can't assume they are
+        ordered the same way the branch was named, so we try every ordered pair of
+        shas, most-likely candidate first.
         """
         radar_obj = Tracker.from_string(f'rdar://{radar_id}')
         assert radar_obj, 'Could not fetch radar object for id {}'.format(radar_id)
@@ -54,7 +73,10 @@ class Conflict(Command):
 
         repo_name = remote.name if '/' not in remote.name else remote.name.split('/', 1)[-1]
         for entry in radar_obj.source_changes:
-            repo, action, sha = entry.split(', ')
+            parsed = cls.parse_source_change(entry)
+            if not parsed:
+                continue
+            repo, action, sha = parsed
             if repo.lower() == repo_name.lower():
                 shas.append(sha)
 
@@ -62,12 +84,22 @@ class Conflict(Command):
             print(f'No source changes for {repo_name} found in {radar_obj}', file=sys.stderr)
             return None
 
-        integration_branches = []
-        for prefix in ('ci', 'conflict'):
-            integration_branches.append("{}/{}/{}_{}".format(cls.INTEGRATION_BRANCH_PREFIX, prefix, shas[0][:Commit.HASH_LABEL_SIZE], shas[-1][:Commit.HASH_LABEL_SIZE]))
+        # Order candidates by likelihood of a hit: a conflict PR is created per
+        # source change, so <sha>_<sha> under the 'conflict' prefix is by far the
+        # common case; ranges (either ordering, since source_changes order isn't
+        # guaranteed) and the 'ci' prefix are fallbacks.
+        sha_pairs = [(sha, sha) for sha in shas]
+        sha_pairs += [(first, last) for first in shas for last in shas if first != last]
+        sha_pairs = list(dict.fromkeys(sha_pairs))
+        integration_branches = [
+            "{}/{}/{}_{}".format(cls.INTEGRATION_BRANCH_PREFIX, prefix, first[:Commit.HASH_LABEL_SIZE], last[:Commit.HASH_LABEL_SIZE])
+            for prefix in cls.INTEGRATION_BRANCH_TYPES
+            for first, last in sha_pairs
+        ]
 
-        for pr in cls.get_open_integration_prs(remote):
-            for branch in integration_branches:
+        prs = list(cls.get_open_integration_prs(remote))
+        for branch in integration_branches:
+            for pr in prs:
                 if pr.head.startswith(branch):
                     return pr
 
@@ -112,7 +144,10 @@ class Conflict(Command):
         msg += "you can run the following commands. Warning: This will require a force push. Any changes made to the pull request branch will therefore be lost."
         msg += f'\n\ngit reset --hard {source_remote}/{conflict_pr.base}\n'
         for source in radar_obj.source_changes:
-            source_sha = source.split(', ')[2]
+            parsed = cls.parse_source_change(source)
+            if not parsed:
+                continue
+            source_sha = parsed[2]
             msg += 'git cherry-pick {}\n'.format(source_sha)
         print(msg)
         return checkout_response

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/conflict_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/conflict_unittest.py
@@ -55,6 +55,37 @@ class TestConflict(testing.PathTestCase):
         rdar.id = 1234
         return rdar
 
+    def _mock_radar_response_malformed(self, *args, **kwargs):
+        # A radar's sourceChanges field is free-form text. When a merge has
+        # multiple source changes they are separated by a blank line, so
+        # splitlines() yields an empty string between entries (rdar://181637205).
+        # That empty line must be skipped rather than crash the 'repo, action,
+        # sha' parse. Uses two distinct shas so the branch is built from the
+        # first and last change.
+        rdar = bmocks.Radar()
+        rdar.sourceChanges = '\n'.join([
+            'WebKit, merge, sha123',
+            '',
+            'WebKit, merge, sha456',
+        ])
+        rdar.source_changes = rdar.sourceChanges.splitlines()
+        rdar.id = 1234
+        return rdar
+
+    def _mock_radar_response_reversed(self, *args, **kwargs):
+        # Source changes are not guaranteed to be ordered the same way the branch
+        # was named: here the branch is sha123_sha456 but the radar lists the
+        # changes in the opposite order, so shas[0]_shas[-1] alone (sha456_sha123)
+        # would not match. Every ordered pair must be tried.
+        rdar = bmocks.Radar()
+        rdar.sourceChanges = '\n'.join([
+            'WebKit, merge, sha456',
+            'WebKit, merge, sha123',
+        ])
+        rdar.source_changes = rdar.sourceChanges.splitlines()
+        rdar.id = 1234
+        return rdar
+
     def test_conflict_not_found(self):
         with (
             OutputCapture() as captured,
@@ -70,6 +101,10 @@ class TestConflict(testing.PathTestCase):
             self.assertEqual(captured.stderr.getvalue(), 'No conflict pull request found with branch integration/conflict/1234\n')
 
     def test_conflict_found(self):
+        # Single source change: the radar lists one 'WebKit, merge, sha123'
+        # entry, so shas[0] == shas[-1] and the branch is the common
+        # <sha>_<sha> shape produced when a conflict PR is created per source
+        # change.
         with (
             OutputCapture(),
             mocks.remote.GitHub() as remote,
@@ -125,3 +160,177 @@ class TestConflict(testing.PathTestCase):
             ).branch)
 
             self.assertEqual('a5fe8afe9bf7d07158fcd9e9732ff02a712db2fd', local.Git(self.path).commit().hash)
+
+    def test_conflict_malformed_source_changes(self):
+        # Regression test: when a radar has multiple source changes they are
+        # separated by a blank line, so splitlines() yields an empty string
+        # that must not crash the 'repo, action, sha' parse (rdar://181637205).
+        # The branch is reconstructed from the first and last change's sha.
+        with (
+            OutputCapture(),
+            mocks.remote.GitHub() as remote,
+            mocks.local.Git(self.path, remote='https://{}'.format(remote.remote)) as repo,
+            mocks.local.Svn(),
+            patch('webkitscmpy.program.conflict.Tracker.from_string', TestConflict._mock_radar_response_malformed),
+            patch('webkitscmpy.program.conflict.Conflict.get_open_integration_prs', lambda x: [Mock(head='integration/conflict/sha123_sha456/target_branch', _metadata={'full_name': 'tcontributor'})])
+        ):
+            remote.users = dict(
+                rreviewer=Contributor('Ricky Reviewer', ['rreviewer@webkit.org'], github='rreviewer'),
+                tcontributor=Contributor('Tim Contributor', ['tcontributor@webkit.org'], github='tcontributor'),
+            )
+            remote.issues = {
+                1: dict(
+                    comments=[],
+                    assignees=[],
+                )
+            }
+            remote.pull_requests = [dict(
+                number=1,
+                state='open',
+                title='Example Change',
+                user=dict(login='tcontributor'),
+                body='''#### a5fe8afe9bf7d07158fcd9e9732ff02a712db2fd
+            <pre>
+            To Be Committed
+
+            Reviewed by NOBODY (OOPS!).
+            </pre>
+            ''',
+                head=dict(ref='tcontributor:integration/conflict/sha123_sha456/target_branch'),
+                base=dict(ref='main'),
+                requested_reviews=[dict(login='rreviewer')],
+                reviews=[dict(user=dict(login='rreviewer'), state='CHANGES_REQUESTED')],
+                draft=False,
+            )]
+            repo.edit_config('remote.tcontributor.url', 'https://github.com/tcontributor/WebKit')
+            repo.commits['remotes/tcontributor/integration/conflict/sha123_sha456/target_branch'] = [
+                repo.commits[repo.default_branch][2],
+                Commit(
+                    hash='a5fe8afe9bf7d07158fcd9e9732ff02a712db2fd',
+                    identifier="3.1@integration/conflict/sha123_sha456/target_branch",
+                    timestamp=int(time.time()) - 60,
+                    author=Contributor('Tim Committer', ['tcommitter@webkit.org']),
+                    message='To Be Committed\n\nReviewed by NOBODY (OOPS!).\n',
+                )
+            ]
+
+            self.assertEqual('integration/conflict/sha123_sha456/target_branch', program.main(
+                args=('conflict', '1234'),
+                path=self.path,
+            ).branch)
+
+    def test_conflict_single_endpoint_branch(self):
+        # Regression test: a radar may accumulate multiple source changes across
+        # independent merges, in which case the conflict branch is named after a
+        # single change repeated (<sha>_<sha>) rather than the first..last range
+        # (rdar://181637205, whose branch is d01d9e5b_d01d9e5b even though it has
+        # two source changes). find_conflict_pr must still locate the PR.
+        with (
+            OutputCapture(),
+            mocks.remote.GitHub() as remote,
+            mocks.local.Git(self.path, remote='https://{}'.format(remote.remote)) as repo,
+            mocks.local.Svn(),
+            patch('webkitscmpy.program.conflict.Tracker.from_string', TestConflict._mock_radar_response_malformed),
+            patch('webkitscmpy.program.conflict.Conflict.get_open_integration_prs', lambda x: [Mock(head='integration/conflict/sha123_sha123/target_branch', _metadata={'full_name': 'tcontributor'})])
+        ):
+            remote.users = dict(
+                rreviewer=Contributor('Ricky Reviewer', ['rreviewer@webkit.org'], github='rreviewer'),
+                tcontributor=Contributor('Tim Contributor', ['tcontributor@webkit.org'], github='tcontributor'),
+            )
+            remote.issues = {
+                1: dict(
+                    comments=[],
+                    assignees=[],
+                )
+            }
+            remote.pull_requests = [dict(
+                number=1,
+                state='open',
+                title='Example Change',
+                user=dict(login='tcontributor'),
+                body='''#### a5fe8afe9bf7d07158fcd9e9732ff02a712db2fd
+            <pre>
+            To Be Committed
+
+            Reviewed by NOBODY (OOPS!).
+            </pre>
+            ''',
+                head=dict(ref='tcontributor:integration/conflict/sha123_sha123/target_branch'),
+                base=dict(ref='main'),
+                requested_reviews=[dict(login='rreviewer')],
+                reviews=[dict(user=dict(login='rreviewer'), state='CHANGES_REQUESTED')],
+                draft=False,
+            )]
+            repo.edit_config('remote.tcontributor.url', 'https://github.com/tcontributor/WebKit')
+            repo.commits['remotes/tcontributor/integration/conflict/sha123_sha123/target_branch'] = [
+                repo.commits[repo.default_branch][2],
+                Commit(
+                    hash='a5fe8afe9bf7d07158fcd9e9732ff02a712db2fd',
+                    identifier="3.1@integration/conflict/sha123_sha123/target_branch",
+                    timestamp=int(time.time()) - 60,
+                    author=Contributor('Tim Committer', ['tcommitter@webkit.org']),
+                    message='To Be Committed\n\nReviewed by NOBODY (OOPS!).\n',
+                )
+            ]
+
+            self.assertEqual('integration/conflict/sha123_sha123/target_branch', program.main(
+                args=('conflict', '1234'),
+                path=self.path,
+            ).branch)
+
+    def test_conflict_source_changes_out_of_order(self):
+        # Regression test: the branch (sha123_sha456) is named in the opposite
+        # order from how the radar lists its source changes (sha456, sha123), so
+        # only shas[0]_shas[-1] would miss it. Every ordered pair must be tried.
+        with (
+            OutputCapture(),
+            mocks.remote.GitHub() as remote,
+            mocks.local.Git(self.path, remote='https://{}'.format(remote.remote)) as repo,
+            mocks.local.Svn(),
+            patch('webkitscmpy.program.conflict.Tracker.from_string', TestConflict._mock_radar_response_reversed),
+            patch('webkitscmpy.program.conflict.Conflict.get_open_integration_prs', lambda x: [Mock(head='integration/conflict/sha123_sha456/target_branch', _metadata={'full_name': 'tcontributor'})])
+        ):
+            remote.users = dict(
+                rreviewer=Contributor('Ricky Reviewer', ['rreviewer@webkit.org'], github='rreviewer'),
+                tcontributor=Contributor('Tim Contributor', ['tcontributor@webkit.org'], github='tcontributor'),
+            )
+            remote.issues = {
+                1: dict(
+                    comments=[],
+                    assignees=[],
+                )
+            }
+            remote.pull_requests = [dict(
+                number=1,
+                state='open',
+                title='Example Change',
+                user=dict(login='tcontributor'),
+                body='''#### a5fe8afe9bf7d07158fcd9e9732ff02a712db2fd
+            <pre>
+            To Be Committed
+
+            Reviewed by NOBODY (OOPS!).
+            </pre>
+            ''',
+                head=dict(ref='tcontributor:integration/conflict/sha123_sha456/target_branch'),
+                base=dict(ref='main'),
+                requested_reviews=[dict(login='rreviewer')],
+                reviews=[dict(user=dict(login='rreviewer'), state='CHANGES_REQUESTED')],
+                draft=False,
+            )]
+            repo.edit_config('remote.tcontributor.url', 'https://github.com/tcontributor/WebKit')
+            repo.commits['remotes/tcontributor/integration/conflict/sha123_sha456/target_branch'] = [
+                repo.commits[repo.default_branch][2],
+                Commit(
+                    hash='a5fe8afe9bf7d07158fcd9e9732ff02a712db2fd',
+                    identifier="3.1@integration/conflict/sha123_sha456/target_branch",
+                    timestamp=int(time.time()) - 60,
+                    author=Contributor('Tim Committer', ['tcommitter@webkit.org']),
+                    message='To Be Committed\n\nReviewed by NOBODY (OOPS!).\n',
+                )
+            ]
+
+            self.assertEqual('integration/conflict/sha123_sha456/target_branch', program.main(
+                args=('conflict', '1234'),
+                path=self.path,
+            ).branch)


### PR DESCRIPTION
#### e3d525653f607bdda5953aefd2687df67d9e69d8
<pre>
[git-webkit] conflict command fails on radars with multiple source changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=318896">https://bugs.webkit.org/show_bug.cgi?id=318896</a>
<a href="https://rdar.apple.com/181637205">rdar://181637205</a>

Two problems prevented `git-webkit conflict &lt;radar&gt;` from working when a
radar had more than one source change (as <a href="https://rdar.apple.com/181547077">rdar://181547077</a> does):

1. Crash: when a merge records multiple source changes, the radar&apos;s
   sourceChanges field separates them with a blank line, so splitlines()
   yields an empty string between entries. The rigid
   `repo, action, sha = entry.split(&apos;, &apos;)` unpack raised &quot;ValueError: not
   enough values to unpack (expected 3, got 1)&quot;.

2. Wrong branch: a conflict PR is created per source change, so a conflict
   branch is almost always &lt;sha&gt;_&lt;sha&gt;. A radar&apos;s source_changes accumulates
   across independent merges with no guaranteed ordering relative to how the
   branch was named. <a href="https://rdar.apple.com/181547077&apos">rdar://181547077&apos</a>;s branch is
   integration/conflict/d01d9e5bf607_d01d9e5bf607 even though it lists two
   source changes, and the old shas[0]_shas[-1]-only reconstruction produced
   d01d9e5bf607_00a7e8b31f8a, which matched no branch.

Add Conflict.parse_source_change, which returns a (repo, action, sha)
tuple only for well-formed entries and None otherwise, and skip entries
that do not parse. Because we can&apos;t assume how source_changes is ordered,
build candidate branch names from every ordered pair of shas, ordered by
likelihood of a hit: &lt;sha&gt;_&lt;sha&gt; under the &apos;conflict&apos; prefix first, then
ranges and the &apos;ci&apos; prefix. Hoist the branch-type prefixes into the
INTEGRATION_BRANCH_TYPES constant.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/conflict.py:
(Conflict.INTEGRATION_BRANCH_TYPES): Added.
(Conflict.parse_source_change): Added.
(Conflict.find_conflict_pr): Skip unparseable entries; try every ordered
pair of source-change shas as a candidate branch name, most-likely first.
(Conflict.main): Skip unparseable entries in the cherry-pick message.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/conflict_unittest.py:
(TestConflict.test_conflict_found): Note it covers the single source
change case.
(TestConflict._mock_radar_response_malformed): Added.
(TestConflict._mock_radar_response_reversed): Added.
(TestConflict.test_conflict_malformed_source_changes): Added.
(TestConflict.test_conflict_single_endpoint_branch): Added.
(TestConflict.test_conflict_source_changes_out_of_order): Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e3d525653f607bdda5953aefd2687df67d9e69d8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173342 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47274 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41343 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182915 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130898 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4e0a8080-690f-425e-8ecd-bf908466ad4d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175207 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48567 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46956 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134783 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95179 "1 flakes 4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6488059b-04e9-4333-a839-5b121e48dbc8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176300 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38200 "Found 1 new test failure: fast/css/getComputedStyle-font-variant-shorthand-crash.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155806 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115258 "Found 1 new API test failure: WPE/TestWebKitWebView:/webkit/WebKitWebView/save (failure)") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/172663 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36842 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35194 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31400 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147266 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35300 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185339 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39396 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143641 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/172742 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46942 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143509 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47621 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31916 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/112722 "The change is no longer eligible for processing.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38455 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46127 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10255 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45529 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45760 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45586 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->