### PR TITLE
Pasting Confluence content is rendered incorrectly if in Dark Mode

### DIFF
--- a/LayoutTests/editing/pasteboard/paste-canvas-background-dark-mode-expected.txt
+++ b/LayoutTests/editing/pasteboard/paste-canvas-background-dark-mode-expected.txt
@@ -1,0 +1,42 @@
+Pasting into a punch-out dark editor (like Mail compose) drops light canvas-like backgrounds and keeps intentional ones.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+--- Dropped: opaque light canvas-like backgrounds ---
+PASS nearWhiteBackground is ""
+PASS lightGrayBackground is ""
+--- Dropped: light background from an unresolved var() fallback (design-system content) ---
+PASS varLightBackground is ""
+--- Dropped: near-black neutral page surface (e.g. dark-mode Confluence #1d2125) ---
+PASS darkSurfaceBackground is ""
+PASS darkSurfaceShorthand is ""
+PASS darkSurfaceVar is ""
+PASS lightSurfaceShorthand is ""
+--- Dropped: near-black neutral surface on an inline element (single-paragraph wrapping span) ---
+PASS darkInlineBackground is ""
+--- Kept: dark but saturated block background (not neutral) ---
+PASS darkSaturatedBackground is "rgb(0, 0, 60)"
+--- Edge cases: element type and threshold boundaries ---
+PASS darkInlineBlockBackground is ""
+PASS boundaryLightnessKept is "rgb(150, 150, 150)"
+PASS boundaryLightnessDropped is ""
+PASS boundaryDarkKept is "rgb(51, 51, 51)"
+PASS nearOpaqueBackground is "rgba(244, 245, 247, 0.99)"
+--- Kept: pure white (renderer punches it out; not dropped here) ---
+PASS pureWhiteBackground is "rgb(255, 255, 255)"
+--- Kept: vivid author background (below the lightness threshold) ---
+PASS vividBackground is "rgb(255, 193, 7)"
+PASS varVividBackground.length > 0 is true
+PASS darkVividBackground is "rgb(0, 135, 90)"
+--- Kept: translucent (not opaque) ---
+PASS translucentBackground is "rgba(255, 255, 255, 0.3)"
+--- Kept: an element with an explicit transparent background keeps its own foreground color ---
+PASS transparentForeground is "rgb(30, 30, 30)"
+--- Kept: semantic / dynamic colors are not dropped ---
+PASS canvasBackground is "rgb(255, 255, 255)"
+PASS currentColorBackground is "currentcolor"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/pasteboard/paste-canvas-background-dark-mode.html
+++ b/LayoutTests/editing/pasteboard/paste-canvas-background-dark-mode.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html><!-- webkit-test-runner [ ColorFilterEnabled=true PunchOutWhiteBackgroundsInDarkMode=true ] -->
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<style> :root { color-scheme: dark; -apple-color-filter: apple-invert-lightness(); } </style>
+</head>
+<body>
+<p id="description"></p>
+<div id="console"></div>
+<script>
+description("Pasting into a punch-out dark editor (like Mail compose) drops light canvas-like backgrounds and keeps intentional ones.");
+
+if (window.internals)
+    internals.settings.setUseDarkAppearance(true);
+if (window.textInputController)
+    textInputController.setPageEditable(true);
+
+function pastedBackgroundColorFor(inlineStyle)
+{
+    let editor = document.createElement("div");
+    editor.contentEditable = true;
+    editor.textContent = "placeholder";
+    document.body.appendChild(editor);
+    editor.focus();
+    getSelection().selectAllChildren(editor);
+    document.execCommand("insertHTML", false, "<p style='" + inlineStyle + "'>content</p>");
+    let paragraph = editor.querySelector("p");
+    let result = paragraph ? paragraph.style.backgroundColor : "(no paragraph)";
+    editor.remove();
+    return result;
+}
+
+function pastedForegroundColorFor(inlineStyle)
+{
+    let editor = document.createElement("div");
+    editor.contentEditable = true;
+    editor.textContent = "placeholder";
+    document.body.appendChild(editor);
+    editor.focus();
+    getSelection().selectAllChildren(editor);
+    document.execCommand("insertHTML", false, "<p style='" + inlineStyle + "'>content</p>");
+    let paragraph = editor.querySelector("p");
+    let result = paragraph ? paragraph.style.color : "(no paragraph)";
+    editor.remove();
+    return result;
+}
+
+function pastedBackgroundColorForHTML(html, selector)
+{
+    let editor = document.createElement("div");
+    editor.contentEditable = true;
+    editor.textContent = "placeholder";
+    document.body.appendChild(editor);
+    editor.focus();
+    getSelection().selectAllChildren(editor);
+    document.execCommand("insertHTML", false, html);
+    let element = editor.querySelector(selector);
+    let result = element ? element.style.backgroundColor : "(no element)";
+    editor.remove();
+    return result;
+}
+
+debug("--- Dropped: opaque light canvas-like backgrounds ---");
+nearWhiteBackground = pastedBackgroundColorFor("background-color: rgb(244, 245, 247); color: rgb(23, 43, 77)");
+shouldBeEqualToString("nearWhiteBackground", "");
+lightGrayBackground = pastedBackgroundColorFor("background-color: rgb(230, 230, 230); color: rgb(23, 43, 77)");
+shouldBeEqualToString("lightGrayBackground", "");
+
+debug("--- Dropped: light background from an unresolved var() fallback (design-system content) ---");
+varLightBackground = pastedBackgroundColorFor("background-color: var(--undefined-token, rgb(171, 245, 209)); color: rgb(23, 43, 77)");
+shouldBeEqualToString("varLightBackground", "");
+
+debug("--- Dropped: near-black neutral page surface (e.g. dark-mode Confluence #1d2125) ---");
+darkSurfaceBackground = pastedBackgroundColorFor("background-color: rgb(29, 33, 37); color: rgb(23, 43, 77)");
+shouldBeEqualToString("darkSurfaceBackground", "");
+darkSurfaceShorthand = pastedBackgroundColorForHTML("<p id='t' style='background: rgb(29, 33, 37); color: rgb(23, 43, 77)'>content</p>", "#t");
+shouldBeEqualToString("darkSurfaceShorthand", "");
+darkSurfaceVar = pastedBackgroundColorForHTML("<p id='t' style='background-color: var(--undefined-token, rgb(29, 33, 37)); color: rgb(23, 43, 77)'>content</p>", "#t");
+shouldBeEqualToString("darkSurfaceVar", "");
+lightSurfaceShorthand = pastedBackgroundColorForHTML("<p id='t' style='background: rgb(244, 245, 247); color: rgb(23, 43, 77)'>content</p>", "#t");
+shouldBeEqualToString("lightSurfaceShorthand", "");
+
+debug("--- Dropped: near-black neutral surface on an inline element (single-paragraph wrapping span) ---");
+darkInlineBackground = pastedBackgroundColorForHTML("<span id='t' style='background-color: rgb(29, 33, 37); color: rgb(23, 43, 77)'>content</span>", "#t");
+shouldBeEqualToString("darkInlineBackground", "");
+
+debug("--- Kept: dark but saturated block background (not neutral) ---");
+darkSaturatedBackground = pastedBackgroundColorForHTML("<p id='t' style='background-color: rgb(0, 0, 60); color: rgb(23, 43, 77)'>content</p>", "#t");
+shouldBeEqualToString("darkSaturatedBackground", "rgb(0, 0, 60)");
+
+debug("--- Edge cases: element type and threshold boundaries ---");
+darkInlineBlockBackground = pastedBackgroundColorForHTML("<span id='t' style='display: inline-block; background-color: rgb(29, 33, 37); color: rgb(23, 43, 77)'>content</span>", "#t");
+shouldBeEqualToString("darkInlineBlockBackground", "");
+boundaryLightnessKept = pastedBackgroundColorFor("background-color: rgb(150, 150, 150); color: rgb(23, 43, 77)");
+shouldBeEqualToString("boundaryLightnessKept", "rgb(150, 150, 150)");
+boundaryLightnessDropped = pastedBackgroundColorFor("background-color: rgb(155, 155, 155); color: rgb(23, 43, 77)");
+shouldBeEqualToString("boundaryLightnessDropped", "");
+boundaryDarkKept = pastedBackgroundColorFor("background-color: rgb(51, 51, 51); color: rgb(23, 43, 77)");
+shouldBeEqualToString("boundaryDarkKept", "rgb(51, 51, 51)");
+nearOpaqueBackground = pastedBackgroundColorFor("background-color: rgba(244, 245, 247, 0.99); color: rgb(23, 43, 77)");
+shouldBeEqualToString("nearOpaqueBackground", "rgba(244, 245, 247, 0.99)");
+
+debug("--- Kept: pure white (renderer punches it out; not dropped here) ---");
+pureWhiteBackground = pastedBackgroundColorFor("background-color: rgb(255, 255, 255); color: rgb(23, 43, 77)");
+shouldBeEqualToString("pureWhiteBackground", "rgb(255, 255, 255)");
+
+debug("--- Kept: vivid author background (below the lightness threshold) ---");
+vividBackground = pastedBackgroundColorFor("background-color: rgb(255, 193, 7); color: rgb(23, 43, 77)");
+shouldBeEqualToString("vividBackground", "rgb(255, 193, 7)");
+varVividBackground = pastedBackgroundColorFor("background-color: var(--undefined-token, rgb(0, 135, 90)); color: rgb(23, 43, 77)");
+shouldBeTrue("varVividBackground.length > 0");
+darkVividBackground = pastedBackgroundColorFor("background-color: rgb(0, 135, 90); color: rgb(23, 43, 77)");
+shouldBeEqualToString("darkVividBackground", "rgb(0, 135, 90)");
+
+debug("--- Kept: translucent (not opaque) ---");
+translucentBackground = pastedBackgroundColorFor("background-color: rgba(255, 255, 255, 0.3); color: rgb(23, 43, 77)");
+shouldBeEqualToString("translucentBackground", "rgba(255, 255, 255, 0.3)");
+
+debug("--- Kept: an element with an explicit transparent background keeps its own foreground color ---");
+transparentForeground = pastedForegroundColorFor("background-color: transparent; color: rgb(30, 30, 30)");
+shouldBeEqualToString("transparentForeground", "rgb(30, 30, 30)");
+
+debug("--- Kept: semantic / dynamic colors are not dropped ---");
+canvasBackground = pastedBackgroundColorFor("background-color: Canvas; color: CanvasText");
+shouldBeEqualToString("canvasBackground", "rgb(255, 255, 255)");
+currentColorBackground = pastedBackgroundColorFor("background-color: currentColor; color: rgb(23, 43, 77)");
+shouldBeEqualToString("currentColorBackground", "currentcolor");
+</script>
+</body>
+</html>

--- a/Source/WebCore/editing/ReplaceSelectionCommand.cpp
+++ b/Source/WebCore/editing/ReplaceSelectionCommand.cpp
@@ -573,10 +573,25 @@ bool ReplaceSelectionCommand::shouldMerge(const VisiblePosition& source, const V
         && !isBlock(*sourceNode) && !isBlock(*destinationNode);
 }
 
+static bool isLightEnoughToTreatAsBackground(double lightness)
+{
+    return lightness > 0.6;
+}
+
+static bool isLightOrDarkNeutralBackgroundColor(const Color& color)
+{
+    auto lightness = color.lightness();
+    if (isLightEnoughToTreatAsBackground(lightness))
+        return true;
+
+    constexpr double lightnessDarkEnoughForBackground = 0.2;
+    constexpr float maxSaturationToTreatAsNeutral = 20;
+    return lightness < lightnessDarkEnoughForBackground && color.toColorTypeLossy<HSLA<float>>().resolved().saturation < maxSaturationToTreatAsNeutral;
+}
+
 static bool nodeTreeHasInlineStyleWithLegibleColorForInvertLightness(const Node& node, std::optional<double> textLightness, std::optional<double> backgroundLightness)
 {
     constexpr double lightnessDarkEnoughForText = 0.4;
-    constexpr double lightnessLightEnoughForBackground = 0.6;
 
     constexpr auto lightnessIgnoringSemanticColors = [](const std::optional<Color>& color) -> std::optional<double> {
         if (!color || !color->isVisible() || color->isSemantic())
@@ -589,7 +604,7 @@ static bool nodeTreeHasInlineStyleWithLegibleColorForInvertLightness(const Node&
         if (textLightness && *textLightness < lightnessDarkEnoughForText)
             return true;
 
-        if (backgroundLightness && *backgroundLightness > lightnessLightEnoughForBackground)
+        if (backgroundLightness && isLightEnoughToTreatAsBackground(*backgroundLightness))
             return true;
 
         return false;
@@ -2015,7 +2030,7 @@ void ReplaceSelectionCommand::updateDirectionForStartOfInsertedContentIfNeeded(c
         setEndingSelection(originalEndingSelection);
 }
 
-using ElementToStyleProperties = HashMap<Ref<StyledElement>, Vector<CSSPropertyID, 2>>;
+using ElementToStyleProperties = HashMap<Ref<StyledElement>, Vector<CSSPropertyID, 3>>;
 [[nodiscard]] static IterationStatus collectStylesToRemove(Node& node, const Node& lastLeaf, double backgroundLuminance, ElementToStyleProperties& stylesToRemove)
 {
     auto addStylesToRemove = [&](StyledElement& element) {
@@ -2031,13 +2046,19 @@ using ElementToStyleProperties = HashMap<Ref<StyledElement>, Vector<CSSPropertyI
             return;
 
         Ref document = node.document();
-        if (auto color = style->propertyAsColor(CSSPropertyBackgroundColor)) {
-            auto compositeOperator = document->compositeOperatorForBackgroundColor(*color, *renderer);
-            if (compositeOperator != CompositeOperator::DestinationIn && compositeOperator != CompositeOperator::DestinationOut)
-                return;
+        Vector<CSSPropertyID, 3> propertiesToRemove;
+        if (auto inlineBackgroundColor = style->propertyAsColor(CSSPropertyBackgroundColor)) {
+            bool inlineColorIsValid = inlineBackgroundColor->isValid();
+            auto backgroundColor = inlineColorIsValid ? *inlineBackgroundColor : renderer->style().visitedDependentBackgroundColor();
+            auto compositeOperator = document->compositeOperatorForBackgroundColor(backgroundColor, *renderer);
+            if (compositeOperator != CompositeOperator::DestinationIn && compositeOperator != CompositeOperator::DestinationOut) {
+                bool inlineColorIsSemantic = inlineColorIsValid && inlineBackgroundColor->isSemantic();
+                if (inlineColorIsSemantic || !document->settings().punchOutWhiteBackgroundsInDarkMode() || !backgroundColor.isOpaque() || !isLightOrDarkNeutralBackgroundColor(backgroundColor))
+                    return;
+                propertiesToRemove.append(CSSPropertyBackgroundColor);
+            }
         }
 
-        Vector<CSSPropertyID, 2> propertiesToRemove;
         for (auto property : { CSSPropertyColor, CSSPropertyCaretColor }) {
             auto color = style->propertyAsColor(property);
             if (!color)

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/PasteHTML.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/PasteHTML.mm
@@ -619,6 +619,30 @@ TEST(PasteHTML, PasteDarkTextOnWhiteBackgroundIntoDarkModeEditor)
     EXPECT_WK_STREQ(computedCaretColor.get(), "rgb(255, 255, 255)");
 }
 
+TEST(PasteHTML, DropsCanvasLikeBackgroundWhenPastingIntoPunchOutEditor)
+{
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
+    [configuration _setColorFilterEnabled:YES];
+    [configuration preferences]._punchOutWhiteBackgroundsInDarkMode = YES;
+    auto preferences = (__bridge WKPreferencesRef)[configuration preferences];
+    WKPreferencesSetDataTransferItemsEnabled(preferences, true);
+    WKPreferencesSetCustomPasteboardDataEnabled(preferences, true);
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration]);
+    [webView _setEditable:YES];
+    [webView forceDarkMode];
+    [webView synchronouslyLoadTestPageNamed:@"rich-color-filtered"];
+
+    writeHTMLToPasteboard(@"<p style=\"color: rgb(23, 43, 77); background-color: rgb(244, 245, 247);\">Overview</p>"
+        "<p style=\"color: rgb(23, 43, 77); background-color: rgb(255, 193, 7);\">At risk</p>");
+
+    [webView stringByEvaluatingJavaScript:@"selectRichText()"];
+    [webView paste:nil];
+
+    EXPECT_WK_STREQ([webView stringByEvaluatingJavaScript:@"rich.querySelectorAll('p')[0].style.backgroundColor"], @"");
+    EXPECT_WK_STREQ([webView stringByEvaluatingJavaScript:@"rich.querySelectorAll('p')[1].style.backgroundColor"], @"rgb(255, 193, 7)");
+}
+
 #endif // ENABLE(DARK_MODE_CSS)
 
 #endif // PLATFORM(COCOA)


### PR DESCRIPTION
#### ad620275e07cc44aee2bcd5cce7855ed78808e39
<pre>
Pasting Confluence content is rendered incorrectly if in Dark Mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=318886">https://bugs.webkit.org/show_bug.cgi?id=318886</a>
<a href="https://rdar.apple.com/178843535">rdar://178843535</a>

Reviewed by Wenson Hsieh and Ryosuke Niwa.

The problem:
This is a regression from bug 308854 (<a href="https://rdar.apple.com/171391621">rdar://171391621</a>), which made copy
preserve the source page&apos;s background-color on the pasted content (matching
Chrome). Multi-paragraph copy writes it onto each &lt;p&gt;; single-paragraph copy
writes it onto the wrapping &lt;span&gt;. Mail&apos;s compose view renders Dark Mode with
the invert-lightness color filter (plus white punch-out), so the preserved
page surface is pasted verbatim and then bands:
- A light page surface such as #f4f5f7 misses white punch-out (only pure white
  is punched out) and is painted as a solid band.
- A dark-mode page surface such as #1d2125 (rgb(29, 33, 37)) inverts into a
  light band.
- Design-system cells specify their fill as var(--token, #fallback), so the
  raw inline value is an unresolved variable reference rather than a color.
WebKit&apos;s dark-mode paste fixup left all of these alone, and it happened on both
single-paragraph (background on an inline &lt;span&gt;) and multi-paragraph pastes.

The fix:
In ReplaceSelectionCommand&apos;s dark-mode paste fixup (collectStylesToRemove),
when pasting into an editor that punches out white backgrounds in Dark Mode,
drop a pasted element&apos;s background-color when it is a canvas-like page surface:
opaque, non-semantic, and either light (lightness &gt; 0.6) or a near-black
neutral (lightness &lt; 0.2 with low saturation). This applies regardless of
whether the element is block-level or inline, so the surface is shed whether
the caused-by placed it on a multi-paragraph &lt;p&gt; or a single-paragraph wrapping
&lt;span&gt;. Saturated status colors (green/red/blue lozenges) survive via the
saturation check; translucent and semantic colors are kept. Pure white is left
to the editor&apos;s existing white punch-out (compositeOperatorForBackgroundColor
returns DestinationIn/Out), so it is not dropped here.

Because a cell&apos;s fill may be a var() reference that propertyAsColor resolves to
an invalid color, the used color is read from the render style
(visitedDependentBackgroundColor) when the inline value is absent or invalid.

The light threshold reuses the constant already used a few functions up for the
invert-lightness legibility check (isLightEnoughToTreatAsBackground), so #f4f5f7
(lightness 0.96) is dropped while a status highlight like #ffc107 (0.51) is
kept. The copy-serialization behavior from bug 308854 (and Chrome parity) is
untouched. This change is entirely on the paste side and only affects editors
that opt into punchOutWhiteBackgroundsInDarkMode.

Note: comparing against documentBackgroundColor() does not work here because it
applies the color filter, so in an invert-lightness editor the canvas reads
dark while the pasted color is raw. lightness() is used (rather than luminance())
to stay consistent with the neighboring heuristic; if we later switch from
lightness() to luminance(), both places should change together.

* Source/WebCore/editing/ReplaceSelectionCommand.cpp:
(WebCore::isLightEnoughToTreatAsBackground): Added; shared lightness threshold.
(WebCore::isLightOrDarkNeutralBackgroundColor): Added; light, or near-black neutral, page surface.
(WebCore::nodeTreeHasInlineStyleWithLegibleColorForInvertLightness): Use the shared threshold.
(WebCore::collectStylesToRemove): Drop canvas-like backgrounds when pasting into a punch-out dark editor, resolving var() fills via the render style.
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/PasteHTML.mm:
(TEST(PasteHTML, DropsCanvasLikeBackgroundWhenPastingIntoPunchOutEditor)): Added.
* LayoutTests/editing/pasteboard/paste-canvas-background-dark-mode.html: Added; covers light/var()/near-black surfaces on block and inline, pure-white punch-out, translucency, boundaries, and kept status colors.
* LayoutTests/editing/pasteboard/paste-canvas-background-dark-mode-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/317029@main">https://commits.webkit.org/317029@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/72a25c164228a826d942ef498d56c03e12f3cb83

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174089 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48022 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41803 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183663 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131957 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/470761d1-4f56-4090-a9df-e204ca6f8637) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175954 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49314 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47704 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135392 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95494 "4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7a0d9903-8558-4bb2-ba64-9de513f7541c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177047 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38824 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156183 "Found 1 new API test failure: TestWebKitAPI.UnifiedPDF.PDFHUDMoveIFrame (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115870 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/effad36b-a98e-405b-8d5e-eff1a2f511a6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37465 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35831 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32147 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147889 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35676 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186089 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39202 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40030 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144293 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47689 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155738 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144153 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38868 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48368 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32293 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113833 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39063 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120254 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46874 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10638 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46277 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46508 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46335 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->