### PR TITLE
[JSC] Make sizeof(Air::Inst) 64

### DIFF
--- a/Source/JavaScriptCore/b3/B3CheckSpecial.cpp
+++ b/Source/JavaScriptCore/b3/B3CheckSpecial.cpp
@@ -75,7 +75,7 @@ unsigned NODELETE numB3Args(Inst& inst)
 CheckSpecial::Key::Key(const Inst& inst)
 {
     m_kind = inst.kind;
-    m_numArgs = inst.args.size();
+    m_numArgs = inst.args().size();
     m_stackmapRole = SameAsRep;
 }
 
@@ -101,10 +101,11 @@ CheckSpecial::~CheckSpecial() = default;
 
 Inst CheckSpecial::hiddenBranch(const Inst& inst) const
 {
-    Inst hiddenBranch(m_checkKind, inst.origin);
-    hiddenBranch.args.appendUsingFunctor(m_numCheckArgs, [&](size_t i) {
-        return inst.args[i + 1];
+    Vector<Arg, 8> args;
+    args.appendUsingFunctor(m_numCheckArgs, [&](size_t i) {
+        return inst.args()[i + 1];
     });
+    Inst hiddenBranch(m_checkKind, inst.origin, WTF::move(args));
     ASSERT(hiddenBranch.isTerminal());
     return hiddenBranch;
 }
@@ -120,8 +121,8 @@ void CheckSpecial::forEachArg(Inst& inst, const ScopedLambda<Inst::EachArgCallba
                 ASSERT(!optionalDefArgWidth); // There can only be one Def'ed arg.
                 optionalDefArgWidth = width;
             }
-            unsigned index = &arg - &hidden.args[0];
-            callback(inst.args[1 + index], role, bank, width);
+            unsigned index = &arg - &hidden.args()[0];
+            callback(inst.args()[1 + index], role, bank, width);
         });
 
     std::optional<unsigned> firstRecoverableIndex;
@@ -140,7 +141,7 @@ bool CheckSpecial::isValid(Inst& inst)
 {
     return hiddenBranch(inst).isValidForm()
         && isValidImpl(numB3Args(inst), m_numCheckArgs + 1, inst)
-        && inst.args.size() - m_numCheckArgs - 1 == inst.origin->numChildren() - numB3Args(inst);
+        && inst.args().size() - m_numCheckArgs - 1 == inst.origin->numChildren() - numB3Args(inst);
 }
 
 bool CheckSpecial::admitsStack(Inst& inst, unsigned argIndex)
@@ -179,7 +180,7 @@ CCallHelpers::Jump CheckSpecial::generate(Inst& inst, CCallHelpers& jit, Generat
     // capture all of inst in the closure below.
     Vector<Arg, 3> args;
     for (unsigned i = 0; i < m_numCheckArgs; ++i)
-        args.append(inst.args[1 + i]);
+        args.append(inst.args()[1 + i]);
 
     context.latePaths.append(std::tuple {
         inst.origin->origin(),

--- a/Source/JavaScriptCore/b3/B3LowerToAir.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerToAir.cpp
@@ -1736,9 +1736,10 @@ private:
     {
         auto printList = Printer::makePrintRecordList(arguments...);
         auto printSpecial = static_cast<Air::PrintSpecial*>(m_code.addSpecial(makeUnique<Air::PrintSpecial>(printList)));
-        Inst inst(Air::Patch, origin, Arg::special(printSpecial));
-        Printer::appendAirArgs(inst, std::forward<Arguments>(arguments)...);
-        append(WTF::move(inst));
+        Vector<Arg> args;
+        args.append(Arg::special(printSpecial));
+        Printer::appendAirArgs(args, std::forward<Arguments>(arguments)...);
+        append(Inst(Air::Patch, origin, WTF::move(args)));
     }
 
     template<typename... Arguments>
@@ -1814,7 +1815,8 @@ private:
         return ensureSpecial(result.iterator->value, key);
     }
 
-    void fillStackmap(Inst& inst, StackmapValue* stackmap, unsigned numSkipped)
+    template<size_t argsInlineCapacity>
+    void fillStackmap(Vector<Arg, argsInlineCapacity>& args, StackmapValue* stackmap, unsigned numSkipped)
     {
         for (unsigned i = numSkipped; i < stackmap->numChildren(); ++i) {
             ConstrainedValue value = stackmap->constrainedChild(i);
@@ -1863,7 +1865,7 @@ private:
                 RELEASE_ASSERT_NOT_REACHED();
                 break;
             }
-            inst.args.append(arg);
+            args.append(arg);
         }
     }
     
@@ -6047,7 +6049,8 @@ private:
             if (deferToAfterRegAlloc) {
                 m_procedure.setUsesColdCCall(true);
 
-                Inst inst(Air::ColdCCall, cCall, Arg::special(m_code.cCallSpecial()));
+                Vector<Arg, 8> args;
+                args.append(Arg::special(m_code.cCallSpecial()));
 
                 // We have a ton of flexibility regarding the callee argument, but currently, we don't
                 // use it yet. It gets weird for reasons:
@@ -6058,18 +6061,18 @@ private:
                 // 4) We don't have an isValidForm() for the CCallSpecial so we have no smart way to
                 //    decide.
                 // FIXME: https://bugs.webkit.org/show_bug.cgi?id=151052
-                inst.args.append(tmp(cCall->child(0)));
+                args.append(tmp(cCall->child(0)));
 
                 if (cCall->type() != Void) {
                     forEachImmOrTmp(cCall, [&](Arg arg, Type, unsigned) {
-                        inst.args.append(arg.tmp());
+                        args.append(arg.tmp());
                     });
                 }
 
                 for (unsigned i = 1; i < cCall->numChildren(); ++i)
-                    inst.args.append(immOrTmp(cCall->child(i)));
+                    args.append(immOrTmp(cCall->child(i)));
 
-                append(WTF::move(inst));
+                append(Inst(Air::ColdCCall, cCall, WTF::move(args)));
                 return;
             }
 
@@ -6171,7 +6174,8 @@ private:
             PatchpointValue* patchpointValue = m_value->as<PatchpointValue>();
             ensureSpecial(m_patchpointSpecial);
             
-            Inst inst(Patch, patchpointValue, Arg::special(m_patchpointSpecial));
+            Vector<Arg, 8> args;
+            args.append(Arg::special(m_patchpointSpecial));
 
             Vector<Inst> after;
             auto generateResultOperand = [&] (Type type, ValueRep rep, Tmp tmp) {
@@ -6182,17 +6186,17 @@ private:
                 case ValueRep::SomeRegister:
                 case ValueRep::SomeEarlyRegister:
                 case ValueRep::SomeLateRegister:
-                    inst.args.append(tmp);
+                    args.append(tmp);
                     return;
                 case ValueRep::Register: {
                     Tmp reg = Tmp(rep.reg());
-                    inst.args.append(reg);
+                    args.append(reg);
                     after.append(Inst(relaxedMoveForType(type), m_value, reg, tmp));
                     return;
                 }
                 case ValueRep::StackArgument: {
                     Arg arg = Arg::callArg(rep.offsetFromSP());
-                    inst.args.append(arg);
+                    args.append(arg);
                     after.append(Inst(moveForType(type), m_value, arg, tmp));
                     return;
                 }
@@ -6207,19 +6211,19 @@ private:
                     generateResultOperand(type, patchpointValue->resultConstraints[index], arg.tmp());
                 });
             }
-            
-            fillStackmap(inst, patchpointValue, 0);
+
+            fillStackmap(args, patchpointValue, 0);
             for (auto& constraint : patchpointValue->resultConstraints) {
                 if (constraint.isReg())
                     patchpointValue->lateClobbered().remove(constraint.reg());
             }
 
             for (unsigned i = patchpointValue->numGPScratchRegisters; i--;)
-                inst.args.append(m_code.newTmp(GP));
+                args.append(m_code.newTmp(GP));
             for (unsigned i = patchpointValue->numFPScratchRegisters; i--;)
-                inst.args.append(m_code.newTmp(FP));
-            
-            m_insts.last().append(WTF::move(inst));
+                args.append(m_code.newTmp(FP));
+
+            m_insts.last().append(Inst(Patch, patchpointValue, WTF::move(args)));
             m_insts.last().appendVector(after);
             return;
         }
@@ -6251,13 +6255,14 @@ private:
                     opcodeForType(BranchNeg32, BranchNeg64, checkValue->type());
                 CheckSpecial* special = ensureCheckSpecial(opcode, 2);
 
-                Inst inst(Patch, checkValue, Arg::special(special));
-                inst.args.append(Arg::resCond(MacroAssembler::Overflow));
-                inst.args.append(result);
+                Vector<Arg, 8> args;
+                args.append(Arg::special(special));
+                args.append(Arg::resCond(MacroAssembler::Overflow));
+                args.append(result);
 
-                fillStackmap(inst, checkValue, 2);
+                fillStackmap(args, checkValue, 2);
 
-                m_insts.last().append(WTF::move(inst));
+                m_insts.last().append(Inst(Patch, checkValue, WTF::move(args)));
                 return;
             }
 
@@ -6336,16 +6341,17 @@ private:
             
             CheckSpecial* special = ensureCheckSpecial(opcode, 2 + sources.size(), stackmapRole);
             
-            Inst inst(Patch, checkValue, Arg::special(special));
+            Vector<Arg, 8> args;
+            args.append(Arg::special(special));
 
-            inst.args.append(Arg::resCond(MacroAssembler::Overflow));
+            args.append(Arg::resCond(MacroAssembler::Overflow));
 
-            inst.args.appendVector(sources);
-            inst.args.append(result);
+            args.appendVector(sources);
+            args.append(result);
 
-            fillStackmap(inst, checkValue, 2);
+            fillStackmap(args, checkValue, 2);
 
-            m_insts.last().append(WTF::move(inst));
+            m_insts.last().append(Inst(Patch, checkValue, WTF::move(args)));
             return;
         }
 
@@ -6353,15 +6359,17 @@ private:
             Inst branch = createBranch(m_value->child(0));
 
             CheckSpecial* special = ensureCheckSpecial(branch);
-            
+
             CheckValue* checkValue = m_value->as<CheckValue>();
-            
-            Inst inst(Patch, checkValue, Arg::special(special));
-            inst.args.appendVector(branch.args);
-            
-            fillStackmap(inst, checkValue, 1);
-            
-            m_insts.last().append(WTF::move(inst));
+
+            Vector<Arg, 8> args;
+            args.append(Arg::special(special));
+            for (const Arg& arg : branch.args())
+                args.append(arg);
+
+            fillStackmap(args, checkValue, 1);
+
+            m_insts.last().append(Inst(Patch, checkValue, WTF::move(args)));
             return;
         }
 

--- a/Source/JavaScriptCore/b3/B3PatchpointSpecial.cpp
+++ b/Source/JavaScriptCore/b3/B3PatchpointSpecial.cpp
@@ -58,16 +58,16 @@ void PatchpointSpecial::forEachArg(Inst& inst, const ScopedLambda<Inst::EachArgC
             role = Arg::Def;
 
         Type argType = type.isTuple() ? procedure.extractFromTuple(type, argIndex - 1) : type;
-        callback(inst.args[argIndex], role, bankForType(argType), widthForType(argType));
+        callback(inst.args()[argIndex], role, bankForType(argType), widthForType(argType));
     }
 
     forEachArgImpl(0, argIndex, inst, SameAsRep, std::nullopt, callback, std::nullopt);
     argIndex += inst.origin->numChildren();
 
     for (unsigned i = patchpoint->numGPScratchRegisters; i--;)
-        callback(inst.args[argIndex++], Arg::Scratch, GP, conservativeWidth(GP));
+        callback(inst.args()[argIndex++], Arg::Scratch, GP, conservativeWidth(GP));
     for (unsigned i = patchpoint->numFPScratchRegisters; i--;)
-        callback(inst.args[argIndex++], Arg::Scratch, FP, procedure.usesSIMD() ? conservativeWidth(FP) : conservativeWidthWithoutVectors(FP));
+        callback(inst.args()[argIndex++], Arg::Scratch, FP, procedure.usesSIMD() ? conservativeWidth(FP) : conservativeWidthWithoutVectors(FP));
 }
 
 bool PatchpointSpecial::isValid(Inst& inst)
@@ -78,12 +78,12 @@ bool PatchpointSpecial::isValid(Inst& inst)
 
     Type type = patchpoint->type();
     for (; argIndex <= procedure.resultCount(type); ++argIndex) {
-        if (argIndex >= inst.args.size())
+        if (argIndex >= inst.args().size())
             return false;
         
-        if (!isArgValidForType(inst.args[argIndex], type.isTuple() ? procedure.extractFromTuple(type, argIndex - 1) : type))
+        if (!isArgValidForType(inst.args()[argIndex], type.isTuple() ? procedure.extractFromTuple(type, argIndex - 1) : type))
             return false;
-        if (!isArgValidForRep(code(), inst.args[argIndex], patchpoint->resultConstraints[argIndex - 1]))
+        if (!isArgValidForRep(code(), inst.args()[argIndex], patchpoint->resultConstraints[argIndex - 1]))
             return false;
     }
 
@@ -92,16 +92,16 @@ bool PatchpointSpecial::isValid(Inst& inst)
     argIndex += patchpoint->numChildren();
 
     if (argIndex + patchpoint->numGPScratchRegisters + patchpoint->numFPScratchRegisters
-        != inst.args.size())
+        != inst.args().size())
         return false;
 
     for (unsigned i = patchpoint->numGPScratchRegisters; i--;) {
-        Arg arg = inst.args[argIndex++];
+        Arg arg = inst.args()[argIndex++];
         if (!arg.isGPTmp())
             return false;
     }
     for (unsigned i = patchpoint->numFPScratchRegisters; i--;) {
-        Arg arg = inst.args[argIndex++];
+        Arg arg = inst.args()[argIndex++];
         if (!arg.isFPTmp())
             return false;
     }
@@ -156,16 +156,16 @@ MacroAssembler::Jump PatchpointSpecial::generate(Inst& inst, CCallHelpers& jit, 
 
     Type type = value->type();
     while (offset <= procedure.resultCount(type))
-        reps.append(repForArg(*context.code, inst.args[offset++]));
+        reps.append(repForArg(*context.code, inst.args()[offset++]));
     reps.appendVector(repsImpl(context, 0, offset, inst));
     offset += value->numChildren();
 
     StackmapGenerationParams params(value, reps, context);
 
     for (unsigned i = value->numGPScratchRegisters; i--;)
-        params.m_gpScratch.append(inst.args[offset++].gpr());
+        params.m_gpScratch.append(inst.args()[offset++].gpr());
     for (unsigned i = value->numFPScratchRegisters; i--;)
-        params.m_fpScratch.append(inst.args[offset++].fpr());
+        params.m_fpScratch.append(inst.args()[offset++].fpr());
     
     value->m_generator->run(jit, params);
 

--- a/Source/JavaScriptCore/b3/B3StackmapSpecial.cpp
+++ b/Source/JavaScriptCore/b3/B3StackmapSpecial.cpp
@@ -81,20 +81,20 @@ void StackmapSpecial::forEachArgImpl(
     ASSERT(value);
 
     // Check that insane things have not happened.
-    ASSERT(inst.args.size() >= numIgnoredAirArgs);
+    ASSERT(inst.args().size() >= numIgnoredAirArgs);
     ASSERT(value->numChildren() >= numIgnoredB3Args);
-    ASSERT(inst.args.size() - numIgnoredAirArgs >= value->numChildren() - numIgnoredB3Args);
-    ASSERT(inst.args[0].kind() == Arg::Kind::Special);
+    ASSERT(inst.args().size() - numIgnoredAirArgs >= value->numChildren() - numIgnoredB3Args);
+    ASSERT(inst.args()[0].kind() == Arg::Kind::Special);
 
     for (unsigned i = 0; i < value->numChildren() - numIgnoredB3Args; ++i) {
-        Arg& arg = inst.args[i + numIgnoredAirArgs];
+        Arg& arg = inst.args()[i + numIgnoredAirArgs];
         ConstrainedValue child = value->constrainedChild(i + numIgnoredB3Args);
 
         Arg::Role role;
         switch (roleMode) {
         case ForceLateUseUnlessRecoverable:
             ASSERT(firstRecoverableIndex);
-            if (arg != inst.args[*firstRecoverableIndex] && arg != inst.args[*firstRecoverableIndex + 1]) {
+            if (arg != inst.args()[*firstRecoverableIndex] && arg != inst.args()[*firstRecoverableIndex + 1]) {
                 role = Arg::LateColdUse;
                 break;
             }
@@ -161,11 +161,11 @@ bool StackmapSpecial::isValidImpl(
     ASSERT(value);
 
     // Check that insane things have not happened.
-    ASSERT(inst.args.size() >= numIgnoredAirArgs);
+    ASSERT(inst.args().size() >= numIgnoredAirArgs);
     ASSERT(value->numChildren() >= numIgnoredB3Args);
 
     // For the Inst to be valid, it needs to have the right number of arguments.
-    if (inst.args.size() - numIgnoredAirArgs < value->numChildren() - numIgnoredB3Args)
+    if (inst.args().size() - numIgnoredAirArgs < value->numChildren() - numIgnoredB3Args)
         return false;
 
     // Regardless of constraints, stackmaps have some basic requirements for their arguments. For
@@ -173,7 +173,7 @@ bool StackmapSpecial::isValidImpl(
     // argument types.
     for (unsigned i = 0; i < value->numChildren() - numIgnoredB3Args; ++i) {
         Value* child = value->child(i + numIgnoredB3Args);
-        Arg& arg = inst.args[i + numIgnoredAirArgs];
+        Arg& arg = inst.args()[i + numIgnoredAirArgs];
 
         if (!isArgValidForType(arg, child->type()))
             return false;
@@ -185,7 +185,7 @@ bool StackmapSpecial::isValidImpl(
     // Verify any explicitly supplied constraints.
     for (unsigned i = numIgnoredB3Args; i < value->m_reps.size(); ++i) {
         ValueRep& rep = value->m_reps[i];
-        Arg& arg = inst.args[i - numIgnoredB3Args + numIgnoredAirArgs];
+        Arg& arg = inst.args()[i - numIgnoredB3Args + numIgnoredAirArgs];
 
         if (!isArgValidForRep(code(), arg, rep))
             return false;
@@ -225,7 +225,7 @@ Vector<ValueRep> StackmapSpecial::repsImpl(Air::GenerationContext& context, unsi
 {
     Vector<ValueRep> result;
     for (unsigned i = 0; i < inst.origin->numChildren() - numIgnoredB3Args; ++i)
-        result.append(repForArg(*context.code, inst.args[i + numIgnoredAirArgs]));
+        result.append(repForArg(*context.code, inst.args()[i + numIgnoredAirArgs]));
     return result;
 }
 

--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackAndGenerateCode.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackAndGenerateCode.cpp
@@ -696,9 +696,9 @@ void GenerateAndAllocateRegisters::generate(CCallHelpers& jit)
                 if (!isOrdinaryMove)
                     return true;
 
-                ASSERT(inst.args.size() >= 2);
-                Arg source = inst.args[0];
-                Arg dest = inst.args[1];
+                ASSERT(inst.args().size() >= 2);
+                Arg source = inst.args()[0];
+                Arg dest = inst.args()[1];
                 if (!source.isTmp() || !dest.isTmp())
                     return true;
 

--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGraphColoring.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGraphColoring.cpp
@@ -1417,7 +1417,7 @@ public:
 
     bool NODELETE isUselessMove(const Inst& inst) const
     {
-        return mayBeCoalescableImpl(inst, nullptr) && inst.args[0].tmp() == inst.args[1].tmp();
+        return mayBeCoalescableImpl(inst, nullptr) && inst.args()[0].tmp() == inst.args()[1].tmp();
     }
 
     Tmp NODELETE getAliasWhenSpilling(Tmp tmp) const
@@ -1636,7 +1636,7 @@ protected:
             unsigned newIndexInWorklist = m_worklistMoves.addMove();
             ASSERT_UNUSED(newIndexInWorklist, newIndexInWorklist == nextMoveIndex);
 
-            for (const Arg& arg : prevInst->args) {
+            for (const Arg& arg : prevInst->args()) {
                 auto& list = m_moveList[TmpMapper::absoluteIndex(arg.tmp())];
                 list.add(nextMoveIndex);
             }
@@ -1670,9 +1670,9 @@ protected:
         for (BasicBlock* block : m_code) {
             for (Inst& inst : *block) {
                 if (std::optional<unsigned> defArgIndex = inst.shouldTryAliasingDef()) {
-                    Arg op1 = inst.args[*defArgIndex - 2];
-                    Arg op2 = inst.args[*defArgIndex - 1];
-                    Arg dest = inst.args[*defArgIndex];
+                    Arg op1 = inst.args()[*defArgIndex - 2];
+                    Arg op2 = inst.args()[*defArgIndex - 1];
+                    Arg dest = inst.args()[*defArgIndex];
 
                     if (op1 == dest || op2 == dest)
                         continue;
@@ -1747,14 +1747,14 @@ protected:
         }
 
         // Avoid the three-argument coalescable spill moves.
-        if (inst.args.size() != 2)
+        if (inst.args().size() != 2)
             return false;
 
-        if (!inst.args[0].isTmp() || !inst.args[1].isTmp())
+        if (!inst.args()[0].isTmp() || !inst.args()[1].isTmp())
             return false;
 
-        ASSERT(inst.args[0].bank() == bank);
-        ASSERT(inst.args[1].bank() == bank);
+        ASSERT(inst.args()[0].bank() == bank);
+        ASSERT(inst.args()[1].bank() == bank);
 
         // We can coalesce a Move32 so long as either of the following holds:
         // - The input is already zero-filled.
@@ -1767,7 +1767,7 @@ protected:
             if (!tmpWidth)
                 return false;
 
-            if (tmpWidth->defWidth(inst.args[0].tmp()) > Width32)
+            if (tmpWidth->defWidth(inst.args()[0].tmp()) > Width32)
                 return false;
         }
         
@@ -1982,8 +1982,8 @@ private:
                     // Move32 is cheaper if we know that it's equivalent to a Move in x86_64. It's
                     // equivalent if the destination's high bits are not observable or if the source's high
                     // bits are all zero.
-                    if (bank == GP && inst.kind.opcode == Move && inst.args[0].isTmp() && inst.args[1].isTmp()) {
-                        if (m_tmpWidth.useWidth(inst.args[1].tmp()) <= Width32 || m_tmpWidth.defWidth(inst.args[0].tmp()) <= Width32)
+                    if (bank == GP && inst.kind.opcode == Move && inst.args()[0].isTmp() && inst.args()[1].isTmp()) {
+                        if (m_tmpWidth.useWidth(inst.args()[1].tmp()) <= Width32 || m_tmpWidth.defWidth(inst.args()[0].tmp()) <= Width32)
                             inst.kind.opcode = Move32;
                     }
                 }
@@ -1991,8 +1991,8 @@ private:
                     // On the other hand, on ARM64, Move is cheaper than Move32. We would like to use Move instead of Move32.
                     // Move32 on ARM64 is explicitly selected in B3LowerToAir for ZExt32 for example. But using ZDef information
                     // here can optimize it from Move32 to Move.
-                    if (bank == GP && inst.kind.opcode == Move32 && inst.args[0].isTmp() && inst.args[1].isTmp()) {
-                        if (m_tmpWidth.defWidth(inst.args[0].tmp()) <= Width32)
+                    if (bank == GP && inst.kind.opcode == Move32 && inst.args()[0].isTmp() && inst.args()[1].isTmp()) {
+                        if (m_tmpWidth.defWidth(inst.args()[0].tmp()) <= Width32)
                             inst.kind.opcode = Move;
                     }
                 }
@@ -2014,8 +2014,8 @@ private:
                     tmp = assignedTmp;
                 });
 
-                if (mayBeCoalescable && inst.args[0].isTmp() && inst.args[1].isTmp()
-                    && inst.args[0].tmp() == inst.args[1].tmp())
+                if (mayBeCoalescable && inst.args()[0].isTmp() && inst.args()[1].isTmp()
+                    && inst.args()[0].tmp() == inst.args()[1].tmp())
                     inst = Inst();
             }
 
@@ -2070,8 +2070,8 @@ private:
                 bool didSpill = false;
                 bool needScratch = false;
                 if (bank == GP && inst.kind.opcode == Move) {
-                    if ((inst.args[0].isTmp() && m_tmpWidth.width(inst.args[0].tmp()) <= Width32)
-                        || (inst.args[1].isTmp() && m_tmpWidth.width(inst.args[1].tmp()) <= Width32))
+                    if ((inst.args()[0].isTmp() && m_tmpWidth.width(inst.args()[0].tmp()) <= Width32)
+                        || (inst.args()[1].isTmp() && m_tmpWidth.width(inst.args()[1].tmp()) <= Width32))
                         canUseMove32IfDidSpill = true;
                 }
 
@@ -2097,10 +2097,10 @@ private:
                             case MoveDouble:
                             case MoveFloat:
                             case Move32: {
-                                unsigned argIndex = &arg - &inst.args[0];
+                                unsigned argIndex = &arg - &inst.args()[0];
                                 unsigned otherArgIndex = argIndex ^ 1;
-                                Arg otherArg = inst.args[otherArgIndex];
-                                if (inst.args.size() == 2
+                                Arg otherArg = inst.args()[otherArgIndex];
+                                if (inst.args().size() == 2
                                     && otherArg.isStack()
                                     && otherArg.stackSlot()->isSpill()) {
                                     needScratchIfSpilledInPlace = true;
@@ -2174,8 +2174,9 @@ private:
                     m_stats[bank].numSpillTmps++;
                     dataLogLnIf(traceDebug, "Add unspillable tmp (scratch) since we introduce it during spill: ", tmp);
                     unspillableTmps.set(AbsoluteTmpMapper<bank>::absoluteIndex(tmp));
-                    inst.args.append(tmp);
-                    RELEASE_ASSERT(inst.args.size() == 3);
+                    ASSERT(inst.args().size() == 2);
+                    inst.setArgs(inst.args()[0], inst.args()[1], tmp);
+                    RELEASE_ASSERT(inst.args().size() == 3);
                     
                     // Without this, a chain of spill moves would need two registers, not one, because
                     // the scratch registers of successive moves would appear to interfere with each

--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
@@ -1297,7 +1297,7 @@ private:
         };
 
         auto coalescableMoveSrc = [&](Inst& inst) {
-            return mayBeCoalescable(inst) ? inst.args[0].tmp() : Tmp();
+            return mayBeCoalescable(inst) ? inst.args()[0].tmp() : Tmp();
         };
 
         auto isLiveAt = [&](Tmp tmp, Point point) {
@@ -1369,24 +1369,24 @@ private:
                     });
                 });
                 if (mayBeCoalescable(inst)) {
-                    ASSERT(inst.args.size() == 2);
-                    if (inst.args[0].isReg() || inst.args[1].isReg()) {
-                        unsigned regIdx = inst.args[0].isReg() ? 0 : 1;
-                        Reg reg = inst.args[regIdx].reg();
-                        Tmp other = inst.args[regIdx ^ 1].tmp();
+                    ASSERT(inst.args().size() == 2);
+                    if (inst.args()[0].isReg() || inst.args()[1].isReg()) {
+                        unsigned regIdx = inst.args()[0].isReg() ? 0 : 1;
+                        Reg reg = inst.args()[regIdx].reg();
+                        Tmp other = inst.args()[regIdx ^ 1].tmp();
                         if (other.isReg())
                             continue;
                         if (m_allAllowedRegisters.contains(reg, IgnoreVectors)) {
                             if (!m_map[other].preferredReg)
-                                m_map[other].preferredReg = inst.args[regIdx].reg();
+                                m_map[other].preferredReg = inst.args()[regIdx].reg();
                             continue;
                         }
                         if (!m_code.isPinned(reg))
                             continue;
                         // Pinned registers fall-through
                     }
-                    ASSERT(inst.args[0].isTmp() && inst.args[1].isTmp());
-                    addMaybeCoalescable(inst.args[0].tmp(), inst.args[1].tmp(), block);
+                    ASSERT(inst.args()[0].isTmp() && inst.args()[1].isTmp());
+                    addMaybeCoalescable(inst.args()[0].tmp(), inst.args()[1].tmp(), block);
                 }
             }
         }
@@ -1996,8 +1996,8 @@ private:
         auto isSameGroupMove = [&](Inst& inst) {
             if (!mayBeCoalescable(inst))
                 return false;
-            Tmp src = inst.args[0].tmp();
-            Tmp dst = inst.args[1].tmp();
+            Tmp src = inst.args()[0].tmp();
+            Tmp dst = inst.args()[1].tmp();
             if (src.isReg() || dst.isReg() || src.bank() != bank || dst.bank() != bank)
                 return false;
             auto srcGroup = tmpToGroup[src];
@@ -2111,8 +2111,8 @@ private:
                     ASSERT(!group.isEmpty() && group.m_representative);
                     tmp = group.m_representative;
                 });
-                if (maybeCoalescable && inst.args[0].tmp() == inst.args[1].tmp()) {
-                    Tmp tmp = inst.args[0].tmp();
+                if (maybeCoalescable && inst.args()[0].tmp() == inst.args()[1].tmp()) {
+                    Tmp tmp = inst.args()[0].tmp();
                     if (tmp.isReg() || tmp.bank() != bank)
                         continue;
                     inst = Inst();
@@ -3057,8 +3057,8 @@ private:
                 Tmp scratchForTmp;
 
                 if (bank == GP && inst.kind.opcode == Move) {
-                    Arg& srcArg = inst.args[0];
-                    Arg& dstArg = inst.args[1];
+                    Arg& srcArg = inst.args()[0];
+                    Arg& dstArg = inst.args()[1];
                     if (dstArg.isTmp() && spillSlot(dstArg.tmp())) {
                         // Storing to spill. If storing to a 4-byte slot, use store32, otherwise storePtr.
                         useMove32IfDidSpill = spillSlot(dstArg.tmp())->byteSize() == 4;
@@ -3089,10 +3089,10 @@ private:
                             case MoveDouble:
                             case MoveFloat:
                             case MoveVector: {
-                                unsigned argIndex = &arg - &inst.args[0];
+                                unsigned argIndex = &arg - &inst.args()[0];
                                 unsigned otherArgIndex = argIndex ^ 1;
-                                Arg otherArg = inst.args[otherArgIndex];
-                                if (inst.args.size() == 2
+                                Arg otherArg = inst.args()[otherArgIndex];
+                                if (inst.args().size() == 2
                                     && otherArg.isStack()
                                     && otherArg.stackSlot()->isSpill()) {
                                     needScratchIfSpilledInPlace = true;
@@ -3138,8 +3138,8 @@ private:
                             // ZDef32 to 64 slot would require two 32-bit accesses (second one for zero extend), so
                             // usually it will be better to ZDef into a register and then storePtr the register.
                             // Unless, this move can have its live range coalesced.
-                            ASSERT_IMPLIES(maybeCoalescable, &arg == &inst.args[1]);
-                            if (!maybeCoalescable || spilledArg != inst.args[0]) {
+                            ASSERT_IMPLIES(maybeCoalescable, &arg == &inst.args()[1]);
+                            if (!maybeCoalescable || spilledArg != inst.args()[0]) {
                                 m_stats[bank].numInPlaceSpillGiveUpSpillWidth++;
                                 return;
                             }
@@ -3161,14 +3161,15 @@ private:
                     ASSERT(scratchForTmp != Tmp());
                     // This has become a Move spillN, spillM. If N==M, we can remove this instruction. Otherwise,
                     // a scratch register is needed in order to execute the move between spill slots.
-                    if (maybeCoalescable && inst.args[0] == inst.args[1]) {
+                    if (maybeCoalescable && inst.args()[0] == inst.args()[1]) {
                         m_stats[bank].numCoalescedStackSlotMoves++;
                         inst = Inst(); // Will be removed during assignRegisters final pass
                         continue;
                     }
                     Tmp tmp = addSpillTmpWithInterval(scratchForTmp, intervalForSpill(indexOfEarly, Arg::Scratch));
-                    inst.args.append(tmp);
-                    RELEASE_ASSERT(inst.args.size() == 3);
+                    ASSERT(inst.args().size() == 2);
+                    inst.setArgs(inst.args()[0], inst.args()[1], tmp);
+                    RELEASE_ASSERT(inst.args().size() == 3);
                     m_stats[bank].numMoveSpillSpillInsts++;
                     ASSERT(inst.isValidForm());
                     // WTF::Liveness and Air::LivenessAdapter do not handle a late-def/use followed by early-def
@@ -3272,7 +3273,7 @@ private:
                             ASSERT(inst.kind.opcode == Move || inst.kind.opcode == Move32
                                 || inst.kind.opcode == MoveFloat || inst.kind.opcode == MoveDouble
                                 || inst.kind.opcode == MoveVector);
-                            ASSERT(inst.args[0].isSomeImm() && inst.args[1] == originalTmp);
+                            ASSERT(inst.args()[0].isSomeImm() && inst.args()[1] == originalTmp);
                             doKillInst = true;
                             dataLogLnIf(verbose(), "Rematerialized BB", *block, " removing def inst: ", inst);
                         } else {
@@ -3515,16 +3516,16 @@ private:
         }
 
         // Avoid the three-argument coalescable spill moves.
-        if (inst.args.size() != 2)
+        if (inst.args().size() != 2)
             return false;
 
-        if (!inst.args[0].isTmp() || !inst.args[1].isTmp())
+        if (!inst.args()[0].isTmp() || !inst.args()[1].isTmp())
             return false;
 
         // We can coalesce a Move32 so long as either of the following holds:
         // - The input is already zero-filled.
         // - The output only cares about the low 32 bits.
-        if (inst.kind.opcode == Move32 && !is32Bit() && m_tmpWidth.defWidth(inst.args[0].tmp()) > Width32)
+        if (inst.kind.opcode == Move32 && !is32Bit() && m_tmpWidth.defWidth(inst.args()[0].tmp()) > Width32)
             return false;
         return true;
     }
@@ -3542,8 +3543,8 @@ private:
                     // Move32 is cheaper if we know that it's equivalent to a Move in x86_64. It's
                     // equivalent if the destination's high bits are not observable or if the source's high
                     // bits are all zero.
-                    if (inst.kind.opcode == Move && inst.args[0].isTmp() && inst.args[1].isTmp()) {
-                        if (m_tmpWidth.useWidth(inst.args[1].tmp()) <= Width32 || m_tmpWidth.defWidth(inst.args[0].tmp()) <= Width32)
+                    if (inst.kind.opcode == Move && inst.args()[0].isTmp() && inst.args()[1].isTmp()) {
+                        if (m_tmpWidth.useWidth(inst.args()[1].tmp()) <= Width32 || m_tmpWidth.defWidth(inst.args()[0].tmp()) <= Width32)
                             inst.kind.opcode = Move32;
                     }
                 }
@@ -3551,8 +3552,8 @@ private:
                     // On the other hand, on ARM64, Move is cheaper than Move32. We would like to use Move instead of Move32.
                     // Move32 on ARM64 is explicitly selected in B3LowerToAir for ZExt32 for example. But using ZDef information
                     // here can optimize it from Move32 to Move.
-                    if (inst.kind.opcode == Move32 && inst.args[0].isTmp() && inst.args[1].isTmp()) {
-                        if (m_tmpWidth.defWidth(inst.args[0].tmp()) <= Width32)
+                    if (inst.kind.opcode == Move32 && inst.args()[0].isTmp() && inst.args()[1].isTmp()) {
+                        if (m_tmpWidth.defWidth(inst.args()[0].tmp()) <= Width32)
                             inst.kind.opcode = Move;
                     }
                 }
@@ -3570,9 +3571,9 @@ private:
                 });
                 ASSERT(inst.isValidForm());
 
-                if (mayBeCoalescable && inst.args[0].isTmp() && inst.args[1].isTmp()
-                    && inst.args[0].tmp() == inst.args[1].tmp()) {
-                    m_stats[inst.args[0].tmp().bank()].numCoalescedRegisterMoves++;
+                if (mayBeCoalescable && inst.args()[0].isTmp() && inst.args()[1].isTmp()
+                    && inst.args()[0].tmp() == inst.args()[1].tmp()) {
+                    m_stats[inst.args()[0].tmp().bank()].numCoalescedRegisterMoves++;
                     inst = Inst();
                 }
             }

--- a/Source/JavaScriptCore/b3/air/AirAllocateStackByGraphColoring.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateStackByGraphColoring.cpp
@@ -84,11 +84,11 @@ protected:
             return false;
         }
 
-        if (inst.args.size() != 3)
+        if (inst.args().size() != 3)
             return false;
 
         for (unsigned i = 0; i < 2; ++i) {
-            Arg arg = inst.args[i];
+            Arg arg = inst.args()[i];
             if (!arg.isStack())
                 return false;
             StackSlot* slot = arg.stackSlot();
@@ -103,7 +103,7 @@ protected:
 
     bool NODELETE isUselessMove(Inst& inst) const
     {
-        return isCoalescableMove(inst) && inst.args[0] == inst.args[1];
+        return isCoalescableMove(inst) && inst.args()[0] == inst.args()[1];
     }
 
     unsigned NODELETE remap(unsigned slotIndex) const
@@ -169,7 +169,7 @@ private:
                 Inst* prevInst = block->get(instIndex);
                 Inst* nextInst = block->get(instIndex + 1);
                 if (prevInst && isCoalescableMove(*prevInst)) {
-                    CoalescableMove move(prevInst->args[0].stackSlot()->index(), prevInst->args[1].stackSlot()->index(), block->frequency());
+                    CoalescableMove move(prevInst->args()[0].stackSlot()->index(), prevInst->args()[1].stackSlot()->index(), block->frequency());
 
                     m_coalescableMoves.append(move);
 
@@ -291,7 +291,7 @@ private:
 
         for (BasicBlock* block : m_code) {
             for (Inst& inst : *block) {
-                for (Arg& arg : inst.args) {
+                for (Arg& arg : inst.args()) {
                     if (arg.isStack())
                         arg = Arg::stack(remapStackSlot(arg.stackSlot()), arg.offset());
                 }

--- a/Source/JavaScriptCore/b3/air/AirCCallSpecial.cpp
+++ b/Source/JavaScriptCore/b3/air/AirCCallSpecial.cpp
@@ -49,27 +49,27 @@ CCallSpecial::~CCallSpecial() = default;
 void CCallSpecial::forEachArg(Inst& inst, const ScopedLambda<Inst::EachArgCallback>& callback)
 {
     for (unsigned i = 0; i < numCalleeArgs; ++i)
-        callback(inst.args[calleeArgOffset + i], Arg::Use, GP, pointerWidth());
+        callback(inst.args()[calleeArgOffset + i], Arg::Use, GP, pointerWidth());
     for (unsigned i = 0; i < numReturnGPArgs; ++i)
-        callback(inst.args[returnGPArgOffset + i], Arg::Def, GP, pointerWidth());
+        callback(inst.args()[returnGPArgOffset + i], Arg::Def, GP, pointerWidth());
     for (unsigned i = 0; i < numReturnFPArgs; ++i)
-        callback(inst.args[returnFPArgOffset + i], Arg::Def, FP, m_isSIMDContext ? conservativeWidth(FP) : conservativeWidthWithoutVectors(FP));
+        callback(inst.args()[returnFPArgOffset + i], Arg::Def, FP, m_isSIMDContext ? conservativeWidth(FP) : conservativeWidthWithoutVectors(FP));
     
-    for (unsigned i = argArgOffset; i < inst.args.size(); ++i) {
+    for (unsigned i = argArgOffset; i < inst.args().size(); ++i) {
         // For the type, we can just query the arg's bank. The arg will have a bank, because we
         // require these args to be argument registers.
-        Bank bank = inst.args[i].bank();
-        callback(inst.args[i], Arg::Use, bank, m_isSIMDContext ? conservativeWidth(bank) : conservativeWidthWithoutVectors(bank));
+        Bank bank = inst.args()[i].bank();
+        callback(inst.args()[i], Arg::Use, bank, m_isSIMDContext ? conservativeWidth(bank) : conservativeWidthWithoutVectors(bank));
     }
 }
 
 bool CCallSpecial::isValid(Inst& inst)
 {
-    if (inst.args.size() < argArgOffset)
+    if (inst.args().size() < argArgOffset)
         return false;
 
     for (unsigned i = 0; i < numCalleeArgs; ++i) {
-        Arg& arg = inst.args[i + calleeArgOffset];
+        Arg& arg = inst.args()[i + calleeArgOffset];
         if (!arg.isGP())
             return false;
         switch (arg.kind()) {
@@ -93,18 +93,18 @@ bool CCallSpecial::isValid(Inst& inst)
     }
 
     // Return args need to be exact.
-    if (inst.args[returnGPArgOffset + 0] != Tmp(GPRInfo::returnValueGPR))
+    if (inst.args()[returnGPArgOffset + 0] != Tmp(GPRInfo::returnValueGPR))
         return false;
-    if (inst.args[returnGPArgOffset + 1] != Tmp(GPRInfo::returnValueGPR2))
+    if (inst.args()[returnGPArgOffset + 1] != Tmp(GPRInfo::returnValueGPR2))
         return false;
-    if (inst.args[returnFPArgOffset + 0] != Tmp(FPRInfo::returnValueFPR))
+    if (inst.args()[returnFPArgOffset + 0] != Tmp(FPRInfo::returnValueFPR))
         return false;
 
-    for (unsigned i = argArgOffset; i < inst.args.size(); ++i) {
-        if (!inst.args[i].isReg())
+    for (unsigned i = argArgOffset; i < inst.args().size(); ++i) {
+        if (!inst.args()[i].isReg())
             return false;
 
-        if (inst.args[i] == Tmp(scratchRegister))
+        if (inst.args()[i] == Tmp(scratchRegister))
             return false;
     }
     return true;
@@ -131,18 +131,18 @@ void CCallSpecial::reportUsedRegisters(Inst&, const RegisterSet&)
 
 CCallHelpers::Jump CCallSpecial::generate(Inst& inst, CCallHelpers& jit, GenerationContext&)
 {
-    switch (inst.args[calleeArgOffset].kind()) {
+    switch (inst.args()[calleeArgOffset].kind()) {
     case Arg::Imm:
     case Arg::BigImm:
-        jit.move(inst.args[calleeArgOffset].asTrustedImmPtr(), scratchRegister);
+        jit.move(inst.args()[calleeArgOffset].asTrustedImmPtr(), scratchRegister);
         jit.call(scratchRegister, OperationPtrTag);
         break;
     case Arg::Tmp:
-        jit.call(inst.args[calleeArgOffset].gpr(), OperationPtrTag);
+        jit.call(inst.args()[calleeArgOffset].gpr(), OperationPtrTag);
         break;
     case Arg::Addr:
     case Arg::ExtendedOffsetAddr:
-        jit.call(inst.args[calleeArgOffset].asAddress(), OperationPtrTag);
+        jit.call(inst.args()[calleeArgOffset].asAddress(), OperationPtrTag);
         break;
     default:
         RELEASE_ASSERT_NOT_REACHED();

--- a/Source/JavaScriptCore/b3/air/AirCCallingConvention.cpp
+++ b/Source/JavaScriptCore/b3/air/AirCCallingConvention.cpp
@@ -205,17 +205,18 @@ Tmp cCallResult(Code& code, CCallValue* value, unsigned index)
 
 Inst buildCCall(Code& code, Value* origin, const Vector<Arg>& arguments)
 {
-    Inst inst(Patch, origin, Arg::special(code.cCallSpecial()));
-    inst.args.append(arguments[0]);
-    inst.args.append(Tmp(GPRInfo::returnValueGPR));
-    inst.args.append(Tmp(GPRInfo::returnValueGPR2));
-    inst.args.append(Tmp(FPRInfo::returnValueFPR));
+    Vector<Arg, 8> args;
+    args.append(Arg::special(code.cCallSpecial()));
+    args.append(arguments[0]);
+    args.append(Tmp(GPRInfo::returnValueGPR));
+    args.append(Tmp(GPRInfo::returnValueGPR2));
+    args.append(Tmp(FPRInfo::returnValueFPR));
     for (unsigned i = 1; i < arguments.size(); ++i) {
         Arg arg = arguments[i];
         if (arg.isTmp())
-            inst.args.append(arg);
+            args.append(arg);
     }
-    return inst;
+    return Inst(Patch, origin, WTF::move(args));
 }
 
 #if CPU(ARM_THUMB2)

--- a/Source/JavaScriptCore/b3/air/AirCustom.cpp
+++ b/Source/JavaScriptCore/b3/air/AirCustom.cpp
@@ -39,11 +39,11 @@ namespace JSC { namespace B3 { namespace Air {
 
 bool PatchCustom::isValidForm(Inst& inst)
 {
-    if (inst.args.size() < 1)
+    if (inst.args().size() < 1)
         return false;
-    if (!inst.args[0].isSpecial())
+    if (!inst.args()[0].isSpecial())
         return false;
-    if (!inst.args[0].special()->isValid(inst))
+    if (!inst.args()[0].special()->isValid(inst))
         return false;
     auto clobberedEarly = inst.extraEarlyClobberedRegs().filter(RegisterSet::allScalarRegisters());
     auto clobberedLate = inst.extraClobberedRegs().filter(RegisterSet::allScalarRegisters());
@@ -66,10 +66,10 @@ bool CCallCustom::isValidForm(Inst& inst)
     if (!value)
         return false;
 
-    if (!inst.args[0].isSpecial())
+    if (!inst.args()[0].isSpecial())
         return false;
 
-    Special* special = inst.args[0].special();
+    Special* special = inst.args()[0].special();
     Code& code = special->code();
 
     size_t resultCount = cCallResultCount(code, value);
@@ -79,38 +79,38 @@ bool CCallCustom::isValidForm(Inst& inst)
         expectedArgCount += cCallArgumentRegisterCount(child->type());
     }
 
-    if (inst.args.size() != expectedArgCount)
+    if (inst.args().size() != expectedArgCount)
         return false;
 
     // The arguments can only refer to the stack, tmps, or immediates.
-    for (unsigned i = inst.args.size() - 1; i; --i) {
-        Arg arg = inst.args[i];
+    for (unsigned i = inst.args().size() - 1; i; --i) {
+        Arg arg = inst.args()[i];
         if (!arg.isTmp() && !arg.isStackMemory() && !arg.isSomeImm())
             return false;
     }
 
     // Callee
-    if (!inst.args[1].isGP())
+    if (!inst.args()[1].isGP())
         return false;
 
     unsigned offset = 2;
 
     // If there is a result then it cannot be an immediate.
     for (size_t i = 0; i < resultCount; ++i) {
-        if (inst.args[offset].isSomeImm())
+        if (inst.args()[offset].isSomeImm())
             return false;
 
         if (value->type().isTuple()) {
             Type type = code.proc().typeAtOffset(value->type(), i);
-            if (!inst.args[offset].canRepresent(type))
+            if (!inst.args()[offset].canRepresent(type))
                 return false;
-        } else if (!inst.args[offset].canRepresent(value))
+        } else if (!inst.args()[offset].canRepresent(value))
             return false;
         offset++;
     }
 
     auto checkNextArg = [&](Value* child) {
-        return inst.args[offset++].canRepresent(child);
+        return inst.args()[offset++].canRepresent(child);
     };
 
     for (unsigned i = 1 ; i < value->numChildren(); ++i) {
@@ -133,7 +133,7 @@ MacroAssembler::Jump CCallCustom::generate(Inst& inst, CCallHelpers&, Generation
 
 bool ShuffleCustom::isValidForm(Inst& inst)
 {
-    if (inst.args.size() % 3)
+    if (inst.args().size() % 3)
         return false;
 
     // A destination may only appear once. This requirement allows us to avoid the undefined behavior
@@ -150,8 +150,8 @@ bool ShuffleCustom::isValidForm(Inst& inst)
     //   or by saving one of the Args to a scratch register and executing it as a shift.
     UncheckedKeyHashSet<Arg> dsts;
 
-    for (unsigned i = 0; i < inst.args.size(); ++i) {
-        Arg arg = inst.args[i];
+    for (unsigned i = 0; i < inst.args().size(); ++i) {
+        Arg arg = inst.args()[i];
         unsigned mode = i % 3;
 
         if (mode == 2) {
@@ -166,7 +166,7 @@ bool ShuffleCustom::isValidForm(Inst& inst)
             if (arg.isSomeImm())
                 continue;
 
-            if (!arg.isCompatibleBank(inst.args[i + 1]))
+            if (!arg.isCompatibleBank(inst.args()[i + 1]))
                 return false;
         } else {
             ASSERT(mode == 1);
@@ -183,7 +183,7 @@ bool ShuffleCustom::isValidForm(Inst& inst)
     // No destination register may appear in any address expressions. The lowering can't handle it
     // and it's not useful for the way we end up using Shuffles. Normally, Shuffles only used for
     // stack addresses and non-stack registers.
-    for (Arg& arg : inst.args) {
+    for (Arg& arg : inst.args()) {
         if (!arg.isMemory())
             continue;
         bool ok = true;
@@ -208,17 +208,17 @@ MacroAssembler::Jump ShuffleCustom::generate(Inst& inst, CCallHelpers&, Generati
 
 bool WasmBoundsCheckCustom::isValidForm(Inst& inst)
 {
-    if (inst.args.size() < 2 || inst.args.size() > 3)
+    if (inst.args().size() < 2 || inst.args().size() > 3)
         return false;
 
-    if (!inst.args[0].isTmp() && !inst.args[0].isSomeImm())
+    if (!inst.args()[0].isTmp() && !inst.args()[0].isSomeImm())
         return false;
 
-    if (!(inst.args[1].isReg() || inst.args[1].isTmp() || inst.args[1].isSomeImm()))
+    if (!(inst.args()[1].isReg() || inst.args()[1].isTmp() || inst.args()[1].isSomeImm()))
         return false;
 
-    if (inst.args.size() == 3)
-        return inst.args[2].isTmp() || inst.args[2].isReg();
+    if (inst.args().size() == 3)
+        return inst.args()[2].isTmp() || inst.args()[2].isReg();
 
     return true;
 }
@@ -228,10 +228,10 @@ MacroAssembler::Jump WasmBoundsCheckCustom::generate(Inst& inst, CCallHelpers& j
     WasmBoundsCheckValue* value = inst.origin->as<WasmBoundsCheckValue>();
 
     MacroAssembler::Jump overflowOOB { };
-    if (inst.args.size() > 2)
-        overflowOOB = Inst((is32Bit() ? Air::Branch32 : Air::Branch64), value, Arg::relCond(MacroAssembler::Below), inst.args[0], inst.args[2]).generate(jit, context);
+    if (inst.args().size() > 2)
+        overflowOOB = Inst((is32Bit() ? Air::Branch32 : Air::Branch64), value, Arg::relCond(MacroAssembler::Below), inst.args()[0], inst.args()[2]).generate(jit, context);
 
-    MacroAssembler::Jump outOfBounds = Inst((is32Bit() ? Air::Branch32 : Air::Branch64), value, Arg::relCond(MacroAssembler::AboveOrEqual), inst.args[0], inst.args[1]).generate(jit, context);
+    MacroAssembler::Jump outOfBounds = Inst((is32Bit() ? Air::Branch32 : Air::Branch64), value, Arg::relCond(MacroAssembler::AboveOrEqual), inst.args()[0], inst.args()[1]).generate(jit, context);
 
     context.latePaths.append(std::tuple {
         value->origin(),

--- a/Source/JavaScriptCore/b3/air/AirCustom.h
+++ b/Source/JavaScriptCore/b3/air/AirCustom.h
@@ -63,9 +63,9 @@ struct PatchCustom {
     {
         // This is basically bogus, but it works for analyses that model Special as an
         // immediate.
-        lambda(inst.args[0], Arg::Use, GP, pointerWidth());
+        lambda(inst.args()[0], Arg::Use, GP, pointerWidth());
         
-        inst.args[0].special()->forEachArg(inst, lambda);
+        inst.args()[0].special()->forEachArg(inst, lambda);
     }
 
     template<typename... Arguments>
@@ -80,40 +80,40 @@ struct PatchCustom {
     {
         if (!argIndex)
             return false;
-        return inst.args[0].special()->admitsStack(inst, argIndex);
+        return inst.args()[0].special()->admitsStack(inst, argIndex);
     }
 
     static bool admitsExtendedOffsetAddr(Inst& inst, unsigned argIndex)
     {
         if (!argIndex)
             return false;
-        return inst.args[0].special()->admitsExtendedOffsetAddr(inst, argIndex);
+        return inst.args()[0].special()->admitsExtendedOffsetAddr(inst, argIndex);
     }
 
     static std::optional<unsigned> shouldTryAliasingDef(Inst& inst)
     {
-        return inst.args[0].special()->shouldTryAliasingDef(inst);
+        return inst.args()[0].special()->shouldTryAliasingDef(inst);
     }
     
     static bool isTerminal(Inst& inst)
     {
-        return inst.args[0].special()->isTerminal(inst);
+        return inst.args()[0].special()->isTerminal(inst);
     }
 
     static bool hasNonArgEffects(Inst& inst)
     {
-        return inst.args[0].special()->hasNonArgEffects(inst);
+        return inst.args()[0].special()->hasNonArgEffects(inst);
     }
 
     static bool hasNonArgNonControlEffects(Inst& inst)
     {
-        return inst.args[0].special()->hasNonArgNonControlEffects(inst);
+        return inst.args()[0].special()->hasNonArgNonControlEffects(inst);
     }
 
     static MacroAssembler::Jump generate(
         Inst& inst, CCallHelpers& jit, GenerationContext& context)
     {
-        return inst.args[0].special()->generate(inst, jit, context);
+        return inst.args()[0].special()->generate(inst, jit, context);
     }
 };
 
@@ -134,13 +134,13 @@ struct CCallCustom : public CommonCustomBase<CCallCustom> {
     {
         CCallValue* value = inst.origin->as<CCallValue>();
 
-        Code& code = inst.args[0].special()->code();
+        Code& code = inst.args()[0].special()->code();
 
         // Skip the CCallSpecial Arg.
         unsigned index = 1;
 
         auto next = [&](Arg::Role role, Bank bank, Width width) {
-            functor(inst.args[index++], role, bank, width);
+            functor(inst.args()[index++], role, bank, width);
         };
 
         next(Arg::Use, GP, pointerWidth()); // callee
@@ -165,7 +165,7 @@ struct CCallCustom : public CommonCustomBase<CCallCustom> {
                 );
             }
         }
-        ASSERT(index == inst.args.size());
+        ASSERT(index == inst.args().size());
     }
 
     template<typename... Arguments>
@@ -217,11 +217,11 @@ struct ShuffleCustom : public CommonCustomBase<ShuffleCustom> {
     template<typename Functor>
     static void forEachArg(Inst& inst, const Functor& functor)
     {
-        unsigned limit = inst.args.size() / 3 * 3;
+        unsigned limit = inst.args().size() / 3 * 3;
         for (unsigned i = 0; i < limit; i += 3) {
-            Arg& src = inst.args[i + 0];
-            Arg& dst = inst.args[i + 1];
-            Arg& widthArg = inst.args[i + 2];
+            Arg& src = inst.args()[i + 0];
+            Arg& dst = inst.args()[i + 1];
+            Arg& widthArg = inst.args()[i + 2];
             Width width = widthArg.width();
             Bank bank = src.isGP() && dst.isGP() ? GP : FP;
             functor(src, Arg::Use, bank, width);
@@ -281,7 +281,7 @@ struct EntrySwitchCustom : public CommonCustomBase<EntrySwitchCustom> {
     
     static bool isValidForm(Inst& inst)
     {
-        return inst.args.isEmpty();
+        return inst.args().empty();
     }
     
     static bool admitsStack(Inst&, unsigned)
@@ -317,10 +317,10 @@ struct WasmBoundsCheckCustom : public CommonCustomBase<WasmBoundsCheckCustom> {
     template<typename Func>
     static void forEachArg(Inst& inst, const Func& functor)
     {
-        functor(inst.args[0], Arg::Use, GP, pointerWidth());
-        functor(inst.args[1], Arg::Use, GP, pointerWidth());
-        if (inst.args.size() > 2)
-            functor(inst.args[2], Arg::Use, GP, pointerWidth());
+        functor(inst.args()[0], Arg::Use, GP, pointerWidth());
+        functor(inst.args()[1], Arg::Use, GP, pointerWidth());
+        if (inst.args().size() > 2)
+            functor(inst.args()[2], Arg::Use, GP, pointerWidth());
     }
 
     template<typename... Arguments>

--- a/Source/JavaScriptCore/b3/air/AirEliminateDeadCode.cpp
+++ b/Source/JavaScriptCore/b3/air/AirEliminateDeadCode.cpp
@@ -79,7 +79,7 @@ bool eliminateDeadCode(Code& code)
     };
 
     auto markArgsLive = [&] (Inst& inst) {
-        for (Arg& arg : inst.args) {
+        for (Arg& arg : inst.args()) {
             if (arg.isStack() && !arg.stackSlot()->isLocked())
                 changed |= liveStackSlots.add(arg.stackSlot());
             arg.forEachTmpFast(

--- a/Source/JavaScriptCore/b3/air/AirEmitShuffle.cpp
+++ b/Source/JavaScriptCore/b3/air/AirEmitShuffle.cpp
@@ -122,10 +122,13 @@ void ShufflePair::dump(PrintStream& out) const
 
 Inst createShuffle(Value* origin, std::span<const ShufflePair> pairs)
 {
-    Inst result(Shuffle, origin);
-    for (const ShufflePair& pair : pairs)
-        result.append(pair.src(), pair.dst(), Arg::widthArg(pair.width()));
-    return result;
+    Vector<Arg, 8> args;
+    for (const ShufflePair& pair : pairs) {
+        args.append(pair.src());
+        args.append(pair.dst());
+        args.append(Arg::widthArg(pair.width()));
+    }
+    return Inst(Shuffle, origin, WTF::move(args));
 }
 
 Vector<Inst> emitShuffle(

--- a/Source/JavaScriptCore/b3/air/AirFixObviousSpills.cpp
+++ b/Source/JavaScriptCore/b3/air/AirFixObviousSpills.cpp
@@ -144,51 +144,51 @@ private:
 
         switch (inst.kind.opcode) {
         case Move:
-            if (inst.args[0].isSomeImm()) {
-                if (inst.args[1].isReg())
-                    func(RegConst(inst.args[1].reg(), inst.args[0].value()));
-                else if (isSpillSlot(inst.args[1]))
-                    func(SlotConst(inst.args[1].stackSlot(), inst.args[0].value()));
-            } else if (isSpillSlot(inst.args[0]) && inst.args[1].isReg()) {
-                if (std::optional<int64_t> constant = m_state.constantFor(inst.args[0]))
-                    func(RegConst(inst.args[1].reg(), *constant));
-                func(RegSlot(inst.args[1].reg(), inst.args[0].stackSlot(), RegSlot::AllBits));
-            } else if (inst.args[0].isReg() && isSpillSlot(inst.args[1])) {
-                if (std::optional<int64_t> constant = m_state.constantFor(inst.args[0]))
-                    func(SlotConst(inst.args[1].stackSlot(), *constant));
-                func(RegSlot(inst.args[0].reg(), inst.args[1].stackSlot(), RegSlot::AllBits));
+            if (inst.args()[0].isSomeImm()) {
+                if (inst.args()[1].isReg())
+                    func(RegConst(inst.args()[1].reg(), inst.args()[0].value()));
+                else if (isSpillSlot(inst.args()[1]))
+                    func(SlotConst(inst.args()[1].stackSlot(), inst.args()[0].value()));
+            } else if (isSpillSlot(inst.args()[0]) && inst.args()[1].isReg()) {
+                if (std::optional<int64_t> constant = m_state.constantFor(inst.args()[0]))
+                    func(RegConst(inst.args()[1].reg(), *constant));
+                func(RegSlot(inst.args()[1].reg(), inst.args()[0].stackSlot(), RegSlot::AllBits));
+            } else if (inst.args()[0].isReg() && isSpillSlot(inst.args()[1])) {
+                if (std::optional<int64_t> constant = m_state.constantFor(inst.args()[0]))
+                    func(SlotConst(inst.args()[1].stackSlot(), *constant));
+                func(RegSlot(inst.args()[0].reg(), inst.args()[1].stackSlot(), RegSlot::AllBits));
             }
             break;
 
         case Move32:
-            if (inst.args[0].isSomeImm()) {
-                if (inst.args[1].isReg())
-                    func(RegConst(inst.args[1].reg(), static_cast<uint32_t>(inst.args[0].value())));
-                else if (isSpillSlot(inst.args[1]))
-                    func(SlotConst(inst.args[1].stackSlot(), static_cast<uint32_t>(inst.args[0].value())));
-            } else if (isSpillSlot(inst.args[0]) && inst.args[1].isReg()) {
-                if (std::optional<int64_t> constant = m_state.constantFor(inst.args[0]))
-                    func(RegConst(inst.args[1].reg(), static_cast<uint32_t>(*constant)));
-                func(RegSlot(inst.args[1].reg(), inst.args[0].stackSlot(), RegSlot::ZExt32));
-            } else if (inst.args[0].isReg() && isSpillSlot(inst.args[1])) {
-                if (std::optional<int64_t> constant = m_state.constantFor(inst.args[0]))
-                    func(SlotConst(inst.args[1].stackSlot(), static_cast<int32_t>(*constant)));
-                func(RegSlot(inst.args[0].reg(), inst.args[1].stackSlot(), RegSlot::Match32));
+            if (inst.args()[0].isSomeImm()) {
+                if (inst.args()[1].isReg())
+                    func(RegConst(inst.args()[1].reg(), static_cast<uint32_t>(inst.args()[0].value())));
+                else if (isSpillSlot(inst.args()[1]))
+                    func(SlotConst(inst.args()[1].stackSlot(), static_cast<uint32_t>(inst.args()[0].value())));
+            } else if (isSpillSlot(inst.args()[0]) && inst.args()[1].isReg()) {
+                if (std::optional<int64_t> constant = m_state.constantFor(inst.args()[0]))
+                    func(RegConst(inst.args()[1].reg(), static_cast<uint32_t>(*constant)));
+                func(RegSlot(inst.args()[1].reg(), inst.args()[0].stackSlot(), RegSlot::ZExt32));
+            } else if (inst.args()[0].isReg() && isSpillSlot(inst.args()[1])) {
+                if (std::optional<int64_t> constant = m_state.constantFor(inst.args()[0]))
+                    func(SlotConst(inst.args()[1].stackSlot(), static_cast<int32_t>(*constant)));
+                func(RegSlot(inst.args()[0].reg(), inst.args()[1].stackSlot(), RegSlot::Match32));
             }
             break;
 
         case MoveFloat:
-            if (isSpillSlot(inst.args[0]) && inst.args[1].isReg())
-                func(RegSlot(inst.args[1].reg(), inst.args[0].stackSlot(), RegSlot::Match32));
-            else if (inst.args[0].isReg() && isSpillSlot(inst.args[1]))
-                func(RegSlot(inst.args[0].reg(), inst.args[1].stackSlot(), RegSlot::Match32));
+            if (isSpillSlot(inst.args()[0]) && inst.args()[1].isReg())
+                func(RegSlot(inst.args()[1].reg(), inst.args()[0].stackSlot(), RegSlot::Match32));
+            else if (inst.args()[0].isReg() && isSpillSlot(inst.args()[1]))
+                func(RegSlot(inst.args()[0].reg(), inst.args()[1].stackSlot(), RegSlot::Match32));
             break;
 
         case MoveDouble:
-            if (isSpillSlot(inst.args[0]) && inst.args[1].isReg())
-                func(RegSlot(inst.args[1].reg(), inst.args[0].stackSlot(), RegSlot::AllBits));
-            else if (inst.args[0].isReg() && isSpillSlot(inst.args[1]))
-                func(RegSlot(inst.args[0].reg(), inst.args[1].stackSlot(), RegSlot::AllBits));
+            if (isSpillSlot(inst.args()[0]) && inst.args()[1].isReg())
+                func(RegSlot(inst.args()[1].reg(), inst.args()[0].stackSlot(), RegSlot::AllBits));
+            else if (inst.args()[0].isReg() && isSpillSlot(inst.args()[1]))
+                func(RegSlot(inst.args()[0].reg(), inst.args()[1].stackSlot(), RegSlot::AllBits));
             break;
             
         default:
@@ -291,13 +291,13 @@ private:
         // First handle some special instructions.
         switch (inst.kind.opcode) {
         case Move: {
-            if (inst.args[0].isBigImm() && inst.args[1].isReg()
+            if (inst.args()[0].isBigImm() && inst.args()[1].isReg()
                 && isValidForm(Add64, Arg::Imm, Arg::Tmp, Arg::Tmp)) {
                 // BigImm materializations are super expensive on both x86 and ARM. Let's try to
                 // materialize this bad boy using math instead. Note that we use unsigned math here
                 // since it's more deterministic.
-                uint64_t myValue = inst.args[0].value();
-                Reg myDest = inst.args[1].reg();
+                uint64_t myValue = inst.args()[0].value();
+                Reg myDest = inst.args()[1].reg();
                 for (const RegConst& regConst : m_state.regConst) {
                     uint64_t otherValue = regConst.constant;
                     
@@ -309,15 +309,10 @@ private:
                     if (Arg::isValidImmForm(delta)) {
                         if (delta) {
                             inst.kind = Add64;
-                            inst.args.resize(3);
-                            inst.args[0] = Arg::imm(delta);
-                            inst.args[1] = Tmp(regConst.reg);
-                            inst.args[2] = Tmp(myDest);
+                            inst.setArgs(Arg::imm(delta), Tmp(regConst.reg), Tmp(myDest));
                         } else {
                             inst.kind = Move;
-                            inst.args.resize(2);
-                            inst.args[0] = Tmp(regConst.reg);
-                            inst.args[1] = Tmp(myDest);
+                            inst.setArgs(Tmp(regConst.reg), Tmp(myDest));
                         }
                         return;
                     }

--- a/Source/JavaScriptCore/b3/air/AirFixPartialRegisterStalls.cpp
+++ b/Source/JavaScriptCore/b3/air/AirFixPartialRegisterStalls.cpp
@@ -76,7 +76,7 @@ bool NODELETE isDependencyBreaking(const Inst& inst)
     case MoveFloat:
     case MoveDouble:
     case MoveVector:
-        return inst.args[0].isFPImmZero();
+        return inst.args()[0].isFPImmZero();
     default:
         return false;
     }
@@ -128,7 +128,7 @@ void updateDistances(Inst& inst, FPDefDistance& localDistance, unsigned& distanc
 
     if (isDependencyBreaking(inst)) {
         // MoveFloat/MoveDouble/MoveVector with FPImm zero: fpImm is args[0], dest tmp is args[1]
-        localDistance.reset(inst.args[1].tmp().fpr());
+        localDistance.reset(inst.args()[1].tmp().fpr());
         return;
     }
 

--- a/Source/JavaScriptCore/b3/air/AirInst.cpp
+++ b/Source/JavaScriptCore/b3/air/AirInst.cpp
@@ -80,7 +80,7 @@ unsigned Inst::jsHash() const
     // https://bugs.webkit.org/show_bug.cgi?id=162751
     unsigned result = static_cast<unsigned>(kind.opcode);
     
-    for (const Arg& arg : args)
+    for (const Arg& arg : args())
         result += arg.jsHash();
     
     return result;
@@ -88,7 +88,7 @@ unsigned Inst::jsHash() const
 
 void Inst::dump(PrintStream& out) const
 {
-    out.print(kind, " ", listDump(args));
+    out.print(kind, " ", listDump(args()));
 }
 
 } } } // namespace JSC::B3::Air

--- a/Source/JavaScriptCore/b3/air/AirInst.h
+++ b/Source/JavaScriptCore/b3/air/AirInst.h
@@ -30,7 +30,11 @@
 #include "AirArg.h"
 #include "AirKind.h"
 #include "MacroAssembler.h"
+#include <new>
+#include <span>
+#include <wtf/FastMalloc.h>
 #include <wtf/ScopedLambda.h>
+#include <wtf/Vector.h>
 
 namespace JSC {
 
@@ -46,51 +50,94 @@ namespace Air {
 struct GenerationContext;
 
 struct Inst {
-    typedef Vector<Arg, 3> ArgList;
+    static constexpr unsigned inlineCapacity = 3;
 
-    Inst()
-        : origin(nullptr)
-    {
-    }
-    
+    Inst() = default;
+
     Inst(Kind kind, Value* origin)
-        : origin(origin)
-        , kind(kind)
+        : kind(kind)
+        , origin(origin)
     {
     }
-    
+
     template<typename... Arguments>
     Inst(Kind kind, Value* origin, Arg arg, Arguments... arguments)
-        : args{ arg, arguments... }
+        : kind(kind)
         , origin(origin)
-        , kind(kind)
     {
+        Arg temp[] { arg, arguments... };
+        initializeArgsFrom(std::span<const Arg> { temp, 1 + sizeof...(Arguments) });
     }
 
-    Inst(Kind kind, Value* origin, const ArgList& arguments)
-        : args(arguments)
+    Inst(Kind kind, Value* origin, std::span<const Arg> arguments)
+        : kind(kind)
         , origin(origin)
-        , kind(kind)
     {
+        initializeArgsFrom(arguments);
     }
 
-    Inst(Kind kind, Value* origin, ArgList&& arguments)
-        : args(WTF::move(arguments))
+    template<size_t passedInlineCapacity>
+    Inst(Kind kind, Value* origin, Vector<Arg, passedInlineCapacity>&& arguments)
+        : kind(kind)
         , origin(origin)
-        , kind(kind)
     {
+        if (arguments.size() > inlineCapacity) {
+            m_size = static_cast<unsigned>(arguments.size());
+            m_storage.outOfLineArgs = arguments.releaseBuffer().leakSpan().data();
+        } else
+            initializeArgsFrom(arguments.span());
     }
 
-    explicit operator bool() const { return origin || kind || args.size(); }
+    Inst(const Inst& other)
+        : kind(other.kind)
+        , origin(other.origin)
+    {
+        initializeArgsFrom(other.args());
+    }
 
-    void append() { }
-    
+    Inst(Inst&& other)
+        : kind(other.kind)
+        , origin(other.origin)
+    {
+        moveArgsFrom(other);
+    }
+
+    Inst& operator=(const Inst& other)
+    {
+        if (this != &other) {
+            destroyArgs();
+            origin = other.origin;
+            kind = other.kind;
+            initializeArgsFrom(other.args());
+        }
+        return *this;
+    }
+
+    Inst& operator=(Inst&& other)
+    {
+        if (this != &other) {
+            destroyArgs();
+            origin = other.origin;
+            kind = other.kind;
+            moveArgsFrom(other);
+        }
+        return *this;
+    }
+
+    ~Inst() { destroyArgs(); }
+
+    std::span<Arg> args() LIFETIME_BOUND { return unsafeMakeSpan(argsData(), m_size); }
+    std::span<const Arg> args() const LIFETIME_BOUND { return unsafeMakeSpan(argsData(), m_size); }
+
     template<typename... Arguments>
-    void append(Arg arg, Arguments... arguments)
+        requires (sizeof...(Arguments) > 0 && (std::is_convertible_v<Arguments, Arg> && ...))
+    void setArgs(Arguments... arguments)
     {
-        args.append(arg);
-        append(arguments...);
+        Arg temp[] { arguments... };
+        setArgs(std::span<const Arg> { temp, sizeof...(Arguments) });
     }
+
+    explicit operator bool() const { return origin || kind || m_size; }
 
     // Note that these functors all avoid using "const" because we want to use them for things that
     // edit IR. IR is meant to be edited; if you're carrying around a "const Inst&" then you're
@@ -101,7 +148,7 @@ struct Inst {
     template<typename Functor>
     void forEachTmpFast(const Functor& functor)
     {
-        for (Arg& arg : args)
+        for (Arg& arg : args())
             arg.forEachTmpFast(functor);
     }
 
@@ -210,15 +257,71 @@ struct Inst {
 
     void dump(PrintStream&) const;
 
-    ArgList args;
-    Value* origin; // The B3::Value that this originated from.
-    Kind kind;
-
 private:
     template<typename Func>
     void forEachArgSimple(const Func&);
     void forEachArgCustom(ScopedLambda<EachArgCallback>);
+
+    Arg* argsData() { return m_size > inlineCapacity ? m_storage.outOfLineArgs : m_storage.inlineArgs.data(); }
+    const Arg* argsData() const { return m_size > inlineCapacity ? m_storage.outOfLineArgs : m_storage.inlineArgs.data(); }
+
+    // Air::Inst owns its out-of-line argument buffer using the same allocator as Vector, so that a
+    // Vector<Arg>'s heap buffer can be adopted directly (see the Vector<Arg>&& constructor).
+    using ArgMalloc = WTF::VectorBufferMalloc;
+
+    void setArgs(std::span<const Arg> arguments)
+    {
+        ASSERT(arguments.empty() || !m_size
+            || reinterpret_cast<uintptr_t>(arguments.data()) + arguments.size_bytes() <= reinterpret_cast<uintptr_t>(argsData())
+            || reinterpret_cast<uintptr_t>(argsData()) + m_size * sizeof(Arg) <= reinterpret_cast<uintptr_t>(arguments.data()));
+        destroyArgs();
+        initializeArgsFrom(arguments);
+    }
+
+    void initializeArgsFrom(std::span<const Arg> source)
+    {
+        static_assert(std::is_trivially_copyable_v<Arg> && std::is_trivially_destructible_v<Arg>);
+        m_size = static_cast<unsigned>(source.size());
+        if (m_size > inlineCapacity)
+            m_storage.outOfLineArgs = static_cast<Arg*>(ArgMalloc::malloc(m_size * sizeof(Arg)));
+        if (!source.empty())
+            memcpySpan(args(), source);
+    }
+
+    void moveArgsFrom(Inst& other)
+    {
+        m_size = other.m_size;
+        if (other.m_size > inlineCapacity)
+            m_storage.outOfLineArgs = std::exchange(other.m_storage.outOfLineArgs, nullptr);
+        else if (other.m_size)
+            memcpySpan(args(), other.args());
+        other.m_size = 0;
+    }
+
+    void destroyArgs()
+    {
+        if (m_size > inlineCapacity)
+            ArgMalloc::free(std::exchange(m_storage.outOfLineArgs, nullptr));
+        m_size = 0;
+    }
+
+public:
+    Kind kind;
+private:
+    unsigned m_size { 0 };
+public:
+    Value* origin { nullptr }; // The B3::Value that this originated from.
+private:
+    union {
+        std::array<Arg, inlineCapacity> inlineArgs { };
+        Arg* outOfLineArgs;
+    } m_storage;
 };
+
+#if USE(JSVALUE64) && !OS(WINDOWS)
+static_assert(sizeof(Inst) == 64, "Air::Inst is expected to stay 64 bytes on JSVALUE64.");
+#endif
+static_assert(std::is_trivially_destructible_v<Arg>);
 
 } } } // namespace JSC::B3::Air
 

--- a/Source/JavaScriptCore/b3/air/AirInstInlines.h
+++ b/Source/JavaScriptCore/b3/air/AirInstInlines.h
@@ -47,13 +47,13 @@ void Inst::forEach(const Functor& functor)
 inline RegisterSet Inst::extraClobberedRegs()
 {
     ASSERT(kind.opcode == Patch);
-    return args[0].special()->extraClobberedRegs(*this);
+    return args()[0].special()->extraClobberedRegs(*this);
 }
 
 inline RegisterSet Inst::extraEarlyClobberedRegs()
 {
     ASSERT(kind.opcode == Patch);
-    return args[0].special()->extraEarlyClobberedRegs(*this);
+    return args()[0].special()->extraEarlyClobberedRegs(*this);
 }
 
 template<typename Thing, typename Functor>
@@ -125,17 +125,17 @@ inline void Inst::forEachDefWithExtraClobberedRegs(
 inline void Inst::reportUsedRegisters(const RegisterSet& usedRegisters)
 {
     ASSERT(kind.opcode == Patch);
-    args[0].special()->reportUsedRegisters(*this, usedRegisters);
+    args()[0].special()->reportUsedRegisters(*this, usedRegisters);
 }
 
 inline bool Inst::admitsStack(Arg& arg)
 {
-    return admitsStack(&arg - &args[0]);
+    return admitsStack(&arg - &args()[0]);
 }
 
 inline bool Inst::admitsExtendedOffsetAddr(Arg& arg)
 {
-    return admitsExtendedOffsetAddr(&arg - &args[0]);
+    return admitsExtendedOffsetAddr(&arg - &args()[0]);
 }
 
 inline std::optional<unsigned> Inst::shouldTryAliasingDef()
@@ -160,7 +160,7 @@ inline std::optional<unsigned> Inst::shouldTryAliasingDef()
     case OrDouble:
     case XorDouble:
     case XorFloat:
-        if (args.size() == 3)
+        if (args().size() == 3)
             return 2;
         break;
     case AddDouble:
@@ -169,12 +169,12 @@ inline std::optional<unsigned> Inst::shouldTryAliasingDef()
     case MulFloat:
         if (isX86_64_AVX())
             return std::nullopt;
-        if (args.size() == 3)
+        if (args().size() == 3)
             return 2;
         break;
     case BranchAdd32:
     case BranchAdd64:
-        if (args.size() == 4)
+        if (args().size() == 4)
             return 3;
         break;
     case MoveConditionally32:
@@ -189,7 +189,7 @@ inline std::optional<unsigned> Inst::shouldTryAliasingDef()
     case MoveDoubleConditionallyTest64:
     case MoveDoubleConditionallyDouble:
     case MoveDoubleConditionallyFloat:
-        if (args.size() == 6)
+        if (args().size() == 6)
             return 5;
         break;
         break;
@@ -204,7 +204,7 @@ inline std::optional<unsigned> Inst::shouldTryAliasingDef()
 inline bool isAddZeroExtend64Valid(const Inst& inst)
 {
 #if CPU(ARM64)
-    return inst.args[1] != Tmp(ARM64Registers::sp);
+    return inst.args()[1] != Tmp(ARM64Registers::sp);
 #else
     UNUSED_PARAM(inst);
     return true;
@@ -214,7 +214,7 @@ inline bool isAddZeroExtend64Valid(const Inst& inst)
 inline bool isAddSignExtend64Valid(const Inst& inst)
 {
 #if CPU(ARM64)
-    return inst.args[1] != Tmp(ARM64Registers::sp);
+    return inst.args()[1] != Tmp(ARM64Registers::sp);
 #else
     UNUSED_PARAM(inst);
     return true;
@@ -224,7 +224,7 @@ inline bool isAddSignExtend64Valid(const Inst& inst)
 inline bool isShiftValid(const Inst& inst)
 {
 #if CPU(X86_64)
-    return inst.args[0] == Tmp(X86Registers::ecx);
+    return inst.args()[0] == Tmp(X86Registers::ecx);
 #else
     UNUSED_PARAM(inst);
     return true;
@@ -284,8 +284,8 @@ inline bool isRotateLeft64Valid(const Inst& inst)
 inline bool isX86DivHelperValid(const Inst& inst)
 {
 #if CPU(X86_64)
-    return inst.args[0] == Tmp(X86Registers::eax)
-        && inst.args[1] == Tmp(X86Registers::edx);
+    return inst.args()[0] == Tmp(X86Registers::eax)
+        && inst.args()[1] == Tmp(X86Registers::edx);
 #else
     UNUSED_PARAM(inst);
     return false;
@@ -325,8 +325,8 @@ inline bool isX86UDiv64Valid(const Inst& inst)
 inline bool isX86MulHighHelperValid(const Inst& inst)
 {
 #if CPU(X86_64)
-    return inst.args[1] == Tmp(X86Registers::eax)
-        && inst.args[2] == Tmp(X86Registers::edx);
+    return inst.args()[1] == Tmp(X86Registers::eax)
+        && inst.args()[2] == Tmp(X86Registers::edx);
 #else
     UNUSED_PARAM(inst);
     return false;
@@ -356,11 +356,11 @@ inline bool isX86UMulHigh64Valid(const Inst& inst)
 inline bool isAtomicStrongCASValid(const Inst& inst)
 {
 #if CPU(X86_64)
-    switch (inst.args.size()) {
+    switch (inst.args().size()) {
     case 3:
-        return inst.args[0] == Tmp(X86Registers::eax);
+        return inst.args()[0] == Tmp(X86Registers::eax);
     case 5:
-        return inst.args[1] == Tmp(X86Registers::eax);
+        return inst.args()[1] == Tmp(X86Registers::eax);
     default:
         return false;
     }
@@ -373,7 +373,7 @@ inline bool isAtomicStrongCASValid(const Inst& inst)
 inline bool isBranchAtomicStrongCASValid(const Inst& inst)
 {
 #if CPU(X86_64)
-    return inst.args[1] == Tmp(X86Registers::eax);
+    return inst.args()[1] == Tmp(X86Registers::eax);
 #else // CPU(X86_64)
     UNUSED_PARAM(inst);
     return false;
@@ -423,7 +423,7 @@ inline bool isBranchAtomicStrongCAS64Valid(const Inst& inst)
 inline bool isVectorSwizzle2Valid(const Inst& inst)
 {
 #if CPU(ARM64)
-    return inst.args[1].fpr() == inst.args[0].fpr() + 1;
+    return inst.args()[1].fpr() == inst.args()[0].fpr() + 1;
 #else
     UNUSED_PARAM(inst);
     return false;

--- a/Source/JavaScriptCore/b3/air/AirLowerAfterRegAlloc.cpp
+++ b/Source/JavaScriptCore/b3/air/AirLowerAfterRegAlloc.cpp
@@ -142,10 +142,10 @@ void lowerAfterRegAlloc(Code& code)
             case Shuffle: {
                 ScalarRegisterSet set = usedRegisters.get(&inst).toScalarRegisterSet();
                 Vector<ShufflePair> pairs;
-                for (unsigned i = 0; i < inst.args.size(); i += 3) {
-                    Arg src = inst.args[i + 0];
-                    Arg dst = inst.args[i + 1];
-                    Width width = inst.args[i + 2].width();
+                for (unsigned i = 0; i < inst.args().size(); i += 3) {
+                    Arg src = inst.args()[i + 0];
+                    Arg dst = inst.args()[i + 1];
+                    Width width = inst.args()[i + 2].width();
 
                     // The used register set contains things live after the shuffle. But
                     // emitShuffle() wants a scratch register that is not just dead but also does not
@@ -187,13 +187,13 @@ void lowerAfterRegAlloc(Code& code)
                 Vector<Arg, 2> originalResults;
                 for (unsigned i = 0; i < cCallResultCount(code, value); ++i) {
                     results.append(cCallResult(code, value, i));
-                    originalResults.append(inst.args[i + 2]);
+                    originalResults.append(inst.args()[i + 2]);
                 }
                 
                 Vector<ShufflePair> pairs;
                 for (unsigned i = 0; i < destinations.size(); ++i) {
                     Value* child = value->child(i);
-                    Arg src = inst.args[i >= 1 ? i + results.size() + 1 : i + 1];
+                    Arg src = inst.args()[i >= 1 ? i + results.size() + 1 : i + 1];
                     Arg dst = destinations[i];
                     Width width = widthForType(child->type());
                     pairs.append(ShufflePair(src, dst, width));

--- a/Source/JavaScriptCore/b3/air/AirLowerStackArgs.cpp
+++ b/Source/JavaScriptCore/b3/air/AirLowerStackArgs.cpp
@@ -42,7 +42,7 @@ void lowerStackArgs(Code& code)
     // Now we need to deduce how much argument area we need.
     for (BasicBlock* block : code) {
         for (Inst& inst : *block) {
-            for (Arg& arg : inst.args) {
+            for (Arg& arg : inst.args()) {
                 if (arg.isCallArg()) {
                     ASSERT(arg.offset() >= 0);
                     // We always check the conservative register bytes for Bank::FP because
@@ -133,29 +133,29 @@ void lowerStackArgs(Code& code)
                 // taking into account the Width to see if we can compute the immediate
                 // is wrong.
                 auto lowerArmLea = [&] (Value::OffsetType offset, Tmp base) {
-                    ASSERT(inst.args[1].isTmp());
+                    ASSERT(inst.args()[1].isTmp());
 
                     if (Arg::isValidImmForm(offset))
-                        inst = Inst(inst.kind.opcode == Lea32 ? Add32 : Add64, inst.origin, Arg::imm(offset), base, inst.args[1]);
+                        inst = Inst(inst.kind.opcode == Lea32 ? Add32 : Add64, inst.origin, Arg::imm(offset), base, inst.args()[1]);
                     else {
                         Air::Tmp tmp = Air::Tmp(extendedOffsetAddrRegister());
                         Arg offsetArg = Arg::bigImm(offset);
                         insertionSet.insert(instIndex, Move, inst.origin, offsetArg, tmp);
-                        inst = Inst(inst.kind.opcode == Lea32 ? Add32 : Add64, inst.origin, tmp, base, inst.args[1]);
+                        inst = Inst(inst.kind.opcode == Lea32 ? Add32 : Add64, inst.origin, tmp, base, inst.args()[1]);
                     }
                 };
 
-                switch (inst.args[0].kind()) {
+                switch (inst.args()[0].kind()) {
                 case Arg::Stack: {
-                    StackSlot* slot = inst.args[0].stackSlot();
-                    lowerArmLea(inst.args[0].offset() + slot->offsetFromFP(), Tmp(GPRInfo::callFrameRegister));
+                    StackSlot* slot = inst.args()[0].stackSlot();
+                    lowerArmLea(inst.args()[0].offset() + slot->offsetFromFP(), Tmp(GPRInfo::callFrameRegister));
                     break;
                 }
                 case Arg::CallArg:
-                    lowerArmLea(inst.args[0].offset() - code.frameSize(), Tmp(GPRInfo::callFrameRegister));
+                    lowerArmLea(inst.args()[0].offset() - code.frameSize(), Tmp(GPRInfo::callFrameRegister));
                     break;
                 case Arg::Addr:
-                    lowerArmLea(inst.args[0].offset(), inst.args[0].base());
+                    lowerArmLea(inst.args()[0].offset(), inst.args()[0].base());
                     break;
                 case Arg::ExtendedOffsetAddr:
                     ASSERT_NOT_REACHED();
@@ -171,18 +171,17 @@ void lowerStackArgs(Code& code)
             // In that case, split the move into separate load and store instructions so that the extendedOffsetReg can
             // be used for each address, one at a time.
             std::optional<Width> moveWidth = isMove(inst);
-            if (isARM64() && moveWidth && inst.args.size() == 3 && inst.args[0].isStack()) {
-                Arg& src = inst.args[0];
+            if (isARM64() && moveWidth && inst.args().size() == 3 && inst.args()[0].isStack()) {
+                Arg& src = inst.args()[0];
                 src = stackAddr(instIndex, src, *moveWidth, src.offset() + src.stackSlot()->offsetFromFP());
                 if (extendedOffsetAddrRegInUse) {
-                    Arg scratch = inst.args[2];
+                    Arg scratch = inst.args()[2];
                     ASSERT(scratch.isReg());
                     // Insert Mov src, scratchReg
                     insertionSet.insert(instIndex, static_cast<Opcode>(inst.kind.opcode), inst.origin, src, scratch);
                     extendedOffsetAddrRegInUse = false; // Used by the inserted instruction; no longer needed.
                     // Modify inst to be 'Move scratch, dest'.
-                    src = scratch;
-                    inst.args.resize(2);
+                    inst.setArgs(scratch, inst.args()[1]);
                 }
                 // Fall through to handle remainder of the original or modified inst, including potential ZDef handling.
             }

--- a/Source/JavaScriptCore/b3/air/AirOptimizeBlockOrder.cpp
+++ b/Source/JavaScriptCore/b3/air/AirOptimizeBlockOrder.cpp
@@ -437,9 +437,9 @@ void optimizeBlockOrder(Code& code)
         case BranchAtomicStrongCAS16:
         case BranchAtomicStrongCAS32:
         case BranchAtomicStrongCAS64:
-            if (code.findNextBlock(block) == block->successorBlock(0) && branch.args[0].isInvertible()) {
+            if (code.findNextBlock(block) == block->successorBlock(0) && branch.args()[0].isInvertible()) {
                 std::swap(block->successor(0), block->successor(1));
-                branch.args[0] = branch.args[0].inverted();
+                branch.args()[0] = branch.args()[0].inverted();
             }
             break;
 

--- a/Source/JavaScriptCore/b3/air/AirOptimizePairedLoadStore.cpp
+++ b/Source/JavaScriptCore/b3/air/AirOptimizePairedLoadStore.cpp
@@ -63,7 +63,7 @@ static inline Width NODELETE accessWidth(Opcode opcode)
 static bool tryStorePair(Code& code, BasicBlock* block, unsigned current, Inst& inst)
 {
     Width instWidth = accessWidth(inst.kind.opcode);
-    int64_t instOffset = static_cast<int64_t>(inst.args[1].offset());
+    int64_t instOffset = static_cast<int64_t>(inst.args()[1].offset());
     unsigned limit = std::min(current, AirOptimizePairedLoadStoreInternal::scanInstructions);
     RegisterSet clobbered;
     for (unsigned count = 1; count <= limit; ++count) {
@@ -108,7 +108,7 @@ static bool tryStorePair(Code& code, BasicBlock* block, unsigned current, Inst& 
             [&] (const Tmp& arg, Arg::Role, Bank, Width, PreservedWidth) {
                 clobbered.add(arg.reg(), IgnoreVectors);
             });
-        if (clobbered.contains(inst.args[1].base().reg(), IgnoreVectors) || (inst.args[0].isTmp() && clobbered.contains(inst.args[0].reg(), IgnoreVectors))) {
+        if (clobbered.contains(inst.args()[1].base().reg(), IgnoreVectors) || (inst.args()[0].isTmp() && clobbered.contains(inst.args()[0].reg(), IgnoreVectors))) {
             logFailed();
             return false;
         }
@@ -122,15 +122,15 @@ static bool tryStorePair(Code& code, BasicBlock* block, unsigned current, Inst& 
             bool interfere = false;
 
             auto clobberMemory = [&](const Tmp& argBase, int64_t argOffset, Width argWidth) {
-                if (argBase == inst.args[1].base()) {
+                if (argBase == inst.args()[1].base()) {
                     Range<int64_t> argRange(argOffset, argOffset + bytesForWidth(argWidth));
                     Range<int64_t> instRange(instOffset, instOffset + bytesForWidth(instWidth));
                     return argRange.overlaps(instRange);
                 }
 
-                if ((argBase == Tmp(CCallHelpers::stackPointerRegister) || argBase == Tmp(GPRInfo::callFrameRegister)) && (inst.args[1].base() == Tmp(CCallHelpers::stackPointerRegister) || inst.args[1].base() == Tmp(GPRInfo::callFrameRegister))) {
+                if ((argBase == Tmp(CCallHelpers::stackPointerRegister) || argBase == Tmp(GPRInfo::callFrameRegister)) && (inst.args()[1].base() == Tmp(CCallHelpers::stackPointerRegister) || inst.args()[1].base() == Tmp(GPRInfo::callFrameRegister))) {
                     int64_t instOffsetFromFP = instOffset;
-                    if (inst.args[1].base() == Tmp(CCallHelpers::stackPointerRegister))
+                    if (inst.args()[1].base() == Tmp(CCallHelpers::stackPointerRegister))
                         instOffsetFromFP = instOffset - code.frameSize();
 
                     int64_t argOffsetFromFP = argOffset;
@@ -174,13 +174,13 @@ static bool tryStorePair(Code& code, BasicBlock* block, unsigned current, Inst& 
         if (target.kind != inst.kind)
             continue;
 
-        if (target.args.size() != 2)
+        if (target.args().size() != 2)
             continue;
 
-        if ((!target.args[0].isTmp() && !target.args[0].isZeroReg()) || !target.args[1].isAddr())
+        if ((!target.args()[0].isTmp() && !target.args()[0].isZeroReg()) || !target.args()[1].isAddr())
             continue;
 
-        if (target.args[1].base() != inst.args[1].base())
+        if (target.args()[1].base() != inst.args()[1].base())
             continue;
 
         Opcode pairOpcode = StorePair32;
@@ -218,17 +218,17 @@ static bool tryStorePair(Code& code, BasicBlock* block, unsigned current, Inst& 
             }
         };
 
-        int64_t targetOffset = static_cast<int64_t>(target.args[1].offset());
+        int64_t targetOffset = static_cast<int64_t>(target.args()[1].offset());
 
         if (isValidOffset(instOffset) && targetOffset == (instOffset + bytesForWidth(instWidth))) {
-            Inst newInst(pairOpcode, target.origin, inst.args[0], target.args[0], inst.args[1]);
+            Inst newInst(pairOpcode, target.origin, inst.args()[0], target.args()[0], inst.args()[1]);
             logFound(newInst);
             target = newInst;
             return true;
         }
 
         if (isValidOffset(targetOffset) && (targetOffset + bytesForWidth(instWidth)) == instOffset) {
-            Inst newInst(pairOpcode, target.origin, target.args[0], inst.args[0], target.args[1]);
+            Inst newInst(pairOpcode, target.origin, target.args()[0], inst.args()[0], target.args()[1]);
             logFound(newInst);
             target = newInst;
             return true;
@@ -236,19 +236,19 @@ static bool tryStorePair(Code& code, BasicBlock* block, unsigned current, Inst& 
 
         // Because str pimm only takes unsigned offset, we tend to pick stackPointerRegister based offsetting.
         // But it is possible that framePointerRegister based offsetting can offer a benefit here.
-        if (target.args[1].base() == Tmp(CCallHelpers::stackPointerRegister)) {
+        if (target.args()[1].base() == Tmp(CCallHelpers::stackPointerRegister)) {
             int64_t instOffsetFromFP = instOffset - code.frameSize();
             int64_t targetOffsetFromFP = targetOffset - code.frameSize();
 
             if (isValidOffset(instOffsetFromFP) && targetOffsetFromFP == (instOffsetFromFP + bytesForWidth(instWidth))) {
-                Inst newInst(pairOpcode, target.origin, inst.args[0], target.args[0], Arg::addr(Air::Tmp(GPRInfo::callFrameRegister), static_cast<int32_t>(instOffsetFromFP)));
+                Inst newInst(pairOpcode, target.origin, inst.args()[0], target.args()[0], Arg::addr(Air::Tmp(GPRInfo::callFrameRegister), static_cast<int32_t>(instOffsetFromFP)));
                 logFound(newInst);
                 target = newInst;
                 return true;
             }
 
             if (isValidOffset(targetOffsetFromFP) && (targetOffsetFromFP + bytesForWidth(instWidth)) == instOffsetFromFP) {
-                Inst newInst(pairOpcode, target.origin, target.args[0], inst.args[0], Arg::addr(Air::Tmp(GPRInfo::callFrameRegister), static_cast<int32_t>(targetOffsetFromFP)));
+                Inst newInst(pairOpcode, target.origin, target.args()[0], inst.args()[0], Arg::addr(Air::Tmp(GPRInfo::callFrameRegister), static_cast<int32_t>(targetOffsetFromFP)));
                 logFound(newInst);
                 target = newInst;
                 return true;
@@ -281,13 +281,13 @@ bool optimizePairedLoadStore(Code& code)
             switch (inst.kind.opcode) {
             case Move:
             case Move32: {
-                if (inst.args.size() != 2)
+                if (inst.args().size() != 2)
                     continue;
 
-                if ((inst.args[0].isGPTmp() || inst.args[0].isZeroReg()) && inst.args[1].isAddr()) {
+                if ((inst.args()[0].isGPTmp() || inst.args()[0].isZeroReg()) && inst.args()[1].isAddr()) {
                     // sp & fp slot usage is, in particular, different for call args and spills.
                     // We would like to do stp merging only for spills.
-                    if ((inst.args[1].base() == Tmp(CCallHelpers::stackPointerRegister) || inst.args[1].base() == Tmp(CCallHelpers::framePointerRegister)) && !inst.kind.spill)
+                    if ((inst.args()[1].base() == Tmp(CCallHelpers::stackPointerRegister) || inst.args()[1].base() == Tmp(CCallHelpers::framePointerRegister)) && !inst.kind.spill)
                         continue;
                     if (tryStorePair(code, block, index, inst)) {
                         block->insts().removeAt(index);

--- a/Source/JavaScriptCore/b3/air/AirPrintSpecial.cpp
+++ b/Source/JavaScriptCore/b3/air/AirPrintSpecial.cpp
@@ -71,7 +71,7 @@ MacroAssembler::Jump PrintSpecial::generate(Inst& inst, CCallHelpers& jit, Gener
     size_t currentArg = 1; // Skip the PrintSpecial arg.
     for (auto& term : *m_printRecordList) {
         if (term.printer == Printer::printAirArg) {
-            const Arg& arg = inst.args[currentArg++];
+            const Arg& arg = inst.args()[currentArg++];
             switch (arg.kind()) {
             case Arg::Tmp:
                 term = Printer::Printer<MacroAssembler::RegisterID>(arg.gpr());

--- a/Source/JavaScriptCore/b3/air/AirPrintSpecial.h
+++ b/Source/JavaScriptCore/b3/air/AirPrintSpecial.h
@@ -46,22 +46,22 @@ concept IsSameOrReference = std::same_as<T, U> || std::same_as<T, U&>;
     
 template<typename T, typename... Arguments>
     requires (IsSameOrReference<T, B3::Air::Tmp> || IsSameOrReference<T, Reg>)
-inline void appendAirArg(B3::Air::Inst& inst, T&& arg)
+inline void appendAirArg(Vector<B3::Air::Arg>& args, T&& arg)
 {
-    inst.args.append(std::forward<T>(arg));
+    args.append(std::forward<T>(arg));
 }
 
 template<typename T, typename... Arguments>
     requires (!IsSameOrReference<T, B3::Air::Tmp> && !IsSameOrReference<T, Reg>)
-inline void appendAirArg(B3::Air::Inst&, T&&, int = 0) { }
+inline void appendAirArg(Vector<B3::Air::Arg>&, T&&, int = 0) { }
 
-inline void appendAirArgs(B3::Air::Inst&) { }
+inline void appendAirArgs(Vector<B3::Air::Arg>&) { }
 
 template<typename T, typename... Arguments>
-inline void appendAirArgs(B3::Air::Inst& inst, T&& t, Arguments&&... others)
+inline void appendAirArgs(Vector<B3::Air::Arg>& args, T&& t, Arguments&&... others)
 {
-    appendAirArg(inst, std::forward<T>(t));
-    appendAirArgs(inst, std::forward<Arguments>(others)...);
+    appendAirArg(args, std::forward<T>(t));
+    appendAirArgs(args, std::forward<Arguments>(others)...);
 }
 
 [[noreturn]] void NODELETE printAirArg(PrintStream&, Context&);

--- a/Source/JavaScriptCore/b3/air/AirTmpWidth.cpp
+++ b/Source/JavaScriptCore/b3/air/AirTmpWidth.cpp
@@ -107,24 +107,24 @@ void TmpWidth::recompute(Code& code)
     std::array<Vector<Inst*>, numBanks> moves;
     for (BasicBlock* block : code) {
         for (Inst& inst : *block) {
-            if (inst.kind.opcode == Move && inst.args[1].isTmp()) {
-                Bank dstBank = Arg(inst.args[1]).bank();
+            if (inst.kind.opcode == Move && inst.args()[1].isTmp()) {
+                Bank dstBank = Arg(inst.args()[1]).bank();
                 if (!shouldProcess(dstBank))
                     continue;
 
-                if (inst.args[0].isTmp()) {
+                if (inst.args()[0].isTmp()) {
                     moves[dstBank].append(&inst);
                     continue;
                 }
 
-                if (inst.args[0].isImm() && inst.args[0].value() >= 0) {
-                    Widths& tmpWidths = widths(inst.args[1].tmp());
+                if (inst.args()[0].isImm() && inst.args()[0].value() >= 0) {
+                    Widths& tmpWidths = widths(inst.args()[1].tmp());
                     Width maxWidth = Width64;
-                    if (inst.args[0].value() <= std::numeric_limits<int8_t>::max())
+                    if (inst.args()[0].value() <= std::numeric_limits<int8_t>::max())
                         maxWidth = Width8;
-                    else if (inst.args[0].value() <= std::numeric_limits<int16_t>::max())
+                    else if (inst.args()[0].value() <= std::numeric_limits<int16_t>::max())
                         maxWidth = Width16;
-                    else if (inst.args[0].value() <= std::numeric_limits<int32_t>::max())
+                    else if (inst.args()[0].value() <= std::numeric_limits<int32_t>::max())
                         maxWidth = Width32;
 
                     tmpWidths.def = std::max(tmpWidths.def, maxWidth);
@@ -155,11 +155,11 @@ void TmpWidth::recompute(Code& code)
             changed = false;
             for (Inst* move : moves) {
                 ASSERT(move->kind.opcode == Move);
-                ASSERT(move->args[0].isTmp());
-                ASSERT(move->args[1].isTmp());
+                ASSERT(move->args()[0].isTmp());
+                ASSERT(move->args()[1].isTmp());
 
-                Widths& srcWidths = widths(move->args[0].tmp());
-                Widths& dstWidths = widths(move->args[1].tmp());
+                Widths& srcWidths = widths(move->args()[0].tmp());
+                Widths& dstWidths = widths(move->args()[1].tmp());
 
                 // Legend:
                 //

--- a/Source/JavaScriptCore/b3/air/AirUseCounts.h
+++ b/Source/JavaScriptCore/b3/air/AirUseCounts.h
@@ -90,13 +90,13 @@ public:
                 switch (inst.kind.opcode) {
                 case Move:
                 case Move32: {
-                    if (inst.args[0].isSomeImm() && inst.args[1].is<Tmp>()) {
-                        Tmp tmp = inst.args[1].as<Tmp>();
+                    if (inst.args()[0].isSomeImm() && inst.args()[1].is<Tmp>()) {
+                        Tmp tmp = inst.args()[1].as<Tmp>();
                         if (tmp.bank() == GP) {
                             auto index = AbsoluteTmpMapper<GP>::absoluteIndex(tmp);
                             if (!m_gpConstDefs.quickGet(index)) {
                                 m_gpConstDefs.quickSet(index);
-                                m_gpConstants[index] = extractGPConstant(inst.kind.opcode, inst.args[0]);
+                                m_gpConstants[index] = extractGPConstant(inst.kind.opcode, inst.args()[0]);
                             } else
                                 gpNonConstDefs.quickSet(index);
                             m_gpNumWarmUsesAndDefs[index] += frequency;
@@ -108,13 +108,13 @@ public:
                 case MoveFloat:
                 case MoveDouble:
                 case MoveVector: {
-                    if (inst.args[0].isSomeImm() && inst.args[1].is<Tmp>()) {
-                        Tmp tmp = inst.args[1].as<Tmp>();
+                    if (inst.args()[0].isSomeImm() && inst.args()[1].is<Tmp>()) {
+                        Tmp tmp = inst.args()[1].as<Tmp>();
                         if (tmp.bank() == FP) {
                             auto index = AbsoluteTmpMapper<FP>::absoluteIndex(tmp);
                             if (!m_fpConstDefs.quickGet(index)) {
                                 m_fpConstDefs.quickSet(index);
-                                m_fpConstants[index] = extractFPConstant(inst.kind.opcode, inst.args[0]);
+                                m_fpConstants[index] = extractFPConstant(inst.kind.opcode, inst.args()[0]);
                                 switch (inst.kind.opcode) {
                                 case MoveFloat:
                                     m_fpConstantWidths[index] = Width32;

--- a/Source/JavaScriptCore/b3/air/AirValidate.cpp
+++ b/Source/JavaScriptCore/b3/air/AirValidate.cpp
@@ -71,7 +71,7 @@ public:
             
             for (unsigned instIndex = 0; instIndex < block->size(); ++instIndex) {
                 Inst& inst = block->at(instIndex);
-                for (Arg& arg : inst.args) {
+                for (Arg& arg : inst.args()) {
                     switch (arg.kind()) {
                     case Arg::Stack:
                         VALIDATE(validSlots.contains(arg.stackSlot()), ("At ", inst, " in ", *block));
@@ -92,8 +92,8 @@ public:
                 // forEachArg must return Arg&'s that point into the args array.
                 inst.forEachArg(
                     [&] (Arg& arg, Arg::Role role, Bank, Width width) {
-                        VALIDATE(&arg >= &inst.args[0], ("At ", arg, " in ", inst, " in ", *block));
-                        VALIDATE(&arg <= &inst.args.last(), ("At ", arg, " in ", inst, " in ", *block));
+                        VALIDATE(&arg >= &inst.args()[0], ("At ", arg, " in ", inst, " in ", *block));
+                        VALIDATE(&arg <= &inst.args().back(), ("At ", arg, " in ", inst, " in ", *block));
 
                         // FIXME: replace with a check for wasm simd instructions.
                         VALIDATE(Options::useWasmSIMD()
@@ -113,16 +113,16 @@ public:
                     break;
                 case VectorExtendLow:
                 case VectorExtendHigh:
-                    VALIDATE(elementByteSize(inst.args[0].simdInfo().lane) <= 8, ("At ", inst, " in ", *block));
-                    VALIDATE(elementByteSize(inst.args[0].simdInfo().lane) >= 2, ("At ", inst, " in ", *block));
+                    VALIDATE(elementByteSize(inst.args()[0].simdInfo().lane) <= 8, ("At ", inst, " in ", *block));
+                    VALIDATE(elementByteSize(inst.args()[0].simdInfo().lane) >= 2, ("At ", inst, " in ", *block));
                     break;
                 case ExtractRegister64:
-                    VALIDATE(inst.args[2].isImm(), ("At ", inst, " in ", *block));
-                    VALIDATE(inst.args[2].asTrustedImm32().m_value < 64, ("At ", inst, " in ", *block));
+                    VALIDATE(inst.args()[2].isImm(), ("At ", inst, " in ", *block));
+                    VALIDATE(inst.args()[2].asTrustedImm32().m_value < 64, ("At ", inst, " in ", *block));
                     break;
                 case ExtractRegister32:
-                    VALIDATE(inst.args[2].isImm(), ("At ", inst, " in ", *block));
-                    VALIDATE(inst.args[2].asTrustedImm32().m_value < 32, ("At ", inst, " in ", *block));
+                    VALIDATE(inst.args()[2].isImm(), ("At ", inst, " in ", *block));
+                    VALIDATE(inst.args()[2].asTrustedImm32().m_value < 32, ("At ", inst, " in ", *block));
                     break;
                 default:
                     break;

--- a/Source/JavaScriptCore/b3/air/opcode_generator.rb
+++ b/Source/JavaScriptCore/b3/air/opcode_generator.rb
@@ -649,7 +649,8 @@ def matchInstOverload(outp, speed, inst)
             yield opcode, nil
         else
             needOverloadSwitch = ((opcode.overloads.size != 1) or speed == :safe)
-            outp.puts "switch (#{inst}->args.size()) {" if needOverloadSwitch
+            argsExpr = inst == "this" ? "args" : "#{inst}->args()"
+            outp.puts "switch (#{argsExpr}.size()) {" if needOverloadSwitch
             opcode.overloads.each {
                 | overload |
                 outp.puts "case #{overload.signature.length}:" if needOverloadSwitch
@@ -677,7 +678,8 @@ def matchInstOverloadForm(outp, speed, inst)
         else
             columnGetter = proc {
                 | columnIndex |
-                "#{inst}->args[#{columnIndex}].kind()"
+                argsExpr = inst == "this" ? "args" : "#{inst}->args()"
+                "#{argsExpr}[#{columnIndex}].kind()"
             }
             filter = proc { false }
             callback = proc {
@@ -797,6 +799,7 @@ writeH("OpcodeUtils") {
     outp.puts "template<typename Func>"
     outp.puts "ALWAYS_INLINE void Inst::forEachArgSimple(const Func& func)"
     outp.puts "{"
+    outp.puts "    auto args = this->args();"
     outp.puts "    size_t numOperands = args.size();"
     outp.puts "    size_t formOffset = (numOperands - 1) * numOperands / 2;"
     outp.puts "    const uint8_t* formBase = g_formTable + kind.opcode * #{formTableWidth} + formOffset;"
@@ -1005,6 +1008,7 @@ writeH("OpcodeGenerated") {
     
     outp.puts "bool Inst::isValidForm()"
     outp.puts "{"
+    outp.puts "auto args = this->args();"
     matchInstOverloadForm(outp, :safe, "this") {
         | opcode, overload, form |
         if opcode.custom
@@ -1089,6 +1093,7 @@ writeH("OpcodeGenerated") {
 
     outp.puts "bool Inst::admitsStack(unsigned argIndex)"
     outp.puts "{"
+    outp.puts "auto args = this->args();"
     outp.puts "switch (kind.opcode) {"
     $opcodes.values.each {
         | opcode |
@@ -1331,6 +1336,7 @@ writeH("OpcodeGenerated") {
     
     outp.puts "CCallHelpers::Jump Inst::generate(CCallHelpers& jit, GenerationContext& context)"
     outp.puts "{"
+    outp.puts "auto args = this->args();"
     outp.puts "UNUSED_PARAM(jit);"
     outp.puts "UNUSED_PARAM(context);"
     outp.puts "CCallHelpers::Jump result;"

--- a/Source/JavaScriptCore/b3/air/testair.cpp
+++ b/Source/JavaScriptCore/b3/air/testair.cpp
@@ -163,6 +163,16 @@ void loadDoubleConstant(BasicBlock* block, double value, Tmp tmp, Tmp scratch)
     loadConstantImpl<double>(block, value, MoveDouble, tmp, scratch);
 }
 
+// Air::Inst has a fixed, non-growable argument buffer, so a Shuffle's (src, dst, width) triples must
+// be accumulated up front and passed to the constructor rather than appended to a live Inst.
+template<size_t inlineCapacity>
+void addShufflePair(Vector<Arg, inlineCapacity>& args, Arg src, Arg dst, Arg width)
+{
+    args.append(src);
+    args.append(dst);
+    args.append(width);
+}
+
 void testShuffleSimpleSwap()
 {
     B3::Procedure proc;
@@ -432,11 +442,12 @@ void testShuffleBroadcastAllRegs()
         if (reg != Reg(GPRInfo::regT0))
             loadConstant(root, count++, Tmp(reg));
     }
-    Inst& shuffle = root->append(Shuffle, nullptr);
+    Vector<Arg, 8> shuffleArgs;
     for (Reg reg : regs) {
         if (reg != Reg(GPRInfo::regT0))
-            shuffle.append(Tmp(GPRInfo::regT0), Tmp(reg), Arg::widthArg(Width32));
+            addShufflePair(shuffleArgs, Tmp(GPRInfo::regT0), Tmp(reg), Arg::widthArg(Width32));
     }
+    root->appendInst(Inst(Shuffle, nullptr, WTF::move(shuffleArgs)));
 
     StackSlot* slot = code.addStackSlot(sizeof(int32_t) * regs.size(), StackSlotKind::Locked);
     for (unsigned i = 0; i < regs.size(); ++i)
@@ -978,9 +989,10 @@ void testShuffleShiftAllRegs()
     BasicBlock* root = code.addBlock();
     for (unsigned i = 0; i < regs.size(); ++i)
         loadConstant(root, 35 + i, Tmp(regs[i]));
-    Inst& shuffle = root->append(Shuffle, nullptr);
+    Vector<Arg, 8> shuffleArgs;
     for (unsigned i = 1; i < regs.size(); ++i)
-        shuffle.append(Tmp(regs[i - 1]), Tmp(regs[i]), Arg::widthArg(Width32));
+        addShufflePair(shuffleArgs, Tmp(regs[i - 1]), Tmp(regs[i]), Arg::widthArg(Width32));
+    root->appendInst(Inst(Shuffle, nullptr, WTF::move(shuffleArgs)));
 
     StackSlot* slot = code.addStackSlot(sizeof(int32_t) * regs.size(), StackSlotKind::Locked);
     for (unsigned i = 0; i < regs.size(); ++i)
@@ -1015,10 +1027,11 @@ void testShuffleRotateAllRegs()
     BasicBlock* root = code.addBlock();
     for (unsigned i = 0; i < regs.size(); ++i)
         loadConstant(root, 35 + i, Tmp(regs[i]));
-    Inst& shuffle = root->append(Shuffle, nullptr);
+    Vector<Arg, 8> shuffleArgs;
     for (unsigned i = 1; i < regs.size(); ++i)
-        shuffle.append(Tmp(regs[i - 1]), Tmp(regs[i]), Arg::widthArg(Width32));
-    shuffle.append(Tmp(regs.last()), Tmp(regs[0]), Arg::widthArg(Width32));
+        addShufflePair(shuffleArgs, Tmp(regs[i - 1]), Tmp(regs[i]), Arg::widthArg(Width32));
+    addShufflePair(shuffleArgs, Tmp(regs.last()), Tmp(regs[0]), Arg::widthArg(Width32));
+    root->appendInst(Inst(Shuffle, nullptr, WTF::move(shuffleArgs)));
 
     StackSlot* slot = code.addStackSlot(sizeof(int32_t) * regs.size(), StackSlotKind::Locked);
     for (unsigned i = 0; i < regs.size(); ++i)
@@ -1300,20 +1313,20 @@ void testShuffleShiftMemoryAllRegs()
     for (unsigned i = 0; i < regs.size(); ++i)
         loadConstant(root, i + 1, Tmp(regs[i]));
     root->append(Move, nullptr, Arg::immPtr(&memory), Tmp(GPRInfo::regT0));
-    Inst& shuffle = root->append(
-        Shuffle, nullptr,
-        
+    Vector<Arg, 8> shuffleArgs;
+    addShufflePair(shuffleArgs,
         Tmp(regs[0]), Arg::addr(Tmp(GPRInfo::regT0), static_cast<int32_t>(0 * sizeof(int32_t))),
-        Arg::widthArg(Width32),
-        
+        Arg::widthArg(Width32));
+    addShufflePair(shuffleArgs,
         Arg::addr(Tmp(GPRInfo::regT0), static_cast<int32_t>(0 * sizeof(int32_t))),
-        Arg::addr(Tmp(GPRInfo::regT0), static_cast<int32_t>(1 * sizeof(int32_t))), Arg::widthArg(Width32),
-
+        Arg::addr(Tmp(GPRInfo::regT0), static_cast<int32_t>(1 * sizeof(int32_t))), Arg::widthArg(Width32));
+    addShufflePair(shuffleArgs,
         Arg::addr(Tmp(GPRInfo::regT0), static_cast<int32_t>(1 * sizeof(int32_t))), Tmp(regs[1]),
         Arg::widthArg(Width32));
 
     for (unsigned i = 2; i < regs.size(); ++i)
-        shuffle.append(Tmp(regs[i - 1]), Tmp(regs[i]), Arg::widthArg(Width32));
+        addShufflePair(shuffleArgs, Tmp(regs[i - 1]), Tmp(regs[i]), Arg::widthArg(Width32));
+    root->appendInst(Inst(Shuffle, nullptr, WTF::move(shuffleArgs)));
 
     Vector<int32_t> things(FillWith { }, regs.size(), 666);
     root->append(Move, nullptr, Arg::bigImm(std::bit_cast<intptr_t>(&things[0])), Tmp(GPRInfo::regT0));
@@ -1353,20 +1366,20 @@ void testShuffleShiftMemoryAllRegs64()
     for (unsigned i = 0; i < regs.size(); ++i)
         loadConstant(root, (i + 1) * 1000000000000ll, Tmp(regs[i]));
     root->append(Move, nullptr, Arg::immPtr(&memory), Tmp(GPRInfo::regT0));
-    Inst& shuffle = root->append(
-        Shuffle, nullptr,
-        
+    Vector<Arg, 8> shuffleArgs;
+    addShufflePair(shuffleArgs,
         Tmp(regs[0]), Arg::addr(Tmp(GPRInfo::regT0), static_cast<int32_t>(0 * sizeof(int64_t))),
-        Arg::widthArg(Width64),
-        
+        Arg::widthArg(Width64));
+    addShufflePair(shuffleArgs,
         Arg::addr(Tmp(GPRInfo::regT0), static_cast<int32_t>(0 * sizeof(int64_t))),
-        Arg::addr(Tmp(GPRInfo::regT0), static_cast<int32_t>(1 * sizeof(int64_t))), Arg::widthArg(Width64),
-
+        Arg::addr(Tmp(GPRInfo::regT0), static_cast<int32_t>(1 * sizeof(int64_t))), Arg::widthArg(Width64));
+    addShufflePair(shuffleArgs,
         Arg::addr(Tmp(GPRInfo::regT0), static_cast<int32_t>(1 * sizeof(int64_t))), Tmp(regs[1]),
         Arg::widthArg(Width64));
 
     for (unsigned i = 2; i < regs.size(); ++i)
-        shuffle.append(Tmp(regs[i - 1]), Tmp(regs[i]), Arg::widthArg(Width64));
+        addShufflePair(shuffleArgs, Tmp(regs[i - 1]), Tmp(regs[i]), Arg::widthArg(Width64));
+    root->appendInst(Inst(Shuffle, nullptr, WTF::move(shuffleArgs)));
 
     Vector<int64_t> things(FillWith { }, regs.size(), 666);
     root->append(Move, nullptr, Arg::bigImm(std::bit_cast<intptr_t>(&things[0])), Tmp(GPRInfo::regT0));
@@ -1415,23 +1428,23 @@ void testShuffleShiftMemoryAllRegsMixedWidth()
     for (unsigned i = 0; i < regs.size(); ++i)
         loadConstant(root, (i + 1) * 1000000000000ll, Tmp(regs[i]));
     root->append(Move, nullptr, Arg::immPtr(&memory), Tmp(GPRInfo::regT0));
-    Inst& shuffle = root->append(
-        Shuffle, nullptr,
-        
+    Vector<Arg, 8> shuffleArgs;
+    addShufflePair(shuffleArgs,
         Tmp(regs[0]), Arg::addr(Tmp(GPRInfo::regT0), static_cast<int32_t>(0 * sizeof(int64_t))),
-        Arg::widthArg(Width32),
-        
+        Arg::widthArg(Width32));
+    addShufflePair(shuffleArgs,
         Arg::addr(Tmp(GPRInfo::regT0), static_cast<int32_t>(0 * sizeof(int64_t))),
-        Arg::addr(Tmp(GPRInfo::regT0), static_cast<int32_t>(1 * sizeof(int64_t))), Arg::widthArg(Width64),
-
+        Arg::addr(Tmp(GPRInfo::regT0), static_cast<int32_t>(1 * sizeof(int64_t))), Arg::widthArg(Width64));
+    addShufflePair(shuffleArgs,
         Arg::addr(Tmp(GPRInfo::regT0), static_cast<int32_t>(1 * sizeof(int64_t))), Tmp(regs[1]),
         Arg::widthArg(Width32));
 
     for (unsigned i = 2; i < regs.size(); ++i) {
-        shuffle.append(
+        addShufflePair(shuffleArgs,
             Tmp(regs[i - 1]), Tmp(regs[i]),
             (i & 1) ? Arg::widthArg(Width32) : Arg::widthArg(Width64));
     }
+    root->appendInst(Inst(Shuffle, nullptr, WTF::move(shuffleArgs)));
 
     Vector<int64_t> things(FillWith { }, regs.size(), 666);
     root->append(Move, nullptr, Arg::bigImm(std::bit_cast<intptr_t>(&things[0])), Tmp(GPRInfo::regT0));
@@ -1613,22 +1626,21 @@ void testShuffleRotateMemoryAllRegs64()
     for (unsigned i = 0; i < regs.size(); ++i)
         loadConstant(root, (i + 1) * 1000000000000ll, Tmp(regs[i]));
     root->append(Move, nullptr, Arg::immPtr(&memory), Tmp(GPRInfo::regT0));
-    Inst& shuffle = root->append(
-        Shuffle, nullptr,
-        
+    Vector<Arg, 8> shuffleArgs;
+    addShufflePair(shuffleArgs,
         Tmp(regs[0]), Arg::addr(Tmp(GPRInfo::regT0), static_cast<int32_t>(0 * sizeof(int64_t))),
-        Arg::widthArg(Width64),
-        
+        Arg::widthArg(Width64));
+    addShufflePair(shuffleArgs,
         Arg::addr(Tmp(GPRInfo::regT0), static_cast<int32_t>(0 * sizeof(int64_t))),
-        Arg::addr(Tmp(GPRInfo::regT0), static_cast<int32_t>(1 * sizeof(int64_t))), Arg::widthArg(Width64),
-
+        Arg::addr(Tmp(GPRInfo::regT0), static_cast<int32_t>(1 * sizeof(int64_t))), Arg::widthArg(Width64));
+    addShufflePair(shuffleArgs,
         Arg::addr(Tmp(GPRInfo::regT0), static_cast<int32_t>(1 * sizeof(int64_t))), Tmp(regs[1]),
-        Arg::widthArg(Width64),
-
-        regs.last(), regs[0], Arg::widthArg(Width64));
+        Arg::widthArg(Width64));
+    addShufflePair(shuffleArgs, regs.last(), regs[0], Arg::widthArg(Width64));
 
     for (unsigned i = 2; i < regs.size(); ++i)
-        shuffle.append(Tmp(regs[i - 1]), Tmp(regs[i]), Arg::widthArg(Width64));
+        addShufflePair(shuffleArgs, Tmp(regs[i - 1]), Tmp(regs[i]), Arg::widthArg(Width64));
+    root->appendInst(Inst(Shuffle, nullptr, WTF::move(shuffleArgs)));
 
     Vector<int64_t> things(FillWith { }, regs.size(), 666);
     root->append(Move, nullptr, Arg::bigImm(std::bit_cast<intptr_t>(&things[0])), Tmp(GPRInfo::regT0));
@@ -1666,22 +1678,21 @@ void testShuffleRotateMemoryAllRegsMixedWidth()
     for (unsigned i = 0; i < regs.size(); ++i)
         loadConstant(root, (i + 1) * 1000000000000ll, Tmp(regs[i]));
     root->append(Move, nullptr, Arg::immPtr(&memory), Tmp(GPRInfo::regT0));
-    Inst& shuffle = root->append(
-        Shuffle, nullptr,
-        
+    Vector<Arg, 8> shuffleArgs;
+    addShufflePair(shuffleArgs,
         Tmp(regs[0]), Arg::addr(Tmp(GPRInfo::regT0), static_cast<int32_t>(0 * sizeof(int64_t))),
-        Arg::widthArg(Width32),
-        
+        Arg::widthArg(Width32));
+    addShufflePair(shuffleArgs,
         Arg::addr(Tmp(GPRInfo::regT0), static_cast<int32_t>(0 * sizeof(int64_t))),
-        Arg::addr(Tmp(GPRInfo::regT0), static_cast<int32_t>(1 * sizeof(int64_t))), Arg::widthArg(Width64),
-
+        Arg::addr(Tmp(GPRInfo::regT0), static_cast<int32_t>(1 * sizeof(int64_t))), Arg::widthArg(Width64));
+    addShufflePair(shuffleArgs,
         Arg::addr(Tmp(GPRInfo::regT0), static_cast<int32_t>(1 * sizeof(int64_t))), Tmp(regs[1]),
-        Arg::widthArg(Width32),
-
-        regs.last(), regs[0], Arg::widthArg(Width32));
+        Arg::widthArg(Width32));
+    addShufflePair(shuffleArgs, regs.last(), regs[0], Arg::widthArg(Width32));
 
     for (unsigned i = 2; i < regs.size(); ++i)
-        shuffle.append(Tmp(regs[i - 1]), Tmp(regs[i]), Arg::widthArg(Width64));
+        addShufflePair(shuffleArgs, Tmp(regs[i - 1]), Tmp(regs[i]), Arg::widthArg(Width64));
+    root->appendInst(Inst(Shuffle, nullptr, WTF::move(shuffleArgs)));
 
     Vector<int64_t> things(FillWith { }, regs.size(), 666);
     root->append(Move, nullptr, Arg::bigImm(std::bit_cast<intptr_t>(&things[0])), Tmp(GPRInfo::regT0));
@@ -2288,8 +2299,7 @@ void testElideHandlesEarlyClobber()
         });
     });
 
-    Inst inst(Patch, patch, Arg::special(code.addSpecial(makeUniqueWithoutFastMallocCheck<JSC::B3::PatchpointSpecial>())));
-    inst.args.append(Tmp(firstCalleeSave));
+    Inst inst(Patch, patch, Arg::special(code.addSpecial(makeUniqueWithoutFastMallocCheck<JSC::B3::PatchpointSpecial>())), Tmp(firstCalleeSave));
     root->appendInst(WTF::move(inst));
 
     Tmp result = code.newTmp(B3::GP);
@@ -2414,9 +2424,7 @@ void testLinearScanSpillRangesLateUse()
 
         });
 
-        Inst inst(Patch, patchpoint, Arg::special(patchpointSpecial));
-        inst.args.append(tmp1);
-        inst.args.append(tmp2);
+        Inst inst(Patch, patchpoint, Arg::special(patchpointSpecial), tmp1, tmp2);
 
         root->append(inst);
     }
@@ -2464,9 +2472,7 @@ void testLinearScanSpillRangesEarlyDef()
             jit.move(CCallHelpers::TrustedImm32(i + 1), params[0].gpr());
         });
 
-        Inst inst(Patch, patchpoint, Arg::special(patchpointSpecial));
-        inst.args.append(tmp2); // def
-        inst.args.append(tmp1); // use
+        Inst inst(Patch, patchpoint, Arg::special(patchpointSpecial), tmp2, tmp1); // def, use
 
         root->append(inst);
     }
@@ -2485,8 +2491,7 @@ void testLinearScanSpillRangesEarlyDef()
             good.link(&jit);
         });
 
-        Inst inst(Patch, patchpoint, Arg::special(patchpointSpecial));
-        inst.args.append(tmp);
+        Inst inst(Patch, patchpoint, Arg::special(patchpointSpecial), tmp);
         root->append(inst);
     }
 
@@ -2674,11 +2679,8 @@ void testEarlyAndLateUseOfSameTmp()
                 good2.link(&jit);
             });
 
-            Inst inst(Patch, patchpoint, Arg::special(patchpointSpecial));
-
             Tmp tmp = tmps[rand];
-            inst.args.append(tmp);
-            inst.args.append(tmp);
+            Inst inst(Patch, patchpoint, Arg::special(patchpointSpecial), tmp, tmp);
             root->append(inst);
         }
 
@@ -2731,10 +2733,8 @@ void testEarlyClobberInterference()
                 good.link(&jit);
             });
 
-            Inst inst(Patch, patchpoint, Arg::special(patchpointSpecial));
-
             Tmp tmp = tmps[rand];
-            inst.args.append(tmp);
+            Inst inst(Patch, patchpoint, Arg::special(patchpointSpecial), tmp);
             root->append(inst);
         }
 

--- a/Source/JavaScriptCore/b3/testb3_2.cpp
+++ b/Source/JavaScriptCore/b3/testb3_2.cpp
@@ -3695,10 +3695,10 @@ void testTernarySubInstructionSelection(B3::Opcode valueModifier, Type valueType
     unsigned numberOfSubInstructions = 0;
     for (auto instruction : *block) {
         if (instruction.kind.opcode == expectedOpcode) {
-            CHECK_EQ(instruction.args.size(), 3ul);
-            CHECK_EQ(instruction.args[0].kind(), Air::Arg::Tmp);
-            CHECK_EQ(instruction.args[1].kind(), Air::Arg::Tmp);
-            CHECK_EQ(instruction.args[2].kind(), Air::Arg::Tmp);
+            CHECK_EQ(instruction.args().size(), 3ul);
+            CHECK_EQ(instruction.args()[0].kind(), Air::Arg::Tmp);
+            CHECK_EQ(instruction.args()[1].kind(), Air::Arg::Tmp);
+            CHECK_EQ(instruction.args()[2].kind(), Air::Arg::Tmp);
             numberOfSubInstructions++;
         }
     }

--- a/Source/JavaScriptCore/b3/testb3_6.cpp
+++ b/Source/JavaScriptCore/b3/testb3_6.cpp
@@ -2392,9 +2392,9 @@ void testBranchBitAndImmFusion(
     // The first basic block must end in a BranchTest64(resCond, tmp, bitImm).
     Air::Inst terminal = proc.code()[0]->last();
     CHECK_EQ(terminal.kind.opcode, expectedOpcode);
-    CHECK_EQ(terminal.args[0].kind(), Air::Arg::ResCond);
-    CHECK_EQ(terminal.args[1].kind(), firstKind);
-    CHECK(terminal.args[2].kind() == Air::Arg::BitImm || terminal.args[2].kind() == Air::Arg::BitImm64);
+    CHECK_EQ(terminal.args()[0].kind(), Air::Arg::ResCond);
+    CHECK_EQ(terminal.args()[1].kind(), firstKind);
+    CHECK(terminal.args()[2].kind() == Air::Arg::BitImm || terminal.args()[2].kind() == Air::Arg::BitImm64);
 }
 
 void testTerminalPatchpointThatNeedsToBeSpilled()

--- a/Source/JavaScriptCore/b3/testb3_7.cpp
+++ b/Source/JavaScriptCore/b3/testb3_7.cpp
@@ -1011,7 +1011,7 @@ void testOptimizeMaterialization()
         for (Air::Inst& inst : *block) {
             if (inst.kind.opcode != Air::Add64)
                 continue;
-            if (inst.args[0] != Air::Arg::imm(35))
+            if (inst.args()[0] != Air::Arg::imm(35))
                 continue;
             found = true;
         }


### PR DESCRIPTION
#### 71208eb12b5e44e08b3f7db2ada7a19addcce765
<pre>
[JSC] Make sizeof(Air::Inst) 64
<a href="https://bugs.webkit.org/show_bug.cgi?id=318899">https://bugs.webkit.org/show_bug.cgi?id=318899</a>
<a href="https://rdar.apple.com/181734365">rdar://181734365</a>

Reviewed by Keith Miller.

This patch reduces sizeof(Air::Inst) from 80 to 64.

1. We stop using Vector&lt;&gt; in Air::Inst. And managing inline buffer and
   allocated buffer inside Air::Inst. We stop modifying the underlying
   Vector directly, and instead, Air::Inst shows setArgs interface,
   which can be used to set arguments.
2. Air::Inst exposes args as std::span instead of Vector.

Doing so reduces the sizeof(Air::Inst). This is critical since Air&apos;s
time consumption is basically coming from iterating Air::Inst instances.
Smaller and dense representation makes it cheaper.

Tests: Source/JavaScriptCore/b3/air/testair.cpp
       Source/JavaScriptCore/b3/testb3_2.cpp
       Source/JavaScriptCore/b3/testb3_6.cpp
       Source/JavaScriptCore/b3/testb3_7.cpp

* Source/JavaScriptCore/b3/B3CheckSpecial.cpp:
(JSC::B3::CheckSpecial::Key::Key):
(JSC::B3::CheckSpecial::hiddenBranch const):
(JSC::B3::CheckSpecial::forEachArg):
(JSC::B3::CheckSpecial::isValid):
(JSC::B3::CheckSpecial::generate):
* Source/JavaScriptCore/b3/B3LowerToAir.cpp:
* Source/JavaScriptCore/b3/B3PatchpointSpecial.cpp:
(JSC::B3::PatchpointSpecial::forEachArg):
(JSC::B3::PatchpointSpecial::isValid):
(JSC::B3::PatchpointSpecial::generate):
* Source/JavaScriptCore/b3/B3StackmapSpecial.cpp:
(JSC::B3::StackmapSpecial::forEachArgImpl):
(JSC::B3::StackmapSpecial::isValidImpl):
(JSC::B3::StackmapSpecial::repsImpl):
* Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackAndGenerateCode.cpp:
(JSC::B3::Air::GenerateAndAllocateRegisters::generate):
* Source/JavaScriptCore/b3/air/AirAllocateRegistersByGraphColoring.cpp:
* Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp:
(JSC::B3::Air::Greedy::GreedyAllocator::buildLiveRanges):
(JSC::B3::Air::Greedy::GreedyAllocator::validateCoalescing):
(JSC::B3::Air::Greedy::GreedyAllocator::rewriteCoalescedTmps):
(JSC::B3::Air::Greedy::GreedyAllocator::emitSpillCodeAndEnqueueNewTmps):
(JSC::B3::Air::Greedy::GreedyAllocator::mayBeCoalescable):
(JSC::B3::Air::Greedy::GreedyAllocator::assignRegisters):
* Source/JavaScriptCore/b3/air/AirAllocateStackByGraphColoring.cpp:
* Source/JavaScriptCore/b3/air/AirCCallSpecial.cpp:
(JSC::B3::Air::CCallSpecial::forEachArg):
(JSC::B3::Air::CCallSpecial::isValid):
(JSC::B3::Air::CCallSpecial::generate):
* Source/JavaScriptCore/b3/air/AirCCallingConvention.cpp:
(JSC::B3::Air::buildCCall):
* Source/JavaScriptCore/b3/air/AirCustom.cpp:
(JSC::B3::Air::PatchCustom::isValidForm):
(JSC::B3::Air::CCallCustom::isValidForm):
(JSC::B3::Air::ShuffleCustom::isValidForm):
(JSC::B3::Air::WasmBoundsCheckCustom::isValidForm):
(JSC::B3::Air::WasmBoundsCheckCustom::generate):
* Source/JavaScriptCore/b3/air/AirCustom.h:
(JSC::B3::Air::PatchCustom::forEachArg):
(JSC::B3::Air::PatchCustom::admitsStack):
(JSC::B3::Air::PatchCustom::admitsExtendedOffsetAddr):
(JSC::B3::Air::PatchCustom::shouldTryAliasingDef):
(JSC::B3::Air::PatchCustom::isTerminal):
(JSC::B3::Air::PatchCustom::hasNonArgEffects):
(JSC::B3::Air::PatchCustom::hasNonArgNonControlEffects):
(JSC::B3::Air::PatchCustom::generate):
(JSC::B3::Air::CCallCustom::forEachArg):
(JSC::B3::Air::ShuffleCustom::forEachArg):
(JSC::B3::Air::EntrySwitchCustom::isValidForm):
(JSC::B3::Air::WasmBoundsCheckCustom::forEachArg):
* Source/JavaScriptCore/b3/air/AirEliminateDeadCode.cpp:
(JSC::B3::Air::eliminateDeadCode):
* Source/JavaScriptCore/b3/air/AirEmitShuffle.cpp:
(JSC::B3::Air::createShuffle):
* Source/JavaScriptCore/b3/air/AirFixObviousSpills.cpp:
* Source/JavaScriptCore/b3/air/AirFixPartialRegisterStalls.cpp:
* Source/JavaScriptCore/b3/air/AirInst.cpp:
(JSC::B3::Air::Inst::jsHash const):
(JSC::B3::Air::Inst::dump const):
* Source/JavaScriptCore/b3/air/AirInst.h:
(JSC::B3::Air::Inst::Inst):
(JSC::B3::Air::Inst::operator=):
(JSC::B3::Air::Inst::~Inst):
(JSC::B3::Air::Inst::setArgs):
(JSC::B3::Air::Inst::operator bool const):
(JSC::B3::Air::Inst::forEachTmpFast):
(JSC::B3::Air::Inst::argsData):
(JSC::B3::Air::Inst::argsData const):
(JSC::B3::Air::Inst::initializeArgsFrom):
(JSC::B3::Air::Inst::moveArgsFrom):
(JSC::B3::Air::Inst::destroyArgs):
(JSC::B3::Air::Inst::kind): Deleted.
(JSC::B3::Air::Inst::append): Deleted.
* Source/JavaScriptCore/b3/air/AirInstInlines.h:
(JSC::B3::Air::Inst::extraClobberedRegs):
(JSC::B3::Air::Inst::extraEarlyClobberedRegs):
(JSC::B3::Air::Inst::reportUsedRegisters):
(JSC::B3::Air::Inst::admitsStack):
(JSC::B3::Air::Inst::admitsExtendedOffsetAddr):
(JSC::B3::Air::Inst::shouldTryAliasingDef):
(JSC::B3::Air::isAddZeroExtend64Valid):
(JSC::B3::Air::isAddSignExtend64Valid):
(JSC::B3::Air::isShiftValid):
(JSC::B3::Air::isX86DivHelperValid):
(JSC::B3::Air::isX86MulHighHelperValid):
(JSC::B3::Air::isAtomicStrongCASValid):
(JSC::B3::Air::isBranchAtomicStrongCASValid):
(JSC::B3::Air::isVectorSwizzle2Valid):
* Source/JavaScriptCore/b3/air/AirLowerAfterRegAlloc.cpp:
(JSC::B3::Air::lowerAfterRegAlloc):
* Source/JavaScriptCore/b3/air/AirLowerStackArgs.cpp:
(JSC::B3::Air::lowerStackArgs):
* Source/JavaScriptCore/b3/air/AirOptimizeBlockOrder.cpp:
(JSC::B3::Air::optimizeBlockOrder):
* Source/JavaScriptCore/b3/air/AirOptimizePairedLoadStore.cpp:
(JSC::B3::Air::tryStorePair):
(JSC::B3::Air::optimizePairedLoadStore):
* Source/JavaScriptCore/b3/air/AirPrintSpecial.cpp:
(JSC::B3::Air::PrintSpecial::generate):
* Source/JavaScriptCore/b3/air/AirPrintSpecial.h:
(JSC::Printer::appendAirArg):
(JSC::Printer::appendAirArgs):
* Source/JavaScriptCore/b3/air/AirTmpWidth.cpp:
(JSC::B3::Air::TmpWidth::recompute):
* Source/JavaScriptCore/b3/air/AirUseCounts.h:
(JSC::B3::Air::UseCounts::UseCounts):
* Source/JavaScriptCore/b3/air/AirValidate.cpp:
* Source/JavaScriptCore/b3/air/opcode_generator.rb:
* Source/JavaScriptCore/b3/air/testair.cpp:
* Source/JavaScriptCore/b3/testb3_2.cpp:
(testTernarySubInstructionSelection):
* Source/JavaScriptCore/b3/testb3_6.cpp:
(testBranchBitAndImmFusion):
* Source/JavaScriptCore/b3/testb3_7.cpp:
(testOptimizeMaterialization):

Canonical link: <a href="https://commits.webkit.org/316782@main">https://commits.webkit.org/316782@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/602e537b3ecfe2561adfdd77c0c883a66c8da7fe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173376 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47308 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40863 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182949 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130932 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48601 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46990 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134811 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ef09aded-12f8-4ec0-8bc8-c1a1c2806667) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176334 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38234 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/155478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115287 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36876 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/35222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31434 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/3991 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147300 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34974 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185374 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/34638 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/38242 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39424 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143671 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46976 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143535 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47655 "Built successfully") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112758 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26344 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38481 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/119404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46161 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9921 "Passed tests") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45563 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45794 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45620 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->