### PR TITLE
Disable ThrottleConsecutiveNoDamageMainFrames for non-stable Chrome channels in the benchmark runner

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/osx_chrome_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/osx_chrome_driver.py
@@ -70,7 +70,7 @@ class OSXChromeCanaryDriver(OSXChromeDriverBase):
         set_binary_location_impl(options, browser_build_path, self.app_name, self.process_name)
 
     def launch_args_with_url(self, url):
-        return super(OSXChromeCanaryDriver, self).launch_args_with_url(url) + ['--enable-field-trial-config']
+        return super(OSXChromeCanaryDriver, self).launch_args_with_url(url) + ['--enable-field-trial-config', '--disable-features=ThrottleConsecutiveNoDamageMainFrames']
 
 
 class OSXChromeBetaDriver(OSXChromeDriverBase):
@@ -83,7 +83,7 @@ class OSXChromeBetaDriver(OSXChromeDriverBase):
         set_binary_location_impl(options, browser_build_path, self.app_name, self.process_name)
 
     def launch_args_with_url(self, url):
-        return super(OSXChromeBetaDriver, self).launch_args_with_url(url) + ['--enable-field-trial-config']
+        return super(OSXChromeBetaDriver, self).launch_args_with_url(url) + ['--enable-field-trial-config', '--disable-features=ThrottleConsecutiveNoDamageMainFrames']
 
 
 class OSXChromeDevDriver(OSXChromeDriverBase):
@@ -96,7 +96,7 @@ class OSXChromeDevDriver(OSXChromeDriverBase):
         set_binary_location_impl(options, browser_build_path, self.app_name, self.process_name)
 
     def launch_args_with_url(self, url):
-        return super(OSXChromeDevDriver, self).launch_args_with_url(url) + ['--enable-field-trial-config']
+        return super(OSXChromeDevDriver, self).launch_args_with_url(url) + ['--enable-field-trial-config', '--disable-features=ThrottleConsecutiveNoDamageMainFrames']
 
 
 class OSXChromeForTestingDriver(OSXChromeDriverBase):
@@ -109,7 +109,7 @@ class OSXChromeForTestingDriver(OSXChromeDriverBase):
         set_binary_location_impl(options, browser_build_path, self.app_name, self.process_name)
 
     def launch_args_with_url(self, url):
-        return super(OSXChromeForTestingDriver, self).launch_args_with_url(url) + ['--enable-field-trial-config']
+        return super(OSXChromeForTestingDriver, self).launch_args_with_url(url) + ['--enable-field-trial-config', '--disable-features=ThrottleConsecutiveNoDamageMainFrames']
 
 
 class OSXChromiumDriver(OSXChromeDriverBase):


### PR DESCRIPTION
#### f484f013d42e1a93110dcc4373f3b6849c27b794
<pre>
Disable ThrottleConsecutiveNoDamageMainFrames for non-stable Chrome channels in the benchmark runner
<a href="https://bugs.webkit.org/show_bug.cgi?id=318900">https://bugs.webkit.org/show_bug.cgi?id=318900</a>
<a href="https://rdar.apple.com/181735852">rdar://181735852</a>

Reviewed by Stephanie Lewis.

ThrottleConsecutiveNoDamageMainFrames is enrolled by default on non-stable Chrome channels via Chrome Experiments (Finch) and interferes with rendering benchmark measurements. Disabling it explicitly for Dev, Beta, Canary, and ForTesting while leaving other field trial behavior as-is.

* Tools/Scripts/webkitpy/benchmark_runner/browser_driver/osx_chrome_driver.py:
(OSXChromeCanaryDriver.launch_args_with_url):
(OSXChromeBetaDriver.launch_args_with_url):
(OSXChromeDevDriver.launch_args_with_url):
(OSXChromeForTestingDriver.launch_args_with_url):

Canonical link: <a href="https://commits.webkit.org/316751@main">https://commits.webkit.org/316751@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0886ce83d8d566cfdca75f673ce3d9c6d8324958

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173347 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47279 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40828 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182920 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/130903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2907de77-0250-410a-a354-8e771ecd4739) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175212 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48572 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46961 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/134787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/130903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b58c8054-a6fd-4082-b761-1d14c5773874) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176305 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/38208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/155444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/115262 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8f1ccd53-c4c6-4c47-ab86-81043f0060d7) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/172668 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/36850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/35198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31405 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/147274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/34941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185344 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/39400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/143645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46947 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/155003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/143513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/38733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47626 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112727 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26325 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38460 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46132 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/9888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45534 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/45765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/45591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->