### PR TITLE
[ews] Remove extra patch related status strings from ews status-bubbles tooltip

### DIFF
--- a/Tools/CISupport/ews-build/events.py
+++ b/Tools/CISupport/ews-build/events.py
@@ -54,7 +54,7 @@ class Events(service.BuildbotService):
     MAX_GITHUB_DESCRIPTION = 140
     STEPS_TO_REPORT = [
         'analyze-api-tests-results', 'analyze-compile-webkit-results', 'analyze-jsc-tests-results',
-        'analyze-layout-tests-results', 'configuration', 'checkout-pull-request', 'apply-patch',
+        'analyze-layout-tests-results', 'configuration', 'checkout-pull-request',
         'compile-webkit', 'compile-webkit-without-change', 'compile-jsc', 'compile-jsc-without-change',
         'layout-tests', 'layout-tests-repeat-failures', 're-run-layout-tests',
         'run-layout-tests-without-change', 'layout-tests-repeat-failures-without-change',
@@ -62,7 +62,7 @@ class Events(service.BuildbotService):
         'run-api-tests', 'run-api-tests-without-change', 're-run-api-tests',
         'scan-build', 'find-unexpected-results', 'display-safer-cpp-results',
         'jscore-test', 'jscore-test-without-change',
-        'add-reviewer-to-commit-message', 'commit-patch', 'push-commit-to-webkit-repo', 'canonicalize-commit',
+        'add-reviewer-to-commit-message', 'push-commit-to-webkit-repo', 'canonicalize-commit',
         'build-webkit-org-unit-tests', 'buildbot-check-config', 'buildbot-check-config-for-build-webkit', 'buildbot-check-config-for-ews',
         'ews-unit-tests', 'resultsdbpy-unit-tests',
         'upload-built-product', 'upload-test-results',


### PR DESCRIPTION
#### 88b60e3e3e9ec79b43ee734fde935ed8c40f710c
<pre>
[ews] Remove extra patch related status strings from ews status-bubbles tooltip
<a href="https://rdar.apple.com/181740464">rdar://181740464</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=318904">https://bugs.webkit.org/show_bug.cgi?id=318904</a>

Reviewed by Ryan Haddad.

Especially this line appears in tooltip for most of the running PRs:
&quot;Skipping applying patch since patch_id isn&apos;t provided&quot;.
This is not really relevant and can be confusing to users.

* Tools/CISupport/ews-build/events.py:

Canonical link: <a href="https://commits.webkit.org/316801@main">https://commits.webkit.org/316801@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b240a33c3c022764c731c34392d4bf98522b45ab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173356 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47288 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/40839 "Build was cancelled. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182929 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/130912 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fa02a9aa-48b2-4702-bf72-62b9d30d4544) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175221 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48581 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46970 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/134795 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/130912 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c1a0473f-411a-4d71-b4e7-b3bf0ce274d9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176314 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/38212 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/40839 "Build was cancelled. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115270 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6a9f0c5a-a2ba-4463-9f7f-db55bc092f04) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/36854 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/35204 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31414 "Built successfully") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/40839 "Build was cancelled. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/147278 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/40839 "Build was cancelled. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185353 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/39406 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/143655 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/172756 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46956 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/40839 "Build was cancelled. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143521 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47635 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/40839 "Build was cancelled. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112738 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26353 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/38470 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46141 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/40839 "Build was cancelled. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/45543 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45774 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45600 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->