### PR TITLE
[GFC] Begin running second iteration of column sizing.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-inline-size-from-stretched-block-size-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-inline-size-from-stretched-block-size-001-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height:100px; background:green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-inline-size-from-stretched-block-size-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-inline-size-from-stretched-block-size-001.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#algo-grid-sizing">
+<meta name="assert" content="A max-content column is re-resolved against a grid item's stretched block size, so an item whose canvas child has an intrinsic aspect ratio and a percentage block size contributes its resolved inline size to the column.">
+<link rel="match" href="../../reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<style>
+.grid {
+  display: grid;
+  grid-template: auto / max-content max-content;
+}
+.green {
+  grid-row: 1 / 2;
+  grid-column: 1 / 2;
+  background: green;
+}
+.green > canvas {
+  height: 100%;
+}
+.spacer {
+  grid-row: 1 / 2;
+  grid-column: 2 / 3;
+}
+.spacer > div {
+  width: 50px;
+  height: 100px;
+}
+</style>
+<div class="grid">
+  <div class="green"><canvas width="10" height="10"></canvas></div>
+  <div class="spacer"><div></div></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-inline-size-from-stretched-block-size-002-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-inline-size-from-stretched-block-size-002-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height:100px; background:green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-inline-size-from-stretched-block-size-002-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-inline-size-from-stretched-block-size-002-ref.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height:100px; background:green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-inline-size-from-stretched-block-size-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-inline-size-from-stretched-block-size-002.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#algo-grid-sizing">
+<meta name="assert" content="A min-content column is re-resolved against a grid item's stretched block size, so an item whose canvas child has an intrinsic aspect ratio and a percentage block size contributes its resolved inline size to the column.">
+<link rel="match" href="grid-item-inline-size-from-stretched-block-size-002-ref.html">
+<p>Test passes if there is a filled green square.</p>
+<style>
+.grid {
+  display: grid;
+  grid-template: auto / min-content max-content;
+}
+.green {
+  grid-row: 1 / 2;
+  grid-column: 1 / 2;
+  background: green;
+}
+.green > canvas {
+  height: 100%;
+}
+.spacer {
+  grid-row: 1 / 2;
+  grid-column: 2 / 3;
+}
+.spacer > div {
+  width: 50px;
+  height: 100px;
+}
+</style>
+<div class="grid">
+  <div class="green"><canvas width="10" height="10"></canvas></div>
+  <div class="spacer"><div></div></div>
+</div>

--- a/Source/WebCore/layout/formattingContexts/grid/GridItemSizingFunctions.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridItemSizingFunctions.cpp
@@ -34,11 +34,11 @@ namespace Layout {
 GridItemSizingFunctions GridItemSizingFunctions::inlineAxis(const IntegrationUtils& integrationUtils)
 {
     return {
-        [&integrationUtils](const PlacedGridItem& gridItem, LayoutUnit blockAxisConstraint) {
-            return GridLayoutUtils::inlineAxisMinContentContribution(gridItem, blockAxisConstraint, integrationUtils);
+        [&integrationUtils](const PlacedGridItem& gridItem, LayoutUnit blockAxisConstraint, std::optional<LayoutUnit> stretchedBlockSize) {
+            return GridLayoutUtils::inlineAxisMinContentContribution(gridItem, blockAxisConstraint, stretchedBlockSize, integrationUtils);
         },
-        [&integrationUtils](const PlacedGridItem& gridItem, LayoutUnit blockAxisConstraint) {
-            return GridLayoutUtils::inlineAxisMaxContentContribution(gridItem, blockAxisConstraint, integrationUtils);
+        [&integrationUtils](const PlacedGridItem& gridItem, LayoutUnit blockAxisConstraint, std::optional<LayoutUnit> stretchedBlockSize) {
+            return GridLayoutUtils::inlineAxisMaxContentContribution(gridItem, blockAxisConstraint, stretchedBlockSize, integrationUtils);
         },
         [&integrationUtils](const PlacedGridItem& gridItem, const TrackSizingFunctionsList& trackSizingFunctions, LayoutUnit borderAndPadding, LayoutUnit availableSpace, LayoutUnit blockAxisConstraint) {
             UNUSED_PARAM(blockAxisConstraint);
@@ -50,10 +50,12 @@ GridItemSizingFunctions GridItemSizingFunctions::inlineAxis(const IntegrationUti
 GridItemSizingFunctions GridItemSizingFunctions::blockAxis(const GridFormattingContext& formattingContext)
 {
     return {
-        [&formattingContext](const PlacedGridItem& gridItem, LayoutUnit inlineAxisConstraint) {
+        [&formattingContext](const PlacedGridItem& gridItem, LayoutUnit inlineAxisConstraint, std::optional<LayoutUnit> stretchedInlineSize) {
+            UNUSED_PARAM(stretchedInlineSize);
             return GridLayoutUtils::blockAxisMinContentContribution(gridItem, inlineAxisConstraint, formattingContext);
         },
-        [&formattingContext](const PlacedGridItem& gridItem, LayoutUnit inlineAxisConstraint) {
+        [&formattingContext](const PlacedGridItem& gridItem, LayoutUnit inlineAxisConstraint, std::optional<LayoutUnit> stretchedInlineSize) {
+            UNUSED_PARAM(stretchedInlineSize);
             return GridLayoutUtils::blockAxisMaxContentContribution(gridItem, inlineAxisConstraint, formattingContext);
         },
         [&formattingContext](const PlacedGridItem& gridItem, const TrackSizingFunctionsList& trackSizingFunctions, LayoutUnit borderAndPadding, LayoutUnit availableSpace, LayoutUnit inlineAxisConstraint) {

--- a/Source/WebCore/layout/formattingContexts/grid/GridItemSizingFunctions.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridItemSizingFunctions.h
@@ -42,7 +42,7 @@ class PlacedGridItem;
 // depends on the axis being sized, so GridItemSizingFunctions supplies them as
 // callbacks — built with inlineAxis() for columns and blockAxis() for rows.
 struct GridItemSizingFunctions {
-    GridItemSizingFunctions(Function<LayoutUnit(const PlacedGridItem&, LayoutUnit oppositeAxisConstraint)> minContentContributionFunction, Function<LayoutUnit(const PlacedGridItem&, LayoutUnit oppositeAxisConstraint)> maxContentContributionFunction,
+    GridItemSizingFunctions(Function<LayoutUnit(const PlacedGridItem&, LayoutUnit oppositeAxisConstraint, std::optional<LayoutUnit> oppositeAxisStretchedSize)> minContentContributionFunction, Function<LayoutUnit(const PlacedGridItem&, LayoutUnit oppositeAxisConstraint, std::optional<LayoutUnit> oppositeAxisStretchedSize)> maxContentContributionFunction,
         Function<LayoutUnit(const PlacedGridItem&, const TrackSizingFunctionsList&, LayoutUnit borderAndPadding, LayoutUnit availableSpace, LayoutUnit oppositeAxisConstraint)> usedMinimumSizeFunction)
             : minContentContribution(WTF::move(minContentContributionFunction))
             , maxContentContribution(WTF::move(maxContentContributionFunction))
@@ -53,8 +53,8 @@ struct GridItemSizingFunctions {
     static GridItemSizingFunctions inlineAxis(const IntegrationUtils&);
     static GridItemSizingFunctions blockAxis(const GridFormattingContext&);
 
-    Function<LayoutUnit(const PlacedGridItem&, LayoutUnit oppositeAxisConstraint)> minContentContribution;
-    Function<LayoutUnit(const PlacedGridItem&, LayoutUnit oppositeAxisConstraint)> maxContentContribution;
+    Function<LayoutUnit(const PlacedGridItem&, LayoutUnit oppositeAxisConstraint, std::optional<LayoutUnit> oppositeAxisStretchedSize)> minContentContribution;
+    Function<LayoutUnit(const PlacedGridItem&, LayoutUnit oppositeAxisConstraint, std::optional<LayoutUnit> oppositeAxisStretchedSize)> maxContentContribution;
     Function<LayoutUnit(const PlacedGridItem&, const TrackSizingFunctionsList&, LayoutUnit borderAndPadding, LayoutUnit availableSpace, LayoutUnit oppositeAxisConstraint)> usedMinimumSize;
 };
 

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
@@ -32,6 +32,7 @@
 #include "GridLayoutUtils.h"
 #include "ImplicitGrid.h"
 #include "LayoutBoxGeometry.h"
+#include "LayoutChildIterator.h"
 #include "LayoutElementBox.h"
 #include "NotImplemented.h"
 #include "PlacedGridItem.h"
@@ -456,7 +457,7 @@ TrackSizes GridLayout::sizeColumnTracks(const PlacedGridItems& placedGridItems, 
     auto columnTrackSizingItems = placedGridItems.map([&](const PlacedGridItem& gridItem) -> TrackSizingItem {
         auto rowSpan = WTF::Range<size_t> { gridItem.rowStartLine(), gridItem.rowEndLine() };
         return { gridItem, gridItem.inlineAxisSizes(), gridItem.usedInlineBorderAndPadding(),
-            { gridItem.columnStartLine(), gridItem.columnEndLine() }, oppositeAxisConstraintForTrackSizing(rowSizesForFirstColumnSizing, rowSpan) };
+            { gridItem.columnStartLine(), gridItem.columnEndLine() }, oppositeAxisConstraintForTrackSizing(rowSizesForFirstColumnSizing, rowSpan), { } };
     });
 
     return TrackSizingAlgorithm::sizeTracks(columnTrackSizingItems, columnTrackSizingFunctionsList,
@@ -476,12 +477,67 @@ TrackSizes GridLayout::sizeRowTracks(const PlacedGridItems& placedGridItems, con
     auto rowTrackSizingItems = placedGridItems.map([&](const PlacedGridItem& gridItem) -> TrackSizingItem {
         auto columnSpan = WTF::Range<size_t> { gridItem.columnStartLine(), gridItem.columnEndLine() };
         return { gridItem, gridItem.blockAxisSizes(), gridItem.usedBlockBorderAndPadding(),
-            { gridItem.rowStartLine(), gridItem.rowEndLine() }, oppositeAxisConstraintForTrackSizing(columnSizes, columnSpan) };
+            { gridItem.rowStartLine(), gridItem.rowEndLine() }, oppositeAxisConstraintForTrackSizing(columnSizes, columnSpan), { } };
     });
 
     return TrackSizingAlgorithm::sizeTracks(rowTrackSizingItems, rowTrackSizingFunctionsList,
         layoutConstraints.blockAxis, GridItemSizingFunctions::blockAxis(formattingContext()),
         layoutState.usedRowGap, layoutState.usedAlignContent);
+}
+
+// https://www.w3.org/TR/css-grid-1/#algo-grid-sizing — step 3.
+// Sizing the rows (step 2) gives a block-stretched item a definite block size, which can change the inline
+// contribution of an item whose inline size depends on it.
+static bool hasItemWithInlineSizeDependentOnGridAreaBlockSize(const PlacedGridItems& placedGridItems)
+{
+    auto hasChildWithInlineSizeComputedFromAspectRatio = [](const PlacedGridItem& gridItem) {
+        for (auto& child : childrenOfType<ElementBox>(gridItem.layoutBox())) {
+            if (GridLayoutUtils::gridItemChildHasInlineSizeComputedFromAspectRatio(child))
+                return true;
+        }
+        return false;
+    };
+
+    return placedGridItems.containsIf([&](const PlacedGridItem& gridItem) {
+        return GridLayoutUtils::hasStretchedBlockSize(gridItem) && hasChildWithInlineSizeComputedFromAspectRatio(gridItem);
+    });
+}
+
+// https://www.w3.org/TR/css-grid-1/#algo-grid-sizing — step 3.
+// The block size a stretched grid item is fixed to when measuring its inline contribution in the second
+// column-sizing pass, since that size can affect the item's inline content contribution.
+static std::optional<LayoutUnit> stretchedBlockSizeForSecondColumnPass(const PlacedGridItem& gridItem, LayoutUnit oppositeAxisConstraint,
+    const TrackSizes& columnSizes, const TrackSizingFunctionsList& rowTrackSizingFunctionsList, const GridFormattingContext& formattingContext)
+{
+    if (!GridLayoutUtils::hasStretchedBlockSize(gridItem))
+        return { };
+
+    // The item is block-stretched, so its used block size is the stretched (row) size clamped by its
+    // min/max block sizes.
+    auto columnSpan = WTF::Range<size_t> { gridItem.columnStartLine(), gridItem.columnEndLine() };
+    auto inlineAxisConstraint = oppositeAxisConstraintForTrackSizing(columnSizes, columnSpan);
+    auto blockBorderAndPadding = gridItem.usedBlockBorderAndPadding();
+    return GridLayoutUtils::blockUsedSize(gridItem, rowTrackSizingFunctionsList, blockBorderAndPadding, oppositeAxisConstraint, formattingContext, inlineAxisConstraint);
+}
+
+// https://www.w3.org/TR/css-grid-1/#algo-grid-sizing — step 3.
+TrackSizes GridLayout::sizeColumnTracksSecondPass(const PlacedGridItems& placedGridItems, const TrackSizingFunctionsList& columnTrackSizingFunctionsList,
+    const TrackSizingFunctionsList& rowTrackSizingFunctionsList, const TrackSizes& columnSizes, const TrackSizes& rowSizes, const GridLayoutState& layoutState) const
+{
+    auto& layoutConstraints = layoutState.gridLayoutConstraints;
+
+    auto columnTrackSizingItems = placedGridItems.map([&](const PlacedGridItem& gridItem) -> TrackSizingItem {
+        auto rowSpan = WTF::Range<size_t> { gridItem.rowStartLine(), gridItem.rowEndLine() };
+        auto oppositeAxisConstraint = oppositeAxisConstraintForTrackSizing(rowSizes, rowSpan);
+        auto stretchedBlockSize = stretchedBlockSizeForSecondColumnPass(gridItem, oppositeAxisConstraint, columnSizes, rowTrackSizingFunctionsList, formattingContext());
+
+        return { gridItem, gridItem.inlineAxisSizes(), gridItem.usedInlineBorderAndPadding(),
+            { gridItem.columnStartLine(), gridItem.columnEndLine() }, oppositeAxisConstraint, stretchedBlockSize };
+    });
+
+    return TrackSizingAlgorithm::sizeTracks(columnTrackSizingItems, columnTrackSizingFunctionsList,
+        layoutConstraints.inlineAxis, GridItemSizingFunctions::inlineAxis(formattingContext().integrationUtils()),
+        layoutState.usedColumnGap, layoutState.usedJustifyContent);
 }
 
 // https://www.w3.org/TR/css-grid-1/#algo-grid-sizing
@@ -500,10 +556,8 @@ UsedTrackSizes GridLayout::performGridSizingAlgorithm(const GridLayoutState& lay
     // 3. Then, if the min-content contribution of any grid item has changed based on the
     // row sizes and alignment calculated in step 2, re-resolve the sizes of the grid
     // columns with the new min-content and max-content contributions (once only).
-    auto resolveGridColumnSizesIfAnyMinContentContributionChanged = [] {
-        notImplemented();
-    };
-    UNUSED_VARIABLE(resolveGridColumnSizesIfAnyMinContentContributionChanged);
+    if (hasItemWithInlineSizeDependentOnGridAreaBlockSize(placedGridItems))
+        columnSizes = sizeColumnTracksSecondPass(placedGridItems, columnTrackSizingFunctionsList, rowTrackSizingFunctionsList, columnSizes, rowSizes, layoutState);
 
     // 4. Next, if the min-content contribution of any grid item has changed based on the
     // column sizes and alignment calculated in step 3, re-resolve the sizes of the grid

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
@@ -73,6 +73,7 @@ private:
 
     UsedTrackSizes performGridSizingAlgorithm(const GridLayoutState&, const PlacedGridItems&, const TrackSizingFunctionsList&, const TrackSizingFunctionsList&) const;
     TrackSizes sizeColumnTracks(const PlacedGridItems&, const TrackSizingFunctionsList& columnTrackSizingFunctions, const TrackSizingFunctionsList& rowTrackSizingFunctions, const GridLayoutState&) const;
+    TrackSizes sizeColumnTracksSecondPass(const PlacedGridItems&, const TrackSizingFunctionsList& columnTrackSizingFunctions, const TrackSizingFunctionsList& rowTrackSizingFunctions, const TrackSizes& columnSizes, const TrackSizes& rowSizes, const GridLayoutState&) const;
     TrackSizes sizeRowTracks(const PlacedGridItems&, const TrackSizes& columnSizes, const TrackSizingFunctionsList& rowTrackSizingFunctions, const GridLayoutState&) const;
 
     std::pair<UsedInlineSizes, UsedBlockSizes> layoutGridItems(const PlacedGridItems&, const GridAreaSizes&,

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
@@ -90,6 +90,16 @@ std::optional<double> preferredAspectRatio(const ElementBox& gridItem)
     return { };
 }
 
+// https://www.w3.org/TR/css-grid-1/#algo-grid-sizing — step 3.
+// Used to find grid items that need the second column pass, and to pick which children to re-measure
+// when running it.
+bool gridItemChildHasInlineSizeComputedFromAspectRatio(const ElementBox& gridItemChild)
+{
+    ASSERT(gridItemChild.parent().isGridItem());
+    bool hasAspectRatio = (gridItemChild.isReplacedBox() && gridItemChild.intrinsicRatio()) || gridItemChild.style().aspectRatio().hasRatio();
+    return hasAspectRatio && gridItemChild.style().width().isAuto() && gridItemChild.style().height().isPercent();
+}
+
 static bool NODELETE spansAutoMinTrackSizingFunction(WTF::Range<size_t> spannedTrackIndexes, const TrackSizingFunctionsList& trackSizingFunctions)
 {
     for (auto trackIndex : std::views::iota(spannedTrackIndexes.begin(), spannedTrackIndexes.end())) {
@@ -491,15 +501,19 @@ LayoutUnit gridAreaDimensionSize(size_t startLine, size_t endLine, const TrackSi
     return sumOfTrackSizes + (numberOfInteriorGaps * gap);
 }
 
-LayoutUnit inlineAxisMinContentContribution(const PlacedGridItem& gridItem, LayoutUnit blockAxisConstraint, const IntegrationUtils& integrationUtils)
+LayoutUnit inlineAxisMinContentContribution(const PlacedGridItem& gridItem, LayoutUnit blockAxisConstraint, std::optional<LayoutUnit> stretchedBlockSize, const IntegrationUtils& integrationUtils)
 {
     UNUSED_PARAM(blockAxisConstraint);
+    if (stretchedBlockSize)
+        return BorderBoxSize::fromIntegrationFunction(integrationUtils.minContentLogicalWidthContributionForStretchedGridItem(gridItem.layoutBox(), *stretchedBlockSize)).value;
     return BorderBoxSize::fromIntegrationFunction(integrationUtils.minContentLogicalWidthContribution(gridItem.layoutBox())).value;
 }
 
-LayoutUnit inlineAxisMaxContentContribution(const PlacedGridItem& gridItem, LayoutUnit blockAxisConstraint, const IntegrationUtils& integrationUtils)
+LayoutUnit inlineAxisMaxContentContribution(const PlacedGridItem& gridItem, LayoutUnit blockAxisConstraint, std::optional<LayoutUnit> stretchedBlockSize, const IntegrationUtils& integrationUtils)
 {
     UNUSED_PARAM(blockAxisConstraint);
+    if (stretchedBlockSize)
+        return BorderBoxSize::fromIntegrationFunction(integrationUtils.maxContentLogicalWidthContributionForStretchedGridItem(gridItem.layoutBox(), *stretchedBlockSize)).value;
     return BorderBoxSize::fromIntegrationFunction(integrationUtils.maxContentLogicalWidthContribution(gridItem.layoutBox())).value;
 }
 

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h
@@ -46,6 +46,8 @@ namespace GridLayoutUtils {
 
 LayoutUnit NODELETE totalGuttersSize(size_t tracksCount, LayoutUnit gapsSize);
 
+bool gridItemChildHasInlineSizeComputedFromAspectRatio(const ElementBox& gridItemChild);
+
 LayoutUnit inlinePreferredSize(const PlacedGridItem&, LayoutUnit borderAndPadding, LayoutUnit columnsSize);
 LayoutUnit blockPreferredSize(const PlacedGridItem&, LayoutUnit borderAndPadding, LayoutUnit rowsSize);
 bool hasStretchedBlockSize(const PlacedGridItem&);
@@ -61,8 +63,8 @@ LayoutUnit blockUsedSize(const PlacedGridItem&, const TrackSizingFunctionsList&,
 LayoutUnit computeGridLinePosition(size_t gridLineIndex, const TrackSizes&, LayoutUnit gap);
 LayoutUnit gridAreaDimensionSize(size_t startLine, size_t endLine, const TrackSizes&, LayoutUnit gap);
 
-LayoutUnit inlineAxisMinContentContribution(const PlacedGridItem&, LayoutUnit blockAxisConstraint, const IntegrationUtils&);
-LayoutUnit inlineAxisMaxContentContribution(const PlacedGridItem&, LayoutUnit blockAxisConstraint, const IntegrationUtils&);
+LayoutUnit inlineAxisMinContentContribution(const PlacedGridItem&, LayoutUnit blockAxisConstraint, std::optional<LayoutUnit> stretchedBlockSize, const IntegrationUtils&);
+LayoutUnit inlineAxisMaxContentContribution(const PlacedGridItem&, LayoutUnit blockAxisConstraint, std::optional<LayoutUnit> stretchedBlockSize, const IntegrationUtils&);
 
 LayoutUnit blockAxisMinContentContribution(const PlacedGridItem&, LayoutUnit inlineAxisConstraint, const GridFormattingContext&);
 LayoutUnit blockAxisMaxContentContribution(const PlacedGridItem&, LayoutUnit inlineAxisConstraint, const GridFormattingContext&);

--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
@@ -191,7 +191,7 @@ static Vector<LayoutUnit> minContentContributions(const TrackSizingItemList& tra
     const GridItemSizingFunctions& gridItemSizingFunctions)
 {
     return gridItemIndexes.map([&](size_t gridItemIndex) {
-        return gridItemSizingFunctions.minContentContribution(trackSizingItems[gridItemIndex].gridItem, trackSizingItems[gridItemIndex].oppositeAxisConstraint);
+        return gridItemSizingFunctions.minContentContribution(trackSizingItems[gridItemIndex].gridItem, trackSizingItems[gridItemIndex].oppositeAxisConstraint, trackSizingItems[gridItemIndex].oppositeAxisStretchedSize);
     });
 }
 
@@ -199,7 +199,7 @@ static Vector<LayoutUnit> maxContentContributions(const TrackSizingItemList& tra
     const GridItemSizingFunctions& gridItemSizingFunctions)
 {
     return gridItemIndexes.map([&](size_t gridItemIndex) {
-        return gridItemSizingFunctions.maxContentContribution(trackSizingItems[gridItemIndex].gridItem, trackSizingItems[gridItemIndex].oppositeAxisConstraint);
+        return gridItemSizingFunctions.maxContentContribution(trackSizingItems[gridItemIndex].gridItem, trackSizingItems[gridItemIndex].oppositeAxisConstraint, trackSizingItems[gridItemIndex].oppositeAxisStretchedSize);
     });
 }
 
@@ -216,7 +216,7 @@ static Vector<LayoutUnit> minimumContributions(const TrackSizingItemList& trackS
         if (GridLayoutUtils::preferredSizeBehavesAsAuto(preferredSize) || GridLayoutUtils::preferredSizeDependsOnContainingBlockSize(preferredSize))
             return gridItemSizingFunctions.usedMinimumSize(trackSizingItems[gridItemIndex].gridItem, trackSizingFunctions, borderAndPaddingList[gridItemIndex], { }, trackSizingItems[gridItemIndex].oppositeAxisConstraint);
         // else the item’s minimum contribution is its min-content contribution.
-        return gridItemSizingFunctions.minContentContribution(trackSizingItems[gridItemIndex].gridItem, trackSizingItems[gridItemIndex].oppositeAxisConstraint);
+        return gridItemSizingFunctions.minContentContribution(trackSizingItems[gridItemIndex].gridItem, trackSizingItems[gridItemIndex].oppositeAxisConstraint, trackSizingItems[gridItemIndex].oppositeAxisStretchedSize);
     });
 }
 
@@ -651,7 +651,7 @@ static void expandFlexibleTracksForMaxContent(UnsizedTracks& unsizedTracks, cons
         if (!itemCrossesFlexibleTrack(unsizedTracks, gridItemSpan))
             continue;
 
-        auto maxContentContribution = gridItemSizingFunctions.maxContentContribution(trackSizingItems[gridItemIndex].gridItem, trackSizingItems[gridItemIndex].oppositeAxisConstraint);
+        auto maxContentContribution = gridItemSizingFunctions.maxContentContribution(trackSizingItems[gridItemIndex].gridItem, trackSizingItems[gridItemIndex].oppositeAxisConstraint, trackSizingItems[gridItemIndex].oppositeAxisStretchedSize);
         auto itemTracks = unsizedTracks.subspan(gridItemSpan.begin(), gridItemSpan.distance());
         double candidateFlexFraction = findSizeOfFr(itemTracks, maxContentContribution, gapSize);
 

--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.h
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.h
@@ -47,6 +47,8 @@ struct TrackSizingItem {
     LayoutUnit borderAndPadding;
     WTF::Range<size_t> spannedLines;
     LayoutUnit oppositeAxisConstraint;
+    // Only needed during the second pass of track sizing.
+    std::optional<LayoutUnit> oppositeAxisStretchedSize;
 };
 
 class TrackSizingAlgorithm {

--- a/Source/WebCore/layout/integration/LayoutIntegrationUtils.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationUtils.cpp
@@ -26,7 +26,10 @@
 #include "config.h"
 #include "LayoutIntegrationUtils.h"
 
+#include "GridLayoutUtils.h"
 #include "LayoutBox.h"
+#include "LayoutChildIterator.h"
+#include "LayoutElementBox.h"
 #include "LayoutIntegrationFormattingContextLayout.h"
 #include "LayoutState.h"
 #include "RenderObject.h"
@@ -116,6 +119,58 @@ LayoutUnit IntegrationUtils::maxContentLogicalWidthContribution(const ElementBox
 {
     ASSERT(box.isGridItem());
     return m_globalLayoutState->logicalWidthWithFormattingContextForBox(box, LayoutIntegration::LogicalWidthType::MaxContentContribution);
+}
+
+// https://www.w3.org/TR/css-grid-1/#algo-grid-sizing — step 3.
+// A stretched grid item's block-size-dependent inline contribution is measured with its block size
+// fixed to the stretched (row) size computed in step 2.
+LayoutUnit IntegrationUtils::minContentLogicalWidthContributionForStretchedGridItem(const ElementBox& box, LayoutUnit stretchedBlockSize) const
+{
+    ASSERT(box.isGridItem());
+    CheckedRef renderer = downcast<RenderBox>(*box.rendererForIntegration());
+
+    renderer->setOverridingBorderBoxLogicalHeight(stretchedBlockSize);
+    renderer->invalidateContentLogicalWidths(MarkingBehavior::MarkOnlyThis);
+
+    // The item's cached inline contribution is derived from its children's, so any child with an
+    // inline size computed from an aspect ratio must be invalidated too for it to be remeasured
+    // against the overridden block size.
+    for (auto& child : childrenOfType<ElementBox>(box)) {
+        if (GridLayoutUtils::gridItemChildHasInlineSizeComputedFromAspectRatio(child))
+            downcast<RenderBox>(*child.rendererForIntegration()).invalidateContentLogicalWidths(MarkingBehavior::MarkOnlyThis);
+    }
+
+    auto contribution = m_globalLayoutState->logicalWidthWithFormattingContextForBox(box, LayoutIntegration::LogicalWidthType::MinContentContribution);
+
+    renderer->clearOverridingBorderBoxLogicalHeight();
+
+    return contribution;
+}
+
+// https://www.w3.org/TR/css-grid-1/#algo-grid-sizing — step 3.
+// A stretched grid item's block-size-dependent inline contribution is measured with its block size
+// fixed to the stretched (row) size computed in step 2.
+LayoutUnit IntegrationUtils::maxContentLogicalWidthContributionForStretchedGridItem(const ElementBox& box, LayoutUnit stretchedBlockSize) const
+{
+    ASSERT(box.isGridItem());
+    CheckedRef renderer = downcast<RenderBox>(*box.rendererForIntegration());
+
+    renderer->setOverridingBorderBoxLogicalHeight(stretchedBlockSize);
+    renderer->invalidateContentLogicalWidths(MarkingBehavior::MarkOnlyThis);
+
+    // The item's cached inline contribution is derived from its children's, so any child with an
+    // inline size computed from an aspect ratio must be invalidated too for it to be remeasured
+    // against the overridden block size.
+    for (auto& child : childrenOfType<ElementBox>(box)) {
+        if (GridLayoutUtils::gridItemChildHasInlineSizeComputedFromAspectRatio(child))
+            downcast<RenderBox>(*child.rendererForIntegration()).invalidateContentLogicalWidths(MarkingBehavior::MarkOnlyThis);
+    }
+
+    auto contribution = m_globalLayoutState->logicalWidthWithFormattingContextForBox(box, LayoutIntegration::LogicalWidthType::MaxContentContribution);
+
+    renderer->clearOverridingBorderBoxLogicalHeight();
+
+    return contribution;
 }
 
 void IntegrationUtils::layoutWithFormattingContextForBlockInInline(const ElementBox& block, LayoutPoint blockLineLogicalTopLeft, const InlineLayoutState& inlineLayoutState) const

--- a/Source/WebCore/layout/integration/LayoutIntegrationUtils.h
+++ b/Source/WebCore/layout/integration/LayoutIntegrationUtils.h
@@ -53,6 +53,8 @@ public:
     LayoutUnit maxContentContributionHeightForGridItem(const ElementBox&, LayoutUnit inlineAxisConstraint) const;
     LayoutUnit minContentLogicalWidthContribution(const ElementBox&) const;
     LayoutUnit maxContentLogicalWidthContribution(const ElementBox&) const;
+    LayoutUnit minContentLogicalWidthContributionForStretchedGridItem(const ElementBox&, LayoutUnit stretchedBlockSize) const;
+    LayoutUnit maxContentLogicalWidthContributionForStretchedGridItem(const ElementBox&, LayoutUnit stretchedBlockSize) const;
     void layoutWithFormattingContextForBlockInInline(const ElementBox& block, LayoutPoint blockLineLogicalTopLeft, const InlineLayoutState&) const;
 
     static BlockLayoutState::MarginState NODELETE toMarginState(const RenderBlockFlow::MarginInfo&);


### PR DESCRIPTION
#### 2be101835896388f9695d28669ac6c9df5f5e5d0
<pre>
[GFC] Begin running second iteration of column sizing.
<a href="https://bugs.webkit.org/show_bug.cgi?id=318905">https://bugs.webkit.org/show_bug.cgi?id=318905</a>
<a href="https://rdar.apple.com/problem/181741228">rdar://problem/181741228</a>

Reviewed by NOBODY (OOPS!).

There are certain scenarios in which we may need to rerun column sizing
after sizing the rows in step 2 of the &quot;Grid Sizing Algorithm.&quot; This is
because the content contributions of items may change if we take into
consideration the rows that were computed as part of step 2 as block
axis space. In fact, the grid spec actually calls out a few different
pieces of content in which this can actually occur in which we would
need to rerun column sizing to compenstae for these new contributions.

In this patch we begin running column sizing again and focus on a
particular case that the spec calls out: grid items which have a child
with an aspect ratio. If the grid item is stretched in the block
direction, then that child may use that definite available space to
compute its width from the aspect ratio.

* Source/WebCore/layout/formattingContexts/grid/GridItemSizingFunctions.cpp:
(WebCore::Layout::GridItemSizingFunctions::inlineAxis):
(WebCore::Layout::GridItemSizingFunctions::blockAxis):
When computing the min/max content contributions we need to know if the
item is being stretched in the opposite axis (e.g. when recomputing the
min/max contribution widths we need to know if the item is stretched in
the block direction) so that we can use those as the overriding border
box sizes during the associated integration API.

(WebCore::Layout::GridItemSizingFunctions::GridItemSizingFunctions):
* Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp:
(WebCore::Layout::GridLayout::sizeColumnTracks const):
(WebCore::Layout::GridLayout::sizeRowTracks const):
The stretching can only occur if we are rerunning rows and columns so
during the initial pass of those we pass in std::nullopt to represent
that.

(WebCore::Layout::hasItemWithInlineSizeDependentOnGridAreaBlockSize):
This is the first implementation of the function that will be used to
determine whether or not we rerun column sizing. It currently just
focuses on the scenario where the grid item has a child with an aspect
ratio but we will need to build this up. I only added this case for now
to keep the patch as simple as possible.

* Source/WebCore/layout/integration/LayoutIntegrationUtils.cpp:
(WebCore::Layout::IntegrationUtils::minContentLogicalWidthContributionForStretchedGridItem const):
(WebCore::Layout::IntegrationUtils::maxContentLogicalWidthContributionForStretchedGridItem const):
These are dedicated functions to be used for this specific case. The
associated API in actual grid layout code will determine whether or not
to call these variants based upon if the item has a stretched size or
not.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2be101835896388f9695d28669ac6c9df5f5e5d0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173358 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47290 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40841 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182931 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130914 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ffba1a45-8b5c-45a1-8d41-a725e7bbc97c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175223 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48583 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46972 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134797 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-inline-size-from-stretched-block-size-001.html imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-inline-size-from-stretched-block-size-002.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95184 "2 flakes 5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f84a3fc3-430b-4af2-83f3-203884e76dc4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176316 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38215 "Found 1 new test failure: fast/css/getComputedStyle-font-variant-shorthand-crash.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155460 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115272 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/076e03d8-198f-4f42-9711-61e0e411cd8e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36857 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35208 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31416 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147281 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34957 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185355 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38223 "Found 4 new failures in layout/integration/LayoutIntegrationUtils.cpp") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39410 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-inline-size-from-stretched-block-size-001.html imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-inline-size-from-stretched-block-size-002.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143660 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-inline-size-from-stretched-block-size-001.html imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-inline-size-from-stretched-block-size-002.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46958 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155019 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143524 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47637 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31794 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112740 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38467 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119386 "Found 1063 new failures in b3/B3Value.h, b3/testb3_7.cpp, WebProcess/Network/WebResourceLoader.cpp, jit/OperationResult.h, UIProcess/WebProcessPool.cpp, testing/MockMediaSessionCoordinator.cpp, Shared/Cocoa/WKNSArray.mm, heap/WeakSet.h, API/tests/Regress141275.mm, Shared/SessionState.cpp ...") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/210391 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46143 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9904 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/210391 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45545 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45776 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45602 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->