### PR TITLE
Fix leak of RemoteMediaSessionClientProxy when site isolation or RemoteMediaSessionManager is enabled

### DIFF
--- a/Source/WebCore/platform/audio/PlatformMediaSessionInterface.h
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionInterface.h
@@ -118,7 +118,7 @@ protected:
 
 inline bool PlatformMediaSessionClient::isRemoteSessionClientProxy() const { return false; }
 
-PlatformMediaSessionClient& NODELETE emptyPlatformMediaSessionClient();
+WEBCORE_EXPORT PlatformMediaSessionClient& NODELETE emptyPlatformMediaSessionClient();
 
 class WEBCORE_EXPORT PlatformMediaSessionInterface
     : public RefCountedAndCanMakeWeakPtr<PlatformMediaSessionInterface>

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionClientProxy.h
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionClientProxy.h
@@ -41,8 +41,10 @@ class RemoteMediaSessionClientProxy final
     : public WebCore::PlatformMediaSessionClient
     , public RefCounted<RemoteMediaSessionClientProxy> {
     WTF_MAKE_TZONE_ALLOCATED(RemoteMediaSessionClientProxy);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RemoteMediaSessionClientProxy);
 public:
-    RemoteMediaSessionClientProxy(const RemoteMediaSessionState&, RemoteMediaSessionManagerProxy&);
+    static Ref<RemoteMediaSessionClientProxy> create(const RemoteMediaSessionState& state, RemoteMediaSessionManagerProxy& manager) { return adoptRef(*new RemoteMediaSessionClientProxy(state, manager)); }
+
     virtual ~RemoteMediaSessionClientProxy();
 
     WebCore::MediaSessionIdentifier sessionIdentifier() const { return m_state.sessionIdentifier; }
@@ -58,6 +60,7 @@ public:
     bool isRemoteSessionClientProxy() const final { return true; }
 
 protected:
+    RemoteMediaSessionClientProxy(const RemoteMediaSessionState&, RemoteMediaSessionManagerProxy&);
 
     RefPtr<WebCore::MediaSessionManagerInterface> sessionManager() const final;
 

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionProxy.cpp
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionProxy.cpp
@@ -38,8 +38,14 @@ namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteMediaSessionProxy);
 
-RemoteMediaSessionProxy::RemoteMediaSessionProxy(const RemoteMediaSessionState& state, RemoteMediaSessionManagerProxy& manager)
-    : PlatformMediaSession(*new RemoteMediaSessionClientProxy(state, manager))
+Ref<RemoteMediaSessionProxy> RemoteMediaSessionProxy::create(RemoteMediaSessionState& state, RemoteMediaSessionManagerProxy& manager)
+{
+    return adoptRef(*new RemoteMediaSessionProxy(RemoteMediaSessionClientProxy::create(state, manager), state, manager));
+}
+
+RemoteMediaSessionProxy::RemoteMediaSessionProxy(Ref<RemoteMediaSessionClientProxy>&& client, const RemoteMediaSessionState& state, RemoteMediaSessionManagerProxy& manager)
+    : PlatformMediaSession(client)
+    , m_client(WTF::move(client))
     , m_manager(manager)
     , m_sessionState(state)
 #if !RELEASE_LOG_DISABLED
@@ -49,7 +55,10 @@ RemoteMediaSessionProxy::RemoteMediaSessionProxy(const RemoteMediaSessionState& 
     setMediaSessionIdentifier(state.sessionIdentifier);
 }
 
-RemoteMediaSessionProxy::~RemoteMediaSessionProxy() = default;
+RemoteMediaSessionProxy::~RemoteMediaSessionProxy()
+{
+    invalidateClient();
+}
 
 void RemoteMediaSessionProxy::updateState(const RemoteMediaSessionState& remoteState)
 {

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionProxy.h
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionProxy.h
@@ -25,26 +25,21 @@
 
 #pragma once
 
-#include "UIProcess/Media/RemoteMediaSessionManagerProxy.h"
 #if ENABLE(VIDEO) || ENABLE(WEB_AUDIO)
 
-#include "RemoteMediaSessionClientProxy.h"
 #include "RemoteMediaSessionManagerProxy.h"
 #include "RemoteMediaSessionState.h"
 #include <WebCore/PlatformMediaSession.h>
 
 namespace WebKit {
+class RemoteMediaSessionClientProxy;
 class RemoteMediaSessionManagerProxy;
 
 class RemoteMediaSessionProxy final
     : public WebCore::PlatformMediaSession {
     WTF_MAKE_TZONE_ALLOCATED(RemoteMediaSessionProxy);
 public:
-    static Ref<RemoteMediaSessionProxy> create(RemoteMediaSessionState& state, RemoteMediaSessionManagerProxy& manager)
-    {
-        return adoptRef(*new RemoteMediaSessionProxy(state, manager));
-    }
-
+    static Ref<RemoteMediaSessionProxy> create(RemoteMediaSessionState&, RemoteMediaSessionManagerProxy&);
     ~RemoteMediaSessionProxy();
 
     void updateState(const RemoteMediaSessionState&);
@@ -55,7 +50,7 @@ public:
     WeakPtr<RemoteMediaSessionManagerProxy> manager() const { return m_manager; }
 
 private:
-    RemoteMediaSessionProxy(const RemoteMediaSessionState&, RemoteMediaSessionManagerProxy&);
+    RemoteMediaSessionProxy(Ref<RemoteMediaSessionClientProxy>&&, const RemoteMediaSessionState&, RemoteMediaSessionManagerProxy&);
 
     WebCore::PlatformMediaSessionState state() const  final { return m_sessionState.state; }
     void setState(WebCore::PlatformMediaSessionState) final;
@@ -86,6 +81,7 @@ private:
     uint64_t logIdentifier() const { return m_sessionState.logIdentifier; }
 #endif
 
+    const Ref<RemoteMediaSessionClientProxy> m_client;
     WeakPtr<RemoteMediaSessionManagerProxy> m_manager;
     RemoteMediaSessionState m_sessionState;
 #if !RELEASE_LOG_DISABLED


### PR DESCRIPTION
#### 00c5301ecd88076bfa94075e6c1497fd8507495f
<pre>
Fix leak of RemoteMediaSessionClientProxy when site isolation or RemoteMediaSessionManager is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=318907">https://bugs.webkit.org/show_bug.cgi?id=318907</a>
<a href="https://rdar.apple.com/181742876">rdar://181742876</a>

Reviewed by Rupin Mittal.

The RemoteMediaSessionProxy constructor was creating a new RemoteMediaSessionClientProxy, but that
client was not adopted so it was not owned so it will never be destroyed.  This adds ownership.

* Source/WebCore/platform/audio/PlatformMediaSessionInterface.h:
* Source/WebKit/UIProcess/Media/RemoteMediaSessionClientProxy.h:
* Source/WebKit/UIProcess/Media/RemoteMediaSessionProxy.cpp:
(WebKit::RemoteMediaSessionProxy::create):
(WebKit::RemoteMediaSessionProxy::RemoteMediaSessionProxy):
(WebKit::RemoteMediaSessionProxy::~RemoteMediaSessionProxy):
* Source/WebKit/UIProcess/Media/RemoteMediaSessionProxy.h:

Canonical link: <a href="https://commits.webkit.org/316780@main">https://commits.webkit.org/316780@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49f5a0ebf12c38c9c2494a18d1c74956c043a3aa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173371 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47303 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40856 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182944 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130927 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e863a9eb-8814-4c9f-9f02-1d48c77f0479) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175236 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48596 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46985 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134808 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176329 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38229 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/155467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115284 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b697a447-da2a-469e-8ee3-1c371163056d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36871 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/35220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31429 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147295 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34964 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185369 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38236 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39422 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143668 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46971 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143532 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47650 "Built successfully") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112753 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26342 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38480 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/119399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46156 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9911 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45558 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45789 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45615 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->