### PR TITLE
git-webkit apply should let you review and choose among a bug's attached patches

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/apply.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/apply.py
@@ -20,26 +20,23 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import argparse
 import os
 import sys
 import tempfile
 
 from .command import Command
 from .diff.html_diff import HTMLDiff
+from .pull_request import PullRequest
 
 from webkitbugspy import radar, Tracker
-from webkitcorepy import run, Terminal
+from webkitcorepy import arguments, run, Terminal
 from webkitscmpy import local, log
 
 
 class Apply(Command):
     name = 'apply'
     help = 'Apply a patch attached to a bug tracker issue (for example, a proposed revert or build fix)'
-
-    # Patch names build-failure triage tends to attach, most-preferred first. When an issue has more
-    # than one patch and the user does not name one, the first of these that is present is the
-    # default selection in the chooser.
-    PREFERRED_PATCHES = ('triage-revert.patch', 'triage-fix.patch')
 
     @classmethod
     def parser(cls, parser, loggers=None):
@@ -72,21 +69,63 @@ class Apply(Command):
         return None
 
     @classmethod
-    def select_patch(cls, patches, name=None):
-        '''Pick one attachment from `patches`. With an explicit `name`, return the exact match (or
-        None if there is none). Otherwise return the only patch, or prompt the user to choose,
-        defaulting to the most-preferred known patch that is present.'''
+    def review(cls, patch, repository, alternatives=False):
+        '''Open the patch as a blocking HTML diff and return whether the user accepted it. Closing the
+        diff or pressing Enter accepts it; answering 'n' rejects it.'''
+        content = patch.contents()
+        if content is None:
+            sys.stderr.write("Could not download '{}'\n".format(patch.name))
+            return False
+        text = content if isinstance(content, str) else content.decode('utf-8', errors='replace')
+        dismiss = 'pick a different patch' if alternatives else 'cancel'
+        sys.stdout.write("Reviewing '{}' -- close the diff or press Enter to apply it, or enter 'n' to {}.\n".format(patch.name, dismiss))
+        with HTMLDiff(block=True, repository=repository) as diff_viewer:
+            diff_viewer.add_lines(text.splitlines())
+        return diff_viewer.accepted
+
+    @classmethod
+    def select_patch(cls, patches, name=None, repository=None, interactive=False):
+        '''Return the patch to apply, or None. With `name`, the exact match. Otherwise non-interactive
+        returns the first patch; interactive shows a menu in the order the tracker lists the patches
+        (skipped when there is only one), defaulting to the first, and reviews the chosen patch's diff
+        -- closing or accepting the diff selects it, while answering 'n' returns to the menu.'''
         by_name = {patch.name: patch for patch in patches}
         if name:
-            return by_name.get(name)
-        if len(patches) == 1:
+            patch = by_name.get(name)
+            if patch is None or not interactive:
+                return patch
+            return patch if cls.review(patch, repository) else None
+        options = [patch.name for patch in patches]
+        if not interactive:
             return patches[0]
-        options = sorted(by_name.keys())
-        default = next((name for name in cls.PREFERRED_PATCHES if name in by_name), options[0])
-        return by_name.get(Terminal.choose(
-            'Which patch would you like to apply?',
-            options=options, default=default, numbered=True,
-        ))
+        while True:
+            choice = options[0] if len(options) == 1 else Terminal.choose(
+                'Which patch would you like to apply?',
+                options=options, default=options[0], numbered=True,
+            )
+            if cls.review(by_name[choice], repository, alternatives=len(options) > 1):
+                return by_name[choice]
+            if len(options) == 1:
+                return None
+
+    @classmethod
+    def edit_commit_message(cls, repository):
+        '''Amend the just-applied commit without a message flag, so git opens its message in the editor.
+        No --date, so `git am`'s preserved author date survives.'''
+        if run([repository.executable(), 'commit', '--amend'], cwd=repository.root_path).returncode:
+            sys.stderr.write("Applied the patch, but couldn't open the commit message for editing; it keeps the patch's message.\n")
+
+    @classmethod
+    def offer_pull_request(cls, repository, **kwargs):
+        '''Offer to open a pull request for the just-applied commit, running pull-request in-process
+        with its default arguments. LoggingGroup supplies the shared verbosity args its main reads,
+        mirroring how the top-level parser builds each sub-command.'''
+        if Terminal.choose('Would you like to create a pull request?', default='Yes') != 'Yes':
+            return
+        parser = argparse.ArgumentParser()
+        arguments.LoggingGroup(parser)
+        PullRequest.parser(parser)
+        PullRequest.main(parser.parse_args([]), repository, **kwargs)
 
     @classmethod
     def main(cls, args, repository, **kwargs):
@@ -110,9 +149,13 @@ class Apply(Command):
             sys.stderr.write('No patches are attached to {}\n'.format(issue.link))
             return 1
 
-        patch = cls.select_patch(patches, name=args.name)
+        interactive = Terminal.isatty(sys.stdout) and Terminal.isatty(sys.stdin)
+        patch = cls.select_patch(patches, name=args.name, repository=repository, interactive=interactive)
         if not patch:
-            sys.stderr.write("No '{}' patch is attached to {}\n".format(args.name, issue.link))
+            if args.name and not any(candidate.name == args.name for candidate in patches):
+                sys.stderr.write("No '{}' patch is attached to {}\n".format(args.name, issue.link))
+            else:
+                sys.stderr.write('No patch applied\n')
             return 1
 
         # The patch is issue-attachment content -- whoever can attach to the issue controls these
@@ -126,13 +169,6 @@ class Apply(Command):
         if not content.strip():
             sys.stderr.write("'{}' on {} is empty\n".format(patch.name, issue.link))
             return 1
-
-        # On an interactive terminal, open the patch as an HTML diff and block until the viewer is
-        # dismissed -- these bytes came from an attachment, so let the user see what they're applying
-        # first. Dismissing the diff continues; a user who disagrees interrupts the program instead.
-        if Terminal.isatty(sys.stdout) and Terminal.isatty(sys.stdin):
-            with HTMLDiff(block=True, repository=repository) as diff_viewer:
-                diff_viewer.add_lines(content.decode('utf-8', errors='replace').splitlines())
 
         handle, patch_path = tempfile.mkstemp(suffix='.patch')
         try:
@@ -154,6 +190,10 @@ class Apply(Command):
                 return 1
         finally:
             os.remove(patch_path)
+
+        if args.commit and interactive:
+            cls.edit_commit_message(repository)
+            cls.offer_pull_request(repository, **kwargs)
 
         log.info("Applied '{}' from {}".format(patch.name, issue.link))
         return 0

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/diff/diff.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/diff/diff.py
@@ -49,7 +49,10 @@ class DiffBase(object, metaclass=DiffMeta):
 
         commit_match = self.FROM_COMMIT_RE.match(line)
         if commit_match and self.repository:
-            commit = self.repository.commit(hash=commit_match.group(1), include_log=False)
+            try:
+                commit = self.repository.commit(hash=commit_match.group(1), include_log=False)
+            except self.repository.Exception:
+                return line
             return 'From {} ({})\n'.format(commit, commit_match.group(1)[:Commit.HASH_LABEL_SIZE])
         author_match = self.FROM_AUTHOR_RE.match(line)
         if author_match:

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/diff/html_diff.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/diff/html_diff.py
@@ -319,6 +319,7 @@ pre, .text {
 
         if self.block is None:
             self.block = False
+        self.accepted = True
 
         self._file_handle = None
         self._div = []
@@ -508,7 +509,8 @@ pre, .text {
 
             def _wait_for_enter():
                 try:
-                    sys.stdin.readline()
+                    if sys.stdin.readline().strip().lower() in ('n', 'no'):
+                        self.accepted = False
                 finally:
                     finished.set()
 

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/apply_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/apply_unittest.py
@@ -80,23 +80,105 @@ class TestApply(unittest.TestCase):
     def test_select_patch_by_name_missing(self):
         self.assertIsNone(Apply.select_patch([self._patch('triage-fix.patch')], name='absent.patch'))
 
-    def test_select_patch_single(self):
+    def test_select_patch_named_reviewed_when_interactive(self):
+        patches = [self._patch('triage-fix.patch'), self._patch('triage-revert.patch')]
+        with patch.object(Apply, 'review', return_value=True) as review:
+            selected = Apply.select_patch(patches, name='triage-fix.patch', repository=self._repo(), interactive=True)
+        self.assertIs(selected, patches[0])
+        review.assert_called_once()
+
+    def test_select_patch_named_rejected_when_interactive_returns_none(self):
+        patches = [self._patch('triage-fix.patch')]
+        with patch.object(Apply, 'review', return_value=False):
+            self.assertIsNone(Apply.select_patch(patches, name='triage-fix.patch', repository=self._repo(), interactive=True))
+
+    def test_select_patch_named_non_interactive_skips_review(self):
+        patches = [self._patch('triage-fix.patch')]
+        with patch.object(Apply, 'review') as review:
+            self.assertIs(Apply.select_patch(patches, name='triage-fix.patch'), patches[0])
+        review.assert_not_called()
+
+    def test_select_patch_non_interactive_returns_single(self):
         patches = [self._patch('only.patch')]
         self.assertIs(Apply.select_patch(patches), patches[0])
 
-    def test_select_patch_prompts_with_preferred_default(self):
-        patches = [self._patch('triage-revert.patch'), self._patch('triage-fix.patch'), self._patch('other.patch')]
-        with patch('webkitscmpy.program.apply.Terminal.choose', return_value='other.patch') as choose:
-            selected = Apply.select_patch(patches)
-        self.assertEqual(selected.name, 'other.patch')
-        self.assertEqual(choose.call_args.kwargs['default'], 'triage-revert.patch')
-        self.assertEqual(choose.call_args.kwargs['options'], ['other.patch', 'triage-fix.patch', 'triage-revert.patch'])
+    def test_select_patch_non_interactive_returns_first_in_tracker_order(self):
+        patches = [self._patch('triage-revert.patch'), self._patch('triage-fix.patch')]
+        self.assertIs(Apply.select_patch(patches), patches[0])
 
-    def test_select_patch_defaults_to_first_when_none_preferred(self):
-        patches = [self._patch('zeta.patch'), self._patch('alpha.patch')]
-        with patch('webkitscmpy.program.apply.Terminal.choose', return_value='alpha.patch') as choose:
-            Apply.select_patch(patches)
-        self.assertEqual(choose.call_args.kwargs['default'], 'alpha.patch')
+    def test_select_patch_menu_preserves_tracker_order_and_defaults_to_first(self):
+        patches = [self._patch('triage-revert.patch'), self._patch('triage-fix.patch')]
+        with patch('webkitscmpy.program.apply.Terminal.choose', return_value='triage-fix.patch') as choose, \
+             patch.object(Apply, 'review', return_value=True):
+            Apply.select_patch(patches, repository=self._repo(), interactive=True)
+        self.assertEqual(choose.call_args.kwargs['options'], ['triage-revert.patch', 'triage-fix.patch'])
+        self.assertEqual(choose.call_args.kwargs['default'], 'triage-revert.patch')
+
+    def test_select_patch_offers_every_variant_in_the_menu(self):
+        patches = [self._patch('triage-fix.patch'), self._patch('triage-fix[2].patch')]
+        with patch('webkitscmpy.program.apply.Terminal.choose', return_value='triage-fix[2].patch') as choose, \
+             patch.object(Apply, 'review', return_value=True):
+            selected = Apply.select_patch(patches, repository=self._repo(), interactive=True)
+        self.assertEqual(selected.name, 'triage-fix[2].patch')
+        self.assertEqual(sorted(choose.call_args.kwargs['options']), ['triage-fix.patch', 'triage-fix[2].patch'])
+
+    def test_select_patch_interactive_accepts_reviewed_patch(self):
+        patches = [self._patch('triage-fix.patch')]
+        with patch.object(Apply, 'review', return_value=True) as review:
+            selected = Apply.select_patch(patches, repository=self._repo(), interactive=True)
+        self.assertIs(selected, patches[0])
+        review.assert_called_once()
+
+    def test_select_patch_interactive_single_rejected_returns_none(self):
+        patches = [self._patch('triage-fix.patch')]
+        with patch.object(Apply, 'review', return_value=False):
+            self.assertIsNone(Apply.select_patch(patches, repository=self._repo(), interactive=True))
+
+    def test_select_patch_interactive_reject_returns_to_menu(self):
+        patches = [self._patch('triage-fix.patch'), self._patch('triage-revert.patch')]
+        with patch('webkitscmpy.program.apply.Terminal.choose', side_effect=['triage-revert.patch', 'triage-fix.patch']) as choose, \
+             patch.object(Apply, 'review', side_effect=[False, True]) as review:
+            selected = Apply.select_patch(patches, repository=self._repo(), interactive=True)
+        self.assertEqual(selected.name, 'triage-fix.patch')
+        self.assertEqual(choose.call_count, 2)
+        self.assertEqual(review.call_count, 2)
+
+    @patch('webkitscmpy.program.apply.HTMLDiff')
+    def test_review_accepts_when_diff_accepted(self, mock_htmldiff):
+        mock_htmldiff.return_value.__enter__.return_value.accepted = True
+        with OutputCapture():
+            self.assertTrue(Apply.review(self._patch('triage-fix.patch', contents=b'PATCH'), self._repo()))
+        self.assertEqual(mock_htmldiff.call_args.kwargs.get('block'), True)
+        mock_htmldiff.return_value.__enter__.return_value.add_lines.assert_called_once()
+
+    @patch('webkitscmpy.program.apply.HTMLDiff')
+    def test_review_rejects_when_diff_rejected(self, mock_htmldiff):
+        mock_htmldiff.return_value.__enter__.return_value.accepted = False
+        with OutputCapture():
+            self.assertFalse(Apply.review(self._patch('triage-fix.patch', contents=b'PATCH'), self._repo()))
+
+    @patch('webkitscmpy.program.apply.HTMLDiff')
+    def test_review_rejects_undownloadable_patch(self, mock_htmldiff):
+        with OutputCapture() as captured:
+            self.assertFalse(Apply.review(self._patch('triage-fix.patch', contents=None), self._repo()))
+        mock_htmldiff.assert_not_called()
+        self.assertIn('Could not download', captured.stderr.getvalue())
+
+    @patch('webkitscmpy.program.apply.PullRequest.main')
+    def test_offer_pull_request_invokes_pull_request_when_accepted(self, pr_main):
+        repository = self._repo()
+        with patch('webkitscmpy.program.apply.Terminal.choose', return_value='Yes'):
+            Apply.offer_pull_request(repository)
+        pr_main.assert_called_once()
+        self.assertIs(pr_main.call_args.args[1], repository)
+        self.assertIsNone(pr_main.call_args.args[0].issue)
+        self.assertTrue(hasattr(pr_main.call_args.args[0], 'verbose'))
+
+    @patch('webkitscmpy.program.apply.PullRequest.main')
+    def test_offer_pull_request_skips_when_declined(self, pr_main):
+        with patch('webkitscmpy.program.apply.Terminal.choose', return_value='No'):
+            Apply.offer_pull_request(self._repo())
+        pr_main.assert_not_called()
 
     @patch('webkitscmpy.program.apply.run')
     def test_main_rejects_non_git_repository(self, mock_run):
@@ -146,6 +228,19 @@ class TestApply(unittest.TestCase):
             result = Apply.main(Namespace(issue='rdar://5', name='absent.patch', commit=True), self._repo())
         self.assertEqual(result, 1)
         self.assertIn("No 'absent.patch' patch is attached", captured.stderr.getvalue())
+        mock_run.assert_not_called()
+
+    @patch('webkitscmpy.program.apply.HTMLDiff')
+    @patch('webkitscmpy.program.apply.run')
+    def test_main_named_patch_rejected_reports_not_applied(self, mock_run, mock_htmldiff):
+        mock_htmldiff.return_value.__enter__.return_value.accepted = False
+        issue = self._issue(patches=[self._patch('triage-fix.patch', contents=b'PATCH')])
+        with patch.object(Apply, 'resolve_issue', return_value=issue), \
+             patch('webkitscmpy.program.apply.Terminal.isatty', return_value=True), OutputCapture() as captured:
+            result = Apply.main(Namespace(issue='rdar://5', name='triage-fix.patch', commit=True), self._repo())
+        self.assertEqual(result, 1)
+        self.assertIn('No patch applied', captured.stderr.getvalue())
+        self.assertNotIn('is attached', captured.stderr.getvalue())
         mock_run.assert_not_called()
 
     @patch('webkitscmpy.program.apply.run')
@@ -258,20 +353,76 @@ class TestApply(unittest.TestCase):
 
     @patch('webkitscmpy.program.apply.HTMLDiff')
     @patch('webkitscmpy.program.apply.run')
-    def test_main_previews_diff_when_interactive(self, mock_run, mock_htmldiff):
+    def test_main_reviews_and_opens_editor_when_interactive(self, mock_run, mock_htmldiff):
         mock_run.return_value = MagicMock(returncode=0)
+        mock_htmldiff.return_value.__enter__.return_value.accepted = True
         issue = self._issue(patches=[self._patch('triage-fix.patch', contents=b'PATCH')])
         with patch.object(Apply, 'resolve_issue', return_value=issue), \
-             patch('webkitscmpy.program.apply.Terminal.isatty', return_value=True), OutputCapture():
+             patch('webkitscmpy.program.apply.Terminal.isatty', return_value=True), \
+             patch('webkitscmpy.program.apply.Terminal.choose', return_value='No'), OutputCapture():
             result = Apply.main(Namespace(issue='rdar://5', name=None, commit=True), self._repo())
         self.assertEqual(result, 0)
-        mock_htmldiff.assert_called_once()
         self.assertEqual(mock_htmldiff.call_args.kwargs.get('block'), True)
-        self.assertEqual(mock_run.call_args.args[0][:2], ['git', 'am'])
+        commands = [call.args[0] for call in mock_run.call_args_list]
+        self.assertEqual(commands[0][:2], ['git', 'am'])
+        self.assertEqual(commands[-1], ['git', 'commit', '--amend'])
+
+    @patch('webkitscmpy.program.apply.PullRequest.main')
+    @patch('webkitscmpy.program.apply.HTMLDiff')
+    @patch('webkitscmpy.program.apply.run')
+    def test_main_creates_pull_request_when_accepted(self, mock_run, mock_htmldiff, pr_main):
+        mock_run.return_value = MagicMock(returncode=0)
+        mock_htmldiff.return_value.__enter__.return_value.accepted = True
+        issue = self._issue(patches=[self._patch('triage-fix.patch', contents=b'PATCH')])
+        with patch.object(Apply, 'resolve_issue', return_value=issue), \
+             patch('webkitscmpy.program.apply.Terminal.isatty', return_value=True), \
+             patch('webkitscmpy.program.apply.Terminal.choose', return_value='Yes'), OutputCapture():
+            result = Apply.main(Namespace(issue='rdar://5', name=None, commit=True), self._repo())
+        self.assertEqual(result, 0)
+        pr_main.assert_called_once()
+
+    @patch('webkitscmpy.program.apply.PullRequest.main')
+    @patch('webkitscmpy.program.apply.HTMLDiff')
+    @patch('webkitscmpy.program.apply.run')
+    def test_main_skips_pull_request_when_declined(self, mock_run, mock_htmldiff, pr_main):
+        mock_run.return_value = MagicMock(returncode=0)
+        mock_htmldiff.return_value.__enter__.return_value.accepted = True
+        issue = self._issue(patches=[self._patch('triage-fix.patch', contents=b'PATCH')])
+        with patch.object(Apply, 'resolve_issue', return_value=issue), \
+             patch('webkitscmpy.program.apply.Terminal.isatty', return_value=True), \
+             patch('webkitscmpy.program.apply.Terminal.choose', return_value='No'), OutputCapture():
+            Apply.main(Namespace(issue='rdar://5', name=None, commit=True), self._repo())
+        pr_main.assert_not_called()
 
     @patch('webkitscmpy.program.apply.HTMLDiff')
     @patch('webkitscmpy.program.apply.run')
-    def test_main_skips_diff_when_not_interactive(self, mock_run, mock_htmldiff):
+    def test_main_no_editor_when_not_committing(self, mock_run, mock_htmldiff):
+        mock_run.return_value = MagicMock(returncode=0)
+        mock_htmldiff.return_value.__enter__.return_value.accepted = True
+        issue = self._issue(patches=[self._patch('triage-fix.patch', contents=b'PATCH')])
+        with patch.object(Apply, 'resolve_issue', return_value=issue), \
+             patch('webkitscmpy.program.apply.Terminal.isatty', return_value=True), OutputCapture():
+            result = Apply.main(Namespace(issue='rdar://5', name=None, commit=False), self._repo())
+        self.assertEqual(result, 0)
+        commands = [call.args[0] for call in mock_run.call_args_list]
+        self.assertEqual(commands[0][:3], ['git', 'apply', '--3way'])
+        self.assertNotIn(['git', 'commit', '--amend', '--date=now'], commands)
+
+    @patch('webkitscmpy.program.apply.HTMLDiff')
+    @patch('webkitscmpy.program.apply.run')
+    def test_main_declined_review_is_not_applied(self, mock_run, mock_htmldiff):
+        mock_htmldiff.return_value.__enter__.return_value.accepted = False
+        issue = self._issue(patches=[self._patch('triage-fix.patch', contents=b'PATCH')])
+        with patch.object(Apply, 'resolve_issue', return_value=issue), \
+             patch('webkitscmpy.program.apply.Terminal.isatty', return_value=True), OutputCapture() as captured:
+            result = Apply.main(Namespace(issue='rdar://5', name=None, commit=True), self._repo())
+        self.assertEqual(result, 1)
+        self.assertIn('No patch applied', captured.stderr.getvalue())
+        mock_run.assert_not_called()
+
+    @patch('webkitscmpy.program.apply.HTMLDiff')
+    @patch('webkitscmpy.program.apply.run')
+    def test_main_skips_review_and_editor_when_not_interactive(self, mock_run, mock_htmldiff):
         mock_run.return_value = MagicMock(returncode=0)
         issue = self._issue(patches=[self._patch('triage-fix.patch', contents=b'PATCH')])
         with patch.object(Apply, 'resolve_issue', return_value=issue), \
@@ -279,6 +430,9 @@ class TestApply(unittest.TestCase):
             result = Apply.main(Namespace(issue='rdar://5', name=None, commit=True), self._repo())
         self.assertEqual(result, 0)
         mock_htmldiff.assert_not_called()
+        commands = [call.args[0] for call in mock_run.call_args_list]
+        self.assertEqual(len(commands), 1)
+        self.assertEqual(commands[0][:2], ['git', 'am'])
 
 
 if __name__ == '__main__':

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/diff_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/diff_unittest.py
@@ -1,0 +1,74 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import unittest
+from unittest.mock import MagicMock
+
+from webkitscmpy import Commit, local
+from webkitscmpy.program.diff.diff import DiffBase
+
+
+class _Commit(object):
+    def __init__(self, identifier):
+        self.identifier = identifier
+
+    def __str__(self):
+        return self.identifier
+
+
+class TestDiffBase(unittest.TestCase):
+    NULL_SHA = '0' * 40
+    RESOLVED_SHA = 'a' * 40
+
+    # add_lines() feeds add_line() the output of str.splitlines(), which strips the trailing
+    # newline; add_line() adds one back. Inputs here omit it to match that real call path.
+    @staticmethod
+    def _from_line(sha):
+        return 'From {} Mon Sep 17 00:00:00 2001'.format(sha)
+
+    def _repo(self, commit=None, unresolvable=False):
+        repository = MagicMock(spec=local.Git)
+        repository.Exception = local.Scm.Exception
+        if unresolvable:
+            repository.commit.side_effect = local.Scm.Exception('no such commit')
+        else:
+            repository.commit.return_value = commit
+        return repository
+
+    def test_from_line_rewritten_when_hash_resolves(self):
+        diff = DiffBase(repository=self._repo(commit=_Commit('271828@main')))
+        result = diff.add_line(self._from_line(self.RESOLVED_SHA))
+        self.assertEqual(result, 'From 271828@main ({})\n'.format(self.RESOLVED_SHA[:Commit.HASH_LABEL_SIZE]))
+
+    def test_from_line_falls_back_when_hash_unresolvable(self):
+        diff = DiffBase(repository=self._repo(unresolvable=True))
+        line = self._from_line(self.NULL_SHA)
+        self.assertEqual(diff.add_line(line), line + '\n')
+
+    def test_from_line_ignored_without_repository(self):
+        diff = DiffBase(repository=None)
+        line = self._from_line(self.NULL_SHA)
+        self.assertEqual(diff.add_line(line), line + '\n')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
#### 4087d3f231d5c4b52ffc8c5be1d3344a9d37ba36
<pre>
git-webkit apply should let you review and choose among a bug&apos;s attached patches
<a href="https://bugs.webkit.org/show_bug.cgi?id=318912">https://bugs.webkit.org/show_bug.cgi?id=318912</a>
<a href="https://rdar.apple.com/181747976">rdar://181747976</a>

Reviewed by Jonathan Bedard.

`git-webkit apply` picked a patch from a numbered list and then rendered
its diff, which crashed on exactly the generated triage patches it targets:
their format-patch `From` line carries the null SHA, and the HTML differ
tried to resolve it as a commit in the checkout. Rework the interactive flow:
present a bug&apos;s patches in the order the tracker lists them, review the chosen
patch as an HTML diff before applying it, and return to the menu when it is rejected.
Closing the diff or pressing Enter accepts; answering &apos;n&apos; rejects.
A named patch is reviewed too. Once a patch is committed, open its
message in the editor and offer to create a pull request.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/apply.py:
(Apply):
(Apply.review):
(Apply.select_patch):
(Apply.edit_commit_message):
(Apply.offer_pull_request):
(Apply.main):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/diff/diff.py:
(DiffBase.add_line):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/diff/html_diff.py:
(__init__):
(__exit__._wait_for_enter):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/apply_unittest.py:
(TestApply.test_select_patch_named_reviewed_when_interactive):
(TestApply):
(TestApply.test_select_patch_named_rejected_when_interactive_returns_none):
(TestApply.test_select_patch_named_non_interactive_skips_review):
(TestApply.test_select_patch_non_interactive_returns_single):
(TestApply.test_select_patch_non_interactive_returns_first_in_tracker_order):
(TestApply.test_select_patch_menu_preserves_tracker_order_and_defaults_to_first):
(TestApply.test_select_patch_offers_every_variant_in_the_menu):
(TestApply.test_select_patch_interactive_accepts_reviewed_patch):
(TestApply.test_select_patch_interactive_single_rejected_returns_none):
(TestApply.test_select_patch_interactive_reject_returns_to_menu):
(TestApply.test_review_accepts_when_diff_accepted):
(TestApply.test_review_rejects_when_diff_rejected):
(TestApply.test_review_rejects_undownloadable_patch):
(TestApply.test_offer_pull_request_invokes_pull_request_when_accepted):
(TestApply.test_offer_pull_request_skips_when_declined):
(TestApply.test_main_named_patch_rejected_reports_not_applied):
(TestApply.test_main_reviews_and_opens_editor_when_interactive):
(TestApply.test_main_creates_pull_request_when_accepted):
(TestApply.test_main_skips_pull_request_when_declined):
(TestApply.test_main_no_editor_when_not_committing):
(TestApply.test_main_declined_review_is_not_applied):
(TestApply.test_main_skips_review_and_editor_when_not_interactive):
(TestApply.test_select_patch_single): Deleted.
(TestApply.test_select_patch_prompts_with_preferred_default): Deleted.
(TestApply.test_select_patch_defaults_to_first_when_none_preferred): Deleted.
(TestApply.test_main_previews_diff_when_interactive): Deleted.
(TestApply.test_main_skips_diff_when_not_interactive): Deleted.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/diff_unittest.py: Added.
(_Commit):
(_Commit.__init__):
(_Commit.__str__):
(TestDiffBase):
(TestDiffBase._from_line):
(TestDiffBase._repo):
(TestDiffBase.test_from_line_rewritten_when_hash_resolves):
(TestDiffBase.test_from_line_falls_back_when_hash_unresolvable):
(TestDiffBase.test_from_line_ignored_without_repository):

Canonical link: <a href="https://commits.webkit.org/316772@main">https://commits.webkit.org/316772@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d1708da2b0aee86608eed3c758719a1b08ded92

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173377 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47309 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40864 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182950 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130933 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b3a15620-79ac-4994-9a6f-ccbed157807b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175242 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48602 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46991 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134806 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95194 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3d88dfea-3710-401e-8017-62a48cae9fd3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176335 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38232 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/155491 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115282 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c3aa57d4-25ed-4fb0-8e21-136715768ab2) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/172698 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36874 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/35225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31435 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147298 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34987 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185375 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/39427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143674 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/172777 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46977 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143537 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38738 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47656 "Built successfully") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112759 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38486 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46162 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/9935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45564 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45795 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45621 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->