### PR TITLE
build-and-analyze: Add -fexperimental-bounds-safety-attributes flag

### DIFF
--- a/Tools/Scripts/build-and-analyze
+++ b/Tools/Scripts/build-and-analyze
@@ -193,8 +193,8 @@ def main(args):
     # on) then collides in the module cache with the toolchain's own Swift
     # interface compiles (`Cxx`, `_StringProcessing`; late-parse off)
     if args.enable_experimental_late_parse_attributes:
-        make_command.append('OTHER_CFLAGS=-fexperimental-late-parse-attributes')
-        make_command.append('OTHER_SWIFT_FLAGS=-Xcc -fexperimental-late-parse-attributes')
+        make_command.append('OTHER_CFLAGS=-fexperimental-late-parse-attributes -fexperimental-bounds-safety-attributes -Wno-error=unsafe-buffer-usage')
+        make_command.append('OTHER_SWIFT_FLAGS=-Xcc -fexperimental-late-parse-attributes -Xcc -fexperimental-bounds-safety-attributes -Xcc -Wno-error=unsafe-buffer-usage')
 
     commands = [
         [set_webkit_config_path, '--{}'.format(args.configuration)],


### PR DESCRIPTION
#### a0e6fdcd56c39ed5693f106b2af99a50fc7cbe28
<pre>
build-and-analyze: Add -fexperimental-bounds-safety-attributes flag
<a href="https://bugs.webkit.org/show_bug.cgi?id=318911">https://bugs.webkit.org/show_bug.cgi?id=318911</a>
<a href="https://rdar.apple.com/181744396">rdar://181744396</a>

Reviewed by David Kilzer.

Add -fexperimental-bounds-safety-attributes flag which only runs when
--enable-experimental-late-parse-attributes is passed into
build-and-analyze.

Also demote unsafe-buffer-usage errors to warnings with
-Wno-error=unsafe-buffer-usage

* Tools/Scripts/build-and-analyze:
(main):

Canonical link: <a href="https://commits.webkit.org/316851@main">https://commits.webkit.org/316851@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7061885846b142353780af6649d6f3e6fe56cc7b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173561 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47494 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/41197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183134 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/131429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/18f2f754-7138-4e46-98a5-331c8db7effd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175426 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48786 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47176 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134958 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/131429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fb4ebbda-e693-4696-9d9e-1b1816709670) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176519 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38386 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155672 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115435 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1fd69621-cf27-4fa9-b0c8-0feb5114500f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37027 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35388 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31619 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147451 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35167 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185560 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/38553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39588 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143838 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47161 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143698 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47840 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/41197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113010 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26387 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38629 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/119707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46346 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10120 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45748 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45979 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45807 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->