### PR TITLE
[Site Isolation]  window.opener is null after a window.open() popup process-swaps to an empty site

### DIFF
--- a/LayoutTests/fast/events/site-isolation/window-open-and-navigate-preserves-opener-expected.txt
+++ b/LayoutTests/fast/events/site-isolation/window-open-and-navigate-preserves-opener-expected.txt
@@ -1,0 +1,3 @@
+This test opens a window (initially about:blank) and then navigates it to a same-origin document. Under site isolation, navigating the opened window process-swaps it since the opener's process committed a meaningful load. This test checks that window.opener still works across that swap, ensuring that the connection exists across processes.
+
+PASS

--- a/LayoutTests/fast/events/site-isolation/window-open-and-navigate-preserves-opener.html
+++ b/LayoutTests/fast/events/site-isolation/window-open-and-navigate-preserves-opener.html
@@ -1,0 +1,37 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<!-- Must run from file://: this page and ../resources/message-opener.html are file:// URLs whose Site
+     has an empty registrable domain. -->
+<html>
+<body>
+<p>This test opens a window (initially about:blank) and then navigates it to a same-origin
+document. Under site isolation, navigating the opened window process-swaps it since the opener's
+process committed a meaningful load. This test checks that window.opener still works across that
+swap, ensuring that the connection exists across processes.</p>
+<div id="log">FAIL: did not receive a message from the opened window (window.opener was likely null).</div>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+const log = document.getElementById('log');
+let openedWindow = window.open('about:blank');
+
+window.onmessage = (event) => {
+    if (event.data == 'load') {
+        log.textContent = 'PASS';
+        if (openedWindow)
+            openedWindow.close();
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }
+};
+
+// ../resources/message-opener.html does: opener.top.postMessage('load', '*') on load. If
+// window.opener is null (the bug), no message arrives and the test times out (rather than
+// racing an arbitrary timeout, which is flaky on slower configurations).
+openedWindow.location.href = '../resources/message-opener.html';
+</script>
+</body>
+</html>

--- a/Source/WebCore/page/DOMWindow.cpp
+++ b/Source/WebCore/page/DOMWindow.cpp
@@ -57,6 +57,7 @@
 #include "ScheduledAction.h"
 #include "Screen.h"
 #include "SecurityOrigin.h"
+#include "Site.h"
 #include "StyleMedia.h"
 #include "VisualViewport.h"
 #include "WebCoreOpaqueRoot.h"
@@ -972,7 +973,8 @@ String DOMWindow::crossDomainAccessErrorMessage(const LocalDOMWindow& activeWind
         return String();
     Ref activeOrigin = protect(activeWindow.document())->securityOrigin();
     const Ref targetOrigin = localDocument ? localDocument->securityOrigin() : remoteFrame->frameDocumentSecurityOriginOrOpaque();
-    ASSERT(!activeOrigin->isSameOriginDomain(targetOrigin));
+    // A remote frame with an empty site may legitimately appear as same-origin.
+    ASSERT(!activeOrigin->isSameOriginDomain(targetOrigin) || (remoteFrame && Site { activeOrigin->data() }.isEmpty()));
 
     // FIXME: This message, and other console messages, have extra newlines. Should remove them.
     String message;

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -2535,7 +2535,9 @@ void Page::finalizeRenderingUpdate(OptionSet<FinalizeRenderingUpdateFlags> flags
     for (auto& rootFrame : m_rootFrames)
         finalizeRenderingUpdateForRootFrame(Ref { rootFrame.get() }, flags);
 
-    ASSERT(m_renderingUpdateRemainingSteps.last().isEmpty());
+    // A site-isolated Page can have no local root frame with a view to consume the per-root-frame steps.
+    ASSERT(m_renderingUpdateRemainingSteps.last().isEmpty()
+        || (settings().siteIsolationEnabled() && m_renderingUpdateRemainingSteps.last() == perRootFrameRenderingUpdateSteps));
     renderingUpdateCompleted();
 }
 

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -364,12 +364,14 @@ constexpr OptionSet<RenderingUpdateStep> updateRenderingSteps = {
     RenderingUpdateStep::AdjustVisibility,
 };
 
-constexpr auto allRenderingUpdateSteps = updateRenderingSteps | OptionSet<RenderingUpdateStep> {
+constexpr auto perRootFrameRenderingUpdateSteps = OptionSet<RenderingUpdateStep> {
     RenderingUpdateStep::LayerFlush,
 #if ENABLE(ASYNC_SCROLLING)
     RenderingUpdateStep::ScrollingTreeUpdate,
 #endif
 };
+
+constexpr auto allRenderingUpdateSteps = updateRenderingSteps | perRootFrameRenderingUpdateSteps;
 
 using WeakElementEdges = RectEdges<WeakPtr<Element, WeakPtrImplWithEventTargetData>>;
 

--- a/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
@@ -166,7 +166,14 @@ void BrowsingContextGroup::addFrameProcessAndInjectPageContextIf(FrameProcess& p
         return;
     auto& site = *process.site();
     for (Ref page : m_pages) {
-        if (site == Site(URL(page->currentURL())))
+        // Under site isolation, a same-site page should be hosted in the same process and
+        // shouldn't need a remote page. Empty sites are the exception as they can span
+        // multiple processes but they appear as same-site.
+        // So for an empty site, only skip when the page really is in this process.
+        bool sameSite = site == Site(URL(page->currentURL()));
+        RefPtr mainFrame = page->mainFrame();
+        bool pageIsInThisProcess = mainFrame && mainFrame->process().coreProcessIdentifier() == process.process().coreProcessIdentifier();
+        if (sameSite && (!site.isEmpty() || pageIsInThisProcess))
             continue;
         createRemotePageIfNeeded(page, site);
     }


### PR DESCRIPTION
#### 177f74567f875555ca57a01715af2ae322e2ffad
<pre>
[Site Isolation]  window.opener is null after a window.open() popup process-swaps to an empty site
<a href="https://bugs.webkit.org/show_bug.cgi?id=318903">https://bugs.webkit.org/show_bug.cgi?id=318903</a>
<a href="https://rdar.apple.com/181740350">rdar://181740350</a>

Reviewed by Alex Christensen.

When site isolation is enabled, a popup opened to about:blank by window.open() will
share its opener&apos;s process.
Then, the popup navigates to another empty site which causes a process swap.
The bug is that after that swap, window.opener is null.

The test fast/events/before-unload-navigate-different-window.html revealed
this bug and is failing with site isolation enabled.

The test does the following:
1. window.open(&apos;about:blank&apos;). The popup stays in the opener&apos;s process.
2. The test navigates the popup to resources/message-opener.html. This
    is treated as a file:// URL which triggers a process swap for the popup.
    A process swap happens because the opener&apos;s process committed a
    meaningful load by loading the main test page (see
    WebProcessPool::processForNavigationInternal + the hasCommittedAnyMeaningfulProvisionalLoads check)
3. Now, we have the opener (which is a file:// empty site) and the popup
   (which is also a file:// empty site). However, the opener and popup
    are in different processes.
4. WebKit sees that the two pages are same site and doesn&apos;t set up a
    RemotePageProxy for the opener in the popup&apos;s new process. This bug
    is in BrowsingContextGroup::addFrameProcessAndInjectPageContextIf.
5. With no RemotePageProxy for the opener, the popup has no way of
    accessing the opener in a different process. So, window.opener is
    null in the test and the test can&apos;t postMessage to the opener.

BrowsingContextGroup::addFrameProcessAndInjectPageContextIf decides which
existing pages need a RemotePageProxy created in a new process. It skipped
creating one for any existing page whose site matched the new process&apos;s site.

In this test case, the logic saw that the new process (popup file:// empty site)
and the existing page (opener main test page file:// empty site) were
same site. As such, it assumed these two pages were in the same process
(which is not true since the popup process-swapped). Therefore, it skipped
adding the opener&apos;s RemotePageProxy in the popup&apos;s new process.

This patch additionally checks process identity in the case where both
the new process&apos;s site and the existing page&apos;s site are empty. When the
existing empty-site page is actually in a different process, we now
create the RemotePageProxy it needs. Behavior for non-empty sites is
unchanged (the process-identity check is only consulted for empty sites).

Added a regression test that opens an about:blank popup, navigates it
cross-process under site isolation, and verifies the popup can still
postMessage back via window.opener. This regression test exposed a
GTK/WPE only assertion so I added a site isolation specific relaxation
which allows a page to not have a local root frame.

Test: fast/events/window-open-and-navigate-preserves-opener-under-site-isolation.html

* LayoutTests/fast/events/site-isolation/window-open-and-navigate-preserves-opener-expected.txt: Added.
* LayoutTests/fast/events/site-isolation/window-open-and-navigate-preserves-opener.html: Added.
* Source/WebCore/page/DOMWindow.cpp:
(WebCore::DOMWindow::crossDomainAccessErrorMessage):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::finalizeRenderingUpdate):
* Source/WebCore/page/Page.h:
* Source/WebKit/UIProcess/BrowsingContextGroup.cpp:
(WebKit::BrowsingContextGroup::addFrameProcessAndInjectPageContextIf):

Canonical link: <a href="https://commits.webkit.org/317670@main">https://commits.webkit.org/317670@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c5410383488f915952a61d80982400e818ba3888

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174303 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48236 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42017 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183877 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132171 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/066acd2e-43eb-4724-99d9-449c4b35f3f4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176168 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49528 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47918 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135591 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95663 "1 flakes 3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b5f46deb-a8ca-4ea1-9c39-ca1cb272abee) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177261 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39017 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156381 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116069 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37658 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36027 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32361 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148081 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35874 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186303 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39503 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40224 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144498 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47903 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155936 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144355 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39288 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48582 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32494 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114121 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39256 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120512 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47088 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11030 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46491 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46722 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46549 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->