### PR TITLE
REGRESSION(316670@main): [iOS macOS release] fast/css/getComputedStyle-font-variant-shorthand-crash.html is flaky crash

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8601,5 +8601,3 @@ webkit.org/b/318157 [ Debug ] imported/w3c/web-platform-tests/IndexedDB/nested-c
 webkit.org/b/318157 [ Debug ] imported/w3c/web-platform-tests/IndexedDB/nested-cloning-large-multiple.any.sharedworker.html [ Failure ]
 
 webkit.org/b/318375 imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-001.html [ Pass ImageOnlyFailure ]
-
-webkit.org/b/318910 [ Release ] fast/css/getComputedStyle-font-variant-shorthand-crash.html [ Skip ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2452,5 +2452,3 @@ webkit.org/b/318732 http/tests/site-isolation/page-zoom.html [ Pass ImageOnlyFai
 [ x86_64 ] webgl/2.0.y/conformance2/textures/webgl_canvas/tex-2d-r11f_g11f_b10f-rgb-float.html [ Skip ]
 [ x86_64 ] webgl/2.0.y/conformance2/textures/webgl_canvas/tex-2d-r11f_g11f_b10f-rgb-half_float.html [ Skip ]
 [ x86_64 ] webgl/pending/conformance/context/context-attributes-alpha-depth-stencil-antialias.html [ Skip ]
-
-webkit.org/b/318910 [ Release ] fast/css/getComputedStyle-font-variant-shorthand-crash.html [ Skip ]

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
@@ -224,10 +224,6 @@ Awaitable<bool> WebFullScreenManagerProxy::enterFullScreen(IPC::Connection& conn
 #endif // ENABLE(QUICKLOOK_FULLSCREEN)
 #endif // PLATFORM(IOS_FAMILY)
 
-    CheckedPtr client = m_client;
-    if (!client)
-        co_return false;
-
     RefPtr page = m_page.get();
     if (!page)
         co_return false;
@@ -239,13 +235,18 @@ Awaitable<bool> WebFullScreenManagerProxy::enterFullScreen(IPC::Connection& conn
     if (auto coordinates = co_await page->convertPointToMainFrameCoordinates({ 0, 0 }, webFrame->rootFrame()->frameID()))
         m_rootFrameOriginInMainFrameCoordinates = IntPoint(*coordinates);
 
-    bool success = co_await AwaitableFromCompletionHandler<bool> { [=] (auto completionHandler) {
-        client->enterFullScreen(mediaDetails.mediaDimensions, WTF::move(completionHandler));
-    } };
+    {
+        CheckedPtr client = m_client;
+        if (!client)
+            co_return false;
+        bool success = co_await AwaitableFromCompletionHandler<bool> { [=] (auto completionHandler) {
+            client->enterFullScreen(mediaDetails.mediaDimensions, WTF::move(completionHandler));
+        } };
+        ALWAYS_LOG(LOGIDENTIFIER);
+        if (!success)
+            co_return false;
+    }
 
-    ALWAYS_LOG(LOGIDENTIFIER);
-    if (!success)
-        co_return false;
     m_fullscreenState = FullscreenState::EnteringFullscreen;
     page->fullscreenClient().willEnterFullscreen(page.get());
 
@@ -317,13 +318,15 @@ Awaitable<void> WebFullScreenManagerProxy::exitFullScreen()
 #if ENABLE(QUICKLOOK_FULLSCREEN)
     m_mediaDetails = std::nullopt;
 #endif
-    CheckedPtr client = m_client;
-    if (!client)
-        co_return;
 
-    co_await AwaitableFromCompletionHandler<void> { [=] (auto completionHandler) {
-        client->exitFullScreen(WTF::move(completionHandler));
-    } };
+    {
+        CheckedPtr client = m_client;
+        if (!client)
+            co_return;
+        co_await AwaitableFromCompletionHandler<void> { [=] (auto completionHandler) {
+            client->exitFullScreen(WTF::move(completionHandler));
+        } };
+    }
 
     m_fullscreenState = FullscreenState::ExitingFullscreen;
     if (RefPtr page = m_page.get())
@@ -389,10 +392,6 @@ void WebFullScreenManagerProxy::prepareQuickLookImageURL(CompletionHandler<void(
 
 std::optional<std::pair<IntRect, IntRect>> WebFullScreenManagerProxy::convertFromRootViewToScreenCoordinates(std::pair<IntRect, IntRect> rectsInRootViewCoordinates)
 {
-    CheckedPtr client = m_client;
-    if (!client)
-        return std::nullopt;
-
     RefPtr page = m_page.get();
     if (!page)
         return std::nullopt;
@@ -400,6 +399,9 @@ std::optional<std::pair<IntRect, IntRect>> WebFullScreenManagerProxy::convertFro
     auto rectsInMainFrameCoordinates = rectsInRootViewCoordinates;
     rectsInMainFrameCoordinates.first.moveBy(m_rootFrameOriginInMainFrameCoordinates);
 
+    CheckedPtr client = m_client;
+    if (!client)
+        return std::nullopt;
     return { {
         IntRect(client->convertMainFrameCoordinatesInFullscreenPlaceholderViewToScreen(*page, IntRect(rectsInMainFrameCoordinates.first))),
         IntRect(page->syncRootViewToScreen(IntRect(rectsInMainFrameCoordinates.second)))
@@ -412,10 +414,6 @@ Awaitable<bool> WebFullScreenManagerProxy::beganEnterFullScreen(FrameIdentifier 
     if (!page)
         co_return false;
 
-    CheckedPtr client = m_client;
-    if (!client)
-        co_return false;
-
     auto rectsInScreenCoordinates = convertFromRootViewToScreenCoordinates({ initialFrameInRootViewCoordinates, finalFrameInRootViewCoordinates });
     if (!rectsInScreenCoordinates)
         co_return false;
@@ -423,11 +421,16 @@ Awaitable<bool> WebFullScreenManagerProxy::beganEnterFullScreen(FrameIdentifier 
 
     co_await page->nextPresentationUpdate();
 
-    bool success = co_await AwaitableFromCompletionHandler<bool> { [=] (auto completionHandler) {
-        client->beganEnterFullScreen(initialFrameInScreenCoordinates, finalFrameInScreenCoordinates, WTF::move(completionHandler));
-    } };
-    if (!success)
-        co_return false;
+    {
+        CheckedPtr client = m_client;
+        if (!client)
+            co_return false;
+        bool success = co_await AwaitableFromCompletionHandler<bool> { [=] (auto completionHandler) {
+            client->beganEnterFullScreen(initialFrameInScreenCoordinates, finalFrameInScreenCoordinates, WTF::move(completionHandler));
+        } };
+        if (!success)
+            co_return false;
+    }
 
     co_return co_await AwaitableFromCompletionHandler<bool> { [this, protectedThis = Ref { *this }] (auto completionHandler) {
         didEnterFullScreen(WTF::move(completionHandler));
@@ -436,18 +439,19 @@ Awaitable<bool> WebFullScreenManagerProxy::beganEnterFullScreen(FrameIdentifier 
 
 Awaitable<void> WebFullScreenManagerProxy::beganExitFullScreen(FrameIdentifier frameID, IntRect initialFrameInRootViewCoordinates, IntRect finalFrameInRootViewCoordinates)
 {
-    CheckedPtr client = m_client;
-    if (!client)
-        co_return;
-
     auto rectsInScreenCoordinates = convertFromRootViewToScreenCoordinates({ finalFrameInRootViewCoordinates, initialFrameInRootViewCoordinates });
     if (!rectsInScreenCoordinates)
         co_return;
     auto [finalFrameInScreenCoordinates, initialFrameInScreenCoordinates] = *rectsInScreenCoordinates;
 
-    co_await AwaitableFromCompletionHandler<void> { [=] (auto completionHandler) {
-        client->beganExitFullScreen(initialFrameInScreenCoordinates, finalFrameInScreenCoordinates, WTF::move(completionHandler));
-    } };
+    {
+        CheckedPtr client = m_client;
+        if (!client)
+            co_return;
+        co_await AwaitableFromCompletionHandler<void> { [=] (auto completionHandler) {
+            client->beganExitFullScreen(initialFrameInScreenCoordinates, finalFrameInScreenCoordinates, WTF::move(completionHandler));
+        } };
+    }
 
     m_fullscreenState = FullscreenState::NotInFullscreen;
     RefPtr page = m_page.get();

--- a/Tools/TestWebKitAPI/glib/TestExpectations.json
+++ b/Tools/TestWebKitAPI/glib/TestExpectations.json
@@ -184,9 +184,6 @@
             },
             "/webkit/WebKitWebView/is-playing-audio": {
                 "expected": {"all": {"status": ["FAIL", "TIMEOUT"], "bug": "webkit.org/b/274344"}}
-            },
-            "/webkit/WebKitWebView/save": {
-                "expected": {"wpe": {"status": ["CRASH"], "bug": "webkit.org/b/318884"}}
             }
         }
     },


### PR DESCRIPTION
#### 8c372f6d3cc97bafda8c3860c9ae00e27d3c2ef3
<pre>
REGRESSION(316670@main): [iOS macOS release] fast/css/getComputedStyle-font-variant-shorthand-crash.html is flaky crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=318910">https://bugs.webkit.org/show_bug.cgi?id=318910</a>
<a href="https://rdar.apple.com/181743226">rdar://181743226</a>

Reviewed by Simon Fraser.

316670@main moved the instantiation of a CheckedPtr&lt;WebFullScreenManagerProxyClient&gt; to before an async call
to WebPageProxy::nextPresentationUpdate, and the CheckedPtr is used after the call to nextPresentationUpdate.
If WebPageProxy::close is called before the next presentation update completes, then
WebFullScreenManagerProxy::detachFromClient is called before DrawingAreaProxy::stopReceivingMessages
completes everything waiting for a presentation update, which destroys the WebFullScreenManagerProxyClient
with an outstanding non-null CheckedPtr to it, which causes a crash.  This happens sometimes when running
whatever test WebKitTestRunner runs after fast/css/fullscreen-style-sharing-crash.html, causing the next test
to crash.

The fix is to only make a CheckedPtr synchronously immediately before it is going to be used, and destroy
the CheckedPtr immediately synchronously after it is done being used to not give any other async task a chance
to destroy the client with an outstanding CheckedPtr pointing to it.  Rather than setting client to nullptr,
I use an additional scope to make it more clear that the scope of the CheckedPtr is important and to make it
harder for future changes to re-introduce code paths that don&apos;t null out the CheckedPtr.

WebFullScreenManagerProxy::enterFullScreen had the same issue before 316670@main, so the test run after
fast/css/fullscreen-style-sharing-crash.html was already a flaky crash.  This should fix all such crashes,
new and old.

* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp:
(WebKit::WebFullScreenManagerProxy::enterFullScreen):
(WebKit::WebFullScreenManagerProxy::exitFullScreen):
(WebKit::WebFullScreenManagerProxy::convertFromRootViewToScreenCoordinates):
(WebKit::WebFullScreenManagerProxy::beganEnterFullScreen):
(WebKit::WebFullScreenManagerProxy::beganExitFullScreen):
* Tools/TestWebKitAPI/glib/TestExpectations.json:

Canonical link: <a href="https://commits.webkit.org/316821@main">https://commits.webkit.org/316821@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f285bd11a26750b3fb6033543dff84fe0c29e23e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173521 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47454 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/41227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183094 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/131389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3fb15521-df3a-41ce-9ec9-86a694dfdcdc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175386 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48746 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47136 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/134930 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/131389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4972c8a4-fd9b-42a6-9f8f-f8c41db797e0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176479 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38358 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/155642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115407 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ea79da0b-59fe-4ece-935b-de3cd4c3bfd4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36999 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/35355 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31579 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147423 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/35137 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185520 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/38503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/39555 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/143807 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47121 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/155199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143665 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47800 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/41227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112963 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26365 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38602 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/119664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46306 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/10088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45708 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45939 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45765 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->