### PR TITLE
Build fix: [WTF] GenericTimeMixin-derived time classes fail to build with Swift C++ interoperability

### DIFF
--- a/Source/WTF/wtf/ApproximateTime.h
+++ b/Source/WTF/wtf/ApproximateTime.h
@@ -39,9 +39,9 @@ class ApproximateTime final : public GenericTimeMixin<ApproximateTime> {
 public:
     static constexpr ClockType clockType = ClockType::Approximate;
 
-    // Re-declare so Swift's C++ interop importer synthesizes a `bool`
-    // conversion; it mishandles the inherited operator (rdar://181622867).
-    using GenericTimeMixin<ApproximateTime>::operator bool;
+    // Declared here, not inherited: Swift's C++ interop importer mishandles
+    // an `operator bool` inherited from a template base (rdar://181622867).
+    explicit constexpr operator bool() const { return !!m_value; }
 
     // This is the epoch. So, x.secondsSinceEpoch() should be the same as x - ApproximateTime().
     constexpr ApproximateTime() = default;

--- a/Source/WTF/wtf/ContinuousApproximateTime.h
+++ b/Source/WTF/wtf/ContinuousApproximateTime.h
@@ -40,9 +40,9 @@ class ContinuousApproximateTime final : public GenericTimeMixin<ContinuousApprox
 public:
     static constexpr ClockType clockType = ClockType::ContinuousApproximate;
 
-    // Re-declare so Swift's C++ interop importer synthesizes a `bool`
-    // conversion; it mishandles the inherited operator (rdar://181622867).
-    using GenericTimeMixin<ContinuousApproximateTime>::operator bool;
+    // Declared here, not inherited: Swift's C++ interop importer mishandles
+    // an `operator bool` inherited from a template base (rdar://181622867).
+    explicit constexpr operator bool() const { return !!m_value; }
 
     // This is the epoch. So, x.secondsSinceEpoch() should be the same as x - ContinuousApproximateTime().
     constexpr ContinuousApproximateTime() = default;

--- a/Source/WTF/wtf/ContinuousTime.h
+++ b/Source/WTF/wtf/ContinuousTime.h
@@ -39,9 +39,9 @@ class ContinuousTime final : public GenericTimeMixin<ContinuousTime> {
 public:
     static constexpr ClockType clockType = ClockType::Continuous;
 
-    // Re-declare so Swift's C++ interop importer synthesizes a `bool`
-    // conversion; it mishandles the inherited operator (rdar://181622867).
-    using GenericTimeMixin<ContinuousTime>::operator bool;
+    // Declared here, not inherited: Swift's C++ interop importer mishandles
+    // an `operator bool` inherited from a template base (rdar://181622867).
+    explicit constexpr operator bool() const { return !!m_value; }
 
     // This is the epoch. So, x.secondsSinceEpoch() should be the same as x - ContinuousTime().
     constexpr ContinuousTime() = default;

--- a/Source/WTF/wtf/MonotonicTime.h
+++ b/Source/WTF/wtf/MonotonicTime.h
@@ -43,9 +43,9 @@ class MonotonicTime final : public GenericTimeMixin<MonotonicTime> {
 public:
     static constexpr ClockType clockType = ClockType::Monotonic;
 
-    // Re-declare so Swift's C++ interop importer synthesizes a `bool`
-    // conversion; it mishandles the inherited operator (rdar://181622867).
-    using GenericTimeMixin<MonotonicTime>::operator bool;
+    // Declared here, not inherited: Swift's C++ interop importer mishandles
+    // an `operator bool` inherited from a template base (rdar://181622867).
+    explicit constexpr operator bool() const { return !!m_value; }
     
     // This is the epoch. So, x.secondsSinceEpoch() should be the same as x - MonotonicTime().
     constexpr MonotonicTime() = default;

--- a/Source/WTF/wtf/ReducedResolutionSeconds.h
+++ b/Source/WTF/wtf/ReducedResolutionSeconds.h
@@ -40,9 +40,9 @@ class ReducedResolutionSeconds final : public GenericTimeMixin<ReducedResolution
 public:
     static constexpr ClockType clockType = ClockType::Monotonic;
 
-    // Re-declare so Swift's C++ interop importer synthesizes a `bool`
-    // conversion; it mishandles the inherited operator (rdar://181622867).
-    using GenericTimeMixin<ReducedResolutionSeconds>::operator bool;
+    // Declared here, not inherited: Swift's C++ interop importer mishandles
+    // an `operator bool` inherited from a template base (rdar://181622867).
+    explicit constexpr operator bool() const { return !!m_value; }
 
     constexpr ReducedResolutionSeconds() = default;
 

--- a/Source/WTF/wtf/UnbarrieredMonotonicTime.h
+++ b/Source/WTF/wtf/UnbarrieredMonotonicTime.h
@@ -65,9 +65,9 @@ class UnbarrieredMonotonicTime final : public GenericTimeMixin<UnbarrieredMonoto
 public:
     static constexpr ClockType clockType = ClockType::UnbarrieredMonotonic;
 
-    // Re-declare so Swift's C++ interop importer synthesizes a `bool`
-    // conversion; it mishandles the inherited operator (rdar://181622867).
-    using GenericTimeMixin<UnbarrieredMonotonicTime>::operator bool;
+    // Declared here, not inherited: Swift's C++ interop importer mishandles
+    // an `operator bool` inherited from a template base (rdar://181622867).
+    explicit constexpr operator bool() const { return !!m_value; }
 
     // This is the epoch. So, x.secondsSinceEpoch() should be the same as x - UnbarrieredMonotonicTime().
     constexpr UnbarrieredMonotonicTime() = default;

--- a/Source/WTF/wtf/WallTime.h
+++ b/Source/WTF/wtf/WallTime.h
@@ -43,9 +43,9 @@ class WallTime final : public GenericTimeMixin<WallTime> {
 public:
     static constexpr ClockType clockType = ClockType::Wall;
 
-    // Re-declare so Swift's C++ interop importer synthesizes a `bool`
-    // conversion; it mishandles the inherited operator (rdar://181622867).
-    using GenericTimeMixin<WallTime>::operator bool;
+    // Declared here, not inherited: Swift's C++ interop importer mishandles
+    // an `operator bool` inherited from a template base (rdar://181622867).
+    explicit constexpr operator bool() const { return !!m_value; }
     
     // This is the epoch. So, x.secondsSinceEpoch() should be the same as x - WallTime().
     constexpr WallTime() = default;


### PR DESCRIPTION
#### 02595a72c0f838bcad5c8608033e680d7e8f8408
<pre>
Build fix: [WTF] GenericTimeMixin-derived time classes fail to build with Swift C++ interoperability
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=318801">https://bugs.webkit.org/show_bug.cgi?id=318801</a>&gt;
&lt;<a href="https://rdar.apple.com/181623908">rdar://181623908</a>&gt;

Unreviewed build fix.

316725@main attempted this fix with a using-declaration, but that does
not work: a using-declaration still resolves to the `operator bool`
declared on the dependent template base `GenericTimeMixin`, which is
what Swift&apos;s C++ interoperability importer mishandles.  Emitting a
Swift module that imports a `GenericTimeMixin`-derived time class
therefore still fails with &quot;cannot convert ... to &apos;bool&apos; without a
conversion operator&quot;.

Declare a genuine `operator bool` on each derived time class.  The
importer synthesizes the conversion correctly when the operator&apos;s
declaring context is the non-dependent derived class; the base
operator remains for all C++ callers.

No new tests since this change is not directly testable.

* Source/WTF/wtf/ApproximateTime.h:
(WTF::ApproximateTime::operator bool):
* Source/WTF/wtf/ContinuousApproximateTime.h:
(WTF::ContinuousApproximateTime::operator bool):
* Source/WTF/wtf/ContinuousTime.h:
(WTF::ContinuousTime::operator bool):
* Source/WTF/wtf/MonotonicTime.h:
(WTF::MonotonicTime::operator bool):
* Source/WTF/wtf/ReducedResolutionSeconds.h:
(WTF::ReducedResolutionSeconds::operator bool):
* Source/WTF/wtf/UnbarrieredMonotonicTime.h:
(WTF::UnbarrieredMonotonicTime::operator bool):
* Source/WTF/wtf/WallTime.h:
(WTF::WallTime::operator bool):

Canonical link: <a href="https://commits.webkit.org/316804@main">https://commits.webkit.org/316804@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c3033353cbc024bfbf63d63a6a7d9fd17b91b69

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173408 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47340 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40897 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182981 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130964 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/43705d93-4152-46cd-a9ba-d7e85aec9601) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48633 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47022 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134851 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3f343a5f-e200-4252-8627-68191e71d05d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176366 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38271 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155510 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115327 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/78b70e5f-0361-4dc4-a054-7a49075eff5b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36912 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35255 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31466 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/4023 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147336 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35006 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185406 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/34670 "Built successfully and passed tests") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38276 "Found 1026 new failures in b3/testb3_7.cpp, b3/B3Value.h, WebProcess/Network/WebResourceLoader.cpp, jit/OperationResult.h, UIProcess/WebProcessPool.cpp, Shared/Cocoa/WKNSArray.mm, heap/WeakSet.h, API/tests/Regress141275.mm, Shared/SessionState.cpp, NetworkProcess/NetworkResourceLoadParameters.cpp ...") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39457 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143710 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47008 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143574 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47687 "Built successfully") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112790 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26355 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38517 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119437 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/210441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46193 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9954 "") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/210441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45595 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45826 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45652 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->