### PR TITLE
[iOS]TestWebKitAPI.WebAuthenticationPanel.PanelTwice is a flaky timeout.

### DIFF
--- a/Tools/TestWebKitAPI/Resources/cocoa/web-authentication-get-assertion-hid-internal-uv-pin-fallback.html
+++ b/Tools/TestWebKitAPI/Resources/cocoa/web-authentication-get-assertion-hid-internal-uv-pin-fallback.html
@@ -18,7 +18,7 @@
     const options = {
         publicKey: {
             challenge: new Uint8Array(16),
-            timeout: 100
+            timeout: 1000
         },
         authenticatorSelection: { userVerification: "required" },
     };

--- a/Tools/TestWebKitAPI/Resources/cocoa/web-authentication-get-assertion-hid-internal-uv.html
+++ b/Tools/TestWebKitAPI/Resources/cocoa/web-authentication-get-assertion-hid-internal-uv.html
@@ -15,7 +15,7 @@
     const options = {
         publicKey: {
             challenge: new Uint8Array(16),
-            timeout: 100
+            timeout: 1000
         },
         authenticatorSelection: { userVerification: "required" },
     };

--- a/Tools/TestWebKitAPI/Resources/cocoa/web-authentication-get-assertion-hid-multiple-accounts.html
+++ b/Tools/TestWebKitAPI/Resources/cocoa/web-authentication-get-assertion-hid-multiple-accounts.html
@@ -41,7 +41,7 @@
     const options = {
         publicKey: {
             challenge: new Uint8Array(16),
-            timeout: 100
+            timeout: 1000
         }
     };
 

--- a/Tools/TestWebKitAPI/Resources/cocoa/web-authentication-get-assertion-hid-no-credentials.html
+++ b/Tools/TestWebKitAPI/Resources/cocoa/web-authentication-get-assertion-hid-no-credentials.html
@@ -9,7 +9,7 @@
     const options = {
         publicKey: {
             challenge: new Uint8Array(16),
-            timeout: 100
+            timeout: 1000
         }
     };
 

--- a/Tools/TestWebKitAPI/Resources/cocoa/web-authentication-get-assertion-hid-pin-auth-blocked-error.html
+++ b/Tools/TestWebKitAPI/Resources/cocoa/web-authentication-get-assertion-hid-pin-auth-blocked-error.html
@@ -13,7 +13,7 @@
     const options = {
         publicKey: {
             challenge: new Uint8Array(16),
-            timeout: 100
+            timeout: 1000
         }
     };
 

--- a/Tools/TestWebKitAPI/Resources/cocoa/web-authentication-get-assertion-hid-pin-invalid-error-retry.html
+++ b/Tools/TestWebKitAPI/Resources/cocoa/web-authentication-get-assertion-hid-pin-invalid-error-retry.html
@@ -18,7 +18,7 @@
     const options = {
         publicKey: {
             challenge: new Uint8Array(16),
-            timeout: 100
+            timeout: 1000
         }
     };
 

--- a/Tools/TestWebKitAPI/Resources/cocoa/web-authentication-get-assertion-hid-pin.html
+++ b/Tools/TestWebKitAPI/Resources/cocoa/web-authentication-get-assertion-hid-pin.html
@@ -18,7 +18,7 @@
     const options = {
         publicKey: {
             challenge: new Uint8Array(16),
-            timeout: 100
+            timeout: 1000
         }
     };
 

--- a/Tools/TestWebKitAPI/Resources/cocoa/web-authentication-get-assertion-hid.html
+++ b/Tools/TestWebKitAPI/Resources/cocoa/web-authentication-get-assertion-hid.html
@@ -14,7 +14,7 @@
     const options = {
         publicKey: {
             challenge: new Uint8Array(16),
-            timeout: 100
+            timeout: 1000
         }
     };
 

--- a/Tools/TestWebKitAPI/Resources/cocoa/web-authentication-make-credential-hid.html
+++ b/Tools/TestWebKitAPI/Resources/cocoa/web-authentication-make-credential-hid.html
@@ -39,7 +39,7 @@
             },
             challenge: new Uint8Array(16),
             pubKeyCredParams: [{ type: "public-key", alg: -7 }],
-            timeout: 100,
+            timeout: 1000,
         }
     };
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/_WKWebAuthenticationPanel.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/_WKWebAuthenticationPanel.mm
@@ -454,12 +454,7 @@ TEST(WebAuthenticationPanel, NfcHardwareBusyRetry)
 }
 #endif
 
-// FIXME rdar://145102423
-#if PLATFORM(IOS) && !defined(NDEBUG)
-TEST(WebAuthenticationPanel, DISABLED_NoPanelHidSuccess)
-#else
 TEST(WebAuthenticationPanel, NoPanelHidSuccess)
-#endif
 {
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid" withExtension:@"html"];
 
@@ -470,12 +465,7 @@ TEST(WebAuthenticationPanel, NoPanelHidSuccess)
     [webView waitForMessage:@"Succeeded!"];
 }
 
-// FIXME rdar://145102423
-#if PLATFORM(IOS) && !defined(NDEBUG)
-TEST(WebAuthenticationPanel, DISABLED_PanelHidSuccess1)
-#else
 TEST(WebAuthenticationPanel, PanelHidSuccess1)
-#endif
 {
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid" withExtension:@"html"];
@@ -494,12 +484,7 @@ TEST(WebAuthenticationPanel, PanelHidSuccess1)
     checkPanel([delegate panel], @"", @[adoptNS([[NSNumber alloc] initWithInt:_WKWebAuthenticationTransportUSB]).get()], _WKWebAuthenticationTypeGet);
 }
 
-// FIXME rdar://145102423
-#if PLATFORM(IOS) && !defined(NDEBUG)
-TEST(WebAuthenticationPanel, DISABLED_PanelHidSuccess2)
-#else
 TEST(WebAuthenticationPanel, PanelHidSuccess2)
-#endif
 {
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-make-credential-hid" withExtension:@"html"];
@@ -565,12 +550,7 @@ TEST(WebAuthenticationPanel, PanelRacy2)
 }
 #endif // HAVE(NEAR_FIELD)
 
-// FIXME rdar://145102423
-#if PLATFORM(IOS) && !defined(NDEBUG)
-TEST(WebAuthenticationPanel, DISABLED_PanelTwice)
-#else
 TEST(WebAuthenticationPanel, PanelTwice)
-#endif
 {
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid" withExtension:@"html"];
@@ -762,12 +742,7 @@ TEST(WebAuthenticationPanel, PanelHidCancel)
     EXPECT_TRUE(webAuthenticationPanelFailed);
 }
 
-// FIXME rdar://145102423
-#if PLATFORM(IOS) && !defined(NDEBUG)
-TEST(WebAuthenticationPanel, DISABLED_PanelHidCtapNoCredentialsFound)
-#else
 TEST(WebAuthenticationPanel, PanelHidCtapNoCredentialsFound)
-#endif
 {
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-no-credentials" withExtension:@"html"];
@@ -797,12 +772,7 @@ TEST(WebAuthenticationPanel, PanelU2fCtapNoCredentialsFound)
     Util::run(&webAuthenticationPanelUpdateNoCredentialsFound);
 }
 
-// FIXME rdar://145102423
-#if PLATFORM(IOS) && !defined(NDEBUG)
-TEST(WebAuthenticationPanel, DISABLED_FakePanelHidSuccess)
-#else
 TEST(WebAuthenticationPanel, FakePanelHidSuccess)
-#endif
 {
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid" withExtension:@"html"];
@@ -834,12 +804,7 @@ TEST(WebAuthenticationPanel, FakePanelHidCtapNoCredentialsFound)
     [webView waitForMessage:@"Operation timed out."];
 }
 
-// FIXME rdar://145102423
-#if PLATFORM(IOS) && !defined(NDEBUG)
-TEST(WebAuthenticationPanel, DISABLED_NullPanelHidSuccess)
-#else
 TEST(WebAuthenticationPanel, NullPanelHidSuccess)
-#endif
 {
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid" withExtension:@"html"];
@@ -905,12 +870,7 @@ TEST(WebAuthenticationPanel, PanelHidCancelReloadNoCrash)
     [webView waitForMessage:@"Operation timed out."];
 }
 
-// FIXME rdar://145102423
-#if PLATFORM(IOS) && !defined(NDEBUG)
-TEST(WebAuthenticationPanel, DISABLED_PanelHidSuccessCancelNoCrash)
-#else
 TEST(WebAuthenticationPanel, PanelHidSuccessCancelNoCrash)
-#endif
 {
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid" withExtension:@"html"];
@@ -925,12 +885,7 @@ TEST(WebAuthenticationPanel, PanelHidSuccessCancelNoCrash)
     [webView waitForMessage:@"Succeeded!"];
 }
 
-// FIXME rdar://145102423
-#if PLATFORM(IOS) && !defined(NDEBUG)
-TEST(WebAuthenticationPanel, DISABLED_PanelHidCtapNoCredentialsFoundCancelNoCrash)
-#else
 TEST(WebAuthenticationPanel, PanelHidCtapNoCredentialsFoundCancelNoCrash)
-#endif
 {
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-no-credentials" withExtension:@"html"];
@@ -1137,12 +1092,7 @@ TEST(WebAuthenticationPanel, MakeCredentialPinInvalidErrorAndRetry)
     EXPECT_TRUE(webAuthenticationPanelUpdatePINInvalid);
 }
 
-// FIXME rdar://145102423
-#if PLATFORM(IOS) && !defined(NDEBUG)
-TEST(WebAuthenticationPanel, DISABLED_GetAssertionPin)
-#else
 TEST(WebAuthenticationPanel, GetAssertionPin)
-#endif
 {
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-pin" withExtension:@"html"];
@@ -1157,12 +1107,7 @@ TEST(WebAuthenticationPanel, GetAssertionPin)
     [webView waitForMessage:@"Succeeded!"];
 }
 
-// FIXME rdar://145102423
-#if PLATFORM(IOS) && !defined(NDEBUG)
-TEST(WebAuthenticationPanel, DISABLED_GetAssertionInternalUV)
-#else
 TEST(WebAuthenticationPanel, GetAssertionInternalUV)
-#endif
 {
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-internal-uv" withExtension:@"html"];
@@ -1176,12 +1121,7 @@ TEST(WebAuthenticationPanel, GetAssertionInternalUV)
     [webView waitForMessage:@"Succeeded!"];
 }
 
-// FIXME rdar://145102423
-#if PLATFORM(IOS) && !defined(NDEBUG)
-TEST(WebAuthenticationPanel, DISABLED_GetAssertionInternalUVPinFallback)
-#else
 TEST(WebAuthenticationPanel, GetAssertionInternalUVPinFallback)
-#endif
 {
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-internal-uv-pin-fallback" withExtension:@"html"];
@@ -1196,12 +1136,7 @@ TEST(WebAuthenticationPanel, GetAssertionInternalUVPinFallback)
     [webView waitForMessage:@"Succeeded!"];
 }
 
-// FIXME rdar://145102423
-#if PLATFORM(IOS) && !defined(NDEBUG)
-TEST(WebAuthenticationPanel, DISABLED_GetAssertionPinAuthBlockedError)
-#else
 TEST(WebAuthenticationPanel, GetAssertionPinAuthBlockedError)
-#endif
 {
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-pin-auth-blocked-error" withExtension:@"html"];
@@ -1217,12 +1152,7 @@ TEST(WebAuthenticationPanel, GetAssertionPinAuthBlockedError)
     EXPECT_FALSE(webAuthenticationPanelUpdatePINInvalid);
 }
 
-// FIXME rdar://145102423
-#if PLATFORM(IOS) && !defined(NDEBUG)
-TEST(WebAuthenticationPanel, DISABLED_GetAssertionPinInvalidErrorAndRetry)
-#else
 TEST(WebAuthenticationPanel, GetAssertionPinInvalidErrorAndRetry)
-#endif
 {
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-pin-invalid-error-retry" withExtension:@"html"];
@@ -1271,12 +1201,7 @@ TEST(WebAuthenticationPanel, MultipleAccountsNullDelegate)
     [webView waitForMessage:@"Operation timed out."];
 }
 
-// FIXME rdar://145102423
-#if PLATFORM(IOS) && !defined(NDEBUG)
-TEST(WebAuthenticationPanel, DISABLED_MultipleAccounts)
-#else
 TEST(WebAuthenticationPanel, MultipleAccounts)
-#endif
 {
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-multiple-accounts" withExtension:@"html"];


### PR DESCRIPTION
#### 1ef26dd11b96ecdc9566612caf9908a96c0fa3a4
<pre>
[iOS]TestWebKitAPI.WebAuthenticationPanel.PanelTwice is a flaky timeout.
<a href="https://bugs.webkit.org/show_bug.cgi?id=318917">https://bugs.webkit.org/show_bug.cgi?id=318917</a>
<a href="https://rdar.apple.com/181067729">rdar://181067729</a>

Reviewed by Pascoe.

Under duress, the main thread may not be able to service the async mock HID pipeline.
Because end-to-end authentication may not complete within the allotted 100ms timeout,
increase the timeout to 1000ms.

* Tools/TestWebKitAPI/Resources/cocoa/web-authentication-get-assertion-hid-internal-uv-pin-fallback.html:
* Tools/TestWebKitAPI/Resources/cocoa/web-authentication-get-assertion-hid-internal-uv.html:
* Tools/TestWebKitAPI/Resources/cocoa/web-authentication-get-assertion-hid-multiple-accounts.html:
* Tools/TestWebKitAPI/Resources/cocoa/web-authentication-get-assertion-hid-no-credentials.html:
* Tools/TestWebKitAPI/Resources/cocoa/web-authentication-get-assertion-hid-pin-auth-blocked-error.html:
* Tools/TestWebKitAPI/Resources/cocoa/web-authentication-get-assertion-hid-pin-invalid-error-retry.html:
* Tools/TestWebKitAPI/Resources/cocoa/web-authentication-get-assertion-hid-pin.html:
* Tools/TestWebKitAPI/Resources/cocoa/web-authentication-get-assertion-hid.html:
* Tools/TestWebKitAPI/Resources/cocoa/web-authentication-make-credential-hid.html:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/_WKWebAuthenticationPanel.mm:
(TestWebKitAPI::TEST(WebAuthenticationPanel, NoPanelHidSuccess)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, PanelHidSuccess1)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, PanelHidSuccess2)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, PanelTwice)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, PanelHidCtapNoCredentialsFound)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, FakePanelHidSuccess)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, NullPanelHidSuccess)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, PanelHidSuccessCancelNoCrash)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, PanelHidCtapNoCredentialsFoundCancelNoCrash)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, GetAssertionPin)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, GetAssertionInternalUV)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, GetAssertionInternalUVPinFallback)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, GetAssertionPinAuthBlockedError)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, GetAssertionPinInvalidErrorAndRetry)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, MultipleAccounts)):

Canonical link: <a href="https://commits.webkit.org/316849@main">https://commits.webkit.org/316849@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d16725df4dba856efaba00fb449eb11835f1a042

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173446 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47378 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/41337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183019 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/131314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7c26ef38-e93b-49ef-bd24-a101010a29ca) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175311 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48671 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47060 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134861 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/131314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5cabd391-4606-47b1-9d4e-1a78ff548863) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176404 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38289 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155532 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115337 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dd88ab84-7ea4-4938-9a7e-90b58e9798dd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36930 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35285 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31504 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147354 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35028 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185444 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39486 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143730 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47046 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143596 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47725 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/41337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112832 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26385 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38531 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46231 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9976 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45633 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45864 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45690 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->