### PR TITLE
corner-shape: Implement scoop and round corner shapes in CornerShapeUtilities

### DIFF
--- a/Source/WebCore/platform/graphics/CornerShapeUtilities.cpp
+++ b/Source/WebCore/platform/graphics/CornerShapeUtilities.cpp
@@ -30,27 +30,67 @@
 #include "GeometryUtilities.h"
 #include "Path.h"
 
+#include <algorithm>
 #include <cmath>
+#include <numbers>
 #include <utility>
 
 namespace WebCore {
 
 namespace {
 
+// Lengths below this are treated as zero (degenerate edge/radius)
+static constexpr float limit = 1e-6f;
+
 struct Corner {
     FloatPoint start;
     FloatPoint outer;
     FloatPoint end;
     FloatPoint center;
+    FloatSize radii { };
     double curvature { 1.0 };
+    BoxCorner orientation;
 };
 
+static FloatSize cornerRadii(const FloatPoint& center, const FloatPoint& outer)
+{
+    return { std::abs(center.x() - outer.x()), std::abs(center.y() - outer.y()) };
+}
+
+static std::pair<float, float> inwardDirection(BoxCorner orientation)
+{
+    float directionX = (orientation == BoxCorner::TopLeft || orientation == BoxCorner::BottomLeft) ? 1.0f : -1.0f; // left corners point right toward center
+    float directionY = (orientation == BoxCorner::TopLeft || orientation == BoxCorner::TopRight) ? 1.0f : -1.0f; // top corners point down toward center
+    return { directionX, directionY };
+}
+
+static bool startsOnVerticalEdge(BoxCorner orientation)
+{
+    return orientation == BoxCorner::TopLeft || orientation == BoxCorner::BottomRight;
+}
+
+static std::pair<float, float> edgeBorders(BoxCorner orientation, double startInset, double endInset)
+{
+    bool startOnVerticalEdge = startsOnVerticalEdge(orientation);
+    float verticalEdgeBorder = float(startOnVerticalEdge ? startInset : endInset);
+    float horizontalEdgeBorder = float(startOnVerticalEdge ? endInset : startInset);
+    return { verticalEdgeBorder, horizontalEdgeBorder };
+}
+
+static bool isConcave(const Corner& corner) { return corner.curvature < 0.0; }
+static bool isRound(const Corner& corner) { return corner.curvature == 1.0; }
+static bool isScoop(const Corner& corner) { return corner.curvature == -1.0; }
 static bool isBevel(const Corner& corner) { return corner.curvature == 0.0; }
 static bool isNotch(const Corner& corner) { return std::isinf(corner.curvature) && corner.curvature < 0.0; }
 static bool isEmpty(const Corner& corner)
 {
-    return (corner.outer - corner.start).diagonalLength() < 1e-6f
-        || (corner.end - corner.outer).diagonalLength() < 1e-6f;
+    return (corner.outer - corner.start).diagonalLength() < limit
+        || (corner.end - corner.outer).diagonalLength() < limit;
+}
+
+static Corner inverseCorner(const Corner& corner)
+{
+    return { corner.start, corner.center, corner.end, corner.outer, corner.radii, -corner.curvature, corner.orientation };
 }
 
 static Corner makeCorner(const CornerInput& input)
@@ -74,10 +114,13 @@ static Corner makeCorner(const CornerInput& input)
         vertices[outer], // outer
         vertices[(outer + 1) % 4], // end
         vertices[(outer + 2) % 4], // center
-        input.curvature
+        cornerRadii(vertices[(outer + 2) % 4], vertices[outer]),
+        input.curvature,
+        input.orientation,
     };
 }
-static std::pair<FloatPoint, FloatPoint> bevelAxisAlignedCorners(const Corner& original, double startInset, double endInset)
+
+static std::pair<FloatPoint, FloatPoint> buildBevelCorners(const Corner& original, double startInset, double endInset)
 {
     auto inwardNormal = (original.end - original.start).perpendicular().normalized();
     auto outerToCenter = original.center - original.outer;
@@ -98,34 +141,130 @@ static std::pair<FloatPoint, FloatPoint> bevelAxisAlignedCorners(const Corner& o
     return { axisAlignedCornerStart, axisAlignedCornerEnd };
 }
 
+static Corner buildScoopCorners(const Corner& original, double startInset, double endInset)
+{
+    float outerRadiusX = original.radii.width();
+    float outerRadiusY = original.radii.height();
+
+    auto [verticalEdgeBorder, horizontalEdgeBorder] = edgeBorders(original.orientation, startInset, endInset);
+
+    float radiusX = outerRadiusX + horizontalEdgeBorder;
+    float radiusY = outerRadiusY + verticalEdgeBorder;
+
+    // Endpoints are where the enlarged ellipse (centered on outer) crosses the inset edges
+    auto [directionX, directionY] = inwardDirection(original.orientation);
+
+    // x^2 / a^2 + y^2 / b^2 = 1 => y = b * sqrt(1 - x^2 / a^2)
+    auto ellipseExtent = [](float radius, float ratio) {
+        return radius * std::sqrt(std::max(0.0f, 1.0f - ratio * ratio));
+    };
+
+    FloatPoint sideIntersection {
+        original.outer.x() + directionX * verticalEdgeBorder,
+        original.outer.y() + directionY * ellipseExtent(radiusY, verticalEdgeBorder / radiusX),
+    };
+    FloatPoint topIntersection {
+        original.outer.x() + directionX * ellipseExtent(radiusX, horizontalEdgeBorder / radiusY),
+        original.outer.y() + directionY * horizontalEdgeBorder,
+    };
+
+    auto innerStart = startsOnVerticalEdge(original.orientation) ? sideIntersection : topIntersection;
+    auto innerEnd = startsOnVerticalEdge(original.orientation) ? topIntersection : sideIntersection;
+
+    return { innerStart, original.outer, innerEnd, original.center, FloatSize(radiusX, radiusY), original.curvature, original.orientation };
+}
+
+static Corner buildRoundCorners(const Corner& original, double startInset, double endInset)
+{
+    float outerRadiusX = original.radii.width();
+    float outerRadiusY = original.radii.height();
+
+    auto [verticalEdgeBorder, horizontalEdgeBorder] = edgeBorders(original.orientation, startInset, endInset);
+
+    float radiusX = std::max(0.0f, outerRadiusX - verticalEdgeBorder);
+    float radiusY = std::max(0.0f, outerRadiusY - horizontalEdgeBorder);
+
+    // Endpoints are axis extremes of the ellipse
+    float scaleX = outerRadiusX > limit ? radiusX / outerRadiusX : 0.0f;
+    float scaleY = outerRadiusY > limit ? radiusY / outerRadiusY : 0.0f;
+    auto scaleToCenter = [&](FloatPoint point) {
+        return original.center + FloatSize((point.x() - original.center.x()) * scaleX, (point.y() - original.center.y()) * scaleY);
+    };
+    auto innerStart = scaleToCenter(original.start);
+    auto innerEnd = scaleToCenter(original.end);
+
+    auto [directionX, directionY] = inwardDirection(original.orientation);
+    FloatPoint innerOuter {
+        original.outer.x() + directionX * verticalEdgeBorder,
+        original.outer.y() + directionY * horizontalEdgeBorder,
+    };
+
+    return { innerStart, innerOuter, innerEnd, original.center, FloatSize(radiusX, radiusY), original.curvature, original.orientation };
+}
+
 static Corner adjustCornerForInset(const Corner& original, double startInset, double endInset)
 {
     if (isEmpty(original) || (startInset == 0.0 && endInset == 0.0))
         return original;
 
     if (isBevel(original)) {
-        auto [cutStart, cutEnd] = bevelAxisAlignedCorners(original, startInset, endInset);
-        return { cutStart, original.outer, cutEnd, original.center, original.curvature };
+        auto [cutStart, cutEnd] = buildBevelCorners(original, startInset, endInset);
+        return { cutStart, original.outer, cutEnd, original.center, cornerRadii(original.center, original.outer), original.curvature, original.orientation };
     }
+
+    if (isScoop(original))
+        return buildScoopCorners(original, startInset, endInset);
+
+    if (isRound(original))
+        return buildRoundCorners(original, startInset, endInset);
+
     double strokeA = 0, strokeB = 0;
     if (isNotch(original)) {
         strokeA = -1;
         strokeB = 1;
     }
-    // TODO: implement inset for bevel, scoop, round, squircle, square (§3.9.4.2 hull direction).
+    // TODO: implement inset for squircle, square (§3.9.4.2 hull direction).
 
     auto offset1 = (original.outer - original.start).directionScaledBy(float(startInset * strokeA));
     auto offset2 = (original.end - original.outer).directionScaledBy(float(startInset * strokeB));
     auto offset3 = (original.center - original.end).directionScaledBy(float(endInset * strokeB));
     auto offset4 = (original.start - original.center).directionScaledBy(float(endInset * strokeA));
 
+    auto adjustedStart = original.start + offset1 + offset2;
+    auto adjustedOuter = original.outer + offset2 + offset3;
+    auto adjustedEnd = original.end + offset3 + offset4;
+    auto adjustedCenter = original.center + offset4 + offset1;
+
     return {
-        original.start + offset1 + offset2,
-        original.outer + offset2 + offset3,
-        original.end + offset3 + offset4,
-        original.center + offset4 + offset1,
+        adjustedStart,
+        adjustedOuter,
+        adjustedEnd,
+        adjustedCenter,
+        cornerRadii(adjustedCenter, adjustedOuter),
         original.curvature,
+        original.orientation,
     };
+}
+
+static void addEllipticalArc(Path& path, const Corner& corner)
+{
+    float radiusX = corner.radii.width();
+    float radiusY = corner.radii.height();
+
+    // Border ate the whole radius: the inner corner collapses to a sharp vertex
+    if (radiusX < limit || radiusY < limit) {
+        path.addLineTo(corner.outer);
+        path.addLineTo(corner.end);
+        return;
+    }
+
+    float startAngle = eccentricAngle(corner.start, corner.center, radiusX, radiusY);
+    float endAngle = eccentricAngle(corner.end, corner.center, radiusX, radiusY);
+
+    float delta = std::remainder(endAngle - startAngle, 2.0f * std::numbers::pi_v<float>);
+    auto direction = delta >= 0.0f ? RotationDirection::Clockwise : RotationDirection::Counterclockwise;
+
+    path.addEllipse(corner.center, radiusX, radiusY, 0.0f, startAngle, startAngle + delta, direction);
 }
 
 static void addCurvedCorner(Path& path, const Corner& corner)
@@ -141,7 +280,17 @@ static void addCurvedCorner(Path& path, const Corner& corner)
         path.addLineTo(corner.end);
         return;
     }
-    // TODO: round, squircle, square, and the general superellipse curve.
+    if (isConcave(corner)) {
+        addCurvedCorner(path, inverseCorner(corner));
+        return;
+    }
+    if (isRound(corner)) {
+        path.addLineTo(corner.start);
+        addEllipticalArc(path, corner);
+        return;
+    }
+
+    // TODO: squircle and the general superellipse curve
     path.addLineTo(corner.start);
     path.addLineTo(corner.outer);
     path.addLineTo(corner.end);

--- a/Source/WebCore/platform/graphics/GeometryUtilities.cpp
+++ b/Source/WebCore/platform/graphics/GeometryUtilities.cpp
@@ -195,6 +195,11 @@ bool ellipseContainsPoint(const FloatPoint& center, const FloatSize& radii, cons
     return std::abs(transformedPoint.x()) + std::abs(transformedPoint.y()) <= transformedRadius || transformedPoint.lengthSquared() <= transformedRadius * transformedRadius;
 }
 
+float eccentricAngle(FloatPoint point, FloatPoint center, float radiusX, float radiusY)
+{
+    return std::atan2((point.y() - center.y()) / radiusY, (point.x() - center.x()) / radiusX);
+}
+
 FloatPoint midPoint(const FloatPoint& first, const FloatPoint& second)
 {
     return { std::midpoint(first.x(), second.x()), std::midpoint(first.y(), second.y()) };

--- a/Source/WebCore/platform/graphics/GeometryUtilities.h
+++ b/Source/WebCore/platform/graphics/GeometryUtilities.h
@@ -61,6 +61,7 @@ FloatSize NODELETE sizeWithAreaAndAspectRatio(float area, float aspectRatio);
 FloatRect boundsOfRotatingRect(const FloatRect&);
 
 bool NODELETE ellipseContainsPoint(const FloatPoint& center, const FloatSize& radii, const FloatPoint&);
+float eccentricAngle(FloatPoint, FloatPoint center, float radiusX, float radiusY);
 
 FloatPoint NODELETE midPoint(const FloatPoint&, const FloatPoint&);
 


### PR DESCRIPTION
#### d3095f5cfe71aed87cd8fa46d122024fc6e9ad69
<pre>
corner-shape: Implement scoop and round corner shapes in CornerShapeUtilities
<a href="https://bugs.webkit.org/show_bug.cgi?id=318922">https://bugs.webkit.org/show_bug.cgi?id=318922</a>
<a href="https://rdar.apple.com/181754123">rdar://181754123</a>

Reviewed by Simon Fraser.

borderContourPath() only handled bevel and notch; other corner-shape values
fall through to a sharp mitered vertex. This implements the two circular
cases: round (superellipse(1)), an elliptical arc between the edge
tangent points, centered on the corner&apos;s center of curvature. scoop
(superellipse(-1)), the concave inverse, rendered by inverting the
corner (swap outer/center, negate curvature) to reuse the round arc code,
centered on the box&apos;s outer vertex. Border insets are handled per shape:
round radii shrink by the border width, scoop radii grow by it (a scoop&apos;s
border bites deeper), with arc endpoints computed where the ellipse crosses
the inset edges.

Passes tests written in another commit

* Source/WebCore/platform/graphics/CornerShapeUtilities.cpp:
* Source/WebCore/platform/graphics/GeometryUtilities.cpp:
(WebCore::eccentricAngle):
* Source/WebCore/platform/graphics/GeometryUtilities.h:

Canonical link: <a href="https://commits.webkit.org/316816@main">https://commits.webkit.org/316816@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80c136816067bed84904b19fb8c5d3827567dc9e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173462 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47394 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/41311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183035 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/131330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175327 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48687 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47076 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134878 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/131330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176420 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38305 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155558 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115354 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36946 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35300 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31520 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147370 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35053 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185460 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38331 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39501 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143745 "Found 1 new test failure: compositing/framesets/composited-frame-alignment.html (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47062 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143611 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47741 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/41311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112858 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26361 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38550 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/119556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46247 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10001 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45649 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45880 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45706 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->