### PR TITLE
REGRESSION(312759@main): Multiple TestWebKitAPI.WebKitLegacy.* fail with debug assert

### DIFF
--- a/Source/WTF/wtf/MainThread.cpp
+++ b/Source/WTF/wtf/MainThread.cpp
@@ -53,6 +53,11 @@ bool canCurrentThreadAccessThreadLocalData(Thread& thread)
 {
     return &thread == &Thread::currentSingleton();
 }
+
+bool canCurrentThreadIDAccessThreadLocalData(uint32_t threadID)
+{
+    return threadID == currentThreadID();
+}
 #endif
 
 bool isMainRunLoop()

--- a/Source/WTF/wtf/MainThread.h
+++ b/Source/WTF/wtf/MainThread.h
@@ -55,6 +55,7 @@ WTF_EXPORT_PRIVATE void callOnWebThreadOrDispatchAsyncOnMainThread(void (^block)
 WTF_EXPORT_PRIVATE bool NODELETE isMainThread();
 
 WTF_EXPORT_PRIVATE bool canCurrentThreadAccessThreadLocalData(Thread&);
+WTF_EXPORT_PRIVATE bool canCurrentThreadIDAccessThreadLocalData(uint32_t);
 
 WTF_EXPORT_PRIVATE bool isMainRunLoop();
 WTF_EXPORT_PRIVATE void callOnMainRunLoop(Function<void()>&&);
@@ -95,6 +96,7 @@ using WTF::callOnMainRunLoopAndWait;
 using WTF::callOnMainThread;
 using WTF::callOnMainThreadAndWait;
 using WTF::canCurrentThreadAccessThreadLocalData;
+using WTF::canCurrentThreadIDAccessThreadLocalData;
 using WTF::ensureOnMainRunLoop;
 using WTF::ensureOnMainThread;
 using WTF::isMainRunLoop;

--- a/Source/WTF/wtf/cocoa/MainThreadCocoa.mm
+++ b/Source/WTF/wtf/cocoa/MainThreadCocoa.mm
@@ -46,7 +46,9 @@ namespace WTF {
 static pthread_t s_webThreadPthread;
 
 static Thread* s_applicationUIThread;
+static std::optional<uint32_t> s_applicationUIThreadID;
 static Thread* s_webThread;
+static std::optional<uint32_t> s_webThreadID;
 #endif
 
 void initializeMainThreadPlatform()
@@ -112,6 +114,7 @@ void initializeApplicationUIThread()
 {
     ASSERT(pthread_main_np());
     s_applicationUIThread = &Thread::currentSingleton();
+    s_applicationUIThreadID = s_applicationUIThread->uid();
 }
 
 void initializeWebThread()
@@ -121,18 +124,24 @@ void initializeWebThread()
         ASSERT(!pthread_main_np());
         s_webThreadPthread = pthread_self();
         s_webThread = &Thread::currentSingleton();
+        s_webThreadID = s_webThread->uid();
         RunLoop::initializeWeb();
     });
 }
 
 bool canCurrentThreadAccessThreadLocalData(Thread& thread)
 {
-    auto& currentThread = Thread::currentSingleton();
-    if (&thread == &currentThread)
+    return canCurrentThreadIDAccessThreadLocalData(thread.uid());
+}
+
+bool canCurrentThreadIDAccessThreadLocalData(uint32_t threadID)
+{
+    auto currentThread = currentThreadID();
+    if (threadID == currentThread)
         return true;
 
-    if (&thread == s_webThread || &thread == s_applicationUIThread)
-        return (&currentThread == s_webThread || &currentThread == s_applicationUIThread) && webThreadIsUninitializedOrLockedOrDisabled();
+    if (threadID == s_webThreadID || threadID == s_applicationUIThreadID)
+        return (currentThread == s_webThreadID || currentThread == s_applicationUIThreadID) && webThreadIsUninitializedOrLockedOrDisabled();
 
     return false;
 }

--- a/Source/WebCore/dom/ActiveDOMObject.cpp
+++ b/Source/WebCore/dom/ActiveDOMObject.cpp
@@ -73,7 +73,7 @@ ActiveDOMObject::ActiveDOMObject(Document& document)
 
 ActiveDOMObject::~ActiveDOMObject()
 {
-    ASSERT(m_creationThreadID == currentThreadID());
+    ASSERT(canCurrentThreadIDAccessThreadLocalData(m_creationThreadID));
 
     // ActiveDOMObject may be inherited by a sub-class whose life-cycle
     // exceeds that of the associated ScriptExecutionContext. In those cases,

--- a/Source/WebCore/platform/Supplementable.h
+++ b/Source/WebCore/platform/Supplementable.h
@@ -29,6 +29,7 @@
 #include <wtf/Assertions.h>
 #include <wtf/CurrentThread.h>
 #include <wtf/HashMap.h>
+#include <wtf/MainThread.h>
 #include <wtf/text/ASCIILiteral.h>
 
 namespace WebCore {
@@ -145,14 +146,14 @@ class Supplementable {
 public:
     void provideSupplement(ASCIILiteral key, std::unique_ptr<Supplement<T>> supplement)
     {
-        ASSERT(m_creationThreadID == currentThreadID());
+        ASSERT(canCurrentThreadIDAccessThreadLocalData(m_creationThreadID));
         ASSERT(!m_supplements.get(key));
         m_supplements.add(key, WTF::move(supplement));
     }
 
     Supplement<T>* requireSupplement(ASCIILiteral key)
     {
-        ASSERT(m_creationThreadID == currentThreadID());
+        ASSERT(canCurrentThreadIDAccessThreadLocalData(m_creationThreadID));
         return m_supplements.get(key);
     }
 

--- a/Source/WebCore/platform/Timer.cpp
+++ b/Source/WebCore/platform/Timer.cpp
@@ -256,17 +256,6 @@ private:
 
 // ----------------
 
-static bool shouldSuppressThreadSafetyCheck()
-{
-#if PLATFORM(IOS_FAMILY)
-    return WebThreadIsEnabled() || !linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::TimerThreadSafetyChecks);
-#elif PLATFORM(MAC)
-    return !isInWebProcess() && !linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::TimerThreadSafetyChecks);
-#else
-    return false;
-#endif
-}
-
 struct SameSizeAsTimer {
     virtual ~SameSizeAsTimer() { }
 
@@ -296,25 +285,9 @@ TimerBase::TimerBase()
 #endif
 }
 
-bool TimerBase::canAccessOnCurrentThread() const
-{
-#if ASSERT_ENABLED
-#if USE(WEB_THREAD)
-    if (m_creationThreadID == currentThreadID())
-        return true;
-    return WebThreadIsCurrent() || pthread_main_np();
-#else
-    return m_creationThreadID == currentThreadID();
-#endif
-#else
-    return true;
-#endif
-}
-
 TimerBase::~TimerBase()
 {
-    ASSERT(canAccessOnCurrentThread());
-    RELEASE_ASSERT(canAccessOnCurrentThread() || shouldSuppressThreadSafetyCheck());
+    ASSERT(canCurrentThreadIDAccessThreadLocalData(m_creationThreadID));
     stop();
     ASSERT(!inHeap());
     if (auto* item = m_heapItemWithBitfields.pointer())
@@ -324,7 +297,7 @@ TimerBase::~TimerBase()
 
 void TimerBase::start(Seconds nextFireInterval, Seconds repeatInterval)
 {
-    ASSERT(canAccessOnCurrentThread());
+    ASSERT(canCurrentThreadIDAccessThreadLocalData(m_creationThreadID));
 
     m_repeatInterval = repeatInterval;
     setNextFireTime(MonotonicTime::now() + nextFireInterval);
@@ -332,7 +305,7 @@ void TimerBase::start(Seconds nextFireInterval, Seconds repeatInterval)
 
 void TimerBase::stopSlowCase()
 {
-    ASSERT(canAccessOnCurrentThread());
+    ASSERT(canCurrentThreadIDAccessThreadLocalData(m_creationThreadID));
 
     m_repeatInterval = 0_s;
     setNextFireTime(MonotonicTime { });
@@ -531,8 +504,7 @@ void TimerBase::setNextFireTime(MonotonicTime newTime)
 #if USE(WEB_THREAD)
     RELEASE_ASSERT(WebThreadIsLockedOrDisabledInMainOrWebThread());
 #endif
-    ASSERT(canAccessOnCurrentThread());
-    RELEASE_ASSERT(canAccessOnCurrentThread() || shouldSuppressThreadSafetyCheck());
+    ASSERT(canCurrentThreadIDAccessThreadLocalData(m_creationThreadID));
     bool timerHasBeenDeleted = m_unalignedNextFireTime.isNaN();
     RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!timerHasBeenDeleted);
 

--- a/Source/WebCore/platform/Timer.h
+++ b/Source/WebCore/platform/Timer.h
@@ -108,7 +108,6 @@ private:
     bool inHeap() const { return m_heapItemWithBitfields.pointer() && m_heapItemWithBitfields.pointer()->isInHeap(); }
 
     bool NODELETE hasValidHeapPosition() const;
-    WEBCORE_EXPORT bool canAccessOnCurrentThread() const;
     void updateHeapIfNeeded(MonotonicTime oldTime);
 
     void heapDecreaseKey();
@@ -198,7 +197,7 @@ inline void TimerBase::stop()
 
 inline bool TimerBase::isActive() const
 {
-    ASSERT(canAccessOnCurrentThread());
+    ASSERT(canCurrentThreadIDAccessThreadLocalData(m_creationThreadID));
     return static_cast<bool>(nextFireTime());
 }
 

--- a/TestExpectations/apitests
+++ b/TestExpectations/apitests
@@ -69,18 +69,6 @@ TestWebKitAPI.WebPageTransferableTests/exportToImage(type:) [ Skip ]
 [ iOS Debug ] TestWebKitAPI.ContentRuleList.RequestMethods [ Pass Timeout ]
 [ iOS Debug ] TestWebKitAPI.ContentRuleList.ResourceTypes [ Pass Timeout ]
 
-# webkit.org/b/318739 [iOS DEBUG] 10x TestWebKitAPI.WebKitLegacy.* (api-tests) are constant crashes.
-[ iOS Debug ] TestWebKitAPI.QuickLook.LegacyQuickLookContent [ Crash ]
-[ iOS Debug ] TestWebKitAPI.WebKitLegacy.DateInputAccessoryViewTest [ Crash ]
-[ iOS Debug ] TestWebKitAPI.WebKitLegacy.DateTimeLocalInputAccessoryViewTest [ Crash ]
-[ iOS Debug ] TestWebKitAPI.WebKitLegacy.MonthInputAccessoryViewTest [ Crash ]
-[ iOS Debug ] TestWebKitAPI.WebKitLegacy.RenderInContextSnapshot [ Crash ]
-[ iOS Debug ] TestWebKitAPI.WebKitLegacy.ScrollToRevealSelection [ Crash ]
-[ iOS Debug ] TestWebKitAPI.WebKitLegacy.SetTimeoutFunction [ Crash ]
-[ iOS Debug ] TestWebKitAPI.WebKitLegacy.TimeInputAccessoryViewTest [ Crash ]
-[ iOS Debug ] TestWebKitAPI.WebKitLegacy.WebGLNoCrashOnOtherThreadAccess [ Crash ]
-[ iOS Debug ] TestWebKitAPI.WebKitLegacy.WebGLPrepareDisplayOnWebThread [ Crash ]
-
 webkit.org/b/319125 [ ios release ] TestWebKitAPI.WKDownload.BlobDownload [ Pass Timeout ]
 
 webkit.org/b/319000 [ ios ] TestWebKitAPI.WKHTTPCookieStore.ObserveCookiesReceivedFromHTTP [ Pass Failure ]


### PR DESCRIPTION
#### 702cd85ba0a2e9acaaf2dc8a73b645f36428f198
<pre>
REGRESSION(312759@main): Multiple TestWebKitAPI.WebKitLegacy.* fail with debug assert
<a href="https://rdar.apple.com/181539181">rdar://181539181</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=318924">https://bugs.webkit.org/show_bug.cgi?id=318924</a>

Reviewed by Ryosuke Niwa.

Restore the behavior of the previous ASSERT by adding a new method,
canCurrentThreadIDAccessThreadLocalData(), which has similar behavior to the existing
canCurrentThreadAccessThreadLocalData() method, which can be implemented in terms of the
canCurrentThreadIDAccessThreadLocalData() method. Partially revert the changes to Timer and
ActiveDOMObject by re-adopting the ID-based version of canCurrentThreadAccessThreadLocalData().

* Source/WTF/wtf/MainThread.cpp:
(WTF::canCurrentThreadIDAccessThreadLocalData):
* Source/WTF/wtf/MainThread.h:
* Source/WTF/wtf/cocoa/MainThreadCocoa.mm:
(WTF::initializeApplicationUIThread):
(WTF::initializeWebThread):
(WTF::canCurrentThreadAccessThreadLocalData):
(WTF::canCurrentThreadIDAccessThreadLocalData):
* Source/WebCore/dom/ActiveDOMObject.cpp:
(WebCore::ActiveDOMObject::~ActiveDOMObject):
* Source/WebCore/platform/Supplementable.h:
(WebCore::Supplementable::provideSupplement):
(WebCore::Supplementable::requireSupplement):
* Source/WebCore/platform/Timer.cpp:
(WebCore::TimerBase::~TimerBase):
(WebCore::TimerBase::start):
(WebCore::TimerBase::stopSlowCase):
(WebCore::TimerBase::setNextFireTime):
(WebCore::TimerBase::canAccessOnCurrentThread const): Deleted.
* Source/WebCore/platform/Timer.h:
(WebCore::TimerBase::isActive const):
* TestExpectations/apitests:

Canonical link: <a href="https://commits.webkit.org/317153@main">https://commits.webkit.org/317153@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/820a95b628e2bca40119b14ea57379ecf0b7fbce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174325 "69 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48258 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42039 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183901 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132193 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/833fe23c-1e9e-4c22-95ec-d5ccc6e2e2a8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176190 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49550 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47940 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135639 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e3c3dd9e-9d06-4ca4-8c8e-195853f077f2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177283 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39039 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156399 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116117 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f05ee7eb-0e84-4581-a859-e48dcd4e9f9e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37680 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36048 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32383 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/4908 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148103 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35891 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186327 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/35587 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39530 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40245 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144527 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47925 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144385 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38948 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48604 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32511 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114146 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39277 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120537 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/211360 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47110 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10855 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55080 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46513 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46744 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46571 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->