### PR TITLE
[webkit-bot] Drop the transitional revert-with-pr alias

### DIFF
--- a/Tools/WebKitBot/src/WebKitBot.mjs
+++ b/Tools/WebKitBot/src/WebKitBot.mjs
@@ -90,7 +90,6 @@ export function buildGitWebkitRevertCommand(gitWebkitPath, revisions, reason, is
         "revert",
         ...revisions,
         "--pr",
-        "--draft",
         "--defaults",
     ];
 
@@ -181,32 +180,24 @@ export default class WebKitBot {
         this._commands = new Map;
 
         let revertCommand = {
-            description: "Opens a bug to revert the specified revision, CCing author + reviewer, and attaching the reverse-diff of the given revisions marked as commit-queue=?.",
-            usage: `\`revert SVN_REVISION [SVN_REVISIONS] REASON\`
-e.g. \`revert 260220 Ensure it is working after refactoring\`
-\`revert 260220,260221 Ensure it is working after refactoring\``,
+            description: "Reverts the specified revision(s) by creating a GitHub pull request. Optionally reuse an existing bug by passing its URL in place of a reason.",
+            usage: `\`revert REVISION [REVISIONS] REASON\` or \`revert REVISION [REVISIONS] BUG_URL\`
+    Examples:
+    • \`revert 260220@main Ensure it is working after refactoring\`
+    • \`revert 260220@main,260221@main Ensure it is working after refactoring\`
+    • \`revert 308300@main https://bugs.webkit.org/show_bug.cgi?id=308859\``,
             operation: this.revertCommand.bind(this),
         };
         this._commands.set("rollout", revertCommand);
         this._commands.set("revert", revertCommand);
         this._commands.set("dry-revert", {
             description: "Parse revert message, but do not revert actually.",
-            usage: `\`dry-revert SVN_REVISION [SVN_REVISIONS] REASON\`
-e.g. \`dry-revert 260220 Ensure it is working after refactoring\`
-\`dry-revert 260220,260221 Ensure it is working after refactoring\``,
+            usage: `\`dry-revert REVISION [REVISIONS] REASON\` or \`dry-revert REVISION [REVISIONS] BUG_URL\`
+    Examples:
+    • \`dry-revert 260220@main Ensure it is working after refactoring\`
+    • \`dry-revert 308300@main https://bugs.webkit.org/show_bug.cgi?id=308859\``,
             operation: this.dryRevertCommand.bind(this),
         });
-        if (process.env.USE_GIT_WEBKIT_REVERT === "true") {
-            this._commands.set("revert-with-pr", {
-                description: "Creates a GitHub PR to revert the specified revision.",
-                usage: `\`revert-with-pr REVISION [REVISIONS] REASON\` or \`revert-with-pr REVISION [REVISIONS] BUG_URL\`
-    Examples:
-    • \`revert-with-pr 260220 Ensure it is working after refactoring\`
-    • \`revert-with-pr 260220,260221 Ensure it is working after refactoring\`
-    • \`revert-with-pr 308300@main https://bugs.webkit.org/show_bug.cgi?id=308859\``,
-                operation: this.revertWithPRCommand.bind(this),
-            });
-        }
         this._commands.set("ping", {
             description: "Responds with pong to check if WebKitBot is alive/working",
             usage: "`ping`",
@@ -266,14 +257,16 @@ e.g. \`dry-revert 260220 Ensure it is working after refactoring\`
         }, defaultPullPeriod);
     }
 
-    async revertCommand(event, command, args, usePR = false)
+    async revertCommand(event, command, args)
     {
         let {revisions, reason} = extractRevisionsAndReason(args);
 
-        // For PR-based reverts (revert-with-pr, or revert/rollout when the
-        // git-webkit flag is on), check if the "reason" is actually a bug URL.
+        const usingGitWebkit = process.env.USE_GIT_WEBKIT_REVERT === "true";
+
+        // When routing through git-webkit, check if the "reason" is actually a
+        // bug URL to reuse as the tracking issue.
         let issueUrl = null;
-        if ((usePR || process.env.USE_GIT_WEBKIT_REVERT === "true") && reason) {
+        if (usingGitWebkit && reason) {
             let bugId = parseBugId(reason);
             if (bugId) {
                 issueUrl = `https://bugs.webkit.org/show_bug.cgi?id=${bugId}`;
@@ -289,7 +282,7 @@ e.g. \`dry-revert 260220 Ensure it is working after refactoring\`
             return;
         }
 
-        if (usePR && !reason && !issueUrl) {
+        if (usingGitWebkit && !reason && !issueUrl) {
             await this.postMessage({
                 channel: event.channel,
                 text: `<@${event.user}> Please provide a reason or a bug URL.`,
@@ -310,7 +303,7 @@ e.g. \`dry-revert 260220 Ensure it is working after refactoring\`
                     }).join(" ")} ...`,
                 });
                 let result = await this._taskQueue.postOrFailWhenExceedingLimit({
-                    command: usePR ? "revert-with-pr" : "revert",
+                    command: "revert",
                     revisions,
                     reason,
                     issueUrl,
@@ -332,7 +325,7 @@ e.g. \`dry-revert 260220 Ensure it is working after refactoring\`
                 let stdout = error.stdout;
                 console.error("STDERR ", stderr);
                 if (typeof stderr === "string") {
-                    if (usePR && stderr.indexOf("CONFLICT") !== -1) {
+                    if (usingGitWebkit && stderr.indexOf("CONFLICT") !== -1) {
                         let conflictFiles = [];
                         for (let line of stderr.split("\n")) {
                             let match = line.match(/CONFLICT.*Merge conflict in (.+)/);
@@ -352,7 +345,7 @@ e.g. \`dry-revert 260220 Ensure it is working after refactoring\`
                         });
                         return;
                     }
-                    if (usePR && stderr.indexOf("already be reverted") !== -1) {
+                    if (usingGitWebkit && stderr.indexOf("already be reverted") !== -1) {
                         await this.postMessage({
                             channel: event.channel,
                             text: `<@${event.user}> The commit(s) appear to already be reverted.`,
@@ -463,11 +456,6 @@ ${escapeForSlackText(stderr)}\`\`\`` : ""),
             channel: event.channel,
             text: `<@${event.user}> ${message}`,
         });
-    }
-
-    async revertWithPRCommand(event, command, args)
-    {
-        return this.revertCommand(event, command, args, true);
     }
 
     async pullCommand(event, command, args)
@@ -768,10 +756,6 @@ Type \`help COMMAND\` for help on my individual commands.`,
         case "revert": {
             let {revisions, reason, issueUrl} = task;
             return this.generateRevertingPatch(revisions, reason, issueUrl);
-        }
-        case "revert-with-pr": {
-            let {revisions, reason, issueUrl} = task;
-            return this.generateRevertingPatchWithGitWebkit(revisions, reason, issueUrl);
         }
         case "pull":
             return this.cleanUpWorkingCopy();


### PR DESCRIPTION
#### 6e586185f0f69b2b15925c51be9ac4f94464510d
<pre>
[webkit-bot] Drop the transitional revert-with-pr alias
<a href="https://bugs.webkit.org/show_bug.cgi?id=318921">https://bugs.webkit.org/show_bug.cgi?id=318921</a>
<a href="https://rdar.apple.com/181753826">rdar://181753826</a>

Reviewed by Aakash Jain.

Now that revert and rollout route through git-webkit when USE_GIT_WEBKIT_REVERT is enabled,
the transitional `revert-with-pr alias` is redundant. Remove it and carry its capabilities into
revert/rollout.

Note that this PR does not remove the code that supports the patch workflow, so we can
switch back to the old path on the server if workflow blocking regressions are encountered.

* Tools/WebKitBot/src/WebKitBot.mjs:
- Update the revert/rollout and dry-revert usage to document the bug-URL form and examples,
and describe creating a pull request.
- Remove the revert-with-pr command registration, revertWithPRCommand, and the &quot;revert-with-pr&quot; action case.
- revertCommand: replace the usePR parameter with a usingGitWebkit local derived from USE_GIT_WEBKIT_REVERT,
so bug-URL detection and the conflict/already-reverted handling apply whenever git-webkit is in use.
- Drive-by: Drop the `--draft` argument to git-webkit, since this was a carryover from testing and development.

Canonical link: <a href="https://commits.webkit.org/316831@main">https://commits.webkit.org/316831@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef6abf3598237ce7026ac69216cec050ae145d3f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173423 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47355 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40914 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182996 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/131137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/84380245-8156-443b-8ebe-92cbca00ec2c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175288 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48648 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47037 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134842 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/131137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/541a631d-ba12-49b0-9dbf-144ae7ebe5c3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176381 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38270 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155512 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115318 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b55c17f3-16be-43aa-8f3a-76791b0cc04f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36911 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35264 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31481 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147335 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35008 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185421 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39466 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143708 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47023 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143572 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47702 "Built successfully") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112806 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26371 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38516 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46208 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9956 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45610 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45841 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45667 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->