### PR TITLE
[CMake] Build fix for Mac ASan

### DIFF
--- a/Tools/TestWebKitAPI/PlatformMac.cmake
+++ b/Tools/TestWebKitAPI/PlatformMac.cmake
@@ -70,6 +70,18 @@ macro(WEBKIT_TEST_ENABLE_SWIFT _target)
     )
     add_dependencies(${_target} TestWebKitAPIStageTesting TestWebKitAPISwiftArgs)
     target_link_libraries(${_target} PRIVATE "-F${CMAKE_LIBRARY_OUTPUT_DIRECTORY}" "-framework Testing")
+    # CMake's Swift executable link ignores CMAKE_EXE_LINKER_FLAGS, so
+    # -fsanitize=address never reaches the link line. C++ object files get
+    # instrumented but the ASan runtime isn't linked so it doesn't work.
+    foreach (_sanitizer IN LISTS ENABLE_SANITIZERS)
+        target_compile_options(${_target} PRIVATE "$<$<COMPILE_LANGUAGE:Swift>:-sanitize=${_sanitizer}>")
+        target_link_options(${_target} PRIVATE "-sanitize=${_sanitizer}")
+        if (_sanitizer STREQUAL "address")
+            target_compile_options(${_target} PRIVATE "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -D__SANITIZE_ADDRESS__>")
+        elseif (_sanitizer STREQUAL "thread")
+            target_compile_options(${_target} PRIVATE "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -D__SANITIZE_THREAD__>")
+        endif ()
+    endforeach ()
 endmacro()
 
 set(TESTWEBKITAPI_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")


### PR DESCRIPTION
#### 87e9665224c3b53c84a8fbdb7516db26a1539515
<pre>
[CMake] Build fix for Mac ASan
<a href="https://bugs.webkit.org/show_bug.cgi?id=318930">https://bugs.webkit.org/show_bug.cgi?id=318930</a>
<a href="https://rdar.apple.com/181763817">rdar://181763817</a>

Reviewed by Keith Miller and David Kilzer.

WEBKIT_TEST_ENABLE_SWIFT (Tools/TestWebKitAPI/PlatformMac.cmake) adds
Swift sources to every Test* executable, which flips the link driver to swiftc.
CMake&apos;s Swift executable link ignores CMAKE_EXE_LINKER_FLAGS, so -fsanitize=address
(set in WebKitCompilerFlags.cmake:427) never reached the link line — C++ objects
were instrumented but the ASan runtime wasn&apos;t linked

* Tools/TestWebKitAPI/PlatformMac.cmake:

Canonical link: <a href="https://commits.webkit.org/316822@main">https://commits.webkit.org/316822@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aaff433f52d460c3644f6a748bc9f863a4213ebe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173524 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47457 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/41231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183097 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/131392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/10793c76-d4a5-40ab-9b26-db214f082dbd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175389 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48749 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47139 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/134932 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/131392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1b6a2ab6-284a-4f92-8506-5ee878bd8ff3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176482 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38361 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/155640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115409 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1dcf9560-aaaf-4b7e-af52-b18fd086ec5d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37002 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/35358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31582 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147426 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/35135 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185523 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/39558 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/143812 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47124 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/155197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143670 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38766 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47803 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/41231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112966 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38603 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46309 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/10086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45711 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45942 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45768 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->