### PR TITLE
Scroll To Text Fragment: text directives should only run in text/html and text/plain documents

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/non-html-documents-json-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/non-html-documents-json-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Text directive blocked in application/json assert_equals: scrolled to fragment expected false but got true
+PASS Text directive blocked in application/json
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/resources/text-html-with-charset.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/resources/text-html-with-charset.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<style>
+  p {
+    position: absolute;
+    top: 200vh;
+  }
+</style>
+<p>
+  target
+</p>

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/resources/text-html-with-charset.html.headers
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/resources/text-html-with-charset.html.headers
@@ -1,0 +1,1 @@
+Content-Type: text/html; charset=utf-8

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/text-directive-mime-type-parameter-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/text-directive-mime-type-parameter-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Text directive allowed in text/html with a charset parameter
+

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/text-directive-mime-type-parameter.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/text-directive-mime-type-parameter.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<title>Allow text fragments when the MIME type has a parameter</title>
+<meta charset=utf-8>
+<link rel="help" href="https://wicg.github.io/scroll-to-text-fragment/#text-directive-allowing-mime-type">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/common/utils.js"></script>
+<script src="stash.js"></script>
+
+<script>
+// A "text directive allowing MIME type" is one whose essence is "text/html" or
+// "text/plain". The essence must be compared after stripping any MIME type
+// parameter, so a document served as e.g. "text/html; charset=utf-8" must still
+// process text directives.
+
+function rAF(win) {
+  return new Promise((resolve) => {
+    win.requestAnimationFrame(resolve);
+  });
+}
+
+function openPopup(url) {
+  return new Promise((resolve) => {
+    test_driver.bless('Open a URL with a text fragment directive', () => {
+      const popup = window.open(url, '_blank', 'width=300,height=300');
+      popup.onload = () => resolve(popup);
+    });
+  });
+}
+
+promise_test(async function (t) {
+  // resources/text-html-with-charset.html is served as "text/html; charset=utf-8".
+  const popup = await openPopup(`resources/text-html-with-charset.html#:~:text=target`);
+
+  // rAF twice in case there is any asynchronicity in scrolling to the target.
+  await rAF(popup);
+  await rAF(popup);
+
+  assert_true(popup.scrollY > 0, 'scrolled to fragment');
+
+  popup.close();
+}, 'Text directive allowed in text/html with a charset parameter');
+</script>

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -3,7 +3,7 @@
  *                     1999 Lars Knoll <knoll@kde.org>
  *                     1999 Antti Koivisto <koivisto@kde.org>
  *                     2000 Dirk Mueller <mueller@kde.org>
- * Copyright (C) 2004-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2026 Apple Inc. All rights reserved.
  *           (C) 2006 Graham Dennis (graham.dennis@gmail.com)
  *           (C) 2006 Alexey Proskuryakov (ap@nypop.com)
  * Copyright (C) 2009 Google Inc. All rights reserved.
@@ -90,6 +90,7 @@
 #include "PageColorSampler.h"
 #include "PageInspectorController.h"
 #include "PageOverlayController.h"
+#include "ParsedContentType.h"
 #include "PerformanceLoggingClient.h"
 #include "PlatformRenderTheme.h"
 #include "ProgressTracker.h"
@@ -3141,6 +3142,15 @@ bool LocalFrameView::scrollToTextFragment(IsRetry isRetry)
         return false;
 
     if (!m_frame->isMainFrame())
+        return false;
+
+    // Text directives are only processed in text/html and text/plain documents. Parse the
+    // content type so that a MIME parameter (e.g. "text/html; charset=UTF-8") is ignored.
+    auto parsedContentType = ParsedContentType::create(document->contentType());
+    if (!parsedContentType)
+        return false;
+    auto mimeType = parsedContentType->mimeType();
+    if (!equalLettersIgnoringASCIICase(mimeType, "text/html"_s) && !equalLettersIgnoringASCIICase(mimeType, "text/plain"_s))
         return false;
 
     // Block text fragments in cross-origin window.open() popups


### PR DESCRIPTION
#### f3abbc493107b5e67649d1dd1fc310e1c422c144
<pre>
Scroll To Text Fragment: text directives should only run in text/html and text/plain documents
<a href="https://bugs.webkit.org/show_bug.cgi?id=318931">https://bugs.webkit.org/show_bug.cgi?id=318931</a>
<a href="https://rdar.apple.com/181763736">rdar://181763736</a>

Reviewed by Abrar Rahman Protyasha.

Per spec [1], a text directive is only processed when the document&apos;s MIME type is a
&quot;text directive allowing MIME type&quot; (essence &quot;text/html&quot; or &quot;text/plain&quot;).

WebKit ran text directives regardless of content type, so `#:~:text=` scrolled
in application/json (and XML/CSS/JS) documents, diverging from other browsers.
Gate scrollToTextFragment() on the document&apos;s MIME type being text/html or
text/plain. The check must use the MIME string, not the document class, since
text/plain and JSON are both TextDocument.

[1] <a href="https://wicg.github.io/scroll-to-text-fragment/#text-directive-allowing-mime-type">https://wicg.github.io/scroll-to-text-fragment/#text-directive-allowing-mime-type</a>

* LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/non-html-documents-json-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/text-directive-mime-type-parameter.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/text-directive-mime-type-parameter-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/resources/text-html-with-charset.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/resources/text-html-with-charset.html.headers: Added.
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::scrollToTextFragment):

Canonical link: <a href="https://commits.webkit.org/316976@main">https://commits.webkit.org/316976@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a6d98ff7d89bb4742ae38eb3f657a123abf6dd27

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173989 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47922 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41703 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183563 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131857 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bd9556fd-91a1-4073-9e8b-f15b2781b529) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175854 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49214 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47604 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135310 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/029203b3-b165-4107-aea9-68b5e368463b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176947 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38740 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156103 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115788 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/22880e0a-6606-4894-8acb-2b08e3674caa) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37381 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35748 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32047 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147805 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35596 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185989 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39065 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39946 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144211 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47589 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155658 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144070 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38838 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48268 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32213 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113655 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38979 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120152 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46774 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10556 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46177 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46408 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46235 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->