### PR TITLE
[WebDriver] Gardening stale selenium expectations still using camelCase names

### DIFF
--- a/WebDriverTests/TestExpectations.json
+++ b/WebDriverTests/TestExpectations.json
@@ -1,7 +1,7 @@
 {
     "imported/selenium/py/test/selenium/webdriver/common/alerts_tests.py": {
         "subtests": {
-            "testShouldHandleAlertOnPageBeforeUnload": {
+            "test_should_handle_alert_on_page_before_unload": {
                 "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/188118"}}
             },
             "test_unexpected_alert_present_exception_contains_alert_text": {
@@ -229,116 +229,113 @@
             },
             "test_selecting_multiple_items": {
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
-            },
-            "test_sending_keys_to_active_element_with_modifier": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/279342"}}
             }
         }
     },
     "imported/selenium/py/test/selenium/webdriver/common/page_load_timeout_tests.py": {
         "subtests": {
-            "testClickShouldTimeout": {
+            "test_click_should_timeout": {
                 "expected": {
                         "gtk": {"status": ["SKIP"], "bug": "webkit.org/b/188118"},
-                        "wpe": {"status": ["SKIP"], "bug": "webkit.org/b/188118"}
+                        "wpe": {"status": ["FAIL"], "bug": "webkit.org/b/188118"}
                 }
             }
         }
     },
     "imported/selenium/py/test/selenium/webdriver/common/position_and_size_tests.py": {
         "subtests": {
-            "testShouldGetCoordinatesOfAnElementInAFrame": {
+            "test_should_get_coordinates_of_an_element_in_aframe": {
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/181735"}}
             },
-            "testShouldGetCoordinatesOfAnElementInANestedFrame": {
+            "test_should_get_coordinates_of_an_element_in_anested_frame": {
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/181735"}}
             },
-            "testShouldGetCoordinatesOfAnElementWithFixedPosition": {
+            "test_should_get_coordinates_of_an_element_with_fixed_position": {
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/213139"}}
             },
-            "testShouldGetCoordinatesOfAnElement[hidden]": {
+            "test_should_get_coordinates_of_an_element[hidden]": {
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/211492"}}
             },
-            "testShouldGetCoordinatesOfAnInvisibleElement": {
+            "test_should_get_coordinates_of_an_invisible_element": {
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/211492"}}
             },
-            "testShouldScrollPageAndGetCoordinatesOfAnElementThatIsOutOfViewPort": {
+            "test_should_scroll_page_and_get_coordinates_of_an_element_that_is_out_of_view_port": {
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/213139"}}
             }
         }
     },
     "imported/selenium/py/test/selenium/webdriver/common/select_class_tests.py": {
         "subtests": {
-            "testSelectByIndexMultiple": {
+            "test_select_by_index_multiple": {
                 "expected": {"all": {"slow": true}}
             },
-            "testSelectByValueMultiple": {
+            "test_select_by_value_multiple": {
                 "expected": {"all": {"slow": true}}
             },
-            "testSelectByVisibleTextMultiple": {
+            "test_select_by_visible_text_multiple": {
                 "expected": {"all": {"slow": true}}
             }
         }
     },
     "imported/selenium/py/test/selenium/webdriver/common/text_handling_tests.py": {
         "subtests": {
-            "testShouldBeAbleToSetMoreThanOneLineOfTextInATextArea": {
+            "test_should_be_able_to_set_more_than_one_line_of_text_in_atext_area": {
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/174617"}}
             },
-            "testShouldHandleSiblingBlockLevelElements": {
+            "test_should_handle_sibling_block_level_elements": {
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/174617"}}
             }
         }
     },
     "imported/selenium/py/test/selenium/webdriver/common/typing_tests.py": {
         "subtests": {
-            "testNumericShiftKeys": {
+            "test_numeric_shift_keys": {
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/182333"}}
             },
-            "testUppercaseAlphaKeys": {
+            "test_uppercase_alpha_keys": {
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/182333"}}
             },
-            "testAllPrintableKeys": {
+            "test_all_printable_keys": {
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/182333"}}
             },
-            "testArrowKeysAndPageUpAndDown": {
+            "test_arrow_keys_and_page_up_and_down": {
+                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/213961"}}
+            },
+            "test_numberpad_and_function_keys": {
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/213961"}}
             },
-            "testNumberpadAndFunctionKeys": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/213961"}}
-            },
-            "testShouldFireKeyPressEvents": {
+            "test_should_fire_key_press_events": {
                 "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/224736"}}
             },
-            "testWillSimulateAKeyPressWhenEnteringTextIntoInputElements" : {
-                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/224736"}}
+            "test_will_simulate_akey_press_when_entering_text_into_input_elements" : {
+                "expected": {
+                    "gtk": {"status": ["FAIL"], "bug": "webkit.org/b/224736"},
+                    "wpe": {"status": ["FAIL"], "bug": "webkit.org/b/224736"}
+                }
             },
-            "testWillSimulateAKeyPressWhenEnteringTextIntoTextAreas" : {
-                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/224736"}}
+            "test_will_simulate_akey_press_when_entering_text_into_text_areas" : {
+                "expected": {
+                    "gtk": {"status": ["FAIL"], "bug": "webkit.org/b/224736"},
+                    "wpe": {"status": ["FAIL"], "bug": "webkit.org/b/224736"}
+                }
             }
         }
     },
     "imported/selenium/py/test/selenium/webdriver/common/w3c_interaction_tests.py": {
         "subtests": {
-            "testSendingKeysToActiveElementWithModifier": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/212953"}}
-            }
 
         }
     },
     "imported/selenium/py/test/selenium/webdriver/common/window_switching_tests.py": {
         "subtests": {
-            "testCanCallGetWindowHandlesAfterClosingAWindow": {
+            "test_can_call_get_window_handles_after_closing_awindow": {
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184963"}}
             },
-            "testClickingOnAButtonThatClosesAnOpenWindowDoesNotCauseTheBrowserToHang": {
+            "test_clicking_on_abutton_that_closes_an_open_window_does_not_cause_the_browser_to_hang": {
                 "expected": {
                     "gtk": {"status": ["FAIL"], "bug": "webkit.org/b/184963"},
                     "wpe": {"status": ["FAIL"], "bug": "webkit.org/b/188509"}
                 }
-            },
-            "testShouldBeAbleToCreateANewWindow": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/212949"}}
             }
         }
     },
@@ -348,11 +345,6 @@
             "test_should_fullscreen_the_current_window": {
                 "expected": {
                     "gtk": {"status": ["FAIL"], "bug": "webkit.org/b/188118"},
-                    "wpe": {"status": ["SKIP"], "bug": "webkit.org/b/212950"}
-                }
-            },
-            "testShouldMaximizeTheWindow": {
-                "expected": {
                     "wpe": {"status": ["SKIP"], "bug": "webkit.org/b/212950"}
                 }
             },


### PR DESCRIPTION
#### eac5a70a2fc40d20ef76619f25970739e4c26d37
<pre>
[WebDriver] Gardening stale selenium expectations still using camelCase names
<a href="https://bugs.webkit.org/show_bug.cgi?id=318927">https://bugs.webkit.org/show_bug.cgi?id=318927</a>

Unreviewed test gardening.

Update the leftover camel case names after the selenium import from
276878@main, and cleanup some related stale expectations.

* WebDriverTests/TestExpectations.json:

Canonical link: <a href="https://commits.webkit.org/316789@main">https://commits.webkit.org/316789@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/19e9490429fd8be54f787d76a5815a5b924047ab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173456 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47388 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/41321 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183029 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/131324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48681 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47070 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/134872 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/131324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176414 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/38300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/155549 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115348 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/36941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/35294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31514 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/147365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/35044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185454 "Built successfully") | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/39495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/143739 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47056 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/155106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143605 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47735 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/41321 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112847 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26348 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38543 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46241 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/9992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45643 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45874 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45700 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->