### PR TITLE
[list-marker] List marker painted in the wrong coordinates inside a multi-column list

### DIFF
--- a/LayoutTests/fast/lists/outside-marker-in-multicol-relpos-content-expected.html
+++ b/LayoutTests/fast/lists/outside-marker-in-multicol-relpos-content-expected.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.list {
+    display: list-item;
+    columns: 2;
+    column-fill: auto;
+    height: 100px;
+    padding-inline-start: 20px;
+    width: 100px;
+    margin-left: 20px;
+}
+
+.list::marker {
+    color: magenta;
+}
+
+.columnFiller {
+    height: 100px;
+    width: 20px;
+    background: green;
+}
+</style>
+</head>
+<body>
+<div class="list">
+    <div class="columnFiller"></div>
+    <div class="itemContent">item</div>
+</div>
+</body>
+</html>

--- a/LayoutTests/fast/lists/outside-marker-in-multicol-relpos-content.html
+++ b/LayoutTests/fast/lists/outside-marker-in-multicol-relpos-content.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="match" href="outside-marker-in-multicol-relpos-content-expected.html">
+<meta name="assert" content="An outside list marker whose line box falls in a later column of a multi-column list item must paint at its column-translated position.">
+<style>
+.container {
+    margin-left: 20px;
+}
+.list {
+    display: list-item;
+    columns: 2;
+    column-fill: auto;
+    height: 100px;
+    padding-inline-start: 20px;
+    width: 100px;
+}
+
+.list::marker {
+    color: magenta;
+}
+
+.columnFiller {
+    height: 100px;
+    width: 20px;
+    background: green;
+}
+
+.itemContent {
+    position: relative;
+}
+</style>
+</head>
+<body>
+<div class="container">
+    <div class="list">
+        <div class="columnFiller"></div>
+        <div class="itemContent">item</div>
+    </div>
+</div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderListMarker.cpp
+++ b/Source/WebCore/rendering/RenderListMarker.cpp
@@ -100,10 +100,13 @@ bool RenderListMarker::shouldPaintInAssociatedListItemLayer() const
     }
 
     for (auto* ancestor = parent(); ancestor && ancestor != associatedListItem; ancestor = ancestor->parent()) {
-        if (!ancestor->hasSelfPaintingLayer())
-            continue;
         if (ancestor->isRenderFragmentedFlow())
             return false;
+    }
+
+    for (auto* ancestor = parent(); ancestor && ancestor != associatedListItem; ancestor = ancestor->parent()) {
+        if (!ancestor->hasSelfPaintingLayer())
+            continue;
         return ancestor->isPositioned();
     }
 


### PR DESCRIPTION
#### e25542d10d0aa4bcfae0694b7bd549937bb8519f
<pre>
[list-marker] List marker painted in the wrong coordinates inside a multi-column list
<a href="https://bugs.webkit.org/show_bug.cgi?id=318928">https://bugs.webkit.org/show_bug.cgi?id=318928</a>
&lt;<a href="https://rdar.apple.com/181763113">rdar://181763113</a>&gt;

Reviewed by NOBODY (OOPS!).

This PR fixes a bug where a list marker is incorrectly painted in its own layer
for multi-column lists instead of going through RenderLayer::collectFragments()
and RenderLayer::paintLayerContents(). This causes the list marker to be painted
at the wrong coordinates.

<a href="https://commits.webkit.org/309188@main">309188@main</a> had a bug in RenderListMarker::shouldPaintInAssociatedListItemLayer()
where the guard to exclude multi-column flow was being skipped when a relative
positioned item is nested between the marker and the multi-column layout.

Screenshot comparison is attached to the bug.

* LayoutTests/fast/lists/outside-marker-in-multicol-relpos-content-expected.html: Added.
* LayoutTests/fast/lists/outside-marker-in-multicol-relpos-content.html: Added.
* Source/WebCore/rendering/RenderListMarker.cpp:
(WebCore::RenderListMarker::shouldPaintInAssociatedListItemLayer const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e25542d10d0aa4bcfae0694b7bd549937bb8519f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173457 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47389 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/41323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183030 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/131325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/28495574-56a0-4f29-8aa1-ac040ce9152b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175322 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48682 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47071 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134873 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/131325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/753072da-d4f7-4422-9aef-8661a168df7c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176415 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38301 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155548 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115349 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1999c4f8-5857-4124-b276-670df18c1e1c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36942 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35295 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31515 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147366 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35043 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185455 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38326 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39496 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143740 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47057 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155105 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143606 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47736 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/41323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112848 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38544 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/119596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46242 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9991 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45644 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45875 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45701 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->