### PR TITLE
[JSC] Convert `InByVal` on the current for-in property name to `EnumeratorInByVal`

### DIFF
--- a/JSTests/microbenchmarks/in-by-val-helper-for-in-loop.js
+++ b/JSTests/microbenchmarks/in-by-val-helper-for-in-loop.js
@@ -1,0 +1,37 @@
+function assert(b) {
+    if (!b)
+        throw new Error;
+}
+
+function test1() {
+    function has(o, p) {
+        return p in o;
+    }
+
+    function count(o) {
+        let c = 0;
+        for (let p in o) {
+            if (has(o, p))
+                c += p.length;
+        }
+        return c;
+    }
+    noInline(count);
+
+    const keys = ['method', 'url', 'status', 'headers', 'body', 'retries', 'timeout', 'ok'];
+    let srcs = [];
+    for (let j = 0; j < 16; j++) {
+        let o = {};
+        for (let k of keys)
+            o[k] = k + j;
+        srcs.push(o);
+    }
+
+    let expected = 0;
+    for (let k of keys)
+        expected += k.length;
+
+    for (let i = 0; i < 1000000; ++i)
+        assert(count(srcs[i & 15]) === expected);
+}
+test1();

--- a/JSTests/microbenchmarks/reflect-has-for-in-loop.js
+++ b/JSTests/microbenchmarks/reflect-has-for-in-loop.js
@@ -1,0 +1,33 @@
+function assert(b) {
+    if (!b)
+        throw new Error;
+}
+
+function test1() {
+    function count(o) {
+        let c = 0;
+        for (let p in o) {
+            if (Reflect.has(o, p))
+                c += p.length;
+        }
+        return c;
+    }
+    noInline(count);
+
+    const keys = ['method', 'url', 'status', 'headers', 'body', 'retries', 'timeout', 'ok'];
+    let srcs = [];
+    for (let j = 0; j < 16; j++) {
+        let o = {};
+        for (let k of keys)
+            o[k] = k + j;
+        srcs.push(o);
+    }
+
+    let expected = 0;
+    for (let k of keys)
+        expected += k.length;
+
+    for (let i = 0; i < 1000000; ++i)
+        assert(count(srcs[i & 15]) === expected);
+}
+test1();

--- a/JSTests/stress/for-in-in-by-val-edge-cases.js
+++ b/JSTests/stress/for-in-in-by-val-edge-cases.js
@@ -1,0 +1,256 @@
+function assert(b, m) {
+    if (!b)
+        throw new Error(m);
+}
+
+function inHelper(o, p) {
+    return p in o;
+}
+
+function oracle(o, p) {
+    let cur = Object(o);
+    while (cur) {
+        if (Reflect.getOwnPropertyDescriptor(cur, p) !== undefined)
+            return true;
+        cur = Object.getPrototypeOf(cur);
+    }
+    return false;
+}
+noInline(oracle);
+
+// The check must observe a delete of the current key.
+function deleteCurrent(o) {
+    const seen = [];
+    for (const p in o) {
+        delete o[p];
+        seen.push(p + ':' + Reflect.has(o, p));
+    }
+    return seen.join(',');
+}
+noInline(deleteCurrent);
+
+function deleteCurrentHelper(o) {
+    const seen = [];
+    for (const p in o) {
+        delete o[p];
+        seen.push(p + ':' + inHelper(o, p));
+    }
+    return seen.join(',');
+}
+noInline(deleteCurrentHelper);
+
+// A call that clobbers the world between the property name production and the check.
+let clobberTarget = null;
+let clobberKey = '';
+function clobber() {
+    if (clobberTarget)
+        delete clobberTarget[clobberKey];
+}
+noInline(clobber);
+
+function checkAfterClobber(o, victim) {
+    const seen = [];
+    for (const p in o) {
+        clobberTarget = p === victim ? o : null;
+        clobberKey = p;
+        clobber();
+        seen.push(p + ':' + inHelper(o, p));
+    }
+    clobberTarget = null;
+    return seen.join(',');
+}
+noInline(checkAfterClobber);
+
+// The check must always agree with a prototype-chain walk over
+// Reflect.getOwnPropertyDescriptor, even while the mutator churns structures,
+// prototypes, and upcoming keys.
+function differential(o, mutate) {
+    let ones = 0;
+    for (const p in o) {
+        if (mutate)
+            mutate(o, p);
+        const got = Reflect.has(o, p);
+        assert(got === oracle(o, p), "differential mismatch for " + p);
+        if (got)
+            ones++;
+    }
+    return ones;
+}
+noInline(differential);
+
+// Loop variable reassignment: q keeps the enumerated name, p does not.
+function reassign(o) {
+    let n = 0;
+    for (let p in o) {
+        const q = p;
+        p = 'not a property';
+        assert(!inHelper(o, p), "reassigned key must miss");
+        if (inHelper(o, q))
+            n++;
+    }
+    return n;
+}
+noInline(reassign);
+
+// Nested enumerations over the same object, checking both loop variables.
+function nested(o) {
+    let n = 0;
+    for (const p in o) {
+        for (const q in o) {
+            if (inHelper(o, p))
+                n++;
+            if (Reflect.has(o, q))
+                n += 10;
+        }
+    }
+    return n;
+}
+noInline(nested);
+
+// The check on a proxy must consult the has trap every time.
+function proxyCheck(o, counter) {
+    let n = 0;
+    for (const p in o) {
+        const before = counter.count;
+        if (inHelper(o, p))
+            n++;
+        assert(counter.count > before, "check must hit the proxy trap");
+    }
+    return n;
+}
+noInline(proxyCheck);
+
+// A trap that starts throwing mid-enumeration must surface the exception.
+function proxyThrow(o, state) {
+    const seen = [];
+    for (const p in o) {
+        seen.push(p + ':' + inHelper(o, p));
+        state.throwing = true;
+    }
+    return seen.join(',');
+}
+noInline(proxyThrow);
+
+// Polymorphic bases: plain, null-proto, frozen, large, array, boxed string.
+function polyBase(o) {
+    let n = 0;
+    for (const p in o) {
+        if (Reflect.has(o, p))
+            n++;
+    }
+    return n;
+}
+noInline(polyBase);
+
+const protoBase = { pa: 1, pb: 2 };
+const shadowProto = { a: 42 };
+
+function makeLarge() {
+    const o = {};
+    for (let i = 0; i < 40; ++i)
+        o['k' + i] = i;
+    return o;
+}
+
+const largeTemplate = makeLarge();
+
+for (let i = 0; i < testLoopCount; ++i) {
+    assert(deleteCurrent({ a: 1, b: 2, c: 3 }) === 'a:false,b:false,c:false', "deleteCurrent");
+    assert(deleteCurrentHelper({ a: 1, b: 2, c: 3 }) === 'a:false,b:false,c:false', "deleteCurrentHelper");
+
+    {
+        // Deleting the own property must still find it on the prototype chain.
+        const o = Object.create(shadowProto);
+        o.a = 1;
+        o.b = 2;
+        assert(deleteCurrentHelper(o) === 'a:true,b:false', "deleteCurrent shadow");
+    }
+
+    assert(checkAfterClobber({ a: 1, b: 2, c: 3 }, 'b') === 'a:true,b:false,c:true', "checkAfterClobber");
+
+    {
+        const o = Object.create(protoBase);
+        o.a = 1;
+        o.b = 2;
+        // Own a, b plus inherited pa, pb are all present for `in`.
+        assert(differential(o, null) === 4, "differential proto");
+    }
+    {
+        const o = { a: 1, b: 2, c: 3 };
+        assert(differential(o, (t, p) => { if (p === 'a') delete t.c; }) === 2, "differential delete upcoming");
+    }
+    {
+        const o = { a: 1, b: 2 };
+        differential(o, (t, p) => { t['n' + p] = 1; });
+    }
+    {
+        const o = Object.create(protoBase);
+        o.a = 1;
+        differential(o, (t, p) => { if (p === 'a') Object.setPrototypeOf(t, { zz: 1 }); });
+    }
+    {
+        const o = { a: 1, b: 2, c: 3, d: 4 };
+        delete o.b;
+        o['k' + (i & 7)] = 1;
+        assert(differential(o, null) === 4, "differential dictionary");
+    }
+
+    assert(reassign({ a: 1, b: 2, c: 3 }) === 3, "reassign");
+    assert(nested({ a: 1, b: 2, c: 3 }) === 99, "nested");
+
+    {
+        const counter = { count: 0 };
+        const proxy = new Proxy({ a: 1, b: 2 }, {
+            has(t, k) {
+                counter.count++;
+                return Reflect.has(t, k);
+            }
+        });
+        assert(proxyCheck(proxy, counter) === 2, "proxyCheck");
+    }
+    {
+        const state = { throwing: false };
+        const proxy = new Proxy({ a: 1, b: 2 }, {
+            has(t, k) {
+                if (state.throwing)
+                    throw new Error('trap');
+                return Reflect.has(t, k);
+            }
+        });
+        let threw = false;
+        let result = null;
+        try {
+            result = proxyThrow(proxy, state);
+        } catch (e) {
+            threw = true;
+            assert(e.message === 'trap', "proxyThrow message");
+        }
+        assert(threw || result === 'a:true,b:true', "proxyThrow " + result);
+    }
+
+    assert(polyBase({ a: 1, b: 2, c: 3 }) === 3, "polyBase object");
+    assert(polyBase(Object("abcd")) === 4, "polyBase string");
+    {
+        const arr = [10, 20, 30];
+        arr.named = 1;
+        delete arr[1];
+        assert(polyBase(arr) === 3, "polyBase array");
+    }
+    {
+        const o = Object.create(null);
+        o.x = 1;
+        o.y = 2;
+        assert(polyBase(o) === 2, "polyBase null proto");
+    }
+    assert(polyBase(Object.freeze({ f1: 1, f2: 2 })) === 2, "polyBase frozen");
+    {
+        const o = { ...largeTemplate };
+        assert(polyBase(o) === 40, "polyBase large");
+    }
+    {
+        const o = Object.create(protoBase);
+        o.own = 1;
+        // for-in visits own + inherited; `in` is true for every visited key.
+        assert(polyBase(o) === 3, "polyBase inherited");
+    }
+}

--- a/JSTests/stress/for-in-in-by-val.js
+++ b/JSTests/stress/for-in-in-by-val.js
@@ -1,0 +1,95 @@
+function assert(b, m) {
+    if (!b)
+        throw new Error(m);
+}
+
+function has(o, p) {
+    return p in o;
+}
+
+function countIn(o) {
+    let present = 0;
+    for (const p in o) {
+        if (Reflect.has(o, p))
+            present++;
+    }
+    return present;
+}
+noInline(countIn);
+
+function countInHelper(o) {
+    let present = 0;
+    for (const p in o) {
+        if (has(o, p))
+            present++;
+    }
+    return present;
+}
+noInline(countInHelper);
+
+function crossCheck(o, other) {
+    let n = 0;
+    for (const p in o) {
+        if (has(other, p))
+            n++;
+    }
+    return n;
+}
+noInline(crossCheck);
+
+function deleteDuring(o, victim) {
+    const seen = [];
+    for (const p in o) {
+        if (p === 'a')
+            delete o[victim];
+        seen.push(p + ':' + has(o, p));
+    }
+    return seen.join(',');
+}
+noInline(deleteDuring);
+
+function countIndexed(o) {
+    let n = 0;
+    for (const p in o) {
+        if (Reflect.has(o, p))
+            n++;
+    }
+    return n;
+}
+noInline(countIndexed);
+
+const proto = { pa: 1, pb: 2 };
+const shadowProto = { a: 42 };
+
+for (let i = 0; i < testLoopCount; ++i) {
+    const o = Object.create(proto);
+    o.a = 1;
+    o.b = 2;
+    o.c = 3;
+    // for-in visits own a, b, c and inherited pa, pb; `in` is true for all of them.
+    assert(countIn(o) === 5, "countIn " + countIn(o));
+    assert(countInHelper(o) === 5, "countInHelper");
+
+    const shadow = Object.create(proto);
+    shadow.pa = 9;
+    shadow.x = 1;
+    // Visits own pa (shadowing), x, and inherited pb.
+    assert(countIn(shadow) === 3, "shadow " + countIn(shadow));
+
+    assert(crossCheck({ a: 1, b: 2, c: 3 }, { a: 1, c: 3 }) === 2, "cross");
+
+    const d = { a: 1, b: 2, c: 3 };
+    const r = deleteDuring(d, 'c');
+    assert(r === 'a:true,b:true' || r === 'a:true,b:true,c:false', "delete " + r);
+
+    // Deleting the own property must still find it on the prototype chain.
+    const s = Object.create(shadowProto);
+    s.a = 1;
+    s.b = 2;
+    const rs = deleteDuring(s, 'a');
+    assert(rs === 'a:true,b:true' || rs === 'a:true,b:true,a:true', "delete shadow " + rs);
+
+    const arr = [10, 20, 30];
+    arr.named = 1;
+    assert(countIndexed(arr) === 4, "indexed");
+}

--- a/Source/JavaScriptCore/dfg/DFGNode.cpp
+++ b/Source/JavaScriptCore/dfg/DFGNode.cpp
@@ -438,6 +438,22 @@ void Node::convertToEnumeratorHasOwnProperty(Graph& graph, Edge base, Edge prope
     children = AdjacencyList(AdjacencyList::Variable, firstChild, 5);
 }
 
+void Node::convertToEnumeratorInByVal(Graph& graph, Edge base, Edge propertyName, Edge index, Edge mode, Edge enumerator, ArrayMode arrayMode, unsigned enumeratorMetadata)
+{
+    ASSERT(op() == InByVal || op() == InByValMegamorphic);
+    setOpAndDefaultFlags(EnumeratorInByVal);
+    m_opInfo = arrayMode.asWord();
+    m_opInfo2 = enumeratorMetadata;
+
+    unsigned firstChild = graph.m_varArgChildren.size();
+    graph.m_varArgChildren.append(base);
+    graph.m_varArgChildren.append(propertyName);
+    graph.m_varArgChildren.append(index);
+    graph.m_varArgChildren.append(mode);
+    graph.m_varArgChildren.append(enumerator);
+    children = AdjacencyList(AdjacencyList::Variable, firstChild, 5);
+}
+
 void Node::convertToObjectDefinePropertyFromFields(Graph& graph, Edge target, Edge key, Edge enumerable, Edge configurable, Edge value, Edge writable, Edge getter, Edge setter)
 {
     ASSERT(op() == ObjectDefineProperty);

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -987,6 +987,7 @@ public:
     void convertToObjectDefinePropertyFromFields(Graph&, Edge target, Edge key, Edge enumerable, Edge configurable, Edge value, Edge writable, Edge getter, Edge setter);
     void convertToPutByIdDirect(Graph&, Edge base, Edge value, CacheableIdentifier, ECMAMode);
     void convertToEnumeratorHasOwnProperty(Graph&, Edge base, Edge propertyName, Edge index, Edge mode, Edge enumerator, ArrayMode, unsigned enumeratorMetadata);
+    void convertToEnumeratorInByVal(Graph&, Edge base, Edge propertyName, Edge index, Edge mode, Edge enumerator, ArrayMode, unsigned enumeratorMetadata);
 
     void convertToSetRegExpObjectLastIndex()
     {

--- a/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
@@ -1701,6 +1701,19 @@ private:
                     m_changed = true;
                 }
             }
+
+            Node* object = baseEdge.node();
+            Node* key = keyEdge.node();
+            if (key->op() == EnumeratorNextUpdatePropertyName && key->child3()->op() == GetPropertyEnumerator && key->child3()->child1().node() == object) {
+                Node* indexNode = key->child1().node();
+                if (indexNode->op() == ExtractFromTuple && indexNode->child1()->op() == EnumeratorNextUpdateIndexAndMode) {
+                    m_node->convertToEnumeratorInByVal(
+                        m_graph, Edge(object, CellUse), Edge(key, UntypedUse),
+                        key->child1(), key->child2(), key->child3(),
+                        indexNode->child1()->arrayMode(), key->enumeratorMetadata().toRaw());
+                    m_changed = true;
+                }
+            }
             break;
         }
 


### PR DESCRIPTION
#### 74acb52138c7a81e142e54cbdfa575041454d611
<pre>
[JSC] Convert `InByVal` on the current for-in property name to `EnumeratorInByVal`
<a href="https://bugs.webkit.org/show_bug.cgi?id=318936">https://bugs.webkit.org/show_bug.cgi?id=318936</a>

Reviewed by NOBODY (OOPS!).

Same conversion as <a href="https://commits.webkit.org/316538@main">316538@main</a>, but for `in`: Reflect.has(o, p) and inlined
helpers containing `p in o` emit a generic InByVal (usually megamorphic, since
the helper&apos;s IC is shared across keys) rather than op_enumerator_in_by_val.

Convert InByVal / InByValMegamorphic to EnumeratorInByVal in DFG strength
reduction under the same conditions. Fixup and backend are already shared, and
the slow path is the same CommonSlowPaths::opInByVal, so `in` semantics are
unchanged.

                                          Baseline                  Patched

in-by-val-helper-for-in-loop            15.4992+-0.1323     ^     10.0777+-0.2586        ^ definitely 1.5380x faster
reflect-has-for-in-loop                 15.2187+-0.1580     ^      9.9996+-0.4449        ^ definitely 1.5219x faster

* JSTests/microbenchmarks/in-by-val-helper-for-in-loop.js: Added.
* JSTests/microbenchmarks/reflect-has-for-in-loop.js: Added.
* JSTests/stress/for-in-in-by-val-edge-cases.js: Added.
* JSTests/stress/for-in-in-by-val.js: Added.
* Source/JavaScriptCore/dfg/DFGNode.cpp:
(JSC::DFG::Node::convertToEnumeratorInByVal):
* Source/JavaScriptCore/dfg/DFGNode.h:
* Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp:
(JSC::DFG::StrengthReductionPhase::handleNode):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/74acb52138c7a81e142e54cbdfa575041454d611

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173459 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47391 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41315 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183032 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131327 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48684 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47073 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134875 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95224 "5 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176417 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38304 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155790 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115351 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36945 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35297 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31517 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/4301 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147369 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35284 "Found 1 new test failure: imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-corner-shape-change.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185457 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/34721 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38328 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39498 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143742 "Found 1 new test failure: imported/w3c/web-platform-tests/resize-observer/callback-cross-realm-report-exception.html (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47059 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143608 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47738 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31899 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112855 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38547 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119753 "Found 1059 new failures in b3/testb3_7.cpp, b3/B3Value.h, WebProcess/Network/WebResourceLoader.cpp, jit/OperationResult.h, UIProcess/WebProcessPool.cpp, testing/MockMediaSessionCoordinator.cpp, Shared/Cocoa/WKNSArray.mm, heap/WeakSet.h, API/tests/Regress141275.mm, Shared/SessionState.cpp ...") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/210492 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46244 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10238 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54912 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45646 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45877 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45703 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->