### PR TITLE
Fix out-of-sync m_adjustmentForViewport after snapshot removal

### DIFF
--- a/LayoutTests/fast/css/css-anchor-position/anchor-scroll-nested-chained-viewport-crash-expected.txt
+++ b/LayoutTests/fast/css/css-anchor-position/anchor-scroll-nested-chained-viewport-crash-expected.txt
@@ -1,0 +1,3 @@
+This test passes if it does not crash.
+
+

--- a/LayoutTests/fast/css/css-anchor-position/anchor-scroll-nested-chained-viewport-crash.html
+++ b/LayoutTests/fast/css/css-anchor-position/anchor-scroll-nested-chained-viewport-crash.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+
+<title>Tests that recapturing scroll snapshots of a fixedpos anchor-positioned box nested in another
+scroll-adjusted fixedpos box, whose default anchor is itself anchor-positioned, does not crash</title>
+<link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=318909">
+
+<style>
+body {
+  margin: 0;
+  width: 1000px;
+  height: 1000px;
+}
+
+div {
+  width: 50px;
+  height: 50px;
+}
+
+#anchor1 {
+  position: absolute;
+  left: 150px;
+  top: 150px;
+  anchor-name: --a1;
+}
+
+#anchor3 {
+  position: absolute;
+  left: 350px;
+  top: 350px;
+  anchor-name: --a3;
+}
+
+/* #anchor2 is itself anchor-positioned (chained to #anchor3), which is what makes
+   #f2's AnchorScrollAdjuster have a chained anchor and therefore stay registered
+   even after its viewport snapshot is (incorrectly) removed below. */
+#anchor2 {
+  position: absolute;
+  position-anchor: --a3;
+  position-area: bottom right;
+  anchor-name: --a2;
+}
+
+#f1 {
+  position: fixed;
+  position-anchor: --a1;
+  position-area: bottom right;
+}
+
+/* #f2 is fixed-positioned and nested inside #f1, which is also fixed-positioned and
+   scroll-adjusted for the viewport, so #f2 unwinds the shared viewport adjustment. */
+#f2 {
+  position: fixed;
+  position-anchor: --a2;
+  position-area: bottom right;
+}
+</style>
+
+<script src="../../../resources/ui-helper.js"></script>
+
+<p>This test passes if it does not crash.</p>
+
+<div id="anchor1"></div>
+<div id="anchor3"></div>
+<div id="anchor2"></div>
+<div id="f1">
+  <div id="wrapper">
+    <div id="f2"></div>
+  </div>
+</div>
+
+<script>
+  if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+  }
+
+  async function doTest() {
+    // Let #f1 acquire its viewport scroll adjustment first.
+    await UIHelper.renderingUpdate();
+    await UIHelper.renderingUpdate();
+
+    // Force #f2 to be laid out again (recapturing its scroll snapshots) now that
+    // #f1 is already tagged with a viewport scroll adjustment, so #f2 unwinds it.
+    f2.style.width = '51px';
+
+    await UIHelper.renderingUpdate();
+    await UIHelper.renderingUpdate();
+
+    if (window.testRunner)
+      testRunner.notifyDone();
+  }
+  window.addEventListener('load', doTest, false);
+</script>

--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -260,6 +260,10 @@ void AnchorScrollAdjuster::removeMatchingSnapshots(const AnchorScrollAdjuster& c
 {
     if (m_adjustmentForViewport != containerAdjuster.m_adjustmentForViewport)
         return;
+    if (containerAdjuster.m_adjustmentForViewport) {
+        ASSERT(!containerAdjuster.m_scrollSnapshots.first().m_scroller && !m_scrollSnapshots.first().m_scroller);
+        m_adjustmentForViewport = 0;
+    }
     for (auto containerSnapshot : containerAdjuster.m_scrollSnapshots) {
         m_scrollSnapshots.removeFirstMatching([containerSnapshot](const auto& selfSnapshot) {
             return selfSnapshot.m_scroller.get() == containerSnapshot.m_scroller.get();


### PR DESCRIPTION
#### 84565916779faa5f54b09bc075add03a779723c1
<pre>
Fix out-of-sync m_adjustmentForViewport after snapshot removal
<a href="https://bugs.webkit.org/show_bug.cgi?id=318909">https://bugs.webkit.org/show_bug.cgi?id=318909</a>
<a href="https://rdar.apple.com/181305647">rdar://181305647</a>

Reviewed by Kiet Ho.

Updates m_adjustmentForViewport when removing viewport snapshot
in AnchorScrollAdjuster::removeMatchingSnapshots() so that the
vector and m_adjustmentForViewport remain in sync.

* LayoutTests/fast/css/css-anchor-position/anchor-scroll-nested-chained-viewport-crash-expected.txt: Added.
* LayoutTests/fast/css/css-anchor-position/anchor-scroll-nested-chained-viewport-crash.html: Added.
* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::AnchorScrollAdjuster::removeMatchingSnapshots):

Canonical link: <a href="https://commits.webkit.org/316817@main">https://commits.webkit.org/316817@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6620ec322942fa411097029a9086a54aa88526d5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173463 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47395 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/41316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183036 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/131331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f9181f88-a354-41e8-b816-ed25f12bac5b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175328 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48688 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47077 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134879 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/131331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/94c56846-9fe7-459c-acd2-1fdffd846637) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176421 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38306 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155557 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115355 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0f834aa4-279f-4554-bd04-0ef091974a18) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36947 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35301 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31521 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147371 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35052 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185461 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38332 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39502 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143746 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47063 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155114 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143612 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38764 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47742 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/41316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112859 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38549 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/119558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46248 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10000 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45650 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45881 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45707 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->