### PR TITLE
[JSC] Add `TokNumberInt32` token type to `LiteralParser` to remove number conversion overhead

### DIFF
--- a/JSTests/microbenchmarks/json-parse-int32-array.js
+++ b/JSTests/microbenchmarks/json-parse-int32-array.js
@@ -1,0 +1,26 @@
+// Parsing JSON payloads dominated by int32 numbers, e.g. time series metrics or tilemap data.
+
+var payloads = [];
+var arrays = [];
+for (var k = 0; k < 16; k++) {
+    var pts = [];
+    for (var j = 0; j < 1024; j++)
+        pts.push(((j * 2654435761 + k * 97) >>> 0) % 100000);
+    arrays.push(pts);
+    payloads.push(JSON.stringify({ series: "cpu", points: pts }));
+}
+
+var iterations = 30000;
+
+var expected = 0;
+for (var i = 0; i < iterations; i++)
+    expected += 1024 + arrays[i & 15][i & 1023];
+
+var sum = 0;
+for (var i = 0; i < iterations; i++) {
+    var o = JSON.parse(payloads[i & 15]);
+    sum += o.points.length + o.points[i & 1023];
+}
+
+if (sum !== expected)
+    throw new Error("bad result: " + sum + " vs " + expected);

--- a/JSTests/stress/json-parse-number-int32-token.js
+++ b/JSTests/stress/json-parse-number-int32-token.js
@@ -1,0 +1,45 @@
+function shouldBe(actual, expected) {
+    if (!Object.is(actual, expected))
+        throw new Error("bad value: " + actual + " expected: " + expected);
+}
+
+var numbers = [
+    "0", "-0", "1", "-1", "9", "10", "42", "123", "1023",
+    "99999", "100000", "999999999", "-999999999",
+    "1000000000", "-1000000000", "2147483647", "2147483648",
+    "-2147483648", "-2147483649", "4294967295", "4294967296",
+    "0.5", "-0.5", "1.5", "123.456", "0.0", "-0.0", "0.1", "-0.0001",
+    "1e2", "1E2", "1e-2", "1e+2", "-1e2", "1e0", "0e0", "-0e0",
+    "1e308", "1e309", "-1e309", "5e-324", "3.141592653589793",
+    "123456789012345678901234567890", "9007199254740993",
+    "900000000", "90000000", "9000000", "900000", "90000", "9000", "900", "90",
+];
+
+for (var i = 0; i < 1e3; ++i) {
+    for (var s of numbers) {
+        var expected = Number(s);
+        shouldBe(JSON.parse(s), expected);
+        shouldBe(JSON.parse(" " + s + " "), expected);
+        var array = JSON.parse("[" + s + "," + s + "]");
+        shouldBe(array[0], expected);
+        shouldBe(array[1], expected);
+        shouldBe(JSON.parse('{"a":' + s + "}").a, expected);
+        shouldBe(JSON.parse('{"あ":' + s + "}")["あ"], expected);
+        shouldBe(JSON.parse("[" + s + ",\"あ\"]")[0], expected);
+        shouldBe(JSON.parse("[" + s + "]", function (key, value) { return value; })[0], expected);
+        shouldBe(JSON.parse('{"a":{"b":[' + s + "]}}").a.b[0], expected);
+    }
+}
+
+var invalid = ["01", "-", "+1", ".5", "1.", "1e", "1e+", "0x10", "Infinity", "NaN", "- 1", "--1", "1..2", "1e2e3"];
+for (var s of invalid) {
+    for (var source of [s, "[" + s + "]", '{"a":' + s + "}"]) {
+        var threw = false;
+        try {
+            JSON.parse(source);
+        } catch (error) {
+            threw = true;
+        }
+        shouldBe(threw, true);
+    }
+}

--- a/JSTests/stress/jsonp-negative-array-index.js
+++ b/JSTests/stress/jsonp-negative-array-index.js
@@ -1,0 +1,24 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}, expected ${expected}`);
+}
+
+globalThis.foo = {};
+loadString('foo[-1]={"a":1};');
+shouldBe(JSON.stringify(foo["-1"]), '{"a":1}');
+shouldBe(foo[0], undefined);
+
+globalThis.bar = {};
+loadString('bar[-2147483648]={"b":2};');
+shouldBe(JSON.stringify(bar["-2147483648"]), '{"b":2}');
+shouldBe(bar[0], undefined);
+
+globalThis.baz = {};
+loadString('baz[-0.5]={"c":3};');
+shouldBe(JSON.stringify(baz["-0.5"]), '{"c":3}');
+shouldBe(baz[0], undefined);
+
+globalThis.qux = [];
+loadString('qux[-0]={"d":4};');
+shouldBe(JSON.stringify(qux[0]), '{"d":4}');
+shouldBe(qux["-0"], undefined);

--- a/Source/JavaScriptCore/runtime/LiteralParser.cpp
+++ b/Source/JavaScriptCore/runtime/LiteralParser.cpp
@@ -94,11 +94,20 @@ bool LiteralParser<CharType, reviverMode>::tryJSONPParse(Vector<JSONPData>& resu
             switch (tokenType) {
             case TokLBracket: {
                 entry.m_type = JSONPPathEntryTypeLookup;
-                if (m_lexer.next() != TokNumber)
+                TokenType numberType = m_lexer.next();
+                if (numberType != TokNumber && numberType != TokNumberInt32)
                     return false;
-                double doubleIndex = m_lexer.currentToken()->numberToken;
-                int index = truncateDoubleToInt32(doubleIndex);
-                if (index != doubleIndex || index < 0)
+                auto token = m_lexer.currentToken();
+                int index;
+                if (token->type == TokNumberInt32)
+                    index = token->int32Token;
+                else {
+                    double doubleIndex = token->numberToken;
+                    index = truncateDoubleToInt32(doubleIndex);
+                    if (index != doubleIndex)
+                        return false;
+                }
+                if (index < 0)
                     return false;
                 entry.m_pathIndex = index;
                 if (m_lexer.next() != TokRBracket)
@@ -1139,21 +1148,24 @@ TokenType LiteralParser<CharType, reviverMode>::Lexer::lexNumber(LiteralParserTo
     const int numberOfDigitsForSafeInt32 = 9; // The numbers from -999999999 to 999999999 are always in range of Int32.
     if (m_ptr < m_end && (*m_ptr != '.' && *m_ptr != 'e' && *m_ptr != 'E') && (m_ptr - start) <= numberOfDigitsForSafeInt32) {
         int32_t result = 0;
-        token.type = TokNumber;
         const CharType* cursor = start;
         do {
             result = result * 10 + (*cursor++) - '0';
         } while (cursor < m_ptr);
 
-        if (!negative)
-            token.numberToken = result;
-        else {
-            if (!result)
-                token.numberToken = -0.0;
-            else
-                token.numberToken = -result;
+        if (!negative) [[likely]] {
+            token.type = TokNumberInt32;
+            token.int32Token = result;
+            return TokNumberInt32;
         }
-        return TokNumber;
+        if (!result) [[unlikely]] {
+            token.type = TokNumber;
+            token.numberToken = -0.0;
+            return TokNumber;
+        }
+        token.type = TokNumberInt32;
+        token.int32Token = -result;
+        return TokNumberInt32;
     }
 
     size_t parsedLength = 0;
@@ -1234,6 +1246,11 @@ ALWAYS_INLINE JSValue LiteralParser<CharType, reviverMode>::parsePrimitiveValue(
     switch (m_lexer.currentToken()->type) {
     case TokString: {
         JSString* result = makeJSString(vm, m_lexer.currentToken());
+        m_lexer.next();
+        return result;
+    }
+    case TokNumberInt32: {
+        JSValue result = jsNumber(m_lexer.currentToken()->int32Token);
         m_lexer.next();
         return result;
     }
@@ -1859,6 +1876,7 @@ JSValue LiteralParser<CharType, reviverMode>::parse(VM& vm, ParserState initialS
             switch (m_lexer.currentToken()->type) {
             case TokLBracket:
             case TokNumber:
+            case TokNumberInt32:
             case TokString: {
                 lastValue = parsePrimitiveValue(vm);
                 if (!lastValue) [[unlikely]]

--- a/Source/JavaScriptCore/runtime/LiteralParser.h
+++ b/Source/JavaScriptCore/runtime/LiteralParser.h
@@ -58,7 +58,7 @@ enum ParserState : uint8_t {
 
 enum TokenType : uint8_t {
     TokLBracket, TokRBracket, TokLBrace, TokRBrace,
-    TokString, TokIdentifier, TokNumber, TokColon,
+    TokString, TokIdentifier, TokNumber, TokNumberInt32, TokColon,
     TokLParen, TokRParen, TokComma, TokTrue, TokFalse,
     TokNull, TokEnd, TokDot, TokAssign, TokSemi, TokError, TokErrorSpace };
 
@@ -117,6 +117,7 @@ template<typename CharacterType> struct LiteralParserToken {
     unsigned stringOrIdentifierLength : 31;
     union {
         double numberToken; // Only used for TokNumber.
+        int32_t int32Token; // Only used for TokNumberInt32.
         const CharacterType* identifierStart;
         const Latin1Character* stringStart8;
         const char16_t* stringStart16;


### PR DESCRIPTION
#### d981384b263dcf7b8d6f247fc803fa9d34c7c449
<pre>
[JSC] Add `TokNumberInt32` token type to `LiteralParser` to remove number conversion overhead
<a href="https://bugs.webkit.org/show_bug.cgi?id=318937">https://bugs.webkit.org/show_bug.cgi?id=318937</a>

Reviewed by Yusuke Suzuki.

LiteralParser&apos;s lexer already computes short integer JSON numbers as
int32, but LiteralParserToken can only hold a double, so the lexer
widens the value to double and parsePrimitiveValue&apos;s jsNumber(double)
re-derives its int32-ness through a double-&gt;int32-&gt;double
convert-and-compare chain for every number.

This patch adds a TokNumberInt32 token type that carries the int32
value in the token directly, so parsePrimitiveValue can box it with
jsNumber(int32_t). Negative zero keeps using TokNumber.

                                 Baseline                  Patched

json-parse-int32-array      275.3648+-3.7552     ^    260.3382+-2.3959        ^ definitely 1.0577x faster

Tests: JSTests/microbenchmarks/json-parse-int32-array.js
       JSTests/stress/json-parse-number-int32-token.js

* JSTests/microbenchmarks/json-parse-int32-array.js: Added.
* JSTests/stress/json-parse-number-int32-token.js: Added.
(shouldBe):
(s.of.invalid.string_appeared_here.s.string_appeared_here.catch):
* Source/JavaScriptCore/runtime/LiteralParser.cpp:
(JSC::requires):
(JSC::reviverMode&gt;::Lexer::lexNumber):
(JSC::reviverMode&gt;::parsePrimitiveValue):
(JSC::reviverMode&gt;::parse):
* Source/JavaScriptCore/runtime/LiteralParser.h:

Canonical link: <a href="https://commits.webkit.org/316806@main">https://commits.webkit.org/316806@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d5efccb69acfe8b5ee317224b2d882ebdbf32120

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173470 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47402 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/41302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183043 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/131338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48695 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47084 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134884 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/131338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176428 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38313 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155568 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115360 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36954 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/35308 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31528 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/4080 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147378 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35063 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185468 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/34732 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/38378 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39509 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143756 "Found 1 new test failure: compositing/framesets/composited-frame-alignment.html (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47070 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143619 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38759 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47749 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/41302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112871 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38555 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/119534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/210503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46255 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10011 "Passed tests") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/210503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45657 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45888 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45714 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->