### PR TITLE
[WPE] don't put page with multimedia to bfCache on low-end devices

### DIFF
--- a/LayoutTests/platform/wpe/fast/history/page-cache-video-media-disabled-expected.txt
+++ b/LayoutTests/platform/wpe/fast/history/page-cache-video-media-disabled-expected.txt
@@ -1,0 +1,11 @@
+Tests that a page with a video element does not go into the back/forward cache when back-forward-cache-with-media is disabled.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+pageshow - not from cache
+PASS Page was not restored from the back/forward cache
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/platform/wpe/fast/history/page-cache-video-media-disabled.html
+++ b/LayoutTests/platform/wpe/fast/history/page-cache-video-media-disabled.html
@@ -1,0 +1,46 @@
+<!-- webkit-test-runner [ UsesBackForwardCache=true BackForwardCacheWithMediaEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../../../resources/js-test-pre.js"></script>
+<script>
+description('Tests that a page with a video element does not go into the back/forward cache when back-forward-cache-with-media is disabled.');
+window.jsTestIsAsync = true;
+
+window.addEventListener("pageshow", function(event) {
+    debug("pageshow - " + (event.persisted ? "" : "not ") + "from cache");
+    if (!window.sessionStorage.pageWithVideoMediaDisabledTestStarted)
+        return;
+
+    delete window.sessionStorage.pageWithVideoMediaDisabledTestStarted;
+
+    if (event.persisted)
+        testFailed("Page did enter and was restored from the back/forward cache");
+    else
+        testPassed("Page was not restored from the back/forward cache");
+
+    finishJSTest();
+}, false);
+
+window.addEventListener("pagehide", function(event) {
+    debug("pagehide - " + (event.persisted ? "" : "not ") + "entering cache");
+    if (event.persisted)
+        testFailed("Page entered the back/forward cache.");
+}, false);
+
+window.addEventListener('load', function() {
+    if (window.sessionStorage.pageWithVideoMediaDisabledTestStarted)
+        return;
+
+    var video = document.createElement("video");
+    document.body.appendChild(video);
+
+    setTimeout(function() {
+        window.sessionStorage.pageWithVideoMediaDisabledTestStarted = true;
+        window.location.href = "resources/page-cache-helper.html";
+    }, 0);
+}, false);
+</script>
+<script src="../../../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/platform/wpe/fast/history/page-cache-video-media-enabled-expected.txt
+++ b/LayoutTests/platform/wpe/fast/history/page-cache-video-media-enabled-expected.txt
@@ -1,0 +1,13 @@
+Tests that a page with a video element goes into the back/forward cache when back-forward-cache-with-media is enabled.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+pageshow - not from cache
+pagehide - entering cache
+pageshow - from cache
+PASS Page did enter and was restored from the back/forward cache
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/platform/wpe/fast/history/page-cache-video-media-enabled.html
+++ b/LayoutTests/platform/wpe/fast/history/page-cache-video-media-enabled.html
@@ -1,0 +1,44 @@
+<!-- webkit-test-runner [ UsesBackForwardCache=true BackForwardCacheWithMediaEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../../../resources/js-test-pre.js"></script>
+<script>
+description('Tests that a page with a video element goes into the back/forward cache when back-forward-cache-with-media is enabled.');
+window.jsTestIsAsync = true;
+
+window.addEventListener("pageshow", function(event) {
+    debug("pageshow - " + (event.persisted ? "" : "not ") + "from cache");
+    if (!window.sessionStorage.pageWithVideoMediaEnabledTestStarted)
+        return;
+
+    delete window.sessionStorage.pageWithVideoMediaEnabledTestStarted;
+
+    if (event.persisted)
+        testPassed("Page did enter and was restored from the back/forward cache");
+    else
+        testFailed("Page was not restored from the back/forward cache");
+
+    finishJSTest();
+}, false);
+
+window.addEventListener("pagehide", function(event) {
+    debug("pagehide - " + (event.persisted ? "" : "not ") + "entering cache");
+}, false);
+
+window.addEventListener('load', function() {
+    if (window.sessionStorage.pageWithVideoMediaEnabledTestStarted)
+        return;
+
+    var video = document.createElement("video");
+    document.body.appendChild(video);
+
+    setTimeout(function() {
+        window.sessionStorage.pageWithVideoMediaEnabledTestStarted = true;
+        window.location.href = "resources/page-cache-helper.html";
+    }, 0);
+}, false);
+</script>
+<script src="../../../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/platform/wpe/fast/history/resources/page-cache-helper.html
+++ b/LayoutTests/platform/wpe/fast/history/resources/page-cache-helper.html
@@ -1,0 +1,18 @@
+This page should go back. If a test outputs the contents of this
+page, then the test page failed to enter the page cache.
+<script>
+  function triggerBackNavigation() {
+      setTimeout(function() {
+          history.back();
+      }, 0);
+  }
+
+  window.addEventListener("pageshow", (event) => {
+      if (event.persisted)
+          triggerBackNavigation();
+  });
+
+  window.addEventListener("load", function() {
+      triggerBackNavigation();
+  });
+</script>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -838,6 +838,21 @@ AzimuthAngleEnabled:
       "PLATFORM(COCOA)": true
       default: false
 
+BackForwardCacheWithMediaEnabled:
+  type: bool
+  status: stable
+  category: media
+  humanReadableName: "Back/Forward Cache with Media"
+  humanReadableDescription: "Enable back/forward cache for pages with media"
+  condition: PLATFORM(WPE)
+  defaultValue:
+    WebKitLegacy:
+      default: true
+    WebKit:
+      default: true
+    WebCore:
+      default: true
+
 BackgroundFetchAPIEnabled:
   type: bool
   status: testable

--- a/Source/WebCore/history/BackForwardCache.cpp
+++ b/Source/WebCore/history/BackForwardCache.cpp
@@ -42,6 +42,7 @@
 #include "FrameDestructionObserverInlines.h"
 #include "FrameLoader.h"
 #include "FrameTree.h"
+#include "HTMLMediaElement.h"
 #include "HTTPParsers.h"
 #include "HistoryController.h"
 #include "LocalDOMWindow.h"
@@ -250,6 +251,17 @@ static bool canCachePage(Page& page)
         logBackForwardCacheFailureDiagnosticMessage(diagnosticLoggingClient, DiagnosticLoggingKeys::isDisabledKey());
         isCacheable = false;
     }
+#if PLATFORM(WPE)
+    if (!page.settings().backForwardCacheWithMediaEnabled()) {
+        bool hasMedia = false;
+        page.forEachMediaElement([&](HTMLMediaElement&) { hasMedia = true; });
+        if (hasMedia) {
+            PCLOG("   -Page contains media elements and back/forward cache with media is disabled"_s);
+            logBackForwardCacheFailureDiagnosticMessage(diagnosticLoggingClient, DiagnosticLoggingKeys::pageContainsMediaEngineKey());
+            isCacheable = false;
+        }
+    }
+#endif
 #if ENABLE(DEVICE_ORIENTATION) && !PLATFORM(IOS_FAMILY)
     if (DeviceMotionController::isActiveAt(&page)) {
         PCLOG("   -Page is using DeviceMotion"_s);


### PR DESCRIPTION
#### e4d9fe534f0de95c0d9a97e688011d04aa07fc24
<pre>
[WPE] don&apos;t put page with multimedia to bfCache on low-end devices
<a href="https://bugs.webkit.org/show_bug.cgi?id=318851">https://bugs.webkit.org/show_bug.cgi?id=318851</a>

Reviewed by Alicia Boya Garcia.

Add a new WPE-only feature `BackForwardCacheWithMediaEnabled` that allows
applications to control whether pages containing audio or video elements
can be placed in the back/forward cache.

When disabled, pages with media elements are excluded from the back/forward
cache. This is particularly useful on low-end embedded devices with a limited
number of hardware decoders, where keeping a suspended media pipeline alive in
the cache may prevent other pages from acquiring the decoder.

The feature is enabled by default (preserving existing behavior).

Two new WPE layout tests verify the behavior:
- page-cache-video-media-disabled.html: verifies pages with media are not
  cached when the feature is disabled.
- page-cache-video-media-enabled.html: verifies pages with media can enter
  and be restored from the back/forward cache when the feature is enabled.

Tests: platform/wpe/fast/history/page-cache-video-media-disabled.html
       platform/wpe/fast/history/page-cache-video-media-enabled.html
* LayoutTests/platform/wpe/fast/history/page-cache-video-media-disabled-expected.txt: Added.
* LayoutTests/platform/wpe/fast/history/page-cache-video-media-disabled.html: Added.
* LayoutTests/platform/wpe/fast/history/page-cache-video-media-enabled-expected.txt: Added.
* LayoutTests/platform/wpe/fast/history/page-cache-video-media-enabled.html: Added.
* LayoutTests/platform/wpe/fast/history/resources/page-cache-helper.html: Added.
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/history/BackForwardCache.cpp:
(WebCore::canCachePage):

Canonical link: <a href="https://commits.webkit.org/316840@main">https://commits.webkit.org/316840@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/98f17b0f87259f0b2bcfa0d49dd4ae8759ad4ad4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173500 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47433 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/41256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183073 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/131368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175365 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48725 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47114 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134915 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/131368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176458 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38344 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155614 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115392 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36985 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35338 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31558 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/4126 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147409 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35109 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185499 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/34762 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/38468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39538 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143791 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47100 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155171 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143649 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38774 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47779 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/41256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112929 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38585 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/119641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/210533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46285 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10089 "Passed tests") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/210533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45687 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45918 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45744 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->