### PR TITLE
[MediaFragmentURIParser] Remove two dead branches in parseNPTTime

### DIFF
--- a/Source/WebCore/html/MediaFragmentURIParser.cpp
+++ b/Source/WebCore/html/MediaFragmentURIParser.cpp
@@ -267,17 +267,12 @@ bool MediaFragmentURIParser::parseNPTTime(std::span<const Latin1Character> timeS
 
     MediaTime fraction;
     if (timeString[offset] == '.') {
-        if (offset == timeString.size())
-            return true;
         auto digits = collectFraction(timeString, offset);
         bool isValid;
         fraction = MediaTime::createWithDouble(digits.toDouble(isValid));
         time = MediaTime::createWithDouble(value1) + fraction;
         return true;
     }
-    
-    if (digits1.length() < 1)
-        return false;
 
     // Collect the next sequence of 0-9 after ':'
     if (offset >= timeString.size() || timeString[offset++] != ':')


### PR DESCRIPTION
#### f55b9f50a0d6935def78b06ebe81cbbd5da11ffa
<pre>
[MediaFragmentURIParser] Remove two dead branches in parseNPTTime
<a href="https://bugs.webkit.org/show_bug.cgi?id=318939">https://bugs.webkit.org/show_bug.cgi?id=318939</a>
<a href="https://rdar.apple.com/181783474">rdar://181783474</a>

Reviewed by Eric Carlson.

Two conditionals in MediaFragmentURIParser::parseNPTTime() are
unreachable and can be removed with no behavior change:

- The `if (offset == timeString.size()) return true;` guard inside the
  fractional-seconds (&apos;.&apos;) branch. Just above it, the earlier check
  `if (offset &gt;= timeString.size() || timeString[offset] == &apos;,&apos;)`
  already returns, so reaching this point guarantees
  offset &lt; timeString.size(); the equality can never hold.

- The `if (digits1.length() &lt; 1) return false;` check. The function&apos;s
  entry guard `if (offset &gt;= timeString.size() || !isASCIIDigit(...))`
  ensures the current character is a digit before collectDigits() runs,
  so digits1 always contains at least one digit.

* Source/WebCore/html/MediaFragmentURIParser.cpp:
(WebCore::MediaFragmentURIParser::parseNPTTime):

Canonical link: <a href="https://commits.webkit.org/316859@main">https://commits.webkit.org/316859@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4176c8cd5151728bdef9ed7819ddc2e4357e83e1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173474 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47406 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/41297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183047 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/131342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/affce7c6-2e16-4726-aab1-a506e2801e37) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175339 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48699 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47088 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134889 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/131342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4dcec5b8-af0a-4f79-ac70-bfedc34de8e1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176432 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38318 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155574 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115365 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e6c65568-4678-4dda-adf3-552516b84d74) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36959 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35312 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31532 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147383 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35069 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185472 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/38460 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39513 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143760 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47074 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143622 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38780 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47753 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/41297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112877 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38560 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/119613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46259 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10018 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45661 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45892 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45718 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->