### PR TITLE
Web Inspector: crash when inspecting a top-level @scope rule with a bare declaration

### DIFF
--- a/LayoutTests/inspector/css/getMatchedStylesForNodeAtRulesDoNotCrash-expected.txt
+++ b/LayoutTests/inspector/css/getMatchedStylesForNodeAtRulesDoNotCrash-expected.txt
@@ -1,0 +1,49 @@
+Tests that CSS.getMatchedStyleForNode does not crash when reparsing stylesheets that contain at-rules which report their rule body to the inspector before consuming their contents.
+
+
+== Running test suite: CSS.getMatchedStyleForNode.AtRulesDoNotCrash
+-- Running test case: CSS.getMatchedStyleForNode.AtRulesDoNotCrash.Import
+PASS: Should have 1 authored rule.
+PASS: Selector text should be "#target-import".
+PASS: Did not crash while building matched styles for the stylesheet.
+
+-- Running test case: CSS.getMatchedStyleForNode.AtRulesDoNotCrash.FontFace
+PASS: Should have 1 authored rule.
+PASS: Selector text should be "#target-font-face".
+PASS: Did not crash while building matched styles for the stylesheet.
+
+-- Running test case: CSS.getMatchedStyleForNode.AtRulesDoNotCrash.FontFeatureValues
+PASS: Should have 1 authored rule.
+PASS: Selector text should be "#target-font-feature-values".
+PASS: Did not crash while building matched styles for the stylesheet.
+
+-- Running test case: CSS.getMatchedStyleForNode.AtRulesDoNotCrash.FontPaletteValues
+PASS: Should have 1 authored rule.
+PASS: Selector text should be "#target-font-palette-values".
+PASS: Did not crash while building matched styles for the stylesheet.
+
+-- Running test case: CSS.getMatchedStyleForNode.AtRulesDoNotCrash.Keyframes
+PASS: Should have 1 authored rule.
+PASS: Selector text should be "#target-keyframes".
+PASS: Did not crash while building matched styles for the stylesheet.
+
+-- Running test case: CSS.getMatchedStyleForNode.AtRulesDoNotCrash.CounterStyle
+PASS: Should have 1 authored rule.
+PASS: Selector text should be "#target-counter-style".
+PASS: Did not crash while building matched styles for the stylesheet.
+
+-- Running test case: CSS.getMatchedStyleForNode.AtRulesDoNotCrash.ViewTransition
+PASS: Should have 1 authored rule.
+PASS: Selector text should be "#target-view-transition".
+PASS: Did not crash while building matched styles for the stylesheet.
+
+-- Running test case: CSS.getMatchedStyleForNode.AtRulesDoNotCrash.PositionTry
+PASS: Should have 1 authored rule.
+PASS: Selector text should be "#target-position-try".
+PASS: Did not crash while building matched styles for the stylesheet.
+
+-- Running test case: CSS.getMatchedStyleForNode.AtRulesDoNotCrash.Layer
+PASS: Should have 1 authored rule.
+PASS: Selector text should be "#target-layer".
+PASS: Did not crash while building matched styles for the stylesheet.
+

--- a/LayoutTests/inspector/css/getMatchedStylesForNodeAtRulesDoNotCrash.html
+++ b/LayoutTests/inspector/css/getMatchedStylesForNodeAtRulesDoNotCrash.html
@@ -1,0 +1,206 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("CSS.getMatchedStyleForNode.AtRulesDoNotCrash");
+
+    function addTestCase({name, description, selector})
+    {
+        suite.addTestCase({
+            name,
+            description,
+            async test() {
+                let documentNode = await WI.domManager.requestDocument();
+                let nodeId = await documentNode.querySelector(selector);
+                let domNode = WI.domManager.nodeForId(nodeId);
+                InspectorTest.assert(domNode, `Should find DOM Node for selector '${selector}'.`);
+
+                let domNodeStyles = WI.cssManager.stylesForNode(domNode);
+                InspectorTest.assert(domNodeStyles, "Should find CSS Styles for DOM Node.");
+
+                // Requesting the matched styles reparses every stylesheet that matched the node (via
+                // parseStyleSheetForInspector). Each target's stylesheet also contains one of the at-rules
+                // that emits startRuleBody()/endRuleBody() before consuming its contents, so reparsing must
+                // not crash the way a top-level @scope with a bare declaration used to.
+                await domNodeStyles.refreshIfNeeded();
+
+                let authoredRules = domNodeStyles.matchedRules.filter((rule) => rule.type === WI.CSSStyleSheet.Type.Author);
+                InspectorTest.expectEqual(authoredRules.length, 1, "Should have 1 authored rule.");
+                InspectorTest.expectEqual(authoredRules[0]?.selectorText, selector, `Selector text should be "${selector}".`);
+
+                InspectorTest.pass("Did not crash while building matched styles for the stylesheet.");
+            },
+        });
+    }
+
+    addTestCase({
+        name: "CSS.getMatchedStyleForNode.AtRulesDoNotCrash.Import",
+        description: "Reparsing a stylesheet containing an @import rule should not crash the web process.",
+        selector: "#target-import",
+    });
+
+    addTestCase({
+        name: "CSS.getMatchedStyleForNode.AtRulesDoNotCrash.FontFace",
+        description: "Reparsing a stylesheet containing a @font-face rule should not crash the web process.",
+        selector: "#target-font-face",
+    });
+
+    addTestCase({
+        name: "CSS.getMatchedStyleForNode.AtRulesDoNotCrash.FontFeatureValues",
+        description: "Reparsing a stylesheet containing a @font-feature-values rule (and its nested feature-value block) should not crash the web process.",
+        selector: "#target-font-feature-values",
+    });
+
+    addTestCase({
+        name: "CSS.getMatchedStyleForNode.AtRulesDoNotCrash.FontPaletteValues",
+        description: "Reparsing a stylesheet containing a @font-palette-values rule should not crash the web process.",
+        selector: "#target-font-palette-values",
+    });
+
+    addTestCase({
+        name: "CSS.getMatchedStyleForNode.AtRulesDoNotCrash.Keyframes",
+        description: "Reparsing a stylesheet containing a @keyframes rule should not crash the web process.",
+        selector: "#target-keyframes",
+    });
+
+    addTestCase({
+        name: "CSS.getMatchedStyleForNode.AtRulesDoNotCrash.CounterStyle",
+        description: "Reparsing a stylesheet containing a @counter-style rule should not crash the web process.",
+        selector: "#target-counter-style",
+    });
+
+    addTestCase({
+        name: "CSS.getMatchedStyleForNode.AtRulesDoNotCrash.ViewTransition",
+        description: "Reparsing a stylesheet containing a @view-transition rule should not crash the web process.",
+        selector: "#target-view-transition",
+    });
+
+    addTestCase({
+        name: "CSS.getMatchedStyleForNode.AtRulesDoNotCrash.PositionTry",
+        description: "Reparsing a stylesheet containing a @position-try rule should not crash the web process.",
+        selector: "#target-position-try",
+    });
+
+    addTestCase({
+        name: "CSS.getMatchedStyleForNode.AtRulesDoNotCrash.Layer",
+        description: "Reparsing a stylesheet containing a @layer rule should not crash the web process.",
+        selector: "#target-layer",
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+    <p>Tests that CSS.getMatchedStyleForNode does not crash when reparsing stylesheets that contain at-rules which report their rule body to the inspector before consuming their contents.</p>
+
+    <style>
+        @import url("data:text/css,");
+
+        #target-import {
+            color: green;
+        }
+    </style>
+    <div id="target-import"></div>
+
+    <style>
+        @font-face {
+            font-family: "TestFace";
+            src: url("data:font/woff2;base64,");
+        }
+
+        #target-font-face {
+            color: green;
+        }
+    </style>
+    <div id="target-font-face"></div>
+
+    <style>
+        @font-feature-values TestFace {
+            @styleset {
+                nice-style: 12;
+            }
+        }
+
+        #target-font-feature-values {
+            color: green;
+        }
+    </style>
+    <div id="target-font-feature-values"></div>
+
+    <style>
+        @font-palette-values --TestPalette {
+            font-family: "TestFace";
+            base-palette: 0;
+        }
+
+        #target-font-palette-values {
+            color: green;
+        }
+    </style>
+    <div id="target-font-palette-values"></div>
+
+    <style>
+        @keyframes testAnimation {
+            from { opacity: 0; }
+            to { opacity: 1; }
+        }
+
+        #target-keyframes {
+            color: green;
+        }
+    </style>
+    <div id="target-keyframes"></div>
+
+    <style>
+        @counter-style testCounter {
+            system: cyclic;
+            symbols: "*";
+            suffix: " ";
+        }
+
+        #target-counter-style {
+            color: green;
+        }
+    </style>
+    <div id="target-counter-style"></div>
+
+    <style>
+        @view-transition {
+            navigation: auto;
+        }
+
+        #target-view-transition {
+            color: green;
+        }
+    </style>
+    <div id="target-view-transition"></div>
+
+    <style>
+        @position-try --testPositionTry {
+            top: 0;
+        }
+
+        #target-position-try {
+            color: green;
+        }
+    </style>
+    <div id="target-position-try"></div>
+
+    <style>
+        @layer testLayer {
+            .unmatched-layer {
+                color: red;
+            }
+        }
+
+        #target-layer {
+            color: green;
+        }
+    </style>
+    <div id="target-layer"></div>
+</body>
+</html>

--- a/LayoutTests/inspector/css/getMatchedStylesForNodeScopeImplicitProperties-expected.txt
+++ b/LayoutTests/inspector/css/getMatchedStylesForNodeScopeImplicitProperties-expected.txt
@@ -1,0 +1,11 @@
+Tests that CSS.getMatchedStyleForNode does not crash for an element matched by a rule inside a top-level @scope containing a bare declaration.
+
+
+== Running test suite: CSS.getMatchedStyleForNode.ScopeImplicitProperties
+-- Running test case: CSS.getMatchedStyleForNode.ScopeImplicitProperties.BareDeclaration
+PASS: Should have 1 authored rule.
+PASS: Selector text should be "#target".
+PASS: Rule should have 1 grouping.
+PASS: Grouping should have a type of "scope-rule".
+PASS: Did not crash while building matched styles for the @scope rule.
+

--- a/LayoutTests/inspector/css/getMatchedStylesForNodeScopeImplicitProperties.html
+++ b/LayoutTests/inspector/css/getMatchedStylesForNodeScopeImplicitProperties.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("CSS.getMatchedStyleForNode.ScopeImplicitProperties");
+
+    suite.addTestCase({
+        name: "CSS.getMatchedStyleForNode.ScopeImplicitProperties.BareDeclaration",
+        description: "Selecting an element matched by a rule inside a top-level @scope that contains a bare (implicitly nested) declaration should not crash the web process.",
+        async test() {
+            let documentNode = await WI.domManager.requestDocument();
+            let nodeId = await documentNode.querySelector("#target");
+            let domNode = WI.domManager.nodeForId(nodeId);
+            InspectorTest.assert(domNode, "Should find DOM Node for selector '#target'.");
+
+            let domNodeStyles = WI.cssManager.stylesForNode(domNode);
+            InspectorTest.assert(domNodeStyles, "Should find CSS Styles for DOM Node.");
+            await domNodeStyles.refreshIfNeeded();
+
+            let authoredRules = domNodeStyles.matchedRules.filter((rule) => rule.type === WI.CSSStyleSheet.Type.Author);
+            InspectorTest.expectEqual(authoredRules.length, 1, "Should have 1 authored rule.");
+
+            let rule = authoredRules[0];
+            InspectorTest.expectEqual(rule.selectorText, "#target", `Selector text should be "#target".`);
+            InspectorTest.expectEqual(rule.groupings.length, 1, "Rule should have 1 grouping.");
+            InspectorTest.expectEqual(rule.groupings[0].type, WI.CSSGrouping.Type.ScopeRule, `Grouping should have a type of "scope-rule".`);
+
+            InspectorTest.pass("Did not crash while building matched styles for the @scope rule.");
+        },
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+    <p>Tests that CSS.getMatchedStyleForNode does not crash for an element matched by a rule inside a top-level @scope containing a bare declaration.</p>
+    <div id="scope-root">
+        <style>
+            @scope {
+                min-height: 160vh;
+
+                #target {
+                    color: green;
+                }
+            }
+        </style>
+        <div id="target"></div>
+    </div>
+</body>
+</html>

--- a/Source/WebCore/css/parser/CSSParser.cpp
+++ b/Source/WebCore/css/parser/CSSParser.cpp
@@ -1286,12 +1286,15 @@ RefPtr<StyleRuleScope> CSSParser::consumeScopeRule(CSSParserTokenRange prelude, 
         observerWrapper->observer().startRuleHeader(StyleRuleType::Scope, observerWrapper->startOffset(preludeRangeCopy));
         observerWrapper->observer().endRuleHeader(observerWrapper->endOffset(prelude));
         observerWrapper->observer().startRuleBody(observerWrapper->previousTokenStartOffset(block));
-        observerWrapper->observer().endRuleBody(observerWrapper->endOffset(block));
     }
 
     m_ancestorRuleTypeStack.append(CSSParserEnum::NestedContextType::Scope);
     auto rules = consumeNestedGroupRules(block);
     m_ancestorRuleTypeStack.removeLast();
+
+    if (RefPtr observerWrapper = m_observerWrapper.get())
+        observerWrapper->observer().endRuleBody(observerWrapper->endOffset(block));
+
     Ref rule = StyleRuleScope::create(WTF::move(scopeStart), WTF::move(scopeEnd), WTF::move(rules));
     if (auto* styleSheet = m_styleSheet.get())
         rule->setStyleSheetContents(*styleSheet);


### PR DESCRIPTION
#### ac97ce8ceae40a5da3237ca72038ba2d4c9ebd14
<pre>
Web Inspector: crash when inspecting a top-level @scope rule with a bare declaration
<a href="https://bugs.webkit.org/show_bug.cgi?id=318379">https://bugs.webkit.org/show_bug.cgi?id=318379</a>
<a href="https://rdar.apple.com/181745000">rdar://181745000</a>

Reviewed by Devin Rousso.

Selecting an element matched by a rule inside a top-level @scope rule that
contains a bare (implicitly nested) declaration crashes the WebContent process.

CSSParser::consumeScopeRule() emitted startRuleBody()/endRuleBody() to the
CSSParserObserver *before* consuming the rule&apos;s nested contents, unlike every
other group at-rule (@media, @supports, @starting-style, @layer, @container).
endRuleBody() pops the rule off StyleSheetHandler::m_currentRuleDataStack, so a
bare declaration then makes consumeNestedGroupRules() call
markRuleBodyContainsImplicitlyNestedProperties(), which dereferences
m_currentRuleDataStack.last() on the now-empty stack (top-level @scope) and
crashes when Web Inspector reparses the sheet via CSS.getMatchedStylesForNode.

Move endRuleBody() to after consumeNestedGroupRules(), matching the other group
at-rules.

Other consume*Rule() functions emit endRuleBody() before consuming contents too
(@import, @font-face, @font-feature-values, @font-palette-values, @keyframes,
@counter-style, @view-transition, @position-try, and @layer&apos;s statement form),
but none need this fix: the crash is only reachable via
markRuleBodyContainsImplicitlyNestedProperties(), whose sole caller is
consumeNestedGroupRules(), which only the group at-rules run (and all call
endRuleBody() after it). The rest consume descriptor lists that never reach it,
and consumeBlockContent() only drives the observer for Style/Keyframe/Page.
Added a regression test reparsing each of these at-rules to confirm no crash.

Tests: inspector/css/getMatchedStylesForNodeScopeImplicitProperties.html
       inspector/css/getMatchedStylesForNodeAtRulesDoNotCrash.html

* LayoutTests/inspector/css/getMatchedStylesForNodeScopeImplicitProperties-expected.txt: Added.
* LayoutTests/inspector/css/getMatchedStylesForNodeScopeImplicitProperties.html: Added.
* LayoutTests/inspector/css/getMatchedStylesForNodeAtRulesDoNotCrash-expected.txt: Added.
* LayoutTests/inspector/css/getMatchedStylesForNodeAtRulesDoNotCrash.html: Added.
* Source/WebCore/css/parser/CSSParser.cpp:
(WebCore::CSSParser::consumeScopeRule):

Canonical link: <a href="https://commits.webkit.org/316987@main">https://commits.webkit.org/316987@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/638baf02aaa52312dda8052123041f00b97c3480

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173979 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47912 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41693 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183553 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131847 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c1096d47-10dc-4960-ad14-7330ef410a90) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175844 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49204 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47594 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135302 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/db8e8b18-7228-4d2a-8939-d1b8ae3395ce) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176937 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38733 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156093 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115780 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e590d6ba-69db-43e5-a92b-9d231ee15ca1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37374 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35740 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32037 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147798 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35586 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185979 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39060 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39938 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144203 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47579 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155648 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144063 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38844 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48258 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32203 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113637 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38971 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120142 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46764 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10546 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46167 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46398 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46225 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->