### PR TITLE
InternalReadableStream/InternalWritableStream methods should catch JS exceptions for non JS code paths

### DIFF
--- a/LayoutTests/streams/handle-exceptions-expected.txt
+++ b/LayoutTests/streams/handle-exceptions-expected.txt
@@ -1,0 +1,3 @@
+
+PASS handle-exceptions
+

--- a/LayoutTests/streams/handle-exceptions.html
+++ b/LayoutTests/streams/handle-exceptions.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+promise_test(async t => {
+    const image = document.createElement("img");
+    const height = image.height;
+    const signal = AbortSignal.timeout(height);
+    const readable = new ReadableStream({
+        cancel: function(r) {
+            try {
+                Object.defineProperty(Promise, Symbol.species, {
+                    value: function(executor) {
+                        eventhandler2();
+                        return new Promise(executor);
+                    }
+                });
+            } catch(e) { }
+            return Promise.resolve();
+        }
+    });
+    const decoder = new TextDecoderStream();
+    const writable = decoder.writable;
+    return promise_rejects_js(t, ReferenceError, readable.pipeTo(writable, { signal: signal, preventClose: true }));
+});
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/streams/ReadableStream.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStream.cpp
@@ -531,12 +531,12 @@ Ref<DOMPromise> ReadableStream::cancel(JSDOMGlobalObject& globalObject, JSC::JSV
 
     if (RefPtr internalStream = m_internalReadableStream) {
         auto result = internalStream->cancel(globalObject, reason);
-        if (!result) {
-            deferred->reject(Exception { ExceptionCode::ExistingExceptionError });
+        if (result.hasException()) {
+            deferred->reject(result.releaseException());
             return promise;
         }
 
-        auto* jsPromise = dynamicDowncast<JSC::JSPromise>(result);
+        auto* jsPromise = dynamicDowncast<JSC::JSPromise>(result.releaseReturnValue());
         if (!jsPromise)
             return promise;
 

--- a/Source/WebCore/Modules/streams/StreamPipeToUtilities.cpp
+++ b/Source/WebCore/Modules/streams/StreamPipeToUtilities.cpp
@@ -249,11 +249,14 @@ static RefPtr<DOMPromise> cancelReadableStream(JSDOMGlobalObject& globalObject, 
     if (!internalReadableStream)
         return stream.cancel(globalObject, reason);
 
-    auto value = internalReadableStream->cancel(globalObject, reason);
-    if (!value)
-        return nullptr;
+    auto valueOrException = internalReadableStream->cancel(globalObject, reason);
+    if (valueOrException.hasException()) {
+        auto [promise, deferred] = createPromiseAndWrapper(globalObject);
+        deferred->reject(valueOrException.releaseException());
+        return WTF::move(promise);
+    }
 
-    auto* promise = dynamicDowncast<JSC::JSPromise>(value);
+    auto* promise = dynamicDowncast<JSC::JSPromise>(valueOrException.releaseReturnValue());
     if (!promise)
         return nullptr;
 
@@ -306,10 +309,13 @@ void StreamPipeToState::handleSignal()
                 if (!globalObject)
                     return nullptr;
 
-                auto value = internalWritableStream->abort(*globalObject, signal->reason().getValue());
-                if (!value)
-                    return nullptr;
-                auto* promise = downcast<JSC::JSPromise>(value);
+                auto valueOrException = internalWritableStream->abort(*globalObject, signal->reason().getValue());
+                if (valueOrException.hasException()) {
+                    auto [rejectedPromise, deferred] = createPromiseAndWrapper(*globalObject);
+                    deferred->reject(valueOrException.releaseException());
+                    return WTF::move(rejectedPromise);
+                }
+                auto* promise = downcast<JSC::JSPromise>(valueOrException.releaseReturnValue());
                 if (!promise)
                     return nullptr;
 
@@ -413,10 +419,13 @@ void StreamPipeToState::errorsMustBePropagatedForward(JSDOMGlobalObject& globalO
                     return nullptr;
 
                 Ref internalWritableStream = protectedThis->m_destination->internalWritableStream();
-                auto value = internalWritableStream->abort(*globalObject, error.get());
-                if (!value)
-                    return nullptr;
-                auto* promise = dynamicDowncast<JSC::JSPromise>(value);
+                auto valueOrException = internalWritableStream->abort(*globalObject, error.get());
+                if (valueOrException.hasException()) {
+                    auto [rejectedPromise, deferred] = createPromiseAndWrapper(*globalObject);
+                    deferred->reject(valueOrException.releaseException());
+                    return WTF::move(rejectedPromise);
+                }
+                auto* promise = dynamicDowncast<JSC::JSPromise>(valueOrException.releaseReturnValue());
                 if (!promise) {
                     auto [result, deferred] = createPromiseAndWrapper(*globalObject);
                     deferred->resolve();
@@ -485,11 +494,11 @@ void StreamPipeToState::errorsMustBePropagatedBackward()
 
     if (m_destination->state() == WritableStream::State::Errored) {
         // FIXME: Check whether ok to take a strong.
-        auto errorOrException = Ref { m_destination->internalWritableStream() }->storedError();
-        if (errorOrException.hasException())
+        auto error = protect(m_destination->internalWritableStream())->storedError();
+        if (!error)
             return;
 
-        propagateErrorSteps(JSC::Strong<JSC::Unknown> { Ref { m_destination->internalWritableStream().globalObject()->vm() }, errorOrException.releaseReturnValue() });
+        propagateErrorSteps(JSC::Strong<JSC::Unknown> { Ref { m_destination->internalWritableStream().globalObject()->vm() }, error });
         return;
     }
 
@@ -555,16 +564,19 @@ void StreamPipeToState::closingMustBePropagatedBackward()
             Ref vm = globalObject->vm();
             // FIXME: Check whether ok to take a strong.
             JSC::Strong<JSC::Unknown> error { vm, getError(*globalObject) };
-            auto value = internalReadableStream->cancel(*globalObject, error.get());
-            if (!value)
-                return nullptr;
+            auto valueOrException = internalReadableStream->cancel(*globalObject, error.get());
+            if (valueOrException.hasException()) {
+                auto [rejectedPromise, deferred] = createPromiseAndWrapper(*globalObject);
+                deferred->reject(valueOrException.releaseException());
+                return WTF::move(rejectedPromise);
+            }
 
             auto getError2 = [error = WTF::move(error)](auto&) {
                 return error.get();
             };
 
             auto [result, deferred] = createPromiseAndWrapper(*globalObject);
-            auto* promise = dynamicDowncast<JSC::JSPromise>(value);
+            auto* promise = dynamicDowncast<JSC::JSPromise>(valueOrException.releaseReturnValue());
             if (!promise)
                 deferred->rejectWithCallback(WTF::move(getError2), RejectAsHandled::Yes);
             else {

--- a/Source/WebCore/bindings/js/InternalReadableStream.cpp
+++ b/Source/WebCore/bindings/js/InternalReadableStream.cpp
@@ -131,13 +131,17 @@ InternalReadableStream::State InternalReadableStream::state() const
     auto* clientData = downcast<JSVMClientData>(globalObject->vm().clientData);
     auto& privateName = clientData->builtinFunctions().readableStreamInternalsBuiltins().readableStreamStatePrivateName();
 
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(globalObject->vm());
+
     JSC::MarkedArgumentBuffer arguments;
     arguments.append(guardedObject());
     ASSERT(!arguments.hasOverflowed());
 
     auto result = invokeReadableStreamFunction(*globalObject, privateName, arguments);
-    if (result.hasException())
+    if (result.hasException()) {
+        (void)scope.tryClearException();
         return State::Errored;
+    }
 
     // Values must match @streamReadable, @streamClosed, @streamErrored in JSDOMGlobalObject.cpp.
     double state = result.returnValue().toNumber(globalObject);
@@ -155,12 +159,18 @@ JSC::JSValue InternalReadableStream::storedError(JSDOMGlobalObject& globalObject
     auto* clientData = downcast<JSVMClientData>(globalObject.vm().clientData);
     auto& privateName = clientData->builtinFunctions().readableStreamInternalsBuiltins().readableStreamStoredErrorPrivateName();
 
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(globalObject.vm());
+
     JSC::MarkedArgumentBuffer arguments;
     arguments.append(guardedObject());
     ASSERT(!arguments.hasOverflowed());
 
     auto result = invokeReadableStreamFunction(globalObject, privateName, arguments);
-    return result.hasException() ? JSC::jsUndefined() : result.releaseReturnValue();
+    if (result.hasException()) {
+        (void)scope.tryClearException();
+        return JSC::jsUndefined();
+    }
+    return result.releaseReturnValue();
 }
 
 void InternalReadableStream::cancel(Exception&& exception)
@@ -216,7 +226,7 @@ ExceptionOr<std::pair<Ref<InternalReadableStream>, Ref<InternalReadableStream>>>
     return std::make_pair(InternalReadableStream::fromObject(jsDOMGlobalObject, *results[0].get()), InternalReadableStream::fromObject(jsDOMGlobalObject, *results[1].get()));
 }
 
-JSC::JSValue InternalReadableStream::cancel(JSC::JSGlobalObject& globalObject, JSC::JSValue reason)
+ExceptionOr<JSC::JSValue> InternalReadableStream::cancel(JSC::JSGlobalObject& globalObject, JSC::JSValue reason)
 {
     auto* clientData = downcast<JSVMClientData>(globalObject.vm().clientData);
     auto& privateName = clientData->builtinFunctions().readableStreamInternalsBuiltins().readableStreamCancelPrivateName();
@@ -226,11 +236,7 @@ JSC::JSValue InternalReadableStream::cancel(JSC::JSGlobalObject& globalObject, J
     arguments.append(reason);
     ASSERT(!arguments.hasOverflowed());
 
-    auto result = invokeReadableStreamFunction(globalObject, privateName, arguments);
-    if (result.hasException())
-        return { };
-
-    return result.returnValue();
+    return invokeReadableStreamFunction(globalObject, privateName, arguments);
 }
 
 JSC::JSValue InternalReadableStream::tee(JSC::JSGlobalObject& globalObject, bool shouldClone)

--- a/Source/WebCore/bindings/js/InternalReadableStream.h
+++ b/Source/WebCore/bindings/js/InternalReadableStream.h
@@ -46,7 +46,7 @@ public:
     void cancel(Exception&&);
     ExceptionOr<std::pair<Ref<InternalReadableStream>, Ref<InternalReadableStream>>> tee(bool shouldClone);
 
-    JSC::JSValue cancel(JSC::JSGlobalObject&, JSC::JSValue);
+    ExceptionOr<JSC::JSValue> cancel(JSC::JSGlobalObject&, JSC::JSValue);
 
     enum class State : uint8_t { Readable, Closed, Errored };
     State state() const;

--- a/Source/WebCore/bindings/js/InternalWritableStream.cpp
+++ b/Source/WebCore/bindings/js/InternalWritableStream.cpp
@@ -167,7 +167,7 @@ JSC::JSValue InternalWritableStream::abortForBindings(JSC::JSGlobalObject& globa
     return result.returnValue();
 }
 
-JSC::JSValue InternalWritableStream::abort(JSC::JSGlobalObject& globalObject, JSC::JSValue reason)
+ExceptionOr<JSC::JSValue> InternalWritableStream::abort(JSC::JSGlobalObject& globalObject, JSC::JSValue reason)
 {
     auto* clientData = downcast<JSVMClientData>(globalObject.vm().clientData);
     auto& privateName = clientData->builtinFunctions().writableStreamInternalsBuiltins().writableStreamAbortPrivateName();
@@ -177,11 +177,7 @@ JSC::JSValue InternalWritableStream::abort(JSC::JSGlobalObject& globalObject, JS
     arguments.append(reason);
     ASSERT(!arguments.hasOverflowed());
 
-    auto result = invokeWritableStreamFunction(globalObject, privateName, arguments);
-    if (result.hasException())
-        return { };
-
-    return result.returnValue();
+    return invokeWritableStreamFunction(globalObject, privateName, arguments);
 }
 
 JSC::JSValue InternalWritableStream::closeForBindings(JSC::JSGlobalObject& globalObject)
@@ -243,21 +239,20 @@ void InternalWritableStream::errorIfPossible(Exception&& exception)
     TRY_CLEAR_EXCEPTION(scope, void());
 }
 
-JSC::JSValue InternalWritableStream::errorIfPossible(JSC::JSGlobalObject& globalObject, JSC::JSValue reason)
+void InternalWritableStream::errorIfPossible(JSC::JSGlobalObject& globalObject, JSC::JSValue reason)
 {
     auto* clientData = downcast<JSVMClientData>(globalObject.vm().clientData);
     auto& privateName = clientData->builtinFunctions().writableStreamInternalsBuiltins().writableStreamErrorIfPossiblePrivateName();
+
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(globalObject.vm());
 
     JSC::MarkedArgumentBuffer arguments;
     arguments.append(guardedObject());
     arguments.append(reason);
     ASSERT(!arguments.hasOverflowed());
 
-    auto result = invokeWritableStreamFunction(globalObject, privateName, arguments);
-    if (result.hasException())
-        return { };
-
-    return result.returnValue();
+    invokeWritableStreamFunction(globalObject, privateName, arguments);
+    TRY_CLEAR_EXCEPTION(scope, void());
 }
 
 JSC::JSValue InternalWritableStream::getWriter(JSC::JSGlobalObject& globalObject)
@@ -282,31 +277,43 @@ String InternalWritableStream::state(JSC::JSGlobalObject& globalObject) const
     auto* clientData = downcast<JSVMClientData>(globalObject.vm().clientData);
     auto& privateName = clientData->builtinFunctions().writableStreamInternalsBuiltins().writableStreamStatePrivateName();
 
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(globalObject.vm());
+
     JSC::MarkedArgumentBuffer arguments;
     arguments.append(guardedObject());
     ASSERT(!arguments.hasOverflowed());
 
     auto result = invokeWritableStreamFunction(globalObject, privateName, arguments);
-    if (result.hasException())
+    if (result.hasException()) {
+        (void)scope.tryClearException();
         return { };
+    }
 
     return result.returnValue().toWTFString(&globalObject);
 }
 
-ExceptionOr<JSC::JSValue> InternalWritableStream::storedError() const
+JSC::JSValue InternalWritableStream::storedError() const
 {
     auto* globalObject = this->globalObject();
     if (!globalObject)
-        return Exception { ExceptionCode::InvalidStateError };
+        return { };
 
     auto* clientData = downcast<JSVMClientData>(globalObject->vm().clientData);
     auto& privateName = clientData->builtinFunctions().writableStreamInternalsBuiltins().writableStreamStoredErrorPrivateName();
+
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(globalObject->vm());
 
     JSC::MarkedArgumentBuffer arguments;
     arguments.append(guardedObject());
     ASSERT(!arguments.hasOverflowed());
 
-    return invokeWritableStreamFunction(*globalObject, privateName, arguments);
+    auto result = invokeWritableStreamFunction(*globalObject, privateName, arguments);
+    if (result.hasException()) {
+        (void)scope.tryClearException();
+        return { };
+    }
+
+    return result.releaseReturnValue();
 }
 
 bool InternalWritableStream::closeQueuedOrInFlight()
@@ -318,13 +325,17 @@ bool InternalWritableStream::closeQueuedOrInFlight()
     auto* clientData = downcast<JSVMClientData>(globalObject->vm().clientData);
     auto& privateName = clientData->builtinFunctions().writableStreamInternalsBuiltins().writableStreamCloseQueuedOrInFlightPrivateName();
 
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(globalObject->vm());
+
     JSC::MarkedArgumentBuffer arguments;
     arguments.append(guardedObject());
     ASSERT(!arguments.hasOverflowed());
 
     auto result = invokeWritableStreamFunction(*globalObject, privateName, arguments);
-    if (result.hasException())
+    if (result.hasException()) {
+        (void)scope.tryClearException();
         return true;
+    }
 
     return result.returnValue().toBoolean(globalObject);
 }

--- a/Source/WebCore/bindings/js/InternalWritableStream.h
+++ b/Source/WebCore/bindings/js/InternalWritableStream.h
@@ -49,13 +49,13 @@ public:
 
     void closeIfPossible();
     void errorIfPossible(Exception&&);
-    JSC::JSValue errorIfPossible(JSC::JSGlobalObject&, JSC::JSValue);
+    void errorIfPossible(JSC::JSGlobalObject&, JSC::JSValue);
 
-    JSC::JSValue abort(JSC::JSGlobalObject&, JSC::JSValue);
+    ExceptionOr<JSC::JSValue> abort(JSC::JSGlobalObject&, JSC::JSValue);
     String state(JSC::JSGlobalObject& globalObject) const;
     bool closeQueuedOrInFlight();
 
-    ExceptionOr<JSC::JSValue> storedError() const;
+    JSC::JSValue storedError() const;
 
 private:
     InternalWritableStream(JSDOMGlobalObject& globalObject, JSC::JSObject& jsObject)


### PR DESCRIPTION
#### d3fcf235bf5d29ac3ad7c97c8c5fdc67e7105e1b
<pre>
InternalReadableStream/InternalWritableStream methods should catch JS exceptions for non JS code paths
<a href="https://rdar.apple.com/181481071">rdar://181481071</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=318940">https://bugs.webkit.org/show_bug.cgi?id=318940</a>

Reviewed by Ryosuke Niwa.

Several methods on InternalReadableStream and InternalWritableStream invoke JS builtins and can leave a pending exception on the VM.
When these methods are reached from a non-JS entry (e.g. an AbortSignal.timeout callback, WebTransport, fetch),
the pending exception survives back to the runloop and is observed by the next microtask reaction as scope.assertNoException(), crashing the process.

We fix this by auditing every InternalReadableStream / InternalWritableStream method and clearing pending exceptions at the C++/JS boundary when the caller cannot own an exception scope.

We make InternalReadableStream::cancel return an ExceptionOr&lt;JSC::JSValue&gt; so that callers need to explictly handle an existing exception, typically by wrapping the exception as a rejected promise. We do the same for InternalWritableStream::abort.
This allows to be more spec compliant by forwarding the JS error to the web page instead of dropping it.

We use more top scopes in internal stream functions to better isolate C++ code from potential JS exceptions.

* LayoutTests/streams/handle-exceptions-expected.txt: Added.
* LayoutTests/streams/handle-exceptions.html: Added.
* Source/WebCore/Modules/streams/ReadableStream.cpp:
(WebCore::ReadableStream::cancel):
* Source/WebCore/Modules/streams/StreamPipeToUtilities.cpp:
(WebCore::cancelReadableStream):
(WebCore::StreamPipeToState::handleSignal):
(WebCore::StreamPipeToState::errorsMustBePropagatedForward):
(WebCore::StreamPipeToState::errorsMustBePropagatedBackward):
(WebCore::StreamPipeToState::closingMustBePropagatedBackward):
* Source/WebCore/bindings/js/InternalReadableStream.cpp:
(WebCore::InternalReadableStream::state const):
(WebCore::InternalReadableStream::storedError const):
(WebCore::InternalReadableStream::cancel):
* Source/WebCore/bindings/js/InternalReadableStream.h:
* Source/WebCore/bindings/js/InternalWritableStream.cpp:
(WebCore::InternalWritableStream::abort):
(WebCore::InternalWritableStream::errorIfPossible):
(WebCore::InternalWritableStream::state const):
(WebCore::InternalWritableStream::storedError const):
(WebCore::InternalWritableStream::closeQueuedOrInFlight):
* Source/WebCore/bindings/js/InternalWritableStream.h:

Canonical link: <a href="https://commits.webkit.org/317079@main">https://commits.webkit.org/317079@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd75b1522ef27fdd8d0a7a86ec6c6fd524d212cc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173728 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47661 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41442 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183302 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131596 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1d95b776-6ca4-4dae-b46e-32683475158a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175593 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48953 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47343 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135095 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95291 "2 flakes 6 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1c9c11ff-98a7-4e7b-a875-3c98cb0c282d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176686 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38520 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155875 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115573 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0ff61022-b93d-4750-b7a1-f3ed26757fc9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37161 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35525 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31786 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147585 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35369 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185728 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38769 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39724 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143981 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47328 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155431 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143840 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38899 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48007 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31985 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113235 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38760 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119887 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46513 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10324 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45915 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46146 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45974 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->