### PR TITLE
DOMAsyncIterator should not store the callNext and callReturn callback as the same member

### DIFF
--- a/LayoutTests/streams/readable-stream-from-cancel-pending-next-crash-expected.txt
+++ b/LayoutTests/streams/readable-stream-from-cancel-pending-next-crash-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Cancelling a pipe with a pending next call on the source DOM async iterator should not crash
+

--- a/LayoutTests/streams/readable-stream-from-cancel-pending-next-crash.html
+++ b/LayoutTests/streams/readable-stream-from-cancel-pending-next-crash.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<script src='../resources/testharness.js'></script>
+<script src='../resources/testharnessreport.js'></script>
+<script>
+test(() => {
+    const video = document.createElement("video");
+    const readableStream = ReadableStream.from(video.audioTracks);
+    const transformStream = new TransformStream();
+    const piped = readableStream.pipeThrough(transformStream);
+    piped.cancel();
+}, "Cancelling a pipe with a pending next call on the source DOM async iterator should not crash");
+</script>

--- a/Source/WebCore/Modules/streams/ReadableStream.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStream.cpp
@@ -201,7 +201,7 @@ private:
     {
         m_iterator->callNext([weakThis = WeakPtr { *this }](auto* globalObject, bool isOK, auto value) {
             RefPtr protectedThis = weakThis.get();
-            if (!protectedThis || !globalObject)
+            if (!protectedThis || !globalObject || protectedThis->m_isCancelled)
                 return;
 
             if (!isOK) {
@@ -225,6 +225,7 @@ private:
 
     void doCancel(JSC::JSValue reason) final
     {
+        m_isCancelled = true;
         m_iterator->callReturn(reason, [weakThis = WeakPtr { *this }](auto* globalObject, bool isOK, auto value) {
             RefPtr protectedThis = weakThis.get();
             if (!protectedThis || !globalObject)
@@ -242,6 +243,7 @@ private:
     }
 
     const Ref<DOMAsyncIterator> m_iterator;
+    bool m_isCancelled { false };
 };
 
 ExceptionOr<Ref<ReadableStream>> ReadableStream::from(JSDOMGlobalObject& globalObject, JSC::JSValue iterable)

--- a/Source/WebCore/bindings/js/DOMAsyncIterator.cpp
+++ b/Source/WebCore/bindings/js/DOMAsyncIterator.cpp
@@ -50,24 +50,8 @@ ExceptionOr<Ref<DOMAsyncIterator>> DOMAsyncIterator::create(JSDOMGlobalObject& g
     return adoptRef(*new DOMAsyncIterator(globalObject, *iteratorObject, *iteratorRecord.nextMethod.asCell()));
 }
 
-void DOMAsyncIterator::handleCallbackWithPromise(JSDOMGlobalObject& globalObject, Callback&& callback, JSC::JSPromise& promise)
-{
-    bool shouldStoreCallback = DOMPromise::whenPromiseIsSettled(&globalObject, &promise, [weakThis = WeakPtr { *this }](auto* globalObject, bool isOK, auto value) {
-        if (RefPtr protectedThis = weakThis.get())
-            std::exchange(protectedThis->m_callback, { })(globalObject, isOK, value);
-    }) == DOMPromise::IsCallbackRegistered::Yes;
-
-    if (!shouldStoreCallback) {
-        callback(&globalObject, false, { });
-        return;
-    }
-
-    m_callback = WTF::move(callback);
-}
-
 void DOMAsyncIterator::callNext(Callback&& callback)
 {
-    ASSERT(!m_callback);
     auto* globalObject = this->globalObject();
     if (!globalObject) {
         callback(nullptr, false, { });
@@ -97,12 +81,11 @@ void DOMAsyncIterator::callNext(Callback&& callback)
         return;
     }
 
-    handleCallbackWithPromise(*globalObject, WTF::move(callback), *promise);
+    DOMPromise::whenPromiseIsSettled(globalObject, promise, WTF::move(callback), nullptr, DOMPromise::ShouldCallCallbackOnRegistrationFailure::Yes);
 }
 
 void DOMAsyncIterator::callReturn(JSC::JSValue reason, Callback&& callback)
 {
-    ASSERT(!m_callback);
     auto* globalObject = this->globalObject();
     if (!globalObject) {
         callback(nullptr, false, { });
@@ -150,7 +133,7 @@ void DOMAsyncIterator::callReturn(JSC::JSValue reason, Callback&& callback)
         return;
     }
 
-    handleCallbackWithPromise(*globalObject, WTF::move(callback), *promise);
+    DOMPromise::whenPromiseIsSettled(globalObject, promise, WTF::move(callback), nullptr, DOMPromise::ShouldCallCallbackOnRegistrationFailure::Yes);
 }
 
 }

--- a/Source/WebCore/bindings/js/DOMAsyncIterator.h
+++ b/Source/WebCore/bindings/js/DOMAsyncIterator.h
@@ -57,10 +57,7 @@ private:
     {
     }
 
-    void handleCallbackWithPromise(JSDOMGlobalObject&, Callback&&, JSC::JSPromise&);
-
     const Ref<IteratorObject> m_iterator;
-    Callback m_callback;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSDOMPromise.cpp
+++ b/Source/WebCore/bindings/js/JSDOMPromise.cpp
@@ -49,12 +49,17 @@ auto DOMPromise::whenSettledWithResult(Function<void(JSDOMGlobalObject*, bool, J
     return whenPromiseIsSettled(globalObject(), promise(), WTF::move(callback), nullptr);
 }
 
-auto DOMPromise::whenPromiseIsSettled(JSDOMGlobalObject* globalObject, JSC::JSPromise* promise, Function<void(JSDOMGlobalObject*, bool, JSC::JSValue)>&& callback, JSC::JSObject* protectedWrapper) -> IsCallbackRegistered
+auto DOMPromise::whenPromiseIsSettled(JSDOMGlobalObject* globalObject, JSC::JSPromise* promise, Function<void(JSDOMGlobalObject*, bool, JSC::JSValue)>&& callback, JSC::JSObject* protectedWrapper, ShouldCallCallbackOnRegistrationFailure shouldCallCallbackOnRegistrationFailure) -> IsCallbackRegistered
 {
     auto& lexicalGlobalObject = *globalObject;
     auto& vm = lexicalGlobalObject.vm();
     JSLockHolder lock(vm);
-    auto* handler = JSC::JSNativeStdFunction::create(vm, globalObject, 1, String { }, [callback = WTF::move(callback)] (JSGlobalObject* globalObject, CallFrame* callFrame) mutable {
+    auto* handler = JSC::JSNativeStdFunction::create(vm, globalObject, 1, String { }, [callback = WTF::move(callback), shouldCallCallbackOnRegistrationFailure] (JSGlobalObject* globalObject, CallFrame* callFrame) mutable {
+        if (shouldCallCallbackOnRegistrationFailure == ShouldCallCallbackOnRegistrationFailure::Yes && !callFrame) {
+            std::exchange(callback, { })(downcast<JSDOMGlobalObject>(globalObject), false, { });
+            return JSC::JSValue::encode(JSC::jsUndefined());
+        }
+
         auto* castedThis = dynamicDowncast<JSC::JSPromise>(callFrame->thisValue());
         ASSERT(castedThis);
         // We exchange callback so that all captured variables are deallocated after the call. This is quicker than waiting for the handler function to be GCed.
@@ -69,8 +74,11 @@ auto DOMPromise::whenPromiseIsSettled(JSDOMGlobalObject* globalObject, JSC::JSPr
     ASSERT(!boundArgs.hasOverflowed());
 
     auto* thisHandler = JSC::JSBoundFunction::create(vm, globalObject, handler, promise, boundArgs, protectedWrapper ? 1 : 0, jsEmptyString(vm), JSC::makeSource("createWhenPromiseSettledFunction"_s, JSC::SourceOrigin(), JSC::SourceTaintedOrigin::Untainted));
-    if (!thisHandler) [[unlikely]]
+    if (!thisHandler) [[unlikely]] {
+        if (shouldCallCallbackOnRegistrationFailure == ShouldCallCallbackOnRegistrationFailure::Yes)
+            handler->function()(globalObject, nullptr);
         return IsCallbackRegistered::No;
+    }
 
     promise->performPromiseThenExported(vm, globalObject, thisHandler, thisHandler, JSC::jsUndefined());
     return IsCallbackRegistered::Yes;

--- a/Source/WebCore/bindings/js/JSDOMPromise.h
+++ b/Source/WebCore/bindings/js/JSDOMPromise.h
@@ -59,7 +59,8 @@ public:
     enum class Status { Pending, Fulfilled, Rejected };
     WEBCORE_EXPORT Status status() const;
 
-    static IsCallbackRegistered whenPromiseIsSettled(JSDOMGlobalObject*, JSC::JSPromise*, Function<void(JSDOMGlobalObject*, bool, JSC::JSValue)>&&, JSC::JSObject* protectedWrapper = nullptr);
+    enum class ShouldCallCallbackOnRegistrationFailure : bool { No, Yes };
+    static IsCallbackRegistered whenPromiseIsSettled(JSDOMGlobalObject*, JSC::JSPromise*, Function<void(JSDOMGlobalObject*, bool, JSC::JSValue)>&&, JSC::JSObject* protectedWrapper = nullptr, ShouldCallCallbackOnRegistrationFailure = ShouldCallCallbackOnRegistrationFailure::No);
 
 private:
     DOMPromise(JSDOMGlobalObject& globalObject, JSC::JSPromise& promise)


### PR DESCRIPTION
#### 6184395225722949a9a83b80a7b78d9aaf3fa829
<pre>
DOMAsyncIterator should not store the callNext and callReturn callback as the same member
<a href="https://rdar.apple.com/181790407">rdar://181790407</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=318941">https://bugs.webkit.org/show_bug.cgi?id=318941</a>

Reviewed by Sihui Liu.

DOMAsyncIterator stored the pending completion callback in a single m_callback member and re-used the slot for both callNext and callReturn.
When callReturn was invoked (e.g. because the ReadableStream wrapping the iterator was cancelled) while a callNext promise was still pending,
the second call overwrites m_callback which could lead to the wrong callback being called.

We move the callback ownership into the lambda captured by DOMPromise::whenPromiseIsSettled, so each callNext/callReturn owns its own callback for the lifetime of its promise.
The m_callback member and the handleCallbackWithPromise helper are no longer needed.

We preserve the old behavior of invoking the caller-supplied callback with isOK=false when JSBoundFunction::create fails to register,
by introducing an opt-in ShouldCallCallbackOnRegistrationFailure parameter to DOMPromise::whenPromiseIsSettled.
This is off by default and used in DOMAsyncIterator call sites.

We guard the ReadableStream::from pull continuation with an m_isCancelled flag set in doCancel.
That way, a callNext result that arrives after cancel does not touch the controller.

Test: streams/readable-stream-from-cancel-pending-next-crash.html

* LayoutTests/streams/readable-stream-from-cancel-pending-next-crash-expected.txt: Added.
* LayoutTests/streams/readable-stream-from-cancel-pending-next-crash.html: Added.
* Source/WebCore/Modules/streams/ReadableStream.cpp:
* Source/WebCore/bindings/js/DOMAsyncIterator.cpp:
(WebCore::DOMAsyncIterator::callNext):
(WebCore::DOMAsyncIterator::callReturn):
(WebCore::DOMAsyncIterator::handleCallbackWithPromise): Deleted.
* Source/WebCore/bindings/js/DOMAsyncIterator.h:
* Source/WebCore/bindings/js/JSDOMPromise.cpp:
(WebCore::DOMPromise::whenPromiseIsSettled):
* Source/WebCore/bindings/js/JSDOMPromise.h:

Canonical link: <a href="https://commits.webkit.org/316874@main">https://commits.webkit.org/316874@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b167f8bf9043093c994c61c3ba0da5b1d2ddc852

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173484 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47417 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41278 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183057 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/131352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175349 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48709 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47098 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134897 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/131352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176442 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38328 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/155780 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115373 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36969 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35322 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31542 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147393 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35274 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185483 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38475 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39522 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143774 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47084 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155336 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143631 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38789 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47763 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112904 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38571 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119626 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46269 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10228 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45671 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45902 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45728 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->