### PR TITLE
Support block-ellipsis:no-ellipsis

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4002,7 +4002,6 @@ imported/w3c/web-platform-tests/css/css-overflow/line-clamp/block-ellipsis-018.h
 imported/w3c/web-platform-tests/css/css-overflow/line-clamp/block-ellipsis-019.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-overflow/line-clamp/block-ellipsis-020.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-overflow/line-clamp/block-ellipsis-021.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-overflow/line-clamp/block-ellipsis-023.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-overflow/line-clamp/block-ellipsis-024.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-overflow/line-clamp/block-ellipsis-025.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-overflow/line-clamp/block-ellipsis-027.html [ ImageOnlyFailure ]

--- a/LayoutTests/fast/inline/pagination-and-css-line-clamp-crash.html
+++ b/LayoutTests/fast/inline/pagination-and-css-line-clamp-crash.html
@@ -1,7 +1,7 @@
 <style>
 div {
   word-break: break-word;
-  line-clamp: 4 none;
+  line-clamp: 4 no-ellipsis;
   widows: 3;
   columns: 40;
 }

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/inheritance-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/inheritance-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Property block-ellipsis has initial value no-ellipsis assert_equals: expected "no-ellipsis" but got "none"
+PASS Property block-ellipsis has initial value no-ellipsis
 PASS Property block-ellipsis inherits
 PASS Property continue has initial value auto
 FAIL Property continue does not inherit assert_equals: expected "collapse" but got "auto"

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/parsing/block-ellipsis-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/parsing/block-ellipsis-invalid-expected.txt
@@ -1,6 +1,6 @@
 
 PASS e.style['block-ellipsis'] = "hidden" should not set the property value
-FAIL e.style['block-ellipsis'] = "none" should not set the property value assert_equals: expected "" but got "none"
+PASS e.style['block-ellipsis'] = "none" should not set the property value
 PASS e.style['block-ellipsis'] = "none auto" should not set the property value
 PASS e.style['block-ellipsis'] = "no-ellipsis auto" should not set the property value
 PASS e.style['block-ellipsis'] = "auto \"string\"" should not set the property value

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/parsing/block-ellipsis-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/parsing/block-ellipsis-valid-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL e.style['block-ellipsis'] = "no-ellipsis" should set the property value assert_not_equals: property should be set got disallowed value ""
+PASS e.style['block-ellipsis'] = "no-ellipsis" should set the property value
 PASS e.style['block-ellipsis'] = "auto" should set the property value
 PASS e.style['block-ellipsis'] = "\" etc., etc. \"" should set the property value
 

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -2452,9 +2452,9 @@
         "block-ellipsis": {
             "animation-type": "discrete",
             "inherited": true,
-            "initial": "none",
+            "initial": "no-ellipsis",
             "values": [
-                "none",
+                "no-ellipsis",
                 "auto"
             ],
             "codegen-properties": {
@@ -2462,7 +2462,7 @@
                 "computed-style-storage-path": ["m_inheritedRareData"],
                 "computed-style-storage-kind": "reference",
                 "computed-style-type": "Style::BlockEllipsis",
-                "parser-grammar": "none | auto | <string>",
+                "parser-grammar": "no-ellipsis | auto | <string>",
                 "parser-exported": true
             },
             "specification": {

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -1956,3 +1956,6 @@ unsafe-url
 
 // <will-change>
 will-change
+
+// block-ellipsis
+no-ellipsis

--- a/Source/WebCore/css/parser/CSSPropertyParserCustom.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserCustom.h
@@ -1922,7 +1922,7 @@ inline bool PropertyParserCustom::consumeLineClampShorthand(CSSParserTokenRange&
         // Sets max-lines to none, continue to auto, and block-ellipsis to none.
         result.addPropertyForCurrentShorthand(state, CSSPropertyMaxLines, CSSKeywordValue::create(CSSValueNone));
         result.addPropertyForCurrentShorthand(state, CSSPropertyContinue, CSSKeywordValue::create(CSSValueAuto));
-        result.addPropertyForCurrentShorthand(state, CSSPropertyBlockEllipsis, CSSKeywordValue::create(CSSValueNone));
+        result.addPropertyForCurrentShorthand(state, CSSPropertyBlockEllipsis, CSSKeywordValue::create(CSSValueNoEllipsis));
         consumeIdent(range);
         return range.atEnd();
     }

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayLineBuilder.cpp
@@ -498,7 +498,7 @@ std::optional<InlineDisplay::Line::Ellipsis> InlineDisplayLineBuilder::applyElli
             return TextUtil::ellipsisTextInInlineDirection(displayLine.isHorizontal());
         }
         return WTF::switchOn(displayBoxes[0].layoutBox().style().blockEllipsis(),
-            [&](const CSS::Keyword::None&) -> AtomString {
+            [&](const CSS::Keyword::NoEllipsis&) -> AtomString {
                 return nullAtom();
             },
             [&](const CSS::Keyword::Auto&) -> AtomString {

--- a/Source/WebCore/style/values/overflow/StyleBlockEllipsis.cpp
+++ b/Source/WebCore/style/values/overflow/StyleBlockEllipsis.cpp
@@ -38,13 +38,13 @@ auto CSSValueConversion<BlockEllipsis>::operator()(BuilderState& state, const CS
 {
     if (auto* keywordValue = dynamicDowncast<CSSKeywordValue>(value)) {
         switch (keywordValue->valueID()) {
-        case CSSValueNone:
-            return CSS::Keyword::None { };
+        case CSSValueNoEllipsis:
+            return CSS::Keyword::NoEllipsis { };
         case CSSValueAuto:
             return CSS::Keyword::Auto { };
         default:
             state.setCurrentPropertyInvalidAtComputedValueTime();
-            return CSS::Keyword::None { };
+            return CSS::Keyword::NoEllipsis { };
         }
     }
 

--- a/Source/WebCore/style/values/overflow/StyleBlockEllipsis.h
+++ b/Source/WebCore/style/values/overflow/StyleBlockEllipsis.h
@@ -33,10 +33,10 @@
 namespace WebCore {
 namespace Style {
 
-// <'block-ellipse'> = none | auto | <string>
+// <'block-ellipse'> = no-ellipsis | auto | <string>
 // https://www.w3.org/TR/css-overflow-4/#propdef-block-ellipsis
 struct BlockEllipsis {
-    BlockEllipsis(CSS::Keyword::None)
+    BlockEllipsis(CSS::Keyword::NoEllipsis)
     {
     }
 
@@ -51,7 +51,7 @@ struct BlockEllipsis {
     {
     }
 
-    bool isNone() const { return m_type == Type::None; }
+    bool isNone() const { return m_type == Type::NoEllipsis; }
     bool isAuto() const { return m_type == Type::Auto; }
     bool isString() const { return m_type == Type::String; }
 
@@ -60,8 +60,8 @@ struct BlockEllipsis {
         auto visitor = WTF::makeVisitor(std::forward<F>(f)...);
 
         switch (m_type) {
-        case Type::None:
-            return visitor(CSS::Keyword::None { });
+        case Type::NoEllipsis:
+            return visitor(CSS::Keyword::NoEllipsis { });
         case Type::Auto:
             return visitor(CSS::Keyword::Auto { });
         case Type::String:
@@ -73,9 +73,9 @@ struct BlockEllipsis {
     bool operator==(const BlockEllipsis&) const = default;
 
 private:
-    enum class Type : uint8_t { None, Auto, String };
+    enum class Type : uint8_t { NoEllipsis, Auto, String };
 
-    Type m_type { Type::None };
+    Type m_type { Type::NoEllipsis };
     AtomString m_string { nullAtom() };
 };
 


### PR DESCRIPTION
#### 81429b6842bef922b10daffc6ce5708881febbdc
<pre>
Support block-ellipsis:no-ellipsis
<a href="https://bugs.webkit.org/show_bug.cgi?id=318943">https://bugs.webkit.org/show_bug.cgi?id=318943</a>

Reviewed by Tim Nguyen.

Support block-ellipsis:no-ellipsis and not block-ellipsis:none, see:
<a href="https://github.com/w3c/csswg-drafts/issues/12416#issuecomment-3206816925">https://github.com/w3c/csswg-drafts/issues/12416#issuecomment-3206816925</a>

* LayoutTests/TestExpectations:
* LayoutTests/fast/inline/pagination-and-css-line-clamp-crash.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/inheritance-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/parsing/block-ellipsis-invalid-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/parsing/block-ellipsis-valid-expected.txt:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/CSSValueKeywords.in:
* Source/WebCore/css/parser/CSSPropertyParserCustom.h:
(WebCore::CSS::PropertyParserCustom::consumeLineClampShorthand):
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayLineBuilder.cpp:
(WebCore::Layout::InlineDisplayLineBuilder::applyEllipsisIfNeeded):
* Source/WebCore/style/values/overflow/StyleBlockEllipsis.cpp:
(WebCore::Style::CSSValueConversion&lt;BlockEllipsis&gt;::operator):
* Source/WebCore/style/values/overflow/StyleBlockEllipsis.h:
(WebCore::Style::BlockEllipsis::BlockEllipsis):
(WebCore::Style::BlockEllipsis::isNone const):
(WebCore::Style::BlockEllipsis::switchOn const):

Canonical link: <a href="https://commits.webkit.org/316811@main">https://commits.webkit.org/316811@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/106698ecb29c2674ba9a590cf788c373915c6252

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173501 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47434 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/41253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183074 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/131369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175366 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48726 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47116 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/134919 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/131369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176459 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38341 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/155617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115396 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36982 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/35339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31559 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147406 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35112 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185500 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/38470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39539 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143789 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47101 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/155174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143647 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38762 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47780 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/41253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112930 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38586 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/119642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46286 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10062 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45688 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45919 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45745 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->