### PR TITLE
Let replaceChildren() replace a document's children

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/ParentNode-replaceChildren-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/ParentNode-replaceChildren-expected.txt
@@ -4,10 +4,6 @@ PASS If node is not a DocumentFragment, DocumentType, Element, Text, ProcessingI
 PASS If node is a Text node and parent is a document, then throw a HierarchyRequestError DOMException.
 PASS If node is a doctype and parent is not a document, then throw a HierarchyRequestError DOMException.
 PASS If node is a DocumentFragment with multiple elements and parent is a document, then throw a HierarchyRequestError DOMException.
-PASS If node is a DocumentFragment with an element and parent is a document with another element, then throw a HierarchyRequestError DOMException.
-PASS If node is an Element and parent is a document with another element, then throw a HierarchyRequestError DOMException.
-PASS If node is a doctype and parent is a document with another doctype, then throw a HierarchyRequestError DOMException.
-PASS If node is a doctype and parent is a document with an element, then throw a HierarchyRequestError DOMException.
 PASS Element.replaceChildren() without any argument, on a parent having no child.
 PASS Element.replaceChildren() with null as an argument, on a parent having no child.
 PASS Element.replaceChildren() with undefined as an argument, on a parent having no child.
@@ -26,6 +22,12 @@ PASS DocumentFragment.replaceChildren() without any argument, on a parent having
 PASS DocumentFragment.replaceChildren() with null as an argument, on a parent having a child.
 PASS DocumentFragment.replaceChildren() with one element and text as argument, on a parent having a child.
 PASS DocumentFragment.replaceChildren() should move nodes in the right order
+PASS Document.replaceChildren() with an element, replacing an existing doctype and element.
+PASS Document.replaceChildren() with a DocumentFragment containing a single element, replacing an existing doctype and element.
+PASS Document.replaceChildren() with a doctype, replacing an existing doctype and element.
+PASS Document.replaceChildren() without any argument, removing an existing doctype and element.
+PASS Document.replaceChildren() with two elements throws a HierarchyRequestError.
+PASS Document.replaceChildren() with text throws a HierarchyRequestError.
 PASS There should be a MutationRecord for the node removed from another parent node.
 PASS There should be MutationRecords for the nodes removed from another parent node.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/ParentNode-replaceChildren.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/ParentNode-replaceChildren.html
@@ -122,6 +122,50 @@
   test_replacechildren(document.createElement('div'), 'Element');
   test_replacechildren(document.createDocumentFragment(), 'DocumentFragment');
 
+  // Document is special: replaceChildren removes the existing children (a
+  // doctype and a document element) before inserting, so the pre-insert
+  // validity checks must ignore them. See
+  // https://github.com/whatwg/dom/issues/1045.
+  test(() => {
+    const doc = document.implementation.createHTMLDocument("title");
+    const el = doc.createElement("a");
+    doc.replaceChildren(el);
+    assert_array_equals(doc.childNodes, [el]);
+  }, "Document.replaceChildren() with an element, replacing an existing doctype and element.");
+
+  test(() => {
+    const doc = document.implementation.createHTMLDocument("title");
+    const df = doc.createDocumentFragment();
+    const el = doc.createElement("a");
+    df.appendChild(el);
+    doc.replaceChildren(df);
+    assert_array_equals(doc.childNodes, [el]);
+  }, "Document.replaceChildren() with a DocumentFragment containing a single element, replacing an existing doctype and element.");
+
+  test(() => {
+    const doc = document.implementation.createHTMLDocument("title");
+    const doctype = doc.doctype.cloneNode();
+    doc.replaceChildren(doctype);
+    assert_array_equals(doc.childNodes, [doctype]);
+  }, "Document.replaceChildren() with a doctype, replacing an existing doctype and element.");
+
+  test(() => {
+    const doc = document.implementation.createHTMLDocument("title");
+    doc.replaceChildren();
+    assert_array_equals(doc.childNodes, []);
+  }, "Document.replaceChildren() without any argument, removing an existing doctype and element.");
+
+  test(() => {
+    const doc = document.implementation.createHTMLDocument("title");
+    assert_throws_dom("HierarchyRequestError",
+      () => doc.replaceChildren(doc.createElement("a"), doc.createElement("b")));
+  }, "Document.replaceChildren() with two elements throws a HierarchyRequestError.");
+
+  test(() => {
+    const doc = document.implementation.createHTMLDocument("title");
+    assert_throws_dom("HierarchyRequestError", () => doc.replaceChildren("text"));
+  }, "Document.replaceChildren() with text throws a HierarchyRequestError.");
+
   async_test(t => {
     let root = document.createElement("div");
     root.innerHTML = "<div id='a'>text<div id='b'>text2</div></div>";

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/pre-insertion-validation-hierarchy.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/pre-insertion-validation-hierarchy.js
@@ -51,31 +51,41 @@ function preInsertionValidateHierarchy(methodName) {
   }, "If node is a DocumentFragment with multiple elements and parent is a document, then throw a HierarchyRequestError DOMException.");
 
   // Step 6, in case of DocumentFragment has multiple elements when document already has an element
-  test(() => {
-    const doc = document.implementation.createHTMLDocument("title");
-    const df = doc.createDocumentFragment();
-    df.appendChild(doc.createElement("a"));
-    assert_throws_dom("HierarchyRequestError", () => insert(doc, df));
-  }, "If node is a DocumentFragment with an element and parent is a document with another element, then throw a HierarchyRequestError DOMException.");
+  if (methodName !== "replaceChildren") {
+    // Skip `.replaceChildren` as it removes the document's existing children first
+    test(() => {
+      const doc = document.implementation.createHTMLDocument("title");
+      const df = doc.createDocumentFragment();
+      df.appendChild(doc.createElement("a"));
+      assert_throws_dom("HierarchyRequestError", () => insert(doc, df));
+    }, "If node is a DocumentFragment with an element and parent is a document with another element, then throw a HierarchyRequestError DOMException.");
+  }
 
   // Step 6, in case of an element
-  test(() => {
-    const doc = document.implementation.createHTMLDocument("title");
-    const el = doc.createElement("a");
-    assert_throws_dom("HierarchyRequestError", () => insert(doc, el));
-  }, "If node is an Element and parent is a document with another element, then throw a HierarchyRequestError DOMException.");
+  if (methodName !== "replaceChildren") {
+    // Skip `.replaceChildren` as it removes the document's existing children first
+    test(() => {
+      const doc = document.implementation.createHTMLDocument("title");
+      const el = doc.createElement("a");
+      assert_throws_dom("HierarchyRequestError", () => insert(doc, el));
+    }, "If node is an Element and parent is a document with another element, then throw a HierarchyRequestError DOMException.");
+  }
 
   // Step 6, in case of a doctype when document already has another doctype
-  test(() => {
-    const doc = document.implementation.createHTMLDocument("title");
-    const doctype = doc.childNodes[0].cloneNode();
-    doc.documentElement.remove();
-    assert_throws_dom("HierarchyRequestError", () => insert(doc, doctype));
-  }, "If node is a doctype and parent is a document with another doctype, then throw a HierarchyRequestError DOMException.");
+  if (methodName !== "replaceChildren") {
+    // Skip `.replaceChildren` as it removes the document's existing children first
+    test(() => {
+      const doc = document.implementation.createHTMLDocument("title");
+      const doctype = doc.childNodes[0].cloneNode();
+      doc.documentElement.remove();
+      assert_throws_dom("HierarchyRequestError", () => insert(doc, doctype));
+    }, "If node is a doctype and parent is a document with another doctype, then throw a HierarchyRequestError DOMException.");
+  }
 
   // Step 6, in case of a doctype when document has an element
-  if (methodName !== "prepend") {
+  if (methodName !== "prepend" && methodName !== "replaceChildren") {
     // Skip `.prepend` as this doesn't throw if `child` is an element
+    // Skip `.replaceChildren` as it removes the document's existing children first
     test(() => {
       const doc = document.implementation.createHTMLDocument("title");
       const doctype = doc.childNodes[0].cloneNode();

--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -562,7 +562,7 @@ static bool containsIncludingHostElements(const Node& possibleAncestor, const No
 }
 
 enum class ShouldValidateChildParent : bool { No, Yes };
-static inline ExceptionOr<void> checkAcceptChild(ContainerNode& newParent, Node& newChild, const Node* refChild, Document::AcceptChildOperation operation, ShouldValidateChildParent shouldValidateChildParent)
+static inline ExceptionOr<void> checkAcceptChild(ContainerNode& newParent, Node& newChild, const Node* refChild, AcceptChildOperation operation, ShouldValidateChildParent shouldValidateChildParent)
 {
     if (containsIncludingHostElements(newChild, newParent))
         return Exception { ExceptionCode::HierarchyRequestError };
@@ -605,11 +605,11 @@ static inline ExceptionOr<void> checkAcceptChildGuaranteedNodeTypes(ContainerNod
 // https://dom.spec.whatwg.org/#concept-node-ensure-pre-insertion-validity
 ExceptionOr<void> ContainerNode::ensurePreInsertionValidity(Node& newChild, Node* refChild)
 {
-    return checkAcceptChild(*this, newChild, refChild, Document::AcceptChildOperation::InsertOrAdd, ShouldValidateChildParent::Yes);
+    return checkAcceptChild(*this, newChild, refChild, AcceptChildOperation::InsertOrAdd, ShouldValidateChildParent::Yes);
 }
 
 // https://dom.spec.whatwg.org/#concept-node-ensure-pre-insertion-validity when node is a new DocumentFragment created in "converting nodes into a node"
-ExceptionOr<void> ContainerNode::ensurePreInsertionValidityForPhantomDocumentFragment(NodeVector& newChildren, Node* refChild)
+ExceptionOr<void> ContainerNode::ensurePreInsertionValidityForPhantomDocumentFragment(NodeVector& newChildren, Node* refChild, AcceptChildOperation operation)
 {
     if (is<Document>(*this)) [[unlikely]] {
         bool hasSeenElement = false;
@@ -622,7 +622,7 @@ ExceptionOr<void> ContainerNode::ensurePreInsertionValidityForPhantomDocumentFra
         }
     }
     for (auto& child : newChildren) {
-        if (auto result = checkAcceptChild(*this, child, refChild, Document::AcceptChildOperation::InsertOrAdd, ShouldValidateChildParent::Yes); result.hasException())
+        if (auto result = checkAcceptChild(*this, child, refChild, operation, ShouldValidateChildParent::Yes); result.hasException())
             return result;
     }
     return { };
@@ -631,7 +631,7 @@ ExceptionOr<void> ContainerNode::ensurePreInsertionValidityForPhantomDocumentFra
 // https://dom.spec.whatwg.org/#concept-node-replace
 static inline ExceptionOr<void> checkPreReplacementValidity(ContainerNode& newParent, Node& newChild, Node& oldChild, ShouldValidateChildParent shouldValidateChildParent)
 {
-    return checkAcceptChild(newParent, newChild, &oldChild, Document::AcceptChildOperation::Replace, shouldValidateChildParent);
+    return checkAcceptChild(newParent, newChild, &oldChild, AcceptChildOperation::Replace, shouldValidateChildParent);
 }
 
 ExceptionOr<void> ContainerNode::insertBefore(Node& newChild, RefPtr<Node>&& refChild)
@@ -1404,7 +1404,7 @@ ExceptionOr<void> ContainerNode::replaceChildren(FixedVector<NodeOrString>&& vec
         return result.releaseException();
     auto newChildren = result.releaseReturnValue();
 
-    if (auto checkResult = ensurePreInsertionValidityForPhantomDocumentFragment(newChildren); checkResult.hasException())
+    if (auto checkResult = ensurePreInsertionValidityForPhantomDocumentFragment(newChildren, nullptr, AcceptChildOperation::ReplaceAll); checkResult.hasException())
         return checkResult;
 
     Ref protectedThis { *this };

--- a/Source/WebCore/dom/ContainerNode.h
+++ b/Source/WebCore/dom/ContainerNode.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <WebCore/DocumentEnums.h>
 #include <WebCore/Node.h>
 
 namespace WebCore {
@@ -150,7 +151,7 @@ public:
     ExceptionOr<void> moveBefore(Node&, RefPtr<Node>&& refChild);
 
     ExceptionOr<void> ensurePreInsertionValidity(Node& newChild, Node* refChild);
-    ExceptionOr<void> ensurePreInsertionValidityForPhantomDocumentFragment(NodeVector& newChildren, Node* refChild = nullptr);
+    ExceptionOr<void> ensurePreInsertionValidityForPhantomDocumentFragment(NodeVector& newChildren, Node* refChild = nullptr, AcceptChildOperation = AcceptChildOperation::InsertOrAdd);
     ExceptionOr<void> insertChildrenBeforeWithoutPreInsertionValidityCheck(NodeVector&&, Node* nextChild = nullptr);
 
 protected:

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -5717,23 +5717,27 @@ bool Document::canAcceptChild(const Node& newChild, const Node* refChild, Accept
     }
     case NodeType::DocumentType: {
         auto* existingDocType = childrenOfType<DocumentType>(*this).first();
+        if (operation == AcceptChildOperation::ReplaceAll)
+            break;
         if (operation == AcceptChildOperation::Replace) {
             //  parent has a doctype child that is not child, or an element is preceding child.
             if (existingDocType && existingDocType != refChild)
                 return false;
             if (refChild->previousElementSibling())
                 return false;
-        } else {
-            ASSERT(operation == AcceptChildOperation::InsertOrAdd);
-            if (existingDocType)
-                return false;
-            if ((refChild && refChild->previousElementSibling()) || (!refChild && firstElementChild()))
-                return false;
+            break;
         }
+        ASSERT(operation == AcceptChildOperation::InsertOrAdd);
+        if (existingDocType)
+            return false;
+        if ((refChild && refChild->previousElementSibling()) || (!refChild && firstElementChild()))
+            return false;
         break;
     }
     case NodeType::Element: {
         auto* existingElementChild = firstElementChild();
+        if (operation == AcceptChildOperation::ReplaceAll)
+            break;
         if (operation == AcceptChildOperation::Replace) {
             if (existingElementChild && existingElementChild != refChild)
                 return false;
@@ -5741,14 +5745,14 @@ bool Document::canAcceptChild(const Node& newChild, const Node* refChild, Accept
                 if (is<DocumentType>(*child))
                     return false;
             }
-        } else {
-            ASSERT(operation == AcceptChildOperation::InsertOrAdd);
-            if (existingElementChild)
+            break;
+        }
+        ASSERT(operation == AcceptChildOperation::InsertOrAdd);
+        if (existingElementChild)
+            return false;
+        for (auto* child = refChild; child; child = child->nextSibling()) {
+            if (is<DocumentType>(*child))
                 return false;
-            for (auto* child = refChild; child; child = child->nextSibling()) {
-                if (is<DocumentType>(*child))
-                    return false;
-            }
         }
         break;
     }

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1069,7 +1069,6 @@ public:
     void nodeWillBeMoved(Node&);
     void parentlessNodeMovedToNewDocument(Node&);
 
-    enum class AcceptChildOperation : bool { Replace, InsertOrAdd };
     bool NODELETE canAcceptChild(const Node& newChild, const Node* refChild, AcceptChildOperation) const;
 
     void textInserted(Node&, unsigned offset, unsigned length);

--- a/Source/WebCore/dom/DocumentEnums.h
+++ b/Source/WebCore/dom/DocumentEnums.h
@@ -76,4 +76,10 @@ enum class CanTriggerCrossDocumentViewTransition : bool {
     Yes
 };
 
+enum class AcceptChildOperation : uint8_t {
+    Replace,
+    ReplaceAll,
+    InsertOrAdd
+};
+
 } // namespace WebCore


### PR DESCRIPTION
#### ced9e679e7f8d49a9f0c299f0db816e7939c3a3f
<pre>
Let replaceChildren() replace a document&apos;s children
<a href="https://bugs.webkit.org/show_bug.cgi?id=318945">https://bugs.webkit.org/show_bug.cgi?id=318945</a>

Reviewed by Ryosuke Niwa.

This aligns us with an upcoming DOM standard change that makes
replaceChildren() consistent with the other mutation methods:

    <a href="https://github.com/whatwg/dom/pull/1487">https://github.com/whatwg/dom/pull/1487</a>

Tests are updated as per:

   <a href="https://github.com/web-platform-tests/wpt/pull/61154">https://github.com/web-platform-tests/wpt/pull/61154</a>

Canonical link: <a href="https://commits.webkit.org/316909@main">https://commits.webkit.org/316909@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dbfae910dc869dd4355d9e73699fe9a9fc8b30af

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173488 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47421 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41270 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183061 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131356 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175353 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48713 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47102 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134905 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95227 "2 flakes 6 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176446 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38331 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155786 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115381 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36972 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35325 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31546 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147396 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35280 "Found 1 new test failure: imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-corner-shape-change.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185487 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/38694 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39525 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143782 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47088 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155342 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143639 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38803 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47767 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31895 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112910 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38574 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119627 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46273 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10234 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45675 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45906 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45732 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->