### PR TITLE
ICECandidate stats address member should be null when obfuscated

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-stats/getStats-remote-candidate-address-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-stats/getStats-remote-candidate-address-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Do not expose in stats remote addresses that are not known to be already exposed to JS assert_equals: address should be null expected (object) null but got (undefined) undefined
-PASS Expose in stats remote addresses that are already exposed to JS
+PASS Do not expose in stats remote addresses that are not known to be already exposed to JS
+FAIL Expose in stats remote addresses that are already exposed to JS assert_not_equals: address should not be null got disallowed value null
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-mandatory-getStats.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-mandatory-getStats.https-expected.txt
@@ -65,7 +65,7 @@ PASS RTCIceCandidatePairStats's bytesReceived
 PASS RTCIceCandidatePairStats's totalRoundTripTime
 PASS RTCIceCandidatePairStats's responsesReceived
 PASS RTCIceCandidatePairStats's currentRoundTripTime
-FAIL RTCIceCandidateStats's address assert_true: Is address present expected true got false
+PASS RTCIceCandidateStats's address
 PASS RTCIceCandidateStats's port
 PASS RTCIceCandidateStats's protocol
 PASS RTCIceCandidateStats's candidateType

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2423,7 +2423,6 @@ webkit.org/b/319501 fast/animation/request-animation-frame-throttle-subframe.htm
 webkit.org/b/318732 http/tests/site-isolation/page-zoom.html [ Pass ImageOnlyFailure ]
 
 webkit.org/b/318879 [ x86_64 Release ] webgl/ [ Skip ]
-webkit.org/b/319003 fast/mediastream/microphone-interruption-and-audio-session.html [ Failure ]
 
 # webkit.org/b/319018 2x media/media-source/* (layout-tests) are flaky timeouts.
 media/media-source/media-source-real-play-after-eos.html [ Pass ImageOnlyFailure Timeout ]

--- a/LayoutTests/webrtc/candidate-stats.html
+++ b/LayoutTests/webrtc/candidate-stats.html
@@ -23,10 +23,10 @@ promise_test(async (test) => {
     });
 
     let stats = await getTypedStats(firstConnection, "local-candidate");
-    assert_true(!stats.address, "address is not exposed");
+    assert_equals(stats.address, null, "address is not exposed");
     assert_true(!stats.networkType, "networkType is not exposed");
 
-    assert_array_equals(Object.keys(stats), ["id","timestamp","type","candidateType","foundation", "port","priority","protocol","transportId", "usernameFragment"], "local");
+    assert_array_equals(Object.keys(stats), ["id","timestamp","type","address","candidateType","foundation", "port","priority","protocol","transportId", "usernameFragment"], "local");
 
     stats = await getTypedStats(firstConnection, "remote-candidate");
 
@@ -37,10 +37,10 @@ promise_test(async (test) => {
     }
 
     // For now, we do not want to expose address or networkType.
-    assert_true(!stats.address, "address is not exposed");
+    assert_equals(stats.address, null, "address is not exposed");
     assert_true(!stats.networkType, "networkType is not exposed");
 
-    assert_array_equals(Object.keys(stats), ["id","timestamp","type","candidateType","foundation", "port","priority","protocol","transportId", "usernameFragment"], "remote");
+    assert_array_equals(Object.keys(stats), ["id","timestamp","type","address","candidateType","foundation", "port","priority","protocol","transportId", "usernameFragment"], "remote");
 }, "ICE candidate data channel stats");
         </script>
     </body>

--- a/LayoutTests/webrtc/datachannel/getStats-no-prflx-remote-candidate.html
+++ b/LayoutTests/webrtc/datachannel/getStats-no-prflx-remote-candidate.html
@@ -60,7 +60,7 @@ async function doTest()
     await remoteDataChannelPromise;
 
     const remoteCandidateStats = getRequiredStats(await localPc.getStats(), "remote-candidate");
-    assert_equals(remoteCandidateStats.address, undefined, "address should remain undefined");
+    assert_equals(remoteCandidateStats.address, null, "address should remain null");
 
     done();
 }

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp
@@ -343,7 +343,7 @@ RTCStatsReport::IceCandidateStats RTCStatsReport::IceCandidateStats::convert(Gst
     return IceCandidateStats {
         Stats::convert(statsType == GST_WEBRTC_STATS_REMOTE_CANDIDATE ? Type::RemoteCandidate : Type::LocalCandidate, structure),
         gstStructureGetString(structure, "transport-id"_s).span(),
-        { }, // NOTE: We have the `address` field in the structure but we don't expose it for privacy reasons. Covered by test: webrtc/candidate-stats.html
+        String { }, // NOTE: We have the `address` field in the structure but we don't expose it for privacy reasons. Covered by test: webrtc/candidate-stats.html
         gstStructureGet<unsigned>(structure, "port"_s),
         gstStructureGetString(structure, "protocol"_s).span(),
         getCandidateType(),

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCStatsCollector.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCStatsCollector.cpp
@@ -343,7 +343,7 @@ RTCStatsReport::IceCandidateStats RTCStatsReport::IceCandidateStats::convert(con
     };
 
     if (result.candidateType == RTCIceCandidateType::Prflx || result.candidateType == RTCIceCandidateType::Host)
-        result.address = { };
+        result.address = String { };
 
     return result;
 }


### PR DESCRIPTION
#### 4633fbc5a77475f264df74ea208e0018c321c1d1
<pre>
ICECandidate stats address member should be null when obfuscated
<a href="https://rdar.apple.com/181801756">rdar://181801756</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=318950">https://bugs.webkit.org/show_bug.cgi?id=318950</a>

Reviewed by Jean-Yves Avenard.

To align with the spec, instead of using undefined we use null when we obfuscate IceCandidate address member.
We rebase some WPT tests and update some layout tests accordingly.

We rebase in particular LayoutTests/imported/w3c/web-platform-tests/webrtc-stats/getStats-remote-candidate-address-expected.txt, one test changes to PASS and one to FAIL.
The first one changes to PASS as the test expects null and WebKit was previously exposing undefined.
The second ones changes to FAIL as the test expects a value not null and WebKit was exposing undefined (and now null).
A follow-up PR should allow exposing remote candidates whose address has been given by the web page, whether an IP or a mDNS address.

* LayoutTests/imported/w3c/web-platform-tests/webrtc-stats/getStats-remote-candidate-address-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-mandatory-getStats.https-expected.txt:
* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/webrtc/candidate-stats.html:
* LayoutTests/webrtc/datachannel/getStats-no-prflx-remote-candidate.html:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp:
(WebCore::RTCStatsReport::IceCandidateStats::convert):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCStatsCollector.cpp:
(WebCore::RTCStatsReport::IceCandidateStats::convert):

Canonical link: <a href="https://commits.webkit.org/317238@main">https://commits.webkit.org/317238@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1fb106b2f73125acb10b3e88efb9b402159072df

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174739 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48672 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42453 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184319 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132607 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/67a9034a-61f9-42df-a820-3b18f89bf284) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176604 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49964 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48355 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135973 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b516ec14-8a6c-4662-ba90-fb2717ffff91) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177697 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39410 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156759 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116451 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d5a869ad-8c77-4c1d-87fd-ad2a9facad29) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38051 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32797 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148474 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36251 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186744 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/40085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144896 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48339 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156315 "") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144756 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39003 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49019 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39630 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/121062 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47525 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11220 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46927 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47158 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46985 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->