### PR TITLE
[css-values-5] Propagate attr()-taint through if() conditions

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-security-if-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-security-if-expected.txt
@@ -4,8 +4,8 @@ PASS 'background-image: image-set(if(style(--true): attr(data-foo);))' with data
 PASS 'background-image: image-set(
                 if(style(--true): url(https://does-not-exist-2.test/404.png);
                    else: attr(data-foo);))' with data-foo="https://does-not-exist-2.test/404.png"
-FAIL 'background-image: image-set(
-                if(style(--some-string): url(https://does-not-exist.test/404.png);))' with data-foo="https://does-not-exist.test/404.png" assert_equals: expected "none" but got "image-set(url(\"https://does-not-exist.test/404.png\") 1dppx)"
+PASS 'background-image: image-set(
+                if(style(--some-string): url(https://does-not-exist.test/404.png);))' with data-foo="https://does-not-exist.test/404.png"
 PASS 'background-image: image-set(
                 if(style(--condition-val: attr(data-foo type(*))): url(https://does-not-exist.test/404.png);))' with data-foo="3"
 PASS 'background-image: image-set(

--- a/Source/WebCore/style/IfConditionEvaluator.cpp
+++ b/Source/WebCore/style/IfConditionEvaluator.cpp
@@ -37,6 +37,7 @@
 #include "MediaQueryParser.h"
 #include "RenderElement.h"
 #include "StyleBuilder.h"
+#include "StyleCustomProperty.h"
 
 namespace WebCore {
 namespace Style {
@@ -109,8 +110,14 @@ MQ::EvaluationResult IfConditionEvaluator::evaluateFeature(const MQ::Feature& fe
 
     // Force resolution of the queried custom property. Range queries comparing
     // literals (e.g. style(5 > 3)) have no custom-property name to resolve.
-    if (!feature.name.isNull())
+    if (!feature.name.isNull()) {
         m_styleBuilder.applyCustomProperty(feature.name);
+
+        // A tainted queried property taints the whole if() substitution value (CSS Values 5 §8.7.2).
+        RefPtr resolved = protect(m_styleBuilder.state().style())->customPropertyValue(feature.name);
+        if (resolved && resolved->isAttrTainted() == IsAttrTainted::Yes)
+            m_referencedAttrTaintedValue = true;
+    }
 
     return feature.schema->evaluate(feature, context);
 }

--- a/Source/WebCore/style/IfConditionEvaluator.h
+++ b/Source/WebCore/style/IfConditionEvaluator.h
@@ -49,6 +49,10 @@ public:
     enum class Result : uint8_t { True, False, Invalid };
     Result evaluate(CSSParserTokenRange branchCondition);
 
+    // True if evaluating the condition read an attr()-tainted custom property. Per CSS Values 5 §8.7.2
+    // that taints the whole if() substitution value, since the tainted value was involved in producing it.
+    bool referencedAttrTaintedValue() const { return m_referencedAttrTaintedValue; }
+
 private:
     friend class MQ::GenericMediaQueryEvaluator<IfConditionEvaluator>;
 
@@ -57,6 +61,7 @@ private:
 
     Builder& m_styleBuilder;
     const CSSParserContext& m_context;
+    mutable bool m_referencedAttrTaintedValue { false };
 };
 
 } // namespace Style

--- a/Source/WebCore/style/StyleSubstitutionResolver.cpp
+++ b/Source/WebCore/style/StyleSubstitutionResolver.cpp
@@ -981,8 +981,9 @@ bool SubstitutionResolver::substituteIfFunction(CSSParserTokenRange argumentsRan
         return false;
 
     for (auto& branch : *branches) {
+        IfConditionEvaluator conditionEvaluator { m_styleBuilder, context };
         auto conditionResult = branch.condition
-            ? IfConditionEvaluator { m_styleBuilder, context }.evaluate(*branch.condition)
+            ? conditionEvaluator.evaluate(*branch.condition)
             : IfConditionEvaluator::Result::True;
 
         // An invalid condition makes the whole if() IACVT. This matches the imported WPT but not the
@@ -995,11 +996,17 @@ bool SubstitutionResolver::substituteIfFunction(CSSParserTokenRange argumentsRan
             continue;
 
         // Substitute the value part and return.
+        auto startIndex = tokens.size();
         auto substitutedValue = substituteTokenRange(branch.valueRange, context);
         if (!substitutedValue)
             return false;
 
         tokens.appendVector(*substitutedValue);
+
+        // A condition that read an attr()-tainted property taints the whole substitution value.
+        if (conditionEvaluator.referencedAttrTaintedValue())
+            propagateAttrTaint(IsAttrTainted::Yes, std::span(tokens).subspan(startIndex));
+
         return true;
     }
 


### PR DESCRIPTION
#### 733936bdb21a71e1cfc778ad75ba009b735cbef3
<pre>
[css-values-5] Propagate attr()-taint through if() conditions
<a href="https://bugs.webkit.org/show_bug.cgi?id=318963">https://bugs.webkit.org/show_bug.cgi?id=318963</a>
<a href="https://rdar.apple.com/181815712">rdar://181815712</a>

Reviewed by Tim Nguyen.

When if(style(--foo):bar) reads an attr() tainted property the taint must propagate
to the substitution value per CSS Values 5 §8.7.2 (&quot;attr()-tainted as a whole if any
attr()-tainted values were involved in creating that substitution value&quot;)

* LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-security-if-expected.txt:
* Source/WebCore/style/IfConditionEvaluator.cpp:
(WebCore::Style::IfConditionEvaluator::evaluateFeature const):

Set m_referencedAttrTaintedValue during evaluation if needed.

* Source/WebCore/style/IfConditionEvaluator.h:
(WebCore::Style::IfConditionEvaluator::referencedAttrTaintedValue const):
* Source/WebCore/style/StyleSubstitutionResolver.cpp:
(WebCore::Style::SubstitutionResolver::substituteIfFunction):

Propagate the taint.

Canonical link: <a href="https://commits.webkit.org/316878@main">https://commits.webkit.org/316878@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d0dc283c2d5c633e4d015d5fb607a02da2c03a24

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173711 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47644 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41425 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183285 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/131579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/95529614-11bb-4e28-b6a3-7204e6fc463b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175576 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48936 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47326 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135080 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/131579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/63247649-2dc4-4747-a60a-8dcfbfd49eff) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176669 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38508 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/155864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115558 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37149 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/35512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31769 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147573 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35358 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185711 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/38751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/39711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143966 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47311 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143825 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38788 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47990 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113197 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38745 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/119870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46496 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/10313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45898 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46129 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45957 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->