### PR TITLE
WPT webrtc RTCPeerConnection-videoDetectorTest.html is failing due to unattached video element not autoplaying

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -345,6 +345,8 @@ imported/w3c/web-platform-tests/webrtc/protocol/h264-profile-levels.https.html?r
 imported/w3c/web-platform-tests/webrtc/simulcast/negotiation-encodings.https.html?interop-2026 [ Pass Failure ]
 imported/w3c/web-platform-tests/webrtc/simulcast/negotiation-encodings.https.html?rest [ Pass Failure ]
 
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-video-element-loadedmetadata-event.html [ Pass Failure ]
+
 # The addstream event is not supported anymore.
 imported/w3c/web-platform-tests/webrtc/legacy/onaddstream.https.html [ Skip ]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-video-element-loadedmetadata-event-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-video-element-loadedmetadata-event-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS RTCPeerConnection-video-element-loadedmetadata-event
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-video-element-loadedmetadata-event.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-video-element-loadedmetadata-event.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html>
+<head>
+<meta charset=utf-8>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="RTCPeerConnection-helper.js"></script>
+</head>
+<body>
+<canvas id=canvas></canvas>
+<video controls id=video autoplay playsinline></video>
+<script>
+'use strict';
+
+promise_test(async t => {
+    const v = document.createElement('video');
+    v.autoplay = true;
+    const pc1 = new RTCPeerConnection();
+    const pc2 = new RTCPeerConnection();
+    t.add_cleanup(() => pc1.close());
+    t.add_cleanup(() => pc2.close());
+    const stream1 = await getNoiseStream({video: {signal: 100}});
+    const [track1] = stream1.getTracks();
+    t.add_cleanup(() => track1.stop());
+
+    const sender = pc1.addTrack(track1);
+    const parameters = sender.getParameters();
+    parameters.degradationPreference = "maintain-resolution";
+    sender.setParameters(parameters);
+
+    const haveTrackEvent = new Promise(r => pc2.ontrack = r);
+    exchangeIceCandidates(pc1, pc2);
+    await exchangeOfferAnswer(pc1, pc2);
+    v.srcObject = new MediaStream([(await haveTrackEvent).track]);
+    v.play();
+
+    await new Promise(resolve => v.onloadedmetadata = resolve);
+    assert_equals(v.videoWidth, 640, "width");
+    assert_equals(v.videoHeight, 480, "height");
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-videoDetectorTest.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-videoDetectorTest.html
@@ -49,11 +49,16 @@ promise_test(async t => {
   t.add_cleanup(() => track1.stop());
 
   const sender = pc1.addTrack(track1);
+  const parameters = sender.getParameters();
+  parameters.degradationPreference = "maintain-resolution";
+  sender.setParameters(parameters);
+
   const haveTrackEvent = new Promise(r => pc2.ontrack = r);
   exchangeIceCandidates(pc1, pc2);
   await exchangeOfferAnswer(pc1, pc2);
   v.srcObject = new MediaStream([(await haveTrackEvent).track]);
-  await new Promise(r => v.onloadedmetadata = r);
+  v.play();
+  await new Promise(r => v.requestVideoFrameCallback(r));
   // The basic signal is a track with signal 100. We replace this
   // with tracks with signal from 0 to 255 and see if they are all
   // reliably detected.


### PR DESCRIPTION
#### a747500e6dd373163d6f633d7f2a5d6b912d0dca
<pre>
WPT webrtc RTCPeerConnection-videoDetectorTest.html is failing due to unattached video element not autoplaying
<a href="https://rdar.apple.com/181805319">rdar://181805319</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=318954">https://bugs.webkit.org/show_bug.cgi?id=318954</a>

Reviewed by Jean-Yves Avenard.

We fix WPT RTCPeerConnection-videoDetectorTest.html for two things:
- We make sure to call play on a video element that is not attached to the DOM, even though its autoplayu is true.
- We make sure to start the signal detection once the video element gets a first video frame via requestVideoFrameCallback instead of loadedmetadata, which is flaky in WebKit.
- We make sure to preserve resolution so that the first video frame is not too small.

We add a test that is specific to testing that when loadedmetadata event fires, a first video frame should have been received.
We mark this test as flakky for now and we will work as a follow-upt to fix this, once we know how to handle the case of audio+video.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-video-element-loadedmetadata-event-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-video-element-loadedmetadata-event.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-videoDetectorTest.html:

Canonical link: <a href="https://commits.webkit.org/317609@main">https://commits.webkit.org/317609@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0852b1b25b7518196d8eea7f112dd86732a0335b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173522 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47455 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41236 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183095 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131390 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/447b21e4-2f00-435d-98e2-05a35d8963b3) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48747 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47137 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134931 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95231 "4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8fbb2a9c-60f3-4857-a2b7-cbdf28530fda) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176480 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38363 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155756 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115408 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/aadec65d-b9b5-460a-b996-be98364f4f0c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37004 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35357 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31580 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147428 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35250 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185521 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39557 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143808 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47122 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155312 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143666 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39246 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47801 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31865 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112964 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38604 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46307 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10203 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45709 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45940 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45766 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->