### PR TITLE
[Netflix.com] Unable to PiP video after navigating to another episode

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -336,6 +336,7 @@ private:
 
     // Remote layer support
     WebCore::HostingContext hostingContext() const final;
+    void requestHostingContext(LayerHostingContextCallback&&) final;
     void setVideoLayerSizeFenced(const WebCore::FloatSize&, WTF::MachSendRightAnnotated&&) final;
     std::optional<MediaPlayerIdentifier> identifier() const final { return m_playerIdentifier; }
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -1556,6 +1556,15 @@ WebCore::HostingContext MediaPlayerPrivateMediaSourceAVFObjC::hostingContext() c
     return m_renderer->hostingContext();
 }
 
+void MediaPlayerPrivateMediaSourceAVFObjC::requestHostingContext(LayerHostingContextCallback&& completionHandler)
+{
+    m_renderer->requestHostingContext([completionHandler = WTF::move(completionHandler)](WebCore::HostingContext hostingContext) mutable {
+        ensureOnMainThread([completionHandler = WTF::move(completionHandler), hostingContext = WTF::move(hostingContext)]() mutable {
+            completionHandler(WTF::move(hostingContext));
+        });
+    });
+}
+
 void MediaPlayerPrivateMediaSourceAVFObjC::setVideoLayerSizeFenced(const WebCore::FloatSize& size, WTF::MachSendRightAnnotated&& sendRightAnnotated)
 {
     m_renderer->setVideoLayerSizeFenced(size, WTF::move(sendRightAnnotated));

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
@@ -293,6 +293,7 @@ private:
 
     // Remote layer support
     WebCore::HostingContext hostingContext() const final;
+    void requestHostingContext(LayerHostingContextCallback&&) final;
     void setVideoLayerSizeFenced(const WebCore::FloatSize&, WTF::MachSendRightAnnotated&&) final;
     std::optional<MediaPlayerIdentifier> identifier() const final { return m_playerIdentifier; }
 

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -1953,6 +1953,15 @@ WebCore::HostingContext MediaPlayerPrivateWebM::hostingContext() const
     return m_renderer->hostingContext();
 }
 
+void MediaPlayerPrivateWebM::requestHostingContext(LayerHostingContextCallback&& completionHandler)
+{
+    m_renderer->requestHostingContext([completionHandler = WTF::move(completionHandler)](WebCore::HostingContext hostingContext) mutable {
+        ensureOnMainThread([completionHandler = WTF::move(completionHandler), hostingContext = WTF::move(hostingContext)]() mutable {
+            completionHandler(WTF::move(hostingContext));
+        });
+    });
+}
+
 void MediaPlayerPrivateWebM::setVideoLayerSizeFenced(const WebCore::FloatSize& size, WTF::MachSendRightAnnotated&& sendRightAnnotated)
 {
     assertIsMainThread();


### PR DESCRIPTION
#### 56441d3640475ce4cceb7f56e6a283f71dc2fef2
<pre>
[Netflix.com] Unable to PiP video after navigating to another episode
<a href="https://bugs.webkit.org/show_bug.cgi?id=318964">https://bugs.webkit.org/show_bug.cgi?id=318964</a>
<a href="https://rdar.apple.com/181092025">rdar://181092025</a>

Reviewed by Jer Noble.

Only the synchronous hostingContext() API was implemented by both MediaPlayerPrivateMediaSourceAVFObjC
and MediaPlayerPrivateWebM, the asynchronous requestHostingContext didn&apos;t and
was always returning a null contextID which caused the entering PiP path to exit early.

Manually verified.

An automated regression test isn&apos;t achievable at this point due to the testing
infrastucture limitation: iPad simulator only and only having the Mock PresentationManager.

* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::requestHostingContext):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::requestHostingContext):

Canonical link: <a href="https://commits.webkit.org/316876@main">https://commits.webkit.org/316876@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/51d0ba9b26c49281713b9b7b0cb0fe5b4b5b024d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173523 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47456 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41232 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183096 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/131391 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/70906d22-98b5-413f-8207-ab0acaabfb92) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175388 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48748 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47138 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134933 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/131391 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7e1b90cd-e246-461b-a2b2-6ff2372aac4e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176481 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38362 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155758 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115410 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fb453ea2-983b-4dfd-953b-5a863d8a60de) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37003 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35356 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31581 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147427 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35252 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185522 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38505 "Found 896 new failures in b3/B3Value.h, b3/testb3_7.cpp, WebProcess/Network/WebResourceLoader.cpp, UIProcess/WebProcessPool.cpp, Shared/Cocoa/WKNSArray.mm, Shared/SessionState.cpp, NetworkProcess/NetworkResourceLoadParameters.cpp, WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm, WebProcess/WebPage/WebPage.cpp, testing/LegacyMockCDM.cpp ...") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39556 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143811 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47123 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143669 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38792 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47802 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112965 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38600 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119666 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46308 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10205 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45710 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45941 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45767 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->