### PR TITLE
MediaFragmentURIParser silently accepts overflowing NPT hours value instead of rejecting the fragment

### DIFF
--- a/LayoutTests/media/media-fragments/TC0096-expected.txt
+++ b/LayoutTests/media/media-fragments/TC0096-expected.txt
@@ -1,0 +1,9 @@
+
+
+Title: TC0096
+Fragment: 't=99999999999:00:05'
+Comment: The npt-hh value overflows the integer range. UA knows that this is an invalid media fragment, so it will play the entire media resource.
+EVENT(canplaythrough)
+EXPECTED (video.currentTime == '0') OK
+END OF TEST
+

--- a/LayoutTests/media/media-fragments/TC0096.html
+++ b/LayoutTests/media/media-fragments/TC0096.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <script src=../media-file.js></script>
+        <script src=../video-test.js></script>
+        <script src=media-fragments.js></script>
+    </head>
+    <body onload="start()">
+</html>

--- a/LayoutTests/media/media-fragments/TC0097-expected.txt
+++ b/LayoutTests/media/media-fragments/TC0097-expected.txt
@@ -1,0 +1,9 @@
+
+
+Title: TC0097
+Fragment: 't=99999999999'
+Comment: The npt-sec value overflows the integer range. UA knows that this is an invalid media fragment, so it will play the entire media resource.
+EVENT(canplaythrough)
+EXPECTED (video.currentTime == '0') OK
+END OF TEST
+

--- a/LayoutTests/media/media-fragments/TC0097.html
+++ b/LayoutTests/media/media-fragments/TC0097.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <script src=../media-file.js></script>
+        <script src=../video-test.js></script>
+        <script src=media-fragments.js></script>
+    </head>
+    <body onload="start()">
+</html>

--- a/LayoutTests/media/media-fragments/TC0098-expected.txt
+++ b/LayoutTests/media/media-fragments/TC0098-expected.txt
@@ -1,0 +1,9 @@
+
+
+Title: TC0098
+Fragment: 't=1000000:00:00'
+Comment: The npt-hh value, when multiplied by the number of seconds per hour, would overflow a 32-bit int. UA computes the seek time using floating point instead. The request lies beyond the end of the resource, so the UA seeks to the end of the media resource.
+EVENT(canplaythrough)
+EXPECTED (video.currentTime == 'duration') OK
+END OF TEST
+

--- a/LayoutTests/media/media-fragments/TC0098.html
+++ b/LayoutTests/media/media-fragments/TC0098.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <script src=../media-file.js></script>
+        <script src=../video-test.js></script>
+        <script src=media-fragments.js></script>
+    </head>
+    <body onload="start()">
+</html>

--- a/LayoutTests/media/media-fragments/media-fragments.js
+++ b/LayoutTests/media/media-fragments/media-fragments.js
@@ -73,7 +73,10 @@
         TC0092 : { start: null, end: null, valid: false, description: "Incorrect percent encoding", fragment: "t%3d10", comment: "UA knows that this is an invalid media fragment, so it will play the entire media resource."},
         TC0093 : { start: null, end: null, valid: false, description: "Incorrect percent encoding", fragment: "t=10%26", comment: "UA knows that this is an invalid media fragment, so it will play the entire media resource."},
         TC0094 : { start: null, end: null, valid: false, description: "Trailing comma", fragment: "t=3,7,", comment: "UA knows that this is an invalid media fragment, so it will play the entire media resource."},
-        TC0095 : { start: 3, end: 7, valid: true, description: "NPT HH:MM:SS format. Single digit npt-hh.", fragment: "t=0:00:03,0:00:07", comment: "The media is requested from a to b."}
+        TC0095 : { start: 3, end: 7, valid: true, description: "NPT HH:MM:SS format. Single digit npt-hh.", fragment: "t=0:00:03,0:00:07", comment: "The media is requested from a to b."},
+        TC0096 : { start: null, end: null, valid: false, description: "NPT hours overflow", fragment: "t=99999999999:00:05", comment: "The npt-hh value overflows the integer range. UA knows that this is an invalid media fragment, so it will play the entire media resource."},
+        TC0097 : { start: null, end: null, valid: false, description: "NPT seconds-only overflow", fragment: "t=99999999999", comment: "The npt-sec value overflows the integer range. UA knows that this is an invalid media fragment, so it will play the entire media resource."},
+        TC0098 : { start: "duration", end: null, valid: false, description: "NPT hours multiplication overflow", fragment: "t=1000000:00:00", comment: "The npt-hh value, when multiplied by the number of seconds per hour, would overflow a 32-bit int. UA computes the seek time using floating point instead. The request lies beyond the end of the resource, so the UA seeks to the end of the media resource."}
     };
 
     function pause()

--- a/Source/WebCore/html/MediaFragmentURIParser.cpp
+++ b/Source/WebCore/html/MediaFragmentURIParser.cpp
@@ -41,8 +41,6 @@
 
 namespace WebCore {
 
-constexpr int secondsPerHour = 3600;
-constexpr int secondsPerMinute = 60;
 constexpr unsigned nptIdentifierLength = 4; // "npt:"
 
 static String collectDigits(std::span<const Latin1Character> input, unsigned& position)
@@ -259,7 +257,10 @@ bool MediaFragmentURIParser::parseNPTTime(std::span<const Latin1Character> timeS
     // npt-ss        =   2DIGIT      ; 0-59
 
     String digits1 = collectDigits(timeString, offset);
-    int value1 = parseInteger<int>(digits1).value_or(0);
+    auto parsedValue1 = parseInteger<int>(digits1);
+    if (!parsedValue1)
+        return false;
+    int value1 = *parsedValue1;
     if (offset >= timeString.size() || timeString[offset] == ',') {
         time = MediaTime::createWithDouble(value1);
         return true;
@@ -317,7 +318,7 @@ bool MediaFragmentURIParser::parseNPTTime(std::span<const Latin1Character> timeS
         fraction = MediaTime::createWithDouble(collectFraction(timeString, offset).toDouble(isValid));
     }
     
-    time = MediaTime::createWithDouble((value1 * secondsPerHour) + (value2 * secondsPerMinute) + value3) + fraction;
+    time = MediaTime::createWithDouble(value1 * 3600.0 + value2 * 60.0 + value3) + fraction;
     return true;
 }
 


### PR DESCRIPTION
#### 31f8a026714a04aa36545ad1aaea0e237f403a09
<pre>
MediaFragmentURIParser silently accepts overflowing NPT hours value instead of rejecting the fragment
<a href="https://bugs.webkit.org/show_bug.cgi?id=318966">https://bugs.webkit.org/show_bug.cgi?id=318966</a>
<a href="https://rdar.apple.com/181820705">rdar://181820705</a>

Reviewed by Chris Dumez.

In parseNPTTime(), the NPT hours field (&quot;npt-hh = 1*DIGIT&quot;, any positive
number) was parsed with parseInteger&lt;int&gt;(digits1).value_or(0). When the
value exceeded the range of int, parseInteger returned nullopt and
value_or(0) silently coerced it to 0 hours, so a fragment such as
&quot;t=99999999999:00:05&quot; was accepted as a valid seek to 00:05 (5 seconds)
rather than being rejected. The same value1 is also used for plain
npt-sec fragments (e.g. &quot;t=99999999999&quot;), so that path was affected too.

Reject the fragment when the hours value fails to parse, consistent with
how the minutes and seconds fields are already validated.

Also fix a related integer overflow: the hours value was multiplied by
secondsPerHour (3600) using plain int arithmetic before being converted
to a double, so an in-range hours value like 1000000
(1000000 * 3600 = 3.6e9) could overflow INT_MAX and produce a wrong or
negative seek time via signed integer overflow. Compute the total in
double precision instead.

Tests: media/media-fragments/TC0096.html
       media/media-fragments/TC0097.html
       media/media-fragments/TC0098.html

* LayoutTests/media/media-fragments/TC0096-expected.txt: Added.
* LayoutTests/media/media-fragments/TC0096.html: Added.
* LayoutTests/media/media-fragments/TC0097-expected.txt: Added.
* LayoutTests/media/media-fragments/TC0097.html: Added.
* LayoutTests/media/media-fragments/TC0098-expected.txt: Added.
* LayoutTests/media/media-fragments/TC0098.html: Added.
* LayoutTests/media/media-fragments/media-fragments.js: Added TC0096,
TC0097, and TC0098, covering an out-of-range npt-hh value, an
out-of-range plain npt-sec value, and an in-range npt-hh value whose
multiplication by secondsPerHour would overflow a 32-bit int.

* Source/WebCore/html/MediaFragmentURIParser.cpp:
(WebCore::MediaFragmentURIParser::parseNPTTime): Return false when the
hours value overflows instead of defaulting it to 0. Compute the total
number of seconds using double arithmetic to avoid a signed-integer
overflow when multiplying the hours value by secondsPerHour. Removed
the now-unused secondsPerHour and secondsPerMinute constants.

Canonical link: <a href="https://commits.webkit.org/317869@main">https://commits.webkit.org/317869@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3cf9e05bd377b13c0bb658d6e78cc042ceb6a2cd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176565 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50500 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44290 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186166 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/139016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/499822ac-01eb-4ae2-ad30-12d4a990366a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178428 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51792 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50184 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137537 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/139016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0f0fd9da-7cad-4e8d-a319-30be0f1608d2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179521 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41029 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158315 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118012 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/485dd15a-7271-4bd2-a19d-6f0f2808aae0) 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/175888 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39679 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38048 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150094 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37813 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34634 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42234 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42277 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188589 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/175968 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50165 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/157860 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146592 "Found 1 new test failure: compositing/color-matching/image-color-matching.html (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39427 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50849 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146401 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41163 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123053 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117131 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49353 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12788 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48755 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48989 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48814 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->