### PR TITLE
corner-shape: Add square special case

### DIFF
--- a/Source/WebCore/platform/graphics/CornerShapeUtilities.cpp
+++ b/Source/WebCore/platform/graphics/CornerShapeUtilities.cpp
@@ -82,6 +82,7 @@ static bool isRound(const Corner& corner) { return corner.curvature == 1.0; }
 static bool isScoop(const Corner& corner) { return corner.curvature == -1.0; }
 static bool isBevel(const Corner& corner) { return corner.curvature == 0.0; }
 static bool isNotch(const Corner& corner) { return std::isinf(corner.curvature) && corner.curvature < 0.0; }
+static bool isSquare(const Corner& corner) { return std::isinf(corner.curvature) && corner.curvature > 0.0; }
 static bool isEmpty(const Corner& corner)
 {
     return (corner.outer - corner.start).diagonalLength() < limit
@@ -223,8 +224,10 @@ static Corner adjustCornerForInset(const Corner& original, double startInset, do
     if (isNotch(original)) {
         strokeA = -1;
         strokeB = 1;
+    } else if (isSquare(original)) {
+        strokeB = 1;
     }
-    // TODO: implement inset for squircle, square (§3.9.4.2 hull direction).
+    // TODO: implement inset for squircle (§3.9.4.2 hull direction).
 
     auto offset1 = (original.outer - original.start).directionScaledBy(float(startInset * strokeA));
     auto offset2 = (original.end - original.outer).directionScaledBy(float(startInset * strokeB));
@@ -288,6 +291,12 @@ static void addCurvedCorner(Path& path, const Corner& corner)
     if (isRound(corner)) {
         path.addLineTo(corner.start);
         addEllipticalArc(path, corner);
+        return;
+    }
+    if (isSquare(corner)) {
+        path.addLineTo(corner.start);
+        path.addLineTo(corner.outer);
+        path.addLineTo(corner.end);
         return;
     }
 


### PR DESCRIPTION
#### ceeeec9a56272c939dad65a4e6543cec456499fa
<pre>
corner-shape: Add square special case
<a href="https://bugs.webkit.org/show_bug.cgi?id=318968">https://bugs.webkit.org/show_bug.cgi?id=318968</a>
<a href="https://rdar.apple.com/181822940">rdar://181822940</a>

Reviewed by Simon Fraser.

Spec defines square as superellipse(inf) so to account for when not all
corners are square, corner-shape has square special cased to return a shape
for that corner

Tests written in another commit

* Source/WebCore/platform/graphics/CornerShapeUtilities.cpp:

Canonical link: <a href="https://commits.webkit.org/317046@main">https://commits.webkit.org/317046@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5657a2992f536d9594b7c0ab562516780e1888d4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173786 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47719 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41500 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183360 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131654 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175651 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49011 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47401 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135140 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95315 "3 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176744 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38572 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155935 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115618 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37213 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35579 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31844 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147637 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35428 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185786 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38833 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39778 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144029 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47386 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143888 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48065 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32044 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113331 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26477 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38816 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119946 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46571 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10383 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45973 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46204 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46032 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->