### PR TITLE
REGRESSION(316796@main): TestWebKitAPI fails to build: cannot convert value of type 'Span<UInt8>' to expected argument type 'RawSpan'

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewSwiftOverlayTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewSwiftOverlayTests.swift
@@ -48,7 +48,7 @@ struct WKWebViewSwiftOverlayTests {
     func wkUserContentControllerRefinements() async throws {
         let controller = WKUserContentController()
         let testData: [UInt8] = [0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x1A, 0x00, 0x00]
-        controller.addBuffer(testData.span, name: "Test", to: WKContentWorld.defaultClient)
+        controller.addBuffer(unsafe testData.span.bytes, name: "Test", to: WKContentWorld.defaultClient)
         controller.removeBuffer(named:"Test", from: WKContentWorld.defaultClient)
     }
 #endif // #if compiler(>=6.4)


### PR DESCRIPTION
#### 9d32cae5b85410c5ba680c984be3e34148f20a52
<pre>
REGRESSION(<a href="https://commits.webkit.org/316796@main">316796@main</a>): TestWebKitAPI fails to build: cannot convert value of type &apos;Span&lt;UInt8&gt;&apos; to expected argument type &apos;RawSpan&apos;
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=318974">https://bugs.webkit.org/show_bug.cgi?id=318974</a>&gt;
&lt;<a href="https://rdar.apple.com/181828656">rdar://181828656</a>&gt;

Unreviewed build fix.

<a href="https://commits.webkit.org/316796@main">316796@main</a> changed the addBuffer(_:name:to:) Swift overlay to take a
RawSpan, but the accompanying test still passes Array&lt;UInt8&gt;.span, which
is a Span&lt;UInt8&gt;.  The test body is guarded by #if compiler(&gt;=6.4).
Older local toolchains skip the block, so the mismatch reached main and
now breaks internal builds that use a Swift 6.4 or newer toolchain.

Convert the buffer to a RawSpan via Span.bytes.  Span.bytes is @unsafe
under -strict-memory-safety, so mark the argument with the unsafe
keyword, matching the existing idiom in USDModel+Deformation.swift and
the API&apos;s own contract that a client-supplied buffer&apos;s safety cannot be
guaranteed.

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewSwiftOverlayTests.swift:
(WKWebViewSwiftOverlayTests.wkUserContentControllerRefinements):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d32cae5b85410c5ba680c984be3e34148f20a52

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173546 "Failed to checkout and rebase branch from PR 69015") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47479 "Failed to checkout and rebase branch from PR 69015") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41086 "Failed to checkout and rebase branch from PR 69015") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183119 "Failed to checkout and rebase branch from PR 69015") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/131414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5b7028b9-28d4-4dc7-8792-555914395f9c) 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175411 "Failed to checkout and rebase branch from PR 69015") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48771 "Failed to checkout and rebase branch from PR 69015") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47161 "Failed to checkout and rebase branch from PR 69015") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/183119 "Failed to checkout and rebase branch from PR 69015") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/131414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e9f8f4bc-2944-4f87-954b-263c1db3fdd0) 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176504 "Failed to checkout and rebase branch from PR 69015") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/48771 "Failed to checkout and rebase branch from PR 69015") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/41086 "Failed to checkout and rebase branch from PR 69015") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/183119 "Failed to checkout and rebase branch from PR 69015") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f647842a-92a5-4d85-8e06-3fe5b45427d5) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/48771 "Failed to checkout and rebase branch from PR 69015") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/47161 "Failed to checkout and rebase branch from PR 69015") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31604 "Failed to checkout and rebase branch from PR 69015") | | 
| [❌ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/168/builds/41086 "Failed to checkout and rebase branch from PR 69015") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/48771 "Failed to checkout and rebase branch from PR 69015") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/41086 "Failed to checkout and rebase branch from PR 69015") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185545 "Failed to checkout and rebase branch from PR 69015") | | 
| | | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/47161 "Failed to checkout and rebase branch from PR 69015") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/185545 "Failed to checkout and rebase branch from PR 69015") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47146 "Failed to checkout and rebase branch from PR 69015") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/41086 "Failed to checkout and rebase branch from PR 69015") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/185545 "Failed to checkout and rebase branch from PR 69015") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47825 "Failed to checkout and rebase branch from PR 69015") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/41086 "Failed to checkout and rebase branch from PR 69015") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112990 "Failed to checkout and rebase branch from PR 69015") | | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/47825 "Failed to checkout and rebase branch from PR 69015") | | | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46331 "Failed to checkout and rebase branch from PR 69015") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/41086 "Failed to checkout and rebase branch from PR 69015") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45733 "Failed to checkout and rebase branch from PR 69015") | | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45964 "Failed to checkout and rebase branch from PR 69015") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45791 "Failed to checkout and rebase branch from PR 69015") | | | | 
<!--EWS-Status-Bubble-End-->