### PR TITLE
[webkitbot] Revert failed with error "Failed to create bug: Login attempts exhausted"

### DIFF
--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py
@@ -48,6 +48,7 @@ class Tracker(GenericTracker):
     ]
     NAME = 'Bugzilla'
     DEFAULT_TIMEOUT = 30
+    MAX_SUMMARY_LENGTH = 255
 
     # Security keywords to detect in title/description.
     # These trigger a prompt to use Security product.
@@ -538,9 +539,9 @@ class Tracker(GenericTracker):
                 )
             except RuntimeError as e:
                 sys.stderr.write('{}\n'.format(e))
-            if response and response.status_code // 100 == 4 and self._logins_left:
+            if response is not None and response.status_code // 100 == 4 and self._logins_left:
                 self._logins_left -= 1
-            if not response or response.status_code // 100 != 2:
+            if response is None or response.status_code // 100 != 2:
                 if assignee:
                     issue._assignee = None
                 if opened is not None:
@@ -576,9 +577,9 @@ class Tracker(GenericTracker):
         except RuntimeError as e:
             sys.stderr.write('{}\n'.format(e))
 
-        if response and response.status_code // 100 == 4 and self._logins_left:
+        if response is not None and response.status_code // 100 == 4 and self._logins_left:
             self._logins_left -= 1
-        if not response or response.status_code // 100 != 2:
+        if response is None or response.status_code // 100 != 2:
             sys.stderr.write("Failed to add comment to '{}'\n".format(issue))
             return None
 
@@ -623,9 +624,9 @@ class Tracker(GenericTracker):
             )
         except requests.exceptions.RequestException as e:
             sys.stderr.write('Request Error: {}\n'.format(e))
-        if response and response.status_code // 100 == 4 and self._logins_left:
+        if response is not None and response.status_code // 100 == 4 and self._logins_left:
             self._logins_left -= 1
-        if not response or response.status_code // 100 != 2:
+        if response is None or response.status_code // 100 != 2:
             sys.stderr.write("Failed to modify '{}'\n".format(issue))
             return None
 
@@ -737,6 +738,9 @@ class Tracker(GenericTracker):
             if keyword not in self.valid_keywords():
                 raise ValueError(f"'{keyword}' is not a valid keyword for '{project}'")
 
+        if len(title) > self.MAX_SUMMARY_LENGTH:
+            title = title[:self.MAX_SUMMARY_LENGTH - 3] + '...'
+
         params = dict(
             summary=title,
             description=description,
@@ -758,11 +762,11 @@ class Tracker(GenericTracker):
             )
         except RuntimeError as e:
             sys.stderr.write('{}\n'.format(e))
-        if response and response.status_code // 100 == 4 and self._logins_left:
+        if response is not None and response.status_code // 100 == 4 and self._logins_left:
             self._logins_left -= 1
-        if not response or response.status_code // 100 != 2:
+        if response is None or response.status_code // 100 != 2:
             sys.stderr.write("Failed to create bug: {}\n".format(
-                response.json().get('message', '?') if response else 'Login attempts exhausted'),
+                response.json().get('message', '?') if response is not None else 'Login attempts exhausted'),
             )
             return None
         return self.issue(response.json()['id'])
@@ -841,9 +845,9 @@ class Tracker(GenericTracker):
                 )
             except RuntimeError as e:
                 sys.stderr.write('{}\n'.format(e))
-            if response and response.status_code // 100 == 4 and self._logins_left:
+            if response is not None and response.status_code // 100 == 4 and self._logins_left:
                 self._logins_left -= 1
-            if not response or response.status_code // 100 != 2:
+            if response is None or response.status_code // 100 != 2:
                 sys.stderr.write("Failed to cc {} on '{}'\n".format(self.radar_importer.name, issue))
             elif radar and isinstance(radar.tracker, RadarTracker):
                 if comment_to_make:

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/bugzilla.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/bugzilla.py
@@ -427,6 +427,17 @@ class Bugzilla(Base, mocks.Requests):
                 url=url,
             )
 
+        if len(data['summary']) > 255:
+            return mocks.Response(
+                status_code=400,
+                text=json.dumps(dict(
+                    error=True,
+                    code=104,
+                    message='The text you entered in the Summary field is too long ({} characters, above the maximum length allowed of 255 characters).'.format(len(data['summary'])),
+                )),
+                url=url,
+            )
+
         id = 1
         while id in self.issues.keys():
             id += 1

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py
@@ -493,6 +493,37 @@ What component in 'WebKit' should the bug be associated with?:
                 )
             self.assertEqual(f"'InvalidKeyword' is not a valid keyword for 'WebKit'", str(e.exception))
 
+    def test_create_surfaces_server_error(self):
+        with mocks.Bugzilla(self.URL.split('://')[1], environment=wkmocks.Environment(
+                BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+                BUGS_EXAMPLE_COM_PASSWORD='password',
+        ), projects=mocks.PROJECTS, issues=mocks.ISSUES), patch.object(bugzilla.Tracker, 'MAX_SUMMARY_LENGTH', 1000):
+            with OutputCapture() as captured:
+                created = bugzilla.Tracker(self.URL).create(
+                    'A' * 300, 'Creating new bug',
+                    project='WebKit', component='Tables', version='Other',
+                )
+            self.assertIsNone(created)
+            self.assertEqual(
+                captured.stderr.getvalue(),
+                'Failed to create bug: The text you entered in the Summary field is too long (300 characters, above the maximum length allowed of 255 characters).\n',
+            )
+
+    def test_create_truncates_summary(self):
+        with mocks.Bugzilla(self.URL.split('://')[1], environment=wkmocks.Environment(
+                BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+                BUGS_EXAMPLE_COM_PASSWORD='password',
+        ), projects=mocks.PROJECTS, issues=mocks.ISSUES):
+            long_title = 'A' * 300
+            created = bugzilla.Tracker(self.URL).create(
+                long_title, 'Creating new bug',
+                project='WebKit', component='Tables', version='Other',
+            )
+            self.assertIsNotNone(created)
+            self.assertEqual(len(created.title), 255)
+            self.assertEqual(created.title, 'A' * 252 + '...')
+            self.assertEqual(created.description, 'Creating new bug')
+
     def test_set_component(self):
         with mocks.Bugzilla(self.URL.split('://')[1], environment=wkmocks.Environment(
                 BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',


### PR DESCRIPTION
#### 9a70448e1bbd9e55645755168287fdfa2d8384b3
<pre>
[webkitbot] Revert failed with error &quot;Failed to create bug: Login attempts exhausted&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=318965">https://bugs.webkit.org/show_bug.cgi?id=318965</a>
<a href="https://rdar.apple.com/problem/181820853">rdar://problem/181820853</a>

Reviewed by Aakash Jain.

When git-webkit revert creates its tracking bug, the --reason is used verbatim as the Bugzilla
summary. A reason longer than Bugzilla&apos;s 255-character summary results in a HTTP 400 response,
which Tracker.create() teated as the same as no response and printed a hard-coded &quot;Login
attempts exhausted&quot; fallback even though authentication had succeeded.

Distinguish &quot;no response&quot; from &quot;a response with an error status&quot; with more explicit checks,
and cap the summary at Bugzilla&apos;s limit so an over-length reason no longer fails. The full
reason is preserved in the bug description.

* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py:
(Tracker): Add MAX_SUMMARY_LENGTH.
(Tracker.cc_radar): Check &quot;response is None&quot; / &quot;response is not None&quot; so a 4xx response is
not mistaken for a missing response.
(Tracker.create): Ditto. Also surface the server&apos;s error message on failure, and truncate the
summary to MAX_SUMMARY_LENGTH.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/bugzilla.py:
(Bugzilla._create): Return Bugzilla&apos;s HTTP 400 for an over-length summary.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py:
(TestBugzilla.test_create_surfaces_server_error): Added.
(TestBugzilla.test_create_truncates_summary): Added.

Canonical link: <a href="https://commits.webkit.org/317356@main">https://commits.webkit.org/317356@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e710f42223cc6455fbffe5eefc555f912e96356a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173547 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47480 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/41207 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/183120 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/131415 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175412 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/48772 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47162 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/183120 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/131415 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176505 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/48772 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/155662 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/183120 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/172868 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/48772 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/35378 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/31605 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/48772 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/35157 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/185546 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/39578 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/185546 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47147 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/155219 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/185546 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47826 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/41207 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/112993 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26599 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/38622 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46332 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/10110 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/45734 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45965 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/45792 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->