### PR TITLE
Web Inspector: [Site Isolation] Show Paint Rects does not draw in cross-origin iframes

### DIFF
--- a/LayoutTests/http/tests/site-isolation/inspector/page/resources/paint-rects-frame.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/page/resources/paint-rects-frame.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<style>
+#target {
+    width: 100px;
+    height: 100px;
+    background-color: gainsboro;
+}
+</style>
+<p>Cross-origin frame for paint rects test.</p>
+<div id="target"></div>

--- a/LayoutTests/http/tests/site-isolation/inspector/page/set-show-paint-rects-cross-origin-iframe-disabled-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/page/set-show-paint-rects-cross-origin-iframe-disabled-expected.txt
@@ -1,0 +1,9 @@
+Test that Page.setShowPaintRects(false) produces no paint rects in cross-origin iframes under site isolation.
+
+
+
+== Running test suite: SiteIsolation.Page.SetShowPaintRectsCrossOriginIFrameDisabled
+-- Running test case: SiteIsolation.Page.SetShowPaintRects.Disabled
+Disabling paint rects...
+PASS: Cross-origin iframe should have no paint rects while disabled.
+

--- a/LayoutTests/http/tests/site-isolation/inspector/page/set-show-paint-rects-cross-origin-iframe-disabled.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/page/set-show-paint-rects-cross-origin-iframe-disabled.html
@@ -1,0 +1,52 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script src="../debugger/resources/site-isolation-debugger-test-utilities.js"></script>
+<script>
+function test() {
+    // Resolve the committed frame target for the static cross-origin iframe by its document URL.
+    // See set-show-paint-rects-cross-origin-iframe.html for why filtering WI.targets by
+    // document.location.href (via frameTargetForURLContaining) picks the live committed target.
+    async function crossOriginTarget() {
+        let target = await frameTargetForURLContaining("paint-rects-frame.html");
+        InspectorTest.assert(target instanceof WI.FrameTarget, "Should resolve a cross-origin FrameTarget.");
+        return target;
+    }
+
+    async function paintRectCountInTarget(target) {
+        let response = await target.RuntimeAgent.evaluate.invoke({expression: "window.internals.inspectorPaintRectCount()", objectGroup: "test", returnByValue: true});
+        return response.result.value;
+    }
+
+    async function triggerPaintInTarget(target) {
+        await target.RuntimeAgent.evaluate.invoke({expression: `document.getElementById("target").style.backgroundColor = "rebeccapurple"`, objectGroup: "test", returnByValue: true});
+    }
+
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.Page.SetShowPaintRectsCrossOriginIFrameDisabled");
+
+    suite.addTestCase({
+        name: "SiteIsolation.Page.SetShowPaintRects.Disabled",
+        description: "A paint in a cross-origin iframe should NOT produce paint rects while disabled.",
+        async test() {
+            let target = await crossOriginTarget();
+
+            // Paint rects are off by default; assert explicitly so the disabled case never depends on
+            // a prior enable case's fade timing (this is a standalone file with fresh state).
+            InspectorTest.log("Disabling paint rects...");
+            await PageAgent.setShowPaintRects(false);
+
+            await triggerPaintInTarget(target);
+
+            // Give the async fan-out + paint-rect path a chance to (incorrectly) fire before asserting.
+            await new Promise((resolve) => { setTimeout(resolve, 500); });
+            InspectorTest.expectEqual(await paintRectCountInTarget(target), 0, "Cross-origin iframe should have no paint rects while disabled.");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+<body onload="runTest()">
+<p>Test that Page.setShowPaintRects(false) produces no paint rects in cross-origin iframes under site isolation.</p>
+<iframe src="http://localhost:8000/site-isolation/inspector/page/resources/paint-rects-frame.html"></iframe>
+</body>

--- a/LayoutTests/http/tests/site-isolation/inspector/page/set-show-paint-rects-cross-origin-iframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/page/set-show-paint-rects-cross-origin-iframe-expected.txt
@@ -1,0 +1,9 @@
+Test that Page.setShowPaintRects produces paint rects in cross-origin iframes under site isolation.
+
+
+
+== Running test suite: SiteIsolation.Page.SetShowPaintRectsCrossOriginIFrame
+-- Running test case: SiteIsolation.Page.SetShowPaintRects.Enabled
+Enabling paint rects...
+PASS: Cross-origin iframe should have paint rects after painting while enabled.
+

--- a/LayoutTests/http/tests/site-isolation/inspector/page/set-show-paint-rects-cross-origin-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/page/set-show-paint-rects-cross-origin-iframe.html
@@ -1,0 +1,91 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script src="../debugger/resources/site-isolation-debugger-test-utilities.js"></script>
+<script>
+function test() {
+    // Resolve the committed frame target for the static cross-origin iframe by its document URL.
+    // The frame target from TargetManager.Event.TargetAdded is the child's initial about:blank
+    // target, hosted in the PARENT's process; when the cross-origin document commits in its own
+    // process that target is destroyed and replaced by a committed one, so evaluating on the
+    // TargetAdded target hangs after commit (its WebFrame is now remote, coreLocalFrame() is null,
+    // and messages are silently dropped). Filtering WI.targets by document.location.href picks the
+    // live committed target -- the proven idiom shared by the runtime/dom/css cross-origin frame
+    // tests (see frameTargetForURLContaining in site-isolation-debugger-test-utilities.js).
+    async function crossOriginTarget() {
+        let target = await frameTargetForURLContaining("paint-rects-frame.html");
+        InspectorTest.assert(target instanceof WI.FrameTarget, "Should resolve a cross-origin FrameTarget.");
+        return target;
+    }
+
+    // paintRectCount is read from the target's OWN process (internals ->
+    // PageInspectorController::paintRectCount -> WebInspectorBackendClient::paintRectCount),
+    // so a nonzero count in the cross-origin iframe target proves the subframe process drew
+    // paint rects locally -- the behavior that was a no-op before webkit.org/b/308899.
+    async function paintRectCountInTarget(target) {
+        let response = await target.RuntimeAgent.evaluate.invoke({expression: "window.internals.inspectorPaintRectCount()", objectGroup: "test", returnByValue: true});
+        return response.result.value;
+    }
+
+    // Alternate the color so each call is a real style change (setting the same value twice is a
+    // no-op and produces no repaint).
+    async function triggerPaintInTarget(target, iteration = 0) {
+        let color = (iteration % 2) ? "papayawhip" : "rebeccapurple";
+        await target.RuntimeAgent.evaluate.invoke({expression: `document.getElementById("target").style.backgroundColor = "${color}"`, objectGroup: "test", returnByValue: true});
+    }
+
+    // Poll: paint rects are created asynchronously after the style change repaints, and fade
+    // out after ~250ms, so we can't read the count synchronously. Re-trigger a paint each
+    // iteration: PageAgent.setShowPaintRects returning only means the main-frame process got the
+    // toggle; the fan-out to the cross-origin subframe process is a further async IPC hop, so an
+    // early single paint can land before m_showPaintRects is set and be silently dropped. Painting
+    // on every poll guarantees at least one paint happens after the toggle arrives. Transient
+    // protocol errors (the committed target still settling) are swallowed so they surface as a
+    // clean count==0 FAIL rather than an unhandled rejection that aborts the suite. Returns the
+    // first nonzero count observed, or 0 if none within the polling window.
+    async function pollForPaintRectCountInTarget(target) {
+        for (let i = 0; i < 50; ++i) {
+            try {
+                await triggerPaintInTarget(target, i);
+                let count = await paintRectCountInTarget(target);
+                if (count)
+                    return count;
+            } catch (e) {
+                if (e instanceof TypeError || e instanceof SyntaxError || e instanceof ReferenceError)
+                    throw e;
+            }
+            await new Promise((resolve) => { setTimeout(resolve, 20); });
+        }
+        return 0;
+    }
+
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.Page.SetShowPaintRectsCrossOriginIFrame");
+
+    suite.addTestCase({
+        name: "SiteIsolation.Page.SetShowPaintRects.Enabled",
+        description: "A paint in a cross-origin iframe should produce paint rects in the iframe's own process while enabled.",
+        async test() {
+            let target = await crossOriginTarget();
+
+            InspectorTest.log("Enabling paint rects...");
+            await PageAgent.setShowPaintRects(true);
+
+            let count = await pollForPaintRectCountInTarget(target);
+            InspectorTest.expectGreaterThan(count, 0, "Cross-origin iframe should have paint rects after painting while enabled.");
+
+            await PageAgent.setShowPaintRects(false);
+        }
+    });
+
+    // FIXME: This asserts paint rects are PRODUCED in the subframe process, not that they are
+    // POSITIONED correctly. A regression test for the coordinate space (rects must not drift by
+    // the frame's scroll offset) needs a pixel/geometry probe the current test harness does not
+    // expose from a cross-origin target. See webkit.org/b/308899.
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+<body onload="runTest()">
+<p>Test that Page.setShowPaintRects produces paint rects in cross-origin iframes under site isolation.</p>
+<iframe src="http://localhost:8000/site-isolation/inspector/page/resources/paint-rects-frame.html"></iframe>
+</body>

--- a/Source/WebCore/inspector/InspectorBackendClient.h
+++ b/Source/WebCore/inspector/InspectorBackendClient.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <WebCore/FrameIdentifier.h>
 #include <optional>
 #include <wtf/Forward.h>
 
@@ -67,6 +68,12 @@ public:
     virtual bool overridesShowPaintRects() const { return false; }
     virtual void setShowPaintRects(bool) { }
     virtual void showPaintRect(const FloatRect&) { }
+    // Frame-aware variant: draw the paint rect scoped to a specific local root frame (Site Isolation
+    // per-frame overlays). Defaults to the frame-less version for clients that don't distinguish frames.
+    virtual void showPaintRect(LocalFrame&, const FloatRect& rect) { showPaintRect(rect); }
+    // Tear down any per-frame paint-rect overlay owned by a local root frame that is going away, so
+    // it isn't retained past the frame's lifetime. No-op for clients without per-frame overlays.
+    virtual void willDestroyFrameOverlays(FrameIdentifier) { }
     virtual unsigned paintRectCount() const { return 0; }
     virtual void didSetSearchingForNode(bool) { }
     virtual void elementSelectionChanged(bool) { }

--- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -673,6 +673,11 @@ void InspectorInstrumentation::didPaintImpl(InstrumentingAgents& instrumentingAg
 
     if (CheckedPtr pageAgent = instrumentingAgents.enabledPageAgent())
         pageAgent->didPaint(renderer, rect);
+
+    // Under Site Isolation a cross-origin subframe process has no enabled InspectorPageAgent; its
+    // per-frame PageAgentProxy draws paint rects instead.
+    if (CheckedPtr pageProxy = instrumentingAgents.enabledPageProxy())
+        pageProxy->didPaint(renderer, rect);
 }
 
 void InspectorInstrumentation::willRecalculateStyleImpl(InstrumentingAgents& instrumentingAgents)

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -4555,6 +4555,21 @@ LocalFrame* Page::localMainFrame() const
     return dynamicDowncast<LocalFrame>(mainFrame());
 }
 
+LocalFrame* Page::localMainOrRootFrame() const
+{
+    if (auto* localMainFrame = this->localMainFrame())
+        return localMainFrame;
+
+    // Under Site Isolation the main frame can be remote in this process; fall back to the first
+    // live local root frame (normally exactly one per WebContent process for a given page).
+    for (auto& rootFrame : m_rootFrames) {
+        if (rootFrame->view())
+            return rootFrame.ptr();
+    }
+
+    return nullptr;
+}
+
 Document* Page::localTopDocument() const
 {
     if (auto* localMainFrame = this->localMainFrame())

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -429,6 +429,10 @@ public:
     WEBCORE_EXPORT bool hasAnyLocalFrame() const;
     WEBCORE_EXPORT Document* localTopDocument() const;
 
+    // localMainFrame() normally; under Site Isolation the main frame can be remote in this process,
+    // so falls back to the local root frame. Document overlays and their geometry are relative to it.
+    WEBCORE_EXPORT LocalFrame* NODELETE localMainOrRootFrame() const;
+
     Frame& mainFrame() const { return m_mainFrame.get(); }
     WEBCORE_EXPORT void setMainFrame(Ref<Frame>&&);
     WEBCORE_EXPORT const URL& NODELETE mainFrameURL() const LIFETIME_BOUND;

--- a/Source/WebCore/page/PageOverlay.cpp
+++ b/Source/WebCore/page/PageOverlay.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "PageOverlay.h"
 
+#include "DocumentView.h"
 #include "GraphicsContext.h"
 #include "LocalFrame.h"
 #include "LocalFrameView.h"
@@ -79,12 +80,34 @@ PageOverlayController* PageOverlay::controller() const
     return &m_page->pageOverlayController();
 }
 
+void PageOverlay::setAssociatedFrame(LocalFrame* frame)
+{
+    m_associatedFrame = frame;
+}
+
+LocalFrame* PageOverlay::associatedFrame() const
+{
+    return m_associatedFrame.get();
+}
+
+// The associated frame if set (per-frame overlays under Site Isolation); otherwise the local main
+// frame, preserving the legacy single-overlay geometry for page-level overlays.
+LocalFrame* PageOverlay::frameForGeometry() const
+{
+    if (LocalFrame* associatedFrame = m_associatedFrame.get())
+        return associatedFrame;
+    return protect(m_page)->localMainFrame();
+}
+
 IntRect PageOverlay::bounds() const
 {
     if (!m_overrideFrame.isEmpty())
         return { { }, m_overrideFrame.size() };
 
-    RefPtr frameView = protect(m_page->mainFrame())->virtualView();
+    // Scope to the associated frame under Site Isolation; the page's main frame can be a RemoteFrame
+    // whose view has no contents size, which would give empty bounds.
+    RefPtr localFrame = frameForGeometry();
+    RefPtr frameView = localFrame ? localFrame->view() : nullptr;
     if (!frameView)
         return IntRect();
 
@@ -135,7 +158,8 @@ IntSize PageOverlay::viewToOverlayOffset() const
         return IntSize();
 
     case OverlayType::Document: {
-        RefPtr frameView = protect(m_page->mainFrame())->virtualView();
+        RefPtr localFrame = frameForGeometry();
+        RefPtr frameView = localFrame ? localFrame->view() : nullptr;
         return frameView ? toIntSize(frameView->viewToContents(IntPoint())) : IntSize();
     }
     }
@@ -186,7 +210,8 @@ void PageOverlay::drawRect(GraphicsContext& graphicsContext, const IntRect& dirt
     GraphicsContextStateSaver stateSaver(graphicsContext);
 
     if (m_overlayType == PageOverlay::OverlayType::Document) {
-        if (RefPtr frameView = protect(m_page->mainFrame())->virtualView()) {
+        RefPtr localFrame = frameForGeometry();
+        if (RefPtr frameView = localFrame ? localFrame->view() : nullptr) {
             auto offset = frameView->scrollOrigin();
             graphicsContext.translate(toFloatSize(offset));
             paintRect.moveBy(-offset);
@@ -200,8 +225,11 @@ bool PageOverlay::mouseEvent(const PlatformMouseEvent& mouseEvent)
 {
     IntPoint mousePositionInOverlayCoordinates(flooredIntPoint(mouseEvent.position()));
 
-    if (m_overlayType == PageOverlay::OverlayType::Document)
-        mousePositionInOverlayCoordinates = protect(protect(m_page->mainFrame())->virtualView())->windowToContents(mousePositionInOverlayCoordinates);
+    if (m_overlayType == PageOverlay::OverlayType::Document) {
+        RefPtr localFrame = frameForGeometry();
+        if (RefPtr frameView = localFrame ? localFrame->view() : nullptr)
+            mousePositionInOverlayCoordinates = frameView->windowToContents(mousePositionInOverlayCoordinates);
+    }
     mousePositionInOverlayCoordinates.moveBy(-frame().location());
 
     // Ignore events outside the bounds.

--- a/Source/WebCore/page/PageOverlay.h
+++ b/Source/WebCore/page/PageOverlay.h
@@ -85,6 +85,13 @@ public:
 
     void setPage(Page*);
     WEBCORE_EXPORT Page* NODELETE page() const;
+
+    // Scope a Document overlay to a specific local root frame: its geometry comes from that frame's
+    // view and it is hosted in that frame's own compositing tree, so sibling local roots in one
+    // process (Site Isolation) each get an independent overlay. Unset keeps the page-level behavior.
+    WEBCORE_EXPORT void setAssociatedFrame(LocalFrame*);
+    WEBCORE_EXPORT LocalFrame* NODELETE associatedFrame() const;
+
     WEBCORE_EXPORT void setNeedsDisplay(const IntRect& dirtyRect);
     WEBCORE_EXPORT void setNeedsDisplay();
 
@@ -132,8 +139,13 @@ private:
     void startFadeAnimation();
     void fadeAnimationTimerFired();
 
+    LocalFrame* frameForGeometry() const;
+
     PageOverlayClient& m_client;
     WeakPtr<Page> m_page;
+
+    // The local root frame this Document overlay is scoped to, if any (see setAssociatedFrame).
+    WeakPtr<LocalFrame> m_associatedFrame;
 
     Timer m_fadeAnimationTimer;
     WallTime m_fadeAnimationStartTime;

--- a/Source/WebCore/page/PageOverlayController.cpp
+++ b/Source/WebCore/page/PageOverlayController.cpp
@@ -80,8 +80,19 @@ void PageOverlayController::installedPageOverlaysChanged()
     else
         detachViewOverlayLayers();
 
-    if (RefPtr localMainFrame = m_page->localMainFrame()) {
-        if (RefPtr frameView = localMainFrame->view())
+    if (RefPtr localFrame = m_page->localMainOrRootFrame()) {
+        if (RefPtr frameView = localFrame->view())
+            frameView->setNeedsCompositingConfigurationUpdate();
+    }
+
+    // Frame-associated overlays are hosted in their own local root's compositing tree, which
+    // localMainOrRootFrame() above doesn't cover; schedule an update for each so its
+    // RenderLayerCompositor re-runs appendDocumentOverlayLayers and picks up its overlay container.
+    for (auto& overlay : m_pageOverlays) {
+        RefPtr associatedFrame = overlay->associatedFrame();
+        if (!associatedFrame)
+            continue;
+        if (RefPtr frameView = associatedFrame->view())
             frameView->setNeedsCompositingConfigurationUpdate();
     }
 
@@ -122,6 +133,25 @@ GraphicsLayer* PageOverlayController::documentOverlayRootLayer() const
     return m_documentOverlayRootLayer.get();
 }
 
+GraphicsLayer& PageOverlayController::documentOverlayRootLayerForFrame(LocalFrame* rootFrame)
+{
+    createRootLayersIfNeeded();
+
+    // Page-level overlays (and the nullptr/main-frame path) share m_documentOverlayRootLayer.
+    // Each associated local root gets its own container: a GraphicsLayer has a single parent, so a
+    // shared one would only appear under whichever root composited last.
+    RefPtr localMainFrame = m_page->localMainFrame();
+    if (!rootFrame || rootFrame == localMainFrame.get())
+        return *m_documentOverlayRootLayer;
+
+    auto& layer = m_frameDocumentOverlayRootLayers.ensure(*rootFrame, [&] {
+        Ref newLayer = GraphicsLayer::create(m_page->chrome().client().graphicsLayerFactory(), *this);
+        newLayer->setName(MAKE_STATIC_STRING_IMPL("Document overlay Container (frame)"));
+        return newLayer;
+    }).iterator->value;
+    return layer.get();
+}
+
 GraphicsLayer* PageOverlayController::viewOverlayRootLayer() const
 {
     return m_viewOverlayRootLayer.get();
@@ -138,9 +168,15 @@ static void updateOverlayGeometry(PageOverlay& overlay, GraphicsLayer& graphicsL
     graphicsLayer.setSize(overlayFrame.size());
 }
 
-GraphicsLayer& PageOverlayController::layerWithDocumentOverlays()
+// Return the document-overlay root layer hosted in `rootFrame`'s compositing tree, containing only
+// the overlays scoped to it. Associated overlays go under their frame's root; unassociated ones are
+// page-level and go under the main frame's root (rootFrame == nullptr also maps there).
+GraphicsLayer& PageOverlayController::layerWithDocumentOverlaysForFrame(LocalFrame* rootFrame)
 {
     createRootLayersIfNeeded();
+
+    RefPtr localMainFrame = m_page->localMainFrame();
+    Ref rootLayer = documentOverlayRootLayerForFrame(rootFrame);
 
     bool inWindow = m_page->isInWindow();
 
@@ -149,17 +185,32 @@ GraphicsLayer& PageOverlayController::layerWithDocumentOverlays()
         if (overlay->overlayType() != PageOverlay::OverlayType::Document)
             continue;
 
+        // An associated overlay belongs to its own frame; an unassociated one is page-level.
+        RefPtr overlayFrame = overlay->associatedFrame();
+        bool belongsToThisRoot = overlayFrame ? (overlayFrame.get() == rootFrame) : (rootFrame == localMainFrame.get());
+        if (!belongsToThisRoot)
+            continue;
+
         auto& layer = overlayAndLayer.value;
         GraphicsLayer::traverse(layer.get(), [inWindow](GraphicsLayer& layer) {
             layer.setIsInWindow(inWindow);
         });
         updateOverlayGeometry(overlay, layer.get());
-        
-        if (!layer->parent())
-            protect(documentOverlayRootLayer())->addChild(layer.copyRef());
+
+        if (layer->parent() != rootLayer.ptr())
+            rootLayer->addChild(layer.copyRef());
     }
 
-    return *m_documentOverlayRootLayer;
+    // documentOverlayRootLayerForFrame() returns a reference into a controller-owned member, so
+    // returning it directly (rather than through the Ref local, whose get() is LIFETIME_BOUND) is
+    // both lifetime-safe and free of -Wreturn-stack-address.
+    return documentOverlayRootLayerForFrame(rootFrame);
+}
+
+void PageOverlayController::willDestroyRootFrameOverlayContainer(LocalFrame& rootFrame)
+{
+    if (auto container = m_frameDocumentOverlayRootLayers.take(rootFrame))
+        container->removeFromParent();
 }
 
 GraphicsLayer& PageOverlayController::layerWithViewOverlays()
@@ -207,17 +258,25 @@ void PageOverlayController::installPageOverlay(PageOverlay& overlay, PageOverlay
     case PageOverlay::OverlayType::View:
         protect(viewOverlayRootLayer())->addChild(layer.get());
         break;
-    case PageOverlay::OverlayType::Document:
-        protect(documentOverlayRootLayer())->addChild(layer.get());
+    case PageOverlay::OverlayType::Document: {
+        // Parent under the root scoped to the overlay's associated frame (or the shared main-frame root).
+        RefPtr associatedFrame = overlay.associatedFrame();
+        Ref { documentOverlayRootLayerForFrame(associatedFrame.get()) }->addChild(layer.get());
         break;
+    }
     }
 
     m_overlayGraphicsLayers.set(overlay, layer.copyRef());
 
     overlay.setPage(protect(m_page).ptr());
 
-    if (RefPtr localMainFrame = m_page->localMainFrame()) {
-        if (RefPtr frameView = localMainFrame->view())
+    // Put the hosting frame in compositing mode so its RenderLayerCompositor picks up the overlay
+    // root: the associated frame for an associated overlay, else the local main-or-root frame.
+    RefPtr hostFrame = overlay.associatedFrame();
+    if (!hostFrame)
+        hostFrame = m_page->localMainOrRootFrame();
+    if (hostFrame) {
+        if (RefPtr frameView = hostFrame->view())
             frameView->enterCompositingMode();
     }
 

--- a/Source/WebCore/page/PageOverlayController.h
+++ b/Source/WebCore/page/PageOverlayController.h
@@ -49,8 +49,13 @@ public:
     bool NODELETE hasDocumentOverlays() const;
     bool NODELETE hasViewOverlays() const;
 
-    GraphicsLayer& layerWithDocumentOverlays();
+    GraphicsLayer& layerWithDocumentOverlaysForFrame(LocalFrame* rootFrame);
     GraphicsLayer& layerWithViewOverlays();
+
+    // Drop the per-frame document-overlay container created for `rootFrame` (see
+    // layerWithDocumentOverlaysForFrame) when that local root is going away, so it isn't retained
+    // for the page's lifetime. No-op for frames that never had one.
+    WEBCORE_EXPORT void willDestroyRootFrameOverlayContainer(LocalFrame&);
 
     const Vector<Ref<PageOverlay>>& pageOverlays() const LIFETIME_BOUND { return m_pageOverlays; }
 
@@ -84,6 +89,7 @@ private:
     void createRootLayersIfNeeded();
 
     WEBCORE_EXPORT GraphicsLayer* NODELETE documentOverlayRootLayer() const;
+    GraphicsLayer& documentOverlayRootLayerForFrame(LocalFrame* rootFrame);
 
     WEBCORE_EXPORT GraphicsLayer* NODELETE viewOverlayRootLayer() const;
 
@@ -105,6 +111,10 @@ private:
     WeakRef<Page> m_page;
     RefPtr<GraphicsLayer> m_documentOverlayRootLayer;
     RefPtr<GraphicsLayer> m_viewOverlayRootLayer;
+
+    // Per-local-root-frame document overlay root layers, for overlays scoped to a specific frame
+    // (see PageOverlay::setAssociatedFrame). The main frame keeps using m_documentOverlayRootLayer.
+    WeakHashMap<LocalFrame, Ref<GraphicsLayer>> m_frameDocumentOverlayRootLayers;
 
     WeakHashMap<PageOverlay, Ref<GraphicsLayer>> m_overlayGraphicsLayers;
     Vector<Ref<PageOverlay>> m_pageOverlays;

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -2050,7 +2050,9 @@ void RenderLayerCompositor::appendDocumentOverlayLayers(Vector<Ref<GraphicsLayer
     if (!page().pageOverlayController().hasDocumentOverlays())
         return;
 
-    Ref<GraphicsLayer> overlayHost = page().pageOverlayController().layerWithDocumentOverlays();
+    // Host the document-overlay root scoped to THIS root frame; under Site Isolation several local
+    // roots can share a process and each needs its own container (a GraphicsLayer has one parent).
+    Ref<GraphicsLayer> overlayHost = page().pageOverlayController().layerWithDocumentOverlaysForFrame(&m_renderView.frameView().frame());
     childList.append(WTF::move(overlayHost));
 }
 
@@ -5392,7 +5394,7 @@ void RenderLayerCompositor::updateRootLayerAttachment()
 
 void RenderLayerCompositor::rootLayerAttachmentChanged()
 {
-    // The document-relative page overlay layer (which is pinned to the main frame's layer tree)
+    // The document-relative page overlay layer (which is pinned to the root frame's layer tree)
     // is moved between different RenderLayerCompositors' layer trees, and needs to be
     // reattached whenever we swap in a new RenderLayerCompositor.
     if (m_rootLayerAttachment == RootLayerUnattached)
@@ -5404,10 +5406,14 @@ void RenderLayerCompositor::rootLayerAttachmentChanged()
     if (auto* backing = layer ? layer->backing() : nullptr)
         backing->updateDrawsContent();
 
-    if (!m_renderView.frameView().frame().isMainFrame())
+    // Host the document overlay in the root frame's layer tree. Under Site Isolation the main frame
+    // can be remote here, so the local root frame owns the compositing tree that reaches the screen
+    // (isRootFrameCompositor(), matching appendDocumentOverlayLayers()). Gating on isMainFrame() would
+    // orphan the overlay in a subframe process across a root-layer re-attach.
+    if (!isRootFrameCompositor())
         return;
 
-    Ref<GraphicsLayer> overlayHost = page().pageOverlayController().layerWithDocumentOverlays();
+    Ref<GraphicsLayer> overlayHost = page().pageOverlayController().layerWithDocumentOverlaysForFrame(&m_renderView.frameView().frame());
     RefPtr { m_rootContentsLayer }->addChild(WTF::move(overlayHost));
 }
 

--- a/Source/WebKit/UIProcess/Inspector/Agents/ProxyingPageAgent.cpp
+++ b/Source/WebKit/UIProcess/Inspector/Agents/ProxyingPageAgent.cpp
@@ -185,6 +185,12 @@ void ProxyingPageAgent::enableInstrumentationForProcess(WebProcessProxy& webProc
     });
     webProcess.addMessageReceiver(Messages::ProxyingPageAgent::messageReceiverName(), pageID, *this);
     webProcess.send(Messages::WebInspectorBackend::EnablePageInstrumentation { }, pageID);
+
+    // Replay the current toggle to this newly-registered process (a cross-origin navigation can
+    // spawn a new WebContent process after setShowPaintRects(true)). This choke point is passed
+    // exactly once per (process, page) registration, guarded above.
+    if (m_showPaintRects)
+        webProcess.send(Messages::WebInspectorBackend::SetShowPaintRects { true }, pageID);
 }
 
 void ProxyingPageAgent::disableInstrumentationForProcess(WebProcessProxy& webProcess, PageIdentifier pageID)
@@ -238,6 +244,10 @@ CommandResult<void> ProxyingPageAgent::disable()
 
     m_enabled = false;
     m_cachedFrameDocumentInfo.clear();
+
+    // Reset so a later frontend reconnect doesn't replay a stale "on" toggle via
+    // enableInstrumentationForProcess. The processes are torn down below, so no "off" send is needed.
+    m_showPaintRects = false;
 
     // Force-teardown: disable all processes unconditionally, bypassing the
     // refcount discipline in disableInstrumentationForProcess(). This is
@@ -661,7 +671,9 @@ void ProxyingPageAgent::searchInResources(const String& text, std::optional<bool
     }
 }
 
-// FIXME: <https://webkit.org/b/308899> Forward overlay state to all WebContent processes.
+// FIXME: <https://webkit.org/b/308899> Draw rulers in every WebContent process. Rulers render via
+// InspectorOverlay, which subframe processes don't have wired up, and need page-wide (cross-process)
+// geometry rather than the per-frame local drawing used for paint rects.
 #if !PLATFORM(IOS_FAMILY)
 CommandResult<void> ProxyingPageAgent::setShowRulers(bool)
 {
@@ -669,8 +681,18 @@ CommandResult<void> ProxyingPageAgent::setShowRulers(bool)
 }
 #endif
 
-CommandResult<void> ProxyingPageAgent::setShowPaintRects(bool)
+// Fan the paint-rects toggle out to every WebContent process and remember it so a process that
+// registers later (enableInstrumentationForProcess) gets it replayed. Each process draws in its own
+// frame's coordinate space; the compositor already positions each process's layer tree.
+CommandResult<void> ProxyingPageAgent::setShowPaintRects(bool show)
 {
+    m_showPaintRects = show;
+
+    Ref inspectedPage = m_inspectedPage.get();
+    inspectedPage->forEachWebContentProcess([&](auto& webProcess, auto pageID) {
+        webProcess.send(Messages::WebInspectorBackend::SetShowPaintRects { show }, pageID);
+    });
+
     return { };
 }
 

--- a/Source/WebKit/UIProcess/Inspector/Agents/ProxyingPageAgent.h
+++ b/Source/WebKit/UIProcess/Inspector/Agents/ProxyingPageAgent.h
@@ -123,6 +123,10 @@ private:
     bool m_enabled { false };
     HashMap<std::pair<WebCore::ProcessIdentifier, WebCore::PageIdentifier>, unsigned> m_instrumentedProcessPageCounts;
 
+    // Latest paint-rects toggle, fanned out to every WebContent process and replayed to any
+    // process that registers later (e.g. a cross-origin navigation spawns a new one).
+    bool m_showPaintRects { false };
+
     // Pin each instrumented WebProcessProxy alive while we hold an IPC message
     // receiver registration on it. Without this, the process can be destructed
     // before ~ProxyingPageAgent runs, leaving the receiver registered against a

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorBackendProxy.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorBackendProxy.cpp
@@ -58,6 +58,11 @@ void WebInspectorBackendProxy::timelineRecordingChanged(bool active)
     m_proxy->timelineRecordingChanged(active);
 }
 
+void WebInspectorBackendProxy::showPaintRectsChanged(bool show)
+{
+    protect(m_proxy)->showPaintRectsChanged(show);
+}
+
 void WebInspectorBackendProxy::setDeveloperPreferenceOverride(WebCore::InspectorBackendClient::DeveloperPreference developerPreference, std::optional<bool> overrideValue)
 {
     protect(m_proxy)->setDeveloperPreferenceOverride(developerPreference, overrideValue);

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorBackendProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorBackendProxy.h
@@ -57,6 +57,7 @@ public:
     void bringToFront();
     void elementSelectionChanged(bool);
     void NODELETE timelineRecordingChanged(bool);
+    void showPaintRectsChanged(bool);
     void setDeveloperPreferenceOverride(WebCore::InspectorBackendClient::DeveloperPreference, std::optional<bool>);
 
 #if ENABLE(INSPECTOR_NETWORK_THROTTLING)

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorBackendProxy.messages.in
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorBackendProxy.messages.in
@@ -31,6 +31,7 @@ messages -> WebInspectorBackendProxy {
     BringToFront()
     ElementSelectionChanged(bool active)
     TimelineRecordingChanged(bool active)
+    ShowPaintRectsChanged(bool show)
     SetDeveloperPreferenceOverride(enum:uint8_t WebCore::InspectorBackendClientDeveloperPreference developerPreference, std::optional<bool> overrideValue)
 #if ENABLE(INSPECTOR_NETWORK_THROTTLING)
     SetEmulatedConditions(std::optional<int64_t> bytesPerSecondLimit)

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.cpp
@@ -775,6 +775,14 @@ void WebInspectorUIProxy::timelineRecordingChanged(bool active)
     m_isProfilingPage = active;
 }
 
+void WebInspectorUIProxy::showPaintRectsChanged(bool show)
+{
+    // The main-frame process already drew its own paint rects; hand the toggle to the inspector
+    // controller so its ProxyingPageAgent fans it out to the cross-origin subframe processes.
+    if (RefPtr inspectedPage = m_inspectedPage.get())
+        inspectedPage->inspectorController().setShowPaintRects(show);
+}
+
 void WebInspectorUIProxy::setDeveloperPreferenceOverride(WebCore::InspectorBackendClient::DeveloperPreference developerPreference, std::optional<bool> overrideValue)
 {
     switch (developerPreference) {

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h
@@ -292,6 +292,7 @@ private:
     void setPageAndTextZoomFactors(double pageZoomFactor, double textZoomFactor);
     void elementSelectionChanged(bool);
     void NODELETE timelineRecordingChanged(bool);
+    void showPaintRectsChanged(bool);
 
     void setDeveloperPreferenceOverride(WebCore::InspectorBackendClient::DeveloperPreference, std::optional<bool>);
 #if ENABLE(INSPECTOR_NETWORK_THROTTLING)

--- a/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp
@@ -561,6 +561,12 @@ bool WebPageInspectorController::isPageInstrumentationEnabled() const
     return m_pageAgent && m_pageAgent->isEnabled();
 }
 
+void WebPageInspectorController::setShowPaintRects(bool show)
+{
+    if (RefPtr pageAgent = m_pageAgent)
+        std::ignore = pageAgent->setShowPaintRects(show);
+}
+
 void WebPageInspectorController::setEnabledBrowserAgent(InspectorBrowserAgent* agent)
 {
     if (m_enabledBrowserAgent == agent)

--- a/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.h
+++ b/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.h
@@ -100,6 +100,8 @@ public:
     bool isNetworkInstrumentationEnabled() const;
     bool isPageInstrumentationEnabled() const;
 
+    void setShowPaintRects(bool);
+
 private:
     WebPageAgentContext NODELETE webPageAgentContext();
     void createLazyAgents();

--- a/Source/WebKit/WebProcess/Inspector/PageAgentProxy.cpp
+++ b/Source/WebKit/WebProcess/Inspector/PageAgentProxy.cpp
@@ -37,17 +37,24 @@
 #include "WebProcess.h"
 #include <WebCore/Document.h>
 #include <WebCore/DocumentLoader.h>
+#include <WebCore/DocumentView.h>
 #include <WebCore/ElementInlines.h>
+#include <WebCore/FloatRect.h>
 #include <WebCore/FrameDestructionObserverInlines.h>
 #include <WebCore/FrameInlines.h>
 #include <WebCore/FrameLoader.h>
 #include <WebCore/FrameTree.h>
 #include <WebCore/HTMLFrameOwnerElement.h>
 #include <WebCore/HTMLNames.h>
+#include <WebCore/InspectorBackendClient.h>
 #include <WebCore/InspectorIdentifierRegistry.h>
+#include <WebCore/InstrumentingAgents.h>
+#include <WebCore/LayoutRect.h>
 #include <WebCore/LocalFrameInlines.h>
+#include <WebCore/LocalFrameView.h>
 #include <WebCore/Page.h>
 #include <WebCore/PageInspectorController.h>
+#include <WebCore/RenderObjectInlines.h>
 #include <WebCore/SecurityOrigin.h>
 #include <WebCore/SecurityOriginData.h>
 #include <wtf/Stopwatch.h>
@@ -205,8 +212,41 @@ void PageAgentProxy::didClearWindowObjectInWorld(LocalFrame&, DOMWrapperWorld&)
 {
 }
 
-void PageAgentProxy::didPaint(RenderObject&, const LayoutRect&)
+void PageAgentProxy::didPaint(RenderObject& renderer, const LayoutRect& rect)
 {
+    if (!m_showPaintRects)
+        return;
+
+    // The main-frame process has a real, enabled InspectorPageAgent that already drew this paint via
+    // the enabledPageAgent() branch in didPaintImpl; drawing again here would double-flash it. This
+    // proxy only draws where no real page agent is enabled -- the cross-origin subframe processes.
+    Ref agents = m_instrumentingAgents.get();
+    if (agents->enabledPageAgent())
+        return;
+
+    Ref inspectedPage = m_inspectedPage.get();
+    auto* client = inspectedPage->inspectorController().inspectorBackendClient();
+    if (!client)
+        return;
+
+    RefPtr view = renderer.document().view();
+    if (!view)
+        return;
+
+    // Draw in this frame's own contents coordinate space. The overlay's layer lives inside the
+    // scrolled-contents layer that the compositor already offsets by -scrollPosition, so passing
+    // contents coords applies that offset exactly once. Do NOT convert with contentsToRootView()
+    // (double-counts scroll) or remap through the main frame (it is a RemoteFrame here).
+    // FIXME: localToAbsoluteQuad is frame-local, so coords are in the painting frame's own space --
+    // correct only when that frame is its own local root. A same-site child frame nested inside a
+    // local root in the same process, or a local subframe reached through a remote ancestor, is
+    // drawn at the wrong offset. See webkit.org/b/308899.
+    LayoutRect absoluteRect = LayoutRect(renderer.localToAbsoluteQuad(FloatRect(rect)).boundingBox());
+
+    // Scope to this frame's local root: the overlay for that root is attached to its own compositing
+    // tree, so sibling local roots in one process each flash independently.
+    Ref rootFrame = view->frame().rootFrame();
+    client->showPaintRect(rootFrame.get(), snappedIntRect(absoluteRect));
 }
 
 void PageAgentProxy::didLayout()

--- a/Source/WebKit/WebProcess/Inspector/PageAgentProxy.h
+++ b/Source/WebKit/WebProcess/Inspector/PageAgentProxy.h
@@ -68,6 +68,8 @@ public:
     Inspector::CommandResult<void> enable() final;
     Inspector::CommandResult<void> disable() final;
 
+    void setShowPaintRects(bool show) { m_showPaintRects = show; }
+
     void domContentEventFired() final;
     void loadEventFired() final;
     void frameNavigated(WebCore::LocalFrame&) final;
@@ -89,6 +91,8 @@ public:
 private:
     WeakRef<WebCore::Page> m_inspectedPage;
     WeakRef<WebPage> m_page;
+
+    bool m_showPaintRects { false };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.cpp
@@ -270,6 +270,14 @@ void WebInspectorBackend::timelineRecordingChanged(bool active)
     protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebInspectorBackendProxy::TimelineRecordingChanged(active), m_page->identifier());
 }
 
+void WebInspectorBackend::showPaintRectsChanged(bool show)
+{
+    // Forward the main-frame process's paint-rects toggle to the UIProcess, which fans it out to the
+    // cross-origin subframe processes via ProxyingPageAgent (the frontend's Page domain only reaches
+    // this main-frame process).
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebInspectorBackendProxy::ShowPaintRectsChanged(show), m_page->identifier());
+}
+
 void WebInspectorBackend::setDeveloperPreferenceOverride(InspectorBackendClient::DeveloperPreference developerPreference, std::optional<bool> overrideValue)
 {
     protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebInspectorBackendProxy::SetDeveloperPreferenceOverride(developerPreference, overrideValue), m_page->identifier());
@@ -416,6 +424,13 @@ void WebInspectorBackend::removeInstrumentationForFrame(FrameIdentifier frameID)
 {
     m_frameNetworkAgentProxies.remove(frameID);
     m_framePageAgentProxies.remove(frameID);
+
+    // Tear down the frame's paint-rect overlay (if it owned one). The overlay is held by the page
+    // overlay controller, so it wouldn't be released just by the proxy above going away.
+    if (RefPtr corePage = m_page ? m_page->corePage() : nullptr) {
+        if (auto* client = corePage->inspectorController().inspectorBackendClient())
+            client->willDestroyFrameOverlays(frameID);
+    }
 }
 
 void WebInspectorBackend::getResponseBody(ResourceLoaderIdentifier resourceID, CompletionHandler<void(Expected<std::pair<String, bool>, String>&&)>&& completionHandler)
@@ -682,6 +697,11 @@ void WebInspectorBackend::ensurePageInstrumentationForFrame(LocalFrame& frame)
 
     auto proxy = makeUnique<PageAgentProxy>(webContext, *page);
     proxy->enable();
+
+    // Seed the just-created proxy with the current toggle: a frame can commit after
+    // setShowPaintRects(true) was fanned out, and would otherwise default to off.
+    proxy->setShowPaintRects(m_showPaintRects);
+
     m_framePageAgentProxies.add(frameID, WTF::move(proxy));
 }
 
@@ -715,8 +735,20 @@ void WebInspectorBackend::disablePageInstrumentation()
     // DisablePageInstrumentation IPC, not process teardown).
     m_framePageAgentProxies.clear();
     m_pageInstrumentationEnabled = false;
+
+    // Reset so a later re-enable seeds fresh proxies as off; the UIProcess ProxyingPageAgent also
+    // resets on disable().
+    m_showPaintRects = false;
 }
 
+void WebInspectorBackend::setShowPaintRects(bool show)
+{
+    // Remember it for frames that commit later (ensurePageInstrumentationForFrame), then drive every
+    // per-frame proxy this process hosts; each draws its frame's paint rects locally.
+    m_showPaintRects = show;
+    for (auto& proxy : m_framePageAgentProxies.values())
+        proxy->setShowPaintRects(show);
+}
 
 void WebInspectorBackend::getFrameResourceData(Vector<WebCore::FrameIdentifier>&& frameIDs, CompletionHandler<void(Vector<std::pair<WebCore::FrameIdentifier, Inspector::FrameResourceData>>&&)>&& completionHandler)
 {

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.h
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.h
@@ -93,6 +93,7 @@ public:
     void stopElementSelection();
     void elementSelectionChanged(bool);
     void timelineRecordingChanged(bool);
+    void showPaintRectsChanged(bool);
 
     void setDeveloperPreferenceOverride(WebCore::InspectorBackendClient::DeveloperPreference, std::optional<bool>);
 #if ENABLE(INSPECTOR_NETWORK_THROTTLING)
@@ -116,6 +117,9 @@ public:
     void searchInRequest(WebCore::ResourceLoaderIdentifier, const String& query, bool caseSensitive, bool isRegex, CompletionHandler<void(Vector<Inspector::SearchMatch>&&, String errorString)>&&);
     void searchInFrameResource(WebCore::FrameIdentifier, const String& url, const String& query, bool caseSensitive, bool isRegex, CompletionHandler<void(Vector<Inspector::SearchMatch>&&, String errorString)>&&);
     void searchInFramesAndRequests(Vector<WebCore::FrameIdentifier>&& frameIDs, const String& query, bool caseSensitive, bool isRegex, CompletionHandler<void(Vector<Inspector::SearchResult>&&)>&&);
+
+    // Fan the paint-rects toggle out to every per-frame PageAgentProxy this process hosts.
+    void setShowPaintRects(bool);
 
     // Set up / tear down every per-frame instrumentation agent for a frame. Callers
     // don't need to know which agents are frame-scoped; each helper no-ops unless its
@@ -164,6 +168,11 @@ private:
 
     HashMap<WebCore::FrameIdentifier, std::unique_ptr<PageAgentProxy>> m_framePageAgentProxies;
     bool m_pageInstrumentationEnabled { false };
+
+    // Latest paint-rects toggle for this process, remembered so a proxy created later by
+    // ensurePageInstrumentationForFrame starts in the correct state (the UIProcess replays state
+    // only on the first (process, page) registration).
+    bool m_showPaintRects { false };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.messages.in
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.messages.in
@@ -53,6 +53,11 @@ messages -> WebInspectorBackend {
     EnablePageInstrumentation()
     DisablePageInstrumentation()
 
+    # Fan out the "show paint rects" toggle. Under Site Isolation the Page domain is served by the
+    # UIProcess ProxyingPageAgent, so this never reaches the per-process InspectorPageAgent; each
+    # process instead draws in its own frame's coordinate space.
+    SetShowPaintRects(bool show)
+
     # Returns, for each requested frame that is local to this process, its committed document's
     # loaderId and cached subresources as typed data, for the UIProcess ProxyingPageAgent to build
     # Page.getResourceTree cross-process under Site Isolation. The proxy walks the frame tree and

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorBackendClient.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorBackendClient.cpp
@@ -51,18 +51,23 @@ using namespace WebCore;
 class RepaintIndicatorLayerClient final : public GraphicsLayerClient {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(RepaintIndicatorLayerClient);
 public:
-    RepaintIndicatorLayerClient(WebInspectorBackendClient& inspectorBackendClient)
+    RepaintIndicatorLayerClient(WebInspectorBackendClient& inspectorBackendClient, LocalFrame& frame)
         : m_inspectorBackendClient(inspectorBackendClient)
+        , m_frame(frame)
     {
     }
     virtual ~RepaintIndicatorLayerClient() = default;
 private:
     void notifyAnimationEnded(const GraphicsLayer* layer, const String&) override
     {
-        m_inspectorBackendClient.animationEndedForLayer(layer);
+        RefPtr frame = m_frame.get();
+        m_inspectorBackendClient.animationEndedForLayer(frame.get(), layer);
     }
 
     WebInspectorBackendClient& m_inspectorBackendClient;
+    // The local root frame whose bucket owns the animating layers. Weak: the frame can be torn down
+    // (cross-origin navigation) mid-fade, after which animationEndedForLayer() no-ops.
+    WeakPtr<LocalFrame> m_frame;
 };
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebInspectorBackendClient);
@@ -74,16 +79,26 @@ WebInspectorBackendClient::WebInspectorBackendClient(WebPage* page)
 
 WebInspectorBackendClient::~WebInspectorBackendClient()
 {
-    for (auto& layer : m_paintRectLayers)
-        layer->removeFromParent();
+    RefPtr page = m_page.get();
+    RefPtr corePage = page ? page->corePage() : nullptr;
 
-    m_paintRectLayers.clear();
+    // Tear down every per-frame bucket: detach its layers, uninstall its overlay (the controller
+    // holds the only Ref keeping it alive), and drop the controller's per-frame container. The page
+    // may already be gone, in which case the controller torn down with it.
+    for (auto entry : m_paintRectOverlays) {
+        Ref frame = entry.key;
+        auto& bucket = entry.value;
+        for (auto& layer : bucket.layers)
+            protect(layer)->removeFromParent();
+        bucket.layers.clear();
 
-    if (RefPtr paintRectOverlay = m_paintRectOverlay) {
-        RefPtr page = m_page.get();
-        if (page && page->corePage())
-            page->corePage()->pageOverlayController().uninstallPageOverlay(*paintRectOverlay, PageOverlay::FadeMode::Fade);
+        if (corePage) {
+            if (RefPtr overlay = bucket.overlay)
+                corePage->pageOverlayController().uninstallPageOverlay(*overlay, PageOverlay::FadeMode::DoNotFade);
+            corePage->pageOverlayController().willDestroyRootFrameOverlayContainer(frame.get());
+        }
     }
+    m_paintRectOverlays.clear();
 }
 
 void WebInspectorBackendClient::inspectedPageDestroyed()
@@ -186,7 +201,42 @@ void WebInspectorBackendClient::hideHighlight()
 #endif
 }
 
+auto WebInspectorBackendClient::ensurePaintRectOverlayForFrame(LocalFrame& frame) -> PaintRectOverlayForFrame&
+{
+    RefPtr page = m_page.get();
+    ASSERT(page && page->corePage());
+
+    auto& bucket = m_paintRectOverlays.ensure(frame, [&] {
+        PaintRectOverlayForFrame newBucket;
+        Ref overlay = PageOverlay::create(*this, PageOverlay::OverlayType::Document);
+        // Scope the overlay to this local root so the controller hosts it in that frame's own
+        // compositing tree; sibling local roots in one process each flash in the right place.
+        overlay->setAssociatedFrame(&frame);
+        newBucket.overlay = overlay.copyRef();
+        newBucket.layerClient = makeUnique<RepaintIndicatorLayerClient>(*this, frame);
+        page->corePage()->pageOverlayController().installPageOverlay(overlay, PageOverlay::FadeMode::DoNotFade);
+        return newBucket;
+    }).iterator->value;
+
+    return bucket;
+}
+
 void WebInspectorBackendClient::showPaintRect(const FloatRect& rect)
+{
+    // Frame-less entry point (single-process main-frame path): resolve this process's overlay-owning
+    // frame and delegate to the frame-aware path.
+    RefPtr page = m_page.get();
+    if (!page || !page->corePage())
+        return;
+
+    RefPtr frame = page->corePage()->localMainOrRootFrame();
+    if (!frame)
+        return;
+
+    showPaintRect(*frame, rect);
+}
+
+void WebInspectorBackendClient::showPaintRect(LocalFrame& frame, const FloatRect& rect)
 {
     RefPtr page = m_page.get();
     if (!page)
@@ -195,17 +245,12 @@ void WebInspectorBackendClient::showPaintRect(const FloatRect& rect)
     if (!page->corePage()->settings().acceleratedCompositingEnabled())
         return;
 
-    RefPtr paintRectOverlay = m_paintRectOverlay;
-    if (!paintRectOverlay) {
-        m_paintRectOverlay = PageOverlay::create(*this, PageOverlay::OverlayType::Document);
-        paintRectOverlay = m_paintRectOverlay.copyRef();
-        page->corePage()->pageOverlayController().installPageOverlay(*paintRectOverlay, PageOverlay::FadeMode::DoNotFade);
-    }
+    auto& bucket = ensurePaintRectOverlayForFrame(frame);
+    RefPtr paintRectOverlay = bucket.overlay;
+    if (!paintRectOverlay)
+        return;
 
-    if (!m_paintIndicatorLayerClient)
-        m_paintIndicatorLayerClient = makeUnique<RepaintIndicatorLayerClient>(*this);
-
-    Ref paintLayer = GraphicsLayer::create(protect(page->drawingArea())->graphicsLayerFactory(), *m_paintIndicatorLayerClient);
+    Ref paintLayer = GraphicsLayer::create(protect(page->drawingArea())->graphicsLayerFactory(), *bucket.layerClient);
 
     paintLayer->setName(MAKE_STATIC_STRING_IMPL("paint rect"));
     paintLayer->setAnchorPoint(FloatPoint3D());
@@ -224,17 +269,63 @@ void WebInspectorBackendClient::showPaintRect(const FloatRect& rect)
     paintLayer->addAnimation(fadeKeyframes, opacityAnimation.ptr(), "opacity"_s, 0);
 
     Ref rawLayer = paintLayer.get();
-    m_paintRectLayers.add(WTF::move(paintLayer));
+    bucket.layers.add(WTF::move(paintLayer));
 
     Ref overlayRootLayer = paintRectOverlay->layer();
     overlayRootLayer->addChild(rawLayer.get());
 }
 
-void WebInspectorBackendClient::animationEndedForLayer(const GraphicsLayer* layer)
+unsigned WebInspectorBackendClient::paintRectCount() const
 {
+    unsigned count = 0;
+    for (auto entry : m_paintRectOverlays)
+        count += entry.value.layers.size();
+    return count;
+}
+
+void WebInspectorBackendClient::animationEndedForLayer(LocalFrame* frame, const GraphicsLayer* layer)
+{
+    // The layer client that fired identifies the bucket directly. If the frame is gone (torn down
+    // mid-fade), its bucket was already uninstalled by willDestroyFrameOverlays -- nothing to do.
+    if (!frame)
+        return;
+
+    auto it = m_paintRectOverlays.find(*frame);
+    if (it == m_paintRectOverlays.end())
+        return;
+
     GraphicsLayer* nonConstLayer = const_cast<GraphicsLayer*>(layer);
     nonConstLayer->removeFromParent();
-    m_paintRectLayers.remove(*nonConstLayer);
+    it->value.layers.remove(*nonConstLayer);
+}
+
+void WebInspectorBackendClient::willDestroyFrameOverlays(WebCore::FrameIdentifier frameID)
+{
+    RefPtr page = m_page.get();
+    RefPtr corePage = page ? page->corePage() : nullptr;
+
+    // Buckets are keyed by local root frame; a detaching frame owns a bucket only if it is that root.
+    // Find it by identity, uninstall its overlay, detach its layers, and drop the controller's
+    // per-frame container so nothing is retained past the frame's lifetime.
+    m_paintRectOverlays.removeIf([frameID, corePage](auto& entry) {
+        Ref frame = entry.key;
+        if (frame->frameID() != frameID)
+            return false;
+
+        auto& bucket = entry.value;
+        for (auto& paintLayer : bucket.layers)
+            paintLayer->removeFromParent();
+        bucket.layers.clear();
+
+        if (corePage) {
+            if (RefPtr overlay = bucket.overlay) {
+                Ref protectedOverlay = overlay.releaseNonNull();
+                corePage->pageOverlayController().uninstallPageOverlay(protectedOverlay, PageOverlay::FadeMode::DoNotFade);
+            }
+            corePage->pageOverlayController().willDestroyRootFrameOverlayContainer(frame.get());
+        }
+        return true;
+    });
 }
 
 #if PLATFORM(IOS_FAMILY)
@@ -281,6 +372,26 @@ void WebInspectorBackendClient::timelineRecordingChanged(bool active)
 
     if (RefPtr inspector = page->inspector())
         inspector->timelineRecordingChanged(active);
+}
+
+void WebInspectorBackendClient::setShowPaintRects(bool show)
+{
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+
+    // Without Site Isolation this is the single-process path: the whole frame tree lives here, the
+    // real InspectorPageAgent already drives the flash via didPaint, and there are no other processes
+    // to fan out to. Leave that path untouched.
+    RefPtr corePage = page->corePage();
+    if (!corePage || !corePage->settings().siteIsolationEnabled())
+        return;
+
+    // Under Site Isolation cross-origin subframes run in their own processes, which the frontend's
+    // Page domain never reaches. Notify the UIProcess so its ProxyingPageAgent fans the toggle out to
+    // every WebContent process (see WebInspectorBackend::setShowPaintRects).
+    if (RefPtr inspector = page->inspector())
+        inspector->showPaintRectsChanged(show);
 }
 
 void WebInspectorBackendClient::setDeveloperPreferenceOverride(WebCore::InspectorBackendClient::DeveloperPreference developerPreference, std::optional<bool> overrideValue)

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorBackendClient.h
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorBackendClient.h
@@ -29,11 +29,13 @@
 #include <WebCore/PageOverlay.h>
 #include <wtf/HashSet.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/WeakHashMap.h>
 
 namespace WebCore {
 class GraphicsContext;
 class GraphicsLayer;
 class IntRect;
+class LocalFrame;
 class PageOverlay;
 }
 
@@ -72,8 +74,11 @@ private:
     void timelineRecordingChanged(bool) override;
 
     bool overridesShowPaintRects() const override { return true; }
+    void setShowPaintRects(bool) override;
     void showPaintRect(const WebCore::FloatRect&) override;
-    unsigned paintRectCount() const override { return m_paintRectLayers.size(); }
+    void showPaintRect(WebCore::LocalFrame&, const WebCore::FloatRect&) override;
+    void willDestroyFrameOverlays(WebCore::FrameIdentifier) override;
+    unsigned paintRectCount() const override;
 
     void setDeveloperPreferenceOverride(WebCore::InspectorBackendClient::DeveloperPreference, std::optional<bool>) final;
 #if ENABLE(INSPECTOR_NETWORK_THROTTLING)
@@ -86,14 +91,23 @@ private:
     void drawRect(WebCore::PageOverlay&, WebCore::GraphicsContext&, const WebCore::IntRect&) override;
     bool mouseEvent(WebCore::PageOverlay&, const WebCore::PlatformMouseEvent&) override;
 
-    void animationEndedForLayer(const WebCore::GraphicsLayer*);
+    // The frame identifying the owning bucket comes from the layer client that fired (each bucket
+    // has its own), so there is no scan over frames.
+    void animationEndedForLayer(WebCore::LocalFrame*, const WebCore::GraphicsLayer*);
 
     WeakPtr<WebPage> m_page;
     WeakPtr<WebCore::PageOverlay> m_highlightOverlay;
 
-    RefPtr<WebCore::PageOverlay> m_paintRectOverlay;
-    std::unique_ptr<RepaintIndicatorLayerClient> m_paintIndicatorLayerClient;
-    HashSet<Ref<WebCore::GraphicsLayer>> m_paintRectLayers;
+    // Paint-rect overlays are per local root frame: under Site Isolation one process can host several
+    // local roots, each with its own compositing tree, so each needs its own Document overlay.
+    struct PaintRectOverlayForFrame {
+        RefPtr<WebCore::PageOverlay> overlay;
+        std::unique_ptr<RepaintIndicatorLayerClient> layerClient;
+        HashSet<Ref<WebCore::GraphicsLayer>> layers;
+    };
+    PaintRectOverlayForFrame& ensurePaintRectOverlayForFrame(WebCore::LocalFrame&);
+
+    WeakHashMap<WebCore::LocalFrame, PaintRectOverlayForFrame> m_paintRectOverlays;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -604,6 +604,14 @@ void WebFrame::removeFromTree()
     if (RefPtr client = localFrameLoaderClient())
         client->removeStorageAccess();
 
+    // Instrumentation is added in createSubframe()/createProvisionalFrame() and normally removed in
+    // detachedFromParent2(). This removal path (a remote parent removing the frame ->
+    // frameWasRemovedInAnotherProcess -> removeFromTree) skips detachedFromParent2(), so tear the
+    // instrumentation (incl. the paint-rect overlay) down here too; removeInstrumentationForFrame() is
+    // idempotent, so the two removal paths never double-free.
+    if (RefPtr backend = webPage->inspector(WebPage::LazyCreationPolicy::UseExistingOnly))
+        backend->removeInstrumentationForFrame(frameID());
+
     if (RefPtr parent = coreFrame->tree().parent())
         parent->tree().removeChild(*coreFrame);
     coreFrame->disconnectView();


### PR DESCRIPTION
#### d8e1779cc82b74f6663e2014b4e499238c553694
<pre>
Web Inspector: [Site Isolation] Show Paint Rects does not draw in cross-origin iframes
<a href="https://bugs.webkit.org/show_bug.cgi?id=308899">https://bugs.webkit.org/show_bug.cgi?id=308899</a>
<a href="https://rdar.apple.com/171780810">rdar://171780810</a>

Reviewed by Qianlang Chen.

Under Site Isolation a cross-origin iframe runs in its own WebContent process,
which has no enabled InspectorPageAgent -- the frontend&apos;s Page domain only reaches
the main-frame process. So Page.setShowPaintRects enabled the overlay in the
main-frame process only, and paints in a cross-origin subframe drew nothing.

Fan the toggle out and draw locally per process:

- The main-frame process notifies the UIProcess (ShowPaintRectsChanged), whose
ProxyingPageAgent sends SetShowPaintRects to every WebContent process and
remembers the state to replay to any process that registers later (e.g. a
cross-origin navigation spawns a new one).

- Each process&apos;s WebInspectorBackend drives the flag on every per-frame
PageAgentProxy it hosts, and seeds proxies that commit later. The proxy&apos;s
didPaint draws in the frame&apos;s own contents coordinate space via the frame-aware
InspectorBackendClient::showPaintRect(LocalFrame&amp;, ...); it bails when an enabled
InspectorPageAgent is present (the main-frame process, which already drew) to
avoid a double-flash.

Draw a Document overlay per local root frame. One process can host several local
roots (same-site sibling cross-origin iframes), and a GraphicsLayer has a single
parent, so a shared overlay root would only appear under whichever frame
composited last. PageOverlay gains an associated frame; PageOverlayController
hosts each associated overlay in that frame&apos;s own compositing tree, and
RenderLayerCompositor gates the overlay host on isRootFrameCompositor() rather
than isMainFrame() so it is not orphaned across a root-layer re-attach. Overlay
geometry resolves from the process&apos;s local main-or-root frame, since the main
frame can be a RemoteFrame here.

Tear down a frame&apos;s overlay when it detaches. The overlay is held by
PageOverlayController, so it (and its per-frame container GraphicsLayer) would
otherwise outlive the frame and, once its associated-frame weak reference cleared,
be re-parented under the main frame&apos;s overlay root and draw stale layers.

Rulers (setShowRulers) are left unimplemented cross-process (they render via
InspectorOverlay, which subframe processes lack, and need page-wide geometry);
tracked as a follow-up. A local subframe nested under a local root, or reached
through a remote ancestor, is positioned by frame-local coordinates only and can
draw at the wrong offset; documented as a FIXME.

Test: http/tests/site-isolation/inspector/page/set-show-paint-rects-cross-origin-iframe.html

* LayoutTests/http/tests/site-isolation/inspector/page/resources/paint-rects-frame.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/page/set-show-paint-rects-cross-origin-iframe-disabled-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/page/set-show-paint-rects-cross-origin-iframe-disabled.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/page/set-show-paint-rects-cross-origin-iframe-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/page/set-show-paint-rects-cross-origin-iframe.html: Added.
* Source/WebCore/inspector/InspectorBackendClient.h:
(WebCore::InspectorBackendClient::showPaintRect):
(WebCore::InspectorBackendClient::willDestroyFrameOverlays):
* Source/WebCore/inspector/InspectorInstrumentation.cpp:
(WebCore::InspectorInstrumentation::didPaintImpl):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::localMainOrRootFrame const):
* Source/WebCore/page/Page.h:
* Source/WebCore/page/PageOverlay.cpp:
(WebCore::PageOverlay::setAssociatedFrame):
(WebCore::PageOverlay::associatedFrame const):
(WebCore::PageOverlay::frameForGeometry const):
(WebCore::PageOverlay::bounds const):
(WebCore::PageOverlay::viewToOverlayOffset const):
(WebCore::PageOverlay::drawRect):
(WebCore::PageOverlay::mouseEvent):
* Source/WebCore/page/PageOverlay.h:
* Source/WebCore/page/PageOverlayController.cpp:
(WebCore::PageOverlayController::installedPageOverlaysChanged):
(WebCore::PageOverlayController::documentOverlayRootLayerForFrame):
(WebCore::PageOverlayController::layerWithDocumentOverlaysForFrame):
(WebCore::PageOverlayController::willDestroyRootFrameOverlayContainer):
(WebCore::PageOverlayController::installPageOverlay):
(WebCore::PageOverlayController::layerWithDocumentOverlays): Deleted.
* Source/WebCore/page/PageOverlayController.h:
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::appendDocumentOverlayLayers):
(WebCore::RenderLayerCompositor::rootLayerAttachmentChanged):
* Source/WebKit/UIProcess/Inspector/Agents/ProxyingPageAgent.cpp:
(Inspector::ProxyingPageAgent::enableInstrumentationForProcess):
(Inspector::ProxyingPageAgent::disable):
(Inspector::ProxyingPageAgent::setShowPaintRects):
* Source/WebKit/UIProcess/Inspector/Agents/ProxyingPageAgent.h:
* Source/WebKit/UIProcess/Inspector/WebInspectorBackendProxy.cpp:
(WebKit::WebInspectorBackendProxy::showPaintRectsChanged):
* Source/WebKit/UIProcess/Inspector/WebInspectorBackendProxy.h:
* Source/WebKit/UIProcess/Inspector/WebInspectorBackendProxy.messages.in:
* Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.cpp:
(WebKit::WebInspectorUIProxy::showPaintRectsChanged):
* Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h:
* Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp:
(WebKit::WebPageInspectorController::setShowPaintRects):
* Source/WebKit/UIProcess/Inspector/WebPageInspectorController.h:
* Source/WebKit/WebProcess/Inspector/PageAgentProxy.cpp:
(WebKit::PageAgentProxy::didPaint):
* Source/WebKit/WebProcess/Inspector/PageAgentProxy.h:
(WebKit::PageAgentProxy::setShowPaintRects):
* Source/WebKit/WebProcess/Inspector/WebInspectorBackend.cpp:
(WebKit::WebInspectorBackend::showPaintRectsChanged):
(WebKit::WebInspectorBackend::removeInstrumentationForFrame):
(WebKit::WebInspectorBackend::ensurePageInstrumentationForFrame):
(WebKit::WebInspectorBackend::disablePageInstrumentation):
(WebKit::WebInspectorBackend::setShowPaintRects):
* Source/WebKit/WebProcess/Inspector/WebInspectorBackend.h:
* Source/WebKit/WebProcess/Inspector/WebInspectorBackend.messages.in:
* Source/WebKit/WebProcess/Inspector/WebInspectorBackendClient.cpp:
(WebKit::WebInspectorBackendClient::~WebInspectorBackendClient):
(WebKit::WebInspectorBackendClient::ensurePaintRectOverlayForFrame):
(WebKit::WebInspectorBackendClient::showPaintRect):
(WebKit::WebInspectorBackendClient::paintRectCount const):
(WebKit::WebInspectorBackendClient::animationEndedForLayer):
(WebKit::WebInspectorBackendClient::willDestroyFrameOverlays):
(WebKit::WebInspectorBackendClient::setShowPaintRects):
* Source/WebKit/WebProcess/Inspector/WebInspectorBackendClient.h:
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::removeFromTree):

Canonical link: <a href="https://commits.webkit.org/318947@main">https://commits.webkit.org/318947@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/663470745ca2ad0891e843ad593975552e5d9ded

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179165 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53104 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46899 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188996 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143474 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3433ffcb-3a76-420e-aa4d-ff1c5b3bdb5e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181028 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54397 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52814 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139717 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96765 "22 flakes 3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b4449ea0-1949-4c7a-8426-67d5ff91bcd9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182122 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43309 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160470 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120166 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/007e79e6-5125-4d4d-a255-8022e37e32c4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41980 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40323 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152380 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39974 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/302 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45710 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44569 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191214 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52774 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159987 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148953 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40085 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53454 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36600 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148699 "Found 1 new API test failure: TestWebKitUserContentManager:/webkit/WebKitWebView/new-with-user-content-manager (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43381 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125725 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120570 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51972 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14954 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51357 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51598 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51418 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->