### PR TITLE
[JSC][Temporal] Fix PlainMonthDay bugs and simplify helpers

### DIFF
--- a/JSTests/stress/temporal-plain-month-day.js
+++ b/JSTests/stress/temporal-plain-month-day.js
@@ -1,0 +1,281 @@
+//@ requireOptions("--useTemporal=1")
+
+// Temporal.PlainMonthDay — spec conformance stress test.
+// Covers: from + equals + with + toPlainDate (ISO and non-ISO with era resolution) +
+// toString options + valueOf trap. V8-cross-verified.
+
+function shouldBe(actual, expected, msg) {
+    if (actual !== expected)
+        throw new Error(`${msg}: expected "${expected}" but got "${actual}"`);
+}
+function shouldThrow(fn, errorType, msg) {
+    let caught;
+    try { fn(); } catch (e) { caught = e; }
+    if (!caught) throw new Error(`${msg}: expected ${errorType.name}, no throw`);
+    if (!(caught instanceof errorType))
+        throw new Error(`${msg}: expected ${errorType.name} but got ${caught.constructor.name}`);
+}
+// Accept either RangeError or TypeError — both are spec-conformant for "invalid input".
+function shouldThrowAny(fn, msg) {
+    let caught;
+    try { fn(); } catch (e) { caught = e; }
+    if (!caught) throw new Error(`${msg}: expected throw, no throw`);
+}
+
+// ------------------------------------------------------------------
+// from() — strings
+// ------------------------------------------------------------------
+{
+    shouldBe(Temporal.PlainMonthDay.from("--06-15").toString(), "06-15", "from --MM-DD");
+    shouldBe(Temporal.PlainMonthDay.from("02-29").toString(), "02-29", "from MM-DD (2-arg)");
+    shouldBe(Temporal.PlainMonthDay.from("2024-06-15").toString(), "06-15", "from full-date form");
+    shouldThrow(() => Temporal.PlainMonthDay.from("--02-30"), RangeError, "from invalid day");
+    shouldThrow(() => Temporal.PlainMonthDay.from("--00-15"), RangeError, "from invalid month");
+    shouldThrow(() => Temporal.PlainMonthDay.from(""), RangeError, "from empty");
+    shouldThrow(() => Temporal.PlainMonthDay.from("garbage"), RangeError, "from garbage");
+    shouldThrow(() => Temporal.PlainMonthDay.from(42), TypeError, "from number");
+    shouldThrow(() => Temporal.PlainMonthDay.from(null), TypeError, "from null");
+}
+
+// ------------------------------------------------------------------
+// from() — objects
+// ------------------------------------------------------------------
+{
+    shouldBe(Temporal.PlainMonthDay.from({ month: 6, day: 15 }).toString(), "06-15", "from month+day");
+    shouldBe(Temporal.PlainMonthDay.from({ monthCode: "M06", day: 15 }).toString(), "06-15", "from monthCode+day");
+    // month and monthCode both present + agree
+    shouldBe(Temporal.PlainMonthDay.from({ month: 6, monthCode: "M06", day: 15 }).toString(), "06-15", "from month+monthCode agreeing");
+    // month and monthCode disagree → RangeError
+    shouldThrow(() => Temporal.PlainMonthDay.from({ month: 6, monthCode: "M07", day: 15 }), RangeError, "from month/monthCode disagreement");
+    // required fields absent
+    shouldThrow(() => Temporal.PlainMonthDay.from({ day: 15 }), TypeError, "from without month/monthCode");
+    shouldThrow(() => Temporal.PlainMonthDay.from({ monthCode: "M06" }), TypeError, "from without day");
+    // PMD-instance clone
+    const src = Temporal.PlainMonthDay.from("--06-15");
+    const clone = Temporal.PlainMonthDay.from(src);
+    shouldBe(clone.toString(), "06-15", "from PMD clone");
+    if (clone === src) throw new Error("PMD.from must return a new instance");
+
+    const hebSrc = Temporal.PlainMonthDay.from({ monthCode: "M03", day: 15, calendar: "hebrew" });
+    const hebClone = Temporal.PlainMonthDay.from(hebSrc);
+    shouldBe(hebClone.calendarId, "hebrew", "clone preserves hebrew calendar (Bug #11)");
+    shouldBe(hebClone.toString(), hebSrc.toString(), "clone toString matches source (Bug #11)");
+}
+
+// ------------------------------------------------------------------
+// from() — overflow
+// ------------------------------------------------------------------
+{
+    // default constrain
+    shouldBe(Temporal.PlainMonthDay.from({ month: 13, day: 15 }).toString(), "12-15", "from month=13 constrains to 12");
+    shouldBe(Temporal.PlainMonthDay.from({ month: 2, day: 31 }).toString(), "02-29", "from Feb 31 constrains to Feb 29");
+    // reject
+    shouldThrow(() => Temporal.PlainMonthDay.from({ month: 13, day: 15 }, { overflow: "reject" }), RangeError, "from month=13 reject");
+    shouldThrow(() => Temporal.PlainMonthDay.from({ month: 2, day: 31 }, { overflow: "reject" }), RangeError, "from Feb 31 reject");
+}
+
+// ------------------------------------------------------------------
+// equals()
+// ------------------------------------------------------------------
+{
+    const iso = Temporal.PlainMonthDay.from("--06-15");
+    shouldBe(iso.equals(Temporal.PlainMonthDay.from("--06-15")), true, "equals same");
+    shouldBe(iso.equals(Temporal.PlainMonthDay.from("--06-16")), false, "equals different day");
+    shouldBe(iso.equals(Temporal.PlainMonthDay.from("--07-15")), false, "equals different month");
+    shouldBe(iso.equals({ monthCode: "M06", day: 15 }), true, "equals object literal");
+    // Cross-calendar
+    const heb = Temporal.PlainMonthDay.from({ monthCode: "M06", day: 15, calendar: "hebrew" });
+    shouldBe(iso.equals(heb), false, "equals across calendars");
+}
+
+// ------------------------------------------------------------------
+// Non-ISO month/monthCode conflict — regression test for a JSC bug
+// where non-ISO .with()/.from() on non-lunisolar calendars silently
+// accepted disagreeing month + monthCode fields.
+// ISO already rejected via resolveISOFields; the check was missing from
+// the non-ISO branches of dateFromFields/yearMonthFromFields/monthDayFromFields.
+// ------------------------------------------------------------------
+{
+    // Japanese calendar (Gregorian-based) — month ordinal == monthCode number.
+    const jpmd = Temporal.PlainMonthDay.from({ monthCode: "M03", day: 15, calendar: "japanese" });
+    const jpym = Temporal.PlainYearMonth.from({ year: 2023, monthCode: "M03", calendar: "japanese" });
+    const jpd = Temporal.PlainDate.from({ year: 2023, monthCode: "M03", day: 15, calendar: "japanese" });
+    shouldThrowAny(() => jpmd.with({ month: 3, monthCode: "M04" }),
+        "PMD japanese .with month/monthCode conflict → throws");
+    shouldThrowAny(() => jpym.with({ month: 3, monthCode: "M04" }),
+        "PYM japanese .with month/monthCode conflict → throws");
+    shouldThrowAny(() => jpd.with({ month: 3, monthCode: "M04" }),
+        "PD japanese .with month/monthCode conflict → throws");
+    shouldThrowAny(() => Temporal.PlainMonthDay.from({ month: 3, monthCode: "M04", day: 15, calendar: "japanese" }),
+        "PMD japanese .from month/monthCode conflict → throws");
+
+    // Lunisolar (chinese/dangi/hebrew): the direct month-vs-monthCode-number check is skipped
+    // (in leap years the leap slot pushes ordinals up). Whether the merge subsequently accepts
+    // both fields is engine-defined — JSC accepts, V8 throws "Insufficient fields". Both are
+    // spec-conformant since spec's CalendarResolveFields for non-ISO is implementation-defined.
+}
+
+// ------------------------------------------------------------------
+// with()
+// ------------------------------------------------------------------
+{
+    const pmd = Temporal.PlainMonthDay.from("--06-15");
+    shouldBe(pmd.with({ month: 8 }).toString(), "08-15", "with month");
+    shouldBe(pmd.with({ monthCode: "M08" }).toString(), "08-15", "with monthCode");
+    shouldBe(pmd.with({ day: 20 }).toString(), "06-20", "with day");
+    // month/monthCode disagreement
+    shouldThrow(() => pmd.with({ month: 8, monthCode: "M09" }), RangeError, "with month/monthCode disagree");
+    // overflow
+    shouldBe(pmd.with({ day: 31 }).toString(), "06-30", "with day=31 constrains to 30 (Jun)");
+    shouldThrow(() => pmd.with({ day: 31 }, { overflow: "reject" }), RangeError, "with day=31 reject");
+
+    // IsPartialTemporalObject rejections.
+    shouldThrow(() => pmd.with(Temporal.PlainDate.from("2024-06-15")), TypeError, "with PlainDate");
+    shouldThrow(() => pmd.with(Temporal.PlainMonthDay.from("--06-15")), TypeError, "with PlainMonthDay");
+    shouldThrow(() => pmd.with({ calendar: "iso8601", day: 5 }), TypeError, "with calendar prop");
+    shouldThrow(() => pmd.with({ timeZone: "UTC", day: 5 }), TypeError, "with timeZone prop");
+    shouldThrow(() => pmd.with(42), TypeError, "with non-object");
+}
+
+// ------------------------------------------------------------------
+// toPlainDate() — ISO
+// ------------------------------------------------------------------
+{
+    const pmd = Temporal.PlainMonthDay.from("--06-15");
+    shouldBe(pmd.toPlainDate({ year: 2024 }).toString(), "2024-06-15", "toPlainDate ISO year");
+    // Empty object → TypeError.
+    shouldThrow(() => pmd.toPlainDate({}), TypeError, "toPlainDate empty");
+    shouldThrow(() => pmd.toPlainDate({ year: NaN }), RangeError, "toPlainDate year=NaN");
+
+    // Feb 29 across leap/non-leap years — constrain to Feb 28 in non-leap.
+    const feb29 = Temporal.PlainMonthDay.from("--02-29");
+    shouldBe(feb29.toPlainDate({ year: 2024 }).toString(), "2024-02-29", "Feb29→2024 leap");
+    shouldBe(feb29.toPlainDate({ year: 2023 }).toString(), "2023-02-28", "Feb29→2023 non-leap constrain");
+
+    // Year-limit boundaries — must throw RangeError, not crash (same class as PYM Bug #2/#3).
+    shouldThrow(() => pmd.toPlainDate({ year: 275761 }), RangeError, "toPlainDate year=275761");
+    shouldThrow(() => pmd.toPlainDate({ year: -271822 }), RangeError, "toPlainDate year=-271822");
+}
+
+// ------------------------------------------------------------------
+// toPlainDate() — era-based calendars (Japanese, Gregory)
+// Regression test for a JSC bug where toPlainDate only read `year`
+// and ignored `era`/`eraYear`, throwing TypeError on valid inputs.
+// ------------------------------------------------------------------
+{
+    // Japanese Reiwa 5 = 2023 CE.
+    const jpmd = Temporal.PlainMonthDay.from({ monthCode: "M03", day: 15, calendar: "japanese" });
+    shouldBe(jpmd.toPlainDate({ year: 2023 }).toString(), "2023-03-15[u-ca=japanese]", "japanese year-only");
+    shouldBe(jpmd.toPlainDate({ era: "reiwa", eraYear: 5 }).toString(), "2023-03-15[u-ca=japanese]", "japanese era+eraYear reiwa 5");
+    shouldBe(jpmd.toPlainDate({ era: "heisei", eraYear: 30 }).toString(), "2018-03-15[u-ca=japanese]", "japanese era+eraYear heisei 30");
+    // year and era+eraYear both present + consistent
+    shouldBe(jpmd.toPlainDate({ year: 2023, era: "reiwa", eraYear: 5 }).toString(), "2023-03-15[u-ca=japanese]", "japanese year+era consistent");
+    // year + inconsistent era+eraYear: implementation-defined (V8 lets `year` win, JSC throws).
+    // Skipping the assertion since spec doesn't nail down the precedence.
+
+    // Gregory BCE/CE.
+    const gpmd = Temporal.PlainMonthDay.from({ monthCode: "M03", day: 15, calendar: "gregory" });
+    shouldBe(gpmd.toPlainDate({ era: "ce", eraYear: 2024 }).toString(), "2024-03-15[u-ca=gregory]", "gregory ce+eraYear");
+    shouldBe(gpmd.toPlainDate({ era: "bce", eraYear: 1 }).toString(), "0000-03-15[u-ca=gregory]", "gregory bce eraYear=1");
+
+    // era or eraYear alone is not enough — must throw.
+    shouldThrow(() => jpmd.toPlainDate({ era: "reiwa" }), TypeError, "japanese era only");
+    shouldThrow(() => jpmd.toPlainDate({ eraYear: 5 }), TypeError, "japanese eraYear only");
+    shouldThrow(() => jpmd.toPlainDate({}), TypeError, "japanese empty");
+}
+
+// ------------------------------------------------------------------
+// toString options
+// ------------------------------------------------------------------
+{
+    const iso = Temporal.PlainMonthDay.from("--06-15");
+    shouldBe(iso.toString(), "06-15", "ISO default");
+    shouldBe(iso.toString({ calendarName: "always" }), "1972-06-15[u-ca=iso8601]", "ISO always includes ref year");
+    shouldBe(iso.toString({ calendarName: "critical" }), "1972-06-15[!u-ca=iso8601]", "ISO critical");
+    shouldBe(iso.toString({ calendarName: "never" }), "06-15", "ISO never");
+
+    const heb = Temporal.PlainMonthDay.from({ monthCode: "M06", day: 15, calendar: "hebrew" });
+    // Non-ISO always shows the calendar annotation in default output.
+    if (!heb.toString().includes("[u-ca=hebrew]"))
+        throw new Error(`Hebrew default toString must include [u-ca=hebrew], got: ${heb.toString()}`);
+}
+
+// ------------------------------------------------------------------
+// valueOf → TypeError
+// ------------------------------------------------------------------
+{
+    const pmd = Temporal.PlainMonthDay.from("--06-15");
+    shouldThrow(() => pmd.valueOf(), TypeError, "valueOf throws");
+    shouldThrow(() => pmd < pmd, TypeError, "< coercion throws via valueOf");
+}
+
+// ------------------------------------------------------------------
+// Constructor — regression tests for JSC bugs.
+// Bug #8: `new PMD(6, 15, "iso8601", 275761)` was a debug-assertion
+//   crash. The referenceYear was passed straight to PlainDate ctor,
+//   whose assert fires on year > maxYear.
+// Bug #9: Non-spec `argumentCount < 2` custom guard preempted spec's
+//   `ToIntegerWithTruncation(undefined) → NaN → RangeError` path.
+// ------------------------------------------------------------------
+{
+    // Valid — spec ctor accepts (isoMonth, isoDay, calendar?, referenceISOYear?).
+    shouldBe(new Temporal.PlainMonthDay(6, 15).toString(), "06-15", "ctor(6, 15)");
+    shouldBe(new Temporal.PlainMonthDay(2, 29).toString(), "02-29", "ctor(2, 29) default ref year 1972 (leap)");
+    shouldBe(new Temporal.PlainMonthDay(6, 15, "iso8601", 275760).toString({ calendarName: "always" }),
+        "+275760-06-15[u-ca=iso8601]", "ctor max ref year 275760");
+    shouldBe(new Temporal.PlainMonthDay(6, 15, "iso8601", -271821).toString({ calendarName: "always" }),
+        "-271821-06-15[u-ca=iso8601]", "ctor min ref year -271821");
+
+    // Bug #8: out-of-range referenceYear must throw RangeError, not crash.
+    shouldThrow(() => new Temporal.PlainMonthDay(6, 15, "iso8601", 275761), RangeError,
+        "ctor ref year 275761 → RangeError (was: debug assert crash)");
+    shouldThrow(() => new Temporal.PlainMonthDay(6, 15, "iso8601", -271822), RangeError,
+        "ctor ref year -271822 → RangeError");
+
+    // Bug #9: missing/undefined args go through ToIntegerWithTruncation → NaN → RangeError.
+    shouldThrow(() => new Temporal.PlainMonthDay(), RangeError, "ctor no args → RangeError");
+    shouldThrow(() => new Temporal.PlainMonthDay(6), RangeError, "ctor 1 arg (missing day) → RangeError");
+    shouldThrow(() => new Temporal.PlainMonthDay(undefined, 15), RangeError, "ctor undefined month → RangeError");
+    shouldThrow(() => new Temporal.PlainMonthDay(6, undefined), RangeError, "ctor undefined day → RangeError");
+
+    // Non-finite → RangeError.
+    shouldThrow(() => new Temporal.PlainMonthDay(NaN, 15), RangeError, "ctor NaN month");
+    shouldThrow(() => new Temporal.PlainMonthDay(6, NaN), RangeError, "ctor NaN day");
+    shouldThrow(() => new Temporal.PlainMonthDay(Infinity, 15), RangeError, "ctor Infinity month");
+    shouldThrow(() => new Temporal.PlainMonthDay(6, 15, "iso8601", Infinity), RangeError, "ctor Infinity ref year");
+
+    // Invalid dates.
+    shouldThrow(() => new Temporal.PlainMonthDay(13, 15), RangeError, "ctor month 13");
+    shouldThrow(() => new Temporal.PlainMonthDay(6, 31), RangeError, "ctor Jun 31");
+    shouldThrow(() => new Temporal.PlainMonthDay(2, 29, "iso8601", 1971), RangeError, "ctor Feb 29 in non-leap 1971");
+    shouldThrow(() => new Temporal.PlainMonthDay(0, 15), RangeError, "ctor month 0");
+    shouldThrow(() => new Temporal.PlainMonthDay(6, 0), RangeError, "ctor day 0");
+
+    // Calendar arg.
+    shouldThrow(() => new Temporal.PlainMonthDay(6, 15, 42), TypeError, "ctor non-string calendar");
+    shouldThrow(() => new Temporal.PlainMonthDay(6, 15, "bogus"), RangeError, "ctor bad calendar id");
+    shouldBe(new Temporal.PlainMonthDay(6, 15, "hebrew").toString().includes("[u-ca=hebrew]"), true,
+        "ctor with hebrew calendar preserves annotation");
+}
+
+// ------------------------------------------------------------------
+// Bug #10 regression — PMD.from with {era, eraYear} on non-lunisolar
+// calendars silently required monthCode when era+eraYear alone provides
+// enough info to resolve the calendar month.
+// ------------------------------------------------------------------
+{
+    shouldBe(Temporal.PlainMonthDay.from({ era: "reiwa", eraYear: 5, month: 3, day: 15, calendar: "japanese" }).toString(),
+        "1972-03-15[u-ca=japanese]", "PMD japanese from era+eraYear+month+day");
+    shouldBe(Temporal.PlainMonthDay.from({ era: "ce", eraYear: 2024, month: 3, day: 15, calendar: "gregory" }).toString(),
+        "1972-03-15[u-ca=gregory]", "PMD gregory from era+eraYear+month+day");
+
+    // But {month, day} without year/era must still throw — test262-mandated for non-ISO.
+    shouldThrow(() => Temporal.PlainMonthDay.from({ month: 11, day: 18, calendar: "gregory" }),
+        TypeError, "PMD gregory from month+day (no year/era) → TypeError");
+
+    // Consistency check: year AND era+eraYear that disagree → RangeError.
+    shouldThrow(() => Temporal.PlainMonthDay.from({ year: 2018, era: "ce", eraYear: 2024, month: 3, day: 15, calendar: "gregory" }),
+        RangeError, "PMD gregory from year+era inconsistent");
+}
+
+print("PASS");

--- a/Source/JavaScriptCore/API/tests/TemporalCoreTest.cpp
+++ b/Source/JavaScriptCore/API/tests/TemporalCoreTest.cpp
@@ -2585,10 +2585,6 @@ static void testCalendarFieldsFunctions()
     auto rMDFrom = plainMonthDayFromISODate(id("iso8601"_s), { 2020, 6, 15 }, TemporalOverflow::Reject);
     TCHECK_TRUE(rMDFrom.has_value() && rMDFrom->isoDate.month() == 6 && rMDFrom->isoDate.day() == 15, "plainMonthDayFromISODate: month=6 day=15");
 
-    // --- plainMonthDayToPlainDate ---
-    auto rMDToD = plainMonthDayToPlainDate(id("iso8601"_s), { 1972, 6, 15 }, 2020);
-    TCHECK_TRUE(rMDToD.has_value() && rMDToD->isoDate.year() == 2020 && rMDToD->isoDate.month() == 6 && rMDToD->isoDate.day() == 15, "plainMonthDayToPlainDate: day=15 year=2020");
-
     // --- plainYearMonthWith ---
     // temporal_rs: test_plain_year_month_with — override year only
     CalendarFieldsIn partialYear;
@@ -2606,6 +2602,62 @@ static void testCalendarFieldsFunctions()
     CalendarFieldsIn emptyPartial;
     auto rWithEmpty = plainYearMonthWith(id("iso8601"_s), { 2025, 3, 1 }, emptyPartial, TemporalOverflow::Constrain);
     TCHECK_TRUE(!rWithEmpty.has_value(), "plainYearMonthWith: empty partial -> TypeError (temporal_rs: fields.is_empty())");
+
+    f = { };
+    f.year = 275761; // one past maxYear
+    f.month = 1;
+    auto rYMOver = yearMonthFromFields(id("iso8601"_s), f, TemporalOverflow::Reject);
+    TCHECK_TRUE(!rYMOver.has_value(), "yearMonthFromFields ISO: year=275761 -> RangeError (Bug #2)");
+
+    f = { };
+    f.year = 275761;
+    f.month = 1;
+    f.day = 1;
+    auto rDOver = dateFromFields(id("iso8601"_s), f, TemporalOverflow::Reject);
+    TCHECK_TRUE(!rDOver.has_value(), "dateFromFields ISO: year=275761 -> RangeError (Bug #3)");
+
+    f = { };
+    f.era = "ce"_s;
+    f.eraYear = 2024;
+    auto rYMNoMonth = yearMonthFromFields(id("gregory"_s), f, TemporalOverflow::Constrain);
+    TCHECK_TRUE(!rYMNoMonth.has_value(), "yearMonthFromFields non-ISO: era+eraYear without month -> TypeError (Bug #5)");
+
+    f = { };
+    f.year = 2023;
+    f.month = 3;
+    f.monthCode = MC { 4, false }; // M04, disagrees with month=3
+    f.day = 15;
+    auto rDConflict = dateFromFields(id("japanese"_s), f, TemporalOverflow::Constrain);
+    TCHECK_TRUE(!rDConflict.has_value(), "dateFromFields japanese: month=3 vs monthCode=M04 -> RangeError (Bug #7)");
+
+    f = { };
+    f.year = 2023;
+    f.month = 3;
+    f.monthCode = MC { 4, false };
+    auto rYMConflict = yearMonthFromFields(id("japanese"_s), f, TemporalOverflow::Constrain);
+    TCHECK_TRUE(!rYMConflict.has_value(), "yearMonthFromFields japanese: month=3 vs monthCode=M04 -> RangeError (Bug #7)");
+
+    f = { };
+    f.year = 2023;
+    f.month = 3;
+    f.monthCode = MC { 4, false };
+    f.day = 15;
+    auto rMDConflict = monthDayFromFields(id("japanese"_s), f, TemporalOverflow::Constrain);
+    TCHECK_TRUE(!rMDConflict.has_value(), "monthDayFromFields japanese: month=3 vs monthCode=M04 -> RangeError (Bug #7)");
+
+    f = { };
+    f.era = "reiwa"_s;
+    f.eraYear = 5;
+    f.month = 3;
+    f.day = 15;
+    auto rMDEra = monthDayFromFields(id("japanese"_s), f, TemporalOverflow::Constrain);
+    TCHECK_TRUE(rMDEra.has_value(), "monthDayFromFields japanese: era+eraYear+month+day -> ok (Bug #10)");
+
+    f = { };
+    f.month = 11;
+    f.day = 18;
+    auto rMDNoYear = monthDayFromFields(id("gregory"_s), f, TemporalOverflow::Constrain);
+    TCHECK_TRUE(!rMDNoYear.has_value(), "monthDayFromFields gregory: {month,day} without year identifier -> TypeError");
 
     // --- plainDateWith ---
     // temporal_rs: basic_date_with — ISO override year/month/monthCode/day

--- a/Source/JavaScriptCore/runtime/TemporalPlainDate.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDate.cpp
@@ -497,31 +497,6 @@ TemporalPlainDate::mergeDateFields(JSGlobalObject* globalObject, JSObject* tempo
     return { yearToUse, monthToUse, dayToUse, otherMonth, overflow, any };
 }
 
-std::optional<int32_t> TemporalPlainDate::toYear(JSGlobalObject* globalObject, JSObject* temporalDateLike)
-{
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    std::optional<int32_t> year;
-    JSValue yearProperty = temporalDateLike->get(globalObject, vm.propertyNames->year);
-    RETURN_IF_EXCEPTION(scope, { });
-    if (!yearProperty.isUndefined()) {
-        double doubleYear = yearProperty.toIntegerWithTruncation(globalObject);
-        RETURN_IF_EXCEPTION(scope, { });
-
-        if (!std::isfinite(doubleYear)) [[unlikely]] {
-            throwRangeError(globalObject, scope, "year property must be finite"_s);
-            return { };
-        }
-
-        if (!ISO8601::isYearWithinLimits(doubleYear)) [[unlikely]]
-            year = ISO8601::outOfRangeYear;
-        else
-            year = static_cast<int32_t>(doubleYear);
-    }
-    return year;
-}
-
 // https://tc39.es/proposal-temporal/#sec-temporal-differencetemporalplaindate
 // Step 1 (ToTemporalDate) done by the prototype host fn via TemporalPlainDate::from().
 // Uses spec's flip-mode + negate-at-end pattern for Since (unlike PlainTime's operand-swap).

--- a/Source/JavaScriptCore/runtime/TemporalPlainDate.h
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDate.h
@@ -54,7 +54,6 @@ public:
     static ISO8601::PlainDate validateAndCreateISODateRecord(JSGlobalObject*, const ISO8601::Duration&);
     static std::tuple<int32_t, unsigned, unsigned, std::optional<ParsedMonthCode>, TemporalOverflow, TemporalAnyProperties>
     mergeDateFields(JSGlobalObject*, JSObject*, JSValue, int32_t, uint32_t, uint32_t);
-    static std::optional<int32_t> toYear(JSGlobalObject*, JSObject*);
     static TemporalPlainDate* from(JSGlobalObject*, JSValue item, JSValue options);
 
     ISO8601::PlainDate plainDate() const { return m_plainDate; }

--- a/Source/JavaScriptCore/runtime/TemporalPlainMonthDay.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainMonthDay.cpp
@@ -56,8 +56,6 @@ TemporalPlainMonthDay::TemporalPlainMonthDay(VM& vm, Structure* structure, ISO86
 {
 }
 
-
-// CreateTemporalMonthDay ( isoDate, calendar [, newTarget ]
 // https://tc39.es/proposal-temporal/#sec-temporal-createtemporalmonthday
 TemporalPlainMonthDay* TemporalPlainMonthDay::tryCreateIfValid(JSGlobalObject* globalObject, Structure* structure, ISO8601::PlainDate&& plainDate)
 {
@@ -69,35 +67,16 @@ TemporalPlainMonthDay* TemporalPlainMonthDay::tryCreateIfValid(JSGlobalObject* g
         return { };
     }
 
+    // Step 1: If ISODateWithinLimits(isoDate) is false, throw RangeError.
     if (!ISO8601::isDateTimeWithinLimits(plainDate.year(), plainDate.month(), plainDate.day(), 12, 0, 0, 0, 0, 0)) [[unlikely]] {
         throwRangeError(globalObject, scope, "PlainMonthDay: date out of range of ECMAScript representation"_s);
         return { };
     }
 
+    // Steps 2-6: OrdinaryCreateFromConstructor + set internal slots.
     return TemporalPlainMonthDay::create(vm, structure, ISO8601::PlainMonthDay(WTF::move(plainDate)));
 }
 
-// https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.with
-String TemporalPlainMonthDay::toString(JSGlobalObject* globalObject, JSValue optionsValue) const
-{
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    JSObject* options = intlGetOptionsObject(globalObject, optionsValue);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    if (!options)
-        return toString();
-
-    String calendarName = temporalShowCalendarName(globalObject, options);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    return ISO8601::temporalMonthDayToString(m_plainMonthDay, calendarName, m_calendarID);
-}
-
-static TemporalPlainMonthDay* fromMonthDayString(JSGlobalObject*, WTF::String);
-
-// https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.from
 // https://tc39.es/proposal-temporal/#sec-temporal-totemporalmonthday
 TemporalPlainMonthDay* TemporalPlainMonthDay::from(JSGlobalObject* globalObject, JSValue itemValue, JSValue optionsValue)
 {
@@ -111,17 +90,72 @@ TemporalPlainMonthDay* TemporalPlainMonthDay::from(JSGlobalObject* globalObject,
     if (itemValue.isString()) {
         auto string = itemValue.toWTFString(globalObject);
         RETURN_IF_EXCEPTION(scope, { });
-        // Steps 4-14: ParseISODateTime → canonicalize calendar → CalendarMonthDayFromFields.
-        auto* result = fromMonthDayString(globalObject, string);
-        RETURN_IF_EXCEPTION(scope, { });
+
+        // Step 4: ParseISODateTime(item, « TemporalMonthDayString »).
+        auto dateTime = ISO8601::parseISODateTime(string, ISO8601::TemporalProduction::MonthDay);
+        if (!dateTime) [[unlikely]] {
+            String message = tryMakeString("Temporal.PlainMonthDay.from: invalid date string "_s, string);
+            throwRangeError(globalObject, scope, message.isNull() ? "Temporal.PlainMonthDay.from: invalid date string"_s : message);
+            return { };
+        }
+        auto [plainDateOpt, plainTimeOptional, timeZoneOptional, calendarOptional, matched, isShortForm] = WTF::move(*dateTime);
+        ASSERT(plainDateOpt);
+        auto plainDate = WTF::move(*plainDateOpt);
+        // (parseISODateTime already enforced Step 4.a.ii.(4): short-form non-iso8601 → nullopt.)
+        bool looksLikeShortForm = isShortForm;
+
+        // Steps 5-7: calendar = result.[[Calendar]] (default "iso8601"); calendar = ? CanonicalizeCalendar(calendar).
+        CalendarID calendarId = iso8601CalendarID();
+        if (calendarOptional) {
+            auto rawCal = StringView(*calendarOptional).convertToASCIILowercase();
+            auto canonicalized = isBuiltinCalendar(rawCal);
+            if (!canonicalized) [[unlikely]] {
+                throwRangeError(globalObject, scope, makeString("'"_s, rawCal, "' is not a valid calendar identifier"_s));
+                return { };
+            }
+            calendarId = *canonicalized;
+        }
+
         // Step 8-9: GetOptionsObject + GetTemporalOverflowOption (validate; overflow unused for strings).
+        //           Spec runs these AFTER parsing; user's options object is validated but its value is unused.
         if (!optionsValue.isUndefined()) {
             JSObject* options = intlGetOptionsObject(globalObject, optionsValue);
             RETURN_IF_EXCEPTION(scope, { });
             toTemporalOverflow(globalObject, options);
             RETURN_IF_EXCEPTION(scope, { });
         }
-        return result;
+
+        // Step 10 (ISO path): referenceISOYear=1972 → CreateTemporalMonthDay({1972,month,day}, iso8601).
+        if (calendarId == iso8601CalendarID()) {
+            auto dateWithoutYear = ISO8601::PlainDate(1972, plainDate.month(), plainDate.day());
+            RELEASE_AND_RETURN(scope, TemporalPlainMonthDay::tryCreateIfValid(globalObject, globalObject->plainMonthDayStructure(), WTF::move(dateWithoutYear)));
+        }
+
+        // Steps 11-12 (non-ISO path): isoDate = {year,month,day}; ISODateWithinLimits check.
+        //   For short form (no year), plainDate.year() defaults to a parser sentinel; for full form,
+        //   it's the parsed year.
+        int32_t fullYear = plainDate.year();
+        if (!ISO8601::isYearWithinLimits(fullYear) || !ISO8601::isDateTimeWithinLimits(fullYear, plainDate.month(), plainDate.day(), 12, 0, 0, 0, 0, 0)) [[unlikely]] {
+            throwRangeError(globalObject, scope, "Date is not within ISO date time limits"_s);
+            return { };
+        }
+
+        // Steps 13-15: ISODateToFields + CalendarMonthDayFromFields(~constrain~) + CreateTemporalMonthDay.
+        //              Fused into plainMonthDayFromISODate for non-ISO full date strings.
+        if (!looksLikeShortForm && ISO8601::isYearWithinLimits(plainDate.year())) {
+            auto resolved = TemporalCore::plainMonthDayFromISODate(calendarId, plainDate, TemporalOverflow::Constrain);
+            if (!resolved) [[unlikely]] {
+                throwRangeError(globalObject, scope, String(resolved.error().message));
+                return { };
+            }
+            auto* result = TemporalPlainMonthDay::create(vm, globalObject->plainMonthDayStructure(), WTF::move(resolved->isoDate));
+                result->setCalendarID(resolved->calendarId);
+            return result;
+        }
+
+        String message = tryMakeString("Temporal.PlainMonthDay.from: invalid date string "_s, string);
+        throwRangeError(globalObject, scope, message.isNull() ? "Temporal.PlainMonthDay.from: invalid date string"_s : message);
+        return { };
     }
 
     // Step 2: item is an Object.
@@ -177,176 +211,13 @@ TemporalPlainMonthDay* TemporalPlainMonthDay::from(JSGlobalObject* globalObject,
         }
 
         auto* result = TemporalPlainMonthDay::create(vm, globalObject->plainMonthDayStructure(), WTF::move(resolved->isoDate));
-        result->setCalendarID(resolved->calendarId);
+            result->setCalendarID(resolved->calendarId);
         return result;
     }
 
     // Step 3: item is not a String — throw TypeError.
     throwTypeError(globalObject, scope, "can only convert to PlainMonthDay from object or string values"_s);
     return { };
-}
-
-// Implements ToTemporalMonthDay steps 4-14 (steps 8-9 done by caller after return):
-// https://tc39.es/proposal-temporal/#sec-temporal-totemporalmonthday
-static TemporalPlainMonthDay* fromMonthDayString(JSGlobalObject* globalObject, WTF::String string)
-{
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    // Step 4: ParseISODateTime(item, « TemporalMonthDayString »).
-    auto dateTime = ISO8601::parseISODateTime(string, ISO8601::TemporalProduction::MonthDay);
-    if (!dateTime) [[unlikely]] {
-        String message = tryMakeString("Temporal.PlainMonthDay.from: invalid date string "_s, string);
-        throwRangeError(globalObject, scope, message.isNull() ? "Temporal.PlainMonthDay.from: invalid date string"_s : message);
-        return { };
-    }
-    auto [plainDateOpt, plainTimeOptional, timeZoneOptional, calendarOptional, matched, isShortForm] = WTF::move(*dateTime);
-    ASSERT(plainDateOpt);
-    auto plainDate = WTF::move(*plainDateOpt);
-
-    // (parseISODateTime already enforced Step 4.a.ii.(4): short-form non-iso8601 → nullopt.)
-    bool looksLikeShortForm = isShortForm;
-
-    // Step 5: Let calendar be result.[[Calendar]].
-    // Step 6: If calendar is ~empty~, set calendar to "iso8601".
-    // Step 7: Set calendar to ? CanonicalizeCalendar(calendar).
-    CalendarID calendarId = iso8601CalendarID();
-    if (calendarOptional) {
-        auto rawCal = StringView(*calendarOptional).convertToASCIILowercase();
-        auto canonicalized = isBuiltinCalendar(rawCal);
-        if (!canonicalized) [[unlikely]] {
-            throwRangeError(globalObject, scope, makeString("'"_s, rawCal, "' is not a valid calendar identifier"_s));
-            return { };
-        }
-        calendarId = *canonicalized;
-    }
-
-    // Step 10: iso8601 path — referenceISOYear=1972, return CreateTemporalMonthDay({1972,month,day}, iso8601).
-    if (calendarId == iso8601CalendarID()) {
-        auto dateWithoutYear = ISO8601::PlainDate(1972, plainDate.month(), plainDate.day());
-        RELEASE_AND_RETURN(scope, TemporalPlainMonthDay::tryCreateIfValid(globalObject, globalObject->plainMonthDayStructure(), WTF::move(dateWithoutYear)));
-    }
-
-    // Steps 11-12: isoDate = {year,month,day}; ISODateWithinLimits check.
-    // For short form (no year), plainDate.year() defaults to a parser sentinel; for full form,
-    // it's the parsed year.
-    int32_t fullYear = plainDate.year();
-    if (!ISO8601::isYearWithinLimits(fullYear) || !ISO8601::isDateTimeWithinLimits(fullYear, plainDate.month(), plainDate.day(), 12, 0, 0, 0, 0, 0)) [[unlikely]] {
-        throwRangeError(globalObject, scope, "Date is not within ISO date time limits"_s);
-        return { };
-    }
-
-    // Steps 13-15: ISODateToFields + CalendarMonthDayFromFields(~constrain~) + CreateTemporalMonthDay.
-    // (Fused into plainMonthDayFromISODate for non-ISO full date strings.)
-    if (!looksLikeShortForm) {
-        if (ISO8601::isYearWithinLimits(plainDate.year())) {
-            auto resolved = TemporalCore::plainMonthDayFromISODate(calendarId, plainDate, TemporalOverflow::Constrain);
-            if (!resolved) [[unlikely]] {
-                throwRangeError(globalObject, scope, String(resolved.error().message));
-                return { };
-            }
-            auto* result = TemporalPlainMonthDay::create(vm, globalObject->plainMonthDayStructure(), WTF::move(resolved->isoDate));
-            result->setCalendarID(resolved->calendarId);
-            return result;
-        }
-    }
-
-    String message = tryMakeString("Temporal.PlainMonthDay.from: invalid date string "_s, string);
-    throwRangeError(globalObject, scope, message.isNull() ? "Temporal.PlainMonthDay.from: invalid date string"_s : message);
-    return { };
-}
-
-// https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.with
-ISO8601::PlainDate TemporalPlainMonthDay::with(JSGlobalObject* globalObject, JSObject* temporalMonthDayLike, JSValue optionsValue)
-{
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    // Steps 1-2: RequireInternalSlot + type check done by prototype caller.
-
-    // Step 3: If ? IsPartialTemporalObject(temporalMonthDayLike) is false, throw TypeError.
-    bool isPartial = isPartialTemporalObject(globalObject, JSValue(temporalMonthDayLike));
-    RETURN_IF_EXCEPTION(scope, { });
-    if (!isPartial) [[unlikely]] {
-        throwTypeError(globalObject, scope, "argument must be a partial Temporal object"_s);
-        return { };
-    }
-
-    // Step 4: calendar = this.[[Calendar]] — m_calendarID.
-    auto calID = m_calendarID;
-
-    // Step 6: PrepareCalendarFields(calendar, temporalMonthDayLike, {year,month,monthCode,day}, {}, ~partial~).
-    // Fields read BEFORE options per spec. skipCalendarRead=true since step 3 ensures no calendar property.
-    CalendarID outCalendarId = calID;
-    auto partialFields = readCalendarFieldsFromObject<FieldSetType::MonthDay, CalendarRead::Skip>(globalObject, temporalMonthDayLike, outCalendarId);
-    RETURN_IF_EXCEPTION(scope, { });
-    if (!partialFields.day && !partialFields.month && !partialFields.monthCode
-        && !partialFields.year && !partialFields.era && !partialFields.eraYear) [[unlikely]] {
-        throwTypeError(globalObject, scope, "Object must contain at least one Temporal date property"_s);
-        return { };
-    }
-
-    // Steps 8-9: GetOptionsObject + GetTemporalOverflowOption (after fields per spec order).
-    JSObject* options = intlGetOptionsObject(globalObject, optionsValue);
-    RETURN_IF_EXCEPTION(scope, { });
-    TemporalOverflow overflow = toTemporalOverflow(globalObject, options);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    // Step 5: ISODateToFields(calendar, this.[[ISODate]], ~month-day~) — get current fields for merge.
-    // Step 7: CalendarMergeFields(calendar, fields, partialMonthDay) — merge current + user fields.
-    // (Steps 5, 7 fused into explicit merge below.)
-    TemporalCore::CalendarFieldsIn merged;
-
-    // Step 5: current day from ISODateToFields (use calendar day for non-ISO).
-    uint8_t currentCalDay = static_cast<uint8_t>(m_plainMonthDay.day());
-    if (!TemporalCore::calendarIsISO(calID)) {
-        auto dayResult = TemporalCore::calendarDay(calID, m_plainMonthDay.isoPlainDate());
-        if (dayResult)
-            currentCalDay = *dayResult;
-    }
-    // Step 7: merge day — user's value takes priority over current.
-    merged.day = partialFields.day.has_value() ? partialFields.day : std::optional<uint8_t>(currentCalDay);
-
-    if (partialFields.month.has_value())
-        merged.month = partialFields.month;
-    if (partialFields.monthCode)
-        merged.monthCode = partialFields.monthCode;
-    if (partialFields.year)
-        merged.year = partialFields.year;
-    if (partialFields.era)
-        merged.era = partialFields.era;
-    if (partialFields.eraYear)
-        merged.eraYear = partialFields.eraYear;
-    if (!partialFields.month.has_value() && !partialFields.monthCode) {
-        // Step 7: fall back to current monthCode from ISODateToFields.
-        if (!TemporalCore::calendarIsISO(calID)) {
-            auto mcStr = TemporalCore::calendarMonthCode(calID, m_plainMonthDay.isoPlainDate());
-            if (!mcStr) [[unlikely]] {
-                throwRangeError(globalObject, scope, String(mcStr.error().message));
-                return { };
-            }
-            merged.monthCode = ISO8601::parseMonthCode(*mcStr);
-        } else
-            merged.month = std::optional<uint32_t>(m_plainMonthDay.month());
-    }
-
-    // For non-ISO: month ordinal alone is ambiguous without monthCode (depends on year).
-    if (!TemporalCore::calendarIsISO(calID) && merged.month.has_value() && !merged.monthCode) [[unlikely]] {
-        throwTypeError(globalObject, scope, "monthCode is required for non-ISO calendar PlainMonthDay.with()"_s);
-        return { };
-    }
-
-    // Step 10: CalendarMonthDayFromFields(calendar, mergedFields, overflow).
-    // Step 11: CreateTemporalMonthDay — done by prototype caller from the returned isoDate.
-    auto resolved = TemporalCore::monthDayFromFields(calID, merged, overflow);
-    if (!resolved) [[unlikely]] {
-        if (resolved.error().kind == TemporalErrorKind::TypeError)
-            throwTypeError(globalObject, scope, String(resolved.error().message));
-        else
-            throwRangeError(globalObject, scope, String(resolved.error().message));
-        return { };
-    }
-    return resolved->isoDate;
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/TemporalPlainMonthDay.h
+++ b/Source/JavaScriptCore/runtime/TemporalPlainMonthDay.h
@@ -59,11 +59,8 @@ public:
     JSC_TEMPORAL_PLAIN_MONTH_DAY_UNITS(JSC_DEFINE_TEMPORAL_PLAIN_MONTH_DAY_FIELD);
 #undef JSC_DEFINE_TEMPORAL_PLAIN_MONTH_DAY_FIELD
 
-    ISO8601::PlainDate with(JSGlobalObject*, JSObject*, JSValue);
-
     String monthCode() const { return ISO8601::monthCode(m_plainMonthDay.month()); }
 
-    String toString(JSGlobalObject*, JSValue options) const;
     String toString() const
     {
         return ISO8601::temporalMonthDayToString(m_plainMonthDay, "auto"_s, m_calendarID);

--- a/Source/JavaScriptCore/runtime/TemporalPlainMonthDayConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainMonthDayConstructor.cpp
@@ -90,37 +90,22 @@ JSC_DEFINE_HOST_FUNCTION(constructTemporalPlainMonthDay, (JSGlobalObject* global
     Structure* structure = JSC_GET_DERIVED_STRUCTURE(vm, plainMonthDayStructure, newTarget, callFrame->jsCallee());
     RETURN_IF_EXCEPTION(scope, { });
 
-    // Step 2: if referenceISOYear is undefined, default to 1972 (first ISO 8601 leap year after epoch).
-    // (Actual read of referenceISOYear happens at step 8 below.)
-    auto argumentCount = callFrame->argumentCount();
+    // Step 3: m = ? ToIntegerWithTruncation(isoMonth).
+    double isoMonth = callFrame->argument(0).toIntegerWithTruncation(globalObject);
+    RETURN_IF_EXCEPTION(scope, { });
+    if (!std::isfinite(isoMonth)) [[unlikely]]
+        return throwVMRangeError(globalObject, scope, "Temporal.PlainMonthDay month property must be finite"_s);
 
-    // Step 3: m = ToIntegerWithTruncation(isoMonth).
-    double isoMonth = 1;
-    if (argumentCount > 0) {
-        auto value = callFrame->uncheckedArgument(0).toIntegerWithTruncation(globalObject);
-        RETURN_IF_EXCEPTION(scope, { });
-        if (!std::isfinite(value)) [[unlikely]]
-            return throwVMRangeError(globalObject, scope, "Temporal.PlainMonthDay month property must be finite"_s);
-        isoMonth = value;
-    }
-
-    // Step 4: d = ToIntegerWithTruncation(isoDay).
-    double isoDay = 1;
-    if (argumentCount > 1) {
-        auto value = callFrame->uncheckedArgument(1).toIntegerWithTruncation(globalObject);
-        RETURN_IF_EXCEPTION(scope, { });
-        if (!std::isfinite(value)) [[unlikely]]
-            return throwVMRangeError(globalObject, scope, "Temporal.PlainMonthDay day property must be finite"_s);
-        isoDay = value;
-    }
-
-    if (argumentCount < 2) [[unlikely]]
-        return throwVMRangeError(globalObject, scope, "Temporal.PlainMonthDay requires at least two arguments"_s);
+    // Step 4: d = ? ToIntegerWithTruncation(isoDay).
+    double isoDay = callFrame->argument(1).toIntegerWithTruncation(globalObject);
+    RETURN_IF_EXCEPTION(scope, { });
+    if (!std::isfinite(isoDay)) [[unlikely]]
+        return throwVMRangeError(globalObject, scope, "Temporal.PlainMonthDay day property must be finite"_s);
 
     // Steps 5-7: if calendar is undefined use "iso8601"; if not a String throw TypeError; CanonicalizeCalendar.
     CalendarID calId = iso8601CalendarID();
-    if (argumentCount > 2 && !callFrame->uncheckedArgument(2).isUndefined()) {
-        JSValue calArg = callFrame->uncheckedArgument(2);
+    JSValue calArg = callFrame->argument(2);
+    if (!calArg.isUndefined()) {
         if (!calArg.isString()) [[unlikely]]
             return throwVMTypeError(globalObject, scope, "calendar must be a string"_s);
         auto rawCalendarId = asString(calArg)->value(globalObject);
@@ -131,19 +116,25 @@ JSC_DEFINE_HOST_FUNCTION(constructTemporalPlainMonthDay, (JSGlobalObject* global
         calId = *canonicalized;
     }
 
-    // Step 8: y = ToIntegerWithTruncation(referenceISOYear).
+    // Step 2/8: y = referenceISOYear default 1972 | ? ToIntegerWithTruncation(referenceISOYear).
     double referenceYear = 1972;
-    if (argumentCount > 3 && !callFrame->uncheckedArgument(3).isUndefined()) {
-        auto value = callFrame->uncheckedArgument(3).toIntegerWithTruncation(globalObject);
+    JSValue refYearArg = callFrame->argument(3);
+    if (!refYearArg.isUndefined()) {
+        referenceYear = refYearArg.toIntegerWithTruncation(globalObject);
         RETURN_IF_EXCEPTION(scope, { });
-        if (!std::isfinite(value)) [[unlikely]]
+        if (!std::isfinite(referenceYear)) [[unlikely]]
             return throwVMRangeError(globalObject, scope, "Temporal.PlainMonthDay reference year must be finite"_s);
-        referenceYear = value;
     }
 
-    // Steps 9-11: IsValidISODate + CreateISODateRecord + CreateTemporalMonthDay.
-    auto* result = TemporalPlainMonthDay::tryCreateIfValid(globalObject, structure, ISO8601::PlainDate(referenceYear, isoMonth, isoDay));
-    RETURN_IF_EXCEPTION(scope, { });
+    // Step 9: If IsValidISODate(y, m, d) is false, throw RangeError.
+    // Step 10: If ISODateWithinLimits(CreateISODateRecord(y, m, d)) is false, throw RangeError.
+    if (!ISO8601::isYearWithinLimits(referenceYear)
+        || !ISO8601::isValidISODate(referenceYear, isoMonth, isoDay)
+        || !ISO8601::isDateTimeWithinLimits(referenceYear, isoMonth, isoDay, 12, 0, 0, 0, 0, 0)) [[unlikely]]
+        return throwVMRangeError(globalObject, scope, "PlainMonthDay: date out of range of ECMAScript representation"_s);
+
+    // Step 11: Return ? CreateTemporalMonthDay(isoDate, calendar).
+    auto* result = TemporalPlainMonthDay::create(vm, structure, ISO8601::PlainMonthDay(ISO8601::PlainDate(referenceYear, isoMonth, isoDay)));
     if (result && calId != iso8601CalendarID())
         result->setCalendarID(calId);
     return JSValue::encode(result);
@@ -160,19 +151,8 @@ JSC_DEFINE_HOST_FUNCTION(callTemporalPlainMonthDay, (JSGlobalObject* globalObjec
 // https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.from
 JSC_DEFINE_HOST_FUNCTION(temporalPlainMonthDayConstructorFuncFrom, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    JSValue itemValue = callFrame->argument(0);
-
-    if (itemValue.inherits<TemporalPlainMonthDay>()) {
-        // Overflow needs to be validated, although it's not used here
-        toTemporalOverflow(globalObject, callFrame->argument(1));
-        RETURN_IF_EXCEPTION(scope, { });
-
-        RELEASE_AND_RETURN(scope, JSValue::encode(TemporalPlainMonthDay::create(vm, globalObject->plainMonthDayStructure(), uncheckedDowncast<TemporalPlainMonthDay>(itemValue)->plainMonthDay())));
-    }
-    RELEASE_AND_RETURN(scope, JSValue::encode(TemporalPlainMonthDay::from(globalObject, itemValue, callFrame->argument(1))));
+    // Step 1: Return ? ToTemporalMonthDay(item, options).
+    return JSValue::encode(TemporalPlainMonthDay::from(globalObject, callFrame->argument(0), callFrame->argument(1)));
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/TemporalPlainMonthDayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainMonthDayPrototype.cpp
@@ -33,6 +33,7 @@
 #include "IntlObjectInlines.h"
 #include "JSCInlines.h"
 #include "ObjectConstructor.h"
+#include "TemporalCalendar.h"
 #include "TemporalDuration.h"
 #include "TemporalPlainDate.h"
 #include "TemporalPlainDateTime.h"
@@ -103,11 +104,25 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainMonthDayPrototypeFuncToString, (JSGlobalOb
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // Steps 1-2: this-value + branding.
     auto* monthDay = dynamicDowncast<TemporalPlainMonthDay>(callFrame->thisValue());
     if (!monthDay) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainMonthDay.prototype.toString called on value that's not a PlainMonthDay"_s);
 
-    RELEASE_AND_RETURN(scope, JSValue::encode(jsString(vm, monthDay->toString(globalObject, callFrame->argument(0)))));
+    // Step 3: resolvedOptions = ? GetOptionsObject(options).
+    JSObject* options = intlGetOptionsObject(globalObject, callFrame->argument(0));
+    RETURN_IF_EXCEPTION(scope, { });
+
+    // Fast path: no options → default showCalendar = "auto" (matches the no-arg toString()).
+    if (!options)
+        RELEASE_AND_RETURN(scope, JSValue::encode(jsString(vm, monthDay->toString())));
+
+    // Step 4: showCalendar = ? GetTemporalShowCalendarNameOption(resolvedOptions).
+    String calendarName = temporalShowCalendarName(globalObject, options);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    // Step 5: Return TemporalMonthDayToString(plainMonthDay, showCalendar).
+    RELEASE_AND_RETURN(scope, JSValue::encode(jsString(vm, ISO8601::temporalMonthDayToString(monthDay->plainMonthDay(), calendarName, monthDay->calendarID()))));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.tojson
@@ -153,21 +168,98 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainMonthDayPrototypeFuncWith, (JSGlobalObject
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // Steps 1-2: this-value + branding.
     auto* monthDay = dynamicDowncast<TemporalPlainMonthDay>(callFrame->thisValue());
     if (!monthDay) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainMonthDay.prototype.with called on value that's not a PlainMonthDay"_s);
 
-    JSValue temporalMonthDayLike  = callFrame->argument(0);
-    if (!temporalMonthDayLike.isObject()) [[unlikely]]
-        return throwVMTypeError(globalObject, scope, "First argument to Temporal.PlainMonthDay.prototype.with must be an object"_s);
+    // Step 3: If ? IsPartialTemporalObject(temporalMonthDayLike) is false, throw TypeError.
+    //   Rejects non-Objects, Temporal instances, and objects carrying calendar/timeZone properties.
+    JSValue temporalMonthDayLike = callFrame->argument(0);
+    bool isPartial = isPartialTemporalObject(globalObject, temporalMonthDayLike);
+    RETURN_IF_EXCEPTION(scope, { });
+    if (!isPartial) [[unlikely]]
+        return throwVMTypeError(globalObject, scope, "First argument to Temporal.PlainMonthDay.prototype.with must be a partial Temporal object"_s);
+    JSObject* like = asObject(temporalMonthDayLike);
 
-    auto result = monthDay->with(globalObject, asObject(temporalMonthDayLike), callFrame->argument(1));
+    // Step 4: calendar = plainMonthDay.[[Calendar]] — held on the receiver.
+    CalendarID calendarId = monthDay->calendarID();
+
+    // Step 6: partialMonthDay = ? PrepareCalendarFields(calendar, temporalMonthDayLike,
+    //         «year, month, monthCode, day», «», ~partial~).
+    //         CalendarRead::Skip — calendar is known from the receiver; Step 3 already rejected a `calendar` property.
+    CalendarID unusedCalId = calendarId;
+    auto partialFields = readCalendarFieldsFromObject<FieldSetType::MonthDay, CalendarRead::Skip>(globalObject, like, unusedCalId);
+    RETURN_IF_EXCEPTION(scope, { });
+    // ~partial~ throws TypeError if none of the requested fields are present with a non-undefined value.
+    if (!partialFields.day && !partialFields.month && !partialFields.monthCode
+        && !partialFields.year && !partialFields.era && !partialFields.eraYear) [[unlikely]]
+        return throwVMTypeError(globalObject, scope, "Object must contain at least one Temporal date property"_s);
+
+    // Steps 8-9: resolvedOptions = ? GetOptionsObject(options); overflow = ? GetTemporalOverflowOption(resolvedOptions).
+    JSObject* options = intlGetOptionsObject(globalObject, callFrame->argument(1));
+    RETURN_IF_EXCEPTION(scope, { });
+    TemporalOverflow overflow = toTemporalOverflow(globalObject, options);
     RETURN_IF_EXCEPTION(scope, { });
 
-    auto* withResult = TemporalPlainMonthDay::tryCreateIfValid(globalObject, globalObject->plainMonthDayStructure(), WTF::move(result));
+    // Steps 5+7: fields = ISODateToFields(calendar, plainMonthDay.[[ISODate]], ~month-day~);
+    //            fields = CalendarMergeFields(calendar, fields, partialMonthDay).
+    //   Fused inline: fill unset merged fields from the receiver's own monthCode/day.
+    TemporalCore::CalendarFieldsIn merged;
+
+    // day from ISODateToFields (use calendar day for non-ISO).
+    uint8_t currentCalDay = static_cast<uint8_t>(monthDay->plainMonthDay().day());
+    bool isISO = TemporalCore::calendarIsISO(calendarId);
+    if (!isISO) {
+        auto dayResult = TemporalCore::calendarDay(calendarId, monthDay->plainMonthDay().isoPlainDate());
+        if (dayResult)
+            currentCalDay = *dayResult;
+    }
+    // User's day takes priority over the receiver's.
+    merged.day = partialFields.day.has_value() ? partialFields.day : std::optional<uint8_t>(currentCalDay);
+
+    if (partialFields.month.has_value())
+        merged.month = partialFields.month;
+    if (partialFields.monthCode)
+        merged.monthCode = partialFields.monthCode;
+    if (partialFields.year)
+        merged.year = partialFields.year;
+    if (partialFields.era)
+        merged.era = partialFields.era;
+    if (partialFields.eraYear)
+        merged.eraYear = partialFields.eraYear;
+    if (!partialFields.month.has_value() && !partialFields.monthCode) {
+        // Neither given — fall back to current monthCode (non-ISO) or numeric month (ISO).
+        if (!isISO) {
+            auto mcStr = TemporalCore::calendarMonthCode(calendarId, monthDay->plainMonthDay().isoPlainDate());
+            if (!mcStr) [[unlikely]] {
+                throwRangeError(globalObject, scope, String(mcStr.error().message));
+                return { };
+            }
+            merged.monthCode = ISO8601::parseMonthCode(*mcStr);
+        } else
+            merged.month = std::optional<uint32_t>(monthDay->plainMonthDay().month());
+    }
+
+    // For non-ISO: month ordinal alone is ambiguous without monthCode (depends on year).
+    if (!isISO && merged.month.has_value() && !merged.monthCode) [[unlikely]]
+        return throwVMTypeError(globalObject, scope, "monthCode is required for non-ISO calendar PlainMonthDay.with()"_s);
+
+    // Step 10: isoDate = ? CalendarMonthDayFromFields(calendar, fields, overflow).
+    auto resolved = TemporalCore::monthDayFromFields(calendarId, merged, overflow);
+    if (!resolved) [[unlikely]] {
+        if (resolved.error().kind == TemporalErrorKind::TypeError)
+            throwTypeError(globalObject, scope, String(resolved.error().message));
+        else
+            throwRangeError(globalObject, scope, String(resolved.error().message));
+        return { };
+    }
+
+    // Step 11: Return ! CreateTemporalMonthDay(isoDate, calendar).
+    auto* withResult = TemporalPlainMonthDay::tryCreateIfValid(globalObject, globalObject->plainMonthDayStructure(), WTF::move(resolved->isoDate));
     RETURN_IF_EXCEPTION(scope, { });
-    if (withResult && monthDay->calendarID() != iso8601CalendarID())
-        withResult->setCalendarID(monthDay->calendarID());
+    if (withResult && calendarId != iso8601CalendarID())
+        withResult->setCalendarID(calendarId);
     return JSValue::encode(withResult);
 }
 
@@ -177,16 +269,20 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainMonthDayPrototypeFuncEquals, (JSGlobalObje
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // Steps 1-2: this-value + branding.
     auto* monthDay = dynamicDowncast<TemporalPlainMonthDay>(callFrame->thisValue());
     if (!monthDay) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainMonthDay.prototype.equals called on value that's not a PlainMonthDay"_s);
 
+    // Step 3: other = ? ToTemporalMonthDay(other).
     auto* other = TemporalPlainMonthDay::from(globalObject, callFrame->argument(0), jsUndefined());
     RETURN_IF_EXCEPTION(scope, { });
 
+    // Step 4: If CompareISODate(monthDay.[[ISODate]], other.[[ISODate]]) != 0, return false.
     if (monthDay->plainMonthDay() != other->plainMonthDay())
         return JSValue::encode(jsBoolean(false));
 
+    // Step 5: Return CalendarEquals(monthDay.[[Calendar]], other.[[Calendar]]).
     return JSValue::encode(jsBoolean(monthDay->calendarID() == other->calendarID()));
 }
 
@@ -196,58 +292,96 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainMonthDayPrototypeFuncToPlainDate, (JSGloba
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // Steps 1-2: this-value + branding.
     auto* monthDay = dynamicDowncast<TemporalPlainMonthDay>(callFrame->thisValue());
     if (!monthDay) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainMonthDay.prototype.toPlainDate called on value that's not a PlainMonthDay"_s);
 
+    // Step 3: If item is not an Object, throw TypeError.
     JSValue itemValue = callFrame->argument(0);
     if (!itemValue.isObject()) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainMonthDay.prototype.toPlainDate: item is not an object"_s);
+    JSObject* item = asObject(itemValue);
 
-    auto thisMonth = monthDay->month();
-    auto thisDay = monthDay->day();
+    // Step 4: calendar = plainMonthDay.[[Calendar]] — held on the receiver.
+    CalendarID calendarId = monthDay->calendarID();
 
-    // PrepareCalendarFields(calendar, item, {year}, {}, {}) — per CalendarExtraFields,
-    // era-based calendars expand {year} to also include era and eraYear (alphabetical order).
-    bool calUsesEras = monthDay->calendarID() != iso8601CalendarID() && monthDay->calendarID() != chineseCalendarID() && monthDay->calendarID() != dangiCalendarID();
-    if (calUsesEras) {
-        JSValue eraValue = asObject(itemValue)->get(globalObject, Identifier::fromString(vm, "era"_s));
+    // Steps 5-7 (fused): fields ← ISODateToFields(receiver, month-day);
+    //   inputFields ← ? PrepareCalendarFields(calendar, item, «year», «», «»);
+    //   merged ← CalendarMergeFields(...).
+    //   Step 6 reads ONLY the fields spec says to read — day/monthCode come from the receiver at
+    //   Step 5, so we must NOT re-read them from `item` (test262 order-of-operations pins this).
+    //   CalendarExtraFields expands «year» to «year, era, eraYear» for era-based calendars.
+    //   Alphabetical read order: era, eraYear, year.
+    TemporalCore::CalendarFieldsIn merged;
+    bool calHasEras = TemporalCore::calendarHasEras(calendarId);
+    if (calHasEras) {
+        JSValue eraProp = item->get(globalObject, Identifier::fromString(vm, "era"_s));
         RETURN_IF_EXCEPTION(scope, { });
-        JSValue eraYearValue = asObject(itemValue)->get(globalObject, Identifier::fromString(vm, "eraYear"_s));
+        if (!eraProp.isUndefined()) {
+            merged.era = eraProp.toWTFString(globalObject);
+            RETURN_IF_EXCEPTION(scope, { });
+        }
+        JSValue eraYearProp = item->get(globalObject, Identifier::fromString(vm, "eraYear"_s));
         RETURN_IF_EXCEPTION(scope, { });
-        if (!eraYearValue.isUndefined()) {
-            double ey = eraYearValue.toIntegerWithTruncation(globalObject);
+        if (!eraYearProp.isUndefined()) {
+            double ey = eraYearProp.toIntegerWithTruncation(globalObject);
             RETURN_IF_EXCEPTION(scope, { });
             if (!std::isfinite(ey)) [[unlikely]]
-                return throwVMRangeError(globalObject, scope, "eraYear property must be finite"_s);
+                return throwVMRangeError(globalObject, scope, "eraYear must be finite"_s);
+            merged.eraYear = clampTo<int32_t>(ey);
         }
-        UNUSED_PARAM(eraValue);
+        if (merged.era.has_value() != merged.eraYear.has_value()) [[unlikely]]
+            return throwVMTypeError(globalObject, scope, "era and eraYear must both be present or both absent"_s);
     }
-
-    auto itemYear = TemporalPlainDate::toYear(globalObject, asObject(itemValue));
+    JSValue yearProp = item->get(globalObject, vm.propertyNames->year);
     RETURN_IF_EXCEPTION(scope, { });
-
-    if (!itemYear) [[unlikely]] {
-        throwTypeError(globalObject, scope, "Temporal.PlainMonthDay.prototype.toPlainDate: item does not have a year field"_s);
+    if (!yearProp.isUndefined()) {
+        double y = yearProp.toIntegerWithTruncation(globalObject);
+        RETURN_IF_EXCEPTION(scope, { });
+        if (!std::isfinite(y)) [[unlikely]]
+            return throwVMRangeError(globalObject, scope, "year must be finite"_s);
+        merged.year = clampTo<int32_t>(y);
+    }
+    // Merge requires a year identifier — either `year` or era+eraYear pair.
+    bool hasEraPair = merged.era.has_value() && merged.eraYear.has_value();
+    if (!merged.year && !hasEraPair) [[unlikely]] {
+        throwTypeError(globalObject, scope, "Temporal.PlainMonthDay.prototype.toPlainDate: item does not have a year or era/eraYear field"_s);
         return { };
     }
 
-    if (monthDay->calendarID() != iso8601CalendarID()) {
-        auto resolved = TemporalCore::plainMonthDayToPlainDate(monthDay->calendarID(), monthDay->plainMonthDay().isoPlainDate(), itemYear.value());
-        if (!resolved) [[unlikely]] {
-            throwRangeError(globalObject, scope, String(resolved.error().message));
+    // Step 5 (receiver side): populate monthCode + day from the PMD's stored ISO date.
+    bool isISO = TemporalCore::calendarIsISO(calendarId);
+    if (isISO) {
+        merged.month = monthDay->month();
+        merged.day = monthDay->day();
+    } else {
+        auto mcStr = TemporalCore::calendarMonthCode(calendarId, monthDay->plainMonthDay().isoPlainDate());
+        if (!mcStr) [[unlikely]] {
+            throwRangeError(globalObject, scope, String(mcStr.error().message));
             return { };
         }
-        RELEASE_AND_RETURN(scope, JSValue::encode(TemporalPlainDate::tryCreateIfValid(globalObject, globalObject->plainDateStructure(), WTF::move(resolved->isoDate), resolved->calendarId)));
+        merged.monthCode = ISO8601::parseMonthCode(*mcStr);
+        auto dayResult = TemporalCore::calendarDay(calendarId, monthDay->plainMonthDay().isoPlainDate());
+        if (!dayResult) [[unlikely]] {
+            throwRangeError(globalObject, scope, String(dayResult.error().message));
+            return { };
+        }
+        merged.day = static_cast<uint8_t>(*dayResult);
     }
 
-    auto plainDateResult = TemporalCore::regulateISODate(itemYear.value(), thisMonth, thisDay, TemporalOverflow::Constrain);
-    if (!plainDateResult) [[unlikely]] {
-        throwRangeError(globalObject, scope, "Temporal.PlainMonthDay.prototype.toPlainDate: date is invalid"_s);
+    // Step 8: isoDate = ? CalendarDateFromFields(calendar, merged, ~constrain~).
+    auto resolved = TemporalCore::dateFromFields(calendarId, merged, TemporalOverflow::Constrain);
+    if (!resolved) [[unlikely]] {
+        if (resolved.error().kind == TemporalErrorKind::TypeError)
+            throwTypeError(globalObject, scope, String(resolved.error().message));
+        else
+            throwRangeError(globalObject, scope, String(resolved.error().message));
         return { };
     }
 
-    RELEASE_AND_RETURN(scope, JSValue::encode(TemporalPlainDate::tryCreateIfValid(globalObject, globalObject->plainDateStructure(), WTF::move(*plainDateResult), monthDay->calendarID())));
+    // Step 9: Return ! CreateTemporalDate(isoDate, calendar).
+    RELEASE_AND_RETURN(scope, JSValue::encode(TemporalPlainDate::tryCreateIfValid(globalObject, globalObject->plainDateStructure(), WTF::move(resolved->isoDate), resolved->calendarId)));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.valueof

--- a/Source/JavaScriptCore/runtime/temporal/core/CalendarFields.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/CalendarFields.cpp
@@ -171,6 +171,15 @@ TemporalResult<ResolvedCalendarDate> dateFromFields(CalendarID calendarId, const
     if (fields.monthCode && fields.monthCode->isLeapMonth && !calendarIsLunisolar(calendarId))
         return makeUnexpected(rangeError("Leap month codes are not valid for this calendar"_s));
 
+    // Reject month/monthCode conflicts on non-ISO non-lunisolar calendars. Lunisolar
+    // (chinese/dangi/hebrew) is skipped because a leap slot pushes ordinals up (Chinese M02L has
+    // ord=3), making numeric comparison meaningless.
+    if (fields.month && fields.monthCode && !calendarIsLunisolar(calendarId)) {
+        uint8_t codeMonth = static_cast<uint8_t>(fields.monthCode->monthNumber);
+        if (clampTo<uint8_t>(*fields.month) != codeMonth)
+            return makeUnexpected(rangeError("month does not match monthCode"_s));
+    }
+
     bool hasEraYear = fields.era.has_value() && fields.eraYear.has_value();
     if (!fields.year && !hasEraYear)
         return makeUnexpected(typeError("year property must be present"_s));
@@ -230,6 +239,15 @@ TemporalResult<ResolvedCalendarDate> yearMonthFromFields(CalendarID calendarId, 
     // Non-lunisolar calendars have no leap months — reject leap month codes.
     if (fields.monthCode && fields.monthCode->isLeapMonth && !calendarIsLunisolar(calendarId))
         return makeUnexpected(rangeError("Leap month codes are not valid for this calendar"_s));
+
+    // Reject month/monthCode conflicts on non-ISO non-lunisolar calendars. Lunisolar
+    // (chinese/dangi/hebrew) is skipped because a leap slot pushes ordinals up (Chinese M02L has
+    // ord=3), making numeric comparison meaningless.
+    if (fields.month && fields.monthCode && !calendarIsLunisolar(calendarId)) {
+        uint8_t codeMonth = static_cast<uint8_t>(fields.monthCode->monthNumber);
+        if (clampTo<uint8_t>(*fields.month) != codeMonth)
+            return makeUnexpected(rangeError("month does not match monthCode"_s));
+    }
 
     bool hasEraYear = fields.era.has_value() && fields.eraYear.has_value();
     if (!fields.year && !hasEraYear)
@@ -308,11 +326,20 @@ TemporalResult<ResolvedCalendarDate> monthDayFromFields(CalendarID calendarId, c
     if (fields.monthCode && fields.monthCode->isLeapMonth && !calendarIsLunisolar(calendarId))
         return makeUnexpected(rangeError("Leap month codes are not valid for this calendar"_s));
 
+    // Reject month/monthCode conflicts on non-ISO non-lunisolar calendars (see analog check in dateFromFields).
+    if (fields.month && fields.monthCode && !calendarIsLunisolar(calendarId)) {
+        uint8_t codeMonth = static_cast<uint8_t>(fields.monthCode->monthNumber);
+        if (clampTo<uint8_t>(*fields.month) != codeMonth)
+            return makeUnexpected(rangeError("month does not match monthCode"_s));
+    }
+
     if (!fields.day)
         return makeUnexpected(typeError("day property must be present"_s));
 
-    // Non-ISO MonthDay requires monthCode (not just month).
-    if (!fields.monthCode && !fields.year)
+    // Non-ISO MonthDay requires monthCode OR a year identifier (year / era+eraYear). test262
+    // `intl402/Temporal/PlainMonthDay/from/fields-missing-properties.js` pins the TypeError.
+    bool hasEraYear = fields.era.has_value() && fields.eraYear.has_value();
+    if (!fields.monthCode && !fields.year && !hasEraYear)
         return makeUnexpected(typeError("monthCode is required for non-ISO calendar MonthDay"_s));
 
     uint8_t month = 1;
@@ -321,34 +348,34 @@ TemporalResult<ResolvedCalendarDate> monthDayFromFields(CalendarID calendarId, c
     else if (fields.monthCode)
         month = static_cast<uint8_t>(fields.monthCode->monthNumber);
 
-    // Default year: use ecmaReferenceYear (ported from icu4x) for non-ISO MonthDay.
-    int32_t year;
+    // Reference year for ICU. Unset on the era+eraYear path (ICU uses UCAL_ERA+UCAL_YEAR).
+    std::optional<int32_t> localYear;
     bool usedRegularMonthFallback = false;
     if (fields.year)
-        year = *fields.year;
+        localYear = *fields.year;
     else if (fields.monthCode) {
-        year = ecmaReferenceYear(calendarId, fields.monthCode->monthNumber, fields.monthCode->isLeapMonth, fields.day ? *fields.day : 1);
+        int32_t refYear = ecmaReferenceYear(calendarId, fields.monthCode->monthNumber, fields.monthCode->isLeapMonth, fields.day ? *fields.day : 1);
         // icu4x: UseRegularIfConstrain — leap month has no reference year near 1972.
         // Constrain: fall back to the non-leap version's reference year AND strip the leap flag.
         // Reject: throw RangeError (this leap month configuration doesn't exist).
-        if (year == ecmaRefYearNotInCalendar)
+        if (refYear == ecmaRefYearNotInCalendar)
             return makeUnexpected(rangeError("This month code does not exist in this calendar"_s));
-        if (year == ecmaRefYearUseRegular) {
+        if (refYear == ecmaRefYearUseRegular) {
             if (overflow == TemporalOverflow::Constrain) {
-                year = ecmaReferenceYear(calendarId, fields.monthCode->monthNumber, false, fields.day ? *fields.day : 1);
+                refYear = ecmaReferenceYear(calendarId, fields.monthCode->monthNumber, false, fields.day ? *fields.day : 1);
                 usedRegularMonthFallback = true;
             } else
                 return makeUnexpected(rangeError("This leap month does not exist in this calendar near the reference year"_s));
         }
-    } else
-        RELEASE_ASSERT_NOT_REACHED();
+        localYear = refYear;
+    }
 
     // ecmaReferenceYear returns ISO proleptic years. On older Apple ICU, UCAL_EXTENDED_YEAR
     // uses epoch-based counting for lunisolar calendars; probe the offset per calendar.
     auto calStr = calendarIDToString(calendarId);
     bool isChineseOrDangi = (calStr == "chinese"_s || calStr == "dangi"_s);
-    if (!fields.year && isChineseOrDangi)
-        year += lunarCalendarExtendedYearFor1972(calendarId) - 1972;
+    if (localYear && !fields.year && isChineseOrDangi)
+        *localYear += lunarCalendarExtendedYearFor1972(calendarId) - 1972;
     std::optional<StringView> era;
     if (fields.era)
         era = StringView(*fields.era);
@@ -364,8 +391,8 @@ TemporalResult<ResolvedCalendarDate> monthDayFromFields(CalendarID calendarId, c
 
     // Era+eraYear path: ICU ignores the year param (uses UCAL_ERA+UCAL_YEAR instead), so pass
     // fields.year (optional) to enable the year-consistency check in calendarDateFromFields.
-    // Non-era path: pass ecmaReferenceYear for correct ICU month resolution.
-    std::optional<int32_t> yearArg = (era && fields.eraYear) ? fields.year : std::optional<int32_t>(year);
+    // Non-era path: pass the computed reference year for correct ICU month resolution.
+    std::optional<int32_t> yearArg = (era && fields.eraYear) ? fields.year : localYear;
     auto result = calendarDateFromFields(calendarId, yearArg, month, *fields.day, era, fields.eraYear, *effectiveMonthCode, overflow);
     if (!result)
         return makeUnexpected(result.error());
@@ -724,39 +751,6 @@ TemporalResult<ResolvedCalendarDate> plainYearMonthFromISODate(CalendarID calend
     fields.monthCode = ISO8601::parseMonthCode(*monthCodeStr);
     // Step 12: CalendarYearMonthFromFields(~constrain~) per spec note.
     return yearMonthFromFields(calendarId, fields, TemporalOverflow::Constrain);
-}
-
-// plainMonthDayToPlainDate — temporal_rs: PlainMonthDay::to_plain_date (src/builtins/core/plain_month_day.rs)
-// https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.toplaindate
-// Implements steps 5, 7, 8; steps 1-4, 6, 9 done by JS-layer caller.
-TemporalResult<ResolvedCalendarDate> plainMonthDayToPlainDate(CalendarID calendarId, const ISO8601::PlainDate& pmdISODate, int32_t year)
-{
-    bool isISO = calendarIsISO(calendarId);
-
-    if (isISO) {
-        // Steps 5+7: ISO ISODateToFields gives month directly; merge year.
-        CalendarFieldsIn fields;
-        fields.year = year;
-        fields.month = pmdISODate.month();
-        fields.day = pmdISODate.day();
-        // Step 8: CalendarDateFromFields(~constrain~).
-        return dateFromFields(calendarId, fields, TemporalOverflow::Constrain);
-    }
-
-    // Steps 5+7 (non-ISO): ISODateToFields via ICU bridge, then merge year.
-    auto monthCodeStr = calendarMonthCode(calendarId, pmdISODate);
-    if (!monthCodeStr)
-        return makeUnexpected(monthCodeStr.error());
-    auto dayResult = calendarDay(calendarId, pmdISODate);
-    if (!dayResult)
-        return makeUnexpected(dayResult.error());
-
-    CalendarFieldsIn fields;
-    fields.year = year;
-    fields.monthCode = ISO8601::parseMonthCode(*monthCodeStr);
-    fields.day = static_cast<uint8_t>(*dayResult);
-    // Step 8: CalendarDateFromFields(~constrain~).
-    return dateFromFields(calendarId, fields, TemporalOverflow::Constrain);
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal-totemporalmonthday (string parse path)

--- a/Source/JavaScriptCore/runtime/temporal/core/CalendarFields.h
+++ b/Source/JavaScriptCore/runtime/temporal/core/CalendarFields.h
@@ -77,8 +77,6 @@ TemporalResult<ResolvedCalendarDate> JS_EXPORT_PRIVATE plainYearMonthToPlainDate
 
 TemporalResult<ResolvedCalendarDate> JS_EXPORT_PRIVATE plainYearMonthFromISODate(CalendarID, const ISO8601::PlainDate& fullISODate);
 
-TemporalResult<ResolvedCalendarDate> JS_EXPORT_PRIVATE plainMonthDayToPlainDate(CalendarID, const ISO8601::PlainDate& pmdISODate, int32_t year);
-
 TemporalResult<ResolvedCalendarDate> JS_EXPORT_PRIVATE plainMonthDayFromISODate(CalendarID, const ISO8601::PlainDate& fullISODate, TemporalOverflow);
 
 } // namespace TemporalCore


### PR DESCRIPTION
#### bdd3b71e35c2327ec2eeb82a52c1e86e7fbd0e3a
<pre>
[JSC][Temporal] Fix PlainMonthDay bugs and simplify helpers
<a href="https://bugs.webkit.org/show_bug.cgi?id=318977">https://bugs.webkit.org/show_bug.cgi?id=318977</a>
<a href="https://rdar.apple.com/181832650">rdar://181832650</a>

Reviewed by Yusuke Suzuki.

Fixes six PMD correctness bugs uncovered by a full audit against V8
and temporal_rs.

Bugs fixed:
.toPlainDate({era, eraYear}) threw TypeError on era-based calendars.
Rewrote handler to read era/eraYear/year per PrepareCalendarFields
&lt;year&gt; + CalendarExtraFields expansion.

Non-ISO non-lunisolar .with()/.from() silently accepted disagreeing
month + monthCode. Added consistency check in all three non-ISO
branches of dateFromFields/yearMonthFromFields/monthDayFromFields.

`new PMD(6, 15, &quot;iso8601&quot;, 275761)` was a debug-assert crash.
Pre-validate year+date before constructing ISO8601::PlainDate.

Non-spec `argumentCount &lt; 2` guard preempted spec&apos;s
ToIntegerWithTruncation(undefined) -&gt; NaN -&gt; RangeError path.

PMD.from({era, eraYear, month, day}) silently required monthCode.
Relaxed check to accept era+eraYear; std::optional&lt;int32_t&gt;
localYear matches temporal_rs&apos;s DateFields::try_from shape.

PMD.from(nonISOPMD) silently dropped the source calendar because
the funcFrom fast-path called create() without setCalendarID().
Removed the redundant fast-path — PMD::from handles clone correctly.

Cleanups:
inlined TemporalPlainMonthDay::with, fromMonthDayString, and
PMD::toString(options) into sole callers. Removed dead
plainMonthDayToPlainDate (core) and TemporalPlainDate::toYear.

Tests:
JSTests/stress/temporal-plain-month-day.js
Source/JavaScriptCore/API/tests/TemporalCoreTest.cpp

Canonical link: <a href="https://commits.webkit.org/316846@main">https://commits.webkit.org/316846@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7502bd390c0abfe2e5fd8ad402f76d9052acfe0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173558 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47491 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/41205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183131 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/131426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9dacbaad-aa05-4038-8073-585c000a51c3) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48783 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47173 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134955 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/131426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176516 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38389 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155664 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115432 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7b080ce5-4d41-4dc7-804c-1138fae396b9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37030 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/35386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31616 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/4176 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147454 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35159 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185557 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/34820 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/38550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39586 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143836 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47158 "Built successfully") | | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143692 "Found 1 new API test failure: WebKitGTK/TestNetworkProcessMemoryPressure:/webkit/WebKitWebsiteData/memory-pressure (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47837 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/41205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113005 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26383 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38626 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/119704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/210591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46343 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10112 "Passed tests") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/210591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45745 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45976 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45803 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->