### PR TITLE
Remove redundant x/y presentation-hint overrides from SVGTextPositioningElement

### DIFF
--- a/Source/WebCore/svg/SVGTextPositioningElement.cpp
+++ b/Source/WebCore/svg/SVGTextPositioningElement.cpp
@@ -80,20 +80,6 @@ void SVGTextPositioningElement::attributeChanged(const QualifiedName& name, cons
     SVGTextContentElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }
 
-void SVGTextPositioningElement::collectPresentationalHintsForAttribute(const QualifiedName& name, const AtomString& value, MutableStyleProperties& style)
-{
-    if (name == SVGNames::xAttr || name == SVGNames::yAttr)
-        return;
-    SVGTextContentElement::collectPresentationalHintsForAttribute(name, value, style);
-}
-
-bool SVGTextPositioningElement::hasPresentationalHintsForAttribute(const QualifiedName& name) const
-{
-    if (name == SVGNames::xAttr || name == SVGNames::yAttr)
-        return false;
-    return SVGTextContentElement::hasPresentationalHintsForAttribute(name);
-}
-
 void SVGTextPositioningElement::svgAttributeChanged(const QualifiedName& attrName)
 {
     if (PropertyRegistry::isKnownAttribute(attrName)) {

--- a/Source/WebCore/svg/SVGTextPositioningElement.h
+++ b/Source/WebCore/svg/SVGTextPositioningElement.h
@@ -53,9 +53,6 @@ protected:
     void svgAttributeChanged(const QualifiedName&) override;
 
 private:
-    bool hasPresentationalHintsForAttribute(const QualifiedName&) const final;
-    void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) final;
-
     bool isSVGTextPositioningElement() const override { return true; }
 
     const Ref<SVGAnimatedLengthList> m_x { SVGAnimatedLengthList::create(this, SVGLengthMode::Width) };


### PR DESCRIPTION
#### 6a672bedbf6c7200860080238f76bdd2c48e2e87
<pre>
Remove redundant x/y presentation-hint overrides from SVGTextPositioningElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=318983">https://bugs.webkit.org/show_bug.cgi?id=318983</a>
<a href="https://rdar.apple.com/181838675">rdar://181838675</a>

Reviewed by Nikolas Zimmermann.

SVGTextPositioningElement (the base for &lt;text&gt;, &lt;tspan&gt;, &lt;tref&gt;, &lt;altGlyph&gt;)
overrode hasPresentationalHintsForAttribute/collectPresentationalHintsForAttribute
to opt x/y out of presentation-hint mapping. That restates a decision the
central SVGElement::cssPropertyIdForSVGAttributeName mapping already makes: its
supportsXY() set is {foreignObject, image, rect, svg, symbol, use}, which excludes
all text-positioning elements, so the base already returns false / emits nothing
for x/y on these elements.

No behavior change.

* Source/WebCore/svg/SVGTextPositioningElement.cpp:
(WebCore::SVGTextPositioningElement::collectPresentationalHintsForAttribute): Deleted.
(WebCore::SVGTextPositioningElement::hasPresentationalHintsForAttribute const): Deleted.
* Source/WebCore/svg/SVGTextPositioningElement.h:

Canonical link: <a href="https://commits.webkit.org/316906@main">https://commits.webkit.org/316906@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94a9955f637b33675e55b8103aad6400b1ee2826

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173570 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47503 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41188 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183143 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131438 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7c093513-720f-48b8-aed6-5906ec5e8c8d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175435 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48795 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47185 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134966 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3eb22707-d026-4a71-92d2-c2e839da0438) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176528 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38397 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155731 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115443 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/407b7faf-c06b-4884-b10a-768e0bb3ae04) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37038 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35398 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31628 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147462 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35226 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185569 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38562 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39598 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143846 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47170 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143703 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47849 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31841 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113023 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26421 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38639 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119717 "Found 1059 new failures in b3/testb3_7.cpp, b3/B3Value.h, WebProcess/Network/WebResourceLoader.cpp, jit/OperationResult.h, UIProcess/WebProcessPool.cpp, testing/MockMediaSessionCoordinator.cpp, Shared/Cocoa/WKNSArray.mm, heap/WeakSet.h, API/tests/Regress141275.mm, Shared/SessionState.cpp ...") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46355 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10179 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45757 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45988 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45816 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->