### PR TITLE
Migrate ASCredentialUpdater to ASCredentialDataManager

### DIFF
--- a/Source/WebKit/WebKitSwift/CredentialUpdaterShim.swift
+++ b/Source/WebKit/WebKitSwift/CredentialUpdaterShim.swift
@@ -31,7 +31,7 @@ import Foundation
 @implementation
 extension CredentialUpdaterShim {
     class func signalUnknownCredential(withRelyingPartyIdentifier relyingPartyIdentifier: String, credentialID: Data) async throws {
-        try await ASCredentialUpdater()
+        try await ASCredentialDataManager()
             .reportUnknownPublicKeyCredential(relyingPartyIdentifier: relyingPartyIdentifier, credentialID: credentialID)
     }
 
@@ -40,7 +40,7 @@ extension CredentialUpdaterShim {
         userHandle: Data,
         acceptedCredentialIDs: [Data]
     ) async throws {
-        try await ASCredentialUpdater()
+        try await ASCredentialDataManager()
             .reportAllAcceptedPublicKeyCredentials(
                 relyingPartyIdentifier: relyingPartyIdentifier,
                 userHandle: userHandle,
@@ -53,7 +53,7 @@ extension CredentialUpdaterShim {
         userHandle: Data,
         newName: String
     ) async throws {
-        try await ASCredentialUpdater()
+        try await ASCredentialDataManager()
             .reportPublicKeyCredentialUpdate(relyingPartyIdentifier: relyingPartyIdentifier, userHandle: userHandle, newName: newName)
     }
 }


### PR DESCRIPTION
#### c889af2828d678eb11e555ef843fec3c961597ea
<pre>
Migrate ASCredentialUpdater to ASCredentialDataManager
<a href="https://bugs.webkit.org/show_bug.cgi?id=318986">https://bugs.webkit.org/show_bug.cgi?id=318986</a>
<a href="https://rdar.apple.com/181831723">rdar://181831723</a>

Reviewed by Richard Robinson.

ASCredentialUpdater has been replaced by ASCredentialDataManager in
AuthenticationServices. This updates CredentialUpdaterShim to use
the new class, fixing a build failure in certain configurations.

* Source/WebKit/WebKitSwift/CredentialUpdaterShim.swift:
(CredentialUpdaterShim.signalUnknownCredential(withRelyingPartyIdentifier:credentialID:)):
(CredentialUpdaterShim.signalAllAcceptedCredentials(withRelyingPartyIdentifier:userHandle:acceptedCredentialIDs:)):
(CredentialUpdaterShim.signalCurrentUserDetails(withRelyingPartyIdentifier:userHandle:newName:)):

Canonical link: <a href="https://commits.webkit.org/317048@main">https://commits.webkit.org/317048@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f2e2bc77d44a7a47d0a833355ff7a77df0f0481

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173578 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47511 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41183 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183151 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131446 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48803 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47193 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134971 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95243 "7 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1396e0db-62a2-4a17-be92-e028aa5a4313) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176536 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38400 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155728 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115448 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/86b76f62-ab82-457d-9a99-71aa4e72e5cd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37041 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35404 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31636 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147465 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35223 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185577 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38572 "Found 1026 new failures in b3/B3Value.h, b3/testb3_7.cpp, WebProcess/Network/WebResourceLoader.cpp, jit/OperationResult.h, UIProcess/WebProcessPool.cpp, Shared/Cocoa/WKNSArray.mm, heap/WeakSet.h, API/tests/Regress141275.mm, Shared/SessionState.cpp, NetworkProcess/NetworkResourceLoadParameters.cpp ...") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39604 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143852 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47178 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143709 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38878 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47857 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31838 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113031 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38646 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119725 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46363 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10176 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45765 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45996 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45824 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->