### PR TITLE
AX: Null-pointer dereference rebuilding accessibility relations during node removal

### DIFF
--- a/LayoutTests/accessibility/relations-update-during-node-removal-crash-expected.txt
+++ b/LayoutTests/accessibility/relations-update-during-node-removal-crash-expected.txt
@@ -1,0 +1,7 @@
+This test ensures we don't crash when accessibility relations are rebuilt while nodes that participate in relations are being removed.
+
+PASS: No crash.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/relations-update-during-node-removal-crash.html
+++ b/LayoutTests/accessibility/relations-update-during-node-removal-crash.html
@@ -1,0 +1,63 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<!-- Stays in the document. Setting a relation attribute on it marks accessibility relations dirty. -->
+<div id="dirtier"></div>
+
+<!-- Container whose subtree (built below via innerHTML) holds the relation-bearing elements we destroy. -->
+<div id="container"></div>
+
+<script>
+var output = "This test ensures we don't crash when accessibility relations are rebuilt while nodes that participate in relations are being removed.\n\n";
+
+if (window.accessibilityController && window.testRunner) {
+    window.jsTestIsAsync = true;
+
+    setTimeout(async function() {
+        var container = document.getElementById("container");
+
+        // Build a subtree of cross-referencing, relation-bearing elements.
+        container.innerHTML =
+            '<div id="d-root" role="group" aria-owns="d-fieldset">' +
+                '<fieldset id="d-fieldset" aria-labelledby="d-label" aria-owns="d-anchor d-button" aria-describedby="d-desc">' +
+                    '<legend id="d-legend" aria-labelledby="d-label">legend</legend>' +
+                    '<div id="d-wrap" aria-describedby="d-desc" aria-owns="d-inner">' +
+                        '<a id="d-anchor" href="#" aria-labelledby="d-label" aria-owns="d-button">link</a>' +
+                        '<button id="d-button" aria-labelledby="d-label" aria-describedby="d-anchor">button</button>' +
+                        '<div id="d-inner" aria-owns="d-anchor" aria-labelledby="d-legend">' +
+                            '<a id="d-inner-anchor" href="#" aria-describedby="d-label" aria-labelledby="d-legend">inner link</a>' +
+                            '<button id="d-inner-button" aria-labelledby="d-desc" aria-describedby="d-inner-anchor">inner button</button>' +
+                        '</div>' +
+                        '<div id="d-label">doomed label</div>' +
+                        '<div id="d-desc">doomed description</div>' +
+                    '</div>' +
+                '</fieldset>' +
+            '</div>';
+
+        await waitFor(() => {
+            // Wait for the new objects to enter the tree.
+            return accessibilityController.accessibleElementById("d-anchor")
+                && accessibilityController.accessibleElementById("d-inner-button");
+        });
+
+        // Dirty accessibility relations.
+        document.getElementById("dirtier").setAttribute("aria-owns", "no-such-target-xyz");
+
+        // With relations dirty, destroy the relation-bearing subtree. This triggers the node-removal
+        // machinery with dirty relations.
+        container.innerHTML = "";
+        gc();
+
+        output += "PASS: No crash.";
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -1406,6 +1406,7 @@ void AXObjectCache::remove(AXID axID)
     if (!object)
         return;
 
+    SetForScope removingNode(m_isRemovingNode, true);
 #if PLATFORM(COCOA)
     if (m_liveRegionManager)
         m_liveRegionManager->unregisterLiveRegion(axID);
@@ -6654,6 +6655,23 @@ void AXObjectCache::updateRelationsIfNeeded()
 {
     if (!m_relationsNeedUpdate)
         return;
+
+    if (m_isRemovingNode) {
+        // Don't rebuild relations while removing a node (see remove(AXID)). Besides being crash-unsafe
+        // mid-destruction, reading the current (stale) relations here is correct: the parent ID that
+        // queueNodeRemoval() records must match the isolated tree's m_nodeMap, which reflects the same
+        // last-built relations. A fresh rebuild would desync from it and make removeSubtreeFromNodeMap()
+        // bail. m_relationsNeedUpdate stays set, so relations are rebuilt on the next update cycle.
+        //
+        // In the future, we should consider changing queueNodeRemoval()'s bail-if-parent-doesn't-match
+        // mechanism to something more robust. Presumably we can determine whether to bail purely based
+        // on whether the object is connected in the AX tree at all, catching the re-parenting scenario
+        // while avoiding the issues with our current mechanism (which can leak subtrees if we read the
+        // parent at the wrong time (the DOM has changed, relations have changed, etc). If we find a way
+        // to do that, we can probably remove this m_isRemovingNode flag.
+        return;
+    }
+
     relationsNeedUpdate(false);
     m_relations.clear();
     m_recentlyRemovedRelations.clear();

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -1123,6 +1123,8 @@ private:
 #endif
     bool m_isSynchronizingSelection { false };
     bool m_performingDeferredCacheUpdate { false };
+    // True while remove(AXID) is tearing down an object.
+    bool m_isRemovingNode { false };
     double m_loadingProgress { 0 };
 
     // Tracks focus landing inside an aria-hidden region. After one rendering update


### PR DESCRIPTION
#### 62d7f19ba485e768f437050b9b146695883c2c02
<pre>
AX: Null-pointer dereference rebuilding accessibility relations during node removal
<a href="https://bugs.webkit.org/show_bug.cgi?id=318992">https://bugs.webkit.org/show_bug.cgi?id=318992</a>
<a href="https://rdar.apple.com/181844005">rdar://181844005</a>

Reviewed by Chris Fleizach.

During node teardown (e.g. a GC sweep destroying DOM nodes), AXObjectCache::remove(Node&amp;)
-&gt; remove(AXID) -&gt; AXIsolatedTree::queueNodeRemoval() computes the removed object&apos;s parent via
parentInCoreTree() -&gt; AccessibilityNodeObject::ownerParentObject(). When relations are dirty,
that reaches owners() -&gt; relatedObjects(AXRelation::OwnedBy) -&gt; relatedObjectIDsFor(...,
UpdateRelations::Yes), which synchronously runs updateRelationsIfNeeded(). Rebuilding relations
walks the DOM and creates accessibility objects in the middle of node destruction, dereferencing
a null pointer.

Guard against this with an m_isRemovingNode flag set across remove(AXID). updateRelationsIfNeeded()
returns early while it is set. queueNodeRemoval() already reads relations without updating them
for its LabelFor lookup (UpdateRelations::No), so this is consistent with the existing intent.

Reading the current (stale) relations during removal is also correct. The parent ID recorded by
queueNodeRemoval() must match the isolated tree&apos;s m_nodeMap, which reflects the same last-built
relations. A fresh rebuild would desync from it and make removeSubtreeFromNodeMap() bail.

* LayoutTests/accessibility/relations-update-during-node-removal-crash-expected.txt: Added.
* LayoutTests/accessibility/relations-update-during-node-removal-crash.html: Added.
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::remove):
(WebCore::AXObjectCache::updateRelationsIfNeeded):
* Source/WebCore/accessibility/AXObjectCache.h:

Canonical link: <a href="https://commits.webkit.org/316915@main">https://commits.webkit.org/316915@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c5c77946bcb60d8d07f178c86990e9329132d71

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173609 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47542 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41151 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183182 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131477 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175474 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48834 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47224 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134993 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176567 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38418 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155705 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115470 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37059 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35425 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31667 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147483 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35200 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185608 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38612 "Found 136 new failures in layout/formattingContexts/inline/InlineLine.cpp, UIProcess/WebProcessPool.cpp, layout/formattingContexts/inline/InlineContentBreaker.cpp, platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm, svg/SVGFELightElement.cpp, Shared/SessionState.cpp, WebProcess/WebPage/WebPage.cpp, inspector/agents/page/PageDOMDebuggerAgent.cpp, layout/formattingContexts/inline/ruby/RubyFormattingContext.cpp, WebProcess/Network/webrtc/WebRTCResolver.cpp ...") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39625 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143876 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47209 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155262 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143733 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38809 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47888 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31815 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113062 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38661 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119758 "Found 1059 new failures in b3/testb3_7.cpp, b3/B3Value.h, WebProcess/Network/WebResourceLoader.cpp, jit/OperationResult.h, UIProcess/WebProcessPool.cpp, testing/MockMediaSessionCoordinator.cpp, Shared/Cocoa/WKNSArray.mm, heap/WeakSet.h, API/tests/Regress141275.mm, Shared/SessionState.cpp ...") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46394 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10153 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45796 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46027 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45855 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->