### PR TITLE
Fix _doAfterNextPresentationUpdate hanging forever in views using _relatedWebView

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
@@ -478,8 +478,11 @@ void RemoteLayerTreeDrawingAreaProxyMac::scheduleDisplayRefreshCallbacks()
     if (m_displayRefreshObserverID)
         return;
 
+    // FIXME: as stated in the header, we should make m_displayID non-optional. An empty display ID
+    // can cause presentation update callbacks for the page to be stuck forever.
     if (!m_displayID) {
-        RELEASE_LOG(DisplayLink, "RemoteLayerTreeDrawingAreaProxyMac::scheduleDisplayLink(): page has no displayID");
+        RefPtr webPageProxy = page();
+        RELEASE_LOG_ERROR(DisplayLink, "%p [pageProxyID=%" PRIu64 ", webPageID=%" PRIu64 ", PID=%i] RemoteLayerTreeDrawingAreaProxyMac::scheduleDisplayRefreshCallbacks(): page has no display ID", this, webPageProxy ? webPageProxy->identifier().toUInt64() : 0, webPageProxy ? webPageProxy->webPageIDInMainFrameProcess().toUInt64() : 0, webPageProxy ? webPageProxy->legacyMainFrameProcessID() : 0);
         return;
     }
 

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -1410,6 +1410,10 @@ WebViewImpl::WebViewImpl(WKWebView *view, WebProcessPool& processPool, Ref<API::
     auto& pageConfiguration = m_page->configuration();
     m_page->initializeWebPage(pageConfiguration.openedSite(), pageConfiguration.initialSandboxFlags(), pageConfiguration.initialReferrerPolicy());
 
+    // This will ensure that DisplayID is set. This default is important so that offscreen webviews
+    // can schedule presentation updates.
+    windowDidChangeScreen();
+
     registerDraggedTypes();
 
     view.wantsLayer = YES;

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -123,6 +123,7 @@ Tests/WebKit/WKWebView/DeviceOrientation.mm @nonARC
 Tests/WebKit/WKWebView/DisableSpellcheck.mm @nonARC
 Tests/WebKit/WKWebView/DisplayName.mm @nonARC
 Tests/WebKit/WKWebView/DoAfterNextPresentationUpdateAfterCrash.mm @nonARC
+Tests/WebKit/WKWebView/DoAfterNextPresentationUpdateOffscreen.mm @nonARC
 Tests/WebKit/WKWebView/DocumentEditingContext.mm @nonARC
 Tests/WebKit/WKWebView/Download.mm @nonARC
 Tests/WebKit/WKWebView/DownloadProgress.mm @nonARC

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/DoAfterNextPresentationUpdateOffscreen.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/DoAfterNextPresentationUpdateOffscreen.mm
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#import "Helpers/Utilities.h"
+#import "Helpers/cocoa/TestNavigationDelegate.h"
+#import <WebKit/WKWebViewConfigurationPrivate.h>
+#import <WebKit/WKWebViewPrivate.h>
+#import <wtf/BlockPtr.h>
+#import <wtf/RetainPtr.h>
+
+TEST(WebKit, DoAfterNextPresentationUpdateOnRelatedOffscreenView)
+{
+    RetainPtr webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100)]);
+    [webView1 loadHTMLString:@"<body>hello world!</body>" baseURL:nil];
+    [webView1 _test_waitForDidFinishNavigation];
+
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configuration _setRelatedWebView:webView1.get()];
+    RetainPtr webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get()]);
+    [webView2 loadHTMLString:@"<body>related</body>" baseURL:nil];
+    [webView2 _test_waitForDidFinishNavigation];
+
+    __block bool firstUpdateFired = false;
+    __block bool secondUpdateFired = false;
+    [webView1 _doAfterNextPresentationUpdate:^{
+        firstUpdateFired = true;
+        [webView2 _doAfterNextPresentationUpdate:^{
+            secondUpdateFired = true;
+        }];
+    }];
+
+    EXPECT_TRUE(TestWebKitAPI::Util::runFor(&secondUpdateFired, 5_s));
+    EXPECT_TRUE(firstUpdateFired);
+    EXPECT_TRUE(secondUpdateFired);
+}


### PR DESCRIPTION
#### e3f74a2799bcd897eccfe38f0f3b827dc3cfcd42
<pre>
Fix _doAfterNextPresentationUpdate hanging forever in views using _relatedWebView
<a href="https://bugs.webkit.org/show_bug.cgi?id=318996">https://bugs.webkit.org/show_bug.cgi?id=318996</a>
<a href="https://rdar.apple.com/181137520">rdar://181137520</a>

Reviewed by Simon Fraser.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/DoAfterNextPresentationUpdateOffscreen.mm

This fixes an issue where `_doAfterNextPresentationUpdate:` sometimes hangs forever. This is bad,
because `_doAfterNextPresentationUpdate:` hangs on to the associated WKWebView forever, which then
causes the associated WebContent process to run forever.

The issue affects offscreen WKWebViews using `_relatedWebView`. The first WKWebView&apos;s WebPageProxy
gets a drawing area with a non-empty display ID, because `WebPageProxy::finishAttachingToWebProcess`
eventually calls `WebViewImpl::windowDidChangeScreen`.

The second WKWebView use `_relatedWebView` and creates a WebPageProxy that has a drawing area with
an empty display ID. This is because those pages go down the `WebPageProxy::ensureRunningProcess()`
path, which never calls `WebViewImpl::windowDidChangeScreen`.

Fix this by making the WebViewImpl constructor always call `windowDidChangeScreen`, so that the
associated WebPageProxy and drawing area always have some non-empty display ID.

A better fix might be to make m_displayID non-optional in RemoteLayerTreeDrawingAreaProxyMac, which
is already mentioned in the header. However, that&apos;s a larger change, so I didn&apos;t attempt it here.

Canonical link: <a href="https://commits.webkit.org/316919@main">https://commits.webkit.org/316919@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1388636ce24b5e5a1c734670572380a2dd27e31f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173793 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47726 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/41507 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183367 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/131661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/849cc5f5-4be7-4945-a745-4b1a34dd8b78) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175658 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49018 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47408 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/135144 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/131661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176751 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38576 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/155941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/115622 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/50079a87-18d7-4b43-8df6-71ffe32032c2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37217 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/35584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31851 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147641 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/35434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185793 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/38841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/39783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/144037 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47393 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/155496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/143897 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38812 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48072 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113338 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38815 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/119954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46578 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/10389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45980 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46211 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46039 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->