### PR TITLE
REGRESSION(316606@main): [macOS x86_64] Multiple webgl tests are crashing

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2410,5 +2410,3 @@ fast/animation/request-animation-frame-throttle-inside-overflow-scroll.html [ Pa
 fast/animation/request-animation-frame-throttle-subframe-display-none.html [ Pass Failure ]
 
 webkit.org/b/318732 http/tests/site-isolation/page-zoom.html [ Pass ImageOnlyFailure ]
-
-webkit.org/b/318879 [ x86_64 Release ] webgl/ [ Skip ]

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_render_utils.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_render_utils.mm
@@ -1190,7 +1190,7 @@ angle::Result ClearUtils::clearWithDraw(const gl::Context *context,
     ContextMtl *contextMtl = GetImpl(context);
     ANGLE_TRY(setupClearWithDraw(context, cmdEncoder, overridedParams));
 
-    angle::Result result;
+    angle::Result result = angle::Result::Continue;
     {
         // Need to disable occlusion query, otherwise clearing will affect the occlusion counting
         ScopedDisableOcclusionQuery disableOcclusionQuery(contextMtl, cmdEncoder, &result);
@@ -1336,7 +1336,7 @@ angle::Result ColorBlitUtils::blitColorWithDraw(const gl::Context *context,
     ContextMtl *contextMtl = GetImpl(context);
     ANGLE_TRY(setupColorBlitWithDraw(context, cmdEncoder, params));
 
-    angle::Result result;
+    angle::Result result = angle::Result::Continue;
     {
         // Need to disable occlusion query, otherwise blitting will affect the occlusion counting
         ScopedDisableOcclusionQuery disableOcclusionQuery(contextMtl, cmdEncoder, &result);
@@ -1544,7 +1544,7 @@ angle::Result DepthStencilBlitUtils::blitDepthStencilWithDraw(const gl::Context 
 
     ANGLE_TRY(setupDepthStencilBlitWithDraw(context, cmdEncoder, params));
 
-    angle::Result result;
+    angle::Result result = angle::Result::Continue;
     {
         // Need to disable occlusion query, otherwise blitting will affect the occlusion counting
         ScopedDisableOcclusionQuery disableOcclusionQuery(contextMtl, cmdEncoder, &result);
@@ -2518,7 +2518,7 @@ angle::Result CopyPixelsUtils::unpackPixelsWithDraw(const gl::Context *context,
     options.textureOffset[1]  = params.textureArea.y;
     cmdEncoder->setFragmentData(options, 0);
 
-    angle::Result result;
+    angle::Result result = angle::Result::Continue;
     {
         // Need to disable occlusion query, otherwise blitting will affect the occlusion counting
         ScopedDisableOcclusionQuery disableOcclusionQuery(contextMtl, cmdEncoder, &result);


### PR DESCRIPTION
#### 5a85b3827be7fce1cb3d3743e5320615ff781e0d
<pre>
REGRESSION(<a href="https://commits.webkit.org/316606@main">316606@main</a>): [macOS x86_64] Multiple webgl tests are crashing
<a href="https://bugs.webkit.org/show_bug.cgi?id=318879">https://bugs.webkit.org/show_bug.cgi?id=318879</a>
<a href="https://rdar.apple.com/181717081">rdar://181717081</a>

Reviewed by NOBODY (OOPS!).

<a href="https://commits.webkit.org/316606@main">316606@main</a> included changes where ScopedDisableOcclusionQuery&apos;s destructor now
only writes to its output result when an occlusion query is active and returns
early when occlusion query is not active. Four callers in mtl_render_utils.mm
never set a starting value for that result, so when no query is active they return
whatever garbage is on the stack instead of a real success or failure value.
This shows up mostly on Intel, where the garbage value tends to look like a
failure and crashes many WebGL tests.

Fix by properly initializing the result variables in mtl_reunder_utils.mm.

* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_render_utils.mm:
(rx::mtl::ClearUtils::clearWithDraw):
(rx::mtl::ColorBlitUtils::blitColorWithDraw):
(rx::mtl::DepthStencilBlitUtils::blitDepthStencilWithDraw):
(rx::mtl::CopyPixelsUtils::unpackPixelsWithDraw):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5a85b3827be7fce1cb3d3743e5320615ff781e0d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173618 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47551 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41161 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183191 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131486 "Failed to checkout and rebase branch from PR 69046") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48843 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47233 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135000 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/131486 "Failed to checkout and rebase branch from PR 69046") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176576 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38429 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155714 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115478 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cb42eaf9-c2d2-4b7a-9e20-f6e28d0383f4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37070 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35436 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31676 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147494 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35209 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185617 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39636 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143884 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47218 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143741 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47897 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31824 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113071 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38668 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46403 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10162 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45805 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46036 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45864 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->