### PR TITLE
[tooling] Make the last-built tree tiebreaker sanitizer-aware

### DIFF
--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -3118,15 +3118,21 @@ sub determineIsCMakeBuild()
         return;
     }
 
-    # Auto-detect a CMake macOS build. The CMake presets place artifacts under
-    # WebKitBuild/cmake-mac/<Configuration>; when both trees exist, Xcode wins
-    # by default unless a caller opts into the last-built tiebreaker via
-    # enableLastBuiltTiebreaker() (read-only path resolvers do; build drivers
-    # like build-webkit do not, so they are never auto-flipped).
+    # CMake macOS presets build into WebKitBuild/cmake-mac/<Configuration>. When
+    # both trees exist, Xcode wins unless a caller opts into the last-built
+    # tiebreaker via enableLastBuiltTiebreaker() (build drivers do not, so they
+    # never auto-flip).
     if (isAppleCocoaWebKit()) {
         determineBaseProductDir();
         determineConfiguration();
-        my $cmakeMacBuild = File::Spec->catdir($baseProductDir, "cmake-mac", $configuration);
+
+        # CMake sanitizer presets build into cmake-mac/ASan or cmake-mac/TSan, so
+        # resolve the tree the way determineConfigurationProductDir() does. Xcode
+        # toggles ASan within Debug/Release, so its path is unchanged.
+        my $cmakeConfiguration = $configuration;
+        $cmakeConfiguration = "ASan" if asanIsEnabled();
+        $cmakeConfiguration = "TSan" if tsanIsEnabled();
+        my $cmakeMacBuild = File::Spec->catdir($baseProductDir, "cmake-mac", $cmakeConfiguration);
         my $xcodeBuild = File::Spec->catdir($baseProductDir, $configuration);
 
         if (-f File::Spec->catfile($cmakeMacBuild, "CMakeCache.txt") && !-d $xcodeBuild) {
@@ -3134,19 +3140,11 @@ sub determineIsCMakeBuild()
             return;
         }
 
-        # Heuristic: prefer whichever tree the developer built most recently,
-        # comparing each build system's own build log rather than a specific
-        # product binary. A product like WebKit.framework only relinks when
-        # WebKit itself changes, so a JSC-only (or WTF-only, tool-only) build
-        # would leave it stale and flip the choice to the wrong tree. Both build
-        # systems instead touch a log on every build of any target:
-        #   - CMake/Ninja:   cmake-mac/<Configuration>/.ninja_log
-        #   - Xcode/XCBuild: WebKitBuild/XCBuildData/build.db
-        # A missing log resolves to mtime 0, so an absent log degrades to the
-        # pre-existing "Xcode wins when both exist" default. Note build.db lives
-        # at the WebKitBuild root and is shared across Xcode configurations, so
-        # with two Xcode configs it reflects the most recent Xcode build of any
-        # of them rather than this specific configuration.
+        # Prefer whichever tree was built most recently, comparing each build
+        # system's log rather than a product binary (which goes stale after a
+        # partial build like JSC-only): cmake-mac's .ninja_log vs Xcode's
+        # XCBuildData/build.db. A missing log is mtime 0, degrading to the
+        # Xcode-wins default. build.db is shared across Xcode configurations.
         if ($shouldPickLastBuilt && -d $cmakeMacBuild && -d $xcodeBuild) {
             my $cmakeMarker = File::Spec->catfile($cmakeMacBuild, ".ninja_log");
             my $xcodeMarker = File::Spec->catfile($baseProductDir, "XCBuildData", "build.db");
@@ -3154,7 +3152,7 @@ sub determineIsCMakeBuild()
             my $xcodeMtime = -f $xcodeMarker ? stat($xcodeMarker)->mtime : 0;
             if ($cmakeMtime > $xcodeMtime) {
                 $isCMakeBuild = 1;
-                print STDERR "Using last-built tree: cmake-mac/$configuration (CMake)\n";
+                print STDERR "Using last-built tree: cmake-mac/$cmakeConfiguration (CMake)\n";
             } elsif ($xcodeMtime && $cmakeMtime) {
                 print STDERR "Using last-built tree: $configuration (Xcode)\n";
             }

--- a/Tools/Scripts/webkitperl/webkitdirs_unittest/determineIsCMakeBuildLastBuiltASan.pl
+++ b/Tools/Scripts/webkitperl/webkitdirs_unittest/determineIsCMakeBuildLastBuiltASan.pl
@@ -1,0 +1,78 @@
+#!/usr/bin/env perl
+#
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Unit test for webkitdirs::determineIsCMakeBuild last-built tiebreaker with a
+# sanitizer build: a CMake ASan build lands in cmake-mac/ASan, so when ASan is
+# enabled the tiebreaker must inspect that tree. Each scenario lives in its own
+# .pl file because determineIsCMakeBuild caches its answer in a script-global.
+use strict;
+use warnings;
+use File::Path qw(make_path);
+use File::Spec;
+use File::Temp qw(tempdir);
+use Test::More;
+use webkitdirs;
+
+plan(tests => 1);
+
+# The tiebreaker is gated on isAppleCocoaWebKit(); force it on so the test
+# is platform-independent (webkitperl runs on non-Cocoa bots too).
+no warnings qw(redefine prototype);
+*webkitdirs::isAppleCocoaWebKit = sub () { 1 };
+use warnings qw(redefine prototype);
+
+my $configuration = "Debug";
+my $base = tempdir(CLEANUP => 1);
+
+# Enable ASan via the marker file that readSanitizerConfiguration() reads.
+open(my $asanFh, ">", File::Spec->catfile($base, "ASan")) or die "Could not create ASan marker: $!";
+print $asanFh "YES\n";
+close($asanFh);
+
+# The CMake ASan build lands in cmake-mac/ASan; Xcode toggles ASan within the
+# Debug tree. Both tree dirs must exist for the tiebreaker to run.
+my $cmakeMarker = File::Spec->catfile($base, "cmake-mac", "ASan", ".ninja_log");
+my $xcodeMarker = File::Spec->catfile($base, "XCBuildData", "build.db");
+make_path(File::Spec->catdir($base, $configuration));
+
+for my $marker ($cmakeMarker, $xcodeMarker) {
+    my ($volume, $dir, $file) = File::Spec->splitpath($marker);
+    make_path(File::Spec->catpath($volume, $dir, ""));
+    open(my $fh, ">", $marker) or die "Could not create $marker: $!";
+    close($fh);
+}
+
+# Make the CMake ASan build log the more recently built one.
+my $now = time();
+utime($now - 100, $now - 100, $xcodeMarker);
+utime($now, $now, $cmakeMarker);
+
+setBaseProductDir($base);
+setConfiguration($configuration);
+enableLastBuiltTiebreaker();
+
+@ARGV = ();
+webkitdirs::determineIsCMakeBuild();
+
+ok(isCMakeBuild(), "last-built tiebreaker inspects cmake-mac/ASan when ASan is enabled");


### PR DESCRIPTION
#### 25a629d8064889274945b87f806275963d2b1945
<pre>
[tooling] Make the last-built tree tiebreaker sanitizer-aware
<a href="https://bugs.webkit.org/show_bug.cgi?id=319001">https://bugs.webkit.org/show_bug.cgi?id=319001</a>
<a href="https://rdar.apple.com/181851997">rdar://181851997</a>

Reviewed by Sammy Gill.

The last-built tiebreaker which landed as <a href="https://commits.webkit.org/316853@main">https://commits.webkit.org/316853@main</a>
looked at cmake-mac/&lt;Configuration&gt;, but a CMake
sanitizer build lands in cmake-mac/ASan or cmake-mac/TSan. So a most-recent
CMake ASan/TSan build was never detected and the tool fell back to Xcode.

Resolve the CMake tree the same way determineConfigurationProductDir() does,
so the auto-detect and the tiebreaker both inspect the tree a sanitizer build
actually populates. Xcode is unchanged (ASan is toggled within Debug/Release).

* Tools/Scripts/webkitdirs.pm:
(determineIsCMakeBuild):
* Tools/Scripts/webkitperl/webkitdirs_unittest/determineIsCMakeBuildLastBuiltASan.pl: Added.

Canonical link: <a href="https://commits.webkit.org/316866@main">https://commits.webkit.org/316866@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de65df3c61586357afc4df5bcf53123d93aeaef7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173625 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47558 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41168 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183198 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/131493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/44158692-1ced-4d34-9e8b-c77742762211) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175490 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48850 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47240 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135006 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/131493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6b979658-78bb-48aa-9ebe-6888bed9d047) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176583 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38436 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155719 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115484 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37077 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35440 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31683 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/4231 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147501 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35214 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185624 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/34887 "Built successfully and passed tests") | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39640 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143891 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47225 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143748 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38785 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47904 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113078 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38672 "Passed tests") | | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/210658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46410 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10167 "Passed tests") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/210658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45812 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46043 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45871 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->