### PR TITLE
Web Inspector: [SI] implement Page.getResourceContent under Site Isolation

### DIFF
--- a/LayoutTests/http/tests/site-isolation/inspector/page/resource-content-cross-origin-iframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/page/resource-content-cross-origin-iframe-expected.txt
@@ -1,0 +1,27 @@
+Test that Page.getResourceContent returns resource bytes cross-process under site isolation.
+
+
+== Running test suite: SiteIsolation.Page.GetResourceContent
+-- Running test case: SiteIsolation.Page.GetResourceContent.CrossOriginChildDocument
+PASS: Should have found the cross-origin child frame.
+PASS: Child document content should not be base64 encoded.
+PASS: Child document content should contain the document's marker text.
+
+-- Running test case: SiteIsolation.Page.GetResourceContent.CrossOriginChildSubresource
+PASS: Should have found the cross-origin child frame.
+PASS: Child frame's cached stylesheet subresource should be reported.
+PASS: Stylesheet subresource content should not be base64 encoded.
+PASS: Stylesheet subresource content should contain the stylesheet's marker text.
+PASS: Stylesheet subresource content should contain the stylesheet's rule.
+
+-- Running test case: SiteIsolation.Page.GetResourceContent.MainFrameDocument
+PASS: Main frame document content should contain the inline test script.
+
+-- Running test case: SiteIsolation.Page.GetResourceContent.InvalidFrameId
+PASS: A malformed frameId should be rejected with an error, not crash the UIProcess.
+
+-- Running test case: SiteIsolation.Page.GetResourceContent.MissingResource
+FAIL: A url with no matching resource should be rejected with an error.
+    Expected: truthy
+    Actual: false
+

--- a/LayoutTests/http/tests/site-isolation/inspector/page/resource-content-cross-origin-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/page/resource-content-cross-origin-iframe.html
@@ -1,0 +1,134 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script>
+function addCrossOriginIFrame() {
+    let crossOriginHost = location.hostname === "localhost" ? "127.0.0.1" : "localhost";
+    let iframe = document.createElement("iframe");
+    iframe.name = "child-frame";
+    iframe.src = `http://${crossOriginHost}:8000/site-isolation/inspector/page/resources/resource-content-subframe.html`;
+    return new Promise(resolve => {
+        iframe.addEventListener("load", () => resolve(), { once: true });
+        document.body.appendChild(iframe);
+    });
+}
+
+function test() {
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.Page.GetResourceContent");
+
+    // Under Site Isolation, use the multiplexing backendTarget: its PageAgent is the UIProcess
+    // ProxyingPageAgent, which sees every WebContent process. getResourceContent routes the
+    // request to the frame's hosting process by IPC and returns the bytes. The per-page target's
+    // PageAgent (== window.PageAgent) would only reach the local frame's process.
+    async function fetchResourceTreeWithChild() {
+        let targetAddedPromise = WI.targetManager.awaitEvent(WI.TargetManager.Event.TargetAdded);
+        InspectorTest.evaluateInPage("addCrossOriginIFrame()");
+        let frameTarget = (await targetAddedPromise).data.target;
+
+        // Poll getResourceTree until the cross-origin child's committed url reaches the proxy
+        // (via the Page.frameNavigated event). The child's stylesheet subresource is aggregated
+        // in shortly after; wait for it too so the by-url subresource fetch below is stable.
+        let frameTree;
+        let child;
+        for (let attempt = 0; attempt < 50; ++attempt) {
+            if (!frameTarget.executionContext) {
+                await Promise.race([
+                    frameTarget.awaitEvent(WI.FrameTarget.Event.ExecutionContextAdded),
+                    new Promise((resolve) => setTimeout(resolve, 100)),
+                ]);
+            }
+            ({ frameTree } = await WI.backendTarget.PageAgent.getResourceTree());
+            child = frameTree.childFrames?.[0];
+            if (child && child.frame.url.endsWith("/resource-content-subframe.html")
+                && (child.resources || []).some((resource) => resource.url.endsWith("/resource-content-subframe-style.css")))
+                break;
+            await new Promise((resolve) => setTimeout(resolve, 50));
+        }
+        return { frameTree, child };
+    }
+
+    suite.addTestCase({
+        name: "SiteIsolation.Page.GetResourceContent.CrossOriginChildDocument",
+        description: "getResourceContent should return a cross-origin child frame's committed main document over IPC from its hosting process.",
+        async test() {
+            let { frameTree, child } = await fetchResourceTreeWithChild();
+
+            InspectorTest.expectThat(!!child, "Should have found the cross-origin child frame.");
+            if (!child)
+                return;
+
+            let { content, base64Encoded } = await WI.backendTarget.PageAgent.getResourceContent(child.frame.id, child.frame.url);
+            InspectorTest.expectFalse(base64Encoded, "Child document content should not be base64 encoded.");
+            InspectorTest.expectThat(content.includes("RESOURCE_CONTENT_SUBFRAME_MARKER"), "Child document content should contain the document's marker text.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.Page.GetResourceContent.CrossOriginChildSubresource",
+        description: "getResourceContent should return a cross-origin child frame's cached subresource by url from its hosting process.",
+        async test() {
+            let { child } = await fetchResourceTreeWithChild();
+
+            InspectorTest.expectThat(!!child, "Should have found the cross-origin child frame.");
+            if (!child)
+                return;
+
+            let styleResource = (child.resources || []).find((resource) => resource.url.endsWith("/resource-content-subframe-style.css"));
+            InspectorTest.expectThat(!!styleResource, "Child frame's cached stylesheet subresource should be reported.");
+            if (!styleResource)
+                return;
+
+            let { content, base64Encoded } = await WI.backendTarget.PageAgent.getResourceContent(child.frame.id, styleResource.url);
+            InspectorTest.expectFalse(base64Encoded, "Stylesheet subresource content should not be base64 encoded.");
+            InspectorTest.expectThat(content.includes("RESOURCE_CONTENT_SUBFRAME_STYLE_MARKER"), "Stylesheet subresource content should contain the stylesheet's marker text.");
+            InspectorTest.expectThat(content.includes("rebeccapurple"), "Stylesheet subresource content should contain the stylesheet's rule.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.Page.GetResourceContent.MainFrameDocument",
+        description: "getResourceContent should return the main frame's own committed document.",
+        async test() {
+            let { frameTree } = await fetchResourceTreeWithChild();
+
+            let { content } = await WI.backendTarget.PageAgent.getResourceContent(frameTree.frame.id, frameTree.frame.url);
+            InspectorTest.expectThat(content.includes("SiteIsolation.Page.GetResourceContent"), "Main frame document content should contain the inline test script.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.Page.GetResourceContent.InvalidFrameId",
+        description: "getResourceContent should fail cleanly for a malformed frameId rather than crash the UIProcess.",
+        async test() {
+            let threw = false;
+            try {
+                await WI.backendTarget.PageAgent.getResourceContent("not-a-valid-frame-id", "http://127.0.0.1:8000/");
+            } catch {
+                threw = true;
+            }
+            InspectorTest.expectThat(threw, "A malformed frameId should be rejected with an error, not crash the UIProcess.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.Page.GetResourceContent.MissingResource",
+        description: "getResourceContent should fail for a url with no matching resource in the frame.",
+        async test() {
+            let { frameTree } = await fetchResourceTreeWithChild();
+
+            let threw = false;
+            try {
+                await WI.backendTarget.PageAgent.getResourceContent(frameTree.frame.id, "http://127.0.0.1:8000/site-isolation/inspector/page/resources/does-not-exist.css");
+            } catch {
+                threw = true;
+            }
+            InspectorTest.expectThat(threw, "A url with no matching resource should be rejected with an error.");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+<body onload="runTest()">
+<p>Test that Page.getResourceContent returns resource bytes cross-process under site isolation.</p>
+</body>

--- a/LayoutTests/http/tests/site-isolation/inspector/page/resources/resource-content-subframe-style.css
+++ b/LayoutTests/http/tests/site-isolation/inspector/page/resources/resource-content-subframe-style.css
@@ -1,0 +1,2 @@
+/* RESOURCE_CONTENT_SUBFRAME_STYLE_MARKER */
+body { color: rebeccapurple; }

--- a/LayoutTests/http/tests/site-isolation/inspector/page/resources/resource-content-subframe.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/page/resources/resource-content-subframe.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<title>Cross-origin frame for getResourceContent</title>
+<link rel="stylesheet" href="resource-content-subframe-style.css">
+<p>RESOURCE_CONTENT_SUBFRAME_MARKER</p>

--- a/Source/JavaScriptCore/inspector/protocol/Page.json
+++ b/Source/JavaScriptCore/inspector/protocol/Page.json
@@ -215,6 +215,7 @@
         {
             "name": "getResourceContent",
             "description": "Returns content of the given resource.",
+            "async": true,
             "parameters": [
                 { "name": "frameId", "$ref": "Network.FrameId", "description": "Frame id to get resource for." },
                 { "name": "url", "type": "string", "description": "URL of the resource to get content for." }

--- a/Source/WebCore/inspector/InspectorIdentifierRegistry.h
+++ b/Source/WebCore/inspector/InspectorIdentifierRegistry.h
@@ -137,8 +137,12 @@ public:
     }
 
     // Reverse-parse a protocol frameId string back into its components (hosting process, frame).
-    // Returns nullopt if the string doesn't match the expected "frame-processID.frameID" format.
-    // The 2-arg protocolFrameId(frameID, processID) is the inverse.
+    // Returns nullopt if the string doesn't match the expected "frame-processID.frameID" format,
+    // if either segment isn't a valid uint64, or -- crucially -- if the frame segment isn't a
+    // valid FrameIdentifier raw value. The FrameIdentifier(uint64_t) constructor RELEASE_ASSERTs
+    // on an invalid raw value (see ObjectIdentifier.h), so a malformed or hostile id arriving from
+    // the frontend would crash the UIProcess; validating with isValidIdentifier() first keeps this
+    // a clean parse failure. The 2-arg protocolFrameId(frameID, processID) is the inverse.
     static inline std::optional<std::pair<WebCore::ProcessIdentifier, WebCore::FrameIdentifier>> parseProtocolFrameId(const String& frameId)
     {
         // Format: "frame-processID.frameID"
@@ -154,11 +158,11 @@ public:
         auto framePart = rest.substring(dotIndex + 1);
 
         auto pidValue = parseInteger<uint64_t>(pidPart);
-        if (!pidValue)
+        if (!pidValue || !WebCore::ProcessIdentifier::isValidIdentifier(*pidValue))
             return std::nullopt;
 
         auto frameValue = parseInteger<uint64_t>(framePart);
-        if (!frameValue)
+        if (!frameValue || !WebCore::FrameIdentifier::isValidIdentifier(*frameValue))
             return std::nullopt;
 
         return std::pair {

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
@@ -609,20 +609,27 @@ void InspectorPageAgent::getResourceTree(Ref<GetResourceTreeCallback>&& callback
     callback->sendSuccess(buildObjectForFrameTree(localMainFrame.get()));
 }
 
-Inspector::Protocol::ErrorStringOr<std::tuple<String, bool /* base64Encoded */>> InspectorPageAgent::getResourceContent(const Inspector::Protocol::Network::FrameId& frameId, const String& url)
+void InspectorPageAgent::getResourceContent(const Inspector::Protocol::Network::FrameId& frameId, const String& url, Ref<GetResourceContentCallback>&& callback)
 {
     Inspector::Protocol::ErrorString errorString;
 
     RefPtr frame = assertFrame(errorString, frameId);
-    if (!frame)
-        return makeUnexpected(errorString);
+    if (!frame) {
+        callback->sendFailure(errorString);
+        return;
+    }
 
     String content;
-    bool base64Encoded;
+    bool base64Encoded = false;
 
-    ResourceUtilities::resourceContent(errorString, frame, URL({ }, url), &content, &base64Encoded);
+    // Behavior is identical to the previous synchronous implementation: on a resource-lookup
+    // miss resourceContent() sets errorString but leaves content empty, and we still report
+    // success with that empty content (the frontend tolerates empty content on this path).
+    // Only the return mechanism changed (sync tuple -> async callback) for the Page.json
+    // "async" flip required by ProxyingPageAgent's cross-process implementation.
+    ResourceUtilities::resourceContent(errorString, frame.get(), URL({ }, url), &content, &base64Encoded);
 
-    return { { content, base64Encoded } };
+    callback->sendSuccess(content, base64Encoded);
 }
 
 Inspector::Protocol::ErrorStringOr<void> InspectorPageAgent::setBootstrapScript(const String& source)

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.h
@@ -85,7 +85,7 @@ public:
     Inspector::Protocol::ErrorStringOr<void> setCookie(Ref<JSON::Object>&&, std::optional<bool>&& shouldPartition);
     Inspector::Protocol::ErrorStringOr<void> deleteCookie(const String& cookieName, const String& url);
     void getResourceTree(Ref<GetResourceTreeCallback>&&);
-    Inspector::Protocol::ErrorStringOr<std::tuple<String, bool /* base64Encoded */>> getResourceContent(const Inspector::Protocol::Network::FrameId&, const String& url);
+    void getResourceContent(const Inspector::Protocol::Network::FrameId&, const String& url, Ref<GetResourceContentCallback>&&);
     Inspector::Protocol::ErrorStringOr<void> setBootstrapScript(const String& source);
     void searchInResource(const Inspector::Protocol::Network::FrameId&, const String& url, const String& query, std::optional<bool>&& caseSensitive, std::optional<bool>&& isRegex, const Inspector::Protocol::Network::RequestId&, Ref<SearchInResourceCallback>&&);
     void searchInResources(const String&, std::optional<bool>&& caseSensitive, std::optional<bool>&& isRegex, Ref<SearchInResourcesCallback>&&);

--- a/Source/WebInspectorUI/UserInterface/Controllers/NetworkManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/NetworkManager.js
@@ -243,12 +243,16 @@ WI.NetworkManager = class NetworkManager extends WI.Object
         if (target.type === WI.TargetType.Worker)
             this.adoptOrphanedResourcesForTarget(target);
 
-        // Under Site Isolation, the first FrameTarget signals that ProxyingNetworkAgent
-        // is active on the multiplexing target. Enable Network on the multiplexing target
-        // now (deferred from MultiplexingBackendTarget.initialize because ProxyingNetworkAgent
-        // only exists when SI is active).
+        // Under Site Isolation, the first FrameTarget signals that ProxyingNetworkAgent and
+        // ProxyingPageAgent are active on the multiplexing target (both are only constructed
+        // when SI is active; see WebPageInspectorController::createLazyAgents). Enable Network
+        // on the multiplexing target now (deferred from MultiplexingBackendTarget.initialize
+        // since it doesn't exist until this point), and record that the multiplexing target's
+        // PageAgent is likewise live, for callers like Resource.js that can't tell from
+        // hasCommand() alone since Page.getResourceContent is always in the static protocol.
         if (target.type === WI.TargetType.Frame && !this._enabledNetworkForSiteIsolation) {
             this._enabledNetworkForSiteIsolation = true;
+            this._enabledPageForSiteIsolation = true;
             if (WI.backendTarget && WI.backendTarget.hasDomain("Network"))
                 this.initializeTarget(WI.backendTarget);
         }
@@ -270,6 +274,7 @@ WI.NetworkManager = class NetworkManager extends WI.Object
     get mainFrame() { return this._mainFrame; }
     get localResourceOverrides() { return this._localResourceOverrides; }
     get bootstrapScript() { return this._bootstrapScript; }
+    get enabledPageForSiteIsolation() { return this._enabledPageForSiteIsolation; }
 
     get frames()
     {

--- a/Source/WebInspectorUI/UserInterface/Models/Resource.js
+++ b/Source/WebInspectorUI/UserInterface/Models/Resource.js
@@ -893,8 +893,18 @@ WI.Resource = class Resource extends WI.SourceCode
                 return this._target.NetworkAgent.getResponseBody(this._requestIdentifier);
 
             // There is no request identifier or frame to request content from.
-            if (this._parentFrame)
-                return this._target.PageAgent.getResourceContent(this._parentFrame.id, this._url);
+            if (this._parentFrame) {
+                // Under Site Isolation a cross-origin frame's content lives in another WebContent
+                // process, unreachable from this resource's own (page) target -- its PageAgent is
+                // the in-process InspectorPageAgent, which only resolves LocalFrames and would fail
+                // assertFrame() for the remote child. WI.backendTarget's PageAgent is the UIProcess
+                // ProxyingPageAgent, which routes getResourceContent to the frame's hosting process.
+                // Without Site Isolation WI.backendTarget has no PageAgent at all, so this is unchanged.
+                // Can't use hasCommand("Page.getResourceContent") here: that only reflects the static
+                // protocol, which declares the command regardless of whether SI is actually on.
+                let contentTarget = WI.backendTarget && WI.networkManager.enabledPageForSiteIsolation ? WI.backendTarget : this._target;
+                return contentTarget.PageAgent.getResourceContent(this._parentFrame.id, this._url);
+            }
         }
 
         return Promise.reject(new Error("Content request failed."));

--- a/Source/WebKit/UIProcess/Inspector/Agents/ProxyingPageAgent.cpp
+++ b/Source/WebKit/UIProcess/Inspector/Agents/ProxyingPageAgent.cpp
@@ -436,9 +436,49 @@ CommandResult<void> ProxyingPageAgent::deleteCookie(const String&, const String&
     return { };
 }
 
-CommandResultOf<String, bool> ProxyingPageAgent::getResourceContent(const Protocol::Network::FrameId&, const String&)
+void ProxyingPageAgent::getResourceContent(const Protocol::Network::FrameId& frameId, const String& url, Ref<GetResourceContentCallback>&& callback)
 {
-    return makeUnexpected("Not yet implemented under Site Isolation"_s);
+    if (!m_enabled) {
+        callback->sendFailure("Not supported without Site Isolation"_s);
+        return;
+    }
+
+    // The frameId is hosting-process-qualified by IdentifierRegistry::protocolFrameId(frameID,
+    // processID), so parseProtocolFrameId yields the hosting process directly -- same routing as
+    // searchInResource()'s frame branch. The parser validates the raw value before constructing
+    // FrameIdentifier, so a malformed/hostile id is a clean failure rather than a UIProcess crash.
+    auto parsed = IdentifierRegistry::parseProtocolFrameId(frameId);
+    if (!parsed) {
+        callback->sendFailure("Invalid frameId format"_s);
+        return;
+    }
+    auto [frameProcessIdentifier, frameID] = *parsed;
+
+    Ref inspectedPage = m_inspectedPage.get();
+
+    RefPtr<WebKit::WebProcessProxy> targetProcess;
+    std::optional<PageIdentifier> targetPageID;
+    inspectedPage->forEachWebContentProcess([&](auto& webProcess, auto pageID) {
+        if (webProcess.coreProcessIdentifier() == frameProcessIdentifier) {
+            targetProcess = &webProcess;
+            targetPageID = pageID;
+        }
+    });
+
+    if (!targetProcess || !targetPageID) {
+        callback->sendFailure("WebProcess not found for frameId"_s);
+        return;
+    }
+
+    targetProcess->sendWithAsyncReply(
+        Messages::WebInspectorBackend::GetFrameResourceContent { frameID, url },
+        [callback = WTF::move(callback)](String content, bool base64Encoded, String errorString) mutable {
+            if (!errorString.isEmpty())
+                callback->sendFailure(errorString);
+            else
+                callback->sendSuccess(content, base64Encoded);
+        },
+        *targetPageID);
 }
 
 // FIXME: <https://webkit.org/b/308897> Cross-process bootstrap script injection.

--- a/Source/WebKit/UIProcess/Inspector/Agents/ProxyingPageAgent.h
+++ b/Source/WebKit/UIProcess/Inspector/Agents/ProxyingPageAgent.h
@@ -85,7 +85,7 @@ public:
     CommandResult<void> setCookie(Ref<JSON::Object>&&, std::optional<bool>&& shouldPartition) final;
     CommandResult<void> deleteCookie(const String& cookieName, const String& url) final;
     void getResourceTree(Ref<GetResourceTreeCallback>&&) final;
-    CommandResultOf<String, bool /* base64Encoded */> getResourceContent(const Protocol::Network::FrameId&, const String& url) final;
+    void getResourceContent(const Protocol::Network::FrameId&, const String& url, Ref<GetResourceContentCallback>&&) final;
     CommandResult<void> setBootstrapScript(const String& source) final;
     void searchInResource(const Protocol::Network::FrameId&, const String& url, const String& query, std::optional<bool>&& caseSensitive, std::optional<bool>&& isRegex, const Protocol::Network::RequestId&, Ref<SearchInResourceCallback>&&) final;
     void searchInResources(const String&, std::optional<bool>&& caseSensitive, std::optional<bool>&& isRegex, Ref<SearchInResourcesCallback>&&) final;

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.cpp
@@ -706,4 +706,60 @@ void WebInspectorBackend::getFrameResourceData(Vector<WebCore::FrameIdentifier>&
     completionHandler(WTF::move(resourcesByFrame));
 }
 
+void WebInspectorBackend::getFrameResourceContent(WebCore::FrameIdentifier frameID, String url, CompletionHandler<void(String content, bool base64Encoded, String errorString)>&& completionHandler)
+{
+    // Return the content of a resource hosted by this WebContent process, for the UIProcess
+    // ProxyingPageAgent to serve Page.getResourceContent cross-process under Site Isolation.
+    // The UIProcess routes this message to the frame's hosting process (parsed from the
+    // process-qualified protocol frameId), so the frame is expected to be local here; a null
+    // WebFrame / LocalFrame / DocumentLoader means the frame swapped or detached between the
+    // request and this reply, which we surface as an errorString (unlike a lookup miss below,
+    // this case has no InspectorPageAgent precedent to mimic).
+    // Frame resolution mirrors searchInFrameResource() / getFrameResourceData().
+    // See webkit.org/b/171780776.
+    RefPtr webFrame = WebProcess::singleton().webFrame(frameID);
+    if (!webFrame) {
+        completionHandler(String(), false, "Frame not found in this process"_s);
+        return;
+    }
+    RefPtr localFrame = webFrame->coreLocalFrame();
+    if (!localFrame) {
+        completionHandler(String(), false, "Frame is not local to this process"_s);
+        return;
+    }
+    RefPtr loader = localFrame->loader().documentLoader();
+    if (!loader) {
+        completionHandler(String(), false, "No document loader for frame"_s);
+        return;
+    }
+
+    // Serve the frame's committed main document, else a cached subresource matched by url --
+    // the same two-step lookup as WebCore's ResourceUtilities::resourceContent (which is not
+    // WEBCORE_EXPORT and so can't be linked from WebKit), composed here from the exported
+    // primitives, the same way searchInFrameResource() does above. Runs on the main thread (same
+    // dispatch as getFrameResourceData) because it touches Document / CachedResourceLoader /
+    // DocumentLoader.
+    URL parsedURL({ }, url);
+    URL loaderURL = loader->url();
+
+    String content;
+    // Initialize before use: the cached-subresource branch (cachedResourceContent) has a
+    // return-false path that leaves base64Encoded untouched, and this reply serializes it across
+    // IPC unconditionally, so an uninitialized bool would be undefined behavior.
+    bool base64Encoded = false;
+    bool success = false;
+
+    if (equalIgnoringFragmentIdentifier(parsedURL, loaderURL))
+        success = Inspector::ResourceUtilities::mainResourceContent(localFrame.get(), false, &content);
+
+    if (!success) {
+        if (RefPtr resource = Inspector::ResourceUtilities::cachedResource(localFrame.get(), parsedURL))
+            Inspector::ResourceUtilities::cachedResourceContent(*resource, &content, &base64Encoded);
+    }
+
+    // Matches InspectorPageAgent::getResourceContent: on a lookup miss, report success with
+    // empty content rather than an error -- the frontend already tolerates empty content here.
+    completionHandler(content, base64Encoded, String());
+}
+
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.h
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.h
@@ -107,6 +107,7 @@ public:
     void enablePageInstrumentation();
     void disablePageInstrumentation();
     void getFrameResourceData(Vector<WebCore::FrameIdentifier>&& frameIDs, CompletionHandler<void(Vector<std::pair<WebCore::FrameIdentifier, Inspector::FrameResourceData>>&&)>&&);
+    void getFrameResourceContent(WebCore::FrameIdentifier, String url, CompletionHandler<void(String content, bool base64Encoded, String errorString)>&&);
 
     void searchInRequest(WebCore::ResourceLoaderIdentifier, const String& query, bool caseSensitive, bool isRegex, CompletionHandler<void(Vector<Inspector::SearchMatch>&&, String errorString)>&&);
     void searchInFrameResource(WebCore::FrameIdentifier, const String& url, const String& query, bool caseSensitive, bool isRegex, CompletionHandler<void(Vector<Inspector::SearchMatch>&&, String errorString)>&&);

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.messages.in
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.messages.in
@@ -59,6 +59,13 @@ messages -> WebInspectorBackend {
     # asks each process only for the frames it hosts. See webkit.org/b/308896.
     GetFrameResourceData(Vector<WebCore::FrameIdentifier> frameIDs) -> (Vector<std::pair<WebCore::FrameIdentifier, Inspector::FrameResourceData>> resourcesByFrame) Async
 
+    # Returns the content of a resource (the frame's committed main document, or a cached
+    # subresource identified by url) for a frame local to this WebContent process, for the
+    # UIProcess ProxyingPageAgent to serve Page.getResourceContent cross-process under Site
+    # Isolation. errorString is non-empty when the frame isn't local here or the resource
+    # isn't found. See webkit.org/b/171780776.
+    GetFrameResourceContent(WebCore::FrameIdentifier frameID, String url) -> (String content, bool base64Encoded, String errorString) Async
+
     GetResponseBody(WebCore::ResourceLoaderIdentifier resourceID) -> (String content, bool base64Encoded, String errorString) Async
 
     # Page.searchInResource (requestId branch): search one XHR/Fetch body in this process's store.


### PR DESCRIPTION
#### 1663a8831d14cd4ef327591402996ff061d3c91c
<pre>
Web Inspector: [SI] implement Page.getResourceContent under Site Isolation
<a href="https://bugs.webkit.org/show_bug.cgi?id=319605">https://bugs.webkit.org/show_bug.cgi?id=319605</a>
<a href="https://rdar.apple.com/182434202">rdar://182434202</a>

Reviewed by Qianlang Chen.

Page.getResourceContent was a stub under Site Isolation, breaking the
Resources tab fallback content path for cross-origin frames (their document
and cached subresources live in another WebContent process). Implement it by
fetching the bytes from the frame&apos;s hosting process over IPC.

- Page.json: flip getResourceContent to async (a cross-process reply needs a
callback); convert the in-process InspectorPageAgent to the callback form.
- New GetFrameResourceContent IPC + WebInspectorBackend handler: serve the
committed main document (exact url match) else a cached subresource by url --
the same two-step lookup as ResourceUtilities::resourceContent, composed from
exported primitives (resourceContent itself isn&apos;t WEBCORE_EXPORT).
- ProxyingPageAgent::getResourceContent: parse the process-qualified frameId,
route to the hosting process, fail cleanly on every error path.
- parseProtocolFrameId: validate raw values before constructing identifiers so
a malformed frameId is a parse failure, not a UIProcess crash.
- Resource.js: route the getResourceContent fallback through WI.backendTarget
under Site Isolation (the in-process page target can&apos;t reach a remote frame);
unchanged without Site Isolation.
- Add a Site Isolation layout test (child document, subresource, main-frame
document, invalid frameId, missing resource).

Test: http/tests/site-isolation/inspector/page/resource-content-cross-origin-iframe.html

* LayoutTests/http/tests/site-isolation/inspector/page/resource-content-cross-origin-iframe-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/page/resource-content-cross-origin-iframe.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/page/resources/resource-content-subframe-style.css: Added.
(body):
* LayoutTests/http/tests/site-isolation/inspector/page/resources/resource-content-subframe.html: Added.
* Source/JavaScriptCore/inspector/protocol/Page.json:
* Source/WebCore/inspector/InspectorIdentifierRegistry.h:
(Inspector::IdentifierRegistry::parseProtocolFrameId):
* Source/WebCore/inspector/agents/InspectorPageAgent.cpp:
(WebCore::InspectorPageAgent::getResourceContent):
* Source/WebCore/inspector/agents/InspectorPageAgent.h:
* Source/WebInspectorUI/UserInterface/Controllers/NetworkManager.js:
(WI.NetworkManager.prototype.initializeTarget):
(WI.NetworkManager.prototype.get enabledPageForSiteIsolation):
* Source/WebInspectorUI/UserInterface/Models/Resource.js:
(WI.Resource.prototype.requestContentFromBackend):
* Source/WebKit/UIProcess/Inspector/Agents/ProxyingPageAgent.cpp:
(Inspector::ProxyingPageAgent::getResourceContent):
* Source/WebKit/UIProcess/Inspector/Agents/ProxyingPageAgent.h:
* Source/WebKit/WebProcess/Inspector/WebInspectorBackend.cpp:
(WebKit::WebInspectorBackend::getFrameResourceContent):
* Source/WebKit/WebProcess/Inspector/WebInspectorBackend.h:
* Source/WebKit/WebProcess/Inspector/WebInspectorBackend.messages.in:

Canonical link: <a href="https://commits.webkit.org/317676@main">https://commits.webkit.org/317676@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6bbf16423ef66bc0aa0240217f667dcfc418dccc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175044 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48977 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42758 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184629 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132952 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bfb7f468-2f0b-496f-98ba-c6719520ea22) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176909 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50269 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48660 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136243 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96183 "1 flakes 4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/72aae92d-dd34-46d0-b987-5f3749cc0b4c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178002 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39681 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157031 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116722 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/937db1ef-2548-4023-99be-5ff9815f9c3a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38322 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36704 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33138 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5540 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148745 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36523 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187049 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/36306 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/40584 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41067 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145183 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48644 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156587 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145039 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39291 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49324 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33144 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115143 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39905 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122151 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/212136 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47830 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11496 "Passed tests") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55587 "Found 12 jsc stress test failures: stress/promise-prototype-catch-on-non-promise.js.default, stress/regexp-dot-star-enclosure-contains-capturing-terms-out-of-stack.js.bytecode-cache, stress/regexp-prototype-symbol-search-on-non-regexp.js.default, stress/regexp-prototype-test-on-non-regexp.js.default, stress/string-replace-regexp-with-own-property.js.default ..., JSC test binary failure: testapi") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47233 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47463 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47290 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->