### PR TITLE
REGRESSION(312482@main): Fix wrong architecture selected when mixing Xcode and CMake builds

### DIFF
--- a/Tools/Scripts/build-webkit
+++ b/Tools/Scripts/build-webkit
@@ -200,6 +200,10 @@ if ($useCCache == 1) {
 
 $ENV{'EXPORT_COMPILE_COMMANDS'} = "YES" if $exportCompileCommands;
 
+# Build driver: build the tree named by --cmake/--xcode (Xcode by default), not an
+# auto-detected one. Must precede the first isCMakeBuild()/productDir() query below.
+disableCMakeAutoDetection();
+
 my $productDir = productDir();
 
 if ((isAppleWebKit() || isPlayStation()) && !-d "WebKitLibraries") {

--- a/Tools/Scripts/set-webkit-configuration
+++ b/Tools/Scripts/set-webkit-configuration
@@ -92,6 +92,10 @@ if (checkForArgumentAndRemoveFromARGV("-h") || checkForArgumentAndRemoveFromARGV
     exit 1;
 }
 
+# Build driver: configure the tree named by --cmake/--xcode (Xcode by default), not
+# an auto-detected one. Must precede the first isCMakeBuild() query below.
+disableCMakeAutoDetection();
+
 my $baseProductDir = baseProductDir();
 if (isAppleCocoaWebKit() && !isCMakeBuild()) {
     markBaseProductDirectoryAsCreatedByXcodeBuildSystem();

--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -104,6 +104,7 @@ BEGIN {
        &determineCurrentSVNRevision
        &determineCrossTarget
        &determineXcodeSDK
+       &disableCMakeAutoDetection
        &enableLastBuiltTiebreaker
        &executableProductDir
        &exitStatus
@@ -281,6 +282,7 @@ my $iosVersion;
 my $generateDsym;
 my $isCMakeBuild;
 my $shouldPickLastBuilt = 0;
+my $cmakeAutoDetectionDisabled = 0;
 my $isGenerateProjectOnly;
 my $shouldBuild32Bit;
 my $isInspectorFrontend;
@@ -1396,6 +1398,8 @@ sub overrideConfiguredXcodeWorkspace($)
 
 sub XcodeOptions
 {
+    # This is an Xcode build; don't let an on-disk CMake tree flip the arch/destination.
+    disableCMakeAutoDetection();
     determineBaseProductDir();
     determineConfiguration();
     determineArchitecture();
@@ -3118,6 +3122,10 @@ sub determineIsCMakeBuild()
         return;
     }
 
+    # Build drivers opt out so they never auto-flip to an on-disk CMake tree;
+    # only read-only path resolvers auto-detect. Explicit --cmake/--xcode win above.
+    return if $cmakeAutoDetectionDisabled;
+
     # Auto-detect a CMake macOS build. The CMake presets place artifacts under
     # WebKitBuild/cmake-mac/<Configuration>; when both trees exist, Xcode wins
     # by default unless a caller opts into the last-built tiebreaker via
@@ -3168,6 +3176,15 @@ sub determineIsCMakeBuild()
 sub enableLastBuiltTiebreaker
 {
     $shouldPickLastBuilt = 1;
+}
+
+# Opt a build driver out of CMake auto-detection in determineIsCMakeBuild(), so it
+# builds/configures the tree named by --cmake/--xcode (Xcode by default) rather than
+# whichever exists on disk. Must be called before the first isCMakeBuild() query,
+# since the result is cached.
+sub disableCMakeAutoDetection
+{
+    $cmakeAutoDetectionDisabled = 1;
 }
 
 sub isCMakeBuild()

--- a/Tools/Scripts/webkitperl/webkitdirs_unittest/determineIsCMakeBuildBuildDriver.pl
+++ b/Tools/Scripts/webkitperl/webkitdirs_unittest/determineIsCMakeBuildBuildDriver.pl
@@ -1,0 +1,65 @@
+#!/usr/bin/env perl
+#
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Unit test for webkitdirs::determineIsCMakeBuild build-driver opt-out:
+# a build driver (build-webkit, set-webkit-configuration, the Xcode options
+# behind `make`) calls disableCMakeAutoDetection() so it is never flipped to
+# CMake by an on-disk CMake tree. This is the same CMake-only layout that
+# determineIsCMakeBuildCMakeOnly.pl auto-detects as CMake; the opt-out must
+# override that and yield Xcode. The function caches its answer in a
+# script-global, so each scenario lives in its own .pl file (test-webkitperl
+# runs each in a fresh process).
+use strict;
+use warnings;
+use File::Path qw(make_path);
+use File::Spec;
+use File::Temp qw(tempdir);
+use Test::More;
+use webkitdirs;
+
+plan(tests => 1);
+
+# Auto-detection is gated on isAppleCocoaWebKit(); force it on so the test is
+# platform-independent (webkitperl runs on non-Cocoa bots too).
+no warnings qw(redefine prototype);
+*webkitdirs::isAppleCocoaWebKit = sub () { 1 };
+use warnings qw(redefine prototype);
+
+my $configuration = "Debug";
+my $base = tempdir(CLEANUP => 1);
+# Build the CMake-only layout that would auto-detect to CMake, to prove the
+# opt-out overrides even a present CMake tree.
+my $cmakeCache = File::Spec->catfile($base, "cmake-mac", $configuration, "CMakeCache.txt");
+make_path(File::Spec->catdir($base, "cmake-mac", $configuration));
+open(my $fh, ">", $cmakeCache) or die "Could not create $cmakeCache: $!";
+close($fh);
+
+setBaseProductDir($base);
+setConfiguration($configuration);
+disableCMakeAutoDetection();
+
+@ARGV = ();
+webkitdirs::determineIsCMakeBuild();
+
+ok(!isCMakeBuild(), "disableCMakeAutoDetection() keeps Xcode despite a present CMake tree");

--- a/Tools/Scripts/webkitperl/webkitdirs_unittest/determineIsCMakeBuildCMakeOnly.pl
+++ b/Tools/Scripts/webkitperl/webkitdirs_unittest/determineIsCMakeBuildCMakeOnly.pl
@@ -1,0 +1,63 @@
+#!/usr/bin/env perl
+#
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Unit test for webkitdirs::determineIsCMakeBuild CMake-only auto-detection:
+# when a CMake tree exists (cmake-mac/<Configuration>/CMakeCache.txt) and no
+# Xcode tree is present, the default (read-only path resolver) behavior is to
+# auto-detect the CMake build. This is the case build drivers must NOT get; see
+# determineIsCMakeBuildBuildDriver.pl for the opt-out. The function caches its
+# answer in a script-global, so each scenario lives in its own .pl file
+# (test-webkitperl runs each in a fresh process).
+use strict;
+use warnings;
+use File::Path qw(make_path);
+use File::Spec;
+use File::Temp qw(tempdir);
+use Test::More;
+use webkitdirs;
+
+plan(tests => 1);
+
+# Auto-detection is gated on isAppleCocoaWebKit(); force it on so the test is
+# platform-independent (webkitperl runs on non-Cocoa bots too).
+no warnings qw(redefine prototype);
+*webkitdirs::isAppleCocoaWebKit = sub () { 1 };
+use warnings qw(redefine prototype);
+
+my $configuration = "Debug";
+my $base = tempdir(CLEANUP => 1);
+# Create only the CMake tree with its CMakeCache.txt, leaving the Xcode tree
+# ($base/$configuration) absent so the "CMake exists, Xcode absent" branch fires.
+my $cmakeCache = File::Spec->catfile($base, "cmake-mac", $configuration, "CMakeCache.txt");
+make_path(File::Spec->catdir($base, "cmake-mac", $configuration));
+open(my $fh, ">", $cmakeCache) or die "Could not create $cmakeCache: $!";
+close($fh);
+
+setBaseProductDir($base);
+setConfiguration($configuration);
+
+@ARGV = ();
+webkitdirs::determineIsCMakeBuild();
+
+ok(isCMakeBuild(), "auto-detects CMake when only a CMake tree exists");

--- a/Tools/Scripts/webkitperl/webkitdirs_unittest/determineIsCMakeBuildDisabledExplicitCMake.pl
+++ b/Tools/Scripts/webkitperl/webkitdirs_unittest/determineIsCMakeBuildDisabledExplicitCMake.pl
@@ -1,0 +1,45 @@
+#!/usr/bin/env perl
+#
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Unit test for webkitdirs::determineIsCMakeBuild precedence: an explicit
+# --cmake must win even when a build driver has opted out of auto-detection via
+# disableCMakeAutoDetection(), because --cmake is checked before the opt-out
+# (e.g. `build-webkit --cmake`). No filesystem layout is needed since the
+# explicit flag short-circuits auto-detection. The function caches its answer in
+# a script-global, so each scenario lives in its own .pl file (test-webkitperl
+# runs each in a fresh process).
+use strict;
+use warnings;
+use Test::More;
+use webkitdirs;
+
+plan(tests => 2);
+
+disableCMakeAutoDetection();
+
+@ARGV = ("--cmake", "leftover");
+webkitdirs::determineIsCMakeBuild();
+
+is_deeply(\@ARGV, ["leftover"], "--cmake is removed from \@ARGV");
+ok(isCMakeBuild(), "--cmake overrides disableCMakeAutoDetection()");


### PR DESCRIPTION
#### 611b60984ebb523f20efbd0bd1d82c8bcedf6fb3
<pre>
REGRESSION(<a href="https://commits.webkit.org/312482@main">312482@main</a>): Fix wrong architecture selected when mixing Xcode and CMake builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=319006">https://bugs.webkit.org/show_bug.cgi?id=319006</a>
<a href="https://rdar.apple.com/181854817">rdar://181854817</a>

Reviewed by NOBODY (OOPS!).

<a href="https://commits.webkit.org/312482@main">312482@main</a> added CMake auto-detection to determineIsCMakeBuild() so
read-only path resolvers like run-javascriptcore-tests could find a CMake
build automatically. But its &quot;CMake tree exists, Xcode tree absent&quot; branch
runs for every caller, so build drivers get flipped to CMake too: `make`,
build-webkit, and set-webkit-configuration all switch to the CMake tree
whenever WebKitBuild/cmake-mac/&lt;config&gt; exists and the Xcode tree does not.
<a href="https://commits.webkit.org/316853@main">316853@main</a> later added the --xcode flag and a last-built tiebreaker gated
behind an opt-in, but left this branch ungated.

For `make release` this is a problem. determineArchitecture() then reads the
architecture from `cmake --system-information` (arm64) instead of the
Xcode default (arm64e under macosx.internal), and xcodebuild fails with
&quot;Unable to find a destination matching { platform:macOS, arch:arm64 }&quot;.

Have build drivers opt out via a new disableCMakeAutoDetection(). The
opt-out is checked after the explicit --cmake/--xcode flags (so those
still win) and before the auto-detect block (so read-only resolvers are
unchanged). build-webkit and set-webkit-configuration call it at entry,
before their first isCMakeBuild()/productDir() query; XcodeOptions()
calls it too, which covers the `make` path.

* Tools/Scripts/build-webkit:
* Tools/Scripts/set-webkit-configuration:
* Tools/Scripts/webkitdirs.pm:
(XcodeOptions):
(determineIsCMakeBuild):
(disableCMakeAutoDetection):
* Tools/Scripts/webkitperl/webkitdirs_unittest/determineIsCMakeBuildBuildDriver.pl: Added.
* Tools/Scripts/webkitperl/webkitdirs_unittest/determineIsCMakeBuildCMakeOnly.pl: Added.
* Tools/Scripts/webkitperl/webkitdirs_unittest/determineIsCMakeBuildDisabledExplicitCMake.pl: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/611b60984ebb523f20efbd0bd1d82c8bcedf6fb3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173634 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47567 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41178 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183207 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131502 "Failed to checkout and rebase branch from PR 69055") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/149a1f92-aef2-4993-a8a9-4e45193072d6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175499 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48859 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47249 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135012 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/131502 "Failed to checkout and rebase branch from PR 69055") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176592 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38444 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155726 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115490 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b2b158be-ac38-41fb-bf04-8a8ab8b6f743) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37085 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35447 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31692 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/4238 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147509 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35221 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185633 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/34896 "Built successfully and passed tests") | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39647 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143899 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47234 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143762 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47913 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31836 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113087 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38680 "Passed tests") | | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/210667 "Failed to checkout and rebase branch from PR 69055") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46419 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10174 "Passed tests") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/210667 "Failed to checkout and rebase branch from PR 69055") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45821 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46052 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45880 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->