### PR TITLE
Digital Credentials: reject get() from opaque origins

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get-opaque-origin-combinations.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get-opaque-origin-combinations.https-expected.txt
@@ -1,0 +1,16 @@
+
+
+PASS get() from an opaque origin (sandboxed iframe) rejects with SecurityError
+PASS get() from an opaque origin (sandboxed srcdoc iframe) rejects with SecurityError
+PASS get() from an opaque origin (iframe whose document has a Content-Security-Policy: sandbox header) rejects with SecurityError
+PASS get() from an opaque origin (plain iframe nested inside a sandboxed iframe (2 levels)) rejects with SecurityError
+PASS get() from an opaque origin (plain iframes nested two deep inside a sandboxed iframe (3 levels)) rejects with SecurityError
+PASS get() from an opaque origin (allow-same-origin iframe nested inside a sandboxed iframe) rejects with SecurityError
+PASS get() from an opaque origin (plain iframe nested inside a Content-Security-Policy: sandbox document (CSP-derived flags propagate)) rejects with SecurityError
+PASS get() from an opaque origin (allow-same-origin iframe nested inside a Content-Security-Policy: sandbox document (cannot escape)) rejects with SecurityError
+PASS get() from a non-opaque origin (sandboxed iframe with allow-same-origin) is not rejected as opaque
+PASS get() from a non-opaque origin (srcdoc iframe without sandbox (inherits the parent origin)) is not rejected as opaque
+PASS get() from a non-opaque origin (blob: iframe (inherits the creator origin)) is not rejected as opaque
+PASS get() in a data: iframe is unavailable (not a secure context) and never reaches the opaque-origin check
+PASS get() in a blob: iframe created inside a sandboxed frame inherits the opaque origin and is unavailable
+

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get-opaque-origin-combinations.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get-opaque-origin-combinations.https.html
@@ -1,0 +1,208 @@
+<!doctype html>
+<meta charset="utf-8" />
+<title>
+  Digital Credentials: get() and opaque origins across framing combinations
+</title>
+<link rel="help" href="https://w3c-fedid.github.io/digital-credentials/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+  <script>
+    const SUPPORT = "/digital-credentials/support/";
+
+    // Inline reporter for the srcdoc / data: / blob: cases, which can neither load an
+    // external page nor carry an id in a URL. Mirrors support/dc-report-get.js: it calls
+    // get() and posts { origin, secure, result } to the top-level test so even deeply
+    // nested / opaque frames can report back.
+    const reportDoc = (
+      id,
+    ) => `<!DOCTYPE html><meta charset=utf-8><body></body><script>
+(async () => {
+  const report = { id: ${JSON.stringify(id)}, origin: String(self.origin), secure: self.isSecureContext, result: "resolved" };
+  try {
+    if (!(navigator.credentials && navigator.credentials.get)) throw new TypeError("navigator.credentials.get is unavailable");
+    await navigator.credentials.get({ digital: { requests: [] } });
+  } catch (error) { report.result = error.name; }
+  (window.top || window.parent).postMessage(report, "*");
+})();
+<\/script>`;
+
+    function awaitReport(id) {
+      return new Promise((resolve) => {
+        addEventListener("message", function handler(event) {
+          if (event.data && event.data.id === id) {
+            removeEventListener("message", handler);
+            resolve(event.data);
+          }
+        });
+      });
+    }
+
+    function runInFrame(id, configure) {
+      const frame = document.createElement("iframe");
+      frame.allow = "digital-credentials-get";
+      configure(frame, id);
+      document.body.appendChild(frame);
+      return awaitReport(id).finally(() => {
+        if (frame.src.startsWith("blob:")) URL.revokeObjectURL(frame.src);
+      });
+    }
+
+    // Opaque calling document -> the opaque-origin guard fires -> SecurityError.
+    const OPAQUE = [
+      [
+        "sandboxed iframe",
+        (frame, id) => {
+          frame.sandbox = "allow-scripts";
+          frame.src = SUPPORT + "dc-report-get.html?id=" + id;
+        },
+      ],
+      [
+        "sandboxed srcdoc iframe",
+        (frame, id) => {
+          frame.sandbox = "allow-scripts";
+          frame.srcdoc = reportDoc(id);
+        },
+      ],
+      [
+        "iframe whose document has a Content-Security-Policy: sandbox header",
+        (frame, id) => {
+          frame.src = SUPPORT + "dc-report-get-csp-sandbox.html?id=" + id;
+        },
+      ],
+      [
+        "plain iframe nested inside a sandboxed iframe (2 levels)",
+        (frame, id) => {
+          frame.sandbox = "allow-scripts";
+          frame.src = SUPPORT + "dc-nest.html?id=" + id + "&depth=0";
+        },
+      ],
+      [
+        "plain iframes nested two deep inside a sandboxed iframe (3 levels)",
+        (frame, id) => {
+          frame.sandbox = "allow-scripts";
+          frame.src = SUPPORT + "dc-nest.html?id=" + id + "&depth=1";
+        },
+      ],
+      [
+        "allow-same-origin iframe nested inside a sandboxed iframe",
+        (frame, id) => {
+          frame.sandbox = "allow-scripts";
+          frame.srcdoc = `<!DOCTYPE html><body><script>
+            const inner = document.createElement("iframe");
+            inner.sandbox = "allow-scripts allow-same-origin";
+            inner.allow = "digital-credentials-get";
+            inner.src = ${JSON.stringify(SUPPORT + "dc-report-get.html?id=" + id)};
+            document.body.appendChild(inner);
+          <\/script>`;
+        },
+      ],
+      [
+        "plain iframe nested inside a Content-Security-Policy: sandbox document (CSP-derived flags propagate)",
+        (frame, id) => {
+          frame.src = SUPPORT + "dc-nest-csp-sandbox.html?id=" + id;
+        },
+      ],
+      [
+        "allow-same-origin iframe nested inside a Content-Security-Policy: sandbox document (cannot escape)",
+        (frame, id) => {
+          frame.src = SUPPORT + "dc-nest-csp-sandbox.html?id=" + id + "&child=aso";
+        },
+      ],
+    ];
+    OPAQUE.forEach(([label, configure], index) => {
+      promise_test(
+        async () => {
+          const report = await runInFrame("opaque-" + index, configure);
+          assert_equals(report.origin, "null", "expected an opaque origin");
+          assert_equals(
+            report.result,
+            "SecurityError",
+            "an opaque origin must reject with SecurityError",
+          );
+        },
+        "get() from an opaque origin (" +
+          label +
+          ") rejects with SecurityError",
+      );
+    });
+
+    // Non-opaque calling document -> the opaque-origin guard must NOT fire.
+    const NON_OPAQUE = [
+      [
+        "sandboxed iframe with allow-same-origin",
+        (frame, id) => {
+          frame.sandbox = "allow-scripts allow-same-origin";
+          frame.src = SUPPORT + "dc-report-get.html?id=" + id;
+        },
+      ],
+      [
+        "srcdoc iframe without sandbox (inherits the parent origin)",
+        (frame, id) => {
+          frame.srcdoc = reportDoc(id);
+        },
+      ],
+      [
+        "blob: iframe (inherits the creator origin)",
+        (frame, id) => {
+          frame.src = URL.createObjectURL(
+            new Blob([reportDoc(id)], { type: "text/html" }),
+          );
+        },
+      ],
+    ];
+    NON_OPAQUE.forEach(([label, configure], index) => {
+      promise_test(
+        async () => {
+          const report = await runInFrame("nonopaque-" + index, configure);
+          assert_not_equals(
+            report.origin,
+            "null",
+            "expected a normal (non-opaque) origin",
+          );
+          assert_not_equals(
+            report.result,
+            "SecurityError",
+            "a non-opaque origin must not be rejected by the opaque-origin check",
+          );
+        },
+        "get() from a non-opaque origin (" +
+          label +
+          ") is not rejected as opaque",
+      );
+    });
+
+    promise_test(async () => {
+      const report = await runInFrame("data", (frame, id) => {
+        frame.src = "data:text/html," + encodeURIComponent(reportDoc(id));
+      });
+      assert_false(report.secure, "a data: document is not a secure context");
+      assert_equals(
+        report.result,
+        "TypeError",
+        "the API is unavailable, so it is a TypeError, not a SecurityError",
+      );
+    }, "get() in a data: iframe is unavailable (not a secure context) and never reaches the opaque-origin check");
+
+    promise_test(async () => {
+      const report = await runInFrame("blob-in-sandbox", (frame, id) => {
+        frame.sandbox = "allow-scripts";
+        frame.src = SUPPORT + "dc-report-get-blob-in-sandbox.html?id=" + id;
+      });
+      assert_equals(
+        report.origin,
+        "null",
+        "the blob inherits the opaque creator origin",
+      );
+      assert_false(
+        report.secure,
+        "a blob: document created in an opaque frame is not a secure context",
+      );
+      assert_equals(
+        report.result,
+        "TypeError",
+        "the API is unavailable, so it is a TypeError, not a SecurityError",
+      );
+    }, "get() in a blob: iframe created inside a sandboxed frame inherits the opaque origin and is unavailable");
+  </script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get-opaque-origin-top-level-allow-same-origin.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get-opaque-origin-top-level-allow-same-origin.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS get() from a top-level sandboxed page with allow-same-origin is not rejected as opaque
+

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get-opaque-origin-top-level-allow-same-origin.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get-opaque-origin-top-level-allow-same-origin.https.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<meta charset="utf-8" />
+<title>
+  Digital Credentials: a top-level sandboxed page with allow-same-origin is not
+  treated as opaque
+</title>
+<link rel="help" href="https://w3c-fedid.github.io/digital-credentials/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+  <script>
+    // Served with `Content-Security-Policy: sandbox allow-scripts allow-same-origin`
+    // (see the .headers file): the page is sandboxed for hardening but keeps its real
+    // origin, so it is NOT opaque and the opaque-origin check does not fire. The call
+    // then fails later for an unrelated reason (no requests) — which is what proves it
+    // was not rejected as opaque.
+    promise_test((t) => {
+      return promise_rejects_js(
+        t,
+        TypeError,
+        navigator.credentials.get({ digital: { requests: [] } }),
+      );
+    }, "get() from a top-level sandboxed page with allow-same-origin is not rejected as opaque");
+  </script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get-opaque-origin-top-level-allow-same-origin.https.html.headers
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get-opaque-origin-top-level-allow-same-origin.https.html.headers
@@ -1,0 +1,1 @@
+Content-Security-Policy: sandbox allow-scripts allow-same-origin

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get-opaque-origin-top-level.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get-opaque-origin-top-level.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS navigator.credentials.get() from a top-level opaque origin rejects with SecurityError
+

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get-opaque-origin-top-level.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get-opaque-origin-top-level.https.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<meta charset="utf-8" />
+<title>
+  Digital Credentials: get() from a top-level opaque origin rejects with
+  SecurityError
+</title>
+<link rel="help" href="https://w3c-fedid.github.io/digital-credentials/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+  <script>
+    // This document is served with `Content-Security-Policy: sandbox allow-scripts`
+    // (see the accompanying .headers file): the top-level document has an opaque
+    // origin while remaining a secure context. Permissions Policy still grants the
+    // feature to a top-level document (it matches its own 'self'), so the
+    // opaque-origin check is the only thing that can reject the request.
+    promise_test(async (t) => {
+      await promise_rejects_dom(
+        t,
+        "SecurityError",
+        navigator.credentials.get({ digital: { requests: [] } }),
+      );
+    }, "navigator.credentials.get() from a top-level opaque origin rejects with SecurityError");
+  </script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get-opaque-origin-top-level.https.html.headers
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get-opaque-origin-top-level.https.html.headers
@@ -1,0 +1,1 @@
+Content-Security-Policy: sandbox allow-scripts

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/support/dc-nest-csp-sandbox.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/support/dc-nest-csp-sandbox.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<meta charset="utf-8" />
+<!--
+  Served with `Content-Security-Policy: sandbox allow-scripts` (see the .headers file), so THIS
+  document has an opaque origin via CSP-derived sandboxing flags. It embeds a child that calls
+  get(). The child inherits this document's active sandboxing flag set (per "determine the
+  creation sandboxing flags"), so the child is opaque too — this exercises CSP-header sandbox
+  PROPAGATION across a nesting boundary, distinct from the iframe `sandbox` attribute path.
+  With ?child=aso the child requests allow-same-origin, which must NOT let it escape the
+  propagated opacity.
+-->
+<body></body>
+<script>
+  const params = new URL(location.href).searchParams;
+  const id = params.get("id");
+  const frame = document.createElement("iframe");
+  frame.allow = "digital-credentials-get";
+  if (params.get("child") === "aso") frame.sandbox = "allow-scripts allow-same-origin";
+  frame.src =
+    "/digital-credentials/support/dc-report-get.html?id=" + encodeURIComponent(id);
+  document.body.appendChild(frame);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/support/dc-nest-csp-sandbox.html.headers
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/support/dc-nest-csp-sandbox.html.headers
@@ -1,0 +1,1 @@
+Content-Security-Policy: sandbox allow-scripts

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/support/dc-nest.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/support/dc-nest.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<meta charset="utf-8" />
+<body></body>
+<script>
+  const params = new URL(location.href).searchParams;
+  const id = params.get("id");
+  const depth = parseInt(params.get("depth") || "0", 10);
+  const nextSrc =
+    depth > 0
+      ? "/digital-credentials/support/dc-nest.html?id=" +
+        encodeURIComponent(id) +
+        "&depth=" +
+        (depth - 1)
+      : "/digital-credentials/support/dc-report-get.html?id=" +
+        encodeURIComponent(id);
+  const frame = document.createElement("iframe");
+  frame.allow = "digital-credentials-get";
+  frame.src = nextSrc;
+  document.body.appendChild(frame);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/support/dc-report-get-blob-in-sandbox.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/support/dc-report-get-blob-in-sandbox.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<meta charset="utf-8" />
+<body></body>
+<script>
+  // Creates a blob: child from this (sandboxed, opaque) context; the blob inherits the opaque origin.
+  const id = new URL(location.href).searchParams.get("id");
+  const inner = `<!doctype html><meta charset=utf-8><body><script>
+(async () => {
+  const report = { id: ${JSON.stringify("__ID__")}, origin: String(self.origin), secure: self.isSecureContext, result: "resolved" };
+  try {
+    if (!(navigator.credentials && navigator.credentials.get)) throw new TypeError("navigator.credentials.get is unavailable");
+    await navigator.credentials.get({ digital: { requests: [] } });
+  } catch (error) { report.result = error.name; }
+  (window.top || window.parent).postMessage(report, "*");
+})();
+<\/script>`.replace("__ID__", id);
+  const frame = document.createElement("iframe");
+  frame.allow = "digital-credentials-get";
+  frame.src = URL.createObjectURL(new Blob([inner], { type: "text/html" }));
+  document.body.appendChild(frame);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/support/dc-report-get-csp-sandbox.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/support/dc-report-get-csp-sandbox.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<meta charset="utf-8" />
+<body></body>
+<script src="dc-report-get.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/support/dc-report-get-csp-sandbox.html.headers
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/support/dc-report-get-csp-sandbox.html.headers
@@ -1,0 +1,1 @@
+Content-Security-Policy: sandbox allow-scripts

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/support/dc-report-get.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/support/dc-report-get.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<meta charset="utf-8" />
+<body></body>
+<script src="dc-report-get.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/support/dc-report-get.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/support/dc-report-get.js
@@ -1,0 +1,20 @@
+// Used by the served (src=) cases. The srcdoc/data:/blob: cases in
+// get-opaque-origin-combinations.https.html inline the same logic because they can
+// neither load an external page nor carry an id in a URL.
+(async () => {
+  const id = new URL(location.href).searchParams.get("id");
+  const report = {
+    id,
+    origin: String(self.origin),
+    secure: self.isSecureContext,
+    result: "resolved",
+  };
+  try {
+    if (!(navigator.credentials && navigator.credentials.get))
+      throw new TypeError("navigator.credentials.get is unavailable");
+    await navigator.credentials.get({ digital: { requests: [] } });
+  } catch (error) {
+    report.result = error.name;
+  }
+  (window.top || window.parent).postMessage(report, "*");
+})();

--- a/Source/WebCore/Modules/identity/DigitalCredential.cpp
+++ b/Source/WebCore/Modules/identity/DigitalCredential.cpp
@@ -133,6 +133,11 @@ void DigitalCredential::discoverFromExternalSource(const Document& document, Cre
 {
     ASSERT(options.digital);
 
+    if (document.securityOrigin().isOpaque()) {
+        promise.reject(Exception { ExceptionCode::SecurityError, "The credential operation is not allowed in an opaque origin."_s });
+        return;
+    }
+
     if (!PermissionsPolicy::isFeatureEnabled(PermissionsPolicy::Feature::DigitalCredentialsGetRule, document, PermissionsPolicy::ShouldReportViolation::No)) {
         promise.reject(Exception { ExceptionCode::NotAllowedError, "Third-party iframes are not allowed to call .get() unless explicitly allowed via Permissions Policy (digital-credentials-get)"_s });
         return;


### PR DESCRIPTION
#### 5da0c4f201f52aad8e9afd76a3acdf6ed66e5039
<pre>
Digital Credentials: reject get() from opaque origins
<a href="https://bugs.webkit.org/show_bug.cgi?id=318947">https://bugs.webkit.org/show_bug.cgi?id=318947</a>

Reviewed by Anne van Kesteren.

Reject navigator.credentials.get({ digital }) with a SecurityError when the
calling document has an opaque origin, implementing the restriction from
<a href="https://github.com/w3c-fedid/digital-credentials/pull/535.">https://github.com/w3c-fedid/digital-credentials/pull/535.</a>

Web platform tests: <a href="https://github.com/web-platform-tests/wpt/pull/61188">https://github.com/web-platform-tests/wpt/pull/61188</a>

* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get-opaque-origin-combinations.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get-opaque-origin-combinations.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get-opaque-origin-top-level-allow-same-origin.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get-opaque-origin-top-level-allow-same-origin.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get-opaque-origin-top-level-allow-same-origin.https.html.headers: Added.
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get-opaque-origin-top-level.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get-opaque-origin-top-level.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get-opaque-origin-top-level.https.html.headers: Added.
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/support/dc-nest.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/support/dc-report-get-blob-in-sandbox.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/support/dc-report-get-csp-sandbox.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/support/dc-report-get-csp-sandbox.html.headers: Added.
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/support/dc-report-get.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/support/dc-report-get.js: Added.
(async const):
(catch):
* Source/WebCore/Modules/identity/DigitalCredential.cpp:
(WebCore::DigitalCredential::discoverFromExternalSource):
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/support/dc-nest-csp-sandbox.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/support/dc-nest-csp-sandbox.html.headers: Added.

Canonical link: <a href="https://commits.webkit.org/317275@main">https://commits.webkit.org/317275@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25814ce38407257bb687139c9cbecba8f80c8165

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174735 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48668 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42449 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184314 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132603 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/82609b8f-d3b6-433f-8697-01e9aa5f7eee) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176600 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49960 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48351 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135972 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e22b529f-915d-4459-a9a2-5f5253648aee) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177693 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39409 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156758 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116450 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9c5df242-fd28-4767-8b10-bc9c60d7b505) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38050 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36425 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32793 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148473 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36250 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186740 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/40081 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40626 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144895 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48335 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156314 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144755 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39023 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49015 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32871 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114794 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39628 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121058 "Found 119 new failures in b3/testb3_7.cpp, b3/B3Value.h, WebProcess/Network/WebResourceLoader.cpp, UIProcess/WebProcessPool.cpp, Shared/Cocoa/WKNSArray.mm, Shared/SessionState.cpp, NetworkProcess/NetworkResourceLoadParameters.cpp, WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm, WebProcess/WebPage/WebPage.cpp, WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm ...") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47521 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11219 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46923 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47154 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46981 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->