### PR TITLE
[Site Isolation] A new document can share a BrowsingContextGroup with a back/forward-cached page

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1628,8 +1628,7 @@ void WebPageProxy::swapToProvisionalPage(Ref<ProvisionalPageProxy>&& provisional
     ASSERT(!m_drawingArea);
     setDrawingArea(provisionalPage->takeDrawingArea());
 
-    // FIXME: Think about what to do if the provisional page didn't get its browsing context group from the SuspendedPageProxy.
-    // We do need to clear it at some point for navigations that aren't from back/forward navigations. Probably in the same place as PSON?
+    // The group was chosen in browsingContextGroupForNavigation(); adopt whatever the provisional page carries.
     setBrowsingContextGroup(provisionalPage->browsingContextGroup());
 
     protect(legacyMainFrameProcess())->addExistingWebPage(*this, WebProcessProxy::BeginsUsingDataStore::No);
@@ -5552,11 +5551,21 @@ Ref<BrowsingContextGroup> WebPageProxy::browsingContextGroupForNavigation(WebFra
         return m_browsingContextGroup;
 
     bool usesSameWebsiteDataStore = &websiteDataStore == &this->websiteDataStore();
-    bool mainFrameSiteChanges = !m_mainFrame || Site { m_mainFrame->url() } != Site { navigation.currentRequest().url() };
+    Site requestedSite { navigation.currentRequest().url() };
+    bool mainFrameSiteChanges = !m_mainFrame || Site { m_mainFrame->url() } != requestedSite;
     if (RefPtr targetBackForwardItem = navigation.targetItem(); targetBackForwardItem && targetBackForwardItem->browsingContextGroup() && usesSameWebsiteDataStore)
         return *targetBackForwardItem->browsingContextGroup();
 
     if (processSwapRequestedByClient == ProcessSwapRequestedByClient::Yes || !usesSameWebsiteDataStore || (navigation.isRequestFromClientOrUserInput() && !navigation.isFromLoadData() && mainFrameSiteChanges))
+        return BrowsingContextGroup::create();
+
+    // Under Site Isolation, keeping the current group for a site-changing, non-back/forward main-frame
+    // navigation would let the incoming document share a group with the outgoing page once that page enters
+    // the back/forward cache, linking their iframe processes across unrelated top-level browsing contexts.
+    // Start a fresh group instead.
+    // FIXME: The non-Site-Isolation PSON path still adopts the outgoing (possibly back/forward-cached) group;
+    // it should get a fresh group here too.
+    if (protect(preferences())->siteIsolationEnabled() && !navigation.targetItem() && m_mainFrame && mainFrameSiteChanges && !requestedSite.isEmpty() && !protect(m_browsingContextGroup)->hasMultiplePages())
         return BrowsingContextGroup::create();
 
     return m_browsingContextGroup;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -3580,11 +3580,9 @@ TEST(SiteIsolation, DrawAfterNavigateToDomainAgain)
 
     [webView evaluateJavaScript:@"window.location = 'https://c.com/c'" completionHandler:nil];
     [navigationDelegate waitForDidFinishNavigation];
+    // c.com is unrelated to the back/forward-cached a.com and gets a fresh group, so it is a lone tree here.
     checkFrameTreesInProcesses(webView.get(), {
-        { "https://c.com"_s },
-        // a.com is BFCached; the b.com iframe process stays alive as a
-        // suspended cached iframe and surfaces here as a remote tree.
-        { RemoteFrame }
+        { "https://c.com"_s }
     });
 
     [webView evaluateJavaScript:@"window.location = 'https://a.com/a'" completionHandler:nil];
@@ -3598,6 +3596,38 @@ TEST(SiteIsolation, DrawAfterNavigateToDomainAgain)
     });
 
     [webView waitForNextPresentationUpdate];
+}
+
+TEST(SiteIsolation, NavigateToUnrelatedDomainDoesNotShareBCGWithSuspendedPage)
+{
+    HTTPServer server({
+        { "/a"_s, { "<iframe src='https://b.com/b'></iframe>"_s } },
+        { "/b"_s, { "hi"_s } },
+        { "/c"_s, { "hi"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(server);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+    while (![webView mainFrame].childFrames.count)
+        Util::spinRunLoop();
+    EXPECT_WK_STREQ([webView mainFrame].info.securityOrigin.host, "a.com");
+    _WKFrameTreeNode *bFrameForA = [webView mainFrame].childFrames.firstObject;
+    EXPECT_WK_STREQ(bFrameForA.info.securityOrigin.host, "b.com");
+    pid_t bProcessForA = bFrameForA.info._processIdentifier;
+    EXPECT_NE(bProcessForA, 0);
+
+    [webView evaluateJavaScript:@"window.location = 'https://c.com/c'" completionHandler:nil];
+    [navigationDelegate waitForDidFinishNavigation];
+    EXPECT_WK_STREQ([webView mainFrame].info.securityOrigin.host, "c.com");
+
+    // a.com's iframe process stays alive in the back/forward cache, but c.com is in a fresh group, so it is a lone
+    // tree not linked to that suspended process.
+    EXPECT_TRUE(processStillRunning(bProcessForA));
+    checkFrameTreesInProcesses(webView.get(), {
+        { "https://c.com"_s }
+    });
 }
 
 TEST(SiteIsolation, CancelProvisionalLoad)


### PR DESCRIPTION
#### 9b6cd50736f52a240fae733a9f66f8dbeb37556a
<pre>
[Site Isolation] A new document can share a BrowsingContextGroup with a back/forward-cached page
<a href="https://bugs.webkit.org/show_bug.cgi?id=319002">https://bugs.webkit.org/show_bug.cgi?id=319002</a>
<a href="https://rdar.apple.com/181851905">rdar://181851905</a>

Reviewed by Sihui Liu.

Under Site Isolation, a non-back/forward main-frame navigation to a different site reused the
current WebPageProxy&apos;s BrowsingContextGroup. When the outgoing page was then placed in the
back/forward cache, its group -- and its still-live iframe processes -- was retained by the
SuspendedPageProxy, so the incoming, unrelated document ended up in that same group and linked
the suspended page&apos;s iframe processes. That is a Site Isolation boundary violation: two
unrelated top-level browsing contexts must not share a group or its processes.

Give such a navigation a fresh BrowsingContextGroup at selection time, mirroring where the COOP
browsing-context-group switch already does. The new branch is gated on the single-page case
(!hasMultiplePages()), which is exactly the condition under which the outgoing page is
back/forward-cached and has no opener/openee that must stay reachable across the navigation, so
opener reachability (LoadStringAfterOpen, NavigateOpenerWindowCrossSite) is preserved.
Empty-site targets (about:blank, data:) and the non-Site-Isolation PSON path are intentionally
left out of scope.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::browsingContextGroupForNavigation): Start a fresh BrowsingContextGroup for
a single-page, site-changing, non-back/forward main-frame navigation under Site Isolation.
(WebKit::WebPageProxy::swapToProvisionalPage): Point the comment at browsingContextGroupForNavigation,
where the group is actually chosen.
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::SiteIsolation::NavigateToUnrelatedDomainDoesNotShareBCGWithSuspendedPage): Added.
(TestWebKitAPI::SiteIsolation::DrawAfterNavigateToDomainAgain): Update the post-navigation
expectation to a lone c.com tree; the previous expectation encoded the bug.

Canonical link: <a href="https://commits.webkit.org/317103@main">https://commits.webkit.org/317103@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c759de11387d92024b79d7968250d312795f1017

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174324 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48257 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/42038 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183900 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/132192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/de9298dc-11e3-4ba9-988b-18a9c2329d6b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176189 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49549 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47939 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/135604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/132192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b8909fef-2d08-410a-9809-4c1addb4a829) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177282 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39038 "Build is in progress. Recent messages:") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/156398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/116082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a74e1d40-a2e7-42a5-984d-63db2a9e5881) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/37679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32382 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/148102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/35890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186326 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/39529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/144513 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47924 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/155952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144371 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38914 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48603 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114145 "Built successfully") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/39276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/120536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47109 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/10854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46512 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46743 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46570 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->