### PR TITLE
[Site Isolation] Web Inspector: Implement Network.loadResource

### DIFF
--- a/LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-load-resource-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-load-resource-expected.txt
@@ -1,0 +1,17 @@
+Tests that Network.loadResource loads a resource in the context of a cross-origin iframe's frame under Site Isolation, routed through ProxyingNetworkAgent to the frame's owning WebContent process.
+
+
+== Running test suite: SiteIsolation.Network.CrossOriginIFrame.LoadResource
+-- Running test case: SiteIsolation.Network.CrossOriginIFrame.LoadResource.AwaitCrossOriginFrame
+PASS: Cross-origin child frame should appear in WI.networkManager.frames.
+PASS: Cross-origin child should have a different security origin from the main frame.
+
+-- Running test case: SiteIsolation.Network.CrossOriginIFrame.LoadResource.Success
+PASS: loadResource should return the served body content.
+PASS: loadResource should return the served MIME type.
+PASS: loadResource should return HTTP status 200.
+
+-- Running test case: SiteIsolation.Network.CrossOriginIFrame.LoadResource.InvalidFrameId
+PASS: Should produce an exception.
+Error: Invalid frameId format
+

--- a/LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-load-resource.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-load-resource.html
@@ -1,0 +1,89 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script>
+function addCrossOriginIFrame() {
+    // Main page is served from 127.0.0.1:8000; the cross-origin host loads in a separate WebContent
+    // process under Site Isolation. The child document just needs to commit in its own process.
+    let crossOriginHost = location.hostname === "localhost" ? "127.0.0.1" : "localhost";
+    let iframe = document.createElement("iframe");
+    iframe.name = "child-frame";
+    iframe.src = `http://${crossOriginHost}:8000/site-isolation/inspector/network/resources/load-resource-iframe.html`;
+    document.body.appendChild(iframe);
+}
+
+function test() {
+    // This test exercises Network.loadResource under Site Isolation. It is routed by frameId + URL
+    // (not requestId) and initiates a load, and is issued against the multiplexing (web-page) target's
+    // NetworkAgent -- where ProxyingNetworkAgent lives under SI.
+    //
+    // Loading a resource that is only same-origin to the *iframe* (cross-origin to the main frame) and
+    // asserting on the returned body proves the load ran in the iframe's process: routing to the wrong
+    // (main-frame) process would yield an opaque, empty NoCors response instead of the served content.
+
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.Network.CrossOriginIFrame.LoadResource");
+
+    let childFrame;
+
+    suite.addTestCase({
+        name: "SiteIsolation.Network.CrossOriginIFrame.LoadResource.AwaitCrossOriginFrame",
+        description: "Add a cross-origin iframe and wait for its frame to appear in the frontend frame model.",
+        async test() {
+            let targetAddedPromise = WI.targetManager.awaitEvent(WI.TargetManager.Event.TargetAdded);
+            InspectorTest.evaluateInPage("addCrossOriginIFrame()");
+            let frameTarget = (await targetAddedPromise).data.target;
+
+            // The cross-origin child commits in its own process; its Page.frameNavigated arrives shortly
+            // after. Drive/await the child's execution context and poll the frame model until it appears.
+            for (let attempt = 0; attempt < 50 && !childFrame; ++attempt) {
+                if (!frameTarget.executionContext) {
+                    await Promise.race([
+                        frameTarget.awaitEvent(WI.FrameTarget.Event.ExecutionContextAdded),
+                        new Promise((resolve) => setTimeout(resolve, 100)),
+                    ]);
+                }
+                childFrame = WI.networkManager.frames.find((frame) => frame.url && frame.url.endsWith("/load-resource-iframe.html"));
+                if (!childFrame)
+                    await new Promise((resolve) => setTimeout(resolve, 20));
+            }
+
+            InspectorTest.expectThat(!!childFrame, "Cross-origin child frame should appear in WI.networkManager.frames.");
+            if (childFrame)
+                InspectorTest.expectThat(childFrame.securityOrigin !== WI.networkManager.mainFrame.securityOrigin, "Cross-origin child should have a different security origin from the main frame.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.Network.CrossOriginIFrame.LoadResource.Success",
+        description: "loadResource should return the decoded body, MIME type, and status for a resource loaded in the cross-origin iframe's context.",
+        async test() {
+            if (!childFrame) {
+                InspectorTest.fail("No cross-origin child frame; cannot run loadResource.");
+                return;
+            }
+
+            // Same-origin to the iframe (not to the main frame), so a correct load returns the served body.
+            let url = childFrame.securityOrigin + "/inspector/network/resources/echo.py?mimetype=text/plain&content=si-load-resource-content";
+            let {content, mimeType, status} = await WI.backendTarget.NetworkAgent.loadResource(childFrame.id, url);
+            InspectorTest.expectEqual(content, "si-load-resource-content", "loadResource should return the served body content.");
+            InspectorTest.expectEqual(mimeType, "text/plain", "loadResource should return the served MIME type.");
+            InspectorTest.expectEqual(status, 200, "loadResource should return HTTP status 200.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.Network.CrossOriginIFrame.LoadResource.InvalidFrameId",
+        description: "loadResource should fail cleanly for a malformed frameId.",
+        async test() {
+            await InspectorTest.expectException(async () => {
+                await WI.backendTarget.NetworkAgent.loadResource("not-a-valid-frame-id", "http://127.0.0.1:8000/inspector/network/resources/echo.py?content=unused");
+            });
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+<body onload="runTest()">
+<p>Tests that Network.loadResource loads a resource in the context of a cross-origin iframe's frame under Site Isolation, routed through ProxyingNetworkAgent to the frame's owning WebContent process.</p>
+</body>

--- a/LayoutTests/http/tests/site-isolation/inspector/network/resources/load-resource-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/network/resources/load-resource-iframe.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<p>Cross-origin iframe document for Network.loadResource testing under Site Isolation. The test loads a
+same-origin resource in this frame's context via Network.loadResource, so this document only needs to
+commit in its own WebContent process.</p>

--- a/Source/JavaScriptCore/inspector/protocol/Network.json
+++ b/Source/JavaScriptCore/inspector/protocol/Network.json
@@ -230,7 +230,7 @@
         {
             "name": "loadResource",
             "description": "Loads a resource in the context of a frame on the inspected page without cross origin checks.",
-            "targetTypes": ["page"],
+            "targetTypes": ["page", "web-page"],
             "async": true,
             "parameters": [
                 { "name": "frameId", "$ref": "FrameId", "description": "Frame to load the resource from." },

--- a/Source/WebCore/inspector/InspectorResourceUtilities.cpp
+++ b/Source/WebCore/inspector/InspectorResourceUtilities.cpp
@@ -33,16 +33,23 @@
 #include "DocumentLoader.h"
 #include "DocumentPage.h"
 #include "DocumentResourceLoader.h"
+#include "FetchOptions.h"
 #include "FrameLoader.h"
 #include "InspectorResourceType.h"
+#include "InspectorThreadableLoaderClient.h"
 #include "LocalFrame.h"
 #include "LocalFrameInlines.h"
 #include "MIMETypeRegistry.h"
 #include "MemoryCache.h"
 #include "Page.h"
+#include "ResourceLoaderOptions.h"
+#include "ResourceRequest.h"
+#include "ScriptExecutionContext.h"
 #include "SharedBuffer.h"
+#include "ThreadableLoader.h"
 #include <JavaScriptCore/ContentSearchUtilities.h>
 #include <JavaScriptCore/InspectorProtocolObjects.h>
+#include <wtf/URL.h>
 
 namespace Inspector {
 
@@ -420,6 +427,35 @@ bool cachedResourceContent(CachedResource& resource, String* result, bool* base6
         *result = base64EncodeToString(buffer->makeContiguous()->span());
         return true;
     }
+}
+
+void loadResource(ScriptExecutionContext& context, const String& urlString, LoadResourceCompletionHandler&& completionHandler)
+{
+    // Backs Network.loadResource: load a URL in a document's context on behalf of the inspector,
+    // bypassing cross-origin checks (e.g. to fetch a source map).
+    URL url = context.encodingParseURL(urlString);
+    ResourceRequest request(WTF::move(url));
+    request.setHTTPMethod("GET"_s);
+    request.setHiddenFromInspector(true);
+
+    ThreadableLoaderOptions options;
+    options.sendLoadCallbacks = SendCallbackPolicy::SendCallbacks; // So InspectorNetworkAgent's willSendRequest/loadingFinished hooks still fire for this hidden request, letting it track and untrack it.
+    options.defersLoadingPolicy = DefersLoadingPolicy::DisallowDefersLoading; // So the request is never deferred.
+    options.mode = FetchOptions::Mode::NoCors;
+    options.credentials = FetchOptions::Credentials::SameOrigin;
+    options.contentSecurityPolicyEnforcement = ContentSecurityPolicyEnforcement::DoNotEnforce;
+
+    Ref client = InspectorThreadableLoaderClient::create(WTF::move(completionHandler));
+    RefPtr loader = ThreadableLoader::create(context, client.get(), WTF::move(request), options);
+    if (!loader) {
+        client->failWithMessage("Could not load requested resource."_s);
+        return;
+    }
+
+    // If the load already finished synchronously the client has disposed itself; only retain the
+    // loader while the load is still in flight.
+    if (client->isActive())
+        client->setLoader(WTF::move(loader));
 }
 
 } // namespace ResourceUtilities

--- a/Source/WebCore/inspector/InspectorResourceUtilities.h
+++ b/Source/WebCore/inspector/InspectorResourceUtilities.h
@@ -30,6 +30,10 @@
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/InspectorResourceType.h>
 #include <WebCore/ResourceLoaderIdentifier.h>
+#include <WebCore/ScriptExecutionContextIdentifier.h>
+#include <tuple>
+#include <wtf/CompletionHandler.h>
+#include <wtf/Expected.h>
 #include <wtf/Forward.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
@@ -39,6 +43,7 @@ class DocumentLoader;
 class FragmentedSharedBuffer;
 class LocalFrame;
 class Page;
+class ScriptExecutionContext;
 class TextResourceDecoder;
 }
 
@@ -93,6 +98,10 @@ struct SearchResult {
     std::optional<WebCore::ResourceLoaderIdentifier> resourceID;
 };
 
+// Completion for Network.loadResource: {content, mimeType, status} on success, or an error string
+// on failure.
+using LoadResourceCompletionHandler = CompletionHandler<void(Expected<std::tuple<String /* content */, String /* mimeType */, int /* status */>, String /* error */>&&)>;
+
 namespace ResourceUtilities {
 
 WEBCORE_EXPORT bool sharedBufferContent(RefPtr<WebCore::FragmentedSharedBuffer>&&, const String& textEncodingName, bool withBase64Encode, String* result);
@@ -117,6 +126,9 @@ WEBCORE_EXPORT bool shouldTreatAsText(const String& mimeType);
 WEBCORE_EXPORT Ref<WebCore::TextResourceDecoder> createTextDecoder(const String& mimeType, const String& textEncodingName);
 WEBCORE_EXPORT std::optional<String> textContentForCachedResource(WebCore::CachedResource&);
 WEBCORE_EXPORT bool cachedResourceContent(WebCore::CachedResource&, String* result, bool* base64Encoded);
+
+// Loads url in the given context on behalf of the inspector, bypassing cross-origin checks (Network.loadResource).
+WEBCORE_EXPORT void loadResource(WebCore::ScriptExecutionContext&, const String& url, LoadResourceCompletionHandler&&);
 
 } // namespace ResourceUtilities
 

--- a/Source/WebCore/inspector/InspectorThreadableLoaderClient.cpp
+++ b/Source/WebCore/inspector/InspectorThreadableLoaderClient.cpp
@@ -30,6 +30,8 @@
 #include "TextResourceDecoder.h"
 #include "ThreadableLoader.h"
 #include <pal/text/TextEncoding.h>
+#include <tuple>
+#include <wtf/Expected.h>
 
 namespace Inspector {
 
@@ -66,14 +68,28 @@ void InspectorThreadableLoaderClient::didFinishLoading(ScriptExecutionContextIde
     if (RefPtr decoder = m_decoder)
         m_responseText.append(decoder->flush());
 
-    m_callback->sendSuccess(m_responseText.toString(), m_mimeType, m_statusCode);
+    auto completionHandler = WTF::move(m_completionHandler);
+    std::tuple<String, String, int> result { m_responseText.toString(), m_mimeType, m_statusCode };
     dispose();
+    if (completionHandler)
+        completionHandler(WTF::move(result));
 }
 
 void InspectorThreadableLoaderClient::didFail(std::optional<ScriptExecutionContextIdentifier>, const ResourceError& error)
 {
-    m_callback->sendFailure(error.isAccessControl() ? "Loading resource for inspector failed access control check"_s : "Loading resource for inspector failed"_s);
+    auto completionHandler = WTF::move(m_completionHandler);
+    auto errorMessage = error.isAccessControl() ? "Loading resource for inspector failed access control check"_s : "Loading resource for inspector failed"_s;
     dispose();
+    if (completionHandler)
+        completionHandler(makeUnexpected(errorMessage));
+}
+
+void InspectorThreadableLoaderClient::failWithMessage(const String& message)
+{
+    auto completionHandler = WTF::move(m_completionHandler);
+    dispose();
+    if (completionHandler)
+        completionHandler(makeUnexpected(message));
 }
 
 void InspectorThreadableLoaderClient::setLoader(RefPtr<ThreadableLoader>&& loader)

--- a/Source/WebCore/inspector/InspectorThreadableLoaderClient.h
+++ b/Source/WebCore/inspector/InspectorThreadableLoaderClient.h
@@ -25,13 +25,12 @@
 
 #pragma once
 
+#include "InspectorResourceUtilities.h" // for Inspector::LoadResourceCompletionHandler.
 #include "ThreadableLoaderClient.h"
-#include <JavaScriptCore/InspectorBackendDispatchers.h> // for LoadResourceCallback.
 #include <wtf/Forward.h>
 #include <wtf/ThreadSafeRefCounted.h>
-
-// FIXME: remove dependency on legacy callbacks in InspectorThreadableLoaderClient.
-using LoadResourceCallback = Inspector::NetworkBackendDispatcherHandler::LoadResourceCallback;
+#include <wtf/text/StringBuilder.h>
+#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 class TextResourceDecoder;
@@ -42,13 +41,16 @@ namespace Inspector {
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(InspectorThreadableLoaderClient);
 
+// Drives a ThreadableLoader for Network.loadResource and reports {content, mimeType, status} (or an
+// error string) through a completion handler, so it can back both the single-process
+// InspectorNetworkAgent and the Site Isolation WebProcess load leg. Use ResourceUtilities::loadResource().
 class InspectorThreadableLoaderClient final : public ThreadSafeRefCounted<InspectorThreadableLoaderClient, WTF::DestructionThread::Main>, public WebCore::ThreadableLoaderClient {
     WTF_MAKE_NONCOPYABLE(InspectorThreadableLoaderClient);
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(InspectorThreadableLoaderClient, InspectorThreadableLoaderClient);
 public:
-    static Ref<InspectorThreadableLoaderClient> create(RefPtr<LoadResourceCallback>&& callback)
+    static Ref<InspectorThreadableLoaderClient> create(LoadResourceCompletionHandler&& completionHandler)
     {
-        return adoptRef(*new InspectorThreadableLoaderClient(WTF::move(callback)));
+        return adoptRef(*new InspectorThreadableLoaderClient(WTF::move(completionHandler)));
     }
 
     ~InspectorThreadableLoaderClient() final = default;
@@ -63,9 +65,15 @@ public:
     void didFail(std::optional<WebCore::ScriptExecutionContextIdentifier>, const WebCore::ResourceError&) override;
     void setLoader(RefPtr<WebCore::ThreadableLoader>&&);
 
+    // True until the completion handler has fired; callers use it to decide whether to retain the loader.
+    bool isActive() const { return !m_hasCalledDeref; }
+
+    // Report a failure before a ThreadableLoader could even be created for the load.
+    void failWithMessage(const String&);
+
 private:
-    explicit InspectorThreadableLoaderClient(RefPtr<LoadResourceCallback>&& callback)
-        : m_callback(WTF::move(callback))
+    explicit InspectorThreadableLoaderClient(LoadResourceCompletionHandler&& completionHandler)
+        : m_completionHandler(WTF::move(completionHandler))
     {
         // FIXME: This is error-prone, we should avoid explicit calls to ref() / deref().
         ref(); // dispose() is in charge of calling deref();
@@ -73,7 +81,7 @@ private:
 
     void dispose();
 
-    const RefPtr<LoadResourceCallback> m_callback;
+    LoadResourceCompletionHandler m_completionHandler;
     RefPtr<WebCore::ThreadableLoader> m_loader;
     RefPtr<WebCore::TextResourceDecoder> m_decoder;
     String m_mimeType;

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
@@ -52,7 +52,6 @@
 #include "InspectorNetworkIntercept.h"
 #include "InspectorResourceType.h"
 #include "InspectorResourceUtilities.h"
-#include "InspectorThreadableLoaderClient.h"
 #include "InspectorTimelineAgent.h"
 #include "InstrumentingAgents.h"
 #include "JSDOMWindowCustom.h"
@@ -87,6 +86,8 @@
 #include <JavaScriptCore/ScriptCallStack.h>
 #include <JavaScriptCore/ScriptCallStackFactory.h>
 #include <WebCore/HTTPStatusCodes.h>
+#include <tuple>
+#include <wtf/Expected.h>
 #include <wtf/JSONValues.h>
 #include <wtf/Lock.h>
 #include <wtf/RefPtr.h>
@@ -983,29 +984,13 @@ void InspectorNetworkAgent::loadResource(const Inspector::Protocol::Network::Fra
         return;
     }
 
-    URL url = context->encodingParseURL(urlString);
-    ResourceRequest request(WTF::move(url));
-    request.setHTTPMethod("GET"_s);
-    request.setHiddenFromInspector(true);
-
-    ThreadableLoaderOptions options;
-    options.sendLoadCallbacks = SendCallbackPolicy::SendCallbacks; // So we remove this from m_hiddenRequestIdentifiers on completion.
-    options.defersLoadingPolicy = DefersLoadingPolicy::DisallowDefersLoading; // So the request is never deferred.
-    options.mode = FetchOptions::Mode::NoCors;
-    options.credentials = FetchOptions::Credentials::SameOrigin;
-    options.contentSecurityPolicyEnforcement = ContentSecurityPolicyEnforcement::DoNotEnforce;
-
-    // InspectorThreadableLoaderClient deletes itself when the load completes or fails.
-    Ref inspectorThreadableLoaderClient = InspectorThreadableLoaderClient::create(callback.copyRef());
-    RefPtr loader = ThreadableLoader::create(*context, inspectorThreadableLoaderClient, WTF::move(request), options);
-    if (!loader) {
-        callback->sendFailure("Could not load requested resource."_s);
-        return;
-    }
-
-    // If the load already completed, no need the set the client.
-    if (callback->isActive())
-        inspectorThreadableLoaderClient->setLoader(WTF::move(loader));
+    ResourceUtilities::loadResource(*context, urlString, [callback = WTF::move(callback)](Expected<std::tuple<String, String, int>, String>&& result) mutable {
+        if (result) {
+            auto& [content, mimeType, status] = result.value();
+            callback->sendSuccess(content, mimeType, status);
+        } else
+            callback->sendFailure(result.error());
+    });
 }
 
 void InspectorNetworkAgent::getSerializedCertificate(const Inspector::Protocol::Network::RequestId& requestId, Ref<GetSerializedCertificateCallback>&& callback)

--- a/Source/WebInspectorUI/UserInterface/Controllers/NetworkManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/NetworkManager.js
@@ -1628,6 +1628,14 @@ WI.NetworkManager = class NetworkManager extends WI.Object
         }
 
         let target = WI.assumingMainTarget();
+
+        // Under Site Isolation, ProxyingNetworkAgent implements Network.loadResource on the backend
+        // (web-page) target, fanning the load out to the frame's owning process. Route there when
+        // Network is enabled on the backend target; otherwise the main target handles it. Mirrors
+        // Resource.requestContentFromBackend.
+        if (this._networkEnabledOnBackendTarget && WI.backendTarget && WI.backendTarget !== target && WI.backendTarget.hasCommand("Network.loadResource"))
+            target = WI.backendTarget;
+
         if (!target.hasCommand("Network.loadResource")) {
             this._sourceMapLoadFailed(sourceMapURL);
             return;

--- a/Source/WebInspectorUI/UserInterface/Models/SourceMapResource.js
+++ b/Source/WebInspectorUI/UserInterface/Models/SourceMapResource.js
@@ -157,7 +157,15 @@ WI.SourceMapResource = class SourceMapResource extends WI.Resource
             });
         }
 
-        if (!this._target.hasCommand("Network.loadResource"))
+        // Under Site Isolation, ProxyingNetworkAgent implements Network.loadResource on the backend
+        // (web-page) target, fanning the load out to the frame's owning process. Route there when
+        // Network is enabled on the backend target; otherwise this resource's target handles it.
+        // Mirrors Resource.requestContentFromBackend.
+        let target = this._target;
+        if (WI.networkManager.networkEnabledOnBackendTarget && WI.backendTarget && WI.backendTarget !== target && WI.backendTarget.hasCommand("Network.loadResource"))
+            target = WI.backendTarget;
+
+        if (!target.hasCommand("Network.loadResource"))
             return sourceMapResourceLoadError.call(this);
 
         var frameIdentifier = null;
@@ -167,7 +175,7 @@ WI.SourceMapResource = class SourceMapResource extends WI.Resource
         if (!frameIdentifier)
             frameIdentifier = WI.networkManager.mainFrame ? WI.networkManager.mainFrame.id : "";
 
-        return this._target.NetworkAgent.loadResource(frameIdentifier, this.url).then(sourceMapResourceLoaded.bind(this)).catch(sourceMapResourceLoadError.bind(this));
+        return target.NetworkAgent.loadResource(frameIdentifier, this.url).then(sourceMapResourceLoaded.bind(this)).catch(sourceMapResourceLoadError.bind(this));
     }
 
     createSourceCodeLocation(lineNumber, columnNumber)

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -1075,6 +1075,7 @@ def class_template_headers(template_string):
         'std::optional': {'headers': ['<optional>'], 'argument_coder_headers': ['"ArgumentCoders.h"']},
         'std::pair': {'headers': ['<utility>'], 'argument_coder_headers': ['"ArgumentCoders.h"']},
         'std::span': {'headers': ['<span>'], 'argument_coder_headers': ['"ArgumentCoders.h"']},
+        'std::tuple': {'headers': ['<tuple>'], 'argument_coder_headers': ['"ArgumentCoders.h"']},
         'Variant': {'headers': ['<wtf/Variant.h>'], 'argument_coder_headers': ['"ArgumentCoders.h"']},
         'IPC::ArrayReferenceTuple': {'headers': ['"ArrayReferenceTuple.h"'], 'argument_coder_headers': ['"ArgumentCoders.h"']},
         'Ref': {'headers': ['<wtf/Ref.h>'], 'argument_coder_headers': ['"ArgumentCoders.h"']},

--- a/Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.cpp
+++ b/Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.cpp
@@ -429,10 +429,54 @@ CommandResult<void> ProxyingNetworkAgent::setClearResourceDataOnNavigate(bool)
     return { };
 }
 
-void ProxyingNetworkAgent::loadResource(const Protocol::Network::FrameId&, const String&, Ref<LoadResourceCallback>&& callback)
+void ProxyingNetworkAgent::loadResource(const Protocol::Network::FrameId& frameId, const String& url, Ref<LoadResourceCallback>&& callback)
 {
-    // FIXME: Route to correct WebContent process for the frame.
-    callback->sendFailure("Not yet implemented"_s);
+    // Routed by frame (frameId + URL), unlike getResponseBody which is routed by requestId: decode the
+    // frame's hosting process from the frameId and forward the load to that process's WebInspectorBackend.
+    auto parsed = IdentifierRegistry::parseProtocolFrameId(frameId);
+    if (!parsed) {
+        callback->sendFailure("Invalid frameId format"_s);
+        return;
+    }
+
+    auto [processIdentifier, frameID] = *parsed;
+
+    RefPtr inspectedPage = m_inspectedPage.get();
+    if (!inspectedPage) {
+        callback->sendFailure("Inspected page is gone"_s);
+        return;
+    }
+
+    RefPtr<WebKit::WebProcessProxy> targetProcess;
+    std::optional<PageIdentifier> targetPageID;
+
+    inspectedPage->forEachWebContentProcess([&](auto& webProcess, auto pageID) {
+        if (webProcess.coreProcessIdentifier() == processIdentifier) {
+            targetProcess = &webProcess;
+            targetPageID = pageID;
+        }
+    });
+
+    if (!targetProcess || !targetPageID) {
+        callback->sendFailure("WebProcess not found for frameId"_s);
+        return;
+    }
+
+    targetProcess->sendWithAsyncReply(
+        Messages::WebInspectorBackend::LoadResource { frameID, url },
+        [callback = WTF::move(callback)](Expected<std::tuple<String, String, int>, String>&& result) mutable {
+            if (result) {
+                auto& [content, mimeType, status] = result.value();
+                callback->sendSuccess(content, mimeType, status);
+            } else if (!result.error().isEmpty())
+                callback->sendFailure(result.error());
+            else {
+                // Empty error string == AsyncReplyError synthesized on connection loss (target
+                // WebProcess is gone), matching getResponseBody.
+                callback->sendFailure("Target WebProcess for frameId is no longer available"_s);
+            }
+        },
+        *targetPageID);
 }
 
 CommandResult<Ref<Protocol::Runtime::RemoteObject>> ProxyingNetworkAgent::resolveWebSocket(const Protocol::Network::RequestId&, const String&)

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.cpp
@@ -440,6 +440,33 @@ void WebInspectorBackend::getSerializedCertificate(ResourceLoaderIdentifier reso
     completionHandler(WTF::move(result));
 }
 
+void WebInspectorBackend::loadResource(WebCore::FrameIdentifier frameID, const String& url, CompletionHandler<void(Expected<std::tuple<String, String, int>, String>&&)>&& completionHandler)
+{
+    // Site Isolation load leg for Network.loadResource: ProxyingNetworkAgent already routed this to
+    // the frame's hosting process, so resolve the frame locally and run the load in its document
+    // context. Failures carry a non-empty error string (empty is reserved for the connection-loss
+    // AsyncReplyError; see WebInspectorBackend.messages.in).
+    RefPtr webFrame = WebProcess::singleton().webFrame(frameID);
+    if (!webFrame) {
+        completionHandler(makeUnexpected("Frame not found in this process"_s));
+        return;
+    }
+
+    RefPtr localFrame = webFrame->coreLocalFrame();
+    if (!localFrame) {
+        completionHandler(makeUnexpected("Frame is not local to this process"_s));
+        return;
+    }
+
+    RefPtr document = localFrame->document();
+    if (!document) {
+        completionHandler(makeUnexpected("No document for frame"_s));
+        return;
+    }
+
+    Inspector::ResourceUtilities::loadResource(*document, url, WTF::move(completionHandler));
+}
+
 // Convert the JSON protocol matches from ContentSearchUtilities::searchInTextByLines into the plain
 // typed-IPC mirror, so the UIProcess rebuilds the protocol objects on its side (as with FrameResource).
 static Vector<Inspector::SearchMatch> convertSearchMatches(JSON::ArrayOf<Inspector::Protocol::GenericTypes::SearchMatch>& matches)

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.h
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.h
@@ -103,6 +103,7 @@ public:
     void disableNetworkInstrumentation();
     void getResponseBody(WebCore::ResourceLoaderIdentifier, CompletionHandler<void(Expected<std::pair<String, bool>, String>&&)>&&);
     void getSerializedCertificate(WebCore::ResourceLoaderIdentifier, CompletionHandler<void(Expected<String, String>&&)>&&);
+    void loadResource(WebCore::FrameIdentifier, const String& url, CompletionHandler<void(Expected<std::tuple<String, String, int>, String>&&)>&&);
 
     void setExtraHTTPHeaders(WebCore::HTTPHeaderMap&&);
     void setResourceCachingDisabled(bool);

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.messages.in
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.messages.in
@@ -75,6 +75,11 @@ messages -> WebInspectorBackend {
     # connection loss); only the success payload differs -- here a single certificate String.
     GetSerializedCertificate(WebCore::ResourceLoaderIdentifier resourceID) -> (Expected<String, String> result) Async
 
+    # Network.loadResource: load a URL in the given frame's document context on behalf of the inspector,
+    # without cross-origin checks. Reply is {content, mimeType, status}, or an unexpected error string
+    # (same empty-string == connection-loss convention as GetResponseBody above).
+    LoadResource(WebCore::FrameIdentifier frameID, String url) -> (Expected<std::tuple<String, String, int>, String> result) Async
+
     # Page.searchInResource (requestId branch): search one XHR/Fetch body in this process's store.
     SearchInRequest(WebCore::ResourceLoaderIdentifier resourceID, String query, bool caseSensitive, bool isRegex) -> (Vector<Inspector::SearchMatch> matches, String errorString) Async
 


### PR DESCRIPTION
#### 28b979b1659bca24e518a83cd0e55d8e8ed7a424
<pre>
[Site Isolation] Web Inspector: Implement Network.loadResource
<a href="https://bugs.webkit.org/show_bug.cgi?id=319019">https://bugs.webkit.org/show_bug.cgi?id=319019</a>
<a href="https://rdar.apple.com/181636193">rdar://181636193</a>

Reviewed by BJ Burg.

Implement the ProxyingNetworkAgent::loadResource that was a stub.

Network.loadResource loads a URL in a frame&apos;s context on behalf of the
inspector (e.g. to fetch a source map). Unlike getResponseBody, which is
routed by a process-qualified requestId and returns already-buffered
content, loadResource is routed by frame (frameId + URL) and initiates a
load, so it needs frame -&gt; process routing and a WebProcess-side load leg
rather than the requestId / BackendResourceDataStore path.

The WebProcess load leg reuses WebCore&apos;s InspectorThreadableLoaderClient,
refactored to report its result through a completion handler instead of a
LoadResourceCallback so it no longer depends on a backend dispatcher. It is
exposed behind a new shared ResourceUtilities::loadResource() helper that
owns the request/options and loader lifetime; the single-process
InspectorNetworkAgent now delegates to the same helper, so both paths share
one implementation.

On the UIProcess side, ProxyingNetworkAgent decodes the frame&apos;s hosting
process from the protocol frameId, the same way getResponseBody decodes it
from a requestId. It keeps getResponseBody&apos;s convention that an empty reply
error string means the WebProcess connection was lost (AsyncReplyError)
rather than a real failure.

Two supporting changes make the command reachable under Site Isolation:
Network.loadResource gains the &quot;web-page&quot; target type so it is exposed on
the multiplexing target where ProxyingNetworkAgent lives (without it the
frontend cannot call it there), and the two frontend callers route to the
backend target when Network is enabled there, mirroring the getResponseBody
reroute in Resource.requestContentFromBackend. Both are no-ops outside Site
Isolation.

Test: http/tests/site-isolation/inspector/network/cross-origin-iframe-load-resource.html

* LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-load-resource-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-load-resource.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/network/resources/load-resource-iframe.html: Added.
* Source/JavaScriptCore/inspector/protocol/Network.json:
* Source/WebCore/inspector/InspectorResourceUtilities.cpp:
(Inspector::ResourceUtilities::loadResource):
* Source/WebCore/inspector/InspectorResourceUtilities.h:
* Source/WebCore/inspector/InspectorThreadableLoaderClient.cpp:
(Inspector::InspectorThreadableLoaderClient::didFinishLoading):
(Inspector::InspectorThreadableLoaderClient::didFail):
(Inspector::InspectorThreadableLoaderClient::failWithMessage):
* Source/WebCore/inspector/InspectorThreadableLoaderClient.h:
* Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp:
(WebCore::InspectorNetworkAgent::loadResource):
* Source/WebInspectorUI/UserInterface/Controllers/NetworkManager.js:
(WI.NetworkManager.prototype._loadAndParseSourceMap):
* Source/WebInspectorUI/UserInterface/Models/SourceMapResource.js:
(WI.SourceMapResource.prototype.requestContentFromBackend):
* Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.cpp:
(Inspector::ProxyingNetworkAgent::loadResource):
* Source/WebKit/WebProcess/Inspector/WebInspectorBackend.cpp:
(WebKit::WebInspectorBackend::loadResource):
* Source/WebKit/WebProcess/Inspector/WebInspectorBackend.h:
* Source/WebKit/WebProcess/Inspector/WebInspectorBackend.messages.in:
* Source/WebKit/Scripts/webkit/messages.py:
(class_template_headers):

Canonical link: <a href="https://commits.webkit.org/317996@main">https://commits.webkit.org/317996@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/120a11fa5fc1e31ffe1d9d9e9af5afe3d8f8d277

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177003 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50940 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/44735 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186606 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d010a200-8c1d-4ad9-878d-1fa332a2a589) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178866 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52233 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50626 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/137920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/14fb982c-43ec-4aed-aaab-a25636ce5797) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179959 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/41429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/158700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118389 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/92db868b-f42a-4ee8-b4db-53d44106cfb1) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/176326 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/40085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/38451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/218/builds/7205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/150495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/38200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35074 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/38274 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/42693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189029 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50607 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/158240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/147000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51290 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146794 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26844 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41547 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/123504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/117791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49795 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/13180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49194 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49431 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49255 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->