### PR TITLE
[Site Isolation] Web Inspector: Implement Network.getSerializedCertificate

### DIFF
--- a/LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-get-serialized-certificate-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-get-serialized-certificate-expected.txt
@@ -1,0 +1,21 @@
+Tests Network.getSerializedCertificate under Site Isolation (routed through ProxyingNetworkAgent to the owning WebContent process's BackendResourceDataStore). A resource loaded over https returns a real certificate; the http, malformed, and unknown-process cases exercise the routing and error paths.
+
+
+== Running test suite: SiteIsolation.Network.CrossOriginIFrame.GetSerializedCertificate
+-- Running test case: SiteIsolation.Network.CrossOriginIFrame.GetSerializedCertificate.SecureCertificate
+PASS: Secure resource should have a request identifier.
+PASS: getSerializedCertificate should return a non-empty base64 certificate.
+
+-- Running test case: SiteIsolation.Network.CrossOriginIFrame.GetSerializedCertificate.MissingCertificateOverHTTP
+PASS: Loaded resource should have a request identifier.
+PASS: Real requestId over http (no certificate): getSerializedCertificate should fail.
+  Error: Missing certificate of resource for given requestId
+
+-- Running test case: SiteIsolation.Network.CrossOriginIFrame.GetSerializedCertificate.Malformed
+PASS: Malformed requestId: getSerializedCertificate should fail.
+  Error: Invalid requestId format
+
+-- Running test case: SiteIsolation.Network.CrossOriginIFrame.GetSerializedCertificate.UnknownProcess
+PASS: Unknown process: getSerializedCertificate should fail.
+  Error: WebProcess not found for requestId
+

--- a/LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-get-serialized-certificate.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-get-serialized-certificate.html
@@ -1,0 +1,125 @@
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script>
+let httpIFrame;
+let httpsIFrame;
+
+function addIFrame() {
+    // Cross-origin (localhost vs the 127.0.0.1 main frame) HTTP iframe -> its own WebContent process
+    // under Site Isolation. Its subresources load over http, so no certificate is captured.
+    httpIFrame = document.createElement("iframe");
+    httpIFrame.src = "http://localhost:8000/site-isolation/inspector/network/resources/get-response-body-iframe.html";
+    httpIFrame.addEventListener("load", () => httpIFrame.contentWindow.postMessage({type: "TriggerLoads"}, "*"));
+    document.body.appendChild(httpIFrame);
+}
+
+function addSecureIFrame() {
+    // Cross-origin HTTPS iframe -> its own WebContent process under Site Isolation, and its
+    // subresource loads over TLS so a certificate is actually captured.
+    httpsIFrame = document.createElement("iframe");
+    httpsIFrame.src = "https://localhost:8443/site-isolation/inspector/network/resources/get-serialized-certificate-iframe.html";
+    httpsIFrame.addEventListener("load", () => httpsIFrame.contentWindow.postMessage({type: "TriggerLoads"}, "*"));
+    document.body.appendChild(httpsIFrame);
+}
+
+function test() {
+    // Exercises Network.getSerializedCertificate under Site Isolation. The command is issued against
+    // the multiplexing (web-page) target's NetworkAgent, where ProxyingNetworkAgent lives under SI.
+    //
+    // The success case loads a resource over https so a real certificate is captured cross-process and
+    // returned as a non-empty base64 string. The remaining cases cover the routing/error paths that do
+    // not need TLS: a real requestId over http (no certificate), a malformed requestId, and a
+    // well-formed requestId whose process does not exist.
+    //
+    // Like cross-origin-iframe-get-response-body, this is requestId-routed and never resolves a frame
+    // target, so resources are driven through the WI.Frame.Event.ResourceWasAdded path with a
+    // dynamically-added iframe (loads triggered only after Network instrumentation is enabled), rather
+    // than the FrameTarget/RuntimeAgent path, which has event-ordering races under SI. The static-iframe
+    // pattern used by the frame-target tests is therefore unnecessary (and would be racy) here.
+
+    function waitForResource(urlSubstring) {
+        return new Promise((resolve) => {
+            function onResourceAdded(event) {
+                let resource = event.data.resource;
+                if (!resource || !resource.url || !resource.url.includes(urlSubstring))
+                    return;
+                WI.Frame.removeEventListener(WI.Frame.Event.ResourceWasAdded, onResourceAdded);
+                resolve(resource);
+            }
+            WI.Frame.addEventListener(WI.Frame.Event.ResourceWasAdded, onResourceAdded);
+        });
+    }
+
+    // Trigger loads in a fresh iframe and resolve once the matching resource has finished loading, so
+    // its response (and thus any certificate) has been received by the owning process's store.
+    async function loadedResource(addFunctionCall, urlSubstring) {
+        let resourcePromise = waitForResource(urlSubstring);
+        InspectorTest.evaluateInPage(addFunctionCall);
+        let resource = await resourcePromise;
+        if (!resource.finished && !resource.failed)
+            await resource.awaitEvent(WI.Resource.Event.LoadingDidFinish);
+        return resource;
+    }
+
+    async function expectToFail(requestId, label) {
+        try {
+            await WI.backendTarget.NetworkAgent.getSerializedCertificate(requestId);
+            InspectorTest.expectThat(false, `${label}: getSerializedCertificate should have failed.`);
+        } catch (e) {
+            InspectorTest.expectThat(true, `${label}: getSerializedCertificate should fail.`);
+            InspectorTest.log(`  Error: ${e.message || e}`);
+        }
+    }
+
+    let realRequestId;
+
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.Network.CrossOriginIFrame.GetSerializedCertificate");
+
+    suite.addTestCase({
+        name: "SiteIsolation.Network.CrossOriginIFrame.GetSerializedCertificate.SecureCertificate",
+        description: "A resource loaded over https in a cross-origin iframe's WebContent process has its certificate captured; getSerializedCertificate routes there and returns a non-empty base64 certificate.",
+        async test() {
+            let resource = await loadedResource("addSecureIFrame()", "square100.png");
+            InspectorTest.expectThat(!!resource.requestIdentifier, "Secure resource should have a request identifier.");
+
+            let {serializedCertificate} = await WI.backendTarget.NetworkAgent.getSerializedCertificate(resource.requestIdentifier);
+            InspectorTest.expectGreaterThan(serializedCertificate.length, 0, "getSerializedCertificate should return a non-empty base64 certificate.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.Network.CrossOriginIFrame.GetSerializedCertificate.MissingCertificateOverHTTP",
+        description: "A valid requestId routes to the owning process; over http there is no certificate, so it fails with a missing-certificate error (proving the routing + store lookup work).",
+        async test() {
+            let resource = await loadedResource("addIFrame()", "echo.py");
+
+            realRequestId = resource.requestIdentifier;
+            InspectorTest.expectThat(!!realRequestId, "Loaded resource should have a request identifier.");
+
+            await expectToFail(realRequestId, "Real requestId over http (no certificate)");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.Network.CrossOriginIFrame.GetSerializedCertificate.Malformed",
+        description: "A malformed requestId should fail to parse.",
+        async test() {
+            await expectToFail("not-a-valid-request-id", "Malformed requestId");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.Network.CrossOriginIFrame.GetSerializedCertificate.UnknownProcess",
+        description: "A well-formed requestId whose process does not exist should fail to route.",
+        async test() {
+            let unknownProcess = realRequestId.replace(/^request-\d+\./, "request-4294967295.");
+            await expectToFail(unknownProcess, "Unknown process");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+
+<body onload="runTest()">
+<p>Tests Network.getSerializedCertificate under Site Isolation (routed through ProxyingNetworkAgent to the owning WebContent process's BackendResourceDataStore). A resource loaded over https returns a real certificate; the http, malformed, and unknown-process cases exercise the routing and error paths.</p>
+</body>

--- a/LayoutTests/http/tests/site-isolation/inspector/network/resources/get-serialized-certificate-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/network/resources/get-serialized-certificate-iframe.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<p>Cross-origin iframe served over HTTPS that loads a secure image subresource, for Network.getSerializedCertificate success-path testing under Site Isolation.</p>
+
+<script>
+window.addEventListener("message", (event) => {
+    if (event.data.type === "TriggerLoads")
+        triggerLoads();
+});
+
+function triggerLoads() {
+    // Secure (HTTPS) image subresource, same-origin to this HTTPS iframe. Loaded over TLS so the
+    // iframe's WebContent process captures a CertificateInfo in its BackendResourceDataStore, which
+    // Network.getSerializedCertificate then serializes. Cache-busted so each run is a fresh load.
+    let img = document.createElement("img");
+    img.src = "https://localhost:8443/resources/square100.png?" + Math.random();
+    document.body.appendChild(img);
+}
+</script>

--- a/Source/JavaScriptCore/inspector/protocol/Network.json
+++ b/Source/JavaScriptCore/inspector/protocol/Network.json
@@ -245,7 +245,8 @@
         {
             "name": "getSerializedCertificate",
             "description": "Fetches a serialized secure certificate for the given requestId to be displayed via InspectorFrontendHost.showCertificate.",
-            "targetTypes": ["page"],
+            "targetTypes": ["page", "web-page"],
+            "async": true,
             "parameters": [
                 { "name": "requestId", "$ref": "RequestId" }
             ],

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
@@ -1008,19 +1008,23 @@ void InspectorNetworkAgent::loadResource(const Inspector::Protocol::Network::Fra
         inspectorThreadableLoaderClient->setLoader(WTF::move(loader));
 }
 
-Inspector::Protocol::ErrorStringOr<String> InspectorNetworkAgent::getSerializedCertificate(const Inspector::Protocol::Network::RequestId& requestId)
+void InspectorNetworkAgent::getSerializedCertificate(const Inspector::Protocol::Network::RequestId& requestId, Ref<GetSerializedCertificateCallback>&& callback)
 {
     auto* resourceData = m_resourcesData->data(requestId);
-    if (!resourceData)
-        return makeUnexpected("Missing resource for given requestId"_s);
+    if (!resourceData) {
+        callback->sendFailure("Missing resource for given requestId"_s);
+        return;
+    }
 
     auto& certificate = resourceData->certificateInfo();
-    if (!certificate || certificate.value().isEmpty())
-        return makeUnexpected("Missing certificate of resource for given requestId"_s);
+    if (!certificate || certificate.value().isEmpty()) {
+        callback->sendFailure("Missing certificate of resource for given requestId"_s);
+        return;
+    }
 
     WTF::Persistence::Encoder encoder;
     WTF::Persistence::Coder<WebCore::CertificateInfo>::encodeForPersistence(encoder, certificate.value());
-    return base64EncodeToString(encoder.span());
+    callback->sendSuccess(base64EncodeToString(encoder.span()));
 }
 
 RefPtr<WebSocket> InspectorNetworkAgent::webSocketForRequestId(const Inspector::Protocol::Network::RequestId& requestId)

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.h
@@ -93,7 +93,7 @@ public:
     Inspector::Protocol::ErrorStringOr<void> setResourceCachingDisabled(bool) final;
     Inspector::Protocol::ErrorStringOr<void> setClearResourceDataOnNavigate(bool) final;
     void loadResource(const Inspector::Protocol::Network::FrameId&, const String& url, Ref<LoadResourceCallback>&&) final;
-    Inspector::Protocol::ErrorStringOr<String> getSerializedCertificate(const Inspector::Protocol::Network::RequestId&) final;
+    void getSerializedCertificate(const Inspector::Protocol::Network::RequestId&, Ref<GetSerializedCertificateCallback>&&) final;
     Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::Runtime::RemoteObject>> resolveWebSocket(const Inspector::Protocol::Network::RequestId&, const String& objectGroup) final;
     Inspector::Protocol::ErrorStringOr<void> setInterceptionEnabled(bool) final;
     Inspector::Protocol::ErrorStringOr<void> addInterception(const String& url, Inspector::Protocol::Network::NetworkStage, std::optional<bool>&& caseSensitive, std::optional<bool>&& isRegex) final;

--- a/Source/WebInspectorUI/UserInterface/Models/Resource.js
+++ b/Source/WebInspectorUI/UserInterface/Models/Resource.js
@@ -1180,7 +1180,12 @@ WI.Resource = class Resource extends WI.SourceCode
         let errorString = WI.UIString("Unable to show certificate for \u201C%s\u201D").format(this.url);
 
         try {
-            let {serializedCertificate} = await this._target.NetworkAgent.getSerializedCertificate(this._requestIdentifier);
+            // The Network domain (ProxyingNetworkAgent) lives on the backend target under Site
+            // Isolation, not the resource's own (page) target; route there like requestContentFromBackend.
+            let webPageTarget = this._target;
+            if (WI.networkManager.networkEnabledOnBackendTarget && WI.backendTarget && WI.backendTarget !== this._target && WI.backendTarget.hasDomain("Network"))
+                webPageTarget = WI.backendTarget;
+            let {serializedCertificate} = await webPageTarget.NetworkAgent.getSerializedCertificate(this._requestIdentifier);
             if (InspectorFrontendHost.showCertificate(serializedCertificate))
                 return;
         } catch (e) {

--- a/Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.cpp
+++ b/Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.cpp
@@ -42,6 +42,7 @@
 #include <WebCore/HTTPHeaderMap.h>
 #include <WebCore/InspectorIdentifierRegistry.h>
 #include <WebCore/ProcessQualified.h>
+#include <tuple>
 #include <utility>
 #include <wtf/Expected.h>
 
@@ -323,25 +324,34 @@ CommandResult<void> ProxyingNetworkAgent::setExtraHTTPHeaders(Ref<JSON::Object>&
     return { };
 }
 
-void ProxyingNetworkAgent::getResponseBody(const Protocol::Network::RequestId& requestId, Ref<GetResponseBodyCallback>&& callback)
+// An empty error string on a reply is the AsyncReplyError synthesized on connection loss (the
+// target WebProcess is gone); report that explicitly instead of surfacing it to the frontend as a
+// spurious success. A non-empty error is a genuine backend failure and is forwarded verbatim.
+static String replyFailureString(const String& replyError)
+{
+    if (!replyError.isEmpty())
+        return replyError;
+    return "Target WebProcess for requestId is no longer available"_s;
+}
+
+// Resolve a requestId-routed command to the WebContent process that performed the load. The
+// requestId encodes the owning process identifier (see IdentifierRegistry::protocolRequestId); on
+// failure the returned string is the frontend-facing error. Shared by the requestId-routed
+// commands (getResponseBody, getSerializedCertificate), which then issue their own async IPC to the
+// resolved process.
+static CommandResultOf<Ref<WebKit::WebProcessProxy>, PageIdentifier, ResourceLoaderIdentifier> resolveRequestProcess(WebKit::WebPageProxy* inspectedPage, const Protocol::Network::RequestId& requestId)
 {
     auto parsed = IdentifierRegistry::parseProtocolRequestId(requestId);
-    if (!parsed) {
-        callback->sendFailure("Invalid requestId format"_s);
-        return;
-    }
+    if (!parsed)
+        return makeUnexpected("Invalid requestId format"_s);
 
     auto [processIdentifier, resourceID] = *parsed;
 
-    RefPtr inspectedPage = m_inspectedPage.get();
-    if (!inspectedPage) {
-        callback->sendFailure("Inspected page is gone"_s);
-        return;
-    }
+    if (!inspectedPage)
+        return makeUnexpected("Inspected page is gone"_s);
 
     RefPtr<WebKit::WebProcessProxy> targetProcess;
     std::optional<PageIdentifier> targetPageID;
-
     inspectedPage->forEachWebContentProcess([&](auto& webProcess, auto pageID) {
         if (webProcess.coreProcessIdentifier() == processIdentifier) {
             targetProcess = &webProcess;
@@ -349,27 +359,53 @@ void ProxyingNetworkAgent::getResponseBody(const Protocol::Network::RequestId& r
         }
     });
 
-    if (!targetProcess || !targetPageID) {
-        callback->sendFailure("WebProcess not found for requestId"_s);
+    if (!targetProcess || !targetPageID)
+        return makeUnexpected("WebProcess not found for requestId"_s);
+
+    return { { targetProcess.releaseNonNull(), *targetPageID, resourceID } };
+}
+
+void ProxyingNetworkAgent::getResponseBody(const Protocol::Network::RequestId& requestId, Ref<GetResponseBodyCallback>&& callback)
+{
+    RefPtr inspectedPage = m_inspectedPage.get();
+    auto resolved = resolveRequestProcess(inspectedPage.get(), requestId);
+    if (!resolved) {
+        callback->sendFailure(resolved.error());
         return;
     }
 
+    auto [targetProcess, targetPageID, resourceID] = WTF::move(resolved.value());
     targetProcess->sendWithAsyncReply(
         Messages::WebInspectorBackend::GetResponseBody { resourceID },
         [callback = WTF::move(callback)](Expected<std::pair<String, bool>, String>&& result) mutable {
             if (result) {
                 auto& [content, base64Encoded] = result.value();
                 callback->sendSuccess(content, base64Encoded);
-            } else if (!result.error().isEmpty()) {
-                // A real failure reported by the target WebProcess (e.g. missing or evicted content).
-                callback->sendFailure(result.error());
-            } else {
-                // Empty error: AsyncReplyError synthesized this reply on connection loss (the target
-                // WebProcess is gone). Fail explicitly so a dead process is never surfaced as success.
-                callback->sendFailure("Target WebProcess for requestId is no longer available"_s);
-            }
+            } else
+                callback->sendFailure(replyFailureString(result.error()));
         },
-        *targetPageID);
+        targetPageID);
+}
+
+void ProxyingNetworkAgent::getSerializedCertificate(const Protocol::Network::RequestId& requestId, Ref<GetSerializedCertificateCallback>&& callback)
+{
+    RefPtr inspectedPage = m_inspectedPage.get();
+    auto resolved = resolveRequestProcess(inspectedPage.get(), requestId);
+    if (!resolved) {
+        callback->sendFailure(resolved.error());
+        return;
+    }
+
+    auto [targetProcess, targetPageID, resourceID] = WTF::move(resolved.value());
+    targetProcess->sendWithAsyncReply(
+        Messages::WebInspectorBackend::GetSerializedCertificate { resourceID },
+        [callback = WTF::move(callback)](Expected<String, String>&& result) mutable {
+            if (result)
+                callback->sendSuccess(result.value());
+            else
+                callback->sendFailure(replyFailureString(result.error()));
+        },
+        targetPageID);
 }
 
 CommandResult<void> ProxyingNetworkAgent::setResourceCachingDisabled(bool disabled)
@@ -397,12 +433,6 @@ void ProxyingNetworkAgent::loadResource(const Protocol::Network::FrameId&, const
 {
     // FIXME: Route to correct WebContent process for the frame.
     callback->sendFailure("Not yet implemented"_s);
-}
-
-CommandResult<String> ProxyingNetworkAgent::getSerializedCertificate(const Protocol::Network::RequestId&)
-{
-    // FIXME: Implement certificate retrieval (P2 -- BackendResourceDataStore).
-    return makeUnexpected("Not yet implemented"_s);
 }
 
 CommandResult<Ref<Protocol::Runtime::RemoteObject>> ProxyingNetworkAgent::resolveWebSocket(const Protocol::Network::RequestId&, const String&)

--- a/Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.h
+++ b/Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.h
@@ -81,7 +81,7 @@ public:
     CommandResult<void> setResourceCachingDisabled(bool) final;
     CommandResult<void> setClearResourceDataOnNavigate(bool) final;
     void loadResource(const Protocol::Network::FrameId&, const String& url, Ref<LoadResourceCallback>&&) final;
-    CommandResult<String> getSerializedCertificate(const Protocol::Network::RequestId&) final;
+    void getSerializedCertificate(const Protocol::Network::RequestId&, Ref<GetSerializedCertificateCallback>&&) final;
     CommandResult<Ref<Protocol::Runtime::RemoteObject>> resolveWebSocket(const Protocol::Network::RequestId&, const String& objectGroup) final;
     CommandResult<void> setInterceptionEnabled(bool) final;
     CommandResult<void> addInterception(const String& url, Protocol::Network::NetworkStage, std::optional<bool>&& caseSensitive, std::optional<bool>&& isRegex) final;

--- a/Source/WebKit/WebProcess/Inspector/BackendResourceDataStore.cpp
+++ b/Source/WebKit/WebProcess/Inspector/BackendResourceDataStore.cpp
@@ -30,8 +30,10 @@
 #include <WebCore/HTTPHeaderNames.h>
 #include <WebCore/InspectorResourceUtilities.h>
 #include <WebCore/ResourceResponse.h>
+#include <WebCore/WebCorePersistentCoders.h>
 #include <utility>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/persistence/PersistentEncoder.h>
 #include <wtf/text/Base64.h>
 
 namespace WebKit {
@@ -327,6 +329,21 @@ Expected<std::pair<String, bool>, String> BackendResourceDataStore::getResponseB
     }
 
     return makeUnexpected("Missing content of resource for given requestId"_s);
+}
+
+Expected<String, String> BackendResourceDataStore::getSerializedCertificate(ResourceLoaderIdentifier resourceID)
+{
+    ResourceData const* resourceData = data(resourceID);
+    if (!resourceData)
+        return makeUnexpected("Missing resource for given requestId"_s);
+
+    auto* certificateInfo = resourceData->certificateInfo();
+    if (!certificateInfo || certificateInfo->isEmpty())
+        return makeUnexpected("Missing certificate of resource for given requestId"_s);
+
+    WTF::Persistence::Encoder encoder;
+    WTF::Persistence::Coder<CertificateInfo>::encodeForPersistence(encoder, *certificateInfo);
+    return base64EncodeToString(encoder.span());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Inspector/BackendResourceDataStore.h
+++ b/Source/WebKit/WebProcess/Inspector/BackendResourceDataStore.h
@@ -115,6 +115,7 @@ public:
         void setBuffer(RefPtr<WebCore::FragmentedSharedBuffer>&& buffer) { m_buffer = WTF::move(buffer); }
 
         void setCertificateInfo(std::unique_ptr<WebCore::CertificateInfo>&&);
+        const WebCore::CertificateInfo* certificateInfo() const LIFETIME_BOUND { return m_certificateInfo.get(); }
 
         bool hasBufferedData() const { return hasData(); }
 
@@ -152,6 +153,9 @@ public:
     BackendResourceDataStore(const Settings&);
     ~BackendResourceDataStore();
 
+    // Gates capture of each response's TLS certificate; set from the page's certificate-display setting.
+    void setSupportsShowingCertificate(bool supports) { m_settings.supportsShowingCertificate = supports; }
+
     void resourceCreated(WebCore::ResourceLoaderIdentifier, WebCore::FrameIdentifier, Inspector::ResourceType);
     void responseReceived(WebCore::ResourceLoaderIdentifier, const WebCore::ResourceResponse&, Inspector::ResourceType);
     void setResourceType(WebCore::ResourceLoaderIdentifier, Inspector::ResourceType);
@@ -167,6 +171,10 @@ public:
     template<typename Visitor> void forEach(NOESCAPE const Visitor&) const;
 
     Expected<std::pair<String, bool>, String> getResponseBody(WebCore::ResourceLoaderIdentifier);
+
+    // Base64-encoded persistence encoding of the response's CertificateInfo, matching
+    // InspectorNetworkAgent::getSerializedCertificate.
+    Expected<String, String> getSerializedCertificate(WebCore::ResourceLoaderIdentifier);
 
 private:
     ResourceData* resourceDataForId(WebCore::ResourceLoaderIdentifier);

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.cpp
@@ -379,6 +379,9 @@ void WebInspectorBackend::enableNetworkInstrumentation()
         m_networkInstrumentationEnabled = true;
         corePage->settings().setDeveloperExtrasEnabled(true);
         corePage->inspectorController().connectRemoteInstrumentation();
+
+        // Buffer certificates only when the page opts in, matching PageNetworkAgent.
+        CheckedRef { m_resourceDataStore.get() }->setSupportsShowingCertificate(corePage->settings().inspectorSupportsShowingCertificate());
     }
 
     corePage->forEachLocalFrame([&](LocalFrame& frame) {
@@ -424,6 +427,15 @@ void WebInspectorBackend::getResponseBody(ResourceLoaderIdentifier resourceID, C
     // FIXME: <https://webkit.org/b/320234> The sibling proxying replies (Page.getResourceContent,
     // Page.searchInResource) still use a bare error-string reply and should adopt this same
     // Expected-based discriminator.
+    ASSERT(result.has_value() || !result.error().isEmpty());
+    completionHandler(WTF::move(result));
+}
+
+void WebInspectorBackend::getSerializedCertificate(ResourceLoaderIdentifier resourceID, CompletionHandler<void(Expected<String, String>&&)>&& completionHandler)
+{
+    CheckedRef resourceDataStore = m_resourceDataStore.get();
+    auto result = resourceDataStore->getSerializedCertificate(resourceID);
+    // See getResponseBody: a genuine failure must carry a non-empty message (empty is connection loss).
     ASSERT(result.has_value() || !result.error().isEmpty());
     completionHandler(WTF::move(result));
 }

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.h
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.h
@@ -102,6 +102,7 @@ public:
     void enableNetworkInstrumentation();
     void disableNetworkInstrumentation();
     void getResponseBody(WebCore::ResourceLoaderIdentifier, CompletionHandler<void(Expected<std::pair<String, bool>, String>&&)>&&);
+    void getSerializedCertificate(WebCore::ResourceLoaderIdentifier, CompletionHandler<void(Expected<String, String>&&)>&&);
 
     void setExtraHTTPHeaders(WebCore::HTTPHeaderMap&&);
     void setResourceCachingDisabled(bool);

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.messages.in
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.messages.in
@@ -70,6 +70,11 @@ messages -> WebInspectorBackend {
     # empty error = connection loss (AsyncReplyError), which ProxyingNetworkAgent fails explicitly.
     GetResponseBody(WebCore::ResourceLoaderIdentifier resourceID) -> (Expected<std::pair<String, bool>, String> result) Async
 
+    # Serialize the resource's response certificate for Network.getSerializedCertificate. Same
+    # Expected error convention as GetResponseBody (empty errorString on the unexpected means
+    # connection loss); only the success payload differs -- here a single certificate String.
+    GetSerializedCertificate(WebCore::ResourceLoaderIdentifier resourceID) -> (Expected<String, String> result) Async
+
     # Page.searchInResource (requestId branch): search one XHR/Fetch body in this process's store.
     SearchInRequest(WebCore::ResourceLoaderIdentifier resourceID, String query, bool caseSensitive, bool isRegex) -> (Vector<Inspector::SearchMatch> matches, String errorString) Async
 


### PR DESCRIPTION
#### 479edb2e4395baaa1f7bec9655aacf4b24a611a6
<pre>
[Site Isolation] Web Inspector: Implement Network.getSerializedCertificate
<a href="https://bugs.webkit.org/show_bug.cgi?id=319020">https://bugs.webkit.org/show_bug.cgi?id=319020</a>
<a href="https://rdar.apple.com/181636486">rdar://181636486</a>

Reviewed by BJ Burg.

Under Site Isolation the Network domain is served by ProxyingNetworkAgent
in the UIProcess, which routes each requestId-keyed command to the
WebContent process that performed the load. A resource&apos;s TLS certificate
has to follow that path: it lives on the ResourceResponse in the loading
process and is not retained afterwards, so it is captured at response
time into the same per-process store that already backs getResponseBody.

That buffering already existed but sat behind a store setting that was
never turned on. We drive the setting from the inspected page&apos;s existing
certificate-display preference rather than forcing it on, so Site
Isolation makes the same embedder- and platform-gated decision as the
non-Site-Isolation path instead of quietly diverging from it. It is
applied when network instrumentation is enabled -- the point where the
page is known to be live and where the other network overrides are
already latched.

The protocol command was synchronous. Serving it that way would mean a
synchronous UIProcess-to-WebContent IPC, which blocks the UIProcess on a
web content process and would require teaching WebPage to forward
synchronous messages to its inspector receiver. Making the command
asynchronous instead lets it reuse the getResponseBody routing and adds
no new IPC plumbing; the shared requestId-to-process resolution is
factored into a helper. The tradeoff is converting the shared WebCore
handler that every non-Site-Isolation port implements from a synchronous
return to a callback; that is mechanical and invisible to the frontend,
which already awaits the command.

Neither shared-code change moves the non-Site-Isolation path: the page
target&apos;s handler still completes synchronously in place (only its return
shape changed, not its timing), and the frontend&apos;s backend-target
reroute is gated on a flag set only under Site Isolation.

Two caveats shared with getResponseBody: the command must be declared
on the web-page target or it is absent from the backend dispatcher
where ProxyingNetworkAgent lives, and the frontend must issue it
against the backend target, since a resource&apos;s own target is the page
target that cannot resolve the requestId under Site Isolation.

A real certificate requires a TLS load, so the test drives the success
path through a cross-origin https iframe and covers the
missing-certificate, malformed-requestId, and unknown-process routing
paths without one.

Test: http/tests/site-isolation/inspector/network/cross-origin-iframe-get-serialized-certificate.html

* LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-get-serialized-certificate-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-get-serialized-certificate.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/network/resources/get-serialized-certificate-iframe.html: Added.
* Source/JavaScriptCore/inspector/protocol/Network.json:
* Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp:
(WebCore::InspectorNetworkAgent::getSerializedCertificate):
* Source/WebCore/inspector/agents/InspectorNetworkAgent.h:
* Source/WebInspectorUI/UserInterface/Models/Resource.js:
(WI.Resource.prototype.async showCertificate):
* Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.cpp:
(Inspector::replyFailureString):
(Inspector::resolveRequestProcess):
(Inspector::ProxyingNetworkAgent::getResponseBody):
(Inspector::ProxyingNetworkAgent::getSerializedCertificate):
* Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.h:
* Source/WebKit/WebProcess/Inspector/BackendResourceDataStore.cpp:
(WebKit::BackendResourceDataStore::getSerializedCertificate):
* Source/WebKit/WebProcess/Inspector/BackendResourceDataStore.h:
(WebKit::BackendResourceDataStore::setSupportsShowingCertificate):
* Source/WebKit/WebProcess/Inspector/WebInspectorBackend.cpp:
(WebKit::WebInspectorBackend::enableNetworkInstrumentation):
(WebKit::WebInspectorBackend::getSerializedCertificate):
* Source/WebKit/WebProcess/Inspector/WebInspectorBackend.h:
* Source/WebKit/WebProcess/Inspector/WebInspectorBackend.messages.in:

Canonical link: <a href="https://commits.webkit.org/317989@main">https://commits.webkit.org/317989@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5bd8928cc60c5b6ded8fd5e3979b70216f6bcd76

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176984 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50921 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44716 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186587 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178847 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52214 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50607 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/137899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179940 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41408 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/158685 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118368 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6b287136-6a10-4ead-8cda-9102f0f7ea4a) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/40064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/38433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7190 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150474 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/38185 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35055 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/38255 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/42674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189010 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50588 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158225 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/146981 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51271 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146777 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26840 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41530 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/123484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117772 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49776 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13165 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49175 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49412 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49236 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->