### PR TITLE
AX: aria-labelledby relation isn't built when its target element is inserted via innerHTML

### DIFF
--- a/LayoutTests/accessibility/aria-labelledby-target-added-via-innerHTML-expected.txt
+++ b/LayoutTests/accessibility/aria-labelledby-target-added-via-innerHTML-expected.txt
@@ -1,0 +1,8 @@
+This test checks that an aria-labelledby relation resolves once its target element is inserted via innerHTML after the initial relations build.
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+fallback name
+the resolved label

--- a/LayoutTests/accessibility/aria-labelledby-target-added-via-innerHTML.html
+++ b/LayoutTests/accessibility/aria-labelledby-target-added-via-innerHTML.html
@@ -1,0 +1,40 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<!-- #source exists initially, but its aria-labelledby target #label does not — this is key to reproducing the bug. -->
+<button id="source" aria-labelledby="label">fallback name</button>
+<div id="host"></div>
+
+<script>
+let output = "This test checks that an aria-labelledby relation resolves once its target element is inserted via innerHTML after the initial relations build.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    // 1. Force the initial relations build. The source is tracked with an unresolved target.
+    accessibilityController.accessibleElementById("source").titleUIElement();
+
+    var source, label;
+    setTimeout(async function() {
+        // 2. Now insert the #label target via innerHTML (this is important for triggering the bug).
+        document.getElementById("host").innerHTML = "<p id='label'>the resolved label</p>";
+
+        // 3. The source's titleUIElement should now resolve to the inserted #label target.
+        await waitFor(() => {
+            source = accessibilityController.accessibleElementById("source");
+            label = accessibilityController.accessibleElementById("label");
+            return source && label && label.isEqual(source.titleUIElement());
+        });
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -5440,6 +5440,13 @@ void AXObjectCache::performDeferredCacheUpdate(ForceLayout forceLayout)
             handleMenuOpened(*element);
             handleLiveRegionCreated(*element);
 
+            if (element->hasID() && m_unresolvedRelationTargetIds.contains(element->getIdAttribute())) {
+                // A previously-unresolved relation target (e.g. an aria-labelledby target that didn't
+                // exist when relations were last built) was just inserted, so dirty relations to
+                // re-resolve them.
+                markRelationsDirty();
+            }
+
             if (RefPtr label = dynamicDowncast<HTMLLabelElement>(*element)) {
                 // A label was added or removed. Update its LabelFor relationships.
                 m_elementsWithRelationAttributes.add(*label);
@@ -6651,6 +6658,7 @@ void AXObjectCache::updateRelationsIfNeeded()
     m_relations.clear();
     m_recentlyRemovedRelations.clear();
     m_relationTargets.clear();
+    m_unresolvedRelationTargetIds.clear();
     m_hasAriaOwnsRelations = false;
 
     if (!m_doneInitialRelationsBuild) {
@@ -6723,6 +6731,17 @@ bool AXObjectCache::addRelation(Element& origin, const QualifiedName& attribute)
     auto relation = attributeToRelationType(attribute);
     if (!m_document)
         return false;
+
+    // Remember any referenced ids whose target doesn't exist yet, so that if an element with one of
+    // these ids is inserted later, we know to dirty relations and re-resolve it
+    if (const auto& value = origin.attributeWithoutSynchronization(attribute); !value.isNull()) {
+        Ref treeScope = origin.treeScope();
+        for (auto& id : SpaceSplitString(value, SpaceSplitString::ShouldFoldCase::No)) {
+            if (!treeScope->elementByIdResolvingReferenceTarget(id))
+                m_unresolvedRelationTargetIds.add(id);
+        }
+    }
+
     if (Element::isElementReflectionAttribute(m_document->settings(), attribute)) {
         if (auto reflectedElement = origin.elementForAttributeInternal(attribute))
             return addRelation(origin, *reflectedElement, relation);

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -1145,6 +1145,10 @@ private:
     HashSet<AXID> m_relationTargets;
     HashMap<AXID, AXRelations> m_recentlyRemovedRelations;
     WeakHashSet<Element, WeakPtrImplWithEventTargetData> m_elementsWithRelationAttributes;
+    // Ids referenced by a relation attribute (e.g. aria-labelledby) whose target didn't exist when
+    // relations were last built. If an element with one of these ids is later inserted, we must
+    // re-resolve relations.
+    HashSet<AtomString> m_unresolvedRelationTargetIds;
 
 #if USE(ATSPI)
     ListHashSet<RefPtr<AccessibilityObject>> m_deferredParentChangedList;


### PR DESCRIPTION
#### 647c7baec5c5ad8ab1975a626d861cfb7769e89a
<pre>
AX: aria-labelledby relation isn&apos;t built when its target element is inserted via innerHTML
<a href="https://bugs.webkit.org/show_bug.cgi?id=317108">https://bugs.webkit.org/show_bug.cgi?id=317108</a>
<a href="https://rdar.apple.com/179677418">rdar://179677418</a>

Reviewed by Dominic Mazzoni.

After the initial relations build, AXObjectCache resolves relations lazily and only
re-resolves when something dirties m_relationsNeedUpdate. When a relation source (e.g. a
&lt;button aria-labelledby=&quot;label&quot;&gt;) already exists but its target is inserted via innerHTML
afterwards, nothing dirties relations, so the source&apos;s aria-labelledby never resolves.

Fix this by remembering the ids referenced by a relation attribute whose target didn&apos;t exist
when relations were last built (m_unresolvedRelationTargetIds). When an element with one of
those ids is later inserted, dirty relations so they re-resolve. This is scoped to
previously-unresolved targets rather than every id-bearing element so that fully-resolvable
pages don&apos;t needlessly trigger the incremental rebuild (which iterates a WeakHashSet in
nondeterministic order and can reorder symmetric reverse-relations).

* LayoutTests/accessibility/aria-labelledby-target-added-via-innerHTML-expected.txt: Added.
* LayoutTests/accessibility/aria-labelledby-target-added-via-innerHTML.html: Added.
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::performDeferredCacheUpdate):
(WebCore::AXObjectCache::updateRelationsIfNeeded):
(WebCore::AXObjectCache::addRelation):
* Source/WebCore/accessibility/AXObjectCache.h:

Canonical link: <a href="https://commits.webkit.org/316913@main">https://commits.webkit.org/316913@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7076ef337f2883ab84cf82d0d4106e27a8805bc6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173677 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47610 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41390 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183251 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/131545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9024621d-0e2e-4d9f-9271-d7bd6d5453ea) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175542 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48902 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47292 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135054 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/131545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/aeb7ba24-cf3f-422d-84eb-74a8065f42bf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176635 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38482 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155837 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115532 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/330063af-7da9-4fd6-980d-0fd7561b02c9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37123 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35485 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31735 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147547 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35331 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185677 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/38713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39685 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143939 "Found 1 new test failure: compositing/framesets/composited-frame-alignment.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47277 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155393 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143798 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38810 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47956 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31947 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113142 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38720 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119859 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46462 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10286 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45864 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46095 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45923 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->