### PR TITLE
Follow-up to 316796@main and subsequent build fixes to document safety invariants and FIXMEs

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.swift
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.swift
@@ -40,7 +40,10 @@ extension WKUserContentController {
     ///     The buffer will only be visible to JavaScript executing in that content world.
     ///
     public func addBuffer(_ buffer: RawSpan, name: Swift.String, to contentWorld: WKContentWorld) {
+        // Safety: This is safe because it's just the pre-API version of the safe `Span(viewing:)` API in Swift 6.4.
+        // FIXME: (rdar://181879532) Adopt `Span(viewing:)` initializer instead of `Span(_bytes:)` in `WKUserContentController/addBuffer` implementation.
         let typedSpan = unsafe Span<UInt8>(_bytes: buffer)
+
         // This use of unsafe is necessary to wrap the RawSpan for immediate processing by WebKit,
         // unknowledging that the safety of the RawSpan passed in by the client cannot be guaranteed.
         // This is fine becuase WebKit is going to immediately make a copy of the passed-in bytes


### PR DESCRIPTION
#### fd3b2868954a7aff5564e6e01ebabf4253728c75
<pre>
Follow-up to 316796@main and subsequent build fixes to document safety invariants and FIXMEs
<a href="https://bugs.webkit.org/show_bug.cgi?id=319024">https://bugs.webkit.org/show_bug.cgi?id=319024</a>
<a href="https://rdar.apple.com/181879513">rdar://181879513</a>

Reviewed by Abrar Rahman Protyasha.

Swift 6.4 has the safe `Span(viewing:)` initializer API (<a href="https://developer.apple.com/documentation/swift/span/init(viewing">https://developer.apple.com/documentation/swift/span/init(viewing</a>:)-9d31g) implemented in <a href="https://github.com/swiftlang/swift/commit/8e5539f6199458258d508210ed2f2256911c6ca3">https://github.com/swiftlang/swift/commit/8e5539f6199458258d508210ed2f2256911c6ca3</a> .

However, some configurations of WebKit use an old Swift 6.4 version which does not yet have such
API. Therefore, a build fix was landed to use the pre-API version of the initializer, which has
an identical implementation but is marked as unsafe since its constraints on the `Span.Element`
type aren&apos;t as strict.

Document this safety reasoning and add a FIXME.

* Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.swift:
(WKUserContentController.addBuffer(_:name:to:)):

Canonical link: <a href="https://commits.webkit.org/316865@main">https://commits.webkit.org/316865@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33e656c9abcea73f04709df32cd1d7a61583660c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173680 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47613 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/41394 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183254 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/131548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a9305d8f-2d02-4774-9b92-2176c75b262a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48905 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47295 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/135058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/131548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/992f7c17-23f2-4179-893c-b952e778651a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176638 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/38485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/155842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/115536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/507d2d31-817c-462e-bc39-f11a410b5483) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/37126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/35488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31738 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/147550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/35336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185680 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/38717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/39688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/143942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47280 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/155398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/143801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47959 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113146 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26395 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/38723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/119837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46465 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/10291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45867 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46098 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45926 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->