### PR TITLE
[bmalloc] Linux: MADV_DONTDUMP toggling fragments the heap into VMAs until madvise() EAGAIN livelocks the scavenger

### DIFF
--- a/Source/JavaScriptCore/heap/StructureAlignedMemoryAllocator.cpp
+++ b/Source/JavaScriptCore/heap/StructureAlignedMemoryAllocator.cpp
@@ -125,6 +125,9 @@ public:
         m_useSystemHeap = !bmalloc::api::isEnabled();
 #if USE(LIBPAS)
         if (!m_useSystemHeap) [[likely]] {
+#if OS(LINUX)
+            OSAllocator::excludeFromCoreDump(reinterpret_cast<void*>(g_jscConfig.startOfStructureHeap), g_jscConfig.sizeOfStructureHeap);
+#endif
 #if PLATFORM(PLAYSTATION)
             // libpas isn't calling pas_page_malloc commit, so we've got to commit the region ourselves
             // https://bugs.webkit.org/show_bug.cgi?id=292771

--- a/Source/WTF/wtf/OSAllocator.h
+++ b/Source/WTF/wtf/OSAllocator.h
@@ -83,6 +83,10 @@ public:
     // Hint to the OS that an address range is not expected to be accessed anytime soon.
     WTF_EXPORT_PRIVATE static void hintMemoryNotNeededSoon(void*, size_t);
 
+#if OS(LINUX)
+    WTF_EXPORT_PRIVATE static void excludeFromCoreDump(void*, size_t);
+#endif
+
     WTF_EXPORT_PRIVATE static void protect(void*, size_t, bool readable, bool writable);
     WTF_EXPORT_PRIVATE static bool tryProtect(void*, size_t, bool readable, bool writable);
 

--- a/Source/WTF/wtf/posix/OSAllocatorPOSIX.cpp
+++ b/Source/WTF/wtf/posix/OSAllocatorPOSIX.cpp
@@ -284,6 +284,13 @@ void OSAllocator::hintMemoryNotNeededSoon(void* address, size_t bytes)
 #endif
 }
 
+#if OS(LINUX)
+void OSAllocator::excludeFromCoreDump(void* address, size_t bytes)
+{
+    madvise(address, bytes, MADV_DONTDUMP);
+}
+#endif
+
 void OSAllocator::releaseDecommitted(void* address, size_t bytes, unsigned numberOfGuardPagesOnEachEnd = 0)
 {
     void* base = address;

--- a/Source/bmalloc/bmalloc/BSyscall.h
+++ b/Source/bmalloc/bmalloc/BSyscall.h
@@ -30,3 +30,9 @@
 #define SYSCALL(x) do { \
     while ((x) == -1 && errno == EAGAIN) { } \
 } while (0);
+
+// For advisory syscalls where retrying on EAGAIN is wrong: madvise() reports a failed
+// VMA split as EAGAIN, and that failure is permanent at vm.max_map_count.
+#define SYSCALL_NO_RETRY(x) do { \
+    (void)(x); \
+} while (0);

--- a/Source/bmalloc/bmalloc/Gigacage.cpp
+++ b/Source/bmalloc/bmalloc/Gigacage.cpp
@@ -143,6 +143,7 @@ void ensureGigacage()
                 BCRASH();
             }
             vmDeallocatePhysicalPages(base, totalSize);
+            vmExcludeFromCoreDump(base, totalSize);
 
             size_t nextCage = 0;
             size_t sliceSize = vmPageSize();

--- a/Source/bmalloc/bmalloc/VMAllocate.h
+++ b/Source/bmalloc/bmalloc/VMAllocate.h
@@ -230,6 +230,17 @@ inline void vmAllocatePhysicalPagesSloppy(void* p, size_t size)
     vmAllocatePhysicalPages(begin, end - begin);
 }
 
+inline void vmExcludeFromCoreDump(void* p, size_t vmSize)
+{
+    vmValidate(p, vmSize);
+#if BOS(LINUX)
+    SYSCALL_NO_RETRY(madvise(p, vmSize, MADV_DONTDUMP));
+#else
+    BUNUSED(p);
+    BUNUSED(vmSize);
+#endif
+}
+
 
 #if !BOS(WINDOWS)
 // POSIX
@@ -325,9 +336,6 @@ inline void vmDeallocatePhysicalPages(void* p, size_t vmSize)
     SYSCALL(madvise(p, vmSize, MADV_FREE));
 #else
     SYSCALL(madvise(p, vmSize, MADV_DONTNEED));
-#if BOS(LINUX)
-    SYSCALL(madvise(p, vmSize, MADV_DONTDUMP));
-#endif
 #endif
 }
 
@@ -343,7 +351,7 @@ inline void vmAllocatePhysicalPages(void* p, size_t vmSize)
 #else
     SYSCALL(madvise(p, vmSize, MADV_NORMAL));
 #if BOS(LINUX)
-    SYSCALL(madvise(p, vmSize, MADV_DODUMP));
+    SYSCALL_NO_RETRY(madvise(p, vmSize, MADV_DODUMP));
 #endif
 #endif
 }

--- a/Source/bmalloc/libpas/src/libpas/pas_page_malloc.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_malloc.c
@@ -385,7 +385,7 @@ static void commit_impl(void* ptr, size_t size, bool do_mprotect, bool is_symmet
 
 #if PAS_OS(LINUX)
     PAS_ASSERT(!is_symmetric);
-    PAS_SYSCALL(madvise(ptr, size, MADV_DODUMP));
+    PAS_SYSCALL_NO_RETRY(madvise(ptr, size, MADV_DODUMP));
 #elif PAS_OS(WINDOWS)
     if (is_symmetric) {
         /*
@@ -474,7 +474,6 @@ static void decommit_impl(void* ptr, size_t size,
 #elif PAS_OS(LINUX)
     PAS_ASSERT(!is_symmetric);
     PAS_SYSCALL(madvise(ptr, size, MADV_DONTNEED));
-    PAS_SYSCALL(madvise(ptr, size, MADV_DONTDUMP));
 #elif PAS_OS(WINDOWS)
     if (is_symmetric) {
         /*

--- a/Source/bmalloc/libpas/src/libpas/pas_utils.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_utils.h
@@ -1328,6 +1328,12 @@ enum cpp_initialization_t { cpp_initialization };
     while ((x) == -1 && errno == EAGAIN) { } \
 } while (0)
 
+/* For advisory syscalls where retrying on EAGAIN is wrong: madvise() reports a failed
+   VMA split as EAGAIN, and that failure is permanent at vm.max_map_count. */
+#define PAS_SYSCALL_NO_RETRY(x) do { \
+    (void)(x); \
+} while (0)
+
 PAS_END_EXTERN_C;
 
 PAS_IGNORE_CLANG_WARNINGS_END // "qualifier-requires-header"

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -157,6 +157,8 @@ set(TestWTF_SOURCES
     Tests/WTF/WeakPtr.cpp
     Tests/WTF/WorkQueue.cpp
     Tests/WTF/WorkerPool.cpp
+
+    Tests/WTF/bmalloc/VMAFragmentation.cpp
 )
 
 set(TestWTF_PRIVATE_INCLUDE_DIRECTORIES

--- a/Tools/TestWebKitAPI/Tests/WTF/bmalloc/VMAFragmentation.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/bmalloc/VMAFragmentation.cpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2026 Anthropic PBC.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include <wtf/FastMalloc.h>
+
+#if !USE(SYSTEM_MALLOC) && BUSE(LIBPAS) && OS(LINUX)
+
+#include <cstdio>
+#include <wtf/Vector.h>
+
+namespace TestWebKitAPI {
+
+// The number of virtual memory areas the kernel tracks for this process.
+static long countVirtualMemoryAreas()
+{
+    FILE* file = fopen("/proc/self/maps", "r");
+    if (!file)
+        return -1;
+    long lines = 0;
+    for (int character = getc_unlocked(file); character != EOF; character = getc_unlocked(file)) {
+        if (character == '\n')
+            ++lines;
+    }
+    fclose(file);
+    return lines;
+}
+
+// Decommitting a scattered live set must not shred the heap into one VMA per chunk,
+// or the process eventually hits vm.max_map_count and madvise() starts failing with a
+// permanent EAGAIN. https://bugs.webkit.org/show_bug.cgi?id=319025
+TEST(bmalloc, DecommitDoesNotFragmentVirtualMemoryMap)
+{
+    if (!WTF::isFastMallocEnabled())
+        return;
+
+    constexpr size_t chunkSize = 16 * KB;
+    constexpr size_t chunkCount = 4000;
+    constexpr long allowedGrowth = 512;
+
+    // Other tests in this process may have left free memory behind; scavenge
+    // first so that the baseline is a settled map.
+    WTF::releaseFastMallocFreeMemory();
+    long before = countVirtualMemoryAreas();
+    ASSERT_GT(before, 0);
+
+    Vector<void*> chunks(chunkCount);
+    for (size_t i = 0; i < chunkCount; ++i) {
+        auto* chunk = static_cast<char*>(WTF::fastMalloc(chunkSize));
+        // Touch the memory so that it is actually committed.
+        chunk[0] = static_cast<char>(i);
+        chunk[chunkSize - 1] = static_cast<char>(i);
+        chunks[i] = chunk;
+    }
+
+    for (size_t i = 0; i < chunkCount; i += 2) {
+        WTF::fastFree(chunks[i]);
+        chunks[i] = nullptr;
+    }
+
+    // Synchronous scavenge: this is what decommits the freed chunks.
+    WTF::releaseFastMallocFreeMemory();
+
+    long after = countVirtualMemoryAreas();
+    ASSERT_GT(after, 0);
+    EXPECT_LT(after - before, allowedGrowth);
+
+    for (void* chunk : chunks) {
+        if (chunk)
+            WTF::fastFree(chunk);
+    }
+}
+
+} // namespace TestWebKitAPI
+
+#endif // !USE(SYSTEM_MALLOC) && BUSE(LIBPAS) && OS(LINUX)


### PR DESCRIPTION
#### 79321e949370d646a7ebd8bcf0e08098c754d8cb
<pre>
[bmalloc] Linux: MADV_DONTDUMP toggling fragments the heap into VMAs until madvise() EAGAIN livelocks the scavenger
<a href="https://bugs.webkit.org/show_bug.cgi?id=319025">https://bugs.webkit.org/show_bug.cgi?id=319025</a>

Reviewed by NOBODY (OOPS!).

On Linux, bmalloc and libpas pair every physical-page decommit with
madvise(MADV_DONTDUMP) and every commit with madvise(MADV_DODUMP), so
that the mostly-empty multi-GB Gigacage reservation does not bloat core
dumps that are streamed over a pipe (bug 177745). But VM_DONTDUMP is a
per-VMA flag: setting it on a sub-range splits the VMA, and adjacent
VMAs whose flags differ cannot merge back. Toggling at chunk granularity
therefore shreds the heap into roughly one VMA per scattered live chunk,
and at libpas&apos;s usual 16KiB decommit granularity, about 1GB of scattered
live JS heap exceeds the default vm.max_map_count of 65530.

At that limit every madvise() that needs a split fails, and the kernel
misreports the failure as EAGAIN instead of ENOMEM. Kernel commit
def5efe0 fixed exactly this in v4.11, but the fix regressed in v6.3 when
the map-count pre-check moved into split_vma(), putting the error back
on the unconditional ENOMEM-to-EAGAIN conversion path (measured on 6.12
and 6.17). The EAGAIN is permanent - retrying cannot lower the process&apos;s
map count - but SYSCALL/PAS_SYSCALL retry EAGAIN unboundedly, so the
scavenger spins inside madvise() forever: a core is burned at 100%,
memory is never returned to the OS again, and with the map count pinned
at the limit, mprotect() (W^X flips), pthread_create() and large
mallocs start failing with ENOMEM/EAGAIN. If any other thread needs a
lock the scavenger is holding, the whole process livelocks.

Fix, Linux-only (Darwin, FreeBSD, PlayStation and Windows unchanged):

* Make the dump exclusion one-way instead of a toggle. The whole
  Gigacage reservation is excluded once, at reservation time, by the new
  vmExcludeFromCoreDump() - a whole-VMA operation that cannot split
  anything. Commit still applies MADV_DODUMP, so committed (live) heap
  data appears in dumps exactly as before; decommit no longer re-applies
  MADV_DONTDUMP, so the checkerboard fragmentation cannot form and the
  VMA count becomes O(1). No dump data is lost: MADV_DONTNEED destroys
  the page contents at decommit time, so re-marking only ever excluded
  empty pages. The cost is that piped dumps now contain zeroes up to the
  committed high-water mark rather than the exact live set.

* Add SYSCALL_NO_RETRY / PAS_SYSCALL_NO_RETRY - issue the syscall once
  and ignore the result - and use them for the remaining MADV_DODUMP and
  the one-shot MADV_DONTDUMP. This is required, not merely tidier: at
  vm.max_map_count a sub-range MADV_DODUMP fails with the same permanent
  EAGAIN, so commit_impl() would livelock the mutator just as
  decommit_impl() livelocks the scavenger. These calls are advisory,
  every errno other than EAGAIN was already silently ignored, and not
  retrying matches glibc and jemalloc. MADV_DONTNEED and MADV_NORMAL
  never require a VMA split, so they keep the existing retry behavior.

* Exclude the Structure heap reservation from core dumps the same way.
  JSC reserves a multi-GB (4GB on desktop) size-aligned range for
  StructureIDs, but nothing ever excluded it from dumps: an idle jsc
  shell produces a 5.9GB piped dump, 4GB of which is the empty part of
  this reservation. Add OSAllocator::excludeFromCoreDump() and call it
  right after reserving, on the libpas path only - libpas re-marks
  committed ranges dumpable through its MADV_DODUMP commit path, while
  the system-heap fallback commits via OSAllocator::commit(), which does
  not, so it must stay fully dumpable.

Net effect on piped core dumps (Linux 6.12, jsc shell): a typical
churned-then-idle heap goes from 6.1GB to 2.0GB, and the worst case for
the one-way exclusion - a 4GB peak followed by idling - stays at today&apos;s
size, because the Structure heap savings offset the high-water-mark
cost. Committed Structure data was verified byte-for-byte present in a
core dump taken with gcore; the excluded ranges are absent.

Covered by a new API test, Tests/WTF/bmalloc/VMAFragmentation.cpp: it
decommits a scattered live set via a synchronous scavenge and asserts
that the process&apos;s VMA count did not grow by one per chunk. Without this
change it reports a growth of 4004 VMAs against a bound of 512; with it,
5.

* Source/JavaScriptCore/heap/StructureAlignedMemoryAllocator.cpp:
* Source/WTF/wtf/OSAllocator.h:
* Source/WTF/wtf/posix/OSAllocatorPOSIX.cpp:
(WTF::OSAllocator::excludeFromCoreDump):
* Source/bmalloc/bmalloc/BSyscall.h:
* Source/bmalloc/bmalloc/Gigacage.cpp:
(Gigacage::ensureGigacage):
* Source/bmalloc/bmalloc/VMAllocate.h:
(bmalloc::vmExcludeFromCoreDump):
(bmalloc::vmDeallocatePhysicalPages):
(bmalloc::vmAllocatePhysicalPages):
* Source/bmalloc/libpas/src/libpas/pas_page_malloc.c:
(commit_impl):
(decommit_impl):
* Source/bmalloc/libpas/src/libpas/pas_utils.h:
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/Tests/WTF/bmalloc/VMAFragmentation.cpp: Added.
(TestWebKitAPI::countVirtualMemoryAreas):
(TestWebKitAPI::TEST):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/79321e949370d646a7ebd8bcf0e08098c754d8cb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174479 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48412 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42193 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184056 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132347 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176344 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49704 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48095 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135747 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95788 "2 flakes 3 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177437 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39180 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156540 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116225 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37821 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36187 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32537 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5049 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148244 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36032 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186482 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/35741 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39715 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40384 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144655 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48079 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144513 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48758 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32652 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/held.https.any.sharedworker.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114352 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39414 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120739 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/211532 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47265 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10996 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55182 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46667 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46898 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46725 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->