### PR TITLE
Reduce VTTCue size by regrouping m_displayDirection with adjacent small enums

### DIFF
--- a/Source/WebCore/html/track/VTTCue.h
+++ b/Source/WebCore/html/track/VTTCue.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011, 2013 Google Inc. All rights reserved.
- * Copyright (C) 2012-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -273,6 +273,7 @@ private:
 
     DirectionSetting m_writingDirection { DirectionSetting::Horizontal };
     AlignSetting m_cueAlignment { AlignSetting::Center };
+    CSSValueID m_displayDirection { CSSValueLtr };
 
     RefPtr<VTTRegion> m_region;
     String m_parsedRegionId;
@@ -286,7 +287,6 @@ private:
     RefPtr<SpeechSynthesisUtterance> m_speechUtterance;
 #endif
 
-    CSSValueID m_displayDirection { CSSValueLtr };
     double m_displaySize { 0 };
     DisplayPosition m_displayPosition;
 


### PR DESCRIPTION
#### 0e86b49069a5e3737c1cc7af554833d06580cc9a
<pre>
Reduce VTTCue size by regrouping m_displayDirection with adjacent small enums
<a href="https://bugs.webkit.org/show_bug.cgi?id=319026">https://bugs.webkit.org/show_bug.cgi?id=319026</a>
<a href="https://rdar.apple.com/181880375">rdar://181880375</a>

Reviewed by Eric Carlson.

m_displayDirection (CSSValueID, a uint16_t enum) was declared immediately
before the double m_displaySize. Sitting on an 8-byte-aligned offset, its
2 bytes forced 6 bytes of padding before the double, wasting a full word.

Move it up next to m_writingDirection and m_cueAlignment (both 1-byte
enums), which already left 6 bytes of padding before the following
RefPtr&lt;VTTRegion&gt;. The enum now folds into that existing hole at no cost,
and m_displaySize leads its group without a preceding gap. This shrinks
the object by 8 bytes with no behavioral change.

* Source/WebCore/html/track/VTTCue.h:

Canonical link: <a href="https://commits.webkit.org/316950@main">https://commits.webkit.org/316950@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01f9dda04c1c20fd4d8b084ed484fd93b143ada1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173682 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47615 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41396 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183256 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131550 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/01138ecc-280d-433e-9f4d-0ea95fd0014f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175547 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48907 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47297 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135060 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5b2d4dc9-c1b6-47b2-a39d-17c3ba729a2a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176640 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38487 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155843 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115538 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/14b7ca58-dbd7-46c0-89c5-b4c5245a38e1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37128 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35489 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31740 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147552 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35337 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185682 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38719 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39689 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143944 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47282 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143803 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38832 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47961 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31953 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113150 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38724 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119839 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46467 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10292 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45869 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46100 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45928 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->