### PR TITLE
Cherry-pick 316713@main (6b6622bd96de). https://bugs.webkit.org/show_bug.cgi?id=315736

### DIFF
--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
@@ -407,10 +407,14 @@ public:
 
     void trackEnded(MediaStreamTrackPrivate&) final
     {
-        GST_INFO_OBJECT(m_src.get(), "Track ended, parent: %" GST_PTR_FORMAT, m_parent);
+        auto parent = m_parent.get();
+        if (!parent)
+            return;
+
+        GST_INFO_OBJECT(m_src.get(), "Track ended, parent: %" GST_PTR_FORMAT, parent.get());
         sourceStopped();
         m_isEnded = true;
-        webkitMediaStreamSrcEnsureStreamCollectionPosted(WEBKIT_MEDIA_STREAM_SRC(m_parent));
+        webkitMediaStreamSrcEnsureStreamCollectionPosted(WEBKIT_MEDIA_STREAM_SRC(parent.get()));
     }
 
     void sourceStopped() final
@@ -436,7 +440,8 @@ public:
         GST_INFO_OBJECT(m_src.get(), "Track enabled: %s, resetting stream", boolForPrinting(track.enabled()));
 
         createGstStream();
-        webkitMediaStreamSrcEnsureStreamCollectionPosted(WEBKIT_MEDIA_STREAM_SRC(m_parent));
+        if (auto parent = m_parent.get())
+            webkitMediaStreamSrcEnsureStreamCollectionPosted(WEBKIT_MEDIA_STREAM_SRC(parent.get()));
 
         if (track.isVideo()) {
             m_enoughData = false;
@@ -448,7 +453,8 @@ public:
 
     void videoFrameAvailable(VideoFrame& videoFrame, VideoFrameTimeMetadata) final
     {
-        if (!m_parent || !m_isObserving)
+        auto parent = m_parent.get();
+        if (!parent || !m_isObserving)
             return;
 
         updateFirstVideoSampleSeenFlag();
@@ -509,7 +515,8 @@ public:
 
     void audioSamplesAvailable(const MediaTime&, const PlatformAudioData& audioData, const AudioStreamDescription&, size_t) final
     {
-        if (!m_parent || !m_isObserving)
+        auto parent = m_parent.get();
+        if (!parent || !m_isObserving)
             return;
 
         if (!m_track)
@@ -749,8 +756,12 @@ private:
             m_silentSampleCaps = adoptGRef(gst_audio_info_to_caps(&info));
         }
 
+        auto parent = m_parent.get();
+        if (!parent)
+            return;
+
         auto buffer = adoptGRef(gst_buffer_new_and_alloc(512));
-        GST_BUFFER_DTS(buffer.get()) = GST_BUFFER_PTS(buffer.get()) = gst_element_get_current_running_time(m_parent);
+        GST_BUFFER_DTS(buffer.get()) = GST_BUFFER_PTS(buffer.get()) = gst_element_get_current_running_time(parent.get());
         GstAudioInfo info;
         gst_audio_info_from_caps(&info, m_silentSampleCaps.get());
         {
@@ -838,7 +849,7 @@ private:
             "total-audio-energy", G_TYPE_DOUBLE, m_totalAudioEnergy, "audio-level", G_TYPE_DOUBLE, m_audioLevel, nullptr);
     }
 
-    GstElement* m_parent { nullptr };
+    GThreadSafeWeakPtr<GstElement> m_parent { nullptr };
     RefPtr<MediaStreamTrackPrivate> m_track;
     RefPtr<RealtimeMediaSource> m_trackSource;
     GRefPtr<GstElement> m_src;
@@ -894,14 +905,21 @@ enum {
 
 void InternalSource::updateFirstVideoSampleSeenFlag()
 {
-    auto src = WEBKIT_MEDIA_STREAM_SRC_CAST(m_parent);
+    auto parent = m_parent.get();
+    if (!parent)
+        return;
+
+    auto src = WEBKIT_MEDIA_STREAM_SRC_CAST(parent.get());
     src->priv->firstVideoSampleSeen = true;
 }
 
 bool InternalSource::receivedAudioSampleBeforeVideo()
 {
-    auto src = WEBKIT_MEDIA_STREAM_SRC_CAST(m_parent);
+    auto parent = m_parent.get();
+    if (!parent)
+        return false;
 
+    auto src = WEBKIT_MEDIA_STREAM_SRC_CAST(parent.get());
     if (src->priv->firstVideoSampleSeen)
         return false;
 

--- a/Source/WebDriver/WebDriverService.cpp
+++ b/Source/WebDriver/WebDriverService.cpp
@@ -1254,12 +1254,13 @@ void WebDriverService::go(RefPtr<JSON::Object>&& parameters, Function<void (Comm
         return;
     }
 
-    m_session->waitForNavigationToComplete([this, url = WTF::move(url), completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
+    auto protectedSession = Ref { *m_session };
+    protectedSession->waitForNavigationToComplete([protectedSession, url = WTF::move(url), completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
         if (result.isError()) {
             completionHandler(WTF::move(result));
             return;
         }
-        m_session->go(url, WTF::move(completionHandler));
+        protectedSession->go(url, WTF::move(completionHandler));
     });
 }
 
@@ -1270,12 +1271,13 @@ void WebDriverService::getCurrentURL(RefPtr<JSON::Object>&& parameters, Function
     if (!findSessionOrCompleteWithError(*parameters, completionHandler))
         return;
 
-    m_session->waitForNavigationToComplete([this, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
+    auto protectedSession = Ref { *m_session };
+    protectedSession->waitForNavigationToComplete([protectedSession, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
         if (result.isError()) {
             completionHandler(WTF::move(result));
             return;
         }
-        m_session->getCurrentURL(WTF::move(completionHandler));
+        protectedSession->getCurrentURL(WTF::move(completionHandler));
     });
 }
 
@@ -1286,12 +1288,13 @@ void WebDriverService::back(RefPtr<JSON::Object>&& parameters, Function<void (Co
     if (!findSessionOrCompleteWithError(*parameters, completionHandler))
         return;
 
-    m_session->waitForNavigationToComplete([this, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
+    auto protectedSession = Ref { *m_session };
+    protectedSession->waitForNavigationToComplete([protectedSession, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
         if (result.isError()) {
             completionHandler(WTF::move(result));
             return;
         }
-        m_session->back(WTF::move(completionHandler));
+        protectedSession->back(WTF::move(completionHandler));
     });
 }
 
@@ -1302,12 +1305,13 @@ void WebDriverService::forward(RefPtr<JSON::Object>&& parameters, Function<void 
     if (!findSessionOrCompleteWithError(*parameters, completionHandler))
         return;
 
-    m_session->waitForNavigationToComplete([this, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
+    auto protectedSession = Ref { *m_session };
+    protectedSession->waitForNavigationToComplete([protectedSession, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
         if (result.isError()) {
             completionHandler(WTF::move(result));
             return;
         }
-        m_session->forward(WTF::move(completionHandler));
+        protectedSession->forward(WTF::move(completionHandler));
     });
 }
 
@@ -1318,12 +1322,13 @@ void WebDriverService::refresh(RefPtr<JSON::Object>&& parameters, Function<void 
     if (!findSessionOrCompleteWithError(*parameters, completionHandler))
         return;
 
-    m_session->waitForNavigationToComplete([this, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
+    auto protectedSession = Ref { *m_session };
+    protectedSession->waitForNavigationToComplete([protectedSession, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
         if (result.isError()) {
             completionHandler(WTF::move(result));
             return;
         }
-        m_session->refresh(WTF::move(completionHandler));
+        protectedSession->refresh(WTF::move(completionHandler));
     });
 }
 
@@ -1334,12 +1339,13 @@ void WebDriverService::getTitle(RefPtr<JSON::Object>&& parameters, Function<void
     if (!findSessionOrCompleteWithError(*parameters, completionHandler))
         return;
 
-    m_session->waitForNavigationToComplete([this, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
+    auto protectedSession = Ref { *m_session };
+    protectedSession->waitForNavigationToComplete([protectedSession, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
         if (result.isError()) {
             completionHandler(WTF::move(result));
             return;
         }
-        m_session->getTitle(WTF::move(completionHandler));
+        protectedSession->getTitle(WTF::move(completionHandler));
     });
 }
 
@@ -1438,14 +1444,15 @@ void WebDriverService::closeWindow(RefPtr<JSON::Object>&& parameters, Function<v
     if (!findSessionOrCompleteWithError(*parameters, completionHandler))
         return;
 
-    m_session->closeWindow([this, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
+    auto protectedSession = Ref { *m_session };
+    m_session->closeWindow([this, protectedSession, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
         if (result.isError()) {
             completionHandler(WTF::move(result));
             return;
         }
 
         auto handles = result.result()->asArray();
-        if (handles && !handles->length())
+        if (handles && !handles->length() && m_session && protectedSession->id() == m_session->id())
             m_session = nullptr;
 
         completionHandler(WTF::move(result));
@@ -1536,12 +1543,13 @@ void WebDriverService::switchToFrame(RefPtr<JSON::Object>&& parameters, Function
         return;
     }
 
-    m_session->waitForNavigationToComplete([this, frameID, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
+    auto protectedSession = Ref { *m_session };
+    protectedSession->waitForNavigationToComplete([protectedSession, frameID, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
         if (result.isError()) {
             completionHandler(WTF::move(result));
             return;
         }
-        m_session->switchToFrame(WTF::move(frameID), WTF::move(completionHandler));
+        protectedSession->switchToFrame(WTF::move(frameID), WTF::move(completionHandler));
     });
 }
 
@@ -1552,12 +1560,13 @@ void WebDriverService::switchToParentFrame(RefPtr<JSON::Object>&& parameters, Fu
     if (!findSessionOrCompleteWithError(*parameters, completionHandler))
         return;
 
-    m_session->waitForNavigationToComplete([this, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
+    auto protectedSession = Ref { *m_session };
+    protectedSession->waitForNavigationToComplete([protectedSession, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
         if (result.isError()) {
             completionHandler(WTF::move(result));
             return;
         }
-        m_session->switchToParentFrame(WTF::move(completionHandler));
+        protectedSession->switchToParentFrame(WTF::move(completionHandler));
     });
 }
 
@@ -1619,12 +1628,13 @@ void WebDriverService::findElement(RefPtr<JSON::Object>&& parameters, Function<v
     if (!findStrategyAndSelectorOrCompleteWithError(*parameters, completionHandler, Session::ElementIsShadowRoot::No, strategy, selector))
         return;
 
-    m_session->waitForNavigationToComplete([this, strategy = WTF::move(strategy), selector = WTF::move(selector), completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
+    auto protectedSession = Ref { *m_session };
+    protectedSession->waitForNavigationToComplete([protectedSession, strategy = WTF::move(strategy), selector = WTF::move(selector), completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
         if (result.isError()) {
             completionHandler(WTF::move(result));
             return;
         }
-        m_session->findElements(strategy, selector, Session::FindElementsMode::Single, emptyString(), Session::ElementIsShadowRoot::No, WTF::move(completionHandler));
+        protectedSession->findElements(strategy, selector, Session::FindElementsMode::Single, emptyString(), Session::ElementIsShadowRoot::No, WTF::move(completionHandler));
     });
 }
 
@@ -1639,12 +1649,13 @@ void WebDriverService::findElements(RefPtr<JSON::Object>&& parameters, Function<
     if (!findStrategyAndSelectorOrCompleteWithError(*parameters, completionHandler, Session::ElementIsShadowRoot::No, strategy, selector))
         return;
 
-    m_session->waitForNavigationToComplete([this, strategy = WTF::move(strategy), selector = WTF::move(selector), completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
+    auto protectedSession = Ref { *m_session };
+    protectedSession->waitForNavigationToComplete([protectedSession, strategy = WTF::move(strategy), selector = WTF::move(selector), completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
         if (result.isError()) {
             completionHandler(WTF::move(result));
             return;
         }
-        m_session->findElements(strategy, selector, Session::FindElementsMode::Multiple, emptyString(), Session::ElementIsShadowRoot::No, WTF::move(completionHandler));
+        protectedSession->findElements(strategy, selector, Session::FindElementsMode::Multiple, emptyString(), Session::ElementIsShadowRoot::No, WTF::move(completionHandler));
     });
 }
 
@@ -1722,12 +1733,13 @@ void WebDriverService::getActiveElement(RefPtr<JSON::Object>&& parameters, Funct
     if (!findSessionOrCompleteWithError(*parameters, completionHandler))
         return;
 
-    m_session->waitForNavigationToComplete([this, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
+    auto protectedSession = Ref { *m_session };
+    protectedSession->waitForNavigationToComplete([protectedSession, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
         if (result.isError()) {
             completionHandler(WTF::move(result));
             return;
         }
-        m_session->getActiveElement(WTF::move(completionHandler));
+        protectedSession->getActiveElement(WTF::move(completionHandler));
     });
 }
 
@@ -2000,12 +2012,13 @@ void WebDriverService::executeScript(RefPtr<JSON::Object>&& parameters, Function
     if (!findScriptAndArgumentsOrCompleteWithError(*parameters, completionHandler, script, arguments))
         return;
 
-    m_session->waitForNavigationToComplete([this, script = WTF::move(script), arguments = WTF::move(arguments), completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
+    auto protectedSession = Ref { *m_session };
+    protectedSession->waitForNavigationToComplete([protectedSession, script = WTF::move(script), arguments = WTF::move(arguments), completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
         if (result.isError()) {
             completionHandler(WTF::move(result));
             return;
         }
-        m_session->executeScript(script, WTF::move(arguments), Session::ExecuteScriptMode::Sync, WTF::move(completionHandler));
+        protectedSession->executeScript(script, WTF::move(arguments), Session::ExecuteScriptMode::Sync, WTF::move(completionHandler));
     });
 }
 
@@ -2021,12 +2034,13 @@ void WebDriverService::executeAsyncScript(RefPtr<JSON::Object>&& parameters, Fun
     if (!findScriptAndArgumentsOrCompleteWithError(*parameters, completionHandler, script, arguments))
         return;
 
-    m_session->waitForNavigationToComplete([this, script = WTF::move(script), arguments = WTF::move(arguments), completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
+    auto protectedSession = Ref { *m_session };
+    protectedSession->waitForNavigationToComplete([protectedSession, script = WTF::move(script), arguments = WTF::move(arguments), completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
         if (result.isError()) {
             completionHandler(WTF::move(result));
             return;
         }
-        m_session->executeScript(script, WTF::move(arguments), Session::ExecuteScriptMode::Async, WTF::move(completionHandler));
+        protectedSession->executeScript(script, WTF::move(arguments), Session::ExecuteScriptMode::Async, WTF::move(completionHandler));
     });
 }
 
@@ -2037,12 +2051,13 @@ void WebDriverService::getAllCookies(RefPtr<JSON::Object>&& parameters, Function
     if (!findSessionOrCompleteWithError(*parameters, completionHandler))
         return;
 
-    m_session->waitForNavigationToComplete([this, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
+    auto protectedSession = Ref { *m_session };
+    protectedSession->waitForNavigationToComplete([protectedSession, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
         if (result.isError()) {
             completionHandler(WTF::move(result));
             return;
         }
-        m_session->getAllCookies(WTF::move(completionHandler));
+        protectedSession->getAllCookies(WTF::move(completionHandler));
     });
 }
 
@@ -2059,12 +2074,13 @@ void WebDriverService::getNamedCookie(RefPtr<JSON::Object>&& parameters, Functio
         return;
     }
 
-    m_session->waitForNavigationToComplete([this, name = WTF::move(name), completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
+    auto protectedSession = Ref { *m_session };
+    protectedSession->waitForNavigationToComplete([protectedSession, name = WTF::move(name), completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
         if (result.isError()) {
             completionHandler(WTF::move(result));
             return;
         }
-        m_session->getNamedCookie(name, WTF::move(completionHandler));
+        protectedSession->getNamedCookie(name, WTF::move(completionHandler));
     });
 }
 
@@ -2139,12 +2155,13 @@ void WebDriverService::addCookie(RefPtr<JSON::Object>&& parameters, Function<voi
         return;
     }
 
-    m_session->waitForNavigationToComplete([this, cookie = WTF::move(cookie), completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
+    auto protectedSession = Ref { *m_session };
+    protectedSession->waitForNavigationToComplete([protectedSession, cookie = WTF::move(cookie), completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
         if (result.isError()) {
             completionHandler(WTF::move(result));
             return;
         }
-        m_session->addCookie(cookie.value(), WTF::move(completionHandler));
+        protectedSession->addCookie(cookie.value(), WTF::move(completionHandler));
     });
 }
 
@@ -2161,12 +2178,13 @@ void WebDriverService::deleteCookie(RefPtr<JSON::Object>&& parameters, Function<
         return;
     }
 
-    m_session->waitForNavigationToComplete([this, name = WTF::move(name), completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
+    auto protectedSession = Ref { *m_session };
+    protectedSession->waitForNavigationToComplete([protectedSession, name = WTF::move(name), completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
         if (result.isError()) {
             completionHandler(WTF::move(result));
             return;
         }
-        m_session->deleteCookie(name, WTF::move(completionHandler));
+        protectedSession->deleteCookie(name, WTF::move(completionHandler));
     });
 }
 
@@ -2177,12 +2195,13 @@ void WebDriverService::deleteAllCookies(RefPtr<JSON::Object>&& parameters, Funct
     if (!findSessionOrCompleteWithError(*parameters, completionHandler))
         return;
 
-    m_session->waitForNavigationToComplete([this, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
+    auto protectedSession = Ref { *m_session };
+    protectedSession->waitForNavigationToComplete([protectedSession, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
         if (result.isError()) {
             completionHandler(WTF::move(result));
             return;
         }
-        m_session->deleteAllCookies(WTF::move(completionHandler));
+        protectedSession->deleteAllCookies(WTF::move(completionHandler));
     });
 }
 
@@ -2626,12 +2645,13 @@ void WebDriverService::dismissAlert(RefPtr<JSON::Object>&& parameters, Function<
     if (!findSessionOrCompleteWithError(*parameters, completionHandler))
         return;
 
-    m_session->waitForNavigationToComplete([this, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
+    auto protectedSession = Ref { *m_session };
+    protectedSession->waitForNavigationToComplete([protectedSession, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
         if (result.isError()) {
             completionHandler(WTF::move(result));
             return;
         }
-        m_session->dismissAlert(WTF::move(completionHandler));
+        protectedSession->dismissAlert(WTF::move(completionHandler));
     });
 }
 
@@ -2642,12 +2662,13 @@ void WebDriverService::acceptAlert(RefPtr<JSON::Object>&& parameters, Function<v
     if (!findSessionOrCompleteWithError(*parameters, completionHandler))
         return;
 
-    m_session->waitForNavigationToComplete([this, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
+    auto protectedSession = Ref { *m_session };
+    protectedSession->waitForNavigationToComplete([protectedSession, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
         if (result.isError()) {
             completionHandler(WTF::move(result));
             return;
         }
-        m_session->acceptAlert(WTF::move(completionHandler));
+        protectedSession->acceptAlert(WTF::move(completionHandler));
     });
 }
 
@@ -2658,12 +2679,13 @@ void WebDriverService::getAlertText(RefPtr<JSON::Object>&& parameters, Function<
     if (!findSessionOrCompleteWithError(*parameters, completionHandler))
         return;
 
-    m_session->waitForNavigationToComplete([this, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
+    auto protectedSession = Ref { *m_session };
+    protectedSession->waitForNavigationToComplete([protectedSession, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
         if (result.isError()) {
             completionHandler(WTF::move(result));
             return;
         }
-        m_session->getAlertText(WTF::move(completionHandler));
+        protectedSession->getAlertText(WTF::move(completionHandler));
     });
 }
 
@@ -2680,12 +2702,13 @@ void WebDriverService::sendAlertText(RefPtr<JSON::Object>&& parameters, Function
         return;
     }
 
-    m_session->waitForNavigationToComplete([this, text = WTF::move(text), completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
+    auto protectedSession = Ref { *m_session };
+    protectedSession->waitForNavigationToComplete([protectedSession, text = WTF::move(text), completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
         if (result.isError()) {
             completionHandler(WTF::move(result));
             return;
         }
-        m_session->sendAlertText(text, WTF::move(completionHandler));
+        protectedSession->sendAlertText(text, WTF::move(completionHandler));
     });
 }
 
@@ -2696,12 +2719,13 @@ void WebDriverService::takeScreenshot(RefPtr<JSON::Object>&& parameters, Functio
     if (!findSessionOrCompleteWithError(*parameters, completionHandler))
         return;
 
-    m_session->waitForNavigationToComplete([this, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
+    auto protectedSession = Ref { *m_session };
+    protectedSession->waitForNavigationToComplete([protectedSession, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
         if (result.isError()) {
             completionHandler(WTF::move(result));
             return;
         }
-        m_session->takeScreenshot(std::nullopt, std::nullopt, WTF::move(completionHandler));
+        protectedSession->takeScreenshot(std::nullopt, std::nullopt, WTF::move(completionHandler));
     });
 }
 
@@ -2716,12 +2740,13 @@ void WebDriverService::takeElementScreenshot(RefPtr<JSON::Object>&& parameters, 
     if (!elementID)
         return;
 
-    m_session->waitForNavigationToComplete([this, elementID, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
+    auto protectedSession = Ref { *m_session };
+    protectedSession->waitForNavigationToComplete([protectedSession, elementID, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
         if (result.isError()) {
             completionHandler(WTF::move(result));
             return;
         }
-        m_session->takeScreenshot(elementID.value(), true, WTF::move(completionHandler));
+        protectedSession->takeScreenshot(elementID.value(), true, WTF::move(completionHandler));
     });
 }
 


### PR DESCRIPTION
#### beeccb322b29141a5e446503dcc747b3c5c5cee2
<pre>
Cherry-pick 316713@main (6b6622bd96de). <a href="https://bugs.webkit.org/show_bug.cgi?id=315736">https://bugs.webkit.org/show_bug.cgi?id=315736</a>

    [WebDriver] Protect session instance in waitForNavigationToComplete callbacks
    <a href="https://bugs.webkit.org/show_bug.cgi?id=315736">https://bugs.webkit.org/show_bug.cgi?id=315736</a>

    Reviewed by Carlos Garcia Campos and BJ Burg.

    Currently, the waitForNavigationToComplete callbacks access
    WebDriverService::m_session directly, although this member could be
    null if the callback arrives after we started to delete or to replace
    the session.

    This commit protects the session instance in these callbacks, as just
    adding a null check would leave the door open for the callback to be
    called on an already replaced session. This creates a temporary cycle
    between the Session, the callback, and the SessionHost (who stashes the
    pending requests), but the cycle is broken when either the session is
    closed or the browser disconnects, flushing the pending requests.

    * Source/WebDriver/WebDriverService.cpp:
    (WebDriver::WebDriverService::go):
    (WebDriver::WebDriverService::getCurrentURL):
    (WebDriver::WebDriverService::back):
    (WebDriver::WebDriverService::forward):
    (WebDriver::WebDriverService::refresh):
    (WebDriver::WebDriverService::getTitle):
    (WebDriver::WebDriverService::closeWindow):
    (WebDriver::WebDriverService::switchToFrame):
    (WebDriver::WebDriverService::switchToParentFrame):
    (WebDriver::WebDriverService::findElement):
    (WebDriver::WebDriverService::findElements):
    (WebDriver::WebDriverService::getActiveElement):
    (WebDriver::WebDriverService::executeScript):
    (WebDriver::WebDriverService::executeAsyncScript):
    (WebDriver::WebDriverService::getAllCookies):
    (WebDriver::WebDriverService::getNamedCookie):
    (WebDriver::WebDriverService::addCookie):
    (WebDriver::WebDriverService::deleteCookie):
    (WebDriver::WebDriverService::deleteAllCookies):
    (WebDriver::WebDriverService::dismissAlert):
    (WebDriver::WebDriverService::acceptAlert):
    (WebDriver::WebDriverService::getAlertText):
    (WebDriver::WebDriverService::sendAlertText):
    (WebDriver::WebDriverService::takeScreenshot):
    (WebDriver::WebDriverService::takeElementScreenshot):

    Canonical link: <a href="https://commits.webkit.org/316713@main">https://commits.webkit.org/316713@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.973@webkitglib/2.52">https://commits.webkit.org/305877.973@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 28c0b30facaee9eb199d4a1800e56204d212788e
<pre>
Cherry-pick 316621@main (857d77450c7e). <a href="https://bugs.webkit.org/show_bug.cgi?id=318635">https://bugs.webkit.org/show_bug.cgi?id=318635</a>

    [GLIB] fast/mediastream/mediastreamtrack-clone-muted.html is a flaky crash
    <a href="https://bugs.webkit.org/show_bug.cgi?id=318635">https://bugs.webkit.org/show_bug.cgi?id=318635</a>

    Reviewed by Xabier Rodriguez-Calvar.

    Store the mediastreamsrc InternalSource parent as weak pointer instead of raw pointer, preventing
    critical warnings in GLib when casting.

    * LayoutTests/platform/glib/TestExpectations:
    * Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp:
    (InternalSource::updateFirstVideoSampleSeenFlag):
    (InternalSource::receivedAudioSampleBeforeVideo):

    Canonical link: <a href="https://commits.webkit.org/316621@main">https://commits.webkit.org/316621@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.972@webkitglib/2.52">https://commits.webkit.org/305877.972@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f6ea4f56993507e2b771fe5a9d4d6eee66f05f0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173691 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/47624 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/41405 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183265 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/131559 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175556 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/48916 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/47306 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135068 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/131559 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176649 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/48916 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/41405 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115546 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/48916 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/47306 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31749 "Built successfully") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/41405 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/48916 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/41405 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185691 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/38728 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/47306 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143952 "Passed tests") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/47291 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/41405 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143811 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/47970 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/41405 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/113167 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26400 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/47970 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/119848 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/46476 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/41405 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/45878 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/46109 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/45937 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->