### PR TITLE
[iOS] Playing, rate, and volume changes originating from a MediaDeviceRoute are not reflected in HTMLMediaElement

### DIFF
--- a/LayoutTests/media/wireless-playback-media-player/muted-expected.txt
+++ b/LayoutTests/media/wireless-playback-media-player/muted-expected.txt
@@ -1,0 +1,12 @@
+
+Test that setting video.muted propagates to a MediaDeviceRoute.
+
+RUN(internals.mockMediaDeviceRouteController.activateRoute(route))
+RUN(video.src = findMediaFile('video', '../content/test'))
+RUN(video.play())
+RUN(route.ready = true)
+EVENT(canplaythrough)
+RUN(video.muted = true)
+EXPECTED (route.muted == 'true') OK
+END OF TEST
+

--- a/LayoutTests/media/wireless-playback-media-player/muted.html
+++ b/LayoutTests/media/wireless-playback-media-player/muted.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html><!-- webkit-test-runner [ WirelessPlaybackMediaPlayerEnabled=true ] -->
+<html>
+    <head>
+        <script src='../media-file.js'></script>
+        <script src='../video-test.js'></script>
+        <script>
+            var route;
+            var video;
+
+            async function start()
+            {
+                if (window.internals)
+                    internals.mockMediaDeviceRouteController.enabled = true;
+
+                route = internals.mockMediaDeviceRouteController.createMockMediaDeviceRoute();
+                run(`internals.mockMediaDeviceRouteController.activateRoute(route)`);
+
+                const urlPromise = new Promise((resolve) => {
+                    route.setURLCallback(async (url) => {
+                        resolve(url);
+                    });
+                });
+
+                video = document.getElementsByTagName('video')[0];
+                run(`video.src = findMediaFile('video', '../content/test')`);
+                run(`video.play()`);
+                await urlPromise;
+
+                const canplaythroughPromise = waitFor(video, 'canplaythrough');
+                run(`route.ready = true`);
+                await canplaythroughPromise;
+
+                run(`video.muted = true`);
+                testExpected(`route.muted`, true);
+
+                endTest();
+            }
+        </script>
+    </head>
+    <body onload='start()'>
+        <video controls></video>
+        <p>Test that setting video.muted propagates to a MediaDeviceRoute.</p>
+    </body>
+</html>

--- a/LayoutTests/media/wireless-playback-media-player/route-muted-change-expected.txt
+++ b/LayoutTests/media/wireless-playback-media-player/route-muted-change-expected.txt
@@ -1,0 +1,12 @@
+
+Test that a MediaDeviceRoute muted change propagates to the video element.
+
+RUN(internals.mockMediaDeviceRouteController.activateRoute(route))
+RUN(video.src = findMediaFile('video', '../content/test'))
+RUN(video.play())
+RUN(route.ready = true)
+EVENT(canplaythrough)
+RUN(route.muted = true)
+EXPECTED (video.muted == 'true') OK
+END OF TEST
+

--- a/LayoutTests/media/wireless-playback-media-player/route-muted-change.html
+++ b/LayoutTests/media/wireless-playback-media-player/route-muted-change.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html><!-- webkit-test-runner [ WirelessPlaybackMediaPlayerEnabled=true ] -->
+<html>
+    <head>
+        <script src='../media-file.js'></script>
+        <script src='../video-test.js'></script>
+        <script>
+            var route;
+            var video;
+
+            async function start()
+            {
+                if (window.internals)
+                    internals.mockMediaDeviceRouteController.enabled = true;
+
+                route = internals.mockMediaDeviceRouteController.createMockMediaDeviceRoute();
+                run(`internals.mockMediaDeviceRouteController.activateRoute(route)`);
+
+                const urlPromise = new Promise((resolve) => {
+                    route.setURLCallback(async (url) => {
+                        resolve(url);
+                    });
+                });
+
+                video = document.getElementsByTagName('video')[0];
+                run(`video.src = findMediaFile('video', '../content/test')`);
+                run(`video.play()`);
+                await urlPromise;
+
+                const canplaythroughPromise = waitFor(video, 'canplaythrough');
+                run(`route.ready = true`);
+                await canplaythroughPromise;
+
+                run(`route.muted = true`);
+                await testExpectedEventually('video.muted', true);
+
+                endTest();
+            }
+        </script>
+    </head>
+    <body onload='start()'>
+        <video controls></video>
+        <p>Test that a MediaDeviceRoute muted change propagates to the video element.</p>
+    </body>
+</html>

--- a/LayoutTests/media/wireless-playback-media-player/route-pauses-playback-expected.txt
+++ b/LayoutTests/media/wireless-playback-media-player/route-pauses-playback-expected.txt
@@ -1,0 +1,17 @@
+
+Test that a MediaDeviceRoute reporting it stopped playing pauses the video element.
+
+RUN(internals.mockMediaDeviceRouteController.activateRoute(route))
+RUN(video.src = findMediaFile('video', '../content/test'))
+RUN(route.playbackRate = 1)
+RUN(route.timeRange = { start: 0, duration: 60 })
+RUN(video.play())
+RUN(route.ready = true)
+EVENT(playing)
+RUN(route.currentPlaybackPosition = 10)
+RUN(route.playing = false)
+EVENT(pause)
+EXPECTED (video.paused == 'true') OK
+EXPECTED (internals.elementEffectivePlaybackRate(video) == '0') OK
+END OF TEST
+

--- a/LayoutTests/media/wireless-playback-media-player/route-pauses-playback.html
+++ b/LayoutTests/media/wireless-playback-media-player/route-pauses-playback.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html><!-- webkit-test-runner [ WirelessPlaybackMediaPlayerEnabled=true ] -->
+<html>
+    <head>
+        <script src='../media-file.js'></script>
+        <script src='../video-test.js'></script>
+        <script>
+            var route;
+            var video;
+
+            async function start()
+            {
+                if (window.internals)
+                    internals.mockMediaDeviceRouteController.enabled = true;
+
+                route = internals.mockMediaDeviceRouteController.createMockMediaDeviceRoute();
+                run(`internals.mockMediaDeviceRouteController.activateRoute(route)`);
+
+                const urlPromise = new Promise((resolve) => {
+                    route.setURLCallback(async (url) => {
+                        resolve(url);
+                    });
+                });
+
+                video = document.getElementsByTagName('video')[0];
+                run(`video.src = findMediaFile('video', '../content/test')`);
+                run(`route.playbackRate = 1`);
+                run(`route.timeRange = { start: 0, duration: 60 }`);
+                run(`video.play()`);
+                await urlPromise;
+
+                const playingPromise = waitFor(video, 'playing');
+                run(`route.ready = true`);
+                await playingPromise;
+
+                run(`route.currentPlaybackPosition = 10`);
+                await waitForConditionOrTimeout('video.currentTime >= 10', true, 3000);
+
+                const pausePromise = waitFor(video, 'pause');
+                run(`route.playing = false`);
+                await pausePromise;
+                testExpected(`video.paused`, true);
+                testExpected(`internals.elementEffectivePlaybackRate(video)`, 0);
+
+                endTest();
+            }
+        </script>
+    </head>
+    <body onload='start()'>
+        <video controls></video>
+        <p>Test that a MediaDeviceRoute reporting it stopped playing pauses the video element.</p>
+    </body>
+</html>

--- a/LayoutTests/media/wireless-playback-media-player/route-playback-rate-change-expected.txt
+++ b/LayoutTests/media/wireless-playback-media-player/route-playback-rate-change-expected.txt
@@ -1,0 +1,14 @@
+
+Test that a MediaDeviceRoute playback rate change propagates to the video element's effective playback rate.
+
+RUN(internals.mockMediaDeviceRouteController.activateRoute(route))
+RUN(video.src = findMediaFile('video', '../content/test'))
+RUN(route.playbackRate = 1)
+RUN(route.timeRange = { start: 0, duration: 60 })
+RUN(video.play())
+RUN(route.ready = true)
+EVENT(canplaythrough)
+RUN(route.playbackRate = 2)
+EXPECTED (internals.elementEffectivePlaybackRate(video) == '2') OK
+END OF TEST
+

--- a/LayoutTests/media/wireless-playback-media-player/route-playback-rate-change.html
+++ b/LayoutTests/media/wireless-playback-media-player/route-playback-rate-change.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html><!-- webkit-test-runner [ WirelessPlaybackMediaPlayerEnabled=true ] -->
+<html>
+    <head>
+        <script src='../media-file.js'></script>
+        <script src='../video-test.js'></script>
+        <script>
+            var route;
+            var video;
+
+            async function start()
+            {
+                if (window.internals)
+                    internals.mockMediaDeviceRouteController.enabled = true;
+
+                route = internals.mockMediaDeviceRouteController.createMockMediaDeviceRoute();
+                run(`internals.mockMediaDeviceRouteController.activateRoute(route)`);
+
+                const urlPromise = new Promise((resolve) => {
+                    route.setURLCallback(async (url) => {
+                        resolve(url);
+                    });
+                });
+
+                video = document.getElementsByTagName('video')[0];
+                run(`video.src = findMediaFile('video', '../content/test')`);
+                run(`route.playbackRate = 1`);
+                run(`route.timeRange = { start: 0, duration: 60 }`);
+                run(`video.play()`);
+                await urlPromise;
+
+                const canplaythroughPromise = waitFor(video, 'canplaythrough');
+                run(`route.ready = true`);
+                await canplaythroughPromise;
+
+                run(`route.playbackRate = 2`);
+                await testExpectedEventually('internals.elementEffectivePlaybackRate(video)', 2);
+
+                endTest();
+            }
+        </script>
+    </head>
+    <body onload='start()'>
+        <video controls></video>
+        <p>Test that a MediaDeviceRoute playback rate change propagates to the video element's effective playback rate.</p>
+    </body>
+</html>

--- a/LayoutTests/media/wireless-playback-media-player/route-stops-advancing-current-time-expected.txt
+++ b/LayoutTests/media/wireless-playback-media-player/route-stops-advancing-current-time-expected.txt
@@ -1,0 +1,15 @@
+
+Test that a MediaDeviceRoute reporting it stopped playing stops advancing currentTime.
+
+RUN(internals.mockMediaDeviceRouteController.activateRoute(route))
+RUN(video.src = findMediaFile('video', '../content/test'))
+RUN(route.playbackRate = 4)
+RUN(route.timeRange = { start: 0, duration: 60 })
+RUN(video.play())
+RUN(route.ready = true)
+EVENT(canplaythrough)
+RUN(route.currentPlaybackPosition = 10)
+RUN(route.playing = false)
+EXPECTED (timeAfterWait - timeAtPause < 0.25 == 'true') OK
+END OF TEST
+

--- a/LayoutTests/media/wireless-playback-media-player/route-stops-advancing-current-time.html
+++ b/LayoutTests/media/wireless-playback-media-player/route-stops-advancing-current-time.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html><!-- webkit-test-runner [ WirelessPlaybackMediaPlayerEnabled=true ] -->
+<html>
+    <head>
+        <script src='../media-file.js'></script>
+        <script src='../video-test.js'></script>
+        <script>
+            var route;
+            var video;
+            var timeAtPause;
+            var timeAfterWait;
+
+            async function start()
+            {
+                if (window.internals)
+                    internals.mockMediaDeviceRouteController.enabled = true;
+
+                route = internals.mockMediaDeviceRouteController.createMockMediaDeviceRoute();
+                run(`internals.mockMediaDeviceRouteController.activateRoute(route)`);
+
+                const urlPromise = new Promise((resolve) => {
+                    route.setURLCallback(async (url) => {
+                        resolve(url);
+                    });
+                });
+
+                video = document.getElementsByTagName('video')[0];
+                run(`video.src = findMediaFile('video', '../content/test')`);
+                run(`route.playbackRate = 4`);
+                run(`route.timeRange = { start: 0, duration: 60 }`);
+                run(`video.play()`);
+                await urlPromise;
+
+                const canplaythroughPromise = waitFor(video, 'canplaythrough');
+                run(`route.ready = true`);
+                await canplaythroughPromise;
+
+                run(`route.currentPlaybackPosition = 10`);
+                await waitForConditionOrTimeout('video.currentTime >= 10', true, 3000);
+
+                run(`route.playing = false`);
+
+                timeAtPause = video.currentTime;
+                await new Promise(r => setTimeout(r, 150));
+                timeAfterWait = video.currentTime;
+                testExpected(`timeAfterWait - timeAtPause < 0.25`, true);
+
+                endTest();
+            }
+        </script>
+    </head>
+    <body onload='start()'>
+        <video controls></video>
+        <p>Test that a MediaDeviceRoute reporting it stopped playing stops advancing currentTime.</p>
+    </body>
+</html>

--- a/LayoutTests/media/wireless-playback-media-player/route-volume-change-expected.txt
+++ b/LayoutTests/media/wireless-playback-media-player/route-volume-change-expected.txt
@@ -1,0 +1,15 @@
+
+Test that a MediaDeviceRoute volume change propagates to the video element.
+
+RUN(internals.mockMediaDeviceRouteController.activateRoute(route))
+RUN(video.src = findMediaFile('video', '../content/test'))
+RUN(video.play())
+RUN(route.ready = true)
+EVENT(canplaythrough)
+RUN(internals.setPageMediaVolume(1))
+RUN(internals.setMediaElementVolumeLocked(video, false))
+RUN(route.volume = 0.25)
+EVENT(volumechange)
+EXPECTED (video.volume == '0.25') OK
+END OF TEST
+

--- a/LayoutTests/media/wireless-playback-media-player/route-volume-change-locked-expected.txt
+++ b/LayoutTests/media/wireless-playback-media-player/route-volume-change-locked-expected.txt
@@ -1,0 +1,16 @@
+
+Test that a MediaDeviceRoute volume change does not propagate to the video element when its volume is locked.
+
+RUN(internals.mockMediaDeviceRouteController.activateRoute(route))
+RUN(video.src = findMediaFile('video', '../content/test'))
+RUN(video.play())
+RUN(route.ready = true)
+EVENT(canplaythrough)
+RUN(internals.setPageMediaVolume(1))
+RUN(internals.setMediaElementVolumeLocked(video, true))
+RUN(route.volume = 0.25)
+RUN(route.muted = true)
+EXPECTED (video.muted == 'true') OK
+EXPECTED (video.volume == '1') OK
+END OF TEST
+

--- a/LayoutTests/media/wireless-playback-media-player/route-volume-change-locked.html
+++ b/LayoutTests/media/wireless-playback-media-player/route-volume-change-locked.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html><!-- webkit-test-runner [ WirelessPlaybackMediaPlayerEnabled=true ] -->
+<html>
+    <head>
+        <script src='../media-file.js'></script>
+        <script src='../video-test.js'></script>
+        <script>
+            var route;
+            var video;
+
+            async function start()
+            {
+                if (window.internals)
+                    internals.mockMediaDeviceRouteController.enabled = true;
+
+                route = internals.mockMediaDeviceRouteController.createMockMediaDeviceRoute();
+                run(`internals.mockMediaDeviceRouteController.activateRoute(route)`);
+
+                route.volume = 1;
+
+                const urlPromise = new Promise((resolve) => {
+                    route.setURLCallback(async (url) => {
+                        resolve(url);
+                    });
+                });
+
+                video = document.getElementsByTagName('video')[0];
+                run(`video.src = findMediaFile('video', '../content/test')`);
+                run(`video.play()`);
+                await urlPromise;
+
+                const canplaythroughPromise = waitFor(video, 'canplaythrough');
+                run(`route.ready = true`);
+                await canplaythroughPromise;
+
+                run(`internals.setPageMediaVolume(1)`);
+                run(`internals.setMediaElementVolumeLocked(video, true)`);
+
+                run(`route.volume = 0.25`);
+                run(`route.muted = true`);
+                await testExpectedEventually('video.muted', true);
+                testExpected(`video.volume`, 1);
+
+                endTest();
+            }
+        </script>
+    </head>
+    <body onload='start()'>
+        <video controls></video>
+        <p>Test that a MediaDeviceRoute volume change does not propagate to the video element when its volume is locked.</p>
+    </body>
+</html>

--- a/LayoutTests/media/wireless-playback-media-player/route-volume-change.html
+++ b/LayoutTests/media/wireless-playback-media-player/route-volume-change.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html><!-- webkit-test-runner [ WirelessPlaybackMediaPlayerEnabled=true ] -->
+<html>
+    <head>
+        <script src='../media-file.js'></script>
+        <script src='../video-test.js'></script>
+        <script>
+            var route;
+            var video;
+
+            async function start()
+            {
+                if (window.internals)
+                    internals.mockMediaDeviceRouteController.enabled = true;
+
+                route = internals.mockMediaDeviceRouteController.createMockMediaDeviceRoute();
+                run(`internals.mockMediaDeviceRouteController.activateRoute(route)`);
+
+                route.volume = 1;
+
+                const urlPromise = new Promise((resolve) => {
+                    route.setURLCallback(async (url) => {
+                        resolve(url);
+                    });
+                });
+
+                video = document.getElementsByTagName('video')[0];
+                run(`video.src = findMediaFile('video', '../content/test')`);
+                run(`video.play()`);
+                await urlPromise;
+
+                const canplaythroughPromise = waitFor(video, 'canplaythrough');
+                run(`route.ready = true`);
+                await canplaythroughPromise;
+
+                run(`internals.setPageMediaVolume(1)`);
+                run(`internals.setMediaElementVolumeLocked(video, false)`);
+
+                const volumeChangePromise = waitFor(video, 'volumechange');
+                run(`route.volume = 0.25`);
+                await volumeChangePromise;
+                testExpected(`video.volume`, 0.25);
+
+                endTest();
+            }
+        </script>
+    </head>
+    <body onload='start()'>
+        <video controls></video>
+        <p>Test that a MediaDeviceRoute volume change propagates to the video element.</p>
+    </body>
+</html>

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp
@@ -357,6 +357,14 @@ double MediaPlayerPrivateWirelessPlayback::rate() const
     return 0;
 }
 
+double MediaPlayerPrivateWirelessPlayback::effectiveRate() const
+{
+    RefPtr route = this->route();
+    if (!route || !route->playing())
+        return 0;
+    return route->playbackSpeed();
+}
+
 void MediaPlayerPrivateWirelessPlayback::setVolumeLocked(bool volumeLocked)
 {
     if (m_volumeLocked == volumeLocked)
@@ -384,6 +392,16 @@ float MediaPlayerPrivateWirelessPlayback::volume() const
     if (RefPtr route = this->route())
         return route->volume();
     return 1;
+}
+
+void MediaPlayerPrivateWirelessPlayback::setMuted(bool muted)
+{
+    RefPtr route = this->route();
+    if (!route || route->muted() == muted)
+        return;
+
+    ALWAYS_LOG(LOGIDENTIFIER, muted);
+    route->setMuted(muted);
 }
 
 void MediaPlayerPrivateWirelessPlayback::setNetworkState(MediaPlayer::NetworkState networkState)
@@ -455,20 +473,77 @@ void MediaPlayerPrivateWirelessPlayback::playbackPositionDidChange(MediaDeviceRo
     ASSERT(&route == this->route());
 
     auto playbackPosition = route.playbackPosition();
-    ALWAYS_LOG(LOGIDENTIFIER, playbackPosition);
 
     updateTimebaseTimeAndRate(playbackPosition, route.playing() ? route.playbackSpeed() : 0);
 
     auto currentTime = this->currentTime();
 
-    if (auto seekPromise = std::exchange(m_seekPromise, std::nullopt))
+    if (auto seekPromise = std::exchange(m_seekPromise, std::nullopt)) {
+        ALWAYS_LOG(LOGIDENTIFIER, playbackPosition);
         seekPromise->resolve(currentTime);
+    }
 
     if (RefPtr player = m_player.get())
         player->timeChanged();
 
     if (m_currentTimeDidChangeCallback)
         m_currentTimeDidChangeCallback(currentTime);
+}
+
+void MediaPlayerPrivateWirelessPlayback::playingDidChange(MediaDeviceRoute& route)
+{
+    ASSERT(&route == this->route());
+
+    auto playing = route.playing();
+    ALWAYS_LOG(LOGIDENTIFIER, playing);
+
+    updateTimebaseTimeAndRate(route.playbackPosition(), playing ? route.playbackSpeed() : 0);
+
+    if (RefPtr player = m_player.get()) {
+        player->rateChanged();
+        player->playbackStateChanged();
+    }
+}
+
+void MediaPlayerPrivateWirelessPlayback::playbackSpeedDidChange(MediaDeviceRoute& route)
+{
+    ASSERT(&route == this->route());
+
+    auto playbackSpeed = route.playbackSpeed();
+    ALWAYS_LOG(LOGIDENTIFIER, playbackSpeed);
+
+    if (RetainPtr timebase = ensureTimebase()) {
+        PAL::CMTimebaseSetRate(timebase, route.playing() ? playbackSpeed : 0);
+        scheduleTimebaseTimer();
+    }
+
+    if (RefPtr player = m_player.get())
+        player->rateChanged();
+}
+
+void MediaPlayerPrivateWirelessPlayback::mutedDidChange(MediaDeviceRoute& route)
+{
+    ASSERT(&route == this->route());
+
+    auto muted = route.muted();
+    ALWAYS_LOG(LOGIDENTIFIER, muted);
+
+    if (RefPtr player = m_player.get())
+        player->muteChanged(muted);
+}
+
+void MediaPlayerPrivateWirelessPlayback::volumeDidChange(MediaDeviceRoute& route)
+{
+    ASSERT(&route == this->route());
+
+    if (m_volumeLocked)
+        return;
+
+    auto volume = route.volume();
+    ALWAYS_LOG(LOGIDENTIFIER, volume);
+
+    if (RefPtr player = m_player.get())
+        player->volumeChanged(volume);
 }
 
 CMTimebaseRef MediaPlayerPrivateWirelessPlayback::ensureTimebase()

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.h
@@ -119,10 +119,11 @@ private:
     bool setCurrentTimeDidChangeCallback(MediaPlayer::CurrentTimeDidChangeCallback&&) final;
     void setRate(float) final;
     double rate() const final;
+    double effectiveRate() const final;
     void setVolumeLocked(bool) final;
     void setVolume(float) final;
     float volume() const final;
-    void setMuted(bool) final { }
+    void setMuted(bool) final;
     String engineDescription() const final;
 
     // MediaDeviceRouteClient
@@ -131,6 +132,10 @@ private:
     void errorDidChange(MediaDeviceRoute&) final;
     void audioOptionsDidChange(MediaDeviceRoute&) final;
     void playbackPositionDidChange(MediaDeviceRoute&) final;
+    void playingDidChange(MediaDeviceRoute&) final;
+    void playbackSpeedDidChange(MediaDeviceRoute&) final;
+    void mutedDidChange(MediaDeviceRoute&) final;
+    void volumeDidChange(MediaDeviceRoute&) final;
 
     CMTimebaseRef ensureTimebase();
     void destroyTimebase();

--- a/Source/WebCore/testing/MockMediaDeviceRoute.h
+++ b/Source/WebCore/testing/MockMediaDeviceRoute.h
@@ -86,6 +86,9 @@ public:
     float volume() const;
     void setVolume(float);
 
+    bool muted() const;
+    void setMuted(bool);
+
 private:
     MockMediaDeviceRoute();
 

--- a/Source/WebCore/testing/MockMediaDeviceRoute.idl
+++ b/Source/WebCore/testing/MockMediaDeviceRoute.idl
@@ -39,6 +39,7 @@
     attribute float currentPlaybackPosition;
     attribute MockMediaDeviceRouteTimeRange timeRange;
     attribute float volume;
+    attribute boolean muted;
 };
 
 [

--- a/Source/WebCore/testing/MockMediaDeviceRoute.mm
+++ b/Source/WebCore/testing/MockMediaDeviceRoute.mm
@@ -167,6 +167,16 @@ void MockMediaDeviceRoute::setVolume(float volume)
     [m_platformRoute setVolume:volume];
 }
 
+bool MockMediaDeviceRoute::muted() const
+{
+    return [m_platformRoute isMuted];
+}
+
+void MockMediaDeviceRoute::setMuted(bool muted)
+{
+    [m_platformRoute setMuted:muted];
+}
+
 } // namespace WebCore
 
 #endif // ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)


### PR DESCRIPTION
#### 13d509ea8a1a250ac12266f8ba6ccfd2b1c5bf0e
<pre>
[iOS] Playing, rate, and volume changes originating from a MediaDeviceRoute are not reflected in HTMLMediaElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=319028">https://bugs.webkit.org/show_bug.cgi?id=319028</a>
<a href="https://rdar.apple.com/181881466">rdar://181881466</a>

Reviewed by Youenn Fablet.

MediaPlayerPrivateWirelessPlayback did not implement playbackPositionDidChange, playingDidChange,
playbackSpeedDidChange, or volumeDidChange from MediaDeviceRouteClient. As a result, changes to
these properties made by the MediaDeviceRoute were not propagated to HTMLMediaElement.
Additionally, MediaPlayerPrivateWirelessPlayback did not properly implement setMuted, preventing
the webage from muting playback occurring on a MediaDeviceRoute.

Addressed these problems by implementing the above functions. While here, made the logging in
playbackPositionDidChange less noisy by only logging during a seek.

Covered by new layout tests.

Tests: media/wireless-playback-media-player/muted.html
       media/wireless-playback-media-player/route-muted-change.html
       media/wireless-playback-media-player/route-pauses-playback.html
       media/wireless-playback-media-player/route-playback-rate-change.html
       media/wireless-playback-media-player/route-stops-advancing-current-time.html
       media/wireless-playback-media-player/route-volume-change.html

* LayoutTests/media/wireless-playback-media-player/muted-expected.txt: Added.
* LayoutTests/media/wireless-playback-media-player/muted.html: Added.
* LayoutTests/media/wireless-playback-media-player/route-muted-change-expected.txt: Added.
* LayoutTests/media/wireless-playback-media-player/route-muted-change.html: Added.
* LayoutTests/media/wireless-playback-media-player/route-pauses-playback-expected.txt: Added.
* LayoutTests/media/wireless-playback-media-player/route-pauses-playback.html: Added.
* LayoutTests/media/wireless-playback-media-player/route-playback-rate-change-expected.txt: Added.
* LayoutTests/media/wireless-playback-media-player/route-playback-rate-change.html: Added.
* LayoutTests/media/wireless-playback-media-player/route-stops-advancing-current-time-expected.txt: Added.
* LayoutTests/media/wireless-playback-media-player/route-stops-advancing-current-time.html: Added.
* LayoutTests/media/wireless-playback-media-player/route-volume-change-expected.txt: Added.
* LayoutTests/media/wireless-playback-media-player/route-volume-change-locked-expected.txt: Added.
* LayoutTests/media/wireless-playback-media-player/route-volume-change-locked.html: Added.
* LayoutTests/media/wireless-playback-media-player/route-volume-change.html: Added.
* Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp:
(WebCore::MediaPlayerPrivateWirelessPlayback::effectiveRate const):
(WebCore::MediaPlayerPrivateWirelessPlayback::setMuted):
(WebCore::MediaPlayerPrivateWirelessPlayback::playbackPositionDidChange):
(WebCore::MediaPlayerPrivateWirelessPlayback::playingDidChange):
(WebCore::MediaPlayerPrivateWirelessPlayback::playbackSpeedDidChange):
(WebCore::MediaPlayerPrivateWirelessPlayback::mutedDidChange):
(WebCore::MediaPlayerPrivateWirelessPlayback::volumeDidChange):
* Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.h:
* Source/WebCore/testing/MockMediaDeviceRoute.h:
* Source/WebCore/testing/MockMediaDeviceRoute.idl:
* Source/WebCore/testing/MockMediaDeviceRoute.mm:
(WebCore::MockMediaDeviceRoute::muted const):
(WebCore::MockMediaDeviceRoute::setMuted):

Canonical link: <a href="https://commits.webkit.org/316924@main">https://commits.webkit.org/316924@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f1506681902f33c830aafc25c0a10aea396f632

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173693 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47626 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41407 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183267 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131561 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/53007f5c-b3ab-4e58-9868-2a3863e54193) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175558 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48918 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47308 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135069 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95283 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3bec8f73-c8e1-41be-b53f-8c25de57fba0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176651 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38494 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155851 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115547 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/aa76fda2-acfc-42c0-acf8-6d56442e4ebd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37135 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35499 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31751 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147559 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35345 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185693 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38730 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39698 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143953 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47293 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155407 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143812 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38817 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47972 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113169 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38733 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119850 "Found 1059 new failures in b3/testb3_7.cpp, b3/B3Value.h, WebProcess/Network/WebResourceLoader.cpp, jit/OperationResult.h, UIProcess/WebProcessPool.cpp, testing/MockMediaSessionCoordinator.cpp, Shared/Cocoa/WKNSArray.mm, heap/WeakSet.h, API/tests/Regress141275.mm, Shared/SessionState.cpp ...") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46478 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10300 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45880 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46111 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45939 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->