### PR TITLE
[resize-observer] Crash when observing an element multiple times

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/resize-observer/observe-015-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/resize-observer/observe-015-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL observe the same target but using a different box should override the previous one assert_unreached: Timed out waiting for notification. (1000ms) Reached unreachable code
+PASS observe the same target but using a different box should override the previous one
 

--- a/LayoutTests/imported/w3c/web-platform-tests/resize-observer/observe-018-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/resize-observer/observe-018-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Box sizing and Resize Observer notifications assert_unreached: Timed out waiting for notification. (1000ms) Reached unreachable code
+PASS Box sizing and Resize Observer notifications
 

--- a/LayoutTests/resize-observer/resize-observer-observe-multiple-then-gc-expected.txt
+++ b/LayoutTests/resize-observer/resize-observer-observe-multiple-then-gc-expected.txt
@@ -1,0 +1,1 @@
+This tests passes if it does not crash.

--- a/LayoutTests/resize-observer/resize-observer-observe-multiple-then-gc.html
+++ b/LayoutTests/resize-observer/resize-observer-observe-multiple-then-gc.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+
+<title>Resize Observer: don't crash when an element is observed multiple times</title>
+
+<script src="../resources/gc.js"></script>
+
+<p>This tests passes if it does not crash.</p>
+<input id="input">
+
+<script>
+  if (window.testRunner)
+    testRunner.dumpAsText();
+
+  let observer = new ResizeObserver(() => {});
+
+  observer.observe(input);
+  observer.observe(input, { box: "border-box" });
+  observer.observe(input, { box: "border-box" });
+
+  // GC the observer and <input>.
+  observer = null;
+  input.remove();
+  gc();
+</script>
+</html>

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -5492,7 +5492,7 @@ bool Element::hasPendingKeyframesUpdate(const std::optional<Style::PseudoElement
 
 void Element::disconnectFromResizeObserversSlow(ResizeObserverData& observerData)
 {
-    for (const auto& observer : observerData.observers)
+    for (RefPtr observer : observerData.observers)
         observer->targetDestroyed(*this);
     observerData.observers.clear();
 }

--- a/Source/WebCore/page/ResizeObserver.cpp
+++ b/Source/WebCore/page/ResizeObserver.cpp
@@ -71,20 +71,28 @@ void ResizeObserver::observeInternal(Element& target, const ResizeObserverBoxOpt
 {
     ASSERT(!m_JSOrNativeCallback.valueless_by_exception());
 
-    auto addResult = m_observationMap.ensure(target, [&]() {
-        return ResizeObservation::create(target, boxOptions);
-    });
-    Ref observation = addResult.iterator->value;
-    if (!addResult.isNewEntry) {
+    if (RefPtr existingObservation = m_observationMap.get(target)) {
         // The spec suggests unconditionally unobserving here, but that causes a test failure:
         // https://github.com/web-platform-tests/wpt/issues/30708
-        if (observation->observedBox() == boxOptions)
+        if (existingObservation->observedBox() == boxOptions)
             return;
+
+        // This removes target from m_observations/m_observationMap.
         unobserve(target);
     }
+
+    Ref newObservation = ResizeObservation::create(target, boxOptions);
+    {
+        auto addResult = m_observationMap.add(target, newObservation);
+
+        // Can't have an existing entry. Either target has never been observed, or it was
+        // previously observed then unobserved (see above)
+        ASSERT_UNUSED(addResult, addResult.isNewEntry);
+    }
+
     auto& observerData = target.ensureResizeObserverData();
-    observerData.observers.append(*this);
-    m_observations.add(WTF::move(observation));
+    observerData.observers.add(*this);
+    m_observations.add(WTF::move(newObservation));
 
     // Per the specification, we should dispatch at least one observation for the target. For this reason, we make sure to keep the
     // target alive until this first observation. This, in turn, will keep the ResizeObserver's JS wrapper alive via
@@ -241,7 +249,7 @@ bool ResizeObserver::removeTarget(Element& target)
         return false;
 
     auto& observers = observerData->observers;
-    return observers.removeFirst(this);
+    return observers.remove(this);
 }
 
 void ResizeObserver::removeAllTargets()

--- a/Source/WebCore/page/ResizeObserver.h
+++ b/Source/WebCore/page/ResizeObserver.h
@@ -32,6 +32,7 @@
 #include <wtf/OrderedHashSet.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/WeakHashMap.h>
+#include <wtf/WeakHashSet.h>
 #include <wtf/WeakPtr.h>
 
 namespace JSC {
@@ -48,7 +49,7 @@ struct ResizeObserverOptions;
 
 struct ResizeObserverData {
     WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(ResizeObserverData);
-    Vector<WeakPtr<ResizeObserver>> observers;
+    WeakHashSet<ResizeObserver> observers;
 };
 
 using NativeResizeObserverCallback = void (*)(const Vector<Ref<ResizeObserverEntry>>&, ResizeObserver&);


### PR DESCRIPTION
#### bd130fc5376dc79334604292566f3073f46dc5a4
<pre>
[resize-observer] Crash when observing an element multiple times
<a href="https://rdar.apple.com/181487491">rdar://181487491</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=319009">https://bugs.webkit.org/show_bug.cgi?id=319009</a>

Reviewed by Ryosuke Niwa.

In ResizeObserver, an observation in m_observations should exist in m_observationMap
and vice versa. But this invariant is broken if an element is observed twice with
different box options:

void ResizeObserver::observeInternal(Element&amp; target, const ResizeObserverBoxOptions boxOptions)
{
    ASSERT(!m_JSOrNativeCallback.valueless_by_exception());

    auto addResult = m_observationMap.ensure(target, [&amp;]() {
        return ResizeObservation::create(target, boxOptions);
    });     &lt;-- (a)
    Ref observation = addResult.iterator-&gt;value;
    if (!addResult.isNewEntry) {
        // The spec suggests unconditionally unobserving here, but that causes a test failure:
        // <a href="https://github.com/web-platform-tests/wpt/issues/30708">https://github.com/web-platform-tests/wpt/issues/30708</a>
        if (observation-&gt;observedBox() == boxOptions)
            return;
        unobserve(target);     &lt;-- (b)
    }

    // (c)
    auto&amp; observerData = target.ensureResizeObserverData();
    observerData.observers.append(*this);
    m_observations.add(WTF::move(observation));
    [...]
}

(a) adds the element to m_observationMap if one doesn&apos;t exist, (b) unobserves
if the element is already being observed but the new observation requests
different box options, and (c) adds the element to m_observations.

If an element is observed twice like this:

    observer.observe(input);
    observer.observe(input, { box: &quot;border-box&quot; });

On the second observation: (a) does not add anything to m_observationMap
because it&apos;s already observed. (b) unobserve() removes the element from both
m_observationMap and m_observations, and (c) adds it to m_observations, but
crucially, it does not add it back to m_observationMap. This breaks the
invariant between m_observation and m_observationMap.

Fix this by first testing if the element is observed first. If it is,
unobserve it before adding the element to m_observationMap and m_observation.

Additionally, harden ResizeObserverData::observers by making it a WeakHashSet,
so iterating through it would skip already freed observers.

Test: imported/w3c/web-platform-tests/resize-observer/observe-015.html
      imported/w3c/web-platform-tests/resize-observer/observe-018.html
      resize-observer/resize-observer-observe-multiple-then-gc.html

* LayoutTests/imported/w3c/web-platform-tests/resize-observer/observe-015-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/resize-observer/observe-018-expected.txt:
    - Test progression.

* LayoutTests/resize-observer/resize-observer-observe-multiple-then-gc-expected.txt: Added.
* LayoutTests/resize-observer/resize-observer-observe-multiple-then-gc.html: Added.
    - Added test. The crash is during when an observed element is freed, so it
      needs to call the internal GC method and can&apos;t be upstreamed to WPT.

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::disconnectFromResizeObserversSlow):
* Source/WebCore/page/ResizeObserver.cpp:
(WebCore::ResizeObserver::observeInternal):
(WebCore::ResizeObserver::removeTarget):
* Source/WebCore/page/ResizeObserver.h:

Canonical link: <a href="https://commits.webkit.org/317224@main">https://commits.webkit.org/317224@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/32c37e754ee8bdd8d4d74ed0fd059525212c7785

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174570 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48503 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42284 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184147 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132438 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176435 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49795 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48186 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135823 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/be83b3e5-7a49-42db-960d-4646328a7ec6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177528 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39256 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156619 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116301 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d6cb7e13-89f7-469e-bfee-591d14269f6c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37897 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36269 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32628 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148320 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36111 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186574 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39839 "Found 1028 new failures in b3/B3Value.h, b3/testb3_7.cpp, WebProcess/Network/WebResourceLoader.cpp, jit/OperationResult.h, UIProcess/WebProcessPool.cpp, Shared/Cocoa/WKNSArray.mm, heap/WeakSet.h, API/tests/Regress141275.mm, Shared/SessionState.cpp, NetworkProcess/NetworkResourceLoadParameters.cpp ...") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40466 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144741 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48170 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156174 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144601 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38995 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48849 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32731 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/held.https.any.sharedworker.html (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39484 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120839 "Found 121 new failures in b3/testb3_7.cpp, b3/B3Value.h, WebProcess/Network/WebResourceLoader.cpp, UIProcess/WebProcessPool.cpp, Shared/Cocoa/WKNSArray.mm, Shared/SessionState.cpp, NetworkProcess/NetworkResourceLoadParameters.cpp, WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm, WebProcess/WebPage/WebPage.cpp, WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm ...") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47356 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11077 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46758 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46989 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46816 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->