### PR TITLE
Web Inspector: add a regression test for clearing the Console across frame targets under site isolation

### DIFF
--- a/LayoutTests/http/tests/site-isolation/inspector/console/clear-across-frame-targets-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/console/clear-across-frame-targets-expected.txt
@@ -1,0 +1,17 @@
+CONSOLE MESSAGE: Hello from http://127.0.0.1:8000/site-isolation/inspector/console/resources/console-messages.html
+CONSOLE MESSAGE: Warning from http://127.0.0.1:8000/site-isolation/inspector/console/resources/console-messages.html
+CONSOLE MESSAGE: Error from http://127.0.0.1:8000/site-isolation/inspector/console/resources/console-messages.html
+CONSOLE MESSAGE: Hello from http://localhost:8000/site-isolation/inspector/console/resources/console-messages.html
+CONSOLE MESSAGE: Warning from http://localhost:8000/site-isolation/inspector/console/resources/console-messages.html
+CONSOLE MESSAGE: Error from http://localhost:8000/site-isolation/inspector/console/resources/console-messages.html
+
+== Running test suite: SiteIsolation.ClearConsoleAcrossFrameTargets
+-- Running test case: ClearConsoleAcrossFrameTargets.FrontendClear
+Adding a same-origin iframe that logs to the console...
+Adding a cross-origin iframe that logs to the console...
+PASS: Main frame, same-origin iframe, and cross-origin iframe should each have a frame target.
+PASS: The frame targets should all support the Console domain.
+Requesting a frontend console clear...
+PASS: Cleared event should fire after a frontend clear across frame targets.
+PASS: No cleared frame target should replay messages when Console is re-enabled.
+

--- a/LayoutTests/http/tests/site-isolation/inspector/console/clear-across-frame-targets.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/console/clear-across-frame-targets.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<script src="/inspector/resources/inspector-test.js"></script>
+<script>
+    // Utilities for page code.
+    function addIFrame(url) {
+        const iframe = document.createElement("iframe");
+        iframe.src = url;
+        document.body.appendChild(iframe);
+    }
+
+    function test() {
+        // A frontend-initiated console clear (the Clear button, or its shortcut) goes
+        // through `WI.consoleManager.requestClearMessages()`, which fans `Console.clearMessages`
+        // out to every Console-capable target and only finishes once a `Console.messagesCleared`
+        // event comes back and `WI.ConsoleManager.Event.Cleared` is dispatched. There is no
+        // local fallback, so if that fan-out ever stops covering a target whose console agent
+        // produced messages, the clear would silently get "stuck" and the log would never empty.
+        //
+        // Under site isolation, messages can come from multiple frame targets (same- and
+        // cross-origin), each with its own console agent. This guards that a frontend clear
+        // still completes across all of them.
+
+        const suite = InspectorTest.createAsyncSuite("SiteIsolation.ClearConsoleAcrossFrameTargets");
+
+        function addFrameAndAwaitMessages(expression, count) {
+            let received = new Promise((resolve) => {
+                let seen = 0;
+                let listener = WI.consoleManager.addEventListener(WI.ConsoleManager.Event.MessageAdded, () => {
+                    if (++seen === count) {
+                        WI.consoleManager.removeEventListener(WI.ConsoleManager.Event.MessageAdded, listener);
+                        resolve();
+                    }
+                });
+            });
+
+            InspectorTest.evaluateInPage(expression);
+
+            return received;
+        }
+
+        suite.addTestCase({
+            name: "ClearConsoleAcrossFrameTargets.FrontendClear",
+            description: "WI.consoleManager.requestClearMessages() should fire Cleared even when messages span multiple frame targets.",
+            async test() {
+                // `console-messages.html` logs three messages (log, warn, and an uncaught error).
+                InspectorTest.log("Adding a same-origin iframe that logs to the console...");
+                await addFrameAndAwaitMessages(`addIFrame("resources/console-messages.html")`, 3);
+
+                InspectorTest.log("Adding a cross-origin iframe that logs to the console...");
+                await addFrameAndAwaitMessages(`addIFrame("http://localhost:8000/site-isolation/inspector/console/resources/console-messages.html")`, 3);
+
+                let frameTargets = WI.targets.filter((target) => target.type === WI.TargetType.Frame);
+                InspectorTest.expectEqual(frameTargets.length, 3, "Main frame, same-origin iframe, and cross-origin iframe should each have a frame target.");
+                InspectorTest.expectThat(frameTargets.every((target) => target.hasDomain("Console")), "The frame targets should all support the Console domain.");
+
+                let clearedEvent = WI.consoleManager.awaitEvent(WI.ConsoleManager.Event.Cleared);
+
+                InspectorTest.log("Requesting a frontend console clear...");
+                WI.consoleManager.requestClearMessages();
+
+                let event = await clearedEvent;
+                InspectorTest.expectThat(event, "Cleared event should fire after a frontend clear across frame targets.");
+
+                // Prove each frame target's backend store is genuinely empty. Re-enabling Console replays any messages
+                // the backend still holds, so a frame target that failed to clear would re-send them here.
+                let replayed = 0;
+                let listener = WI.consoleManager.addEventListener(WI.ConsoleManager.Event.MessageAdded, (event) => {
+                    if (frameTargets.includes(event.data.message.target))
+                        ++replayed;
+                });
+
+                for (let target of frameTargets) {
+                    await target.ConsoleAgent.disable();
+                    await target.ConsoleAgent.enable(); // any leftover messages are replayed before this resolves
+                }
+
+                WI.consoleManager.removeEventListener(WI.ConsoleManager.Event.MessageAdded, listener);
+                InspectorTest.expectEqual(replayed, 0, "No cleared frame target should replay messages when Console is re-enabled.");
+            }
+        });
+
+        suite.runTestCasesAndFinish();
+    }
+</script>
+
+<body onload="runTest()"></body>


### PR DESCRIPTION
#### f010ba868212b2113ca0727ce46f06273cb5fd0a
<pre>
Web Inspector: add a regression test for clearing the Console across frame targets under site isolation
<a href="https://bugs.webkit.org/show_bug.cgi?id=319035">https://bugs.webkit.org/show_bug.cgi?id=319035</a>
<a href="https://rdar.apple.com/181885109">rdar://181885109</a>

Reviewed by Qianlang Chen.

A frontend-initiated console clear (the Clear button and its keyboard
shortcut) routes through `WI.consoleManager.requestClearMessages()`,
which fans `Console.clearMessages` out to every Console-capable target
and only completes once a `Console.messagesCleared` event comes back and
`WI.ConsoleManager.Event.Cleared` is dispatched. There is no local
fallback, so if that fan-out ever stopped covering a target whose
console agent produced messages, the clear would silently get stuck and
the log would never empty.

Under site isolation, messages can originate from multiple frame targets
(same- and cross-origin), each with its own console agent. Today this
works because the frontend enables Console on exactly the same target
set it later clears (`WI.Target` init vs. `requestClearMessages()`), so
every cleared target is already enabled and echoes `messagesCleared`.
Add a test that locks in this invariant: it logs from a same-origin and
a cross-origin iframe, confirms exactly the three expected frame targets
(main frame, same-origin iframe, cross-origin iframe) exist and support
Console, requests a frontend clear, asserts the `Cleared` event fires,
and finally re-enables Console on each frame target to confirm no
messages get replayed from the backend, proving the clear actually
reached and executed there rather than just producing a frontend event.

No behavior change; test only.

* LayoutTests/http/tests/site-isolation/inspector/console/clear-across-frame-targets.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/console/clear-across-frame-targets-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/317743@main">https://commits.webkit.org/317743@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ac739cbfe8ffe8bede4621b0ca62548b708254d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175550 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49482 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43263 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185136 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/db906ffe-1515-40f0-b810-0ca2919db715) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50774 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49165 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136689 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b38f8b02-4afe-4366-a4fc-6c0a00763201) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178507 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40112 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157451 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117167 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/01ba8d11-0401-471b-8a66-422cdefc6677) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38753 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37139 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149175 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36944 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33611 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41342 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187561 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49149 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/157007 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145659 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39339 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49829 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33568 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145496 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40317 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115804 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48336 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11920 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47738 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47968 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47795 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->