### PR TITLE
[WebXR] Nothing is rendered in Android

### DIFF
--- a/Source/WebCore/platform/graphics/android/GraphicsContextGLTextureMapperAndroid.cpp
+++ b/Source/WebCore/platform/graphics/android/GraphicsContextGLTextureMapperAndroid.cpp
@@ -117,10 +117,6 @@ bool GraphicsContextGLTextureMapperAndroid::enableRequiredWebXRExtensionsImpl()
     return enableExtensionsImpl({
         "GL_OES_EGL_image"_s,
         "GL_OES_EGL_image_external"_s,
-        "EGL_KHR_image_base"_s,
-        "EGL_KHR_surfaceless_context"_s,
-        "EGL_ANDROID_get_native_client_buffer"_s,
-        "EGL_ANDROID_image_native_buffer"_s,
     });
 }
 #endif // ENABLE(WEBXR)


### PR DESCRIPTION
#### 9b3aeb16b3e6a4fe7b979bca2397232ced32440f
<pre>
[WebXR] Nothing is rendered in Android
<a href="https://bugs.webkit.org/show_bug.cgi?id=319038">https://bugs.webkit.org/show_bug.cgi?id=319038</a>

Reviewed by Alejandro G. Castro.

In df6bba12@main we added an extra check whenever xrCompatible flag was
used to create a canvas. In those cases we should verify the
availability of certain GL extensions before returning a compatible
canvas. That change was correct but it unveiled a previous bug that was
hidden in the android specific implementation.

GraphicsContextGLTextureMapperAndroid::enableRequiredWebXRExtensionsImpl()
passed EGL extension names (EGL_KHR_image_base, EGL_KHR_surfaceless_context,
EGL_ANDROID_get_native_client_buffer...) to enableExtensionsImpl(),
which does only check GL extensions. That&apos;s why this method was always
returning false, and thus, rejected the creation of XR compatible GL
canvases.

The required EGL extensions are already validated in
platformInitializeExtensions(), except EGL_KHR_surfaceless_context
which was also incorrectly included in the list of required extensions,
the code would use it if available but is not required (also it only
makes sense whenever DMABuf is used which is not the case for android).

* Source/WebCore/platform/graphics/android/GraphicsContextGLTextureMapperAndroid.cpp:
(WebCore::GraphicsContextGLTextureMapperAndroid::enableRequiredWebXRExtensionsImpl):

Canonical link: <a href="https://commits.webkit.org/316903@main">https://commits.webkit.org/316903@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ff981ea9b2311c285624299398b076ff8a20771

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173759 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47692 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41473 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183333 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/131627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175624 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48984 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47374 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135123 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/131627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176717 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38551 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/155908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115601 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37192 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35556 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31817 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/147616 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35401 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185759 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/38805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/39755 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144010 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47359 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143869 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38800 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48038 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113296 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38790 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/119918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46544 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10356 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45946 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46177 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46005 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->