### PR TITLE
REGRESSION(316809@main): RPi4 build broken with older OpenXR SDK

### DIFF
--- a/Tools/TestWebKitAPI/openxr-mock/MockOpenXRRuntime.cpp
+++ b/Tools/TestWebKitAPI/openxr-mock/MockOpenXRRuntime.cpp
@@ -25,8 +25,15 @@
 
 #include <cstring>
 #include <openxr/openxr.h>
-#include <openxr/openxr_loader_negotiation.h>
 #include <string_view>
+
+// The loader negotiation structs live in openxr_loader_negotiation.h since OpenXR 1.1.x,
+// but older SDKs (still used on some bots) expose them via loader_interfaces.h.
+#if __has_include(<openxr/openxr_loader_negotiation.h>)
+#include <openxr/openxr_loader_negotiation.h>
+#else
+#include <openxr/loader_interfaces.h>
+#endif
 
 namespace {
 


### PR DESCRIPTION
#### 92ff1ae602c42a7ac693fc255e24b0d4efe8533c
<pre>
REGRESSION(<a href="https://commits.webkit.org/316809@main">316809@main</a>): RPi4 build broken with older OpenXR SDK
<a href="https://bugs.webkit.org/show_bug.cgi?id=319040">https://bugs.webkit.org/show_bug.cgi?id=319040</a>

Reviewed by NOBODY (OOPS!).

The __has_include header selection in <a href="https://commits.webkit.org/316870@main">316870@main</a> was not enough. The
loader negotiation structs (XrNegotiateLoaderInfo, XrNegotiateRuntimeRequest)
are only exposed by an installed public header, openxr_loader_negotiation.h,
since OpenXR 1.1. Older SDKs keep them in a loader-internal header that is not
shipped in the runtime package, so neither include branch resolves and the
mock runtime cannot build there at all.

Rather than guard the source, stop building the mock runtime on old SDKs.
Expose the detected OpenXR version as a cache variable so it reaches the
TestWebKitAPI subdirectory, then build MockOpenXRRuntime and the
TestOpenXRInstanceLifecycle test that dlopens it only when the SDK is 1.1 or
newer. TestWebKitWebXR stays unconditional, so older bots keep that coverage.
With the mock now limited to 1.1+, revert MockOpenXRRuntime.cpp back to a
plain include of openxr_loader_negotiation.h.

* Source/cmake/OptionsGTK.cmake:
* Source/cmake/OptionsWPE.cmake:
* Tools/TestWebKitAPI/glib/CMakeLists.txt:
* Tools/TestWebKitAPI/openxr-mock/MockOpenXRRuntime.cpp:
</pre>
----------------------------------------------------------------------
#### 6bf24b60070d3d1aa87a62722708faf9ca02cbcb
<pre>
REGRESSION(<a href="https://commits.webkit.org/316809@main">316809@main</a>): RPi4 build broken with older OpenXR SDK
<a href="https://bugs.webkit.org/show_bug.cgi?id=319040">https://bugs.webkit.org/show_bug.cgi?id=319040</a>

Unreviewed build fix.

MockOpenXRRuntime.cpp unconditionally included openxr_loader_negotiation.h,
which only exists in OpenXR 1.1.x. Older SDKs on the RPi4 bots expose the
same loader negotiation structs via loader_interfaces.h. Select the header
with __has_include so both SDK versions build.

* Tools/TestWebKitAPI/openxr-mock/MockOpenXRRuntime.cpp:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6bf24b60070d3d1aa87a62722708faf9ca02cbcb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173709 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47642 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/41423 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/183283 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/131577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175574 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48934 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47324 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/183283 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/131577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176667 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/38506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/155862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/183283 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/37147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/35510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31767 "Failed to checkout and rebase branch from PR 69086") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/147571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/35356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/185709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/39709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/185709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47309 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/155418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/185709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47988 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113195 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26398 "Built successfully and passed tests") | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38744 "Failed to checkout and rebase branch from PR 69086") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46494 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/10311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45896 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46127 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45955 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->