### PR TITLE
[GTK][WPE][Skia] Render the compositor output into a renderbuffer instead of a texture

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp
@@ -44,11 +44,14 @@
 #include <wtf/SystemTracing.h>
 #include <wtf/TZoneMallocInlines.h>
 
+#include <WebCore/FontRenderOptions.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkCanvas.h>
+#include <skia/core/SkColorSpace.h>
 #include <skia/gpu/ganesh/GrBackendSurface.h>
 #include <skia/gpu/ganesh/SkSurfaceGanesh.h>
 #include <skia/gpu/ganesh/gl/GrGLBackendSurface.h>
+#include <skia/gpu/ganesh/gl/GrGLTypes.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
 #if PLATFORM(GTK) || ENABLE(WPE_PLATFORM)
@@ -175,15 +178,18 @@ AcceleratedSurface::RenderTargetShareableBuffer::RenderTargetShareableBuffer(Acc
     : RenderTarget(surface)
     , m_initialSize(size)
 {
-    if (m_surface->useSkia())
-        return;
+    if (!m_surface->useSkia())
+        createFramebuffer();
+}
 
+void AcceleratedSurface::RenderTargetShareableBuffer::createFramebuffer()
+{
     glGenFramebuffers(1, &m_fbo);
     glBindFramebuffer(GL_FRAMEBUFFER, m_fbo);
 
     glGenRenderbuffers(1, &m_depthStencilBuffer);
     glBindRenderbuffer(GL_RENDERBUFFER, m_depthStencilBuffer);
-    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8_OES, size.width(), size.height());
+    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8_OES, m_initialSize.width(), m_initialSize.height());
 
     glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, m_depthStencilBuffer);
     glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_RENDERBUFFER, m_depthStencilBuffer);
@@ -191,10 +197,15 @@ AcceleratedSurface::RenderTargetShareableBuffer::RenderTargetShareableBuffer(Acc
 
 AcceleratedSurface::RenderTargetShareableBuffer::~RenderTargetShareableBuffer()
 {
-    if (!m_surface->useSkia()) {
+    if (m_fbo || m_depthStencilBuffer) {
+        std::optional<GLContext::ScopedGLContextCurrent> scopedCurrent;
+        if (m_surface->useSkia()) {
+            ASSERT(!RunLoop::isMain());
+            scopedCurrent.emplace(*PlatformDisplay::sharedDisplay().skiaGLContext());
+        }
+
         if (m_fbo)
             glDeleteFramebuffers(1, &m_fbo);
-
         if (m_depthStencilBuffer)
             glDeleteRenderbuffers(1, &m_depthStencilBuffer);
     }
@@ -304,11 +315,7 @@ AcceleratedSurface::RenderTargetEGLImage::RenderTargetEGLImage(AcceleratedSurfac
     : RenderTargetShareableBuffer(surface, size)
     , m_image(image)
 {
-    if (m_surface->useSkia()) {
-        m_texture = BitmapTexture::create(m_image, size);
-        createSkiaSurfaceForTexture(*m_texture);
-    } else
-        initializeColorBuffer();
+    initializeColorBuffer();
     WebProcess::singleton().parentProcessConnection()->send(Messages::AcceleratedBackingStore::DidCreateDMABufBuffer(m_id, WTF::move(dmaBufAttributes), usage), m_surface->surfaceID());
 }
 #endif // USE(GBM)
@@ -377,11 +384,7 @@ AcceleratedSurface::RenderTargetEGLImage::RenderTargetEGLImage(AcceleratedSurfac
     : RenderTargetShareableBuffer(surface, size)
     , m_image(image)
 {
-    if (m_surface->useSkia()) {
-        m_texture = BitmapTexture::create(m_image, size);
-        createSkiaSurfaceForTexture(*m_texture);
-    } else
-        initializeColorBuffer();
+    initializeColorBuffer();
     WebProcess::singleton().parentProcessConnection()->send(Messages::AcceleratedBackingStore::DidCreateAndroidBuffer(m_id, WTF::move(hardwareBuffer)), m_surface->surfaceID());
 }
 #endif // OS(ANDROID)
@@ -389,19 +392,51 @@ AcceleratedSurface::RenderTargetEGLImage::RenderTargetEGLImage(AcceleratedSurfac
 #if USE(GBM) || OS(ANDROID)
 void AcceleratedSurface::RenderTargetEGLImage::initializeColorBuffer()
 {
-    ASSERT(!m_surface->useSkia());
+    bool useSkia = m_surface->useSkia();
+    auto& display = PlatformDisplay::sharedDisplay();
+
+    std::optional<GLContext::ScopedGLContextCurrent> scopedCurrent;
+    if (useSkia) {
+        scopedCurrent.emplace(*display.skiaGLContext());
+        createFramebuffer();
+    }
+
+    glBindFramebuffer(GL_FRAMEBUFFER, m_fbo);
     glGenRenderbuffers(1, &m_colorBuffer);
     glBindRenderbuffer(GL_RENDERBUFFER, m_colorBuffer);
     glEGLImageTargetRenderbufferStorageOES(GL_RENDERBUFFER, m_image);
     glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, m_colorBuffer);
+
+    if (!useSkia)
+        return;
+
+    if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
+        LOG_ERROR("AcceleratedSurface was unable to construct a complete framebuffer for the Skia render target");
+        return;
+    }
+
+    GrGLFramebufferInfo framebufferInfo;
+    framebufferInfo.fFBOID = m_fbo;
+    framebufferInfo.fFormat = GL_RGBA8;
+    static constexpr int stencilBits = 8;
+    auto backendRenderTarget = GrBackendRenderTargets::MakeGL(m_initialSize.width(), m_initialSize.height(), 0, stencilBits, framebufferInfo);
+
+    auto origin = m_surface->shouldPaintMirrored() ? kBottomLeft_GrSurfaceOrigin : kTopLeft_GrSurfaceOrigin;
+    auto properties = FontRenderOptions::singleton().createSurfaceProps();
+    m_skiaSurface = SkSurfaces::WrapBackendRenderTarget(display.skiaGrContext(), backendRenderTarget, origin, kRGBA_8888_SkColorType, SkColorSpace::MakeSRGB(), &properties);
 }
 
 AcceleratedSurface::RenderTargetEGLImage::~RenderTargetEGLImage()
 {
-    if (!m_surface->useSkia()) {
-        if (m_colorBuffer)
-            glDeleteRenderbuffers(1, &m_colorBuffer);
+    std::optional<GLContext::ScopedGLContextCurrent> scopedCurrent;
+    if (m_surface->useSkia()) {
+        ASSERT(!RunLoop::isMain());
+        scopedCurrent.emplace(*PlatformDisplay::sharedDisplay().skiaGLContext());
+        m_skiaSurface = nullptr;
     }
+
+    if (m_colorBuffer)
+        glDeleteRenderbuffers(1, &m_colorBuffer);
 
     if (m_image)
         PlatformDisplay::sharedDisplay().destroyEGLImage(m_image);

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h
@@ -221,6 +221,8 @@ private:
         void sync(bool) override;
         void setReleaseFenceFD(UnixFileDescriptor&&) override;
 
+        void createFramebuffer();
+
         unsigned m_fbo { 0 };
         unsigned m_depthStencilBuffer { 0 };
         UnixFileDescriptor m_renderingFenceFD;
@@ -286,7 +288,6 @@ private:
 
         unsigned m_colorBuffer { 0 };
         EGLImage m_image { nullptr };
-        RefPtr<WebCore::BitmapTexture> m_texture;
     };
 #endif // USE(GBM) || OS(ANDROID)
 


### PR DESCRIPTION
#### 4c210c36136d9f1a45327c44a6704c6f6b973ba9
<pre>
[GTK][WPE][Skia] Render the compositor output into a renderbuffer instead of a texture
<a href="https://bugs.webkit.org/show_bug.cgi?id=319083">https://bugs.webkit.org/show_bug.cgi?id=319083</a>

Reviewed by NOBODY (OOPS!).

The Skia compositor imported the shared scanout dma-buf as a GL_TEXTURE_2D and
wrapped it in a Skia texture surface (SkSurfaces::WrapBackendTexture), so the frame
was rendered into a sampleable texture. The web process never samples this buffer.
Import it as a GL renderbuffer and render into it with a wrapped backend render
target (SkSurfaces::WrapBackendRenderTarget) instead. This matches the TextureMapper
compositor and keeps the scanout buffer a pure render target, so drivers might
optimize for the fact that it is not sampleable.

RenderTargetShareableBuffer owns the framebuffer and its depth and stencil buffer.
The TextureMapper path always creates them in the constructor. Under Skia only the
EGLImage target needs a framebuffer, so it creates one in initializeColorBuffer() on
the Skia GL context. The SHM and Texture targets let Ganesh own the framebuffer. The
shared setup lives in createFramebuffer(), and the base class deletes whatever
framebuffer is set.

initializeColorBuffer() now handles both compositors. They only differ in the Skia GL
context and the final SkSurface wrap. It leaves the Skia surface unset when the
framebuffer is not complete, so a broken buffer is skipped instead of rendered into.
The destructors that delete Skia GPU objects assert they do not run on the main
thread, because those objects belong to the compositor thread&apos;s Skia GL context.

* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp:
(WebKit::AcceleratedSurface::RenderTargetShareableBuffer::RenderTargetShareableBuffer):
(WebKit::AcceleratedSurface::RenderTargetShareableBuffer::createFramebuffer):
(WebKit::AcceleratedSurface::RenderTargetShareableBuffer::~RenderTargetShareableBuffer):
(WebKit::AcceleratedSurface::RenderTargetEGLImage::RenderTargetEGLImage):
(WebKit::AcceleratedSurface::RenderTargetEGLImage::initializeColorBuffer):
(WebKit::AcceleratedSurface::RenderTargetEGLImage::~RenderTargetEGLImage):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c210c36136d9f1a45327c44a6704c6f6b973ba9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173727 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47660 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41441 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183301 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131595 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48952 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47342 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135094 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95289 "2 flakes 4 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176685 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38522 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155874 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115572 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37163 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35524 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31785 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147587 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35368 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185727 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38768 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39723 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143980 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47327 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143839 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48006 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31984 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113236 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38757 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119886 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46512 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10323 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45914 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46145 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45973 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->