### PR TITLE
fast/mediastream/microphone-interruption-and-audio-session.html is a constant TEXT failure

### DIFF
--- a/LayoutTests/fast/mediastream/microphone-interruption-and-audio-session.html
+++ b/LayoutTests/fast/mediastream/microphone-interruption-and-audio-session.html
@@ -8,19 +8,19 @@
  </head>
 <body>
     <script>
-    function wait1sForMute(track, testName)
+    function wait10sForMute(track, testName)
     {
         return new Promise((resolve, reject) => {
             track.onmute = resolve;
-            setTimeout(() => reject("rejected mute for " + testName), 1000);
+            setTimeout(() => reject("rejected mute for " + testName), 10000);
         });
     }
 
-    function wait1sForUnmute(track, testName)
+    function wait10sForUnmute(track, testName)
     {
         return new Promise((resolve, reject) => {
             track.onunmute = resolve;
-            setTimeout(() => reject("rejected unmute for " + testName), 1000);
+            setTimeout(() => reject("rejected unmute for " + testName), 10000);
         });
     }
 
@@ -36,7 +36,7 @@
         assert_equals(internals.audioSessionCategory(), "PlayAndRecord", "test1");
 
         // Muting capture should trigger change of category.
-        const onMutePromise1 = wait1sForMute(stream.getAudioTracks()[0], "onMutePromise1");
+        const onMutePromise1 = wait10sForMute(stream.getAudioTracks()[0], "onMutePromise1");
         if (window.internals)
             internals.setPageMuted("capturedevices");
         await onMutePromise1;
@@ -45,7 +45,7 @@
         streams.push(clone);
         assert_equals(internals.audioSessionCategory(), "AmbientSound", "test2");
 
-        const onUnmutePromise1 = wait1sForUnmute(stream.getAudioTracks()[0], "onUnmutePromise1");
+        const onUnmutePromise1 = wait10sForUnmute(stream.getAudioTracks()[0], "onUnmutePromise1");
         if (window.internals)
             internals.setPageMuted("");
         await onUnmutePromise1;
@@ -54,7 +54,7 @@
         assert_equals(internals.audioSessionCategory(), "PlayAndRecord", "test3");
 
         // PlayAndRecord should stick even with capture interruption.
-        const onMutePromise2 = wait1sForMute(stream.getAudioTracks()[0], "onMutePromise2");
+        const onMutePromise2 = wait10sForMute(stream.getAudioTracks()[0], "onMutePromise2");
         if (window.internals)
             internals.beginAudioSessionInterruption();
         await onMutePromise2;
@@ -62,7 +62,7 @@
         streams.push(clone);
         assert_equals(internals.audioSessionCategory(), "PlayAndRecord", "test4");
 
-        const onUnmutePromise2 = wait1sForUnmute(stream.getAudioTracks()[0], "onUnmutePromise2");
+        const onUnmutePromise2 = wait10sForUnmute(stream.getAudioTracks()[0], "onUnmutePromise2");
         if (window.internals)
             internals.endAudioSessionInterruption();
         await onUnmutePromise2;


### PR DESCRIPTION
#### dc9c99a89e44f7add3eb502e9fe807c3aacd97f1
<pre>
fast/mediastream/microphone-interruption-and-audio-session.html is a constant TEXT failure
<a href="https://rdar.apple.com/181852376">rdar://181852376</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=319086">https://bugs.webkit.org/show_bug.cgi?id=319086</a>

Reviewed by Eric Carlson.

I can only reproduce the debug failure when running concurrently 20 WKTR on this test.
Increasing the time to get the mute event fixes the flakiness, which is what this PR is doing.

* LayoutTests/fast/mediastream/microphone-interruption-and-audio-session.html:

Canonical link: <a href="https://commits.webkit.org/316890@main">https://commits.webkit.org/316890@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/03381a3df058738618b255c85ab8ef5cfe9ec148

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173737 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47670 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41451 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183311 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/131605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/624610d7-eb81-4bdb-a0bb-6ccc390c1b41) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48962 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47352 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135100 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/131605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/54b09a3b-3b2d-47e4-a309-be63f05f3e06) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176695 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38529 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/155883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115578 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d3bb6bcf-907c-4cd8-8cbb-3d4aba26d2a8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37170 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/35535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31795 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147594 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35377 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185737 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39734 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143988 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47337 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155439 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143846 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38796 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48016 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113246 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38766 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46522 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10332 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45924 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46155 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45983 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->