### PR TITLE
Have requestHostingContext return a NativePromise

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -9449,14 +9449,12 @@ bool HTMLMediaElement::shouldOverridePauseDuringRouteChange() const
 #endif
 }
 
-void HTMLMediaElement::requestHostingContext(Function<void(HostingContext)>&& completionHandler)
+Ref<MediaPlayer::HostingContextPromise> HTMLMediaElement::requestHostingContext()
 {
-    if (RefPtr player = m_player) {
-        player->requestHostingContext(WTF::move(completionHandler));
-        return;
-    }
+    if (RefPtr player = m_player)
+        return player->requestHostingContext();
 
-    completionHandler({ });
+    return HostingContextPromise::createAndReject();
 }
 
 HostingContext HTMLMediaElement::layerHostingContext()

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -699,7 +699,8 @@ public:
 
     bool hasSource() const { return hasCurrentSrc() || srcObject(); }
 
-    WEBCORE_EXPORT void requestHostingContext(Function<void(HostingContext)>&&);
+    using HostingContextPromise = MediaPlayer::HostingContextPromise;
+    WEBCORE_EXPORT Ref<HostingContextPromise> requestHostingContext();
     WEBCORE_EXPORT WebCore::HostingContext layerHostingContext();
     WEBCORE_EXPORT WebCore::FloatSize naturalSize();
     WEBCORE_EXPORT WebCore::FloatSize NODELETE videoLayerSize() const;

--- a/Source/WebCore/platform/graphics/AudioVideoRenderer.h
+++ b/Source/WebCore/platform/graphics/AudioVideoRenderer.h
@@ -96,8 +96,8 @@ public:
 #endif
     virtual PlatformLayer* platformVideoLayer() const { return nullptr; }
 
-    using LayerHostingContextCallback = CompletionHandler<void(HostingContext)>;
-    virtual void requestHostingContext(LayerHostingContextCallback&& completionHandler) { completionHandler({ }); }
+    using HostingContextPromise = NativePromise<WebCore::HostingContext, void, WTF::PromiseOption::Default | WTF::PromiseOption::WithoutCrossThreadCopy>;
+    virtual Ref<HostingContextPromise> requestHostingContext() { return HostingContextPromise::createAndReject(); }
     virtual HostingContext hostingContext() const { return { }; }
     virtual WebCore::FloatSize videoLayerSize() const { return { }; }
     virtual void notifyVideoLayerSizeChanged(Function<void(const MediaTime&, FloatSize)>&&) { }

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -1374,9 +1374,9 @@ void MediaPlayer::setShouldMaintainAspectRatio(bool maintainAspectRatio)
     protect(m_private)->setShouldMaintainAspectRatio(maintainAspectRatio);
 }
 
-void MediaPlayer::requestHostingContext(LayerHostingContextCallback&& callback)
+Ref<MediaPlayer::HostingContextPromise> MediaPlayer::requestHostingContext()
 {
-    return protect(m_private)->requestHostingContext(WTF::move(callback));
+    return protect(m_private)->requestHostingContext();
 }
 
 HostingContext MediaPlayer::hostingContext() const

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -53,6 +53,7 @@
 #include <wtf/HashSet.h>
 #include <wtf/Logger.h>
 #include <wtf/MediaTime.h>
+#include <wtf/NativePromise.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/URL.h>
@@ -413,8 +414,8 @@ public:
     bool isVideoFullscreenStandby() const;
 #endif
 
-    using LayerHostingContextCallback = CompletionHandler<void(HostingContext)>;
-    void requestHostingContext(LayerHostingContextCallback&&);
+    using HostingContextPromise = NativePromise<HostingContext, void, WTF::PromiseOption::Default | WTF::PromiseOption::WithoutCrossThreadCopy>;
+    Ref<HostingContextPromise> requestHostingContext();
     HostingContext hostingContext() const;
     FloatSize videoLayerSize() const;
     void videoLayerSizeDidChange(const FloatSize&);

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivate.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivate.cpp
@@ -106,6 +106,11 @@ MediaTime MediaPlayerPrivateInterface::currentOrPendingSeekTime() const
     return currentTime();
 }
 
+auto MediaPlayerPrivateInterface::requestHostingContext() -> Ref<HostingContextPromise>
+{
+    return HostingContextPromise::createAndReject();
+}
+
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
 OptionSet<MediaPlaybackTargetType> MediaPlayerPrivateInterface::supportedPlaybackTargetTypes() const
 {

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
@@ -97,8 +97,8 @@ public:
     virtual void videoFullscreenStandbyChanged() { }
 #endif
 
-    using LayerHostingContextCallback = CompletionHandler<void(HostingContext)>;
-    virtual void requestHostingContext(LayerHostingContextCallback&& completionHandler) { completionHandler({ }); }
+    using HostingContextPromise = MediaPlayer::HostingContextPromise;
+    virtual Ref<HostingContextPromise> requestHostingContext();
     virtual HostingContext hostingContext() const { return { }; }
     virtual FloatSize videoLayerSize() const { return { }; }
     virtual void setVideoLayerSizeFenced(const FloatSize&, WTF::MachSendRightAnnotated&&) { }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -336,7 +336,7 @@ private:
 
     // Remote layer support
     WebCore::HostingContext hostingContext() const final;
-    void requestHostingContext(LayerHostingContextCallback&&) final;
+    Ref<HostingContextPromise> requestHostingContext() final;
     void setVideoLayerSizeFenced(const WebCore::FloatSize&, WTF::MachSendRightAnnotated&&) final;
     std::optional<MediaPlayerIdentifier> identifier() const final { return m_playerIdentifier; }
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -1553,16 +1553,14 @@ void MediaPlayerPrivateMediaSourceAVFObjC::isInFullscreenOrPictureInPictureChang
 
 WebCore::HostingContext MediaPlayerPrivateMediaSourceAVFObjC::hostingContext() const
 {
+    assertIsMainThread();
     return m_renderer->hostingContext();
 }
 
-void MediaPlayerPrivateMediaSourceAVFObjC::requestHostingContext(LayerHostingContextCallback&& completionHandler)
+Ref<MediaPlayer::HostingContextPromise> MediaPlayerPrivateMediaSourceAVFObjC::requestHostingContext()
 {
-    m_renderer->requestHostingContext([completionHandler = WTF::move(completionHandler)](WebCore::HostingContext hostingContext) mutable {
-        ensureOnMainThread([completionHandler = WTF::move(completionHandler), hostingContext = WTF::move(hostingContext)]() mutable {
-            completionHandler(WTF::move(hostingContext));
-        });
-    });
+    assertIsMainThread();
+    return m_renderer->requestHostingContext();
 }
 
 void MediaPlayerPrivateMediaSourceAVFObjC::setVideoLayerSizeFenced(const WebCore::FloatSize& size, WTF::MachSendRightAnnotated&& sendRightAnnotated)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h
@@ -247,7 +247,7 @@ private:
 
     HostingContext hostingContext() const final;
     void setVideoLayerSizeFenced(const FloatSize&, WTF::MachSendRightAnnotated&&) final;
-    void requestHostingContext(LayerHostingContextCallback&&) final;
+    Ref<HostingContextPromise> requestHostingContext() final;
 
 
     ThreadSafeWeakPtr<MediaPlayer> m_player;
@@ -324,7 +324,7 @@ private:
 
     std::optional<CGRect> m_storedBounds;
     static NativeImageCreator m_nativeImageCreator;
-    LayerHostingContextCallback m_layerHostingContextCallback;
+    Vector<HostingContextPromise::AutoRejectProducer> m_layerHostingContextPromises;
     bool m_shouldMaintainAspectRatio { true };
 };
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
@@ -50,6 +50,7 @@
 #import <wtf/Lock.h>
 #import <wtf/MachSendRightAnnotated.h>
 #import <wtf/MainThread.h>
+#import <wtf/NativePromise.h>
 #import <wtf/NeverDestroyed.h>
 #import <wtf/TZoneMallocInlines.h>
 #import <wtf/text/MakeString.h>
@@ -474,8 +475,8 @@ void MediaPlayerPrivateMediaStreamAVFObjC::layersAreInitialized(IntSize size, bo
 
     m_canEnqueueDisplayLayer = true;
 
-    if (m_layerHostingContextCallback)
-        m_layerHostingContextCallback(sampleBufferDisplayLayer->hostingContext());
+    for (auto& promise : std::exchange(m_layerHostingContextPromises, { }))
+        promise.resolve(sampleBufferDisplayLayer->hostingContext());
 }
 
 void MediaPlayerPrivateMediaStreamAVFObjC::destroyLayers()
@@ -1302,14 +1303,15 @@ void MediaPlayerPrivateMediaStreamAVFObjC::setVideoLayerSizeFenced(const FloatSi
     sampleBufferDisplayLayer->updateBoundsAndPosition(*m_storedBounds, WTF::move(fence));
 }
 
-void MediaPlayerPrivateMediaStreamAVFObjC::requestHostingContext(LayerHostingContextCallback&& callback)
+Ref<MediaPlayer::HostingContextPromise> MediaPlayerPrivateMediaStreamAVFObjC::requestHostingContext()
 {
     auto context = hostingContext();
-    if (context.contextID) {
-        callback(context);
-        return;
-    }
-    m_layerHostingContextCallback = WTF::move(callback);
+    if (context.contextID)
+        return HostingContextPromise::createAndResolve(WTF::move(context));
+    HostingContextPromise::AutoRejectProducer producer;
+    Ref promise = producer.promise();
+    m_layerHostingContextPromises.append(WTF::move(producer));
+    return promise;
 }
 
 void MediaPlayerPrivateMediaStreamAVFObjC::setShouldMaintainAspectRatio(bool shouldMaintainAspectRatio)

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
@@ -293,7 +293,7 @@ private:
 
     // Remote layer support
     WebCore::HostingContext hostingContext() const final;
-    void requestHostingContext(LayerHostingContextCallback&&) final;
+    Ref<HostingContextPromise> requestHostingContext() final;
     void setVideoLayerSizeFenced(const WebCore::FloatSize&, WTF::MachSendRightAnnotated&&) final;
     std::optional<MediaPlayerIdentifier> identifier() const final { return m_playerIdentifier; }
 

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -1953,13 +1953,10 @@ WebCore::HostingContext MediaPlayerPrivateWebM::hostingContext() const
     return m_renderer->hostingContext();
 }
 
-void MediaPlayerPrivateWebM::requestHostingContext(LayerHostingContextCallback&& completionHandler)
+Ref<MediaPlayer::HostingContextPromise> MediaPlayerPrivateWebM::requestHostingContext()
 {
-    m_renderer->requestHostingContext([completionHandler = WTF::move(completionHandler)](WebCore::HostingContext hostingContext) mutable {
-        ensureOnMainThread([completionHandler = WTF::move(completionHandler), hostingContext = WTF::move(hostingContext)]() mutable {
-            completionHandler(WTF::move(hostingContext));
-        });
-    });
+    assertIsMainThread();
+    return m_renderer->requestHostingContext();
 }
 
 void MediaPlayerPrivateWebM::setVideoLayerSizeFenced(const WebCore::FloatSize& size, WTF::MachSendRightAnnotated&& sendRightAnnotated)

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp
@@ -750,7 +750,13 @@ void RemoteAudioVideoRendererProxyManager::requestHostingContext(RemoteAudioVide
     ALWAYS_LOG(LOGIDENTIFIER, identifier.loggingString());
 #if PLATFORM(COCOA)
     MESSAGE_CHECK_COMPLETION(m_renderers.contains(identifier), completionHandler({ }));
-    contextFor(identifier).layerHostingContextManager.requestHostingContext(WTF::move(completionHandler));
+    contextFor(identifier).layerHostingContextManager.requestHostingContext()->whenSettled(RunLoop::mainSingleton(), [completionHandler = WTF::move(completionHandler)](auto&& result) mutable {
+        if (!result) {
+            completionHandler({ });
+            return;
+        }
+        completionHandler(WTF::move(*result));
+    });
 #else
     completionHandler({ });
 #endif

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
@@ -631,7 +631,7 @@ void RemoteMediaPlayerProxy::mediaPlayerRenderingModeChanged()
     protect(m_webProcessConnection)->send(Messages::MediaPlayerPrivateRemote::RenderingModeChanged(), m_id);
 }
 
-void RemoteMediaPlayerProxy::requestHostingContext(LayerHostingContextCallback&& completionHandler)
+void RemoteMediaPlayerProxy::requestHostingContext(CompletionHandler<void(WebCore::HostingContext)>&& completionHandler)
 {
     completionHandler({ });
 }

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
@@ -369,8 +369,7 @@ private:
     void bitmapImageForCurrentTime(CompletionHandler<void(std::optional<WebCore::ShareableBitmap::Handle>&&)>&&);
 
     void setShouldDisableHDR(bool);
-    using LayerHostingContextCallback = WebCore::MediaPlayer::LayerHostingContextCallback;
-    void requestHostingContext(LayerHostingContextCallback&&);
+    void requestHostingContext(CompletionHandler<void(WebCore::HostingContext)>&&);
     void setShouldCheckHardwareSupport(bool);
 #if HAVE(SPATIAL_TRACKING_LABEL)
     void setDefaultSpatialTrackingLabel(const String&);

--- a/Source/WebKit/GPUProcess/media/cocoa/RemoteMediaPlayerProxyCocoa.mm
+++ b/Source/WebKit/GPUProcess/media/cocoa/RemoteMediaPlayerProxyCocoa.mm
@@ -77,7 +77,13 @@ void RemoteMediaPlayerProxy::mediaPlayerRenderingModeChanged()
 
 void RemoteMediaPlayerProxy::requestHostingContext(CompletionHandler<void(WebCore::HostingContext)>&& completionHandler)
 {
-    m_layerHostingContextManager->requestHostingContext(WTF::move(completionHandler));
+    m_layerHostingContextManager->requestHostingContext()->whenSettled(RunLoop::mainSingleton(), [completionHandler = WTF::move(completionHandler)](auto&& result) mutable {
+        if (!result) {
+            completionHandler({ });
+            return;
+        }
+        completionHandler(WTF::move(*result));
+    });
 }
 
 void RemoteMediaPlayerProxy::setVideoLayerSizeFenced(const WebCore::FloatSize& size, WTF::MachSendRightAnnotated&& sendRightAnnotated)

--- a/Source/WebKit/Platform/cocoa/LayerHostingContextManager.h
+++ b/Source/WebKit/Platform/cocoa/LayerHostingContextManager.h
@@ -29,6 +29,7 @@
 #include <WebCore/FloatSize.h>
 #include <WebCore/PlatformLayer.h>
 #include <wtf/CompletionHandler.h>
+#include <wtf/NativePromise.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
@@ -45,9 +46,8 @@ public:
     LayerHostingContextManager& operator=(LayerHostingContextManager&&);
     ~LayerHostingContextManager();
 
-    using LayerHostingContextCallback = CompletionHandler<void(WebCore::HostingContext)>;
-
-    void requestHostingContext(LayerHostingContextCallback&&);
+    using HostingContextPromise = NativePromise<WebCore::HostingContext, void, WTF::PromiseOption::Default | WTF::PromiseOption::WithoutCrossThreadCopy>;
+    Ref<HostingContextPromise> requestHostingContext();
     std::optional<WebCore::HostingContext> createHostingContextIfNeeded(const PlatformLayerContainer&, bool canShowWhileLocked);
     void setVideoLayerSize(const WebCore::FloatSize&);
     void setVideoLayerSizeFenced(const WebCore::FloatSize&, WTF::MachSendRightAnnotated&&, NOESCAPE CompletionHandler<void()>&& postCommitAction);
@@ -56,7 +56,7 @@ public:
     void NODELETE setInitialVideoLayerSize(const WebCore::FloatSize&);
 
 private:
-    Vector<LayerHostingContextCallback> m_layerHostingContextRequests;
+    Vector<HostingContextPromise::AutoRejectProducer> m_layerHostingContextRequests;
     std::unique_ptr<LayerHostingContext> m_inlineLayerHostingContext;
     WebCore::FloatSize m_videoLayerSize;
 };

--- a/Source/WebKit/Platform/cocoa/LayerHostingContextManager.mm
+++ b/Source/WebKit/Platform/cocoa/LayerHostingContextManager.mm
@@ -39,20 +39,17 @@ LayerHostingContextManager::LayerHostingContextManager() = default;
 LayerHostingContextManager::LayerHostingContextManager(LayerHostingContextManager&&) = default;
 LayerHostingContextManager& LayerHostingContextManager::operator=(LayerHostingContextManager&&) = default;
 
-LayerHostingContextManager::~LayerHostingContextManager()
-{
-    for (auto& request : std::exchange(m_layerHostingContextRequests, { }))
-        request({ });
-}
+LayerHostingContextManager::~LayerHostingContextManager() = default;
 
-void LayerHostingContextManager::requestHostingContext(LayerHostingContextCallback&& completionHandler)
+auto LayerHostingContextManager::requestHostingContext() -> Ref<HostingContextPromise>
 {
-    if (m_inlineLayerHostingContext) {
-        completionHandler(m_inlineLayerHostingContext->hostingContext());
-        return;
-    }
+    if (m_inlineLayerHostingContext)
+        return HostingContextPromise::createAndResolve(m_inlineLayerHostingContext->hostingContext());
 
-    m_layerHostingContextRequests.append(WTF::move(completionHandler));
+    HostingContextPromise::AutoRejectProducer producer;
+    Ref promise = producer.promise();
+    m_layerHostingContextRequests.append(WTF::move(producer));
+    return promise;
 }
 
 void LayerHostingContextManager::setInitialVideoLayerSize(const WebCore::FloatSize& size)
@@ -80,7 +77,7 @@ std::optional<WebCore::HostingContext> LayerHostingContextManager::createHosting
         auto& size = m_videoLayerSize;
         [layer setFrame:CGRectMake(0, 0, size.width(), size.height())];
         for (auto& request : std::exchange(m_layerHostingContextRequests, { }))
-            request(m_inlineLayerHostingContext->hostingContext());
+            request.resolve(m_inlineLayerHostingContext->hostingContext());
         hadLayer = true;
     } else if (!layer && m_inlineLayerHostingContext) {
         m_inlineLayerHostingContext = nullptr;

--- a/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp
@@ -162,8 +162,6 @@ AudioVideoRendererRemote::~AudioVideoRendererRemote() WTF_IGNORES_THREAD_SAFETY_
         });
     }
 
-    for (auto& request : std::exchange(m_layerHostingContextRequests, { }))
-        request({ });
 }
 
 void AudioVideoRendererRemote::setVolume(float volume)
@@ -935,37 +933,37 @@ void AudioVideoRendererRemote::resolveRequestMediaDataWhenReadyIfNeeded(TrackIde
     m_requestMediaDataWhenReadyDataPromises.take(iterator)->resolve(trackIdentifier);
 }
 
-void AudioVideoRendererRemote::requestHostingContext(LayerHostingContextCallback&& completionHandler)
+Ref<AudioVideoRenderer::HostingContextPromise> AudioVideoRendererRemote::requestHostingContext()
 {
-    ensureOnDispatcher([weakThis = ThreadSafeWeakPtr { *this }, completionHandler = WTF::move(completionHandler)]() mutable {
+    return invokeAsync(queueSingleton(), [weakThis = ThreadSafeWeakPtr { *this }] {
         RefPtr protectedThis = weakThis.get();
-        if (!protectedThis) {
-            completionHandler({ });
-            return;
-        }
+        if (!protectedThis)
+            return HostingContextPromise::createAndReject();
         assertIsCurrent(queueSingleton());
 
         // FIXME: should it be called on the main thread???
         RefPtr gpuProcessConnection = protectedThis->m_gpuProcessConnection.get();
-        if (!protectedThis->isGPURunning() || !gpuProcessConnection) {
-            completionHandler({ });
-            return;
-        }
+        if (!protectedThis->isGPURunning() || !gpuProcessConnection)
+            return HostingContextPromise::createAndReject();
 
         auto layerHostingContext = [&] {
             Locker locker { protectedThis->m_lock };
             return protectedThis->m_layerHostingContext;
         }();
-        if (layerHostingContext.contextID) {
-            completionHandler(layerHostingContext);
-            return;
-        }
+        if (layerHostingContext.contextID)
+            return HostingContextPromise::createAndResolve(WTF::move(layerHostingContext));
 
-        protectedThis->m_layerHostingContextRequests.append(WTF::move(completionHandler));
-        gpuProcessConnection->connection().sendWithAsyncReplyOnDispatcher(Messages::RemoteAudioVideoRendererProxyManager::RequestHostingContext(protectedThis->m_identifier), queueSingleton(), [weakThis] (WebCore::HostingContext context) {
-            if (RefPtr protectedThis = weakThis.get())
-                protectedThis->setLayerHostingContext(WTF::move(context));
+        HostingContextPromise::AutoRejectProducer producer;
+        Ref promise = producer.promise();
+        gpuProcessConnection->connection().sendWithAsyncReplyOnDispatcher(Messages::RemoteAudioVideoRendererProxyManager::RequestHostingContext(protectedThis->m_identifier), queueSingleton(), [weakThis, producer = WTF::move(producer)] (WebCore::HostingContext context) mutable {
+            RefPtr protectedThis = weakThis.get();
+            if (!protectedThis || !context.contextID)
+                return;
+            assertIsCurrent(queueSingleton());
+            protectedThis->setLayerHostingContext(WebCore::HostingContext { context });
+            producer.resolve(WTF::move(context));
         }, 0);
+        return promise;
     });
 }
 
@@ -979,22 +977,13 @@ void AudioVideoRendererRemote::setLayerHostingContext(WebCore::HostingContext&& 
 {
     assertIsCurrent(queueSingleton());
 
-    Vector<LayerHostingContextCallback> layerHostingContextRequests;
-    HostingContext layerHostingContext { hostingContext };
-    {
-        Locker locker { m_lock };
-        if (m_layerHostingContext.contextID == hostingContext.contextID)
-            return;
-
-        m_layerHostingContext = WTF::move(hostingContext);
+    Locker locker { m_lock };
+    if (m_layerHostingContext.contextID == hostingContext.contextID)
+        return;
+    m_layerHostingContext = WTF::move(hostingContext);
 #if PLATFORM(COCOA)
-        m_videoLayer = nullptr;
+    m_videoLayer = nullptr;
 #endif
-    }
-    callOnMainRunLoop([layerHostingContext = WTF::move(layerHostingContext), layerHostingContextRequests = std::exchange(m_layerHostingContextRequests, { })]() mutable {
-        for (auto& request : layerHostingContextRequests)
-            request(layerHostingContext);
-    });
 }
 
 bool AudioVideoRendererRemote::inVideoFullscreenOrPictureInPicture() const

--- a/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h
@@ -184,8 +184,7 @@ private:
     void setSpatialTrackingInfo(bool, SoundStageSize, const String&, const String&, const String&) final;
 
     // Remote Layers
-    using LayerHostingContextCallback = CompletionHandler<void(WebCore::HostingContext)>;
-    void requestHostingContext(LayerHostingContextCallback&&) final;
+    Ref<HostingContextPromise> requestHostingContext() final;
     WebCore::HostingContext hostingContext() const final;
     void setLayerHostingContext(WebCore::HostingContext&&);
 #if PLATFORM(COCOA)
@@ -282,7 +281,6 @@ private:
     HashMap<TrackIdentifier, Function<void(TrackIdentifier, const MediaTime&)>> m_trackNeedsReenqueuingCallbacks WTF_GUARDED_BY_CAPABILITY(queueSingleton());
     HashMap<TrackIdentifier, WebCore::MediaSampleConverter> m_mediaSampleConverters WTF_GUARDED_BY_CAPABILITY(queueSingleton());
 
-    Vector<LayerHostingContextCallback> m_layerHostingContextRequests WTF_GUARDED_BY_CAPABILITY(queueSingleton());
     WebCore::HostingContext m_layerHostingContext WTF_GUARDED_BY_LOCK(m_lock);
     WebCore::FloatSize m_naturalSize WTF_GUARDED_BY_LOCK(m_lock);
 

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
@@ -213,9 +213,6 @@ MediaPlayerPrivateRemote::~MediaPlayerPrivateRemote()
         audioSourceProvider->close();
 #endif
 
-    for (auto& request : std::exchange(m_layerHostingContextRequests, { }))
-        request({ });
-
     // Shutdown any stale MediaResources.
     // This condition can happen if the MediaPlayer gets reloaded half-way.
     ensureOnMainThread([resources = std::exchange(m_mediaResources, { })] {
@@ -1597,18 +1594,21 @@ WTFLogChannel& MediaPlayerPrivateRemote::logChannel() const
 }
 #endif
 
-void MediaPlayerPrivateRemote::requestHostingContext(LayerHostingContextCallback&& completionHandler)
+Ref<MediaPlayer::HostingContextPromise> MediaPlayerPrivateRemote::requestHostingContext()
 {
-    if (m_layerHostingContext.contextID) {
-        completionHandler(m_layerHostingContext);
-        return;
-    }
+    if (m_layerHostingContext.contextID)
+        return HostingContextPromise::createAndResolve(m_layerHostingContext);
 
-    m_layerHostingContextRequests.append(WTF::move(completionHandler));
-    protect(connection())->sendWithAsyncReply(Messages::RemoteMediaPlayerProxy::RequestHostingContext(), [weakThis = ThreadSafeWeakPtr { *this }] (WebCore::HostingContext context) {
-        if (RefPtr protectedThis = weakThis.get())
-            protectedThis->setLayerHostingContext(WTF::move(context));
+    HostingContextPromise::AutoRejectProducer producer;
+    Ref promise = producer.promise();
+    protect(connection())->sendWithAsyncReply(Messages::RemoteMediaPlayerProxy::RequestHostingContext(), [weakThis = ThreadSafeWeakPtr { *this }, producer = WTF::move(producer)] (WebCore::HostingContext context) mutable {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis || !context.contextID)
+            return;
+        protectedThis->setLayerHostingContext(WebCore::HostingContext { context });
+        producer.resolve(WTF::move(context));
     }, m_id);
+    return promise;
 }
 
 WebCore::HostingContext MediaPlayerPrivateRemote::hostingContext() const
@@ -1620,14 +1620,10 @@ void MediaPlayerPrivateRemote::setLayerHostingContext(WebCore::HostingContext&& 
 {
     if (m_layerHostingContext.contextID == hostingContext.contextID)
         return;
-
     m_layerHostingContext = WTF::move(hostingContext);
 #if PLATFORM(COCOA)
     m_videoLayer = nullptr;
 #endif
-
-    for (auto& request : std::exchange(m_layerHostingContextRequests, { }))
-        request(m_layerHostingContext);
 }
 
 #if ENABLE(MEDIA_SOURCE)

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
@@ -195,7 +195,7 @@ public:
     const Logger& mediaPlayerLogger() const { return logger(); }
 #endif
 
-    void requestHostingContext(LayerHostingContextCallback&&) override;
+    Ref<HostingContextPromise> requestHostingContext() override;
     WebCore::HostingContext hostingContext() const override;
     void setLayerHostingContext(WebCore::HostingContext&&);
 
@@ -543,7 +543,6 @@ private:
     RefPtr<RemoteVideoFrameProxy> m_videoFrameGatheredWithVideoFrameMetadata;
 #endif
 
-    Vector<LayerHostingContextCallback> m_layerHostingContextRequests;
     WebCore::HostingContext m_layerHostingContext;
     std::optional<WebCore::VideoFrameMetadata> m_videoFrameMetadata;
     bool m_isGatheringVideoFrameMetadata { false };

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
@@ -489,10 +489,11 @@ void VideoPresentationManager::enterVideoFullscreenForVideoElement(HTMLVideoElem
     if (blockMediaLayerRehosting) {
         hostingContext = videoElement.layerHostingContext();
         if (!hostingContext.contextID) {
-            videoElement.requestHostingContext([protectedThis = Ref { *this }, videoElement = Ref { videoElement }, setupFullscreenHandler = WTF::move(setupFullscreen)] (WebCore::HostingContext hostingContext) {
-                if (!hostingContext.contextID)
+            videoElement.requestHostingContext()->whenSettled(RunLoop::mainSingleton(), [protectedThis = Ref { *this }, videoElement = Ref { videoElement }, setupFullscreenHandler = WTF::move(setupFullscreen)](auto&& result) {
+                if (!result)
                     return;
-                setupFullscreenHandler(hostingContext, FloatSize(videoElement->videoWidth(), videoElement->videoHeight()));
+                ASSERT(result->contextID);
+                setupFullscreenHandler(*result, FloatSize(videoElement->videoWidth(), videoElement->videoHeight()));
             });
             return;
         }


### PR DESCRIPTION
#### 22443b9b5c910d7e3c077d847507b189b61e0688
<pre>
Have requestHostingContext return a NativePromise
<a href="https://bugs.webkit.org/show_bug.cgi?id=319091">https://bugs.webkit.org/show_bug.cgi?id=319091</a>
<a href="https://rdar.apple.com/181900927">rdar://181900927</a>

Reviewed by Youenn Fablet.

Replace the CompletionHandler arguments and have related methods return a NativePromise
instead.
This conversion process exposed several issues:
1- CompletionHandler was never called on error (contextID would have been detected as not changing and code returned early)
2- In the MediaPlayerPrivateMediaStreamAVFObjC should more than one call
be made to requestHostingContext, only the last CompletionHandler would have been resolved.
We fix those.

Covered by existing tests

* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::requestHostingContext):
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/platform/graphics/AudioVideoRenderer.h:
(WebCore::VideoInterface::requestHostingContext):
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::MediaPlayer::requestHostingContext):
* Source/WebCore/platform/graphics/MediaPlayer.h:
* Source/WebCore/platform/graphics/MediaPlayerPrivate.cpp:
(WebCore::MediaPlayerPrivateInterface::requestHostingContext):
* Source/WebCore/platform/graphics/MediaPlayerPrivate.h:
(WebCore::MediaPlayerPrivateInterface::requestHostingContext): Deleted.
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::hostingContext const):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::requestHostingContext):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::~MediaPlayerPrivateMediaStreamAVFObjC):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::layersAreInitialized):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::requestHostingContext):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::requestHostingContext):
* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp:
(WebKit::RemoteAudioVideoRendererProxyManager::requestHostingContext):
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp:
(WebKit::RemoteMediaPlayerProxy::requestHostingContext):
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h:
* Source/WebKit/GPUProcess/media/cocoa/RemoteMediaPlayerProxyCocoa.mm:
(WebKit::RemoteMediaPlayerProxy::requestHostingContext):
* Source/WebKit/Platform/cocoa/LayerHostingContextManager.h:
* Source/WebKit/Platform/cocoa/LayerHostingContextManager.mm:
(WebKit::LayerHostingContextManager::~LayerHostingContextManager):
(WebKit::LayerHostingContextManager::requestHostingContext):
(WebKit::LayerHostingContextManager::createHostingContextIfNeeded):
* Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp:
(WebKit::AudioVideoRendererRemote::requestHostingContext):
(WebKit::AudioVideoRendererRemote::setLayerHostingContext):
* Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h:
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::~MediaPlayerPrivateRemote):
(WebKit::MediaPlayerPrivateRemote::requestHostingContext):
(WebKit::MediaPlayerPrivateRemote::setLayerHostingContext):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h:
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm:
(WebKit::VideoPresentationManager::enterVideoFullscreenForVideoElement):

Canonical link: <a href="https://commits.webkit.org/316960@main">https://commits.webkit.org/316960@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a262f02edf23df98f23bd6855099ff32a9a6af56

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173853 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47786 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41567 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183427 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131721 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6401b03b-38bc-4e5d-a81b-b5c3b8f5c9bf) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175718 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49078 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47468 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135202 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/68142bc7-a08c-424c-bf59-f9027b80f29a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176811 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38635 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155991 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115680 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9ccb96ef-e071-4794-ac05-53c509c0ce98) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37276 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35638 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31911 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147700 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35484 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185853 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38903 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39837 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144097 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47453 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143956 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38835 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48132 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32100 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113444 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38871 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120016 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46638 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10440 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46040 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46271 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46099 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->