### PR TITLE
Correct the realm of nodes

### DIFF
--- a/LayoutTests/fast/images/pagewide-play-pause-offscreen-animations.html
+++ b/LayoutTests/fast/images/pagewide-play-pause-offscreen-animations.html
@@ -89,8 +89,8 @@ async function verifyAnimationsArePaused(expectPaused) {
     svgSvgElement = element;
     testOutput += `Testing #${svgSvgElement.id}.\n`;
 
-    if (!(svgSvgElement.children[0] instanceof SVGRectElement))
-      testOutput += `FAIL: 'children[0]' of ${svgSvgElement.id} should've been an SVGRectElement but wasn't, so this test won't behave as expected.\n`;
+    if (svgSvgElement.children[0].localName !== "rect")
+      testOutput += `FAIL: 'children[0]' of ${svgSvgElement.id} should've been an SVG rect but wasn't, so this test won't behave as expected.\n`;
 
     testOutput += expect(`svgSvgElement.children[0].x.animVal.value ${expectPaused ? "===" : "!=="} 0`, "true");
   }

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/attach-shadow-realm-after-adoption-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/attach-shadow-realm-after-adoption-expected.txt
@@ -1,7 +1,7 @@
 
 
 PASS Precondition (built-in host): node document and relevant realm differ after adoption
-FAIL attachShadow() on an adopted built-in host: shadow root uses the node document realm assert_true: shadow root is from the node document's (top-level) realm expected true got false
+PASS attachShadow() on an adopted built-in host: shadow root uses the node document realm
 PASS Precondition (custom element host): node document and relevant realm differ after adoption
 PASS attachShadow() on an adopted custom element host: shadow root uses the node document realm
 PASS attachShadow() invoked via another realm's method uses the node document realm

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/create-element-realm-after-adoption-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/create-element-realm-after-adoption-expected.txt
@@ -1,8 +1,8 @@
 
 
 PASS Precondition: the host's node document and relevant realm differ after adoption
-FAIL Built-in element: innerHTML creates it in the node document's realm assert_true: <p> is from the node document's (top-level) realm expected true got false
-FAIL Built-in element: the created element's realm is independent of the setter's realm assert_true: <p> is from the node document's (top-level) realm expected true got false
+PASS Built-in element: innerHTML creates it in the node document's realm
+PASS Built-in element: the created element's realm is independent of the setter's realm
 PASS Custom element: innerHTML upgrades it using the node document's registry
 PASS Custom element: the registry used is independent of the setter's realm
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/node-creation-realm-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/node-creation-realm-expected.txt
@@ -12,5 +12,5 @@ PASS DOMImplementation.createHTMLDocument() creates the document and its content
 PASS cloneNode() clones into the node's node document realm
 PASS importNode() imports into the target document's realm
 PASS Range.cloneContents() builds the fragment in the range's node document realm
-FAIL innerHTML parses Text and Comment nodes in the node document's realm after adoption assert_true: is a top-level-realm Text expected true got false
+PASS innerHTML parses Text and Comment nodes in the node document's realm after adoption
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/node-realm-adoption-after-frame-removal-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/node-realm-adoption-after-frame-removal-expected.txt
@@ -1,0 +1,11 @@
+x
+
+x
+
+x
+
+
+PASS Never-wrapped node keeps its creation realm: subtree detached, iframe removed, then adopted
+PASS Never-wrapped node keeps its creation realm: iframe removed before adoption (subtree not pre-detached)
+PASS Node reached through the adopting document still reports its creation realm (frame removed before adoption)
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/node-realm-adoption-after-frame-removal.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/node-realm-adoption-after-frame-removal.html
@@ -1,0 +1,88 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>A node's creation realm is preserved when its creating frame is removed before adoption</title>
+<link rel=help href="https://dom.spec.whatwg.org/#concept-create-node">
+<link rel=help href="https://dom.spec.whatwg.org/#concept-node-adopt">
+<link rel=help href="https://github.com/whatwg/dom/issues/977">
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<body>
+<script>
+// The <p>/<b> nodes are built by the HTML parser and never touched from script
+// before the frame is removed, so no JS object is ever created for them in the
+// inner realm. This checks that the creation realm is recorded on the node when
+// it is created, rather than derived on demand from a pre-existing JS object: by
+// adoption time the inner realm is gone and can no longer be consulted.
+// Interface objects are captured before removal since a detached window can no
+// longer be queried. Each test asserts on both a direct child and a deep
+// descendant so the realm is checked throughout the parsed subtree.
+
+function freshIframe() {
+  const iframe = document.createElement("iframe");
+  document.body.appendChild(iframe);
+  return iframe;
+}
+
+test(() => {
+  const iframe = freshIframe();
+  const inner = iframe.contentWindow;
+  const InnerParagraph = inner.HTMLParagraphElement;
+  const InnerBold = inner.HTMLElement;
+
+  const container = inner.document.createElement("div");
+  container.innerHTML = "<p><b>x</b></p>";
+  inner.document.body.appendChild(container);
+  container.remove();
+  iframe.remove();
+
+  document.body.appendChild(container);
+  const p = container.querySelector("p");
+  const b = container.querySelector("b");
+  assert_equals(p.ownerDocument, document, "adopted into the top-level document");
+  assert_true(p instanceof InnerParagraph, "keeps its creation realm");
+  assert_true(b instanceof InnerBold, "deep descendant keeps its creation realm");
+}, "Never-wrapped node keeps its creation realm: subtree detached, iframe removed, then adopted");
+
+test(() => {
+  const iframe = freshIframe();
+  const inner = iframe.contentWindow;
+  const InnerParagraph = inner.HTMLParagraphElement;
+  const InnerBold = inner.HTMLElement;
+
+  const container = inner.document.createElement("div");
+  container.innerHTML = "<p><b>x</b></p>";
+  inner.document.body.appendChild(container);
+  iframe.remove(); // removed without first detaching the subtree
+
+  document.body.appendChild(container);
+  const p = container.querySelector("p");
+  const b = container.querySelector("b");
+  assert_equals(p.ownerDocument, document, "adopted into the top-level document");
+  assert_true(p instanceof InnerParagraph, "keeps its creation realm");
+  assert_true(b instanceof InnerBold, "deep descendant keeps its creation realm");
+}, "Never-wrapped node keeps its creation realm: iframe removed before adoption (subtree not pre-detached)");
+
+// The tests above reach the adopted nodes through `container`, whose JS object is
+// in the creation realm. The test below reaches them through the adopting
+// document instead, so the realm must be preserved independently of the access
+// path.
+
+test(() => {
+  const iframe = freshIframe();
+  const inner = iframe.contentWindow;
+  const InnerParagraph = inner.HTMLParagraphElement;
+  const InnerBold = inner.HTMLElement;
+
+  const container = inner.document.createElement("div");
+  container.innerHTML = "<p id=frame-removal-node><b id=frame-removal-node-deep>x</b></p>";
+  inner.document.body.appendChild(container);
+  iframe.remove();
+
+  document.body.appendChild(container);
+  const p = document.getElementById("frame-removal-node"); // reached through the top-level document
+  const b = document.getElementById("frame-removal-node-deep");
+  assert_equals(p.ownerDocument, document, "adopted into the top-level document");
+  assert_true(p instanceof InnerParagraph, "keeps its creation realm regardless of access path");
+  assert_true(b instanceof InnerBold, "deep descendant keeps its creation realm regardless of access path");
+}, "Node reached through the adopting document still reports its creation realm (frame removed before adoption)");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/node-realm-mixed-across-adoption-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/node-realm-mixed-across-adoption-expected.txt
@@ -1,0 +1,7 @@
+
+
+PASS Element parsed into an adopted container takes the node-document realm, not the container's creation realm
+PASS Text parsed into an adopted container takes the node-document realm, not the container's creation realm
+PASS Never-wrapped node keeps its creation realm across multiple adoptions
+PASS Custom element parsed into an adopted container uses the node-document realm and registry
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/node-realm-mixed-across-adoption.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/node-realm-mixed-across-adoption.html
@@ -1,0 +1,66 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>A node's realm across adoption when creation realm, node document, and adopting realm all differ</title>
+<link rel=help href="https://dom.spec.whatwg.org/#concept-create-node">
+<link rel=help href="https://dom.spec.whatwg.org/#concept-node-adopt">
+<link rel=help href="https://github.com/whatwg/dom/issues/977">
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<body>
+<iframe id=a></iframe>
+<iframe id=b></iframe>
+<script>
+// A node is created in its node document's realm, not the realm of its ancestors
+// or the realm it is later adopted into. In particular an element parsed into a
+// container created in a different realm takes the container's node-document
+// realm, not the container's creation realm.
+
+const innerA = document.getElementById("a").contentWindow;
+const innerB = document.getElementById("b").contentWindow;
+
+test(() => {
+  const container = innerA.document.createElement("div");
+  document.body.appendChild(container);
+  assert_true(container instanceof innerA.HTMLDivElement, "precondition: container keeps realm A after adoption");
+
+  container.innerHTML = "<p></p>"; // <p>'s node document is the top-level document
+  innerB.document.body.appendChild(container); // move to realm B without wrapping <p>
+
+  const p = container.querySelector("p");
+  assert_equals(p.ownerDocument, innerB.document, "moved into realm B's document");
+  assert_true(p instanceof window.HTMLParagraphElement, "realm is the top-level document it was parsed into");
+}, "Element parsed into an adopted container takes the node-document realm, not the container's creation realm");
+
+test(() => {
+  const container = innerA.document.createElement("div");
+  document.body.appendChild(container);
+  container.innerHTML = "text";
+  innerB.document.body.appendChild(container);
+  const text = container.firstChild;
+  assert_true(text instanceof window.Text, "realm is the top-level document it was parsed into");
+}, "Text parsed into an adopted container takes the node-document realm, not the container's creation realm");
+
+test(() => {
+  const container = innerA.document.createElement("div");
+  innerA.document.body.appendChild(container);
+  container.innerHTML = "<p></p>"; // <p>'s node document is realm A's document
+  innerB.document.body.appendChild(container); // hop through B
+  document.body.appendChild(container); // then to the top-level document
+  const p = container.querySelector("p");
+  assert_equals(p.ownerDocument, document, "ended up in the top-level document");
+  assert_true(p instanceof innerA.HTMLParagraphElement, "keeps its creation realm A across multiple adoptions");
+}, "Never-wrapped node keeps its creation realm across multiple adoptions");
+
+test(() => {
+  innerA.customElements.define("x-mixed", class extends innerA.HTMLElement {});
+  window.customElements.define("x-mixed", class extends HTMLElement {});
+
+  const container = innerA.document.createElement("div");
+  document.body.appendChild(container);
+  container.innerHTML = "<x-mixed></x-mixed>"; // upgraded with the top-level registry
+  innerB.document.body.appendChild(container);
+
+  const el = container.querySelector("x-mixed");
+  assert_true(el instanceof window.customElements.get("x-mixed"), "uses the node-document (top-level) realm and registry");
+}, "Custom element parsed into an adopted container uses the node-document realm and registry");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/node-realm-preserved-across-frameless-adoption-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/node-realm-preserved-across-frameless-adoption-expected.txt
@@ -1,0 +1,9 @@
+
+text
+x
+
+PASS Built-in element from a frameless document keeps its creation realm after adoption
+PASS Text node from a frameless document keeps its creation realm after adoption
+PASS Comment node from a frameless document keeps its creation realm after adoption
+PASS Never-wrapped descendant from a frameless document keeps its creation realm after adoption
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/node-realm-preserved-across-frameless-adoption.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/node-realm-preserved-across-frameless-adoption.html
@@ -1,0 +1,71 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>A node created in a frameless document keeps its creation realm across adoption</title>
+<link rel=help href="https://dom.spec.whatwg.org/#concept-create-node">
+<link rel=help href="https://dom.spec.whatwg.org/#concept-node-adopt">
+<link rel=help href="https://github.com/whatwg/dom/issues/977">
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<body>
+<iframe></iframe>
+<script>
+// A document created via DOMImplementation.createHTMLDocument() (or DOMParser)
+// has no browsing context; its realm is that of the document that created it.
+// A node created in such a frameless document must keep that creation realm when
+// adopted into a document belonging to a different realm.
+//
+// Here the frameless document is created by the inner (iframe) realm. Each subtree
+// is built with innerHTML and only inspected after adoption, so no wrapper exists
+// until then; the correct realm is the inner one, not the top-level one.
+
+const inner = document.querySelector("iframe").contentWindow;
+
+function assertInnerRealm(node, iface) {
+  assert_true(node instanceof inner[iface], `is an inner-realm ${iface}`);
+}
+
+// The frameless document belongs to the inner realm (createHTMLDocument() was
+// called on the inner realm's DOMImplementation), so its context document is
+// the inner document.
+function innerFramelessDocument() {
+  return inner.document.implementation.createHTMLDocument("");
+}
+
+test(() => {
+  const container = innerFramelessDocument().createElement("div");
+  container.innerHTML = "<p></p>"; // <p> created in the frameless document, not wrapped
+  document.body.appendChild(container); // adopts container and <p> to top-level
+  const p = container.querySelector("p"); // first access, after adoption
+  assert_equals(p.ownerDocument, document, "p was adopted into the top-level document");
+  assertInnerRealm(p, "HTMLParagraphElement");
+}, "Built-in element from a frameless document keeps its creation realm after adoption");
+
+test(() => {
+  const container = innerFramelessDocument().createElement("div");
+  container.innerHTML = "text"; // Text created in the frameless document, not wrapped
+  document.body.appendChild(container);
+  const text = container.firstChild;
+  assert_equals(text.ownerDocument, document, "text was adopted into the top-level document");
+  assertInnerRealm(text, "Text");
+}, "Text node from a frameless document keeps its creation realm after adoption");
+
+test(() => {
+  const container = innerFramelessDocument().createElement("div");
+  container.innerHTML = "<!--comment-->"; // Comment created in the frameless document, not wrapped
+  document.body.appendChild(container);
+  const comment = container.firstChild;
+  assert_equals(comment.ownerDocument, document, "comment was adopted into the top-level document");
+  assertInnerRealm(comment, "Comment");
+}, "Comment node from a frameless document keeps its creation realm after adoption");
+
+// A deeper tree: a never-wrapped descendant of a frameless-document subtree must
+// still report the inner realm once adopted.
+test(() => {
+  const container = innerFramelessDocument().createElement("div");
+  container.innerHTML = "<section><b>x</b></section>";
+  document.body.appendChild(container);
+  const b = container.querySelector("b");
+  assert_equals(b.ownerDocument, document, "descendant was adopted into the top-level document");
+  assertInnerRealm(b, "HTMLElement");
+}, "Never-wrapped descendant from a frameless document keeps its creation realm after adoption");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/w3c-import.log
@@ -272,7 +272,10 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/dom/nodes/name-validation.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/nodes/node-appendchild-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/nodes/node-creation-realm.html
+/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/node-realm-adoption-after-frame-removal.html
+/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/node-realm-mixed-across-adoption.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/nodes/node-realm-preserved-across-adoption.html
+/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/node-realm-preserved-across-frameless-adoption.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/nodes/pre-insertion-validation-hierarchy.js
 /LayoutTests/imported/w3c/web-platform-tests/dom/nodes/pre-insertion-validation-notfound.js
 /LayoutTests/imported/w3c/web-platform-tests/dom/nodes/prepend-on-Document.html

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/traversal/TreeWalker-realm-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/traversal/TreeWalker-realm-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Node returned by TreeWalker from different realm assert_true: expected true got false
-FAIL Node returned by TreeWalker from different realm with acceptNode assert_true: expected true got false
+PASS Node returned by TreeWalker from different realm
+PASS Node returned by TreeWalker from different realm with acceptNode
 

--- a/Source/WebCore/bindings/js/JSDOMWindowBase.cpp
+++ b/Source/WebCore/bindings/js/JSDOMWindowBase.cpp
@@ -43,6 +43,7 @@
 #include "JSFetchResponse.h"
 #include "JSNode.h"
 #include "JSTrustedScript.h"
+#include "LocalDOMWindow.h"
 #include "LocalFrame.h"
 #include "Logging.h"
 #include "Microtasks.h"
@@ -153,6 +154,11 @@ void JSDOMWindowBase::finishCreation(VM& vm, JSWindowProxy* proxy)
 
     if ((m_wrapped->frame() && m_wrapped->frame()->settings().showModalDialogEnabled()) || (m_wrapped->documentIfLocal() && protect(m_wrapped->documentIfLocal())->quirks().shouldExposeShowModalDialog()))
         putDirectCustomAccessor(vm, builtinNames(vm).showModalDialogPublicName(), CustomGetterSetter::create(vm, showModalDialogGetter, nullptr), std::to_underlying(PropertyAttribute::CustomValue));
+
+    if (worldIsNormal()) {
+        if (auto* window = dynamicDowncast<LocalDOMWindow>(m_wrapped.get()))
+            window->setCachedMainWorldGlobalObject(this);
+    }
 }
 
 void JSDOMWindowBase::destroy(JSCell* cell)

--- a/Source/WebCore/bindings/js/JSElementCustom.cpp
+++ b/Source/WebCore/bindings/js/JSElementCustom.cpp
@@ -40,6 +40,7 @@
 #include "JSDOMConvertSequences.h"
 #include "JSHTMLElementWrapperFactory.h"
 #include "JSMathMLElementWrapperFactory.h"
+#include "JSNodeCustom.h"
 #include "JSNodeList.h"
 #include "JSSVGElementWrapperFactory.h"
 #include "MathMLElement.h"
@@ -71,7 +72,7 @@ JSValue toJS(JSGlobalObject*, JSDOMGlobalObject* globalObject, Element& element)
 {
     if (auto* wrapper = getCachedWrapper(globalObject->world(), element))
         return wrapper;
-    return createNewElementWrapper(globalObject, element);
+    return createNewElementWrapper(globalObjectForNode(element, globalObject), element);
 }
 
 JSValue toJSNewlyCreated(JSGlobalObject*, JSDOMGlobalObject* globalObject, Ref<Element>&& element)
@@ -83,7 +84,7 @@ JSValue toJSNewlyCreated(JSGlobalObject*, JSDOMGlobalObject* globalObject, Ref<E
         ASSERT(!globalObject->vm().exceptionForInspection());
     }
     ASSERT(!getCachedWrapper(globalObject->world(), element));
-    return createNewElementWrapper(globalObject, WTF::move(element));
+    return createNewElementWrapper(globalObjectForNode(element, globalObject), WTF::move(element));
 }
 
 static JSValue getElementsArrayAttribute(JSGlobalObject& lexicalGlobalObject, const JSElement& thisObject, const QualifiedName& attributeName)

--- a/Source/WebCore/bindings/js/JSHTMLElementCustom.cpp
+++ b/Source/WebCore/bindings/js/JSHTMLElementCustom.cpp
@@ -149,7 +149,7 @@ JSValue toJS(JSGlobalObject*, JSDOMGlobalObject* globalObject, HTMLElement& elem
 {
     if (auto* wrapper = getCachedWrapper(globalObject->world(), element))
         return wrapper;
-    return createJSHTMLWrapper(globalObject, element);
+    return createJSHTMLWrapper(globalObjectForNode(element, globalObject), element);
 }
 
 JSValue toJSNewlyCreated(JSGlobalObject*, JSDOMGlobalObject* globalObject, Ref<HTMLElement>&& element)
@@ -161,7 +161,7 @@ JSValue toJSNewlyCreated(JSGlobalObject*, JSDOMGlobalObject* globalObject, Ref<H
         ASSERT(!globalObject->vm().exceptionForInspection());
     }
     ASSERT(!getCachedWrapper(globalObject->world(), element));
-    return createJSHTMLWrapper(globalObject, WTF::move(element));
+    return createJSHTMLWrapper(globalObjectForNode(element, globalObject), WTF::move(element));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSNodeCustom.cpp
+++ b/Source/WebCore/bindings/js/JSNodeCustom.cpp
@@ -52,6 +52,7 @@
 #include "JSSVGElementWrapperFactory.h"
 #include "JSShadowRoot.h"
 #include "JSText.h"
+#include "LocalDOMWindow.h"
 #include "MathMLElement.h"
 #include "Node.h"
 #include "ProcessingInstruction.h"
@@ -92,11 +93,23 @@ void JSNode::visitAdditionalChildrenInGCThread(Visitor& visitor)
 
 DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSNode);
 
-static ALWAYS_INLINE JSValue createWrapperInline(JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, Ref<Node>&& node)
+JSDOMGlobalObject* globalObjectForNode(Node& node, JSDOMGlobalObject* globalObject)
+{
+    // window is owned by node's document, which outlives this call.
+    SUPPRESS_UNCOUNTED_LOCAL auto* window = globalObject->worldIsNormal() ? node.document().window() : nullptr;
+    if (window && window->cachedMainWorldGlobalObject() == globalObject) [[likely]]
+        return globalObject;
+
+    if (auto* documentGlobalObject = toJSDOMGlobalObject(node.document(), globalObject->world()))
+        return documentGlobalObject;
+    return globalObject;
+}
+
+static ALWAYS_INLINE JSValue createWrapperForGlobalObject(JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, Ref<Node>&& node)
 {
     ASSERT(!getCachedWrapper(globalObject->world(), node));
-    
-    JSDOMObject* wrapper;    
+
+    JSDOMObject* wrapper;
     switch (node->nodeType()) {
     case NodeType::Element:
         if (is<HTMLElement>(node))
@@ -144,6 +157,11 @@ static ALWAYS_INLINE JSValue createWrapperInline(JSGlobalObject* lexicalGlobalOb
     return wrapper;
 }
 
+static ALWAYS_INLINE JSValue createWrapperInline(JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, Ref<Node>&& node)
+{
+    return createWrapperForGlobalObject(lexicalGlobalObject, globalObjectForNode(node, globalObject), WTF::move(node));
+}
+
 JSValue createWrapper(JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, Ref<Node>&& node)
 {
     return createWrapperInline(lexicalGlobalObject, globalObject, WTF::move(node));
@@ -160,16 +178,24 @@ JSC::JSObject* getOutOfLineCachedWrapper(JSDOMGlobalObject* globalObject, Node& 
     return globalObject->world().wrappers().get(&node);
 }
 
-void willCreatePossiblyOrphanedTreeByRemovalSlowCase(Node& root)
+void createNodeWrapperInDocumentRealmSlowCase(Node& node, Document& document)
 {
-    RefPtr frame = root.document().frame();
-    if (!frame)
+    ASSERT(!node.wrapper());
+
+    // FIXME: This only preserves the realm for the main world.
+    auto* globalObject = [&] -> JSDOMGlobalObject* {
+        Ref contextDocument = document.contextDocument();
+        if (RefPtr frame = contextDocument->frame())
+            return &mainWorldGlobalObject(*frame);
+        if (RefPtr window = contextDocument->window())
+            return window->cachedMainWorldGlobalObject();
+        return nullptr;
+    }();
+    if (!globalObject)
         return;
 
-    auto& globalObject = mainWorldGlobalObject(*frame);
-    JSLockHolder lock(&globalObject);
-    ASSERT(!root.wrapper());
-    createWrapper(&globalObject, &globalObject, root);
+    JSLockHolder lock(globalObject);
+    createWrapperForGlobalObject(globalObject, globalObject, node);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSNodeCustom.h
+++ b/Source/WebCore/bindings/js/JSNodeCustom.h
@@ -54,6 +54,8 @@ namespace WebCore {
 WEBCORE_EXPORT JSC::JSValue createWrapper(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<Node>&&);
 WEBCORE_EXPORT JSC::JSObject* getOutOfLineCachedWrapper(JSDOMGlobalObject*, Node&);
 
+WEBCORE_EXPORT JSDOMGlobalObject* globalObjectForNode(Node&, JSDOMGlobalObject*);
+
 inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, Node& node)
 {
     if (globalObject->worldIsNormal()) [[likely]] {
@@ -71,11 +73,25 @@ inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalOb
 // root. In the JavaScript DOM, a node tree survives as long as there is a
 // reference to any node in the tree. To model the JavaScript DOM on top of
 // the C++ DOM, we ensure that the root of every tree has a JavaScript wrapper.
-void willCreatePossiblyOrphanedTreeByRemovalSlowCase(Node& root);
+//
+// The wrapper is created in the given document's realm, bypassing the usual
+// globalObjectForNode() remap: the caller has already determined the correct
+// document (e.g., the node's tree scope may have moved on during adoption).
+void createNodeWrapperInDocumentRealmSlowCase(Node&, Document&);
+
 inline void willCreatePossiblyOrphanedTreeByRemoval(Node& root)
 {
     if (!root.wrapper() && root.hasChildNodes())
-        willCreatePossiblyOrphanedTreeByRemovalSlowCase(root);
+        createNodeWrapperInDocumentRealmSlowCase(root, protect(root.document()));
+}
+
+inline void ensureWrapperForAdoptedNodeWithForeignGlobalObjectIfNeeded(Node& node, Document& oldDocument, Document& newDocument)
+{
+    if (node.wrapper())
+        return;
+    if (&oldDocument.contextDocument() == &newDocument.contextDocument())
+        return;
+    createNodeWrapperInDocumentRealmSlowCase(node, oldDocument);
 }
 
 inline WebCoreOpaqueRoot root(Node&);

--- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -5765,6 +5765,10 @@ END
 #endif
 END
         AddToImplIncludes("JSDOMWrapperCache.h");
+        if ($codeGenerator->InheritsInterface($interface, "Node")) {
+            AddToImplIncludes("JSNodeCustom.h");
+            push(@implContent, "    globalObject = globalObjectForNode(impl.get(), globalObject);\n");
+        }
         push(@implContent, "    return createWrapper<${implType}>(globalObject, WTF::move(impl));\n");
         push(@implContent, "}\n\n");
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDOMJIT.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDOMJIT.cpp
@@ -45,6 +45,7 @@
 #include "JSDOMOperation.h"
 #include "JSDOMWrapperCache.h"
 #include "JSElement.h"
+#include "JSNodeCustom.h"
 #include "JSNodeList.h"
 #include "ScriptExecutionContext.h"
 #include "WebCoreJSClientData.h"
@@ -1315,6 +1316,7 @@ JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlo
 #if ENABLE(BINDING_INTEGRITY)
     verifyVTable<TestDOMJIT>(impl.ptr());
 #endif
+    globalObject = globalObjectForNode(impl.get(), globalObject);
     return createWrapper<TestDOMJIT>(globalObject, WTF::move(impl));
 }
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNode.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNode.cpp
@@ -45,6 +45,7 @@
 #include "JSDOMOperation.h"
 #include "JSDOMOperationReturningPromise.h"
 #include "JSDOMWrapperCache.h"
+#include "JSNodeCustom.h"
 #include "JSTestNode.h"
 #include "ScriptExecutionContext.h"
 #include "WebCoreJSClientData.h"
@@ -556,6 +557,7 @@ JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlo
 #if ENABLE(BINDING_INTEGRITY)
     verifyVTable<TestNode>(impl.ptr());
 #endif
+    globalObject = globalObjectForNode(impl.get(), globalObject);
     return createWrapper<TestNode>(globalObject, WTF::move(impl));
 }
 

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -56,6 +56,7 @@
 #include "HTMLStyleElement.h"
 #include "InputEvent.h"
 #include "InspectorInstrumentation.h"
+#include "JSNodeCustom.h"
 #include "KeyboardEvent.h"
 #include "LiveNodeListInlines.h"
 #include "LocalDOMWindow.h"
@@ -2302,6 +2303,8 @@ void Node::moveNodeToNewDocumentFastCase(Document& oldDocument, Document& newDoc
     ASSERT(!transientMutationObserverRegistry());
     ASSERT(!oldDocument.numberOfIntersectionObservers());
 
+    ensureWrapperForAdoptedNodeWithForeignGlobalObjectIfNeeded(*this, oldDocument, newDocument);
+
     if (usesNullCustomElementRegistry() && !newDocument.usesNullCustomElementRegistry()) [[unlikely]]
         clearUsesNullCustomElementRegistry();
 
@@ -2318,6 +2321,8 @@ void Node::moveNodeToNewDocumentFastCase(Document& oldDocument, Document& newDoc
 
 void Node::moveNodeToNewDocumentSlowCase(Document& oldDocument, Document& newDocument)
 {
+    ensureWrapperForAdoptedNodeWithForeignGlobalObjectIfNeeded(*this, oldDocument, newDocument);
+
     newDocument.incrementReferencingNodeCount();
     oldDocument.decrementReferencingNodeCount();
 

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -587,6 +587,16 @@ void LocalDOMWindow::willDetachDocumentFromFrame()
     InspectorInstrumentation::frameWindowDiscarded(*protect(frame()), this);
 }
 
+JSDOMGlobalObject* LocalDOMWindow::cachedMainWorldGlobalObject() const
+{
+    return m_cachedMainWorldGlobalObject.get();
+}
+
+void LocalDOMWindow::setCachedMainWorldGlobalObject(JSDOMGlobalObject* globalObject)
+{
+    m_cachedMainWorldGlobalObject = JSC::Weak<JSDOMGlobalObject> { globalObject };
+}
+
 #if ENABLE(GAMEPAD)
 
 void LocalDOMWindow::incrementGamepadEventListenerCount()

--- a/Source/WebCore/page/LocalDOMWindow.h
+++ b/Source/WebCore/page/LocalDOMWindow.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <JavaScriptCore/HandleForward.h>
+#include <JavaScriptCore/Weak.h>
 #include <WebCore/ContextDestructionObserver.h>
 #include <WebCore/DOMHighResTimeStamp.h>
 #include <WebCore/DOMWindow.h>
@@ -55,6 +56,7 @@ template <typename, ShouldStrongDestructorGrabLock> class Strong;
 namespace WebCore {
 
 class CloseWatcherManager;
+class JSDOMGlobalObject;
 class SecurityOriginData;
 struct ScrollToOptions;
 struct UserGestureTokenData;
@@ -362,6 +364,9 @@ public:
     void willDetachDocumentFromFrame();
     void willDestroyCachedFrame();
 
+    JSDOMGlobalObject* cachedMainWorldGlobalObject() const;
+    void setCachedMainWorldGlobalObject(JSDOMGlobalObject*);
+
     void enableSuddenTermination();
     void disableSuddenTermination();
 
@@ -522,6 +527,8 @@ private:
 #if ENABLE(DECLARATIVE_WEB_PUSH)
     const std::unique_ptr<PushManager> m_pushManager;
 #endif
+
+    JSC::Weak<JSDOMGlobalObject> m_cachedMainWorldGlobalObject;
 };
 
 inline String LocalDOMWindow::status() const


### PR DESCRIPTION
#### df39c2cbd60522face8fdae91375f045709ea923
<pre>
Correct the realm of nodes
<a href="https://bugs.webkit.org/show_bug.cgi?id=319097">https://bugs.webkit.org/show_bug.cgi?id=319097</a>

Reviewed by Ryosuke Niwa.

Align WebKit with the model proposed over at:

   <a href="https://github.com/whatwg/dom/issues/977">https://github.com/whatwg/dom/issues/977</a>

fast/images/pagewide-play-pause-offscreen-animations.html is changed
slightly so the element checks are realm-agnostic.

Tests: imported/w3c/web-platform-tests/dom/nodes/node-realm-adoption-after-frame-removal.html
       imported/w3c/web-platform-tests/dom/nodes/node-realm-mixed-across-adoption.html
       imported/w3c/web-platform-tests/dom/nodes/node-realm-preserved-across-frameless-adoption.html

Upstream: <a href="https://github.com/web-platform-tests/wpt/pull/61212">https://github.com/web-platform-tests/wpt/pull/61212</a>
Canonical link: <a href="https://commits.webkit.org/317457@main">https://commits.webkit.org/317457@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f58887102c45ddd45bb0d3874b77cc5f83b1864

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175205 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49137 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42918 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184790 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/133247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177069 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50429 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48820 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136379 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/133247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178162 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39800 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157155 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116858 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38441 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36828 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33263 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148864 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36648 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187211 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/40824 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41031 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145325 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48804 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156711 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145182 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39141 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49484 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33269 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115352 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40024 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121670 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47990 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11621 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47393 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47623 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47450 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->