### PR TITLE
[GTK][WPE][Skia] Render the compositor output into a renderbuffer instead of a texture

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp
@@ -30,6 +30,7 @@
 #include "WebPage.h"
 #include "WebProcess.h"
 #include <WebCore/BitmapTexture.h>
+#include <WebCore/FontRenderOptions.h>
 #include <WebCore/GLContext.h>
 #include <WebCore/GLFence.h>
 #include <WebCore/Page.h>
@@ -46,6 +47,7 @@
 
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkCanvas.h>
+#include <skia/core/SkColorSpace.h>
 #include <skia/gpu/ganesh/GrBackendSurface.h>
 #include <skia/gpu/ganesh/SkSurfaceGanesh.h>
 #include <skia/gpu/ganesh/gl/GrGLBackendSurface.h>
@@ -139,9 +141,10 @@ static uint64_t generateTargetID()
     return ++identifier;
 }
 
-AcceleratedSurface::RenderTarget::RenderTarget(AcceleratedSurface& surface)
+AcceleratedSurface::RenderTarget::RenderTarget(AcceleratedSurface& surface, const IntSize& size)
     : m_id(generateTargetID())
     , m_surface(surface)
+    , m_size(size)
 {
 }
 
@@ -160,22 +163,35 @@ void AcceleratedSurface::RenderTarget::addDamage(const std::optional<Damage>& da
 }
 #endif
 
-void AcceleratedSurface::RenderTarget::createSkiaSurfaceForTexture(const BitmapTexture& texture)
+void AcceleratedSurface::RenderTarget::createSkiaSurfaceForFramebuffer(unsigned fbo)
 {
+    if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
+        LOG_ERROR("AcceleratedSurface was unable to construct a complete framebuffer for the Skia render target");
+        return;
+    }
+
+    GLint stencilBits;
+    glGetIntegerv(GL_STENCIL_BITS, &stencilBits);
+
     auto& display = PlatformDisplay::sharedDisplay();
     GLContext::ScopedGLContextCurrent scopedCurrent(*display.skiaGLContext());
+
+    GrGLFramebufferInfo framebufferInfo;
+    framebufferInfo.fFBOID = fbo;
+    framebufferInfo.fFormat = GL_RGBA8;
+    auto backendRenderTarget = GrBackendRenderTargets::MakeGL(m_size.width(), m_size.height(), 0, stencilBits, framebufferInfo);
     auto origin = m_surface->shouldPaintMirrored() ? kBottomLeft_GrSurfaceOrigin : kTopLeft_GrSurfaceOrigin;
-    m_skiaSurface = texture.createSkiaSurface(display.skiaGrContext(), origin);
+    auto properties = FontRenderOptions::singleton().createSurfaceProps();
+    m_skiaSurface = SkSurfaces::WrapBackendRenderTarget(display.skiaGrContext(), backendRenderTarget, origin, kRGBA_8888_SkColorType, SkColorSpace::MakeSRGB(), &properties);
 }
 
 #if PLATFORM(GTK) || ENABLE(WPE_PLATFORM)
 WTF_MAKE_TZONE_ALLOCATED_IMPL(AcceleratedSurface::RenderTargetShareableBuffer);
 
 AcceleratedSurface::RenderTargetShareableBuffer::RenderTargetShareableBuffer(AcceleratedSurface& surface, const IntSize& size)
-    : RenderTarget(surface)
-    , m_initialSize(size)
+    : RenderTarget(surface, size)
 {
-    if (m_surface->useSkia())
+    if (!m_surface->usesGL())
         return;
 
     glGenFramebuffers(1, &m_fbo);
@@ -191,15 +207,32 @@ AcceleratedSurface::RenderTargetShareableBuffer::RenderTargetShareableBuffer(Acc
 
 AcceleratedSurface::RenderTargetShareableBuffer::~RenderTargetShareableBuffer()
 {
-    if (!m_surface->useSkia()) {
-        if (m_fbo)
-            glDeleteFramebuffers(1, &m_fbo);
+    m_skiaSurface = nullptr;
 
-        if (m_depthStencilBuffer)
-            glDeleteRenderbuffers(1, &m_depthStencilBuffer);
-    }
+    if (m_fbo)
+        glDeleteFramebuffers(1, &m_fbo);
+
+    if (m_depthStencilBuffer)
+        glDeleteRenderbuffers(1, &m_depthStencilBuffer);
+
+    if (m_colorBuffer)
+        glDeleteRenderbuffers(1, &m_colorBuffer);
 
     WebProcess::singleton().parentProcessConnection()->send(Messages::AcceleratedBackingStore::DidDestroyBuffer(m_id), m_surface->surfaceID());
+}
+
+void AcceleratedSurface::RenderTargetShareableBuffer::initializeColorBuffer(EGLImage image)
+{
+    glGenRenderbuffers(1, &m_colorBuffer);
+    glBindRenderbuffer(GL_RENDERBUFFER, m_colorBuffer);
+    if (image)
+        glEGLImageTargetRenderbufferStorageOES(GL_RENDERBUFFER, image);
+    else
+        glRenderbufferStorage(GL_RENDERBUFFER, GL_RGBA8, m_size.width(), m_size.height());
+    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, m_colorBuffer);
+
+    if (m_surface->useSkia())
+        createSkiaSurfaceForFramebuffer(m_fbo);
 }
 
 void AcceleratedSurface::RenderTargetShareableBuffer::sendFrame(Vector<WebCore::IntRect, 1>&& damageRects)
@@ -304,11 +337,7 @@ AcceleratedSurface::RenderTargetEGLImage::RenderTargetEGLImage(AcceleratedSurfac
     : RenderTargetShareableBuffer(surface, size)
     , m_image(image)
 {
-    if (m_surface->useSkia()) {
-        m_texture = BitmapTexture::create(m_image, size);
-        createSkiaSurfaceForTexture(*m_texture);
-    } else
-        initializeColorBuffer();
+    initializeColorBuffer(m_image);
     WebProcess::singleton().parentProcessConnection()->send(Messages::AcceleratedBackingStore::DidCreateDMABufBuffer(m_id, WTF::move(dmaBufAttributes), usage), m_surface->surfaceID());
 }
 #endif // USE(GBM)
@@ -377,32 +406,14 @@ AcceleratedSurface::RenderTargetEGLImage::RenderTargetEGLImage(AcceleratedSurfac
     : RenderTargetShareableBuffer(surface, size)
     , m_image(image)
 {
-    if (m_surface->useSkia()) {
-        m_texture = BitmapTexture::create(m_image, size);
-        createSkiaSurfaceForTexture(*m_texture);
-    } else
-        initializeColorBuffer();
+    initializeColorBuffer(m_image);
     WebProcess::singleton().parentProcessConnection()->send(Messages::AcceleratedBackingStore::DidCreateAndroidBuffer(m_id, WTF::move(hardwareBuffer)), m_surface->surfaceID());
 }
 #endif // OS(ANDROID)
 
 #if USE(GBM) || OS(ANDROID)
-void AcceleratedSurface::RenderTargetEGLImage::initializeColorBuffer()
-{
-    ASSERT(!m_surface->useSkia());
-    glGenRenderbuffers(1, &m_colorBuffer);
-    glBindRenderbuffer(GL_RENDERBUFFER, m_colorBuffer);
-    glEGLImageTargetRenderbufferStorageOES(GL_RENDERBUFFER, m_image);
-    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, m_colorBuffer);
-}
-
 AcceleratedSurface::RenderTargetEGLImage::~RenderTargetEGLImage()
 {
-    if (!m_surface->useSkia()) {
-        if (m_colorBuffer)
-            glDeleteRenderbuffers(1, &m_colorBuffer);
-    }
-
     if (m_image)
         PlatformDisplay::sharedDisplay().destroyEGLImage(m_image);
 }
@@ -429,29 +440,15 @@ AcceleratedSurface::RenderTargetSHMImage::RenderTargetSHMImage(AcceleratedSurfac
     : RenderTargetShareableBuffer(surface, size)
     , m_bitmap(WTF::move(bitmap))
 {
-    if (m_surface->useSkia()) {
-        if (m_surface->usesGL()) {
-            m_texture = BitmapTexture::create(size);
-            createSkiaSurfaceForTexture(*m_texture);
-        } else
-            m_skiaSurface = m_bitmap->createSurface();
-    } else {
-        glGenRenderbuffers(1, &m_colorBuffer);
-        glBindRenderbuffer(GL_RENDERBUFFER, m_colorBuffer);
-        glRenderbufferStorage(GL_RENDERBUFFER, GL_RGBA8, size.width(), size.height());
-        glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, m_colorBuffer);
-    }
+    if (m_surface->usesGL())
+        initializeColorBuffer();
+    else if (m_surface->useSkia())
+        m_skiaSurface = m_bitmap->createSurface();
 
     WebProcess::singleton().parentProcessConnection()->send(Messages::AcceleratedBackingStore::DidCreateSHMBuffer(m_id, WTF::move(bitmapHandle)), m_surface->surfaceID());
 }
 
-AcceleratedSurface::RenderTargetSHMImage::~RenderTargetSHMImage()
-{
-    if (!m_surface->useSkia()) {
-        if (m_colorBuffer)
-            glDeleteRenderbuffers(1, &m_colorBuffer);
-    }
-}
+AcceleratedSurface::RenderTargetSHMImage::~RenderTargetSHMImage() = default;
 
 void AcceleratedSurface::RenderTargetSHMImage::didRenderFrame()
 {
@@ -519,10 +516,9 @@ AcceleratedSurface::RenderTargetTexture::RenderTargetTexture(AcceleratedSurface&
     : RenderTargetShareableBuffer(surface, size)
     , m_texture(WTF::move(texture))
 {
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_texture->id(), 0);
     if (m_surface->useSkia())
-        createSkiaSurfaceForTexture(m_texture.get());
-    else
-        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_texture->id(), 0);
+        createSkiaSurfaceForFramebuffer(m_fbo);
 
     WebProcess::singleton().parentProcessConnection()->send(Messages::AcceleratedBackingStore::DidCreateDMABufBuffer(m_id, { size, format, WTF::move(fds), WTF::move(offsets), WTF::move(strides), modifier }, RendererBufferFormat::Usage::Rendering), m_surface->surfaceID());
 }
@@ -538,8 +534,7 @@ std::unique_ptr<AcceleratedSurface::RenderTarget> AcceleratedSurface::RenderTarg
 }
 
 AcceleratedSurface::RenderTargetWPEBackend::RenderTargetWPEBackend(AcceleratedSurface& surface, const IntSize& initialSize, UnixFileDescriptor&& hostFD)
-    : RenderTarget(surface)
-    , m_size(initialSize)
+    : RenderTarget(surface, initialSize)
 {
     ASSERT(hostFD, "RenderTargetWPEBackend created with invalid host FD");
     m_backend = wpe_renderer_backend_egl_target_create(hostFD.release());
@@ -592,18 +587,9 @@ void AcceleratedSurface::RenderTargetWPEBackend::resize(const IntSize& size)
 void AcceleratedSurface::RenderTargetWPEBackend::willRenderFrame()
 {
     if (m_surface->useSkia() && !m_skiaSurface) {
-        GLint stencilBits;
-        glGetIntegerv(GL_STENCIL_BITS, &stencilBits);
         GLint fbo;
         glGetIntegerv(GL_FRAMEBUFFER_BINDING, &fbo);
-
-        GrGLFramebufferInfo fbInfo;
-        fbInfo.fFBOID = fbo;
-        fbInfo.fFormat = GL_RGBA8;
-        GrBackendRenderTarget renderTargetSkia = GrBackendRenderTargets::MakeGL(m_size.width(), m_size.height(), 0, stencilBits, fbInfo);
-        auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
-        RELEASE_ASSERT(grContext);
-        m_skiaSurface = SkSurfaces::WrapBackendRenderTarget(grContext, renderTargetSkia, kBottomLeft_GrSurfaceOrigin, kRGBA_8888_SkColorType, nullptr, nullptr);
+        createSkiaSurfaceForFramebuffer(fbo);
     }
     wpe_renderer_backend_egl_target_frame_will_render(m_backend);
 }

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h
@@ -110,6 +110,10 @@ public:
     uint64_t surfaceID() const { return m_id; }
     bool shouldPaintMirrored() const
     {
+#if USE(WPE_RENDERER)
+        if (m_swapChain.type() == SwapChain::Type::WPEBackend)
+            return true;
+#endif
 #if PLATFORM(WPE) || (PLATFORM(GTK) && USE(GTK4))
         return false;
 #else
@@ -190,12 +194,13 @@ private:
 #endif
 
     protected:
-        explicit RenderTarget(AcceleratedSurface&);
+        RenderTarget(AcceleratedSurface&, const WebCore::IntSize&);
 
-        void createSkiaSurfaceForTexture(const WebCore::BitmapTexture&);
+        void createSkiaSurfaceForFramebuffer(unsigned);
 
         uint64_t m_id { 0 };
         const CheckedRef<AcceleratedSurface> m_surface;
+        WebCore::IntSize m_size;
         sk_sp<SkSurface> m_skiaSurface;
 #if ENABLE(DAMAGE_TRACKING)
         std::optional<WebCore::Damage> m_damage;
@@ -221,11 +226,13 @@ private:
         void sync(bool) override;
         void setReleaseFenceFD(UnixFileDescriptor&&) override;
 
+        void initializeColorBuffer(EGLImage = nullptr);
+
         unsigned m_fbo { 0 };
         unsigned m_depthStencilBuffer { 0 };
+        unsigned m_colorBuffer { 0 };
         UnixFileDescriptor m_renderingFenceFD;
         UnixFileDescriptor m_releaseFenceFD;
-        WebCore::IntSize m_initialSize;
     };
 
 #if USE(GBM) || OS(ANDROID)
@@ -282,11 +289,8 @@ private:
 
     private:
         bool supportsExplicitSync() const override { return true; }
-        void initializeColorBuffer();
 
-        unsigned m_colorBuffer { 0 };
         EGLImage m_image { nullptr };
-        RefPtr<WebCore::BitmapTexture> m_texture;
     };
 #endif // USE(GBM) || OS(ANDROID)
 
@@ -300,9 +304,7 @@ private:
         bool supportsExplicitSync() const override { return false; }
         void didRenderFrame() override;
 
-        unsigned m_colorBuffer { 0 };
         const Ref<WebCore::ShareableBitmap> m_bitmap;
-        RefPtr<WebCore::BitmapTexture> m_texture;
     };
 
     class RenderTargetTexture final : public RenderTargetShareableBuffer {
@@ -333,7 +335,6 @@ private:
         void didRenderFrame() override;
 
         struct wpe_renderer_backend_egl_target* m_backend { nullptr };
-        WebCore::IntSize m_size;
     };
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
@@ -80,7 +80,7 @@ ThreadedCompositor::ThreadedCompositor(WebPage& webPage, LayerTreeHost& layerTre
     , m_useSkia(webPage.corePage()->settings().useSkiaForComposition())
     , m_surface(AcceleratedSurface::create(webPage, [this] { frameComplete(); }, AcceleratedSurface::RenderingPurpose::Composited, m_useSkia))
     , m_sceneState(&sceneState)
-    , m_flipY(m_surface->shouldPaintMirrored())
+    , m_flipY(!m_surface->shouldPaintMirrored())
     , m_renderTimer(m_workQueue->runLoop(), "ThreadedCompositor::RenderTimer"_s, this, &ThreadedCompositor::renderLayerTree)
 {
     ASSERT(RunLoop::isMain());
@@ -129,8 +129,6 @@ ThreadedCompositor::ThreadedCompositor(WebPage& webPage, LayerTreeHost& layerTre
         } else {
             m_context = WTF::move(context);
             m_textureMapper = TextureMapper::create();
-            if (!nativeSurfaceHandle)
-                m_flipY = !m_flipY;
         }
     });
 }


### PR DESCRIPTION
#### 441a3adb238e19682d95df52241bf97e9971ecba
<pre>
[GTK][WPE][Skia] Render the compositor output into a renderbuffer instead of a texture
<a href="https://bugs.webkit.org/show_bug.cgi?id=319083">https://bugs.webkit.org/show_bug.cgi?id=319083</a>

Reviewed by Alejandro G. Castro.

The Skia compositor imported the shared scanout dma-buf as a
GL_TEXTURE_2D and wrapped it in a Skia texture surface
(SkSurfaces::WrapBackendTexture), so the frame was rendered into a
sampleable texture. The web process never samples this buffer. Import it
as a GL renderbuffer and render into it with a wrapped backend render
target (SkSurfaces::WrapBackendRenderTarget) instead. This matches the
TextureMapper compositor and keeps the scanout buffer a pure render
target, so drivers might optimize for the fact that it is not sampleable.

RenderTargetShareableBuffer owns the framebuffer and its depth and
stencil buffer. They are now created always in the constructor when the
surface is using GL. The skia surface is now created in initializeColorBuffer()
that receives an optional EGLImage so that it can be shared with SHM
targets. It leaves the Skia surface unset when the framebuffer is not
complete, so a broken buffer is skipped instead of rendered into.
createSkiaSurfaceForTexture() has been replaced by createSkiaSurfaceForFramebuffer().

* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp:
(WebKit::AcceleratedSurface::RenderTarget::RenderTarget):
(WebKit::AcceleratedSurface::RenderTarget::createSkiaSurfaceForFramebuffer):
(WebKit::AcceleratedSurface::RenderTargetShareableBuffer::RenderTargetShareableBuffer):
(WebKit::AcceleratedSurface::RenderTargetShareableBuffer::~RenderTargetShareableBuffer):
(WebKit::AcceleratedSurface::RenderTargetShareableBuffer::initializeColorBuffer):
(WebKit::AcceleratedSurface::RenderTargetEGLImage::RenderTargetEGLImage):
(WebKit::AcceleratedSurface::RenderTargetEGLImage::~RenderTargetEGLImage):
(WebKit::AcceleratedSurface::RenderTargetSHMImage::RenderTargetSHMImage):
(WebKit::AcceleratedSurface::RenderTargetTexture::RenderTargetTexture):
(WebKit::AcceleratedSurface::RenderTargetWPEBackend::RenderTargetWPEBackend):
(WebKit::AcceleratedSurface::RenderTargetWPEBackend::willRenderFrame):
(WebKit::AcceleratedSurface::RenderTarget::createSkiaSurfaceForTexture): Deleted.
(WebKit::AcceleratedSurface::RenderTargetEGLImage::initializeColorBuffer): Deleted.
(WebKit::AcceleratedSurface::RenderTargetSHMImage::~RenderTargetSHMImage): Deleted.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h:

Co-authored-by: Nikolas Zimmermann &lt;nzimmermann@igalia.com&gt;
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp:
(WebKit::m_renderTimer):

Canonical link: <a href="https://commits.webkit.org/317149@main">https://commits.webkit.org/317149@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ec7fa47ec2dcd22d8dab624ee7f78536d64d15c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174172 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48105 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41886 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183746 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132040 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49397 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47787 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135470 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95565 "1 flakes 3 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177130 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38902 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156263 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115948 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37543 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35912 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32230 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147967 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35756 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186172 "Built successfully") | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39359 "Found 1026 new failures in b3/testb3_7.cpp, b3/B3Value.h, WebProcess/Network/WebResourceLoader.cpp, jit/OperationResult.h, UIProcess/WebProcessPool.cpp, Shared/Cocoa/WKNSArray.mm, heap/WeakSet.h, API/tests/Regress141275.mm, Shared/SessionState.cpp, NetworkProcess/NetworkResourceLoadParameters.cpp ...") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40109 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144374 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47772 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144234 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48451 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32375 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113960 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26517 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39142 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120355 "Found 1059 new failures in b3/testb3_7.cpp, b3/B3Value.h, WebProcess/Network/WebResourceLoader.cpp, jit/OperationResult.h, UIProcess/WebProcessPool.cpp, testing/MockMediaSessionCoordinator.cpp, Shared/Cocoa/WKNSArray.mm, heap/WeakSet.h, API/tests/Regress141275.mm, Shared/SessionState.cpp ...") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46957 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10718 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46360 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46591 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46418 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->