### PR TITLE
mapHostNames misparses a colon in userinfo as the port separator

### DIFF
--- a/Source/WTF/wtf/URLHelpers.cpp
+++ b/Source/WTF/wtf/URLHelpers.cpp
@@ -793,10 +793,9 @@ static void applyHostNameFunctionToURLString(const String& string, URLDecodeFunc
         return;
     }
 
-    // Find the host name in a hierarchical URL.
-    // It comes after a "://" sequence, with scheme characters preceding.
-    // If ends with the end of the string or a ":", "/", or a "?".
-    // If there is a "@" character, the host part is just the part after the "@".
+    // Find the host name in a hierarchical URL. It comes after a "://" sequence, with scheme
+    // characters preceding. The authority ends at the end of the string or a "/", "?", or "#".
+    // If there is a "@", the host is the part after the last one, up to a ":" port separator.
     static constexpr auto separator = "://"_s;
     auto separatorIndex = string.find(separator);
     if (separatorIndex == notFound)
@@ -810,15 +809,21 @@ static void applyHostNameFunctionToURLString(const String& string, URLDecodeFunc
     }))
         return;
 
-    // Find terminating character.
-    auto hostNameTerminator = string.find([](char16_t character) {
-        return character == ':' || character == '/' || character == '?' || character == '#';
+    auto authorityTerminator = string.find([](char16_t character) {
+        return character == '/' || character == '?' || character == '#';
     }, authorityStart);
-    unsigned hostNameEnd = hostNameTerminator == notFound ? string.length() : hostNameTerminator;
+    unsigned authorityEnd = authorityTerminator == notFound ? string.length() : authorityTerminator;
 
-    // Find "@" for the start of the host name. There might be more than one and we try to find the last one.
-    auto lastUserInfoTerminator = StringView { string }.left(hostNameEnd).reverseFind('@');
+    auto lastUserInfoTerminator = StringView { string }.left(authorityEnd).reverseFind('@');
     unsigned hostNameStart = lastUserInfoTerminator == notFound ? authorityStart : lastUserInfoTerminator + 1;
+
+    // Skip IPv6 literals, whose brackets contain ":" characters that aren't a port separator.
+    unsigned hostNameEnd = authorityEnd;
+    if (hostNameStart < authorityEnd && string[hostNameStart] != '[') {
+        auto portSeparator = string.find(':', hostNameStart);
+        if (portSeparator != notFound && portSeparator < authorityEnd)
+            hostNameEnd = portSeparator;
+    }
 
     collectRangesThatNeedMapping(string, hostNameStart, hostNameEnd - hostNameStart, array, decodeFunction);
 }

--- a/Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm
@@ -345,6 +345,19 @@ TEST(URLExtras, URLExtras_File)
     EXPECT_STREQ("file:///%E2%98%83", [[WTF::URLWithUserTypedString(@"file:///☃", nil) absoluteString] UTF8String]);
 }
 
+TEST(URLExtras, URLExtras_UserInfoColon)
+{
+    // A ":" in the userinfo must not be mistaken for the port separator: the host after
+    // the "@" (not the username before the ":") is what gets IDN-encoded.
+    EXPECT_STREQ("http://user:pass@xn--mnchen-3ya.de/", originalDataAsString(WTF::URLWithUserTypedString(@"http://user:pass@münchen.de/", nil)));
+
+    // The real host's port is still handled, and only the host is encoded.
+    EXPECT_STREQ("http://user:pass@xn--mnchen-3ya.de:8080/", originalDataAsString(WTF::URLWithUserTypedString(@"http://user:pass@münchen.de:8080/", nil)));
+
+    // The '%' defeats the ASCII fast path so this exercises the host-parsing code.
+    EXPECT_STREQ("http://user:pass@[::1]:8080/path%20x", originalDataAsString(WTF::URLWithUserTypedString(@"http://user:pass@[::1]:8080/path%20x", nil)));
+}
+
 TEST(URLExtras, URLExtras_ParsingError)
 {
     // Expect IDN failure.


### PR DESCRIPTION
#### bff1e092438a6e16c0304ec50a6f7517f8bc54bb
<pre>
mapHostNames misparses a colon in userinfo as the port separator
<a href="https://bugs.webkit.org/show_bug.cgi?id=314919">https://bugs.webkit.org/show_bug.cgi?id=314919</a>
<a href="https://rdar.apple.com/177742288">rdar://177742288</a>

Reviewed by Alex Christensen.

applyHostNameFunctionToURLString found the host name&apos;s terminator (the
first &quot;:&quot;, &quot;/&quot;, &quot;?&quot;, or &quot;#&quot;) before looking for the userinfo &quot;@&quot;. For a
URL like &quot;<a href="https://user">https://user</a>:pass@münchen.de/&quot; the &quot;:&quot; in the userinfo was
taken as the port separator, so the &quot;@&quot; fell outside the searched range
and &quot;user&quot; was mapped as the host instead of &quot;münchen.de&quot;, leaving the
real host without IDN processing.

Find the authority end (&quot;/&quot;, &quot;?&quot;, &quot;#&quot;, or end of string) first, then the
last &quot;@&quot; within it, and only then the &quot;:&quot; port separator. This also lets
IPv6 literals with a port or userinfo pass through correctly.

Test: Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm
Canonical link: <a href="https://commits.webkit.org/317346@main">https://commits.webkit.org/317346@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6efc8f9e2970171b47b0000552dd09deb0fadf8c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173956 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47889 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41670 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183530 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131824 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d226265f-7e7d-4251-94b2-c634b9caf444) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175821 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49181 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47571 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135284 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95388 "1 flakes 4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/993aef14-e8bd-4abd-88b6-4da2fae4d46f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176914 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38714 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156075 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115762 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b8af705a-2543-445d-889e-86d0860a95d2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37355 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35722 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32014 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/4585 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147779 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35568 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185956 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/35218 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39018 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39920 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144185 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47556 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144043 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39071 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48235 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32185 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113595 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38953 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120119 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/210990 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46741 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10526 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54968 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46144 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46375 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46202 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->