### PR TITLE
[Win] Configure ccache via inline KEY=VALUE arguments

### DIFF
--- a/Source/cmake/WebKitCCache.cmake
+++ b/Source/cmake/WebKitCCache.cmake
@@ -38,6 +38,29 @@ exec '${CCACHE_FOUND}' \"$@\"
             set(CMAKE_ASM_COMPILER_LAUNCHER "${_ccache_launcher}")
             set(CMAKE_OBJC_COMPILER_LAUNCHER "${_ccache_launcher}")
             set(CMAKE_OBJCXX_COMPILER_LAUNCHER "${_ccache_launcher}")
+        elseif (WIN32)
+            # Pass the ccache configuration inline as "KEY=VALUE ... compiler" arguments (a core
+            # ccache feature), so it is baked into every ninja compile command and applied per
+            # invocation. This avoids relying on environment set at configure time -- which does not
+            # survive to the ninja-spawned compile -- and avoids a launcher script: a .cmd wrapper
+            # would hit cmd.exe's 8191-char command-line limit on WebCore's long compile lines.
+            set(_ccache_config
+                base_dir=${CMAKE_SOURCE_DIR}
+                hash_dir=false
+                sloppiness=time_macros,include_file_mtime,include_file_ctime
+            )
+            message(STATUS "Enabling ccache: ${CCACHE_FOUND} with inline config (base_dir=${CMAKE_SOURCE_DIR}).")
+            set(CMAKE_C_COMPILER_LAUNCHER   ${CCACHE_FOUND} ${_ccache_config})
+            set(CMAKE_CXX_COMPILER_LAUNCHER ${CCACHE_FOUND} ${_ccache_config})
+            set(CMAKE_ASM_COMPILER_LAUNCHER ${CCACHE_FOUND} ${_ccache_config})
+            # Disable precompiled headers when ccache is in use, matching the GTK/WPE developer-mode
+            # ports (OptionsGTK.cmake / OptionsWPE.cmake set CMAKE_DISABLE_PRECOMPILE_HEADERS ON).
+            # Caching a PCH under clang-cl is fragile: ccache can restore a PCH built against a
+            # different-sized generated header (e.g. PlatformEnable.h drifts as feature flags change),
+            # which clang then rejects ("... has been modified since the precompiled header was built").
+            # Dropping PCH removes that whole failure class; ccache still serves unchanged objects as
+            # hits, so the clean-rebuild speedup is retained (PCH only accelerates ccache misses).
+            set(CMAKE_DISABLE_PRECOMPILE_HEADERS ON)
         else ()
             if (NOT DEFINED ENV{CCACHE_SLOPPINESS})
                 set(ENV{CCACHE_SLOPPINESS} time_macros)


### PR DESCRIPTION
#### b28c618947150c97094ecec0dd0da16b145b7ab3
<pre>
[Win] Configure ccache via inline KEY=VALUE arguments
<a href="https://bugs.webkit.org/show_bug.cgi?id=319102">https://bugs.webkit.org/show_bug.cgi?id=319102</a>

Unreviewed build fix.

Apply the ccache configuration by passing it as inline &quot;KEY=VALUE ... compiler&quot;
arguments to ccache (a core ccache feature), so the settings are baked into every
ninja compile command and applied per invocation. This avoids relying on
environment set at configure time (which does not survive to the ninja-spawned
compile) and avoids a launcher script -- a .cmd wrapper hits cmd.exe&apos;s 8191-char
command-line limit on WebCore&apos;s long compile lines.

Disable precompiled headers when ccache is enabled, matching the GTK and WPE
developer-mode ports. Caching a PCH under clang-cl is fragile -- ccache can
restore a PCH built against a different-sized generated header, which clang then
rejects -- and PCH only accelerates ccache misses, so dropping it keeps the
clean-rebuild speedup while removing that failure class.

* Source/cmake/WebKitCCache.cmake:

Canonical link: <a href="https://commits.webkit.org/318031@main">https://commits.webkit.org/318031@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fdd86baecf5ace5f24bafa2b9ead98dec8bc6c47

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176974 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50911 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44706 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186577 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52204 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50597 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137885 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179930 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41397 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158678 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118354 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40053 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38419 "Passed tests") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7183 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150463 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38178 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35045 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/38245 "Built successfully and passed tests") | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42637 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189000 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50578 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146967 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51261 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34802 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146763 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26863 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41521 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117762 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49766 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13158 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49165 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49402 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49226 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->