### PR TITLE
Relative links with "://" in them are never colored as visited after being clicked

### DIFF
--- a/LayoutTests/fast/history/visited-relative-link-with-colon-slash-slash-expected.txt
+++ b/LayoutTests/fast/history/visited-relative-link-with-colon-slash-slash-expected.txt
@@ -1,0 +1,12 @@
+A relative link whose URL contains '://' in the query should still be colored as visited after the same URL is visited. See https://bugs.webkit.org/show_bug.cgi?id=13755
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS firstStyle.color became different from secondStyle.color
+PASS successfullyParsed is true
+
+TEST COMPLETE
+These two links should be different colors (green and orange):
+
+One (unvisited) Two (visited)

--- a/LayoutTests/fast/history/visited-relative-link-with-colon-slash-slash.html
+++ b/LayoutTests/fast/history/visited-relative-link-with-colon-slash-slash.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<style>
+:link { color: green; }
+:visited { color: orange; }
+</style>
+</head>
+<body>
+<iframe src="resources/dummy.html?redirect=http://example.com/" style="display:none"></iframe>
+
+<p>These two links should be different colors (green and orange):</p>
+<p>
+<a href="http://madeup.site.com" id="one">One (unvisited)</a>
+<a href="resources/dummy.html?redirect=http://example.com/" id="two">Two (visited)</a>
+</p>
+<script>
+jsTestIsAsync = true;
+
+description("A relative link whose URL contains '://' in the query should still be colored as visited after the same URL is visited. See https://bugs.webkit.org/show_bug.cgi?id=13755");
+
+if (window.testRunner)
+    window.testRunner.keepWebHistory();
+
+onload = function() {
+    if (!window.internals)
+        return;
+    // 'one' is an unvisited baseline. 'two' points at the same relative URL the
+    // hidden iframe navigated to, so it should be styled as :visited.
+    firstStyle = internals.computedStyleIncludingVisitedInfo(document.getElementById('one'));
+    secondStyle = internals.computedStyleIncludingVisitedInfo(document.getElementById('two'));
+    shouldBecomeDifferent('firstStyle.color', 'secondStyle.color', finishJSTest);
+};
+</script>
+</body>
+</html>

--- a/Source/WebCore/platform/SharedStringHash.cpp
+++ b/Source/WebCore/platform/SharedStringHash.cpp
@@ -24,6 +24,7 @@
 #include "config.h"
 #include "SharedStringHash.h"
 
+#include <wtf/ASCIICType.h>
 #include <wtf/HashFunctions.h>
 #include <wtf/URL.h>
 #include <wtf/text/AtomString.h>
@@ -72,16 +73,19 @@ static inline size_t NODELETE findSlashDotSlash(std::span<const CharacterType> c
 }
 
 template <typename CharacterType>
-static inline bool NODELETE containsColonSlashSlash(std::span<const CharacterType> characters)
+static inline bool NODELETE startsWithSchemeColonSlashSlash(std::span<const CharacterType> characters)
 {
-    if (characters.size() < 3)
+    if (!isASCIIAlpha(characters[0]))
         return false;
-    unsigned loopLimit = characters.size() - 2;
-    for (unsigned i = 0; i < loopLimit; ++i) {
-        if (characters[i] == ':' && characters[i + 1] == '/' && characters[i + 2] == '/')
-            return true;
+    size_t i = 1;
+    for (; i < characters.size(); ++i) {
+        auto character = characters[i];
+        if (character == ':')
+            break;
+        if (!isASCIIAlphanumeric(character) && character != '+' && character != '-' && character != '.')
+            return false;
     }
-    return false;
+    return i + 2 < characters.size() && characters[i] == ':' && characters[i + 1] == '/' && characters[i + 2] == '/';
 }
 
 template <typename CharacterType>
@@ -231,14 +235,10 @@ static ALWAYS_INLINE SharedStringHash computeSharedStringHashInline(const URL& b
     // FIXME: It's missing a lot of what completeURL does and a lot of what URL does.
     // For example, it does not handle international domain names properly.
 
-    // FIXME: It is wrong that we do not do further processing on strings that have "://" in them:
-    //    1) The "://" could be in the query or anchor.
-    //    2) The URL's path could have a "/./" or a "/../" or a "//" sequence in it.
-
     // FIXME: needsTrailingSlash does not properly return true for a URL that has no path, but does
     // have a query or anchor.
 
-    if (containsColonSlashSlash(characters)) {
+    if (startsWithSchemeColonSlashSlash(characters)) {
         if (!needsTrailingSlash(characters))
             return computeSharedStringHashInline(characters);
 
@@ -251,9 +251,11 @@ static ALWAYS_INLINE SharedStringHash computeSharedStringHashInline(const URL& b
     }
 
     Vector<CharacterType, 512> buffer;
-    if (characters.empty())
-        append(buffer, base.string());
-    else {
+    if (characters.size() >= 2 && characters[0] == '/' && characters[1] == '/') {
+        // Protocol-relative URL; inherit the scheme from the base URL.
+        append(buffer, base.protocol());
+        buffer.append(':');
+    } else {
         switch (characters[0]) {
         case '/':
             append(buffer, StringView(base.string()).left(base.pathStart()));


### PR DESCRIPTION
#### b0aa853a94c66d7211b6e1a302db01e861bcb006
<pre>
Relative links with &quot;://&quot; in them are never colored as visited after being clicked
<a href="https://bugs.webkit.org/show_bug.cgi?id=13755">https://bugs.webkit.org/show_bug.cgi?id=13755</a>
<a href="https://rdar.apple.com/181748643">rdar://181748643</a>

Reviewed by Alex Christensen.

computeVisitedLinkHash() decided a URL was absolute by scanning the whole
string for &quot;://&quot;, so a relative URL with &quot;://&quot; in its query or fragment
(e.g. &quot;/search?q=<a href="http://...&quot">http://...&quot</a>;) was hashed unresolved and never matched the
visited link. Check for a scheme in the leading position instead; this also
bails at the first non-scheme character, so the hot path is not regressed.
Also resolve protocol-relative URLs (&quot;//host/path&quot;) by inheriting the base
URL&apos;s scheme.

Note that there are still many cases that remain broken. A proper solution
requires using the URL parser while somehow not regressing performance.

Test: fast/history/visited-relative-link-with-colon-slash-slash.html
Canonical link: <a href="https://commits.webkit.org/316957@main">https://commits.webkit.org/316957@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6850b3c06325e2169a3107a30478c45e6ccd5bd9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173779 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47712 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41493 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183353 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131647 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a9194220-dd22-4893-afc4-860c1ac041df) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175644 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49004 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47394 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135135 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95312 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/57ca5235-853a-493c-92da-b4da31449d82) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176737 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38570 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155926 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115613 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/89c8f638-dfe9-403c-83a3-6ad2c2f85819) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37211 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35570 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31837 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147635 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35419 "Found 1 new test failure: imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-corner-shape-change.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185779 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38826 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39769 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144024 "Found 1 new test failure: compositing/framesets/composited-frame-alignment.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47379 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155481 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143883 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48058 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32035 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113324 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26445 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38804 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119939 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46564 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10374 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45966 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46197 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46025 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->