### PR TITLE
corner-shape: Add square reftests

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6661,6 +6661,8 @@ webkit.org/b/277912 imported/w3c/web-platform-tests/css/css-borders/corner-shape
 webkit.org/b/277912 imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-overflow-clip-margin.html [ ImageOnlyFailure ]
 webkit.org/b/277912 imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-scoop.html [ ImageOnlyFailure ]
 webkit.org/b/277912 imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-square.html [ ImageOnlyFailure ]
+webkit.org/b/277912 imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-square-notch-mixed.html [ ImageOnlyFailure ]
+webkit.org/b/277912 imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-square-notch-superellipse.html [ ImageOnlyFailure ]
 webkit.org/b/277912 imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-superellipse-bevel.html [ ImageOnlyFailure ]
 webkit.org/b/277912 imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-superellipse-negative-100.html [ ImageOnlyFailure ]
 webkit.org/b/277912 imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-superellipse-scoop.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-square-notch-mixed-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-square-notch-mixed-expected.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<head>
+<title>CSS Borders and Box Decorations 4: per-corner 'corner-shape' with mixed square and notch corners — reference</title>
+<style>
+    .target {
+        position: relative;
+        background: red;
+        width: 100px;
+        height: 100px;
+        box-sizing: border-box;
+        clip-path: polygon(
+            0px 0px, 75px 0px, 75px 25px, 100px 25px,
+            100px 100px, 25px 100px, 25px 75px, 0px 75px);
+    }
+    .target::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background: green;
+        clip-path: polygon(
+            5px 5px, 70px 5px, 70px 30px, 95px 30px,
+            95px 95px, 30px 95px, 30px 70px, 5px 70px);
+    }
+</style>
+</head>
+<div class=target></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-square-notch-mixed-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-square-notch-mixed-ref.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<head>
+<title>CSS Borders and Box Decorations 4: per-corner 'corner-shape' with mixed square and notch corners — reference</title>
+<style>
+    .target {
+        position: relative;
+        background: red;
+        width: 100px;
+        height: 100px;
+        box-sizing: border-box;
+        clip-path: polygon(
+            0px 0px, 75px 0px, 75px 25px, 100px 25px,
+            100px 100px, 25px 100px, 25px 75px, 0px 75px);
+    }
+    .target::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background: green;
+        clip-path: polygon(
+            5px 5px, 70px 5px, 70px 30px, 95px 30px,
+            95px 95px, 30px 95px, 30px 70px, 5px 70px);
+    }
+</style>
+</head>
+<div class=target></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-square-notch-mixed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-square-notch-mixed.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<head>
+<title>CSS Borders and Box Decorations 4: per-corner 'corner-shape' with mixed square and notch corners</title>
+<link rel="help" href="https://drafts.csswg.org/css-borders-4/#corner-shaping">
+<link rel="match" href="corner-shape-square-notch-mixed-ref.html">
+<style>
+    .target {
+        background: green;
+        width: 100px;
+        height: 100px;
+        border-radius: 25px;
+        box-sizing: border-box;
+        border: 5px solid red;
+        corner-shape: square notch square notch;
+    }
+</style>
+</head>
+<div class=target></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-square-notch-superellipse-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-square-notch-superellipse-expected.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<head>
+<title>CSS Borders and Box Decorations 4: per-corner 'corner-shape' with mixed square and notch corners — reference</title>
+<style>
+    .target {
+        position: relative;
+        background: red;
+        width: 100px;
+        height: 100px;
+        box-sizing: border-box;
+        clip-path: polygon(
+            0px 0px, 75px 0px, 75px 25px, 100px 25px,
+            100px 100px, 25px 100px, 25px 75px, 0px 75px);
+    }
+    .target::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background: green;
+        clip-path: polygon(
+            5px 5px, 70px 5px, 70px 30px, 95px 30px,
+            95px 95px, 30px 95px, 30px 70px, 5px 70px);
+    }
+</style>
+</head>
+<div class=target></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-square-notch-superellipse-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-square-notch-superellipse-ref.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<head>
+<title>CSS Borders and Box Decorations 4: per-corner 'corner-shape' square/notch superellipse equivalents — reference</title>
+<style>
+    .target {
+        position: relative;
+        background: red;
+        width: 100px;
+        height: 100px;
+        box-sizing: border-box;
+        clip-path: polygon(
+            0px 0px, 75px 0px, 75px 25px, 100px 25px,
+            100px 100px, 25px 100px, 25px 75px, 0px 75px);
+    }
+    .target::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background: green;
+        clip-path: polygon(
+            5px 5px, 70px 5px, 70px 30px, 95px 30px,
+            95px 95px, 30px 95px, 30px 70px, 5px 70px);
+    }
+</style>
+</head>
+<div class=target></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-square-notch-superellipse.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-square-notch-superellipse.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<head>
+<title>CSS Borders and Box Decorations 4: per-corner 'corner-shape' square/notch superellipse equivalents</title>
+<link rel="help" href="https://drafts.csswg.org/css-borders-4/#corner-shaping">
+<link rel="match" href="corner-shape-square-notch-superellipse-ref.html">
+<style>
+    .target {
+        background: green;
+        width: 100px;
+        height: 100px;
+        border-radius: 25px;
+        box-sizing: border-box;
+        border: 5px solid red;
+        corner-shape: superellipse(infinity) superellipse(-infinity) superellipse(infinity) superellipse(-infinity);
+    }
+</style>
+</head>
+<div class=target></div>


### PR DESCRIPTION
#### 97ff5d5a62bc6ed494cd58608bdf420b7beab2ff
<pre>
corner-shape: Add square reftests
<a href="https://bugs.webkit.org/show_bug.cgi?id=318969">https://bugs.webkit.org/show_bug.cgi?id=318969</a>
<a href="https://rdar.apple.com/181824343">rdar://181824343</a>

Reviewed by Alan Baradlay.

Tests shapes with mixed corners and border shapes including square and notch

* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-square-notch-mixed-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-square-notch-mixed-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-square-notch-mixed.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-square-notch-superellipse-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-square-notch-superellipse-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-square-notch-superellipse.html: Added.
* LayoutTests/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/317045@main">https://commits.webkit.org/317045@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d425becd7652d4e955ffb9a04fc154ea74cfebed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173791 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47724 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41505 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183365 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131659 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49016 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47406 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135145 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95316 "2 flakes 6 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176749 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38575 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155933 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115623 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; 3 api tests failed or timed out; 7 api tests failed or timed out; Compiled WebKit (warnings); run-api-tests-without-change; Passed API tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37216 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35582 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31849 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147640 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35426 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185791 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39781 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144036 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47391 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155488 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143895 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48070 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32042 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113336 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26476 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38819 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46576 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10381 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45978 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46209 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46037 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->