### PR TITLE
[JSC][Temporal] Deduplicate GetISODateTimeFor and align with temporal_rs

### DIFF
--- a/JSTests/stress/temporal-now.js
+++ b/JSTests/stress/temporal-now.js
@@ -1,0 +1,86 @@
+//@ requireOptions("--useTemporal=1")
+
+function shouldBe(actual, expected, label) {
+    if (actual !== expected)
+        throw new Error(`${label}: expected ${String(expected)}, got ${String(actual)}`);
+}
+function shouldThrow(fn, ctor, label) {
+    let caught = null;
+    try { fn(); } catch (e) { caught = e; }
+    if (!caught) throw new Error(`${label}: expected ${ctor.name}, got no throw`);
+    if (!(caught instanceof ctor))
+        throw new Error(`${label}: expected ${ctor.name}, got ${caught.constructor.name}`);
+}
+
+// Types + calendar defaults.
+shouldBe(Temporal.Now.instant() instanceof Temporal.Instant, true, "instant is Instant");
+shouldBe(Temporal.Now.plainDateISO().calendarId, "iso8601", "plainDateISO calendar");
+shouldBe(Temporal.Now.plainDateTimeISO().calendarId, "iso8601", "plainDateTimeISO calendar");
+shouldBe(Temporal.Now.zonedDateTimeISO().calendarId, "iso8601", "zonedDateTimeISO calendar");
+shouldBe(typeof Temporal.Now.timeZoneId(), "string", "timeZoneId returns string");
+
+// Explicit tz string.
+shouldBe(Temporal.Now.zonedDateTimeISO("UTC").timeZoneId, "UTC", "explicit tz UTC");
+shouldBe(Temporal.Now.zonedDateTimeISO("Asia/Tokyo").timeZoneId, "Asia/Tokyo", "explicit tz IANA");
+shouldBe(Temporal.Now.zonedDateTimeISO("+05:30").timeZoneId, "+05:30", "explicit tz offset");
+
+// ZDT arg forwards its [[TimeZone]], not its getter.
+{
+    class SpyZDT extends Temporal.ZonedDateTime {
+        get timeZoneId() { throw new Error("getter must not fire"); }
+    }
+    const z = new SpyZDT(0n, "America/New_York");
+    shouldBe(Temporal.Now.zonedDateTimeISO(z).timeZoneId, "America/New_York", "ZDT arg forwards [[TimeZone]]");
+}
+
+// Arg validation.
+shouldThrow(() => Temporal.Now.plainDateISO("bogus"), RangeError, "invalid tz string");
+shouldThrow(() => Temporal.Now.plainDateISO(42), TypeError, "number tz");
+shouldThrow(() => Temporal.Now.plainDateISO({}), TypeError, "object tz");
+shouldThrow(() => Temporal.Now.plainDateISO(Symbol()), TypeError, "symbol tz");
+shouldThrow(() => Temporal.Now.plainDateTimeISO("+05:30:15"), RangeError, "sub-minute offset rejected");
+shouldThrow(() => Temporal.Now.plainDateTimeISO(""), RangeError, "empty tz string");
+
+// arg.toString must NOT be called (spec forbids object coercion for tz).
+{
+    let called = 0;
+    try { Temporal.Now.plainDateISO({ toString() { called++; return "UTC"; } }); } catch (e) {}
+    shouldBe(called, 0, "no arg.toString coercion");
+}
+
+// timeZoneId ignores extra args.
+shouldBe(Temporal.Now.timeZoneId("extra"), Temporal.Now.timeZoneId(), "timeZoneId ignores args");
+
+// Freshness: successive calls produce non-decreasing epoch.
+{
+    let prev = 0n;
+    for (let i = 0; i < 20; i++) {
+        const n = Temporal.Now.instant().epochNanoseconds;
+        if (n < prev) throw new Error("instant not monotonic");
+        prev = n;
+    }
+}
+
+// Cross-fn consistency: date derived via plainDateISO() must match date part of
+// plainDateTimeISO() and zonedDateTimeISO(). We compare across three near-simultaneous
+// calls; they can disagree only if a day boundary crosses between them, so retry.
+for (let retry = 0; retry < 3; retry++) {
+    const a = Temporal.Now.plainDateISO().toString();
+    const b = Temporal.Now.plainDateTimeISO().toString().slice(0, 10);
+    const c = Temporal.Now.zonedDateTimeISO().toPlainDate().toString();
+    if (a === b && b === c) break;
+    if (retry === 2) throw new Error(`day-boundary consistency: ${a} vs ${b} vs ${c}`);
+}
+
+// Cross-fn consistency: default tz result must match explicit system-tz result.
+{
+    const tz = Temporal.Now.timeZoneId();
+    shouldBe(Temporal.Now.plainDateISO().equals(Temporal.Now.plainDateISO(tz)), true, "default tz date == explicit tz date");
+}
+
+// Calendar override post-creation works (Now.* always returns iso8601, then user can convert).
+shouldBe(Temporal.Now.plainDateISO().withCalendar("japanese").calendarId, "japanese", "withCalendar japanese");
+shouldBe(Temporal.Now.zonedDateTimeISO("UTC").withCalendar("gregory").calendarId, "gregory", "withCalendar gregory on ZDT");
+
+// undefined arg == no arg.
+shouldBe(Temporal.Now.plainDateISO().equals(Temporal.Now.plainDateISO(undefined)), true, "undefined vs no arg (date)");

--- a/JSTests/stress/temporal-plain-month-day.js
+++ b/JSTests/stress/temporal-plain-month-day.js
@@ -277,5 +277,3 @@ function shouldThrowAny(fn, msg) {
     shouldThrow(() => Temporal.PlainMonthDay.from({ year: 2018, era: "ce", eraYear: 2024, month: 3, day: 15, calendar: "gregory" }),
         RangeError, "PMD gregory from year+era inconsistent");
 }
-
-print("PASS");

--- a/Source/JavaScriptCore/API/tests/TemporalCoreTest.cpp
+++ b/Source/JavaScriptCore/API/tests/TemporalCoreTest.cpp
@@ -2862,22 +2862,20 @@ static void testCalendarICUNonISO()
 
 static void testExactTimeToLocalDateAndTime()
 {
-    ISO8601::PlainDate date;
-    ISO8601::PlainTime time;
     // epoch=0, offset=0 -> 1970-01-01T00:00:00
-    exactTimeToLocalDateAndTime(ISO8601::ExactTime(Int128(0)), 0, date, time);
+    auto [date, time] = exactTimeToLocalDateAndTime(ISO8601::ExactTime(Int128(0)), 0);
     TCHECK_EQ(date.year(), 1970, "localDT: epoch year");
     TCHECK_EQ(date.month(), 1u, "localDT: epoch month");
     TCHECK_EQ(date.day(), 1u, "localDT: epoch day");
     TCHECK_EQ(time.hour(), 0u, "localDT: epoch hour");
     // epoch=86400000000000 (1 day), offset=0 -> 1970-01-02T00:00:00
-    exactTimeToLocalDateAndTime(ISO8601::ExactTime(Int128(86400000000000LL)), 0, date, time);
-    TCHECK_EQ(date.year(), 1970, "localDT: +1day year");
-    TCHECK_EQ(date.day(), 2u, "localDT: +1day day");
+    auto [date2, time2] = exactTimeToLocalDateAndTime(ISO8601::ExactTime(Int128(86400000000000LL)), 0);
+    TCHECK_EQ(date2.year(), 1970, "localDT: +1day year");
+    TCHECK_EQ(date2.day(), 2u, "localDT: +1day day");
     // offset=-18000000000000 ns (UTC-5): epoch=0 -> 1969-12-31T19:00:00
-    exactTimeToLocalDateAndTime(ISO8601::ExactTime(Int128(0)), -18000000000000LL, date, time);
-    TCHECK_EQ(date.year(), 1969, "localDT: UTC-5 epoch year");
-    TCHECK_EQ(time.hour(), 19u, "localDT: UTC-5 epoch hour");
+    auto [date3, time3] = exactTimeToLocalDateAndTime(ISO8601::ExactTime(Int128(0)), -18000000000000LL);
+    TCHECK_EQ(date3.year(), 1969, "localDT: UTC-5 epoch year");
+    TCHECK_EQ(time3.hour(), 19u, "localDT: UTC-5 epoch hour");
 }
 
 static void testInterpretISODateTimeOffset()
@@ -3240,11 +3238,9 @@ static void testToZonedDateTime()
     auto r = getEpochNanosecondsFor(utc, { 2020, 1, 1 }, { 0, 0, 0, 0, 0, 0 }, TemporalDisambiguation::Compatible);
     TCHECK_TRUE(r.has_value(), "toZDT: 2020-01-01 UTC ok");
     // Verify round-trip: epoch -> local date/time
-    ISO8601::PlainDate date;
-    ISO8601::PlainTime time;
     auto offset = getOffsetNanosecondsFor(utc, *r);
     TCHECK_TRUE(offset.has_value(), "toZDT: offset ok");
-    exactTimeToLocalDateAndTime(*r, *offset, date, time);
+    auto [date, time] = exactTimeToLocalDateAndTime(*r, *offset);
     TCHECK_EQ(date.year(), 2020, "toZDT: year=2020");
     TCHECK_EQ(date.month(), 1u, "toZDT: month=1");
     TCHECK_EQ(date.day(), 1u, "toZDT: day=1");

--- a/Source/JavaScriptCore/runtime/ISO8601.cpp
+++ b/Source/JavaScriptCore/runtime/ISO8601.cpp
@@ -46,6 +46,8 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 namespace JSC {
 namespace ISO8601 {
 
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PlainDateTime);
+
 static constexpr int64_t nsPerHour = 1000LL * 1000 * 1000 * 60 * 60;
 static constexpr int64_t nsPerMinute = 1000LL * 1000 * 1000 * 60;
 static constexpr int64_t nsPerSecond = 1000LL * 1000 * 1000;

--- a/Source/JavaScriptCore/runtime/ISO8601.h
+++ b/Source/JavaScriptCore/runtime/ISO8601.h
@@ -391,6 +391,22 @@ private:
 };
 static_assert(sizeof(PlainDate) == sizeof(int32_t));
 
+class PlainDateTime {
+    WTF_MAKE_TZONE_ALLOCATED(PlainDateTime);
+public:
+    constexpr PlainDateTime() = default;
+    constexpr PlainDateTime(PlainDate d, PlainTime t)
+        : date(d)
+        , time(t)
+    {
+    }
+
+    friend bool operator==(const PlainDateTime&, const PlainDateTime&) = default;
+
+    PlainDate date { };
+    PlainTime time { };
+};
+
 class PlainYearMonth final {
     WTF_MAKE_TZONE_ALLOCATED(PlainYearMonth);
 public:

--- a/Source/JavaScriptCore/runtime/TemporalDuration.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalDuration.cpp
@@ -869,14 +869,12 @@ static std::optional<double> differenceZonedDateTimeWithTotal(JSGlobalObject* gl
     }
 
     // Step 3: dateTime = GetISODateTimeFor(tz, nsA).
-    ISO8601::PlainDate startDate;
-    ISO8601::PlainTime startTime;
-    auto offsetResult = TemporalCore::getOffsetNanosecondsFor(tz, endpoints.startExact);
-    if (!offsetResult) [[unlikely]] {
-        throwRangeError(globalObject, scope, offsetResult.error().message);
+    auto isoDTResult = TemporalCore::getISODateTimeFor(tz, endpoints.startExact);
+    if (!isoDTResult) [[unlikely]] {
+        throwRangeError(globalObject, scope, isoDTResult.error().message);
         return std::nullopt;
     }
-    TemporalCore::exactTimeToLocalDateAndTime(endpoints.startExact, *offsetResult, startDate, startTime);
+    auto [startDate, startTime] = *isoDTResult;
 
     // Step 4: Return ? TotalRelativeDuration — via nudgeToCalendarUnit with Trunc/1.0.
     int32_t sign = (endpoints.nsB > endpoints.nsA) ? 1 : (endpoints.nsB < endpoints.nsA) ? -1 : 1;

--- a/Source/JavaScriptCore/runtime/TemporalNow.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalNow.cpp
@@ -34,9 +34,7 @@
 #include "TemporalPlainTime.h"
 #include "TemporalZonedDateTime.h"
 #include "TimeZoneICUBridge.h"
-#include <unicode/ucal.h>
 #include <wtf/DateMath.h>
-#include <wtf/unicode/icu/ICUHelpers.h>
 
 namespace JSC {
 
@@ -116,36 +114,34 @@ static std::optional<TimeZone> resolveNowTimeZone(JSGlobalObject* globalObject, 
     return toTemporalTimeZoneIdentifier(globalObject, arg);
 }
 
-// https://tc39.es/proposal-temporal/#sec-temporal-getoffsetnanosecondsfor
-// Compute UTC offset in nanoseconds for a TimeZone at epoch milliseconds.
-// For named timezones, uses ICU to sum UCAL_ZONE_OFFSET + UCAL_DST_OFFSET.
-static int64_t getOffsetNanosecondsForTimeZone(const TimeZone& timeZone, double epochMs)
+// https://tc39.es/proposal-temporal/#sec-temporal-systemdatetime
+static ISO8601::PlainDateTime systemDateTime(JSGlobalObject* globalObject, JSValue timeZoneLike)
 {
-    if (timeZone.isUTCOffset())
-        return timeZone.utcOffsetNanoseconds();
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // Named timezone: open a temporary ICU calendar and query the offset.
-    String timeZoneForICU = timeZone.toICUString();
-    StringView view(timeZoneForICU);
-    auto upconverted = view.upconvertedCharacters();
+    // Steps 1-2: If tzLike is undefined, tz = SystemTimeZoneIdentifier(); else tz = ? ToTemporalTimeZoneIdentifier(tzLike).
+    auto tzOpt = resolveNowTimeZone(globalObject, timeZoneLike);
+    RETURN_IF_EXCEPTION(scope, { });
 
-    UErrorCode status = U_ZERO_ERROR;
-    auto calendar = std::unique_ptr<UCalendar, ICUDeleter<ucal_close>>(
-        ucal_open(upconverted, view.length(), "", UCAL_DEFAULT, &status));
-    if (U_FAILURE(status))
-        return 0;
+    // Step 3: Let epochNs be SystemUTCEpochNanoseconds().
+    auto exactTime = ISO8601::ExactTime::now();
 
-    ucal_setMillis(calendar.get(), epochMs, &status);
-    if (U_FAILURE(status))
-        return 0;
-
-    int32_t rawOffset = ucal_get(calendar.get(), UCAL_ZONE_OFFSET, &status);
-    int32_t dstOffset = ucal_get(calendar.get(), UCAL_DST_OFFSET, &status);
-    if (U_FAILURE(status))
-        return 0;
-
-    constexpr int64_t nsPerMs = static_cast<int64_t>(ISO8601::ExactTime::nsPerMillisecond);
-    return static_cast<int64_t>(rawOffset + dstOffset) * nsPerMs;
+    // Step 4: Return GetISODateTimeFor(tz, epochNs).
+    if (!tzOpt) {
+        // Fast path for system tz: use DateCache's cached offset directly,
+        // then decompose via the canonical exactTimeToLocalDateAndTime.
+        GregorianDateTime dt;
+        vm.dateCache.msToGregorianDateTime(static_cast<double>(exactTime.floorEpochMilliseconds()), TimeType::LocalTime, dt);
+        int64_t offsetNs = static_cast<int64_t>(dt.utcOffsetInMinute()) * WTF::Int64Milliseconds::msPerMinute * static_cast<int64_t>(ISO8601::ExactTime::nsPerMillisecond);
+        return TemporalCore::exactTimeToLocalDateAndTime(exactTime, offsetNs);
+    }
+    auto result = TemporalCore::getISODateTimeFor(*tzOpt, exactTime);
+    if (!result) [[unlikely]] {
+        throwTemporalError(globalObject, scope, result.error());
+        return { };
+    }
+    return *result;
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.now.plaindateiso
@@ -154,29 +150,12 @@ JSC_DEFINE_HOST_FUNCTION(temporalNowFuncPlainDateISO, (JSGlobalObject* globalObj
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // Step 1: Return ? SystemDate("iso8601", temporalTimeZoneLike).
-    // SystemDate step 1: SystemDateTime — ToTemporalTimeZoneIdentifier(temporalTimeZoneLike).
-    auto tzOpt = resolveNowTimeZone(globalObject, callFrame->argument(0));
+    // Step 1: Let isoDateTime be ? SystemDateTime(temporalTimeZoneLike).
+    auto isoDT = systemDateTime(globalObject, callFrame->argument(0));
     RETURN_IF_EXCEPTION(scope, { });
 
-    // SystemDate step 1 (cont): SystemUTCEpochNanoseconds().
-    auto exactTime = ISO8601::ExactTime::now();
-    ISO8601::PlainDate plainDate;
-
-    if (!tzOpt) {
-        // Use system timezone via DateCache.
-        GregorianDateTime dt;
-        vm.dateCache.msToGregorianDateTime(static_cast<double>(exactTime.floorEpochMilliseconds()), TimeType::LocalTime, dt);
-        plainDate = ISO8601::PlainDate(dt.year(), static_cast<uint8_t>(dt.month() + 1), static_cast<uint8_t>(dt.monthDay()));
-    } else {
-        // SystemDate step 1 (cont): GetOffsetNanosecondsFor + GetISODateTimeFor.
-        int64_t offsetNs = getOffsetNanosecondsForTimeZone(*tzOpt, static_cast<double>(exactTime.floorEpochMilliseconds()));
-        ISO8601::PlainTime unusedTime;
-        TemporalCore::exactTimeToLocalDateAndTime(exactTime, offsetNs, plainDate, unusedTime);
-    }
-
-    // SystemDate step 2: CreateTemporalDate(isoDateTime.[[ISODate]], "iso8601").
-    return JSValue::encode(TemporalPlainDate::create(vm, globalObject->plainDateStructure(), WTF::move(plainDate)));
+    // Step 2: Return ! CreateTemporalDate(isoDateTime.[[ISODate]], "iso8601").
+    return JSValue::encode(TemporalPlainDate::create(vm, globalObject->plainDateStructure(), WTF::move(isoDT.date)));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.now.plaindatetimeiso
@@ -185,31 +164,12 @@ JSC_DEFINE_HOST_FUNCTION(temporalNowFuncPlainDateTimeISO, (JSGlobalObject* globa
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // Step 1: Return ? SystemDateTime("iso8601", temporalTimeZoneLike).
-    // SystemDateTime step 1: ToTemporalTimeZoneIdentifier(temporalTimeZoneLike).
-    auto tzOpt = resolveNowTimeZone(globalObject, callFrame->argument(0));
+    // Step 1: Let isoDateTime be ? SystemDateTime(temporalTimeZoneLike).
+    auto isoDT = systemDateTime(globalObject, callFrame->argument(0));
     RETURN_IF_EXCEPTION(scope, { });
 
-    // SystemDateTime step 2: SystemUTCEpochNanoseconds().
-    auto exactTime = ISO8601::ExactTime::now();
-    ISO8601::PlainDate plainDate;
-    ISO8601::PlainTime plainTime;
-
-    if (!tzOpt) {
-        // Use system timezone via DateCache for millisecond resolution.
-        GregorianDateTime dt;
-        vm.dateCache.msToGregorianDateTime(static_cast<double>(exactTime.floorEpochMilliseconds()), TimeType::LocalTime, dt);
-        // Reconstruct offset from the system timezone to reuse exactTimeToLocalDateAndTime for sub-ms.
-        int64_t offsetMs = static_cast<int64_t>(dt.utcOffsetInMinute()) * WTF::Int64Milliseconds::msPerMinute;
-        TemporalCore::exactTimeToLocalDateAndTime(exactTime, offsetMs * static_cast<int64_t>(ISO8601::ExactTime::nsPerMillisecond), plainDate, plainTime);
-    } else {
-        // SystemDateTime step 3: GetISODateTimeFor(timeZone, epochNs).
-        int64_t offsetNs = getOffsetNanosecondsForTimeZone(*tzOpt, static_cast<double>(exactTime.floorEpochMilliseconds()));
-        TemporalCore::exactTimeToLocalDateAndTime(exactTime, offsetNs, plainDate, plainTime);
-    }
-
-    // Step 1 (cont): CreateTemporalDateTime(isoDateTime, "iso8601").
-    return JSValue::encode(TemporalPlainDateTime::create(vm, globalObject->plainDateTimeStructure(), WTF::move(plainDate), WTF::move(plainTime)));
+    // Step 2: Return ! CreateTemporalDateTime(isoDateTime, "iso8601").
+    return JSValue::encode(TemporalPlainDateTime::create(vm, globalObject->plainDateTimeStructure(), WTF::move(isoDT.date), WTF::move(isoDT.time)));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.now.plaintimeiso
@@ -218,29 +178,12 @@ JSC_DEFINE_HOST_FUNCTION(temporalNowFuncPlainTimeISO, (JSGlobalObject* globalObj
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // Step 1: Return ? SystemTime("iso8601", temporalTimeZoneLike).
-    // SystemTime step 1: ToTemporalTimeZoneIdentifier(temporalTimeZoneLike).
-    auto tzOpt = resolveNowTimeZone(globalObject, callFrame->argument(0));
+    // Step 1: Let isoDateTime be ? SystemDateTime(temporalTimeZoneLike).
+    auto isoDT = systemDateTime(globalObject, callFrame->argument(0));
     RETURN_IF_EXCEPTION(scope, { });
 
-    // SystemTime step 2: SystemUTCEpochNanoseconds().
-    auto exactTime = ISO8601::ExactTime::now();
-    ISO8601::PlainDate unusedDate;
-    ISO8601::PlainTime plainTime;
-
-    if (!tzOpt) {
-        GregorianDateTime dt;
-        vm.dateCache.msToGregorianDateTime(static_cast<double>(exactTime.floorEpochMilliseconds()), TimeType::LocalTime, dt);
-        int64_t offsetMs = static_cast<int64_t>(dt.utcOffsetInMinute()) * WTF::Int64Milliseconds::msPerMinute;
-        TemporalCore::exactTimeToLocalDateAndTime(exactTime, offsetMs * static_cast<int64_t>(ISO8601::ExactTime::nsPerMillisecond), unusedDate, plainTime);
-    } else {
-        // SystemTime step 3: GetISODateTimeFor(timeZone, epochNs).
-        int64_t offsetNs = getOffsetNanosecondsForTimeZone(*tzOpt, static_cast<double>(exactTime.floorEpochMilliseconds()));
-        TemporalCore::exactTimeToLocalDateAndTime(exactTime, offsetNs, unusedDate, plainTime);
-    }
-
-    // Step 1 (cont): CreateTemporalTime(isoDateTime.[[Time]]).
-    return JSValue::encode(TemporalPlainTime::create(vm, globalObject->plainTimeStructure(), WTF::move(plainTime)));
+    // Step 2: Return ! CreateTemporalTime(isoDateTime.[[Time]]).
+    return JSValue::encode(TemporalPlainTime::create(vm, globalObject->plainTimeStructure(), WTF::move(isoDT.time)));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.now.zoneddatetimeiso
@@ -249,18 +192,15 @@ JSC_DEFINE_HOST_FUNCTION(temporalNowFuncZonedDateTimeISO, (JSGlobalObject* globa
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // Step 1: If temporalTimeZoneLike is undefined, let tz be SystemTimeZoneIdentifier();
+    //   else, let tz be ? ToTemporalTimeZoneIdentifier(temporalTimeZoneLike).
     auto tzOpt = resolveNowTimeZone(globalObject, callFrame->argument(0));
     RETURN_IF_EXCEPTION(scope, { });
+    TimeZone tz = tzOpt ? *tzOpt : vm.dateCache.defaultTimeZone();
 
-    auto exactTime = ISO8601::ExactTime::now();
-
-    TimeZone tz;
-    if (tzOpt)
-        tz = *tzOpt;
-    else
-        tz = vm.dateCache.defaultTimeZone();
-
-    RELEASE_AND_RETURN(scope, JSValue::encode(TemporalZonedDateTime::create(vm, globalObject->zonedDateTimeStructure(), exactTime, tz, iso8601CalendarID())));
+    // Step 2: Let epochNs be SystemUTCEpochNanoseconds().
+    // Step 3: Return ! CreateTemporalZonedDateTime(epochNs, tz, "iso8601").
+    RELEASE_AND_RETURN(scope, JSValue::encode(TemporalZonedDateTime::create(vm, globalObject->zonedDateTimeStructure(), ISO8601::ExactTime::now(), tz, iso8601CalendarID())));
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/TemporalPlainDate.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDate.cpp
@@ -190,9 +190,7 @@ static TemporalPlainDate* fromImpl(JSGlobalObject* globalObject, JSValue itemVal
 
         if (itemValue.inherits<TemporalZonedDateTime>()) {
             auto* zdt = uncheckedDowncast<TemporalZonedDateTime>(itemValue);
-            ISO8601::PlainDate date;
-            ISO8601::PlainTime time;
-            zdt->getLocalDateAndTime(globalObject, date, time);
+            auto [date, time] = zdt->getLocalDateTime(globalObject);
             RETURN_IF_EXCEPTION(scope, { });
             if (!TemporalCore::calendarIsISO(zdt->calendarID()))
                 return TemporalPlainDate::create(vm, globalObject->plainDateStructure(), WTF::move(date), String(zdt->calendarId()));
@@ -295,9 +293,7 @@ TemporalPlainDate* TemporalPlainDate::from(JSGlobalObject* globalObject, JSValue
         //   GetISODateTimeFor (before options, per spec order) + overflow + CreateTemporalDate.
         if (itemValue.inherits<TemporalZonedDateTime>()) {
             auto* zdt = uncheckedDowncast<TemporalZonedDateTime>(itemValue);
-            ISO8601::PlainDate date;
-            ISO8601::PlainTime time;
-            zdt->getLocalDateAndTime(globalObject, date, time);
+            auto [date, time] = zdt->getLocalDateTime(globalObject);
             RETURN_IF_EXCEPTION(scope, { });
             toTemporalOverflow(globalObject, optionsValue);
             RETURN_IF_EXCEPTION(scope, { });

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateTime.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateTime.cpp
@@ -257,7 +257,6 @@ static TemporalPlainDateTime* fromImpl(JSGlobalObject* globalObject, JSValue ite
             }
         }
 
-
         // Validate/clamp month and day at double level before double→unsigned cast.
         // static_cast<unsigned> of values >= 2^32 is UB and wraps to 0 on x86.
         if (!isNonISO) {
@@ -376,9 +375,7 @@ TemporalPlainDateTime* TemporalPlainDateTime::from(JSGlobalObject* globalObject,
         if (itemValue.inherits<TemporalZonedDateTime>()) {
             // Step 2.b.i: GetISODateTimeFor FIRST (before options — spec step order).
             auto* zdt = uncheckedDowncast<TemporalZonedDateTime>(itemValue);
-            ISO8601::PlainDate date;
-            ISO8601::PlainTime time;
-            zdt->getLocalDateAndTime(globalObject, date, time);
+            auto [date, time] = zdt->getLocalDateTime(globalObject);
             RETURN_IF_EXCEPTION(scope, { });
             // Step 2.b.ii: GetOptionsObject + overflow.
             toTemporalOverflow(globalObject, optionsValue);

--- a/Source/JavaScriptCore/runtime/TemporalPlainTime.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainTime.cpp
@@ -516,9 +516,7 @@ TemporalPlainTime* TemporalPlainTime::from(JSGlobalObject* globalObject, JSValue
         // Return ! CreateTemporalTime(isoDateTime.[[Time]]).
         if (itemValue.inherits<TemporalZonedDateTime>()) {
             auto* zdt = uncheckedDowncast<TemporalZonedDateTime>(itemValue);
-            ISO8601::PlainDate date;
-            ISO8601::PlainTime time;
-            zdt->getLocalDateAndTime(globalObject, date, time);
+            auto [date, time] = zdt->getLocalDateTime(globalObject);
             RETURN_IF_EXCEPTION(scope, { });
             toTemporalOverflow(globalObject, optionsValue);
             RETURN_IF_EXCEPTION(scope, { });

--- a/Source/JavaScriptCore/runtime/TemporalZonedDateTime.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalZonedDateTime.cpp
@@ -89,14 +89,10 @@ TemporalZonedDateTime::TemporalZonedDateTime(VM& vm, Structure* structure, ISO86
 {
 }
 
-// https://tc39.es/proposal-temporal/#sec-temporal-getoffsetnanosecondsfor
 std::optional<int64_t> TemporalZonedDateTime::getOffsetNanoseconds(JSGlobalObject* globalObject) const
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    // Step 1: If timeZone is an offset timezone, return offsetMinutes × 60 × 10⁹.
-    // Step 2: Return GetNamedTimeZoneOffsetNanoseconds(timeZone, epochNanoseconds).
-    // (Both paths are handled by TemporalCore::getOffsetNanosecondsFor.)
     auto result = TemporalCore::getOffsetNanosecondsFor(m_timeZone, exactTime());
     if (!result) [[unlikely]] {
         if (result.error().kind == TemporalErrorKind::RangeError)
@@ -109,15 +105,20 @@ std::optional<int64_t> TemporalZonedDateTime::getOffsetNanoseconds(JSGlobalObjec
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal-getisodatetimefor
-void TemporalZonedDateTime::getLocalDateAndTime(JSGlobalObject* globalObject, ISO8601::PlainDate& outDate, ISO8601::PlainTime& outTime) const
+// Thin JS-side wrapper: forwards TemporalResult errors to the caller's ThrowScope.
+ISO8601::PlainDateTime TemporalZonedDateTime::getLocalDateTime(JSGlobalObject* globalObject) const
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    // Step 1: Let offsetNanoseconds be ! GetOffsetNanosecondsFor(timeZone, epochNanoseconds).
-    auto offsetOpt = getOffsetNanoseconds(globalObject);
-    RETURN_IF_EXCEPTION(scope, void());
-    // Step 2: Return BalanceISODateTime(epochNanoseconds + offsetNanoseconds).
-    TemporalCore::exactTimeToLocalDateAndTime(exactTime(), *offsetOpt, outDate, outTime);
+    auto result = TemporalCore::getISODateTimeFor(m_timeZone, exactTime());
+    if (!result) [[unlikely]] {
+        if (result.error().kind == TemporalErrorKind::RangeError)
+            throwRangeError(globalObject, scope, result.error().message);
+        else
+            throwTypeError(globalObject, scope, result.error().message);
+        return { };
+    }
+    return *result;
 }
 
 // Internal helper: extracts the runtime TimeZone handle from an already-parsed TimeZoneRecord.

--- a/Source/JavaScriptCore/runtime/TemporalZonedDateTime.h
+++ b/Source/JavaScriptCore/runtime/TemporalZonedDateTime.h
@@ -64,9 +64,7 @@ public:
 
     std::optional<int64_t> getOffsetNanoseconds(JSGlobalObject*) const;
 
-    // Decomposes this ZDT into local (PlainDate, PlainTime) via GetISODateTimeFor.
-    // Throws on ICU failure; out-params are valid only when no exception is set after the call.
-    void getLocalDateAndTime(JSGlobalObject*, ISO8601::PlainDate&, ISO8601::PlainTime&) const;
+    ISO8601::PlainDateTime getLocalDateTime(JSGlobalObject*) const;
 
     static std::optional<ISO8601::ExactTime> getEpochNanosecondsFor(JSGlobalObject*, const TimeZone&, const ISO8601::PlainDate&, const ISO8601::PlainTime&, TemporalDisambiguation);
 

--- a/Source/JavaScriptCore/runtime/TemporalZonedDateTimePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalZonedDateTimePrototype.cpp
@@ -201,9 +201,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalZonedDateTimePrototypeFuncStartOfDay, (JSGlobal
         return throwVMTypeError(globalObject, scope, "Temporal.ZonedDateTime.prototype.startOfDay called on value that's not a ZonedDateTime"_s);
 
     // Steps 3-5: Get timeZone, calendar, and local isoDateTime via GetISODateTimeFor.
-    ISO8601::PlainDate date;
-    ISO8601::PlainTime time;
-    zdt->getLocalDateAndTime(globalObject, date, time);
+    auto [date, time] = zdt->getLocalDateTime(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
     // Step 6: Let epochNanoseconds be ? GetStartOfDay(timeZone, isoDateTime.[[ISODate]]).
@@ -234,9 +232,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalZonedDateTimePrototypeFuncWithPlainTime, (JSGlo
     // Step 3: Let timeZone be zonedDateTime.[[TimeZone]].
     // Step 4: Let calendar be zonedDateTime.[[Calendar]].
     // Step 5: Let isoDateTime be GetISODateTimeFor(timeZone, zonedDateTime.[[EpochNanoseconds]]).
-    ISO8601::PlainDate date;
-    ISO8601::PlainTime unused;
-    zdt->getLocalDateAndTime(globalObject, date, unused);
+    auto [date, unused] = zdt->getLocalDateTime(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
     JSValue timeArg = callFrame->argument(0);
@@ -479,9 +475,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalZonedDateTimePrototypeFuncRound, (JSGlobalObjec
 
     // Steps 15-17: thisNs, timeZone, calendar.
     // Step 18: isoDateTime = GetISODateTimeFor(timeZone, thisNs).
-    ISO8601::PlainDate date;
-    ISO8601::PlainTime time;
-    zdt->getLocalDateAndTime(globalObject, date, time);
+    auto [date, time] = zdt->getLocalDateTime(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
     Int128 epochNs = zdt->exactTime().epochNanoseconds();
@@ -641,9 +635,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalZonedDateTimePrototypeFuncWith, (JSGlobalObject
     // Steps 4-6: epochNs, timeZone, calendar from this ZDT.
     // Steps 7-8: offsetNanoseconds = GetOffsetNanosecondsFor(timeZone, epochNs);
     //            isoDateTime = GetISODateTimeFor(timeZone, epochNs).
-    ISO8601::PlainDate curDate;
-    ISO8601::PlainTime curTime;
-    zdt->getLocalDateAndTime(globalObject, curDate, curTime);
+    auto [curDate, curTime] = zdt->getLocalDateTime(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
     auto curOffsetNsOpt = zdt->getOffsetNanoseconds(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
@@ -887,9 +879,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalZonedDateTimePrototypeFuncToPlainDate, (JSGloba
         return throwVMTypeError(globalObject, scope, "Temporal.ZonedDateTime.prototype.toPlainDate called on value that's not a ZonedDateTime"_s);
 
     // Step 3: isoDateTime = GetISODateTimeFor(timeZone, epochNanoseconds).
-    ISO8601::PlainDate date;
-    ISO8601::PlainTime time;
-    zdt->getLocalDateAndTime(globalObject, date, time);
+    auto [date, time] = zdt->getLocalDateTime(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
     // Step 4: Return ! CreateTemporalDate(isoDateTime.[[ISODate]], zonedDateTime.[[Calendar]]).
@@ -909,9 +899,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalZonedDateTimePrototypeFuncToPlainTime, (JSGloba
         return throwVMTypeError(globalObject, scope, "Temporal.ZonedDateTime.prototype.toPlainTime called on value that's not a ZonedDateTime"_s);
 
     // Step 3: isoDateTime = GetISODateTimeFor(timeZone, epochNanoseconds).
-    ISO8601::PlainDate date;
-    ISO8601::PlainTime time;
-    zdt->getLocalDateAndTime(globalObject, date, time);
+    auto [date, time] = zdt->getLocalDateTime(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
     // Step 4: Return ! CreateTemporalTime(isoDateTime.[[Time]]).
@@ -931,9 +919,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalZonedDateTimePrototypeFuncToPlainDateTime, (JSG
         return throwVMTypeError(globalObject, scope, "Temporal.ZonedDateTime.prototype.toPlainDateTime called on value that's not a ZonedDateTime"_s);
 
     // Step 3: isoDateTime = GetISODateTimeFor(timeZone, epochNanoseconds).
-    ISO8601::PlainDate date;
-    ISO8601::PlainTime time;
-    zdt->getLocalDateAndTime(globalObject, date, time);
+    auto [date, time] = zdt->getLocalDateTime(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
     // Step 4: Return ! CreateTemporalDateTime(isoDateTime, zonedDateTime.[[Calendar]]).
@@ -970,9 +956,7 @@ static String temporalZonedDateTimeToString(JSGlobalObject* globalObject, const 
     }
 
     // Step 8: Let isoDateTime be GetISODateTimeFor(timeZone, epochNs).
-    ISO8601::PlainDate date;
-    ISO8601::PlainTime time;
-    TemporalCore::exactTimeToLocalDateAndTime(roundedExact, *offsetOpt, date, time);
+    auto [date, time] = TemporalCore::exactTimeToLocalDateAndTime(roundedExact, *offsetOpt);
 
     // Step 9: Let dateTimeString be ISODateTimeToString(isoDateTime, "iso8601", precision, ~never~).
     StringBuilder sb;
@@ -1240,9 +1224,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalZonedDateTimePrototypeGetterYear, (JSGlobalObje
         return throwVMTypeError(globalObject, scope, "Temporal.ZonedDateTime.prototype.year called on value that's not a ZonedDateTime"_s);
 
     // Step 3: isoDateTime = GetISODateTimeFor(timeZone, epochNanoseconds).
-    ISO8601::PlainDate date;
-    ISO8601::PlainTime time;
-    zdt->getLocalDateAndTime(globalObject, date, time);
+    auto [date, time] = zdt->getLocalDateTime(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
     // Step 4: Return ? CalendarYear(calendar, isoDateTime.[[ISODate]]).
@@ -1265,10 +1247,8 @@ JSC_DEFINE_CUSTOM_GETTER(temporalZonedDateTimePrototypeGetterMonth, (JSGlobalObj
     if (!zdt) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.ZonedDateTime.prototype.month called on value that's not a ZonedDateTime"_s);
 
-    ISO8601::PlainDate date;
-    ISO8601::PlainTime time;
     // Step 3: isoDateTime = GetISODateTimeFor(timeZone, epochNanoseconds).
-    zdt->getLocalDateAndTime(globalObject, date, time);
+    auto [date, time] = zdt->getLocalDateTime(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
     // Step 4: Return ? CalendarMonth(calendar, isoDateTime.[[ISODate]]).
@@ -1291,10 +1271,8 @@ JSC_DEFINE_CUSTOM_GETTER(temporalZonedDateTimePrototypeGetterMonthCode, (JSGloba
     if (!zdt) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.ZonedDateTime.prototype.monthCode called on value that's not a ZonedDateTime"_s);
 
-    ISO8601::PlainDate date;
-    ISO8601::PlainTime time;
     // Step 3: isoDateTime = GetISODateTimeFor(timeZone, epochNanoseconds).
-    zdt->getLocalDateAndTime(globalObject, date, time);
+    auto [date, time] = zdt->getLocalDateTime(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
     // Step 4: Return ? CalendarMonthCode(calendar, isoDateTime.[[ISODate]]).
@@ -1317,10 +1295,8 @@ JSC_DEFINE_CUSTOM_GETTER(temporalZonedDateTimePrototypeGetterDay, (JSGlobalObjec
     if (!zdt) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.ZonedDateTime.prototype.day called on value that's not a ZonedDateTime"_s);
 
-    ISO8601::PlainDate date;
-    ISO8601::PlainTime time;
     // Step 3: isoDateTime = GetISODateTimeFor(timeZone, epochNanoseconds).
-    zdt->getLocalDateAndTime(globalObject, date, time);
+    auto [date, time] = zdt->getLocalDateTime(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
     // Step 4: Return ? CalendarDay(calendar, isoDateTime.[[ISODate]]).
@@ -1343,10 +1319,8 @@ JSC_DEFINE_CUSTOM_GETTER(temporalZonedDateTimePrototypeGetterHour, (JSGlobalObje
     if (!zdt) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.ZonedDateTime.prototype.hour called on value that's not a ZonedDateTime"_s);
 
-    ISO8601::PlainDate date;
-    ISO8601::PlainTime time;
     // Step 3: isoDateTime = GetISODateTimeFor(timeZone, epochNanoseconds).
-    zdt->getLocalDateAndTime(globalObject, date, time);
+    auto [date, time] = zdt->getLocalDateTime(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
     // Step 4: Return isoDateTime.[[Time]].[[Hour]].
     return JSValue::encode(jsNumber(time.hour()));
@@ -1362,10 +1336,8 @@ JSC_DEFINE_CUSTOM_GETTER(temporalZonedDateTimePrototypeGetterMinute, (JSGlobalOb
     if (!zdt) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.ZonedDateTime.prototype.minute called on value that's not a ZonedDateTime"_s);
 
-    ISO8601::PlainDate date;
-    ISO8601::PlainTime time;
     // Step 3: isoDateTime = GetISODateTimeFor(timeZone, epochNanoseconds).
-    zdt->getLocalDateAndTime(globalObject, date, time);
+    auto [date, time] = zdt->getLocalDateTime(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
     // Step 4: Return isoDateTime.[[Time]].[[Minute]].
     return JSValue::encode(jsNumber(time.minute()));
@@ -1381,10 +1353,8 @@ JSC_DEFINE_CUSTOM_GETTER(temporalZonedDateTimePrototypeGetterSecond, (JSGlobalOb
     if (!zdt) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.ZonedDateTime.prototype.second called on value that's not a ZonedDateTime"_s);
 
-    ISO8601::PlainDate date;
-    ISO8601::PlainTime time;
     // Step 3: isoDateTime = GetISODateTimeFor(timeZone, epochNanoseconds).
-    zdt->getLocalDateAndTime(globalObject, date, time);
+    auto [date, time] = zdt->getLocalDateTime(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
     // Step 4: Return isoDateTime.[[Time]].[[Second]].
     return JSValue::encode(jsNumber(time.second()));
@@ -1400,10 +1370,8 @@ JSC_DEFINE_CUSTOM_GETTER(temporalZonedDateTimePrototypeGetterMillisecond, (JSGlo
     if (!zdt) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.ZonedDateTime.prototype.millisecond called on value that's not a ZonedDateTime"_s);
 
-    ISO8601::PlainDate date;
-    ISO8601::PlainTime time;
     // Step 3: isoDateTime = GetISODateTimeFor(timeZone, epochNanoseconds).
-    zdt->getLocalDateAndTime(globalObject, date, time);
+    auto [date, time] = zdt->getLocalDateTime(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
     // Step 4: Return isoDateTime.[[Time]].[[Millisecond]].
     return JSValue::encode(jsNumber(time.millisecond()));
@@ -1419,10 +1387,8 @@ JSC_DEFINE_CUSTOM_GETTER(temporalZonedDateTimePrototypeGetterMicrosecond, (JSGlo
     if (!zdt) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.ZonedDateTime.prototype.microsecond called on value that's not a ZonedDateTime"_s);
 
-    ISO8601::PlainDate date;
-    ISO8601::PlainTime time;
     // Step 3: isoDateTime = GetISODateTimeFor(timeZone, epochNanoseconds).
-    zdt->getLocalDateAndTime(globalObject, date, time);
+    auto [date, time] = zdt->getLocalDateTime(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
     // Step 4: Return isoDateTime.[[Time]].[[Microsecond]].
     return JSValue::encode(jsNumber(time.microsecond()));
@@ -1438,10 +1404,8 @@ JSC_DEFINE_CUSTOM_GETTER(temporalZonedDateTimePrototypeGetterNanosecond, (JSGlob
     if (!zdt) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.ZonedDateTime.prototype.nanosecond called on value that's not a ZonedDateTime"_s);
 
-    ISO8601::PlainDate date;
-    ISO8601::PlainTime time;
     // Step 3: isoDateTime = GetISODateTimeFor(timeZone, epochNanoseconds).
-    zdt->getLocalDateAndTime(globalObject, date, time);
+    auto [date, time] = zdt->getLocalDateTime(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
     // Step 4: Return isoDateTime.[[Time]].[[Nanosecond]].
     return JSValue::encode(jsNumber(time.nanosecond()));
@@ -1457,10 +1421,8 @@ JSC_DEFINE_CUSTOM_GETTER(temporalZonedDateTimePrototypeGetterDayOfWeek, (JSGloba
     if (!zdt) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.ZonedDateTime.prototype.dayOfWeek called on value that's not a ZonedDateTime"_s);
 
-    ISO8601::PlainDate date;
-    ISO8601::PlainTime time;
     // Step 3: isoDateTime = GetISODateTimeFor(timeZone, epochNanoseconds).
-    zdt->getLocalDateAndTime(globalObject, date, time);
+    auto [date, time] = zdt->getLocalDateTime(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
     // Step 4: Return 𝔽(CalendarISOToDate(calendar, isoDateTime.[[ISODate]]).[[DayOfWeek]]).
     // DayOfWeek is universal across all calendar systems (Mon=1 … Sun=7).
@@ -1477,10 +1439,8 @@ JSC_DEFINE_CUSTOM_GETTER(temporalZonedDateTimePrototypeGetterDayOfYear, (JSGloba
     if (!zdt) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.ZonedDateTime.prototype.dayOfYear called on value that's not a ZonedDateTime"_s);
 
-    ISO8601::PlainDate date;
-    ISO8601::PlainTime time;
     // Step 3: isoDateTime = GetISODateTimeFor(timeZone, epochNanoseconds).
-    zdt->getLocalDateAndTime(globalObject, date, time);
+    auto [date, time] = zdt->getLocalDateTime(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
     // Step 4: Return 𝔽(CalendarISOToDate(calendar, isoDateTime.[[ISODate]]).[[DayOfYear]]).
     // NOTE: for non-ISO calendars this should return the day within the calendar year, not the ISO year.
@@ -1498,10 +1458,8 @@ JSC_DEFINE_CUSTOM_GETTER(temporalZonedDateTimePrototypeGetterWeekOfYear, (JSGlob
     if (!zdt) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.ZonedDateTime.prototype.weekOfYear called on value that's not a ZonedDateTime"_s);
 
-    ISO8601::PlainDate date;
-    ISO8601::PlainTime time;
     // Step 3: isoDateTime = GetISODateTimeFor(timeZone, epochNanoseconds).
-    zdt->getLocalDateAndTime(globalObject, date, time);
+    auto [date, time] = zdt->getLocalDateTime(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
     // Step 4: Return ? CalendarWeekOfYear(calendar, isoDateTime.[[ISODate]]). Undefined for non-ISO.
     if (!TemporalCore::calendarIsISO(zdt->calendarID()))
@@ -1519,10 +1477,8 @@ JSC_DEFINE_CUSTOM_GETTER(temporalZonedDateTimePrototypeGetterYearOfWeek, (JSGlob
     if (!zdt) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.ZonedDateTime.prototype.yearOfWeek called on value that's not a ZonedDateTime"_s);
 
-    ISO8601::PlainDate date;
-    ISO8601::PlainTime time;
     // Step 3: isoDateTime = GetISODateTimeFor(timeZone, epochNanoseconds).
-    zdt->getLocalDateAndTime(globalObject, date, time);
+    auto [date, time] = zdt->getLocalDateTime(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
     // Step 4: Return ? CalendarYearOfWeek(calendar, isoDateTime.[[ISODate]]). Undefined for non-ISO.
     if (!TemporalCore::calendarIsISO(zdt->calendarID()))
@@ -1542,9 +1498,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalZonedDateTimePrototypeGetterHoursInDay, (JSGlob
         return throwVMTypeError(globalObject, scope, "Temporal.ZonedDateTime.prototype.hoursInDay called on value that's not a ZonedDateTime"_s);
 
     // Steps 3-5: timeZone, isoDateTime = GetISODateTimeFor, today = isoDateTime.[[ISODate]].
-    ISO8601::PlainDate date;
-    ISO8601::PlainTime plainTime;
-    zdt->getLocalDateAndTime(globalObject, date, plainTime);
+    auto [date, plainTime] = zdt->getLocalDateTime(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
     // Step 6: tomorrow = AddDaysToISODate(today, 1) — simple epoch-day +1, no calendar needed.
@@ -1584,9 +1538,8 @@ JSC_DEFINE_CUSTOM_GETTER(temporalZonedDateTimePrototypeGetterDaysInWeek, (JSGlob
         return throwVMTypeError(globalObject, scope, "Temporal.ZonedDateTime.prototype.daysInWeek called on value that's not a ZonedDateTime"_s);
 
     // Step 3: isoDateTime = GetISODateTimeFor(timeZone, epochNanoseconds).
-    ISO8601::PlainDate date;
-    ISO8601::PlainTime time;
-    zdt->getLocalDateAndTime(globalObject, date, time);
+    //   (Call for its side effect only — all calendars have a 7-day week.)
+    zdt->getLocalDateTime(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
     // Step 4: Return 𝔽(CalendarISOToDate(calendar, isoDate).[[DaysInWeek]]).
@@ -1604,10 +1557,8 @@ JSC_DEFINE_CUSTOM_GETTER(temporalZonedDateTimePrototypeGetterDaysInMonth, (JSGlo
     if (!zdt) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.ZonedDateTime.prototype.daysInMonth called on value that's not a ZonedDateTime"_s);
 
-    ISO8601::PlainDate date;
-    ISO8601::PlainTime time;
     // Step 3: isoDateTime = GetISODateTimeFor(timeZone, epochNanoseconds).
-    zdt->getLocalDateAndTime(globalObject, date, time);
+    auto [date, time] = zdt->getLocalDateTime(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
     // Step 4: Return ? CalendarDaysInMonth(calendar, isoDateTime.[[ISODate]]).
@@ -1630,10 +1581,8 @@ JSC_DEFINE_CUSTOM_GETTER(temporalZonedDateTimePrototypeGetterDaysInYear, (JSGlob
     if (!zdt) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.ZonedDateTime.prototype.daysInYear called on value that's not a ZonedDateTime"_s);
 
-    ISO8601::PlainDate date;
-    ISO8601::PlainTime time;
     // Step 3: isoDateTime = GetISODateTimeFor(timeZone, epochNanoseconds).
-    zdt->getLocalDateAndTime(globalObject, date, time);
+    auto [date, time] = zdt->getLocalDateTime(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
     // Step 4: Return ? CalendarDaysInYear(calendar, isoDateTime.[[ISODate]]).
@@ -1658,9 +1607,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalZonedDateTimePrototypeGetterMonthsInYear, (JSGl
 
     if (!TemporalCore::calendarIsISO(zdt->calendarID())) {
         // Step 3: isoDateTime = GetISODateTimeFor(timeZone, epochNanoseconds).
-        ISO8601::PlainDate date;
-        ISO8601::PlainTime time2;
-        zdt->getLocalDateAndTime(globalObject, date, time2);
+        auto [date, time2] = zdt->getLocalDateTime(globalObject);
         RETURN_IF_EXCEPTION(scope, { });
         // Step 4: Return ? CalendarMonthsInYear(calendar, isoDateTime.[[ISODate]]).
         auto result = TemporalCore::calendarMonthsInYear(zdt->calendarID(), date);
@@ -1682,10 +1629,8 @@ JSC_DEFINE_CUSTOM_GETTER(temporalZonedDateTimePrototypeGetterInLeapYear, (JSGlob
     if (!zdt) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.ZonedDateTime.prototype.inLeapYear called on value that's not a ZonedDateTime"_s);
 
-    ISO8601::PlainDate date;
-    ISO8601::PlainTime time;
     // Step 3: isoDateTime = GetISODateTimeFor(timeZone, epochNanoseconds).
-    zdt->getLocalDateAndTime(globalObject, date, time);
+    auto [date, time] = zdt->getLocalDateTime(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
     // Step 4: Return ? CalendarInLeapYear(calendar, isoDateTime.[[ISODate]]).
@@ -1708,10 +1653,8 @@ JSC_DEFINE_CUSTOM_GETTER(temporalZonedDateTimePrototypeGetterEra, (JSGlobalObjec
     if (!zdt) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.ZonedDateTime.prototype.era called on value that's not a ZonedDateTime"_s);
 
-    ISO8601::PlainDate date;
-    ISO8601::PlainTime time;
     // Step 3: isoDateTime = GetISODateTimeFor(timeZone, epochNanoseconds).
-    zdt->getLocalDateAndTime(globalObject, date, time);
+    auto [date, time] = zdt->getLocalDateTime(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
     // Step 4: Return ? CalendarEra(calendar, isoDateTime.[[ISODate]]).
     auto result = TemporalCore::calendarEra(zdt->calendarID(), date);
@@ -1734,9 +1677,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalZonedDateTimePrototypeGetterEraYear, (JSGlobalO
         return throwVMTypeError(globalObject, scope, "Temporal.ZonedDateTime.prototype.eraYear called on value that's not a ZonedDateTime"_s);
 
     // Step 3: isoDateTime = GetISODateTimeFor(timeZone, epochNanoseconds).
-    ISO8601::PlainDate date;
-    ISO8601::PlainTime time2;
-    zdt->getLocalDateAndTime(globalObject, date, time2);
+    auto [date, time2] = zdt->getLocalDateTime(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
     // Step 4: result = CalendarISOToDate(calendar, isoDate).[[EraYear]].
     auto result = TemporalCore::calendarEraYear(zdt->calendarID(), date);

--- a/Source/JavaScriptCore/runtime/temporal/core/CalendarFields.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/CalendarFields.cpp
@@ -724,7 +724,8 @@ TemporalResult<ResolvedCalendarDate> plainYearMonthToPlainDate(CalendarID calend
 
 // plainYearMonthFromISODate — no 1:1 temporal_rs function; inlined in PlainYearMonth::from_parsed
 // https://tc39.es/proposal-temporal/#sec-temporal-totemporalyearmonth (string parse path)
-// Implements steps 10, 12; step 9 (ISOYearMonthWithinLimits) done by JS-layer caller.
+// Implements steps 10 and 12; the within-limits check (spec step 9) runs inside
+// yearMonthFromFields (see ISOYearMonthWithinLimits guard below in that function).
 TemporalResult<ResolvedCalendarDate> plainYearMonthFromISODate(CalendarID calendarId, const ISO8601::PlainDate& fullISODate)
 {
     bool isISO = calendarIsISO(calendarId);
@@ -754,7 +755,8 @@ TemporalResult<ResolvedCalendarDate> plainYearMonthFromISODate(CalendarID calend
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal-totemporalmonthday (string parse path)
-// Implements steps 10, 12; step 9 (ISODateWithinLimits) done by JS-layer caller.
+// Implements steps 10 and 12; the within-limits check (spec step 9) runs inside
+// monthDayFromFields (see ISODateWithinLimits guard in that function).
 TemporalResult<ResolvedCalendarDate> plainMonthDayFromISODate(CalendarID calendarId, const ISO8601::PlainDate& fullISODate, TemporalOverflow overflow)
 {
     bool isISO = calendarIsISO(calendarId);

--- a/Source/JavaScriptCore/runtime/temporal/core/DurationArithmetic.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/DurationArithmetic.cpp
@@ -624,7 +624,7 @@ static TemporalResult<std::optional<NudgeWindow>> computeNudgeWindow(
         startEpochNs = originEpochNs;
     else {
         auto startResult = TemporalCore::calendarDateAdd(calendarId, isoDate, startDuration, TemporalOverflow::Constrain);
-        if (!startResult)
+        if (!startResult) [[unlikely]]
             return makeUnexpected(startResult.error());
         auto start = *startResult;
         double startDayCount = dateToDaysFrom1970(start.year(), static_cast<int>(start.month()) - 1, static_cast<int>(start.day()));
@@ -637,7 +637,7 @@ static TemporalResult<std::optional<NudgeWindow>> computeNudgeWindow(
     }
     // Step 9: end = CalendarDateAdd(calendar, isoDateTime.[[ISODate]], endDuration, constrain).
     auto endResult = TemporalCore::calendarDateAdd(calendarId, isoDate, endDuration, TemporalOverflow::Constrain);
-    if (!endResult)
+    if (!endResult) [[unlikely]]
         return makeUnexpected(endResult.error());
     auto end = *endResult;
     double endDayCount = dateToDaysFrom1970(end.year(), static_cast<int>(end.month()) - 1, static_cast<int>(end.day()));
@@ -732,7 +732,7 @@ TemporalResult<NudgeResult> nudgeToZonedTime(int32_t sign,
 {
     // Step 1: Let start be ? CalendarDateAdd(calendar, isoDateTime.[[ISODate]], duration.[[Date]], ~constrain~).
     auto startResult = TemporalCore::calendarDateAdd(calendarId, isoDate, duration.dateDuration(), TemporalOverflow::Constrain);
-    if (!startResult)
+    if (!startResult) [[unlikely]]
         return makeUnexpected(startResult.error());
     auto start = *startResult;
     // Step 2: startDateTime = CombineISODateAndTimeRecord(start, isoDateTime.[[Time]]).
@@ -882,7 +882,7 @@ TemporalResult<ISO8601::InternalDuration> bubbleRelativeDuration(
             }
             // Step 6.b.iv: Let end be ? CalendarDateAdd(calendar, isoDateTime.[[ISODate]], endDuration, ~constrain~).
             auto endResult = TemporalCore::calendarDateAdd(calendarId, isoDate, endDuration, TemporalOverflow::Constrain);
-            if (!endResult)
+            if (!endResult) [[unlikely]]
                 return makeUnexpected(endResult.error());
             // Step 6.b.v: endDateTime = CombineISODateAndTimeRecord(end, isoDateTime.[[Time]]).
             // Step 6.b.vi: endEpochNs = GetUTCEpochNanoseconds/GetEpochNanosecondsFor. (v+vi fused)

--- a/Source/JavaScriptCore/runtime/temporal/core/TimeZoneICUBridge.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/TimeZoneICUBridge.cpp
@@ -114,38 +114,73 @@ static double isoDateTimeToLocalMs(const ISO8601::PlainDate& date, const ISO8601
     return makeDate(days, timeMs);
 }
 
-// exactTimeToLocalDateAndTime — internal: decomposes an exact epoch time + offset into PlainDate + PlainTime.
-void exactTimeToLocalDateAndTime(ISO8601::ExactTime exactTime, int64_t offsetNs, ISO8601::PlainDate& outDate, ISO8601::PlainTime& outTime)
+static constexpr std::pair<int64_t, int64_t> floorDivMod(int64_t num, int64_t denom)
 {
-    int64_t epochMs = exactTime.floorEpochMilliseconds();
-    int64_t offsetMs = offsetNs / static_cast<int64_t>(ISO8601::ExactTime::nsPerMillisecond);
-    int64_t localMs = epochMs + offsetMs;
+    int64_t q = num / denom;
+    int64_t r = num % denom;
+    if (r < 0) {
+        r += denom;
+        q -= 1;
+    }
+    return { q, r };
+}
 
-    WTF::Int64Milliseconds localMsWT(localMs);
-    int32_t days = WTF::msToDays(localMsWT);
-    int32_t timeInDayMs = WTF::timeInDay(localMsWT, days);
+// temporal_rs: IsoTime::balance (src/iso.rs:664). Cascades ns→μs→ms→s→m→h; returns overflow days.
+static std::pair<int64_t, ISO8601::PlainTime> balanceIsoTime(int64_t hour, int64_t minute, int64_t second, int64_t millisecond, int64_t microsecond, int64_t nanosecond)
+{
+    auto [nq, ns] = floorDivMod(nanosecond, 1000);
+    microsecond += nq;
+    auto [uq, us] = floorDivMod(microsecond, 1000);
+    millisecond += uq;
+    auto [mq, ms] = floorDivMod(millisecond, 1000);
+    second += mq;
+    auto [sq, s] = floorDivMod(second, 60);
+    minute += sq;
+    auto [minq, min] = floorDivMod(minute, 60);
+    hour += minq;
+    auto [days, h] = floorDivMod(hour, 24);
+    return { days, ISO8601::PlainTime(static_cast<int>(h), static_cast<int>(min), static_cast<int>(s), static_cast<int>(ms), static_cast<int>(us), static_cast<int>(ns)) };
+}
 
-    auto [year, month, day] = WTF::yearMonthDayFromDays(days);
-    // month from yearMonthDayFromDays is 0-indexed; ISO8601::PlainDate wants 1-indexed.
-    outDate = ISO8601::PlainDate(year, static_cast<uint8_t>(month + 1), static_cast<uint8_t>(day));
+// temporal_rs: IsoDate::balance (src/iso.rs:343). Normalizes (y, m, d) via epoch-days round-trip.
+static ISO8601::PlainDate balanceIsoDate(int32_t year, int32_t month, int64_t day)
+{
+    double epochDays = makeDay(year, month - 1, static_cast<int>(day));
+    auto [y, m0, d] = WTF::yearMonthDayFromDays(static_cast<int32_t>(epochDays));
+    return ISO8601::PlainDate(y, static_cast<uint8_t>(m0 + 1), static_cast<uint8_t>(d));
+}
 
-    const int32_t msPerHour = 3'600'000; // nsPerHour / nsPerMillisecond
-    const int32_t msPerMinute = 60'000; // nsPerMinute / nsPerMillisecond
-    const int32_t msPerSecond = 1'000; // nsPerSecond / nsPerMillisecond
-    int hour = timeInDayMs / msPerHour;
-    int minute = (timeInDayMs / msPerMinute) % 60;
-    int second = (timeInDayMs / msPerSecond) % 60;
-    int millisecond = timeInDayMs % msPerSecond;
+// temporal_rs: IsoDateTime::from_epoch_nanos (src/iso.rs:87).
+// Steps 2-3 of GetISODateTimeFor with caller-supplied offset.
+ISO8601::PlainDateTime exactTimeToLocalDateAndTime(ISO8601::ExactTime exactTime, int64_t offsetNs)
+{
+    // Floor-split epochNs into (epochMs, remainderNs).
+    Int128 epochNs = exactTime.epochNanoseconds();
+    Int128 nsPerMs = ISO8601::ExactTime::nsPerMillisecond;
+    Int128 remainderNs128 = epochNs % nsPerMs;
+    Int128 epochMs128 = epochNs / nsPerMs;
+    if (remainderNs128 < 0) {
+        remainderNs128 += nsPerMs;
+        epochMs128 -= 1;
+    }
+    int64_t epochMs = static_cast<int64_t>(epochMs128);
+    int64_t remainderNs = static_cast<int64_t>(remainderNs128);
 
-    // Sub-millisecond precision from the nanosecond timestamp.
-    auto epochNs = exactTime.epochNanoseconds();
-    auto nsInMs = static_cast<int32_t>(epochNs % ISO8601::ExactTime::nsPerMillisecond);
-    if (nsInMs < 0)
-        nsInMs += static_cast<int32_t>(ISO8601::ExactTime::nsPerMillisecond);
-    int microsecond = nsInMs / static_cast<int32_t>(ISO8601::ExactTime::nsPerMicrosecond);
-    int nanosecond = nsInMs % static_cast<int32_t>(ISO8601::ExactTime::nsPerMicrosecond);
+    // Raw y/m/d/h/m/s/ms from epochMs; μs/ns from remainderNs. Offset is applied by balance below.
+    WTF::Int64Milliseconds epochMsWT(epochMs);
+    int32_t days = WTF::msToDays(epochMsWT);
+    int32_t timeInDayMs = WTF::timeInDay(epochMsWT, days);
+    auto [year, month0, day] = WTF::yearMonthDayFromDays(days);
 
-    outTime = ISO8601::PlainTime(hour, minute, second, millisecond, microsecond, nanosecond);
+    int64_t hour = timeInDayMs / 3'600'000;
+    int64_t minute = (timeInDayMs / 60'000) % 60;
+    int64_t second = (timeInDayMs / 1'000) % 60;
+    int64_t millisecond = timeInDayMs % 1'000;
+    int64_t microsecond = remainderNs / 1'000;
+    int64_t nanosecond = remainderNs % 1'000;
+
+    auto [overflowDays, time] = balanceIsoTime(hour, minute, second, millisecond, microsecond, nanosecond + offsetNs);
+    return ISO8601::PlainDateTime(balanceIsoDate(year, month0 + 1, static_cast<int64_t>(day) + overflowDays), time);
 }
 
 // getOffsetNanosecondsFor — temporal_rs: TimeZone::get_offset_nanos_for (src/builtins/core/time_zone.rs)
@@ -169,6 +204,17 @@ TemporalResult<int64_t> getOffsetNanosecondsFor(const TimeZone& timeZone, ISO860
         constexpr int64_t nsPerMs = 1'000'000;
         return static_cast<int64_t>(*offsetMs) * nsPerMs;
     });
+}
+
+// https://tc39.es/proposal-temporal/#sec-temporal-getisodatetimefor
+TemporalResult<ISO8601::PlainDateTime> getISODateTimeFor(const TimeZone& timeZone, ISO8601::ExactTime epochNs)
+{
+    // Step 1: Let offsetNs be GetOffsetNanosecondsFor(tz, epochNs).
+    auto offsetResult = getOffsetNanosecondsFor(timeZone, epochNs);
+    if (!offsetResult) [[unlikely]]
+        return makeUnexpected(offsetResult.error());
+    // Steps 2-3: GetISOPartsFromEpoch(ℝ(epochNs) + offsetNs) + CombineISODateAndTimeRecord.
+    return exactTimeToLocalDateAndTime(epochNs, *offsetResult);
 }
 
 // tryPreLMTFallback — workaround for ICU4C snapping pre-first-transition dates to the wrong year.
@@ -530,13 +576,10 @@ TemporalResult<ISO8601::ExactTime> addZonedDateTime(ISO8601::ExactTime startEpoc
     }
 
     // 2. Let isoDateTime be GetISODateTimeFor(timeZone, epochNanoseconds).
-    // NOTE: GetISODateTimeFor = GetOffsetNanosecondsFor + ExactTimeToLocalDateAndTime.
-    auto offsetResult = getOffsetNanosecondsFor(timeZone, startEpochNs);
-    if (!offsetResult)
-        return makeUnexpected(offsetResult.error());
-    ISO8601::PlainDate date;
-    ISO8601::PlainTime time;
-    exactTimeToLocalDateAndTime(startEpochNs, *offsetResult, date, time);
+    auto isoDateTimeResult = getISODateTimeFor(timeZone, startEpochNs);
+    if (!isoDateTimeResult) [[unlikely]]
+        return makeUnexpected(isoDateTimeResult.error());
+    auto [date, time] = *isoDateTimeResult;
 
     // 3. Let addedDate be ? CalendarDateAdd(calendar, isoDateTime.[[ISODate]], duration.[[Date]], overflow).
     ISO8601::Duration dateDuration(duration.years(), duration.months(), duration.weeks(), duration.days(), 0, 0, 0, 0, 0, 0);

--- a/Source/JavaScriptCore/runtime/temporal/core/TimeZoneICUBridge.h
+++ b/Source/JavaScriptCore/runtime/temporal/core/TimeZoneICUBridge.h
@@ -70,7 +70,7 @@ inline std::span<const ISO8601::ExactTime> epochCandidates(const PossibleEpochNa
 }
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
-void JS_EXPORT_PRIVATE exactTimeToLocalDateAndTime(ISO8601::ExactTime, int64_t offsetNs, ISO8601::PlainDate&, ISO8601::PlainTime&);
+ISO8601::PlainDateTime JS_EXPORT_PRIVATE exactTimeToLocalDateAndTime(ISO8601::ExactTime, int64_t offsetNs);
 
 // https://tc39.es/proposal-canonical-tz/#sec-temporal-timezoneequals
 // Fast path: both operands are already Time Zone Identifier Records. No parsing,
@@ -81,6 +81,8 @@ bool JS_EXPORT_PRIVATE timeZoneEquals(const TimeZone&, const TimeZone&);
 bool JS_EXPORT_PRIVATE timeZoneEquals(StringView id1, StringView id2);
 
 TemporalResult<int64_t> JS_EXPORT_PRIVATE getOffsetNanosecondsFor(const TimeZone&, ISO8601::ExactTime);
+
+TemporalResult<ISO8601::PlainDateTime> JS_EXPORT_PRIVATE getISODateTimeFor(const TimeZone&, ISO8601::ExactTime);
 
 TemporalResult<PossibleEpochNanoseconds> JS_EXPORT_PRIVATE getPossibleEpochNanosecondsFor(const TimeZone&, const ISO8601::PlainDate&, const ISO8601::PlainTime&);
 

--- a/Source/JavaScriptCore/runtime/temporal/core/ZonedDateTimeCore.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/ZonedDateTimeCore.cpp
@@ -165,17 +165,15 @@ static TemporalResult<ISO8601::InternalDuration> differenceZonedDateTime(ISO8601
     if (nsA == nsB)
         return ISO8601::InternalDuration::combineDateAndTimeDuration(ISO8601::Duration(), 0);
 
-    // Steps 2–3: GetISODateTimeFor(timeZone, ns1/ns2). (split: getOffsetNanosecondsFor + exactTimeToLocalDateAndTime)
-    auto offset1Result = getOffsetNanosecondsFor(timeZone, ns1);
-    if (!offset1Result)
-        return makeUnexpected(offset1Result.error());
-    auto offset2Result = getOffsetNanosecondsFor(timeZone, ns2);
-    if (!offset2Result)
-        return makeUnexpected(offset2Result.error());
-    ISO8601::PlainDate startDate, endDate;
-    ISO8601::PlainTime startTime, endTime;
-    exactTimeToLocalDateAndTime(ns1, *offset1Result, startDate, startTime);
-    exactTimeToLocalDateAndTime(ns2, *offset2Result, endDate, endTime);
+    // Steps 2–3: GetISODateTimeFor(timeZone, ns1/ns2).
+    auto startResult = getISODateTimeFor(timeZone, ns1);
+    if (!startResult) [[unlikely]]
+        return makeUnexpected(startResult.error());
+    auto endResult = getISODateTimeFor(timeZone, ns2);
+    if (!endResult) [[unlikely]]
+        return makeUnexpected(endResult.error());
+    auto [startDate, startTime] = *startResult;
+    auto [endDate, endTime] = *endResult;
 
     // Step 4: If startDate = endDate -> timeDuration = ns2 - ns1, return.
     if (!isoDateCompare(startDate, endDate))
@@ -278,13 +276,11 @@ TemporalResult<ISO8601::InternalDuration> differenceZonedDateTimeWithRounding(
     if (smallestUnit == TemporalUnit::Nanosecond && increment == 1)
         return internalDuration;
 
-    // Step 4: dateTime = GetISODateTimeFor(timeZone, ns1). (split: getOffsetNanosecondsFor + exactTimeToLocalDateAndTime)
-    auto offset1 = getOffsetNanosecondsFor(timeZone, ns1);
-    if (!offset1)
-        return makeUnexpected(offset1.error());
-    ISO8601::PlainDate startDate;
-    ISO8601::PlainTime startTime;
-    exactTimeToLocalDateAndTime(ns1, *offset1, startDate, startTime);
+    // Step 4: dateTime = GetISODateTimeFor(timeZone, ns1).
+    auto startResult = getISODateTimeFor(timeZone, ns1);
+    if (!startResult) [[unlikely]]
+        return makeUnexpected(startResult.error());
+    auto [startDate, startTime] = *startResult;
 
     // Step 5: Return RoundRelativeDuration(difference, ns1, ns2, dateTime, ...).
     auto roundResult = roundRelativeDuration(internalDuration, nsA, nsB, startDate, startTime,


### PR DESCRIPTION
#### f9f65c7ff4f625567d7010206419ed4503ed379d
<pre>
[JSC][Temporal] Deduplicate GetISODateTimeFor and align with temporal_rs
<a href="https://rdar.apple.com/181926853">rdar://181926853</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=319109">https://bugs.webkit.org/show_bug.cgi?id=319109</a>

Reviewed by Yusuke Suzuki.

Add TemporalCore::getISODateTimeFor as the single spec-AO impl; five inline
sites now delegate to it. Introduce ISO8601::PlainDateTime as the value-return
type; TemporalZonedDateTime::getLocalDateAndTime renamed to getLocalDateTime
and returns ISO8601::PlainDateTime by value.

Port exactTimeToLocalDateAndTime to temporal_rs&apos;s IsoDateTime::from_epoch_nanos
via new balanceIsoTime and balanceIsoDate helpers. Offset is applied at ns
precision (fixes latent sub-ms truncation).

Refactor TemporalNow: extract systemDateTime; each plainXxxISO factory mirrors
the spec&apos;s 2-step form.

Tests: JSTests/stress/temporal-now.js
       Source/JavaScriptCore/API/tests/TemporalCoreTest.cpp

Canonical link: <a href="https://commits.webkit.org/316969@main">https://commits.webkit.org/316969@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/406886fb5f8fe6854fa51ec53fd75781a6df3f5b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173990 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47923 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/41704 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183564 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131858 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e011e5a8-d873-4ad2-a5ac-69dd31afea68) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49215 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47605 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/135311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7247e67a-a3e8-4345-9cb7-e64dffc7b891) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176948 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/38741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/156101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/115789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2f791633-d483-42e3-b487-e7aee27f05a3) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/37382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/35749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32048 "Built successfully") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/218/builds/4611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/147806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/35594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185990 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/35252 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39066 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/39947 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/144212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47590 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/155656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/144071 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48269 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/113658 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26450 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/38980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120153 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/211024 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46775 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/10554 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/54970 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46178 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46409 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46236 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->