### PR TITLE
TLF: Add results database schema for storing EWS test results and flaky tests

### DIFF
--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/ews_context.py
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/ews_context.py
@@ -1,0 +1,91 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import calendar
+import json
+import time
+
+from cassandra.cqlengine import columns
+from datetime import datetime
+from resultsdbpy.model.commit_context import CommitContext
+from resultsdbpy.model.configuration_context import ClusteredByConfiguration
+from resultsdbpy.model.test_context import Expectations
+from resultsdbpy.model.upload_context import UploadCallbackContext
+
+
+TTL_SECONDS = 30 * 24 * 60 * 60
+FLAKY_TTL_SECONDS = 7 * 24 * 60 * 60
+
+
+class EWSContext(UploadCallbackContext):
+    DEFAULT_LIMIT = 100
+
+    class EWSResultsBase(ClusteredByConfiguration):
+        suite = columns.Text(partition_key=True, required=True)
+        branch = columns.Text(partition_key=True, required=True)
+        uuid = columns.BigInt(primary_key=True, required=True, clustering_order='DESC')
+        start_time = columns.DateTime(primary_key=True, required=True)
+        result = columns.Integer(required=True)
+        remote = columns.Text(required=False)
+        pr_number = columns.Integer(required=False)
+        commit_hash = columns.Text(required=False)
+        details = columns.Text(required=False)  # Catch all json blob after deploy
+
+        def unpack(self):
+            results = dict(
+                uuid=self.uuid,
+                start_time=calendar.timegm(self.start_time.timetuple()),
+                result=Expectations.state_ids_to_string([self.result]),
+            )
+            if self.remote:
+                results['remote'] = self.remote
+            if self.pr_number is not None:
+                results['pr_number'] = self.pr_number
+            if self.commit_hash:
+                results['commit_hash'] = self.commit_hash
+            if self.details:
+                results['details'] = json.loads(self.details)
+            return results
+
+    class EWSFailedTestsByCommit(EWSResultsBase):
+        # test in the partition: one test's failure history is a single-partition read.
+        __table_name__ = 'ews_failed_tests_by_commit'
+        test = columns.Text(partition_key=True, required=True)
+
+    class EWSFlakyTestsByCommit(EWSResultsBase):
+        # test as the leading clustering key: the (configuration, suite, branch) partition
+        # holds the small set of flaky tests, so we can list them all or check one cheaply.
+        __table_name__ = 'ews_flaky_tests_by_commit'
+        test = columns.Text(primary_key=True, required=True)
+        flaky_type = columns.Text(required=True)  # InterStep, IntraStep, etc.
+
+        def unpack(self):
+            results = super().unpack()
+            results['flaky_type'] = self.flaky_type
+            return results
+
+    def __init__(self, *args, **kwargs):
+        super(EWSContext, self).__init__('ews-results', *args, **kwargs)
+
+        with self:
+            self.cassandra.create_table(self.EWSFailedTestsByCommit)
+            self.cassandra.create_table(self.EWSFlakyTestsByCommit)


### PR DESCRIPTION
#### dbc6200b76340c429945cfb392a1d7887faf9955
<pre>
TLF: Add results database schema for storing EWS test results and flaky tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=319113">https://bugs.webkit.org/show_bug.cgi?id=319113</a>
<a href="https://rdar.apple.com/181932732">rdar://181932732</a>

Reviewed by Jonathan Bedard.

Add the results database storage layer for EWS test results. EWSContext
defines two Cassandra tables, both clustered by configuration, suite and
branch. EWSFailedTestsByCommit keeps test in the partition key so one
test&apos;s failure history is a single-partition read, and uses the default
30-day TTL. EWSFlakyTestsByCommit keeps test as the leading clustering
key so the small per-configuration set of flaky tests can be listed or
checked cheaply, uses a shorter 7-day TTL so a test drops out of the
flaky set once it stops flaking, and adds a flaky_type column recording
how the flake was observed (InterStep, IntraStep, etc.). A details
column on the shared base carries a JSON blob for fields added after
deploy, avoiding Cassandra schema migrations.

This is the storage layer only; the API endpoints and ews-build
integration that read and write these tables follow in a separate change.

* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/ews_context.py: Added.
(EWSContext):
(EWSContext.EWSResultsBase):
(EWSContext.EWSResultsBase.unpack):
(EWSContext.EWSFailedTestsByCommit):
(EWSContext.EWSFlakyTestsByCommit):
(EWSContext.EWSFlakyTestsByCommit.unpack):
(EWSContext.__init__):
(EWSContext.register):
(EWSContext.register_flaky):
(EWSContext._register):
(EWSContext._register.callback):
(EWSContext.find_for_test):
(EWSContext.find_flaky_for_test):
(EWSContext._find):

Canonical link: <a href="https://commits.webkit.org/316938@main">https://commits.webkit.org/316938@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd7a5fd1f7013807f9a2c249c9e13f5129612ad0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173836 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47769 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41550 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183410 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/131704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175701 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49061 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47451 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135186 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/131704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176794 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38615 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/155974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115664 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/173157 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/37256 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35621 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31894 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147680 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35467 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185836 "Built successfully") | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/39820 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144078 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/173236 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47436 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143937 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38822 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48115 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/113417 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38855 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46621 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10422 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46023 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46254 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46082 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->