### PR TITLE
Simplify WKUserContentController._addBuffer

### DIFF
--- a/Source/WebCore/platform/SharedMemory.cpp
+++ b/Source/WebCore/platform/SharedMemory.cpp
@@ -55,7 +55,7 @@ RefPtr<SharedMemory> SharedMemory::copyBuffer(const FragmentedSharedBuffer& buff
     if (buffer.isEmpty())
         return nullptr;
 
-    auto sharedMemory = allocate(buffer.size());
+    RefPtr sharedMemory = allocate(buffer.size());
     if (!sharedMemory)
         return nullptr;
 
@@ -64,6 +64,17 @@ RefPtr<SharedMemory> SharedMemory::copyBuffer(const FragmentedSharedBuffer& buff
         memcpySpan(consumeSpan(destination, segment.size()), segment);
     });
 
+    return sharedMemory;
+}
+
+RefPtr<SharedMemory> SharedMemory::copySpan(std::span<const uint8_t> span)
+{
+    if (span.empty())
+        return nullptr;
+    RefPtr sharedMemory = allocate(span.size());
+    if (!sharedMemory)
+        return nullptr;
+    memcpySpan(sharedMemory->mutableSpan(), span);
     return sharedMemory;
 }
 

--- a/Source/WebCore/platform/SharedMemory.h
+++ b/Source/WebCore/platform/SharedMemory.h
@@ -120,6 +120,7 @@ public:
     // FIXME: Change these factory functions to return Ref<SharedMemory> and crash on failure.
     WEBCORE_EXPORT static RefPtr<SharedMemory> allocate(size_t);
     WEBCORE_EXPORT static RefPtr<SharedMemory> copyBuffer(const WebCore::FragmentedSharedBuffer&);
+    WEBCORE_EXPORT static RefPtr<SharedMemory> copySpan(std::span<const uint8_t>);
     WEBCORE_EXPORT static RefPtr<SharedMemory> map(Handle&&, Protection, CopyOnWrite = CopyOnWrite::No);
 #if USE(UNIX_DOMAIN_SOCKETS)
     WEBCORE_EXPORT static RefPtr<SharedMemory> wrapMap(void*, size_t, int fileDescriptor);

--- a/Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.mm
@@ -232,7 +232,7 @@ private:
     protect(*_userContentControllerProxy)->removeAllUserMessageHandlers();
 }
 
-- (void)_addBuffer:(NSData *)buffer dataSpan:(std::span<const uint8_t>)dataSpan name:(NSString *)name contentWorld:(WKContentWorld *)world
+- (void)_addBuffer:(std::span<const uint8_t>)dataSpan name:(NSString *)name contentWorld:(WKContentWorld *)world
 {
     auto isInReadOnlyRegion = [] (std::span<const uint8_t> span) {
         if (span.empty())
@@ -262,14 +262,8 @@ private:
     if (isInReadOnlyRegion(dataSpan))
         sharedMemory = WebCore::SharedMemory::wrapMap(dataSpan, WebCore::SharedMemoryProtection::ReadOnly);
 
-    if (!sharedMemory) {
-        // If we have a Data, wrapping it can possibly give us a memory usage win.
-        // Otherwise, it's fine to fallback to the dataSpan version.
-        if (buffer)
-            sharedMemory = WebCore::SharedMemory::copyBuffer(WebCore::SharedBuffer::create(buffer));
-        else
-            sharedMemory = WebCore::SharedMemory::copyBuffer(WebCore::SharedBuffer::create(dataSpan));
-    }
+    if (!sharedMemory)
+        sharedMemory = WebCore::SharedMemory::copySpan(dataSpan);
 
     if (!sharedMemory) {
         ASSERT_NOT_REACHED();
@@ -281,12 +275,12 @@ private:
 
 - (void)addBuffer:(NSData *)buffer name:(NSString *)name contentWorld:(WKContentWorld *)world
 {
-    [self _addBuffer:buffer dataSpan:span(buffer) name:name contentWorld:world];
+    [self _addBuffer:span(buffer) name:name contentWorld:world];
 }
 
 - (void)_addDataSpan:(std::span<const uint8_t>)dataSpan name:(NSString *)name contentWorld:(WKContentWorld *)world
 {
-    [self _addBuffer:nil dataSpan:dataSpan name:name contentWorld:world];
+    [self _addBuffer:dataSpan name:name contentWorld:world];
 }
 
 - (void)removeBufferWithName:(NSString *)name contentWorld:(WKContentWorld *)world
@@ -401,3 +395,12 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 ALLOW_DEPRECATED_DECLARATIONS_END
 
 @end
+
+namespace WebKit {
+
+void _addDataSpanForSwift(WKUserContentController *controller, NOESCAPE std::span<const uint8_t> dataSpan, NSString *name, WKContentWorld *world)
+{
+    [controller _addDataSpan:dataSpan name:name contentWorld:world];
+}
+
+}

--- a/Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.swift
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.swift
@@ -49,7 +49,7 @@ extension WKUserContentController {
         // This is fine because WebKit is going to immediately make a copy of the passed-in bytes
         // into a safely managed object.
         // rdar://181746505
-        unsafe _addDataSpan(.init(typedSpan), name: name, contentWorld: contentWorld)
+        unsafe WebKit._addDataSpanForSwift(self, .init(typedSpan), name, contentWorld)
     }
 
     /// Removes a previously added data buffer from the given `WKContentWorld`.

--- a/Source/WebKit/UIProcess/API/Cocoa/WKUserContentControllerInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUserContentControllerInternal.h
@@ -37,6 +37,7 @@ template<> struct WrapperTraits<WebUserContentControllerProxy> {
 };
 
 class WebScriptMessageHandler;
+void _addDataSpanForSwift(WKUserContentController *, NOESCAPE std::span<const uint8_t>, NSString *, WKContentWorld *);
 }
 
 @interface WKUserContentController () <WKObject> {


### PR DESCRIPTION
#### e18dd70078065f2ff3f52985c7ba355aa28f3d3d
<pre>
Simplify WKUserContentController._addBuffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=319114">https://bugs.webkit.org/show_bug.cgi?id=319114</a>
<a href="https://rdar.apple.com/181933648">rdar://181933648</a>

Reviewed by NOBODY (OOPS!).

SharedMemory::copySpan prevents the double copy from copying to a SharedBuffer
then copying to a SharedMemory.

* Source/WebCore/platform/SharedMemory.cpp:
(WebCore::SharedMemory::copyBuffer):
(WebCore::SharedMemory::copySpan):
* Source/WebCore/platform/SharedMemory.h:
* Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.mm:
(-[WKUserContentController _addBuffer:name:contentWorld:]):
(-[WKUserContentController addBuffer:name:contentWorld:]):
(-[WKUserContentController _addDataSpan:name:contentWorld:]):
(WebKit::_addDataSpanForSwift):
(-[WKUserContentController _addBuffer:dataSpan:name:contentWorld:]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.swift:
(WKUserContentController.addBuffer(_:name:to:)):
* Source/WebKit/UIProcess/API/Cocoa/WKUserContentControllerInternal.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e18dd70078065f2ff3f52985c7ba355aa28f3d3d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173843 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47776 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41557 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183417 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131711 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b8fec4cc-eed6-4b83-a0b1-13337f0a31f3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175708 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49068 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47458 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135192 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95329 "1 flakes 3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f5acc0c8-7c0b-48b8-a0b0-02e33d1f5975) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176801 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38621 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155979 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115670 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/253a5aa4-c90c-4251-bd40-bf4e0d990338) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37262 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35626 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31901 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147686 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35472 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185843 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38893 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39825 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144084 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47443 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143943 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48122 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32088 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113433 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38860 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120006 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46628 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10428 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46030 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46261 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46089 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->