### PR TITLE
Re-import html/semantics/popovers WPT

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-nesting-hints.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-nesting-hints.html
@@ -25,18 +25,18 @@
 
   <div> Nested auto/hint ancestors, target is auto
     <div popover=auto class=target data-stay-open=true>
-      <div popover=hint data-stay-open=true data-stay-open-fullscreen=false></div>
+      <div popover=hint data-stay-open=true></div>
     </div>
   </div>
 
   <div> Unrelated hint, target=hint
-    <div popover=auto data-stay-open=true data-stay-open-fullscreen=false></div>
+    <div popover=auto data-stay-open=true></div>
     <div popover=hint class=target data-stay-open=true></div>
   </div>
 
   <div> Unrelated hint, target=auto
     <div popover=auto class=target data-stay-open=true></div>
-    <div popover=hint data-stay-open=true data-stay-open-fullscreen=false></div>
+    <div popover=hint data-stay-open=true></div>
   </div>
 </div>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/resources/popover-top-layer-nesting.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/resources/popover-top-layer-nesting.js
@@ -8,11 +8,7 @@ function createTopLayerElement(t,topLayerType) {
       break;
     case 'fullscreen':
       element = document.createElement('div');
-      show = async (topmostElement) => {
-        // Be sure to add user activation to the topmost visible target:
-        await blessTopLayer(topmostElement);
-        await element.requestFullscreen();
-      };
+      show = () => element.requestFullscreen();
       showing = () => document.fullscreenElement === element;
       break;
     default:
@@ -31,6 +27,7 @@ function runTopLayerTests(testCases) {
     assert_true(popovers.length > 0,'No popovers found');
     ['dialog','fullscreen'].forEach(topLayerType => {
       promise_test(async t => {
+        await test_driver.bless('activate top layer');
         const {element,show,showing} = createTopLayerElement(t,topLayerType);
         target.appendChild(element);
 
@@ -40,7 +37,7 @@ function runTopLayerTests(testCases) {
         popovers.forEach(popover => assert_true(popover.matches(':popover-open'),'All popovers should be open'));
 
         // Activate the top layer element.
-        await show(popovers[popovers.length-1]);
+        await show();
         assert_true(showing());
         popovers.forEach(popover => assert_equals(popover.matches(':popover-open'),popover.dataset.stayOpen==='true','Incorrect behavior'));
 
@@ -53,11 +50,20 @@ function runTopLayerTests(testCases) {
         assert_true(showing(),'top layer element should still be top layer');
         newPopover.showPopover();
         assert_true(newPopover.matches(':popover-open'));
-        popovers.forEach(popover => assert_equals(popover.matches(':popover-open'),popover.dataset.stayOpen==='true','Showing the popover shouldn\'t change anything'));
+        popovers.forEach(popover => {
+          let expected = popover.dataset.stayOpen === 'true';
+          // Only one hint popover chain can be open at a time; showing a new hint
+          // closes other non-ancestor hints.
+          if (popover.getAttribute('popover') === 'hint' && !popover.contains(newPopover)) {
+            expected = false;
+          }
+          assert_equals(popover.matches(':popover-open'), expected, 'Showing the popover shouldn\'t change anything');
+        });
         assert_true(showing(),'top layer element should still be top layer');
       },`${description} with ${topLayerType}`);
 
       promise_test(async t => {
+        await test_driver.bless('activate top layer');
         const {element,show,showing} = createTopLayerElement(t,topLayerType);
         element.popover = 'hint';
         target.appendChild(element);
@@ -74,7 +80,7 @@ function runTopLayerTests(testCases) {
         assert_equals(target.matches(':popover-open'),targetWasOpenPopover,'target shouldn\'t change popover state');
 
         try {
-          await show(element);
+          await show();
           assert_unreached('It is an error to activate a top layer element that is already a showing popover');
         } catch (e) {
           // We expect an InvalidStateError for dialogs, and a TypeError for fullscreens.


### PR DESCRIPTION
#### 38d831e1b2567d783e416b0fe0790df29ada1c20
<pre>
Re-import html/semantics/popovers WPT
<a href="https://bugs.webkit.org/show_bug.cgi?id=319122">https://bugs.webkit.org/show_bug.cgi?id=319122</a>
<a href="https://rdar.apple.com/181941217">rdar://181941217</a>

Reviewed by Brent Fulgham.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/366adfdfb5edeff03be1c37d71b00c034cd23eb6">https://github.com/web-platform-tests/wpt/commit/366adfdfb5edeff03be1c37d71b00c034cd23eb6</a>

There was one extra change after my last import.

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-nesting-hints.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/resources/popover-top-layer-nesting.js:
(createTopLayerElement):
(runTopLayerTests):

Canonical link: <a href="https://commits.webkit.org/316940@main">https://commits.webkit.org/316940@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9338a182c415c82bc42dc4b4eed1aae33f5eebf0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173827 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47760 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41541 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183401 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/131695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b21e6ecd-446e-4658-9508-0f42f0fbbcbd) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49052 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47442 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135177 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/131695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3767f905-1ea4-4379-bf52-26e984eaf4be) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176785 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38606 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/155964 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115655 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37247 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35612 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31885 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147671 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35457 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185827 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39811 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144069 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47427 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155519 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143928 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48106 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113400 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26437 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38846 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46612 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10412 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46014 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46245 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46073 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->