### PR TITLE
RegExpStringIterator next can't use SpecObjectOther type check filtering

### DIFF
--- a/JSTests/stress/regexp-string-iterator-next-wrong-receiver.js
+++ b/JSTests/stress/regexp-string-iterator-next-wrong-receiver.js
@@ -1,0 +1,45 @@
+const regExpIteratorProto = Object.getPrototypeOf("aa".matchAll(/a/g));
+const regExpIteratorNext = regExpIteratorProto.next;
+
+function sink(a, b, c, d, e, f) {
+    return a || b || c || d || e || f;
+}
+
+function makeRegExpIterator(i) {
+    const subject = (i & 1) ? "ababa" : "aaaa";
+    const pattern = (i & 2) ? /a/g : /(?:a)/g;
+    return subject.matchAll(pattern);
+}
+
+function makeWrongIterator(i) {
+    const array = [i, i + 1, i + 2, i + 3];
+    if (i & 4)
+        array.extra = "shape";
+    return array[Symbol.iterator]();
+}
+
+function probe(i) {
+    let iter;
+    const spreadIter = makeRegExpIterator(i);
+    const proto = Object.getPrototypeOf(spreadIter);
+    try {
+        sink(...spreadIter, ...proto);
+    } catch (e) {
+    }
+    if (i & 1)
+        iter = makeWrongIterator(i);
+    else
+        iter = makeRegExpIterator(i);
+    if (i & 2)
+        iter = Object.getPrototypeOf(iter);
+    if (i & 4)
+        iter = [iter, i + 1, i + 2, i + 3][Symbol.iterator]();
+    try {
+        return regExpIteratorNext.call(iter);
+    } catch (e) {
+        return e;
+    }
+}
+
+for (let i = 0; i < testLoopCount; ++i)
+    probe(i);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -1740,7 +1740,7 @@ void SpeculativeJIT::compileRegExpStringIteratorNext(Node* node)
     GPRReg scratchGPR = scratch.gpr();
 
     // FIXME: Detach iterator advancement and result object creation from this node so that the iterator allocation can be sunk.
-    speculateCellType(node->child1(), iteratorGPR, SpecObjectOther, JSRegExpStringIteratorType);
+    speculateCellTypeWithoutTypeFiltering(node->child1(), iteratorGPR, JSRegExpStringIteratorType);
 
     flushRegisters();
     callOperation(operationRegExpStringIteratorNext, JSValueRegs(valueGPR), LinkableConstant::globalObject(*this, node), iteratorGPR);

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -19629,7 +19629,7 @@ IGNORE_CLANG_WARNINGS_END
         ASSERT(structure->inlineCapacity() == 2);
 
         LValue iterator = lowCell(m_node->child1());
-        FTL_TYPE_CHECK(jsValueValue(iterator), m_node->child1(), SpecObjectOther, isNotType(iterator, JSRegExpStringIteratorType));
+        speculate(BadType, jsValueValue(iterator), m_node->child1().node(), isNotType(iterator, JSRegExpStringIteratorType));
 
         // FIXME: Detach iterator advancement and result object creation from this node so that the iterator allocation can be sunk.
         LValue match = vmCall(Int64, operationRegExpStringIteratorNext, weakPointer(globalObject), iterator);


### PR DESCRIPTION
#### e6fd50a3da8403cf38fa2d44745fd770783cff38
<pre>
RegExpStringIterator next can&apos;t use SpecObjectOther type check filtering
<a href="https://bugs.webkit.org/show_bug.cgi?id=318142">https://bugs.webkit.org/show_bug.cgi?id=318142</a>
<a href="https://rdar.apple.com/180958970">rdar://180958970</a>

Reviewed by Yusuke Suzuki.

SpecObjectOther type filtering is too wide for the assumptions of the
operationRegExpStringIteratorNext operation. Since DFG/FTL_TYPE_CHECK
use the speculated type as equivalent to the runtime check this causes
us to skip a type check. This allows any object to flow into the
operationRegExpStringIteratorNext call.

Test: JSTests/stress/regexp-string-iterator-next-wrong-receiver.js
Canonical link: <a href="https://commits.webkit.org/316994@main">https://commits.webkit.org/316994@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a5bb98dbfdd7a5a338e37e38112f092278313ef9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173855 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47788 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41569 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183429 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131723 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3a437969-7b72-44e9-bc50-3d7b383ec7c9) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49080 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47470 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135200 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95335 "4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b61cd546-e009-4683-8b07-656ad1d70f53) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176813 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38633 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155990 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115678 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/51505b9b-a267-42dd-8150-facc9eb5a1d1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37274 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35636 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31913 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/4500 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147698 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35483 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185855 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/35117 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38905 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39835 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144096 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47455 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143955 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48134 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32099 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113446 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26459 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38870 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120018 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/210889 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46640 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10439 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54943 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46042 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46273 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46101 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->