### PR TITLE
REGRESSION(316735@main?): [macOS] TestWebKitAPI.WKWebView.InputChangeFiresOnWindowBlur is flaky failure

### DIFF
--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -541,7 +541,7 @@ void FocusController::setFocused(bool focused)
     protect(m_page)->setActivityState(focused ? m_activityState | ActivityState::IsFocused : m_activityState - ActivityState::IsFocused);
 }
 
-void FocusController::setFocusedInternal()
+void FocusController::setFocusedInternal(bool focused)
 {
     if (!isFocused()) {
         if (RefPtr focusedOrMainFrame = this->focusedOrMainFrame())
@@ -552,8 +552,10 @@ void FocusController::setFocusedInternal()
         setFocusedFrame(protect(m_page->mainFrame()).ptr());
 
     RefPtr focusedFrame = localFocusedFrame();
-    if (focusedFrame && focusedFrame->view())
-        protect(focusedFrame->selection())->setFocused(isFocused());
+    if (focusedFrame && focusedFrame->view()) {
+        protect(focusedFrame->selection())->setFocused(focused);
+        dispatchEventsOnWindowAndFocusedElement(protect(focusedFrame->document()).get(), focused);
+    }
 }
 
 FocusableElementSearchResult FocusController::findFocusableElementStartingWithLocalFrame(FocusDirection direction, const FocusEventData& focusEventData, LocalFrame& frame, ShouldFocusElement shouldFocusElement)
@@ -1235,24 +1237,16 @@ bool FocusController::setFocusedElement(Element* element, Frame* newFocusedFrame
 
 void FocusController::setActivityState(OptionSet<ActivityState> activityState)
 {
-    static constexpr OptionSet activeAndFocused { ActivityState::IsFocused, ActivityState::WindowIsActive };
-    bool wasActiveAndFocused = m_activityState.containsAll(activeAndFocused);
     auto changed = m_activityState ^ activityState;
     m_activityState = activityState;
-    bool isActiveAndFocused = m_activityState.containsAll(activeAndFocused);
-    bool shouldDispatchEvent = wasActiveAndFocused != isActiveAndFocused;
 
     if (changed & ActivityState::IsFocused)
-        setFocusedInternal();
+        setFocusedInternal(activityState.contains(ActivityState::IsFocused));
     if (changed & ActivityState::WindowIsActive) {
-        setActiveInternal();
+        setActiveInternal(activityState.contains(ActivityState::WindowIsActive));
         if (changed & ActivityState::IsVisible)
             setIsVisibleAndActiveInternal(activityState.contains(ActivityState::WindowIsActive));
     }
-
-    RefPtr focusedFrame = localFocusedFrame();
-    if (focusedFrame && shouldDispatchEvent)
-        dispatchEventsOnWindowAndFocusedElement(protect(focusedFrame->document()), isActiveAndFocused);
 }
 
 void FocusController::setActive(bool active)
@@ -1260,7 +1254,7 @@ void FocusController::setActive(bool active)
     protect(m_page)->setActivityState(active ? m_activityState | ActivityState::WindowIsActive : m_activityState - ActivityState::WindowIsActive);
 }
 
-void FocusController::setActiveInternal()
+void FocusController::setActiveInternal(bool active)
 {
     RefPtr localMainFrame = m_page->localMainFrame();
     if (!localMainFrame)
@@ -1274,6 +1268,10 @@ void FocusController::setActiveInternal()
 
     if (RefPtr focusedOrMainFrame = this->focusedOrMainFrame())
         focusedOrMainFrame->selection().pageActivationChanged();
+
+    RefPtr focusedFrame = localFocusedFrame();
+    if (focusedFrame && isFocused())
+        dispatchEventsOnWindowAndFocusedElement(protect(focusedFrame->document()).get(), active);
 }
 
 static void contentAreaDidShowOrHide(ScrollableArea* scrollableArea, bool didShow)

--- a/Source/WebCore/page/FocusController.h
+++ b/Source/WebCore/page/FocusController.h
@@ -91,8 +91,8 @@ public:
     WEBCORE_EXPORT FocusableElementSearchResult findFocusableElementContinuingFromFrame(FocusDirection, WebCore::FrameIdentifier, const FocusEventData&, LocalFrame&, ShouldFocusElement);
 
 private:
-    void setActiveInternal();
-    void setFocusedInternal();
+    void setActiveInternal(bool);
+    void setFocusedInternal(bool);
     void setIsVisibleAndActiveInternal(bool);
 
     enum class InitialFocus : bool { No, Yes };

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FocusWebView.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FocusWebView.mm
@@ -399,53 +399,18 @@ TEST(FocusWebView, NoFocusEventsForBackgroundWindow)
 #endif
     [webView waitForNextPresentationUpdate];
 
+#if PLATFORM(MAC)
+    // FIXME: rdar://168467484 (Blur and Focus events should only be dispatched if the window is both active and focused.)
+    // Expected count is 1, not 2. On Mac, input.focus() flips IsFocused before the window is active (via
+    // Widget::setFocus → MakeFirstResponder), causing an extra dispatch. iOS's Widget::setFocus is a no-op.
+    // This extra focus event on Mac will be correctly suppressed with rdar://168467484.
+    int expectedFocusEventCount = 2;
+#else
+    int expectedFocusEventCount = 1;
+#endif
+
     NSNumber *focusEventCount = [webView objectByEvaluatingJavaScript:@"getFocusEventCount()"];
-    EXPECT_EQ([focusEventCount intValue], 1);
-}
-
-TEST(FocusWebView, SingleBlurEventWhenNoLongerActiveAndFocused)
-{
-    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration]);
-
-    NSString *html = @"<!DOCTYPE html>"
-        "<html>"
-        "<body>"
-        "<input id='input' type='text'>"
-        "<script>"
-        "let blurEventCount = 0;"
-        "input.addEventListener('blur', () => {"
-        "    blurEventCount++;"
-        "});"
-        "function getBlurEventCount() { return blurEventCount; }"
-        "</script>"
-        "</body>"
-        "</html>";
-    [webView synchronouslyLoadHTMLString:html];
-
-    [[webView window] makeKeyWindow];
-#if PLATFORM(IOS_FAMILY)
-    [webView becomeFirstResponder];
-#else
-    [[webView window] makeFirstResponder:webView];
-#endif
-    [webView objectByEvaluatingJavaScript:@"input.focus()"];
-
-#if PLATFORM(IOS_FAMILY)
-    [webView resignFirstResponder];
-#else
-    [[webView window] makeFirstResponder:nil];
-#endif
-    [webView waitForNextPresentationUpdate];
-
-    NSNumber *blurEventCount = [webView objectByEvaluatingJavaScript:@"getBlurEventCount()"];
-    EXPECT_EQ([blurEventCount intValue], 1);
-
-    [[webView window] resignKeyWindow];
-    [webView waitForNextPresentationUpdate];
-
-    blurEventCount = [webView objectByEvaluatingJavaScript:@"getBlurEventCount()"];
-    EXPECT_EQ([blurEventCount intValue], 1);
+    EXPECT_EQ([focusEventCount intValue], expectedFocusEventCount);
 }
 
 


### PR DESCRIPTION
#### ecc86d1123b5473b7c069e193893f2828e2e546b
<pre>
REGRESSION(<a href="https://commits.webkit.org/316735@main">316735@main</a>?): [macOS] TestWebKitAPI.WKWebView.InputChangeFiresOnWindowBlur is flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=319127">https://bugs.webkit.org/show_bug.cgi?id=319127</a>
<a href="https://rdar.apple.com/181947537">rdar://181947537</a>

Reviewed by NOBODY (OOPS!).

Revert <a href="https://commits.webkit.org/316735@main">https://commits.webkit.org/316735@main</a> for
&quot;Blur and Focus events should only be dispatched if the window is both active and focused.&quot;

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FocusWebView.mm

* Source/WebCore/page/FocusController.cpp:
(WebCore::FocusController::setFocusedInternal):
(WebCore::FocusController::setActivityState):
(WebCore::FocusController::setActiveInternal):
* Source/WebCore/page/FocusController.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FocusWebView.mm:
(TestWebKitAPI::NoFocusEventsForBackgroundWindow)):
(TestWebKitAPI::SingleBlurEventWhenNoLongerActiveAndFocused)): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ecc86d1123b5473b7c069e193893f2828e2e546b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173856 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47789 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41570 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183430 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/131724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/65ab8b35-036f-4b68-b08e-ca56f6633610) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175721 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49081 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47471 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/135204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/131724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9061044b-8de8-49b2-89ef-ed2723886176) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176814 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/38634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/155992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115682 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b464b80d-909e-458e-9430-8a345d4056d2) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/37275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/35640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31914 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/147699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/35485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185856 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/38906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/39839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/144098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47456 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/155547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143957 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48135 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113447 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38872 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/120019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46641 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/10441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46043 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46274 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46102 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->