### PR TITLE
REGRESSION(314752@main): [Intel] WPT server fails to start due to unbuildable dependencies

### DIFF
--- a/Tools/Scripts/webkitpy/layout_tests/servers/web_platform_test_server.py
+++ b/Tools/Scripts/webkitpy/layout_tests/servers/web_platform_test_server.py
@@ -23,6 +23,7 @@
 
 import json
 import logging
+import os
 import sys
 import time
 
@@ -172,7 +173,8 @@ class WebPlatformTestServer(http_server_base.HttpServerBase):
         python_interp = sys.executable
 
         wpt_file = self._filesystem.join(self._doc_root_path, "wpt.py")
-        self._start_cmd = [python_interp, wpt_file, "serve", "--config", self._config_filename]
+        # --venv is required whenever --skip-venv-setup is passed, but the path itself is never used.
+        self._start_cmd = [python_interp, wpt_file, "--venv", os.devnull, "--skip-venv-setup", "serve", "--config", self._config_filename]
 
         self._mappings = []
         config = wpt_config_json(port_obj)

--- a/Tools/Scripts/webkitpy/layout_tests/servers/web_platform_test_server_integrationtest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/servers/web_platform_test_server_integrationtest.py
@@ -1,0 +1,50 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. AND ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Integration test for WebPlatformTestServer."""
+
+import os
+import tempfile
+import unittest
+
+from webkitpy.common.system.systemhost import SystemHost
+from webkitpy.layout_tests.servers.web_platform_test_server import WebPlatformTestServer
+from webkitpy.port.factory import PortFactory
+
+
+class WPTServeIntegrationTest(unittest.TestCase):
+    def integration_test_serve_starts_without_pip_install(self):
+        port = PortFactory(SystemHost.get_default()).get()
+        wpt_dir = port.host.filesystem.join(port.layout_tests_dir(), 'imported', 'w3c', 'web-platform-tests')
+        venv_path = os.path.join(wpt_dir, '_venv3')
+
+        if os.path.exists(venv_path):
+            holding_path = tempfile.mkdtemp(prefix='_venv3-integrationtest-', dir=wpt_dir)
+            os.rename(venv_path, holding_path)
+            self.addCleanup(os.rename, holding_path, venv_path)
+
+        pidfile = os.path.join(tempfile.mkdtemp(prefix='wpt-serve-integrationtest-'), 'wpttest.pid')
+        server = WebPlatformTestServer(port, 'wpttest_integrationtest', pidfile)
+        self.addCleanup(server.stop)
+        server.start()
+        self.assertTrue(server._is_server_running_on_all_ports())
+        self.assertFalse(os.path.exists(venv_path))

--- a/Tools/Scripts/webkitpy/w3c/wpt_linter.py
+++ b/Tools/Scripts/webkitpy/w3c/wpt_linter.py
@@ -30,6 +30,8 @@ import os
 import subprocess
 import tempfile
 
+from webkitcorepy import AutoInstall
+
 _log = logging.getLogger(__name__)
 
 
@@ -39,7 +41,9 @@ class WPTLinter(object):
 
     def lint(self, paths=None):
         """Yield each ``./wpt lint --json`` error dict."""
-        cmd = ['./wpt', 'lint', '--json', '--repo-root', '.']
+        AutoInstall.install('yaml')
+        # --venv is required whenever --skip-venv-setup is passed, but the path itself is never used.
+        cmd = ['./wpt', '--venv', os.devnull, '--skip-venv-setup', 'lint', '--json', '--repo-root', '.']
 
         if paths is not None:
             paths_file = None
@@ -58,10 +62,15 @@ class WPTLinter(object):
 
     def _run_lint(self, cmd):
         _log.debug('Running WPT linter: %s (cwd=%s)', ' '.join(cmd), self.wpt_path)
+        env = dict(os.environ)
+        if AutoInstall.directory:
+            env['PYTHONPATH'] = os.pathsep.join(
+                [AutoInstall.directory] + ([env['PYTHONPATH']] if env.get('PYTHONPATH') else []))
         result = subprocess.run(
             cmd,
             cwd=self.wpt_path,
             capture_output=True,
+            env=env,
         )
         for line in result.stdout.splitlines():
             if not line.strip():

--- a/Tools/Scripts/webkitpy/w3c/wpt_linter_integrationtest.py
+++ b/Tools/Scripts/webkitpy/w3c/wpt_linter_integrationtest.py
@@ -1,0 +1,75 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. AND ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Integration test for WPTLinter."""
+
+import os
+import tempfile
+import unittest
+
+from webkitpy.common.system.systemhost import SystemHost
+from webkitpy.port.factory import PortFactory
+from webkitpy.w3c.wpt_linter import WPTLinter
+
+
+class WPTLintIntegrationTest(unittest.TestCase):
+    def integration_test_lint_runs_without_venv(self):
+        port = PortFactory(SystemHost.get_default()).get()
+        wpt_dir = port.host.filesystem.join(port.layout_tests_dir(), 'imported', 'w3c', 'web-platform-tests')
+        venv_path = os.path.join(wpt_dir, '_venv3')
+
+        if os.path.exists(venv_path):
+            holding_path = tempfile.mkdtemp(prefix='_venv3-integrationtest-', dir=wpt_dir)
+            os.rename(venv_path, holding_path)
+            self.addCleanup(os.rename, holding_path, venv_path)
+
+        for error in WPTLinter(wpt_dir).lint(paths=['README.md']):
+            self.assertIsInstance(error, dict)
+
+        self.assertFalse(os.path.exists(venv_path))
+
+    def integration_test_lint_reports_multiple_errors(self):
+        port = PortFactory(SystemHost.get_default()).get()
+        wpt_dir = port.host.filesystem.join(port.layout_tests_dir(), 'imported', 'w3c', 'web-platform-tests')
+
+        f = tempfile.NamedTemporaryFile(dir=wpt_dir, suffix='.txt', delete=False)
+        self.addCleanup(os.remove, f.name)
+        f.write(b'\thas a leading tab\n')
+        f.write(b'has trailing whitespace \n')
+        f.write(b'has a trailing CR\r\n')
+        f.close()
+
+        errors = list(WPTLinter(wpt_dir).lint(paths=[f.name]))
+
+        # wpt reports paths relative to its own `os.getcwd()`, which
+        # canonicalizes symlinks; f.name doesn't, so we must resolve wpt_dir
+        # (but not f.name) through realpath to construct a matching
+        # expectation, the same way wpt's `os.path.relpath` ends up doing.
+        expected_path = os.path.relpath(f.name, os.path.realpath(wpt_dir))
+        self.assertEqual([
+            {'path': expected_path, 'lineno': 1, 'rule': 'INDENT TABS',
+             'message': 'Test-file line starts with one or more tab characters'},
+            {'path': expected_path, 'lineno': 2, 'rule': 'TRAILING WHITESPACE',
+             'message': 'Whitespace at EOL'},
+            {'path': expected_path, 'lineno': 3, 'rule': 'CR AT EOL',
+             'message': 'Test-file line ends with CR (U+000D) character'},
+        ], errors)


### PR DESCRIPTION
#### ddf079fd729f2f1b4ce80b33683e79b489bd14aa
<pre>
REGRESSION(314752@main): [Intel] WPT server fails to start due to unbuildable dependencies
<a href="https://bugs.webkit.org/show_bug.cgi?id=317060">https://bugs.webkit.org/show_bug.cgi?id=317060</a>
<a href="https://rdar.apple.com/179542775">rdar://179542775</a>

Reviewed by Basuke Suzuki.

wpt serve fails to start on EWS&apos;s Intel macOS bots because the import
in 314752@main flipped the serve command&apos;s commands.json entry from
&quot;virtualenv&quot;: false to true.

Due to a bug, WPT includes its supposedly optional requirements,
pulling in aioquic, whose loose pyopenssl&gt;=24 constraint lets pip&apos;s
legacy resolver pick a pyOpenSSL release that in turn requires
cryptography&gt;=49. This is the first release after cryptography stopped
supporting and publishing wheels for x86_64 macOS, causing pip to
attempt to build it from source, which fails because cryptography has
native dependencies which may not be installed, and server startup
times out.

Dependencies for wpt&apos;s own tools should come from webkitcorepy&apos;s
AutoInstaller rather than pip, matching the rest of webkitpy. wpt
serve doesn&apos;t actually have any real dependencies of its own so pass
--venv &lt;path&gt; --skip-venv-setup when invoking it, which skips venv
creation and the pip install entirely. wpt lint&apos;s one real dependency,
pyyaml, moves to the AutoInstaller instead, and gets the same flags
for the same reason.

Add integration tests that drive the real WebPlatformTestServer and
WPTLinter classes rather than mocking the subprocess out so we get
coverage of our ability to actually run the imported code outside of
run-webkit-tests.

* Tools/Scripts/webkitpy/layout_tests/servers/web_platform_test_server.py:
(WebPlatformTestServer.__init__):
* Tools/Scripts/webkitpy/layout_tests/servers/web_platform_test_server_integrationtest.py: Added.
(WPTServeIntegrationTest):
(WPTServeIntegrationTest.integration_test_serve_starts_without_pip_install):
* Tools/Scripts/webkitpy/w3c/wpt_linter.py:
(WPTLinter.lint):
(WPTLinter._run_lint):
* Tools/Scripts/webkitpy/w3c/wpt_linter_integrationtest.py: Added.
(WPTLintIntegrationTest):
(WPTLintIntegrationTest.integration_test_lint_runs_without_venv):
(WPTLintIntegrationTest.integration_test_lint_reports_multiple_errors):

Canonical link: <a href="https://commits.webkit.org/317106@main">https://commits.webkit.org/317106@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8de6f222ecb9b1faa66efea8e1f566f64152bf4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174334 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48267 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/42048 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/183910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/132202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fb810853-e28a-4b65-9631-e875ea54a379) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176199 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49559 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47949 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/183910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/132202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/df51373e-5100-474d-98fb-6c119461f164) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177292 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/39055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/156404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/183910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b93d4808-159e-410e-912a-8c76a0910f20) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/173655 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/37696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32392 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/148119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/35896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186336 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/144522 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47934 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/155958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144380 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38917 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48613 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114155 "Built successfully") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/39280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47119 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/10860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/46522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/46753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/46580 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->