### PR TITLE
[AppKit Gestures] Trackpad scrub on apple.com/events video leads to page navigation

### DIFF
--- a/Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.h
+++ b/Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.h
@@ -72,6 +72,7 @@ struct InteractionInformationAtPosition {
         bool isDHTMLDraggable,
         bool isColorInput,
         bool isRangeInput,
+        bool isARIASlider,
         bool isNearMarkedText,
 #if PLATFORM(IOS_FAMILY)
         bool touchCalloutEnabled,
@@ -142,6 +143,7 @@ struct InteractionInformationAtPosition {
     bool isDHTMLDraggable { false };
     bool isColorInput { false };
     bool isRangeInput { false };
+    bool isARIASlider { false };
 
     bool isNearMarkedText { false };
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.mm
+++ b/Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.mm
@@ -45,6 +45,7 @@ InteractionInformationAtPosition::InteractionInformationAtPosition(
     bool isDHTMLDraggable,
     bool isColorInput,
     bool isRangeInput,
+    bool isARIASlider,
     bool isNearMarkedText,
 #if PLATFORM(IOS_FAMILY)
     bool touchCalloutEnabled,
@@ -111,6 +112,7 @@ InteractionInformationAtPosition::InteractionInformationAtPosition(
     , isDHTMLDraggable(isDHTMLDraggable)
     , isColorInput(isColorInput)
     , isRangeInput(isRangeInput)
+    , isARIASlider(isARIASlider)
     , isNearMarkedText(isNearMarkedText)
 #if PLATFORM(IOS_FAMILY)
     , touchCalloutEnabled(touchCalloutEnabled)

--- a/Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.serialization.in
@@ -43,6 +43,7 @@ struct WebKit::InteractionInformationAtPosition {
     bool isDHTMLDraggable;
     bool isColorInput;
     bool isRangeInput;
+    bool isARIASlider;
     bool isNearMarkedText;
 #if PLATFORM(IOS_FAMILY)
     bool touchCalloutEnabled;

--- a/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
+++ b/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
@@ -919,7 +919,8 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     static constexpr int panPositionInformationToleranceRadius = 15;
     bool requestIsValid = [self _positionInformationRequestIsValidAtLocation:locationInViewCoordinates withRadius:panPositionInformationToleranceRadius];
 
-    bool prefersInteraction = _positionInformation.isRangeInput;
+    // FIXME: (rdar://181964604) Because of this logic, vertically scrolling over these elements likely will not work.
+    bool prefersInteraction = _positionInformation.isRangeInput || _positionInformation.isARIASlider;
     bool yieldToContent = requestIsValid && prefersInteraction;
 
     WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/PositionInformationForWebPage.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/PositionInformationForWebPage.mm
@@ -33,6 +33,7 @@
 #import "PluginView.h"
 #import "ShareableBitmapUtilities.h"
 #import "WebPage.h"
+#import <WebCore/AccessibilityObject.h>
 #import <WebCore/ContainerNodeInlines.h>
 #import <WebCore/DataDetection.h>
 #import <WebCore/DataDetectionResultsStorage.h>
@@ -359,7 +360,7 @@ static void selectionPositionInformation(WebPage& page, const InteractionInforma
 
     auto contentsPoint = frameView->rootViewToContents(request.point);
 
-    constexpr OptionSet<WebCore::HitTestRequest::Type> hitType {
+    constexpr OptionSet hitType {
         WebCore::HitTestRequest::Type::ReadOnly,
         WebCore::HitTestRequest::Type::Active,
         WebCore::HitTestRequest::Type::AllowVisibleChildFrameContentOnly
@@ -434,6 +435,28 @@ static void selectionPositionInformation(WebPage& page, const InteractionInforma
         if (info.prefersDraggingOverTextSelection || info.isDHTMLDraggable || info.isColorInput || info.isRangeInput)
             break;
     }
+
+#if HAVE(APPKIT_GESTURES_SUPPORT)
+    if (!info.isRangeInput) {
+        constexpr auto sliderHitType = hitType | OptionSet {
+            WebCore::HitTestRequest::Type::CollectMultipleElements,
+            WebCore::HitTestRequest::Type::IncludeAllElementsUnderPoint,
+        };
+        const auto sliderResult = localMainFrame->eventHandler().hitTestResultAtPoint(contentsPoint, sliderHitType);
+        for (Ref node : sliderResult.listBasedTestResult()) {
+            const RefPtr element = dynamicDowncast<WebCore::Element>(node);
+            if (!element)
+                continue;
+
+            const auto ariaRole = element->attributeWithoutSynchronization(WebCore::HTMLNames::roleAttr);
+            if (WebCore::AccessibilityObject::ariaRoleToWebCoreRole(ariaRole) == WebCore::AccessibilityRole::Slider) {
+                info.isARIASlider = true;
+                break;
+            }
+        }
+    }
+#endif // HAVE(APPKIT_GESTURES_SUPPORT)
+
 #if PLATFORM(MACCATALYST)
     bool isInsideFixedPosition;
     WebCore::VisiblePosition caretPosition(renderer->visiblePositionForPoint(contentsPoint, WebCore::HitTestSource::User));

--- a/Tools/TestWebKitAPI/Resources/cocoa/playback-scrubber.html
+++ b/Tools/TestWebKitAPI/Resources/cocoa/playback-scrubber.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+    html, body { margin: 0; overflow: hidden; }
+
+    #scrubber { position: absolute; left: 20px; bottom: 20px; width: 600px; height: 24px; background: #ccc; }
+    #scrubber [role="slider"] { position: absolute; inset: 0; }
+    #playhead { position: absolute; top: 0; left: 0; width: 16px; height: 100%; background: #333; }
+</style>
+<body>
+    <div id="scrubber">
+        <div role="slider" aria-label="Seek Slider" aria-valuemin="0" aria-valuemax="1" aria-valuenow="0"></div>
+        <div id="playhead"></div>
+    </div>
+<script>
+    const scrubber = document.getElementById("scrubber");
+    const slider = scrubber.querySelector('[role="slider"]');
+    const playhead = document.getElementById("playhead");
+
+    window.scrubbedValues = [];
+
+    function scrubTo(clientX) {
+        const rect = scrubber.getBoundingClientRect();
+        const fraction = Math.max(0, Math.min(1, (clientX - rect.left) / rect.width));
+        slider.setAttribute("aria-valuenow", fraction);
+        playhead.style.left = (fraction * (rect.width - playhead.offsetWidth)) + "px";
+        window.scrubbedValues.push(fraction);
+    }
+
+    let dragging = false;
+    scrubber.addEventListener("pointerdown", e => { dragging = true; scrubber.setPointerCapture(e.pointerId); scrubTo(e.clientX); e.preventDefault(); });
+    scrubber.addEventListener("pointermove", e => { if (dragging) scrubTo(e.clientX); });
+    scrubber.addEventListener("pointerup", () => { dragging = false; });
+    scrubber.addEventListener("pointercancel", () => { dragging = false; });
+</script>
+</body>
+</html>

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift
@@ -56,6 +56,7 @@ extension AppKitGesturesTests {
 
             self.window = NSWindow(size: contentSize) { [page] in
                 WebView(page)
+                    .webViewBackForwardNavigationGestures(.enabled)
             }
 
             self.window.setFrameOrigin(.zero)
@@ -986,6 +987,42 @@ extension AppKitGesturesTests.Basic {
                     extent: .init(in: "div", at: onesRange.upperBound)
                 )
         )
+    }
+
+    @Test
+    func scrubbingVideoTimelineDoesNotTriggerBackNavigation() async throws {
+        // Establish a back-forward history entry so that a "swipe back" gesture would have somewhere to navigate to.
+        try await page.load(URL(string: "about:blank?1")).wait()
+
+        let videoPlayerURL = try #require(Bundle.testResources.url(forResource: "playback-scrubber", withExtension: "html"))
+        try await page.load(videoPlayerURL).wait()
+        await page.waitForNextPresentationUpdate()
+
+        let urlBeforeScrub = page.url
+        #expect(page.backForwardList.backList.count == 1)
+
+        let scrubberBounds = try await screenBounds(ofElementWithID: "scrubber")
+        let thumbBounds = try await screenBounds(ofElementWithID: "playhead")
+        let start = thumbBounds.center
+        let end = CGPoint(x: scrubberBounds.maxX - 10, y: start.y)
+
+        await recap.play { composer in
+            composer._wk_scroll(withStart: start, end: end, duration: .seconds(0.5))
+        }
+
+        await page.waitForNextPresentationUpdate()
+
+        // Allow any (incorrectly) triggered back navigation to occur before asserting it did not.
+        try await Task.sleep(for: .seconds(1))
+
+        #expect(page.url == urlBeforeScrub)
+        #expect(page.backForwardList.backList.count == 1)
+
+        let scrubbedValues = try await page.callJavaScript(returning: [Double].self) {
+            "return window.scrubbedValues ?? [];"
+        }
+        let lastScrubbedValue = try #require(scrubbedValues.last)
+        #expect(lastScrubbedValue > 0)
     }
 }
 


### PR DESCRIPTION
#### 58a1d2ec485a3ca3300040a18689386f5d16238c
<pre>
[AppKit Gestures] Trackpad scrub on apple.com/events video leads to page navigation
<a href="https://bugs.webkit.org/show_bug.cgi?id=319135">https://bugs.webkit.org/show_bug.cgi?id=319135</a>
<a href="https://rdar.apple.com/176277349">rdar://176277349</a>

Reviewed by Tim Horton and Abrar Rahman Protyasha.

Add the ability to determine if a node is a &quot;slider&quot; by checking the ARIA role attribute of the elements at its position,
then use that information to prevent page navigation where needed.

Test: Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift

* Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.h:
* Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.mm:
(WebKit::InteractionInformationAtPosition::InteractionInformationAtPosition):
* Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.serialization.in:
* Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm:
(-[WKAppKitGestureController _panShouldBeginAtLocation:]):
* Source/WebKit/WebProcess/WebPage/Cocoa/PositionInformationForWebPage.mm:
(WebKit::selectionPositionInformation):
* Tools/TestWebKitAPI/Resources/cocoa/playback-scrubber.html: Added.
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift:

Canonical link: <a href="https://commits.webkit.org/316955@main">https://commits.webkit.org/316955@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/748a9ebeeb9d3b0c30d6384b3691385f5c6a4312

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173916 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47849 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41630 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183490 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/131784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e9b06f4a-722a-4aa9-9c75-777376d54ec9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175781 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49141 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47531 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135250 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/131784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3e2816eb-faa5-4669-bfda-2ebe4933911e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176874 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38678 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156039 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115728 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/24c4c059-8dfe-4c51-84ad-80272b2d9a51) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37319 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/35686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31974 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147743 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35532 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185916 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/38971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/39884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144148 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47516 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144012 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38833 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48195 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32149 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113517 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38916 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120079 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46701 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10489 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46104 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46335 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46162 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->