### PR TITLE
[Grid][Cleanup] Store resolved track listings separate from positions

### DIFF
--- a/Source/WebCore/inspector/InspectorOverlay.cpp
+++ b/Source/WebCore/inspector/InspectorOverlay.cpp
@@ -1699,7 +1699,7 @@ std::optional<InspectorOverlay::Highlight::GridHighlightOverlay> InspectorOverla
     gridHighlightOverlay.color = gridOverlay.config.gridColor;
 
     // Draw columns and rows.
-    auto columnWidths = renderGrid->trackSizesForComputedStyle(Style::GridTrackSizingDirection::Columns);
+    auto& columnWidths = renderGrid->trackSizesForComputedStyle(Style::GridTrackSizingDirection::Columns);
     auto columnLineNames = gridLineNames(node->renderStyle(), Style::GridTrackSizingDirection::Columns, columnPositions.size());
     auto authoredTrackColumnSizes = authoredGridTrackSizes(node, Style::GridTrackSizingDirection::Columns, columnWidths.size());
     FloatLine previousColumnEndLine;
@@ -1788,7 +1788,7 @@ std::optional<InspectorOverlay::Highlight::GridHighlightOverlay> InspectorOverla
         }
     }
 
-    auto rowHeights = renderGrid->trackSizesForComputedStyle(Style::GridTrackSizingDirection::Rows);
+    auto& rowHeights = renderGrid->trackSizesForComputedStyle(Style::GridTrackSizingDirection::Rows);
     auto rowLineNames = gridLineNames(node->renderStyle(), Style::GridTrackSizingDirection::Rows, rowPositions.size());
     auto authoredTrackRowSizes = authoredGridTrackSizes(node, Style::GridTrackSizingDirection::Rows, rowHeights.size());
     FloatLine previousRowEndLine;

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -471,6 +471,10 @@ void RenderGrid::layoutGrid(RelayoutChildren relayoutChildren)
             return;
         }
 
+        // We are committed to a full grid layout; invalidate the resolved track list now so that a
+        // stale read asserts if we fail to repopulate it below (see updateResolvedTrackListsAfterLayout).
+        m_resolvedTrackList.invalidate();
+
         // Fieldsets need to find their legend and position it inside the border of the object.
         // The legend then gets skipped during normal layout. The same is true for ruby text.
         // It doesn't get included in the normal layout process but is instead skipped.
@@ -543,6 +547,8 @@ void RenderGrid::layoutGrid(RelayoutChildren relayoutChildren)
 
         layoutGridItems(gridLayoutState);
 
+        updateResolvedTrackListsAfterLayout();
+
         endAndCommitUpdateScrollInfoAfterLayoutTransaction();
 
         updateInFlowDescendantTransformsAfterLayout();
@@ -594,6 +600,10 @@ void RenderGrid::layoutMasonry(RelayoutChildren relayoutChildren)
         RenderGridLayoutState gridLayoutState;
 
         clearGridItemOverridingSizesBeforeLayout(*this);
+
+        // We are committed to a full masonry layout; invalidate the resolved track list now so that a
+        // stale read asserts if we fail to repopulate it below (see updateResolvedTrackListsAfterLayout).
+        m_resolvedTrackList.invalidate();
 
         preparePaginationBeforeBlockLayout(relayoutChildren);
         beginUpdateScrollInfoAfterLayoutTransaction();
@@ -691,6 +701,8 @@ void RenderGrid::layoutMasonry(RelayoutChildren relayoutChildren)
         }
 
         layoutMasonryItems(gridLayoutState);
+
+        updateResolvedTrackListsAfterLayout();
 
         endAndCommitUpdateScrollInfoAfterLayoutTransaction();
 
@@ -1478,7 +1490,7 @@ void RenderGrid::setNeedsItemPlacement(SubgridDidChange subgridDidChange)
     }
 }
 
-Vector<LayoutUnit> RenderGrid::trackSizesForComputedStyle(Style::GridTrackSizingDirection direction) const
+Vector<LayoutUnit> RenderGrid::computeResolvedTrackList(Style::GridTrackSizingDirection direction) const
 {
     const auto& positions = this->positions(direction);
     auto numPositions = positions.size();
@@ -1516,6 +1528,21 @@ Vector<LayoutUnit> RenderGrid::trackSizesForComputedStyle(Style::GridTrackSizing
     }
 
     return tracks;
+}
+
+const Vector<LayoutUnit>& RenderGrid::trackSizesForComputedStyle(Style::GridTrackSizingDirection direction) const
+{
+    // FIXME: The grid formatting context path does not yet populate the resolved track list, so
+    // only assert validity for the legacy layout path.
+    ASSERT(m_hasGridFormattingContextLayout.value_or(false) || m_resolvedTrackList.isValid);
+    return m_resolvedTrackList.sizes(direction);
+}
+
+void RenderGrid::updateResolvedTrackListsAfterLayout()
+{
+    m_resolvedTrackList.sizes(Style::GridTrackSizingDirection::Columns) = computeResolvedTrackList(Style::GridTrackSizingDirection::Columns);
+    m_resolvedTrackList.sizes(Style::GridTrackSizingDirection::Rows) = computeResolvedTrackList(Style::GridTrackSizingDirection::Rows);
+    m_resolvedTrackList.isValid = true;
 }
 
 static const StyleContentAlignmentData& NODELETE contentAlignmentNormalBehaviorGrid()

--- a/Source/WebCore/rendering/RenderGrid.h
+++ b/Source/WebCore/rendering/RenderGrid.h
@@ -88,7 +88,7 @@ public:
     const std::optional<LayoutUnit> availableLogicalHeightForContentBox() const;
 
     void setNeedsItemPlacement(SubgridDidChange descendantSubgridsNeedItemPlacement = SubgridDidChange::No);
-    Vector<LayoutUnit> trackSizesForComputedStyle(Style::GridTrackSizingDirection) const;
+    const Vector<LayoutUnit>& trackSizesForComputedStyle(Style::GridTrackSizingDirection) const LIFETIME_BOUND;
 
     const Vector<LayoutUnit>& columnPositions() const LIFETIME_BOUND { return m_columnPositions; }
     const Vector<LayoutUnit>& rowPositions() const LIFETIME_BOUND { return m_rowPositions; }
@@ -277,6 +277,13 @@ private:
 
     Vector<LayoutUnit>& positions(Style::GridTrackSizingDirection direction) LIFETIME_BOUND { return direction == Style::GridTrackSizingDirection::Columns ? m_columnPositions : m_rowPositions; }
 
+    // https://drafts.csswg.org/css-grid-2/#resolved-track-list
+    // The resolved value of grid-template-columns / grid-template-rows for a grid container is its
+    // used value: every track listed individually with its size serialized as a length in pixels.
+    // We compute this once at the end of layout instead of on demand for each getComputedStyle query.
+    Vector<LayoutUnit> computeResolvedTrackList(Style::GridTrackSizingDirection) const;
+    void updateResolvedTrackListsAfterLayout();
+
     ContentAlignmentData& offsetBetweenTracks(Style::GridTrackSizingDirection direction) LIFETIME_BOUND { return direction == Style::GridTrackSizingDirection::Columns ? m_offsetBetweenColumns : m_offsetBetweenRows; }
     const ContentAlignmentData& offsetBetweenTracks(Style::GridTrackSizingDirection direction) const LIFETIME_BOUND { return direction == Style::GridTrackSizingDirection::Columns ? m_offsetBetweenColumns : m_offsetBetweenRows; }
 
@@ -298,6 +305,25 @@ private:
     Vector<LayoutUnit> m_rowPositions;
     ContentAlignmentData m_offsetBetweenColumns;
     ContentAlignmentData m_offsetBetweenRows;
+
+    // Cached resolved value of grid-template-columns / grid-template-rows (see computeResolvedTrackList).
+    // Invalidated when a full (non-simplified) layout begins and repopulated at the end of that layout,
+    // so a stale read trips the assert in trackSizesForComputedStyle().
+    struct ResolvedTrackList {
+        Vector<LayoutUnit> columnSizes;
+        Vector<LayoutUnit> rowSizes;
+        bool isValid { false };
+
+        void invalidate()
+        {
+            isValid = false;
+            columnSizes.clear();
+            rowSizes.clear();
+        }
+
+        const Vector<LayoutUnit>& sizes(Style::GridTrackSizingDirection direction) const LIFETIME_BOUND { return direction == Style::GridTrackSizingDirection::Columns ? columnSizes : rowSizes; }
+        Vector<LayoutUnit>& sizes(Style::GridTrackSizingDirection direction) LIFETIME_BOUND { return direction == Style::GridTrackSizingDirection::Columns ? columnSizes : rowSizes; }
+    } m_resolvedTrackList;
 
     mutable GridMasonryLayout m_masonryLayout;
 

--- a/Source/WebCore/style/StyleExtractorCustom.h
+++ b/Source/WebCore/style/StyleExtractorCustom.h
@@ -1440,7 +1440,7 @@ template<GridTrackSizingDirection direction> Ref<CSSValue> extractGridTemplateVa
         CSS::GridTrackList trackList;
 
         OrderedNamedLinesCollectorInGridLayout collector(state, tracks, renderGrid->autoRepeatCountForDirection(direction), autoRepeatTrackSizes.size());
-        auto computedTrackSizes = renderGrid->trackSizesForComputedStyle(direction);
+        auto& computedTrackSizes = renderGrid->trackSizesForComputedStyle(direction);
         // Named grid line indices are relative to the explicit grid, but we are including all tracks.
         // So we need to subtract the number of leading implicit tracks in order to get the proper line index.
         int offset = -renderGrid->explicitGridStartForDirection(direction);


### PR DESCRIPTION
#### b1286c345d237f025d733fae0bd38a4b4bdec004
<pre>
[Grid][Cleanup] Store resolved track listings separate from positions
<a href="https://bugs.webkit.org/show_bug.cgi?id=319134">https://bugs.webkit.org/show_bug.cgi?id=319134</a>
<a href="https://rdar.apple.com/problem/181952698">rdar://problem/181952698</a>

Reviewed by Alan Baradlay.

The resolved value of grid-template-columns / grid-template-rows for a grid
container is its used value: every track listed individually with its size
serialized as a length in pixels:
<a href="https://drafts.csswg.org/css-grid-2/#resolved-track-list.">https://drafts.csswg.org/css-grid-2/#resolved-track-list.</a>

We currently reverse engineer this value from the positions that were
computed during layout and then return it.

Instead, at the end of grid layout we can compute the values and store
them in a dedicated ResolvedTrackList struct that lives on the renderer.

One thing we also do is add an extra bit to keep track of whether this
value is stale or not. We mark this bit dirty at the beginning of layout
and assert that it is not stale whenever callers ask for it. One small
exception is that GFC does not set these values so we have to make sure
that we do not accidentally assert if we ran GFC. This will be fixed in
a follow up patch.

* Source/WebCore/inspector/InspectorOverlay.cpp:
(WebCore::InspectorOverlay::buildGridOverlay):
* Source/WebCore/style/StyleExtractorCustom.h:
(WebCore::Style::extractGridTemplateValue):
Some changes to make sure we get the value by reference in the above
functions so we don&apos;t make a copy when we don&apos;t need to.

Canonical link: <a href="https://commits.webkit.org/317067@main">https://commits.webkit.org/317067@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/baf122390357826f2c58a26306f0d087cce82aaf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173866 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47799 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41580 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183440 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131734 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5bb692ed-d6d0-4779-97ea-54162ac1b5f3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175731 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49091 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47481 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135211 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95339 "4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/329fd474-14f6-4851-8011-3efd1bd2046a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176824 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38643 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155999 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115689 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/903580e5-f6b8-4155-890a-de0d31f2a1bb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37284 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35653 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31924 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147708 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35492 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185866 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38917 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39846 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144108 "Found 1 new test failure: compositing/reflections/animation-inside-reflection.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47466 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143966 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38894 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48145 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32108 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113457 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38881 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120029 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46651 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10448 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46053 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46284 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46112 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->