### PR TITLE
WKWebView.InputChangeFiresOnWindowBlur should wait for activity state to update

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WindowBlurInputChangeEvent.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WindowBlurInputChangeEvent.mm
@@ -49,10 +49,14 @@ TEST(WKWebView, InputChangeFiresOnWindowBlur)
         </html>
     )"];
 
+    [webView waitForNextPresentationUpdate];
+
     [webView objectByEvaluatingJavaScript:@"document.getElementById('input').focus();"];
     [webView typeCharacter:'a'];
 
     [webView setVisibility:NO];
+
+    [webView waitForNextPresentationUpdate];
 
     EXPECT_TRUE([[webView objectByEvaluatingJavaScript:@"window.changeFired"] boolValue]);
 }


### PR DESCRIPTION
#### bccd327ae8fa248866778f6eece944139795b69d
<pre>
WKWebView.InputChangeFiresOnWindowBlur should wait for activity state to update
<a href="https://bugs.webkit.org/show_bug.cgi?id=319138">https://bugs.webkit.org/show_bug.cgi?id=319138</a>
<a href="https://rdar.apple.com/181954984">rdar://181954984</a>

Reviewed by Ryosuke Niwa.

We should ensures that the window&apos;s updated activity state always propogates to the
test / UI Process.

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WindowBlurInputChangeEvent.mm:
(TEST(WKWebView, InputChangeFiresOnWindowBlur)):

Canonical link: <a href="https://commits.webkit.org/317177@main">https://commits.webkit.org/317177@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b38508e66976545a35d86251e3462e1382711b9c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173872 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47805 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41586 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183446 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131740 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175737 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49097 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47487 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135214 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95343 "1 flakes 5 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176830 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38652 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156007 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115692 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37293 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35656 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31930 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147717 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35500 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185872 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39854 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144114 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47472 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143972 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48151 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32117 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113463 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26524 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38888 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46657 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10457 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46059 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46290 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46118 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->