### PR TITLE
[CSS Fonts] Apply @font-face metric override descriptors to font metrics

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4919,7 +4919,6 @@ webkit.org/b/214300 imported/w3c/web-platform-tests/css/css-fonts/hiragana-katak
 imported/w3c/web-platform-tests/css/css-fonts/font-face-local-not-family.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-fonts/font-family-name-000.xht [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-fonts/font-palette-23b.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-fonts/font-size-adjust-metrics-override.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-fonts/font-synthesis-position-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-fonts/font-variant-emoji-003.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-fonts/font-variant-emoji-004.html [ ImageOnlyFailure ]
@@ -4939,12 +4938,6 @@ webkit.org/b/150081 imported/w3c/web-platform-tests/css/css-fonts/font-language-
 webkit.org/b/182042 imported/w3c/web-platform-tests/css/css-fonts/font-default-04.html [ ImageOnlyFailure ]
 webkit.org/b/182042 imported/w3c/web-platform-tests/css/css-fonts/font-kerning-03.html [ ImageOnlyFailure ]
 webkit.org/b/86071 imported/w3c/web-platform-tests/css/css-fonts/font-kerning-05.html [ ImageOnlyFailure ]
-
-# @font-face: ascent-override, descent-override, and line-gap-override
-webkit.org/b/219735 imported/w3c/web-platform-tests/css/css-fonts/ascent-descent-override.html [ ImageOnlyFailure ]
-webkit.org/b/219735 imported/w3c/web-platform-tests/css/css-fonts/line-gap-override.html [ ImageOnlyFailure ]
-webkit.org/b/219735 imported/w3c/web-platform-tests/css/css-fonts/font-face-unicode-range-nbsp.html [ ImageOnlyFailure ]
-webkit.org/b/219735 imported/w3c/web-platform-tests/css/css-font-loading/fontface-override-descriptors.html [ ImageOnlyFailure ]
 
 # We intentionally do not want to allow disabling required ligatures, so we don't honor this optional test.
 imported/w3c/web-platform-tests/css/css-fonts/font-variant-ligatures-11.optional.html [ ImageOnlyFailure ]

--- a/LayoutTests/fast/text/font-face-metric-overrides-cache-expected.txt
+++ b/LayoutTests/fast/text/font-face-metric-overrides-cache-expected.txt
@@ -1,0 +1,23 @@
+Tests font metric overrides across local font cache entries and URL fonts, including updates to loaded descriptors.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS reference.offsetWidth is 100
+PASS urlFont.offsetWidth is 100
+PASS noOverride.offsetHeight is 100
+PASS reference.offsetHeight is 70
+PASS ascent.offsetHeight is 120
+PASS descent.offsetHeight is 130
+PASS lineGap.offsetHeight is 140
+PASS urlFont.offsetHeight is 200
+PASS reference.offsetHeight is 120
+PASS reference.offsetHeight is 70
+PASS reference.offsetHeight is 130
+PASS reference.offsetHeight is 70
+PASS reference.offsetHeight is 140
+PASS reference.offsetHeight is 70
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/text/font-face-metric-overrides-cache.html
+++ b/LayoutTests/fast/text/font-face-metric-overrides-cache.html
@@ -1,0 +1,153 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<style>
+@font-face {
+    font-family: NoMetricsOverride;
+    src: local(Ahem);
+}
+
+@font-face {
+    font-family: ReferenceMetricsOverride;
+    src: local(Ahem);
+    ascent-override: 50%;
+    descent-override: 20%;
+    line-gap-override: 0%;
+}
+
+@font-face {
+    font-family: AscentMetricsOverride;
+    src: local(Ahem);
+    ascent-override: 100%;
+    descent-override: 20%;
+    line-gap-override: 0%;
+}
+
+@font-face {
+    font-family: DescentMetricsOverride;
+    src: local(Ahem);
+    ascent-override: 50%;
+    descent-override: 80%;
+    line-gap-override: 0%;
+}
+
+@font-face {
+    font-family: LineGapMetricsOverride;
+    src: local(Ahem);
+    ascent-override: 50%;
+    descent-override: 20%;
+    line-gap-override: 70%;
+}
+
+@font-face {
+    font-family: URLMetricsOverride;
+    src: url("../../resources/Ahem.ttf");
+    ascent-override: 50%;
+    descent-override: 80%;
+    line-gap-override: 70%;
+}
+
+.test {
+    display: inline-block;
+    font-size: 100px;
+    line-height: normal;
+}
+
+#noOverride {
+    font-family: NoMetricsOverride;
+}
+
+#reference {
+    font-family: ReferenceMetricsOverride;
+}
+
+#ascent {
+    font-family: AscentMetricsOverride;
+}
+
+#descent {
+    font-family: DescentMetricsOverride;
+}
+
+#lineGap {
+    font-family: LineGapMetricsOverride;
+}
+
+#urlFont {
+    font-family: URLMetricsOverride;
+}
+</style>
+</head>
+<body>
+<div id="noOverride" class="test">X</div>
+<div id="reference" class="test">X</div>
+<div id="ascent" class="test">X</div>
+<div id="descent" class="test">X</div>
+<div id="lineGap" class="test">X</div>
+<div id="urlFont" class="test">X</div>
+<script>
+description("Tests font metric overrides across local font cache entries and URL fonts, including updates to loaded descriptors.");
+self.jsTestIsAsync = true;
+
+var noOverride = document.getElementById("noOverride");
+var reference = document.getElementById("reference");
+var ascent = document.getElementById("ascent");
+var descent = document.getElementById("descent");
+var lineGap = document.getElementById("lineGap");
+var urlFont = document.getElementById("urlFont");
+
+document.fonts.load("100px URLMetricsOverride").then(function() {
+    var referenceFace;
+    for (let face of document.fonts) {
+        if (face.family == "ReferenceMetricsOverride") {
+            referenceFace = face;
+            break;
+        }
+    }
+    if (!referenceFace) {
+        testFailed("Should find the reference font face.");
+        finishJSTest();
+        return;
+    }
+
+    // Every Ahem glyph has an advance width of 1em, so these checks verify both source paths.
+    shouldBe("reference.offsetWidth", "100");
+    shouldBe("urlFont.offsetWidth", "100");
+
+    // Each local face differs from the reference in exactly one descriptor.
+    shouldBe("noOverride.offsetHeight", "100");
+    shouldBe("reference.offsetHeight", "70");
+    shouldBe("ascent.offsetHeight", "120");
+    shouldBe("descent.offsetHeight", "130");
+    shouldBe("lineGap.offsetHeight", "140");
+
+    // The URL face has non-default values for all three descriptors.
+    shouldBe("urlFont.offsetHeight", "200");
+
+    // Mutating a loaded face must invalidate its cached font data.
+    referenceFace.ascentOverride = "100%";
+    shouldBe("reference.offsetHeight", "120");
+    referenceFace.ascentOverride = "50%";
+    shouldBe("reference.offsetHeight", "70");
+
+    referenceFace.descentOverride = "80%";
+    shouldBe("reference.offsetHeight", "130");
+    referenceFace.descentOverride = "20%";
+    shouldBe("reference.offsetHeight", "70");
+
+    referenceFace.lineGapOverride = "70%";
+    shouldBe("reference.offsetHeight", "140");
+    referenceFace.lineGapOverride = "0%";
+    shouldBe("reference.offsetHeight", "70");
+
+    for (let element of document.querySelectorAll(".test"))
+        element.style.display = "none";
+    finishJSTest();
+}, function() {
+    testFailed("The URL Ahem font face should load.");
+    finishJSTest();
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/ipc/cache-font-null-palette-colors-crash.html
+++ b/LayoutTests/ipc/cache-font-null-palette-colors-crash.html
@@ -28,6 +28,7 @@ if (window.testRunner) {
             platformData: {
                 m_size: 12, m_orientation: 0, m_widthVariant: 0, m_textRenderingMode: 0,
                 m_syntheticBold: false, m_syntheticOblique: false,
+                metricsOverrides: { ascentOverride: { value: {} }, descentOverride: { value: {} }, lineGapOverride: { value: {} } },
                 serializableAttributes: { optionalValue: {
                     fontName: "Helvetica", descriptorLanguage: "", descriptorTextStyle: "",
                     matrix: {}, ignoreLegibilityWeight: {}, baselineAdjust: {}, fallbackOption: {},

--- a/LayoutTests/ipc/move-to-image-buffer-cross-thread-font-crash.html
+++ b/LayoutTests/ipc/move-to-image-buffer-cross-thread-font-crash.html
@@ -82,7 +82,8 @@ if (window.testRunner) {
         platformData: {
             m_metadata: {
                 pointSize: 10, orientation: 0, widthVariant: 0, textRenderingMode: 0,
-                isSyntheticBold: false, isSyntheticOblique: false
+                isSyntheticBold: false, isSyntheticOblique: false,
+                metricsOverrides: { ascentOverride: { value: {} }, descentOverride: { value: {} }, lineGapOverride: { value: {} } }
             },
             serializableAttributes: {},
             m_options: 0,

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2529,6 +2529,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/FontFeatureValues.h
     platform/graphics/FontGenericFamilies.h
     platform/graphics/FontMetrics.h
+    platform/graphics/FontMetricsOverrides.h
     platform/graphics/FontPalette.h
     platform/graphics/FontPaletteValues.h
     platform/graphics/FontPlatformData.h
@@ -3323,6 +3324,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     style/values/fonts/StyleFontFamily.h
     style/values/fonts/StyleFontFamilyName.h
     style/values/fonts/StyleFontFeatureSettings.h
+    style/values/fonts/StyleFontMetricsOverride.h
     style/values/fonts/StyleFontPalette.h
     style/values/fonts/StyleFontSizeAdjust.h
     style/values/fonts/StyleFontStyle.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3389,6 +3389,7 @@ style/values/flexbox/StyleFlexBasis.cpp
 style/values/fonts/StyleFontFamily.cpp
 style/values/fonts/StyleFontFamilyName.cpp
 style/values/fonts/StyleFontFeatureSettings.cpp
+style/values/fonts/StyleFontMetricsOverride.cpp
 style/values/fonts/StyleFontPalette.cpp
 style/values/fonts/StyleFontSizeAdjust.cpp @header:RenderStyleGetters @cost:5
 style/values/fonts/StyleFontStyle.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -329,6 +329,7 @@
 		0844B01D1255B4E600B9CDD0 /* SVGBoundingBoxComputation.h in Headers */ = {isa = PBXBuildFile; fileRef = 0844B01D1255E4E600B9CDD0 /* SVGBoundingBoxComputation.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0844B01D1255B5A610B8AFD1 /* SVGContainerLayout.h in Headers */ = {isa = PBXBuildFile; fileRef = 0844B01D1255E5A610B8AFD1 /* SVGContainerLayout.h */; };
 		0845680812B90DA600960A9F /* FontMetrics.h in Headers */ = {isa = PBXBuildFile; fileRef = 0845680712B90DA600960A9F /* FontMetrics.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BC0A30A32F800004007B809D /* FontMetricsOverrides.h in Headers */ = {isa = PBXBuildFile; fileRef = BC0A30A22F800003007B809D /* FontMetricsOverrides.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0854B0151255E4E600B9CDD0 /* RenderSVGInline.h in Headers */ = {isa = PBXBuildFile; fileRef = 0854B0031255E4E600B9CDD0 /* RenderSVGInline.h */; };
 		0854B0171255E4E600B9CDD0 /* RenderSVGInlineText.h in Headers */ = {isa = PBXBuildFile; fileRef = 0854B0051255E4E600B9CDD0 /* RenderSVGInlineText.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0854B0191255E4E600B9CDD0 /* RenderSVGText.h in Headers */ = {isa = PBXBuildFile; fileRef = 0854B0071255E4E600B9CDD0 /* RenderSVGText.h */; };
@@ -5111,6 +5112,7 @@
 		BC0A309A2E875E8A007B809D /* StyleFontWeight.h in Headers */ = {isa = PBXBuildFile; fileRef = BC0A30932E874E8D007B809D /* StyleFontWeight.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC0A309B2E875E98007B809D /* StyleFontWidth.h in Headers */ = {isa = PBXBuildFile; fileRef = BC0A30952E875222007B809D /* StyleFontWidth.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC0A309E2E8771BD007B809D /* StyleFontSizeAdjust.h in Headers */ = {isa = PBXBuildFile; fileRef = BC0A309C2E876826007B809D /* StyleFontSizeAdjust.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BC0A30A02F800001007B809D /* StyleFontMetricsOverride.h in Headers */ = {isa = PBXBuildFile; fileRef = BC0A309F2F800001007B809D /* StyleFontMetricsOverride.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC10137C25C3624B00DC773C /* ColorModels.h in Headers */ = {isa = PBXBuildFile; fileRef = BC10137B25C3624B00DC773C /* ColorModels.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC10137F25C3631600DC773C /* ColorTransferFunctions.h in Headers */ = {isa = PBXBuildFile; fileRef = BC10137E25C3631600DC773C /* ColorTransferFunctions.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC10D76817D8EE71005E2626 /* RenderBlockFlow.h in Headers */ = {isa = PBXBuildFile; fileRef = BCFB45F317D8E39200444446 /* RenderBlockFlow.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -8191,6 +8193,7 @@
 		0844B01D1255E4E600B9CDD0 /* SVGBoundingBoxComputation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SVGBoundingBoxComputation.h; sourceTree = "<group>"; };
 		0844B01D1255E5A610B8AFD1 /* SVGContainerLayout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SVGContainerLayout.h; sourceTree = "<group>"; };
 		0845680712B90DA600960A9F /* FontMetrics.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FontMetrics.h; sourceTree = "<group>"; };
+		BC0A30A22F800003007B809D /* FontMetricsOverrides.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FontMetricsOverrides.h; sourceTree = "<group>"; };
 		0854B0021255E4E600B9CDD0 /* RenderSVGInline.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RenderSVGInline.cpp; sourceTree = "<group>"; };
 		0854B0031255E4E600B9CDD0 /* RenderSVGInline.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RenderSVGInline.h; sourceTree = "<group>"; };
 		0854B0041255E4E600B9CDD0 /* RenderSVGInlineText.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RenderSVGInlineText.cpp; sourceTree = "<group>"; };
@@ -19162,6 +19165,8 @@
 		BC0A30982E875609007B809D /* StyleFontStyle.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StyleFontStyle.cpp; sourceTree = "<group>"; };
 		BC0A309C2E876826007B809D /* StyleFontSizeAdjust.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleFontSizeAdjust.h; sourceTree = "<group>"; };
 		BC0A309D2E876826007B809D /* StyleFontSizeAdjust.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StyleFontSizeAdjust.cpp; sourceTree = "<group>"; };
+		BC0A309F2F800001007B809D /* StyleFontMetricsOverride.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleFontMetricsOverride.h; sourceTree = "<group>"; };
+		BC0A30A12F800002007B809D /* StyleFontMetricsOverride.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StyleFontMetricsOverride.cpp; sourceTree = "<group>"; };
 		BC0CA74C264AED0A004FDC62 /* PixelBufferConversion.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PixelBufferConversion.h; sourceTree = "<group>"; };
 		BC0CA74D264AED0A004FDC62 /* PixelBufferConversion.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = PixelBufferConversion.cpp; sourceTree = "<group>"; };
 		BC0D730E2FB64F6000952D29 /* CSSMaskBorder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CSSMaskBorder.h; sourceTree = "<group>"; };
@@ -36838,6 +36843,7 @@
 				E44EE3A717576E5500EEE8CF /* FontGenericFamilies.h */,
 				59763CF0AFE56B2B76896F18 /* FontInlines.h */,
 				0845680712B90DA600960A9F /* FontMetrics.h */,
+				BC0A30A22F800003007B809D /* FontMetricsOverrides.h */,
 				1C4674FD26F4843600B61273 /* FontPalette.h */,
 				1C5E1DA626F949B900E07AF1 /* FontPaletteValues.h */,
 				84B62684133138F90095A489 /* FontPlatformData.cpp */,
@@ -38369,6 +38375,8 @@
 				BC6F79AA2EC25C050049BA02 /* StyleFontFamilyName.h */,
 				BCB02AB72E8F8216008A0B68 /* StyleFontFeatureSettings.cpp */,
 				BCB02AB62E8F8216008A0B68 /* StyleFontFeatureSettings.h */,
+				BC0A30A12F800002007B809D /* StyleFontMetricsOverride.cpp */,
+				BC0A309F2F800001007B809D /* StyleFontMetricsOverride.h */,
 				BCB02AC82E9035BA008A0B68 /* StyleFontOpentypeTag.h */,
 				BC7826742E845D5400FB0C7E /* StyleFontPalette.cpp */,
 				BC7826732E845D5400FB0C7E /* StyleFontPalette.h */,
@@ -45685,6 +45693,7 @@
 				658436860AE01B7400E53743 /* FontLoadRequest.h in Headers */,
 				BC4A532F256057CD0028C592 /* FontLoadTimingOverride.h in Headers */,
 				0845680812B90DA600960A9F /* FontMetrics.h in Headers */,
+				BC0A30A32F800004007B809D /* FontMetricsOverrides.h in Headers */,
 				1C7A6EB526F5D8F50096D8C7 /* FontPalette.h in Headers */,
 				1C5E1DA826F94B9000E07AF1 /* FontPaletteValues.h in Headers */,
 				B5320D6B122A24E9002D1440 /* FontPlatformData.h in Headers */,
@@ -49086,6 +49095,7 @@
 				BC6F79892EC1294A0049BA02 /* StyleFontFamily.h in Headers */,
 				BC6F79AC2EC25C110049BA02 /* StyleFontFamilyName.h in Headers */,
 				BCB02ACA2E903C46008A0B68 /* StyleFontFeatureSettings.h in Headers */,
+				BC0A30A02F800001007B809D /* StyleFontMetricsOverride.h in Headers */,
 				BC7826762E845D6000FB0C7E /* StyleFontPalette.h in Headers */,
 				BC0A309E2E8771BD007B809D /* StyleFontSizeAdjust.h in Headers */,
 				E4D58EB917B4ED8900CBDCA8 /* StyleFontSizeFunctions.h in Headers */,

--- a/Source/WebCore/css/CSSFontFace.cpp
+++ b/Source/WebCore/css/CSSFontFace.cpp
@@ -48,6 +48,7 @@
 #include "SVGFontFaceElement.h"
 #include "Settings.h"
 #include "SharedBuffer.h"
+#include "StyleFontMetricsOverride.h"
 #include "StyleKeyword+Mappings.h"
 #include "StylePrimitiveNumericTypes+Conversions.h"
 #include "StylePrimitiveNumericTypes+DeprecatedCSSValueConversion.h"
@@ -362,6 +363,15 @@ void CSSFontFace::setAscentOverride(CSSValue& value)
 {
     protect(mutableProperties())->setProperty(CSSPropertyAscentOverride, value);
 
+    FontMetricsOverride ascentOverride;
+    if (auto percentage = Style::deprecatedToStyleFromCSSValue<Style::FontMetricsOverride>(value)->tryValue())
+        ascentOverride = { percentage->value / 100 };
+
+    if (m_metricsOverrides.ascentOverride == ascentOverride)
+        return;
+
+    m_metricsOverrides.ascentOverride = ascentOverride;
+
     iterateClients(m_clients, [&](CSSFontFaceClient& client) {
         client.fontPropertyChanged(*this);
     });
@@ -371,6 +381,15 @@ void CSSFontFace::setDescentOverride(CSSValue& value)
 {
     protect(mutableProperties())->setProperty(CSSPropertyDescentOverride, value);
 
+    FontMetricsOverride descentOverride;
+    if (auto percentage = Style::deprecatedToStyleFromCSSValue<Style::FontMetricsOverride>(value)->tryValue())
+        descentOverride = { percentage->value / 100 };
+
+    if (m_metricsOverrides.descentOverride == descentOverride)
+        return;
+
+    m_metricsOverrides.descentOverride = descentOverride;
+
     iterateClients(m_clients, [&](CSSFontFaceClient& client) {
         client.fontPropertyChanged(*this);
     });
@@ -379,6 +398,15 @@ void CSSFontFace::setDescentOverride(CSSValue& value)
 void CSSFontFace::setLineGapOverride(CSSValue& value)
 {
     protect(mutableProperties())->setProperty(CSSPropertyLineGapOverride, value);
+
+    FontMetricsOverride lineGapOverride;
+    if (auto percentage = Style::deprecatedToStyleFromCSSValue<Style::FontMetricsOverride>(value)->tryValue())
+        lineGapOverride = { percentage->value / 100 };
+
+    if (m_metricsOverrides.lineGapOverride == lineGapOverride)
+        return;
+
+    m_metricsOverrides.lineGapOverride = lineGapOverride;
 
     iterateClients(m_clients, [&](CSSFontFaceClient& client) {
         client.fontPropertyChanged(*this);
@@ -780,7 +808,7 @@ RefPtr<Font> CSSFontFace::font(const FontDescription& fontDescription, bool synt
             return Font::create(protect(FontCache::forCurrentThread())->lastResortFallbackFont(fontDescription)->platformData(), Font::Origin::Local, Font::IsInterstitial::Yes, visibility);
         }
         case CSSFontFaceSource::Status::Success: {
-            FontCreationContext fontCreationContext { m_featureSettings, m_fontSelectionCapabilities, fontPaletteValues, fontFeatureValues, m_sizeAdjust };
+            FontCreationContext fontCreationContext { m_featureSettings, m_fontSelectionCapabilities, fontPaletteValues, fontFeatureValues, m_sizeAdjust, m_metricsOverrides };
             if (auto result = source->font(fontDescription, syntheticBold, syntheticItalic, fontCreationContext))
                 return result;
             break;

--- a/Source/WebCore/css/CSSFontFace.h
+++ b/Source/WebCore/css/CSSFontFace.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "FontMetricsOverrides.h"
 #include "FontSelectionAlgorithm.h"
 #include "FontTaggedSettings.h"
 #include "RenderStyleConstants.h"
@@ -187,6 +188,7 @@ private:
     FontLoadingBehavior m_loadingBehavior { FontLoadingBehavior::Auto };
 
     float m_sizeAdjust { 1.0 };
+    FontMetricsOverrides m_metricsOverrides;
 
     Vector<std::unique_ptr<CSSFontFaceSource>, 0, CrashOnOverflow, 0> m_sources;
     WeakHashSet<CSSFontFaceClient> m_clients;

--- a/Source/WebCore/platform/graphics/Font.cpp
+++ b/Source/WebCore/platform/graphics/Font.cpp
@@ -115,6 +115,7 @@ Font::Font(const FontPlatformData& platformData, Origin origin, IsInterstitial i
         m_hasVerticalGlyphs = m_verticalData.get() && m_verticalData->hasVerticalMetrics();
     }
 #endif
+    applyFontMetricsOverrides();
 }
 
 Font::Font(IsSystemFallbackFontPlaceholder isSystemFontFallbackPlaceholder)
@@ -122,6 +123,25 @@ Font::Font(IsSystemFallbackFontPlaceholder isSystemFontFallbackPlaceholder)
 {
     // This ctor is to be used only for representing a system font fallback placeholder (createSystemFallbackFontPlaceholder)
     ASSERT(isSystemFontFallbackPlaceholder == IsSystemFallbackFontPlaceholder::Yes);
+}
+
+void Font::applyFontMetricsOverrides()
+{
+    if (m_platformData.metricsOverrides().ascentOverride.isNormal()
+        && m_platformData.metricsOverrides().descentOverride.isNormal()
+        && m_platformData.metricsOverrides().lineGapOverride.isNormal())
+        return;
+
+    if (!m_platformData.metricsOverrides().ascentOverride.isNormal())
+        m_fontMetrics.setAscent(*m_platformData.metricsOverrides().ascentOverride.value * platformData().size());
+
+    if (!m_platformData.metricsOverrides().descentOverride.isNormal())
+        m_fontMetrics.setDescent(*m_platformData.metricsOverrides().descentOverride.value * platformData().size());
+
+    if (!m_platformData.metricsOverrides().lineGapOverride.isNormal())
+        m_fontMetrics.setLineGap(*m_platformData.metricsOverrides().lineGapOverride.value * platformData().size());
+
+    m_fontMetrics.setLineSpacing(lroundf(m_fontMetrics.ascent()) + lroundf(m_fontMetrics.descent()) + lroundf(m_fontMetrics.lineGap()));
 }
 
 // Estimates of avgCharWidth and maxCharWidth for platforms that don't support accessing these values from the font.

--- a/Source/WebCore/platform/graphics/Font.h
+++ b/Source/WebCore/platform/graphics/Font.h
@@ -271,6 +271,8 @@ private:
     void platformCharWidthInit();
     void NODELETE platformDestroy();
 
+    void applyFontMetricsOverrides();
+
     void initCharWidths();
 
     RefPtr<Font> createFontWithoutSynthesizableFeatures() const;

--- a/Source/WebCore/platform/graphics/FontCache.cpp
+++ b/Source/WebCore/platform/graphics/FontCache.cpp
@@ -87,11 +87,7 @@ struct FontPlatformDataCacheKeyHashTraits : public SimpleClassHashTraits<FontPla
 };
 
 struct FontDataCacheKeyTraits : WTF::GenericHashTraits<FontPlatformData> {
-#if USE(SKIA)
     static constexpr bool emptyValueIsZero = false;
-#else
-    static constexpr bool emptyValueIsZero = true;
-#endif
 
     static const FontPlatformData& emptyValue()
     {

--- a/Source/WebCore/platform/graphics/FontCreationContext.h
+++ b/Source/WebCore/platform/graphics/FontCreationContext.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/FontFeatureValues.h>
+#include <WebCore/FontMetricsOverrides.h>
 #include <WebCore/FontPaletteValues.h>
 #include <WebCore/FontSelectionAlgorithm.h>
 #include <WebCore/FontTaggedSettings.h>
@@ -35,9 +36,9 @@ namespace WebCore {
 
 class FontCreationContextRareData : public RefCounted<FontCreationContextRareData> {
 public:
-    static Ref<FontCreationContextRareData> create(const FontFeatureSettings& fontFaceFeatures, const FontPaletteValues& fontPaletteValues, RefPtr<FontFeatureValues> fontFeatureValues, float sizeAdjust)
+    static Ref<FontCreationContextRareData> create(const FontFeatureSettings& fontFaceFeatures, const FontPaletteValues& fontPaletteValues, RefPtr<FontFeatureValues> fontFeatureValues, float sizeAdjust, const FontMetricsOverrides& metricsOverrides)
     {
-        return adoptRef(*new FontCreationContextRareData(fontFaceFeatures, fontPaletteValues, fontFeatureValues, sizeAdjust));
+        return adoptRef(*new FontCreationContextRareData(fontFaceFeatures, fontPaletteValues, fontFeatureValues, sizeAdjust, metricsOverrides));
     }
 
     const FontFeatureSettings& fontFaceFeatures() const
@@ -48,6 +49,11 @@ public:
     float sizeAdjust() const
     {
         return m_sizeAdjust;
+    }
+
+    const FontMetricsOverrides& metricsOverrides() const
+    {
+        return m_metricsOverrides;
     }
 
     const FontPaletteValues& fontPaletteValues() const
@@ -65,15 +71,17 @@ public:
         return m_fontFaceFeatures == other.m_fontFaceFeatures
             && m_fontPaletteValues == other.m_fontPaletteValues
             && m_fontFeatureValues.get() == other.m_fontFeatureValues.get()
-            && m_sizeAdjust == other.m_sizeAdjust;
+            && m_sizeAdjust == other.m_sizeAdjust
+            && m_metricsOverrides == other.m_metricsOverrides;
     }
 
 private:
-    FontCreationContextRareData(const FontFeatureSettings& fontFaceFeatures, const FontPaletteValues& fontPaletteValues, RefPtr<FontFeatureValues> fontFeatureValues, float sizeAdjust)
+    FontCreationContextRareData(const FontFeatureSettings& fontFaceFeatures, const FontPaletteValues& fontPaletteValues, RefPtr<FontFeatureValues> fontFeatureValues, float sizeAdjust, const FontMetricsOverrides& metricsOverrides)
         : m_fontFaceFeatures(fontFaceFeatures)
         , m_fontPaletteValues(fontPaletteValues)
         , m_fontFeatureValues(fontFeatureValues)
         , m_sizeAdjust(sizeAdjust)
+        , m_metricsOverrides(metricsOverrides)
     {
     }
 
@@ -81,17 +89,18 @@ private:
     FontPaletteValues m_fontPaletteValues;
     RefPtr<FontFeatureValues> m_fontFeatureValues;
     float m_sizeAdjust;
+    FontMetricsOverrides m_metricsOverrides;
 };
 
 class FontCreationContext {
 public:
     FontCreationContext() = default;
 
-    FontCreationContext(const FontFeatureSettings& fontFaceFeatures, const FontSelectionSpecifiedCapabilities& fontFaceCapabilities, const FontPaletteValues& fontPaletteValues, RefPtr<FontFeatureValues> fontFeatureValues, float sizeAdjust)
+    FontCreationContext(const FontFeatureSettings& fontFaceFeatures, const FontSelectionSpecifiedCapabilities& fontFaceCapabilities, const FontPaletteValues& fontPaletteValues, RefPtr<FontFeatureValues> fontFeatureValues, float sizeAdjust, const FontMetricsOverrides& metricsOverrides = { })
         : m_fontFaceCapabilities(fontFaceCapabilities)
     {
-        if (!fontFaceFeatures.isEmpty() || fontPaletteValues || (fontFeatureValues && !fontFeatureValues->isEmpty()) || sizeAdjust != 1.0)
-            m_rareData = FontCreationContextRareData::create(fontFaceFeatures, fontPaletteValues, fontFeatureValues, sizeAdjust);
+        if (!fontFaceFeatures.isEmpty() || fontPaletteValues || (fontFeatureValues && !fontFeatureValues->isEmpty()) || sizeAdjust != 1.0 || !metricsOverrides.isNormal())
+            m_rareData = FontCreationContextRareData::create(fontFaceFeatures, fontPaletteValues, fontFeatureValues, sizeAdjust, metricsOverrides);
     }
 
     const FontFeatureSettings* fontFaceFeatures() const
@@ -102,6 +111,11 @@ public:
     float sizeAdjust() const
     {
         return m_rareData ? m_rareData->sizeAdjust() : 1.0;
+    }
+
+    FontMetricsOverrides metricsOverrides() const
+    {
+        return m_rareData ? m_rareData->metricsOverrides() : FontMetricsOverrides { };
     }
 
     const FontSelectionSpecifiedCapabilities& fontFaceCapabilities() const
@@ -141,6 +155,8 @@ inline void add(Hasher& hasher, const FontCreationContext& fontCreationContext)
         add(hasher, *fontCreationContext.fontFeatureValues());
     if (fontCreationContext.sizeAdjust())
         add(hasher, fontCreationContext.sizeAdjust());
+    if (!fontCreationContext.metricsOverrides().isNormal())
+        add(hasher, fontCreationContext.metricsOverrides());
 }
 
 }

--- a/Source/WebCore/platform/graphics/FontMetricsOverrides.h
+++ b/Source/WebCore/platform/graphics/FontMetricsOverrides.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2026 Taishi Eguchi
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Hasher.h>
+#include <wtf/Markable.h>
+
+namespace WebCore {
+
+// Computed values of the @font-face ascent-override, descent-override, and
+// line-gap-override descriptors, as fractions of the used font size.
+// https://www.w3.org/TR/css-fonts-4/#font-metrics-override-desc
+struct FontMetricsOverride {
+    bool isNormal() const { return !value; }
+
+    friend bool operator==(const FontMetricsOverride&, const FontMetricsOverride&) = default;
+
+    Markable<float> value { };
+};
+
+struct FontMetricsOverrides {
+    bool isNormal() const { return ascentOverride.isNormal() && descentOverride.isNormal() && lineGapOverride.isNormal(); }
+
+    friend bool operator==(const FontMetricsOverrides&, const FontMetricsOverrides&) = default;
+
+    FontMetricsOverride ascentOverride;
+    FontMetricsOverride descentOverride;
+    FontMetricsOverride lineGapOverride;
+};
+
+inline void add(Hasher& hasher, const FontMetricsOverride& metricsOverride)
+{
+    if (!metricsOverride.value) {
+        add(hasher, false);
+        return;
+    }
+
+    // operator== treats +0.0f and -0.0f as equal, so they must hash identically.
+    float value = *metricsOverride.value;
+    if (!value)
+        value = 0.0f;
+
+    add(hasher, true, value);
+}
+
+inline void add(Hasher& hasher, const FontMetricsOverrides& metricsOverrides)
+{
+    add(hasher, metricsOverrides.ascentOverride, metricsOverrides.descentOverride, metricsOverrides.lineGapOverride);
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/FontPlatformData.cpp
+++ b/Source/WebCore/platform/graphics/FontPlatformData.cpp
@@ -43,8 +43,8 @@ FontPlatformData::FontPlatformData(WTF::HashTableDeletedValueType)
 
 FontPlatformData::FontPlatformData() = default;
 
-FontPlatformData::FontPlatformData(float size, bool syntheticBold, bool syntheticOblique, FontOrientation orientation, FontWidthVariant widthVariant, TextRenderingMode textRenderingMode, const FontCustomPlatformData* customPlatformData)
-: m_metadata { size, orientation, widthVariant, textRenderingMode, syntheticBold, syntheticOblique }
+FontPlatformData::FontPlatformData(float size, bool syntheticBold, bool syntheticOblique, FontOrientation orientation, FontWidthVariant widthVariant, TextRenderingMode textRenderingMode, const FontMetricsOverrides& metricsOverrides, const FontCustomPlatformData* customPlatformData)
+: m_metadata { size, orientation, widthVariant, textRenderingMode, syntheticBold, syntheticOblique, metricsOverrides }
 , m_customPlatformData(customPlatformData)
 {
 }

--- a/Source/WebCore/platform/graphics/FontPlatformData.h
+++ b/Source/WebCore/platform/graphics/FontPlatformData.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <WebCore/FontMetricsOverrides.h>
 #include <WebCore/SharedBuffer.h>
 #include <WebCore/ShouldLocalizeAxisNames.h>
 #include <WebCore/TextFlags.h>
@@ -98,6 +99,7 @@ struct FontMetadata {
     TextRenderingMode textRenderingMode = TextRenderingMode::Auto;
     bool isSyntheticBold = false;
     bool isSyntheticOblique = false;
+    FontMetricsOverrides metricsOverrides { };
 
     friend bool operator==(const FontMetadata&, const FontMetadata&) = default;
 };
@@ -306,23 +308,23 @@ public:
     FontPlatformData(WTF::HashTableDeletedValueType);
     FontPlatformData();
 
-    FontPlatformData(float size, bool syntheticBold, bool syntheticOblique, FontOrientation = FontOrientation::Horizontal, FontWidthVariant = FontWidthVariant::RegularWidth, TextRenderingMode = TextRenderingMode::Auto, const FontCustomPlatformData* = nullptr);
+    FontPlatformData(float size, bool syntheticBold, bool syntheticOblique, FontOrientation = FontOrientation::Horizontal, FontWidthVariant = FontWidthVariant::RegularWidth, TextRenderingMode = TextRenderingMode::Auto, const FontMetricsOverrides& = { }, const FontCustomPlatformData* = nullptr);
     FontPlatformData(const FontMetadata&, const FontCustomPlatformData* = nullptr);
 
 #if USE(CORE_TEXT)
-    WEBCORE_EXPORT FontPlatformData(RetainPtr<CTFontRef>&&, float size, bool syntheticBold = false, bool syntheticOblique = false, FontOrientation = FontOrientation::Horizontal, FontWidthVariant = FontWidthVariant::RegularWidth, TextRenderingMode = TextRenderingMode::Auto, const FontCustomPlatformData* = nullptr);
+    WEBCORE_EXPORT FontPlatformData(RetainPtr<CTFontRef>&&, float size, bool syntheticBold = false, bool syntheticOblique = false, FontOrientation = FontOrientation::Horizontal, FontWidthVariant = FontWidthVariant::RegularWidth, TextRenderingMode = TextRenderingMode::Auto, const FontMetricsOverrides& = { }, const FontCustomPlatformData* = nullptr);
     WEBCORE_EXPORT FontPlatformData(RetainPtr<CTFontRef>&&, const FontMetadata&, const FontCustomPlatformData* = nullptr);
 #endif
 
 #if PLATFORM(WIN) && USE(CAIRO)
-    WEBCORE_EXPORT FontPlatformData(GDIObject<HFONT>, float size, bool syntheticBold, bool syntheticOblique, const FontCustomPlatformData* = nullptr);
-    FontPlatformData(GDIObject<HFONT>, cairo_font_face_t*, float size, bool bold, bool italic, const FontCustomPlatformData* = nullptr);
+    WEBCORE_EXPORT FontPlatformData(GDIObject<HFONT>, float size, bool syntheticBold, bool syntheticOblique, const FontMetricsOverrides& = { }, const FontCustomPlatformData* = nullptr);
+    FontPlatformData(GDIObject<HFONT>, cairo_font_face_t*, float size, bool bold, bool italic, const FontMetricsOverrides& = { }, const FontCustomPlatformData* = nullptr);
 #endif
 
 #if USE(FREETYPE) && USE(CAIRO)
-    FontPlatformData(cairo_font_face_t*, RefPtr<FcPattern>&&, float size, bool fixedWidth, bool syntheticBold, bool syntheticOblique, FontOrientation, const FontCustomPlatformData* = nullptr);
+    FontPlatformData(cairo_font_face_t*, RefPtr<FcPattern>&&, float size, bool fixedWidth, bool syntheticBold, bool syntheticOblique, FontOrientation, const FontMetricsOverrides& = { }, const FontCustomPlatformData* = nullptr);
 #elif USE(SKIA)
-    WEBCORE_EXPORT FontPlatformData(sk_sp<SkTypeface>&&, float size, bool syntheticBold, bool syntheticOblique, FontOrientation, FontWidthVariant, TextRenderingMode, Vector<hb_feature_t>&&, const FontCustomPlatformData* = nullptr);
+    WEBCORE_EXPORT FontPlatformData(sk_sp<SkTypeface>&&, float size, bool syntheticBold, bool syntheticOblique, FontOrientation, FontWidthVariant, TextRenderingMode, Vector<hb_feature_t>&&, const FontMetricsOverrides& = { }, const FontCustomPlatformData* = nullptr);
     WEBCORE_EXPORT FontPlatformData(sk_sp<SkTypeface>&&, const FontMetadata&, Vector<hb_feature_t>&&, const FontCustomPlatformData* = nullptr);
 #endif
 
@@ -376,6 +378,7 @@ public:
     FontOrientation orientation() const { return m_metadata.orientation; }
     FontWidthVariant widthVariant() const { return m_metadata.widthVariant; }
     TextRenderingMode textRenderingMode() const { return m_metadata.textRenderingMode; }
+    const FontMetricsOverrides& metricsOverrides() const { return m_metadata.metricsOverrides; }
     const FontMetadata& metadata() const { return m_metadata; }
     bool isForTextCombine() const { return widthVariant() != FontWidthVariant::RegularWidth; } // Keep in sync with callers of FontDescription::setWidthVariant().
 

--- a/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
@@ -738,7 +738,7 @@ std::unique_ptr<FontPlatformData> FontCache::createFontPlatformData(const FontDe
 
     auto [syntheticBold, syntheticOblique] = computeNecessarySynthesis(font.get(), fontDescription, options).boldObliquePair();
 
-    FontPlatformData platformData(font.get(), size, syntheticBold, syntheticOblique, fontDescription.orientation(), fontDescription.widthVariant(), fontDescription.textRenderingMode());
+    FontPlatformData platformData(font.get(), size, syntheticBold, syntheticOblique, fontDescription.orientation(), fontDescription.widthVariant(), fontDescription.textRenderingMode(), fontCreationContext.metricsOverrides());
 
     platformData.updateSizeWithFontSizeAdjust(fontDescription.fontSizeAdjust(), fontDescription.computedSize());
     return makeUnique<FontPlatformData>(platformData);
@@ -831,7 +831,7 @@ RefPtr<Font> FontCache::systemFallbackForCharacterCluster(const FontDescription&
     RefPtr<const FontCustomPlatformData> customPlatformData = nullptr;
     if (safeCFEqual(ctFont.get(), substituteFont.get()))
         customPlatformData = platformData.customPlatformData();
-    FontPlatformData alternateFont(substituteFont.get(), platformData.size(), syntheticBold, syntheticOblique, platformData.orientation(), platformData.widthVariant(), platformData.textRenderingMode(), customPlatformData.get());
+    FontPlatformData alternateFont(substituteFont.get(), platformData.size(), syntheticBold, syntheticOblique, platformData.orientation(), platformData.widthVariant(), platformData.textRenderingMode(), platformData.metricsOverrides(), customPlatformData.get());
 
     return fontForPlatformData(alternateFont);
 }

--- a/Source/WebCore/platform/graphics/cocoa/FontPlatformDataCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/FontPlatformDataCocoa.mm
@@ -37,7 +37,7 @@ namespace WebCore {
 unsigned FontPlatformData::hash() const
 {
     // FIXME: Hashing a CFHash is unfortunate here.
-    return computeHash(CFHash(m_font.get()), m_isHashTableDeletedValue, m_metadata.widthVariant, m_metadata.textRenderingMode, m_metadata.orientation, m_metadata.isSyntheticBold, m_metadata.isSyntheticOblique);
+    return computeHash(CFHash(m_font.get()), m_isHashTableDeletedValue, m_metadata.widthVariant, m_metadata.textRenderingMode, m_metadata.orientation, m_metadata.isSyntheticBold, m_metadata.isSyntheticOblique, m_metadata.metricsOverrides);
 }
 
 bool FontPlatformData::platformIsEqual(const FontPlatformData& other) const

--- a/Source/WebCore/platform/graphics/coretext/FontCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCoreText.cpp
@@ -346,7 +346,7 @@ bool Font::supportsAllPetiteCaps() const
     return m_supportsAllPetiteCaps == SupportsFeature::Yes;
 }
 
-static RefPtr<Font> createDerivativeFont(CTFontRef font, float size, FontOrientation orientation, CTFontSymbolicTraits fontTraits, bool syntheticBold, bool syntheticItalic, FontWidthVariant fontWidthVariant, TextRenderingMode textRenderingMode, const FontCustomPlatformData* customPlatformData)
+static RefPtr<Font> createDerivativeFont(CTFontRef font, float size, FontOrientation orientation, CTFontSymbolicTraits fontTraits, bool syntheticBold, bool syntheticItalic, FontWidthVariant fontWidthVariant, TextRenderingMode textRenderingMode, const FontCustomPlatformData* customPlatformData, const FontMetricsOverrides& metricsOverrides)
 {
     if (!font)
         return nullptr;
@@ -360,7 +360,7 @@ static RefPtr<Font> createDerivativeFont(CTFontRef font, float size, FontOrienta
 
     bool usedSyntheticBold = (fontTraits & kCTFontBoldTrait) && !(scaledFontTraits & kCTFontTraitBold);
     bool usedSyntheticOblique = (fontTraits & kCTFontItalicTrait) && !(scaledFontTraits & kCTFontTraitItalic);
-    FontPlatformData scaledFontData(font, size, usedSyntheticBold, usedSyntheticOblique, orientation, fontWidthVariant, textRenderingMode, customPlatformData);
+    FontPlatformData scaledFontData(font, size, usedSyntheticBold, usedSyntheticOblique, orientation, fontWidthVariant, textRenderingMode, metricsOverrides, customPlatformData);
 
     return Font::create(scaledFontData);
 }
@@ -501,7 +501,7 @@ RefPtr<Font> Font::createFontWithoutSynthesizableFeatures() const
     RetainPtr ctFont = this->ctFont();
     CTFontSymbolicTraits fontTraits = CTFontGetSymbolicTraits(ctFont.get());
     RetainPtr newCTFont = createCTFontWithoutSynthesizableFeatures(ctFont.get());
-    return createDerivativeFont(newCTFont.get(), size, m_platformData.orientation(), fontTraits, m_platformData.syntheticBold(), m_platformData.syntheticOblique(), m_platformData.widthVariant(), m_platformData.textRenderingMode(), protect(m_platformData.customPlatformData()).get());
+    return createDerivativeFont(newCTFont.get(), size, m_platformData.orientation(), fontTraits, m_platformData.syntheticBold(), m_platformData.syntheticOblique(), m_platformData.widthVariant(), m_platformData.textRenderingMode(), protect(m_platformData.customPlatformData()).get(), m_platformData.metricsOverrides());
 }
 
 RefPtr<Font> Font::platformCreateScaledFont(const FontDescription&, float scaleFactor) const
@@ -512,7 +512,7 @@ RefPtr<Font> Font::platformCreateScaledFont(const FontDescription&, float scaleF
     RetainPtr<CTFontDescriptorRef> fontDescriptor = adoptCF(CTFontCopyFontDescriptor(ctFont.get()));
     RetainPtr<CTFontRef> scaledFont = adoptCF(CTFontCreateWithFontDescriptor(fontDescriptor.get(), size, nullptr));
 
-    return createDerivativeFont(scaledFont.get(), size, m_platformData.orientation(), fontTraits, m_platformData.syntheticBold(), m_platformData.syntheticOblique(), m_platformData.widthVariant(), m_platformData.textRenderingMode(), protect(m_platformData.customPlatformData()).get());
+    return createDerivativeFont(scaledFont.get(), size, m_platformData.orientation(), fontTraits, m_platformData.syntheticBold(), m_platformData.syntheticOblique(), m_platformData.widthVariant(), m_platformData.textRenderingMode(), protect(m_platformData.customPlatformData()).get(), m_platformData.metricsOverrides());
 }
 
 bool supportsOpenTypeFeature(CTFontRef font, CFStringRef featureTag)
@@ -569,7 +569,7 @@ RefPtr<Font> Font::platformCreateHalfWidthFont() const
     auto attributesDescriptor = adoptCF(CTFontDescriptorCreateWithAttributes(attributes.get()));
     auto halfWidthFont = adoptCF(CTFontCreateCopyWithAttributes(ctFont.get(), size, nullptr, attributesDescriptor.get()));
 
-    return createDerivativeFont(halfWidthFont.get(), size, m_platformData.orientation(), fontTraits, m_platformData.syntheticBold(), m_platformData.syntheticOblique(), m_platformData.widthVariant(), m_platformData.textRenderingMode(), protect(m_platformData.customPlatformData()).get());
+    return createDerivativeFont(halfWidthFont.get(), size, m_platformData.orientation(), fontTraits, m_platformData.syntheticBold(), m_platformData.syntheticOblique(), m_platformData.widthVariant(), m_platformData.textRenderingMode(), protect(m_platformData.customPlatformData()).get(), m_platformData.metricsOverrides());
 }
 
 float Font::platformWidthForGlyph(Glyph glyph) const

--- a/Source/WebCore/platform/graphics/coretext/FontCustomPlatformDataCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCustomPlatformDataCoreText.cpp
@@ -60,7 +60,7 @@ FontPlatformData FontCustomPlatformData::fontPlatformData(const FontDescription&
     bool hasSlopeVariationAxis = variationAxes.contains(FontVariationAxisTag::slnt) || variationAxes.contains(FontVariationAxisTag::ital);
     bool syntheticBold = computeSyntheticBold(hasWeightVariationAxis, fontDescription, fontCreationContext);
     bool syntheticItalic = computeSyntheticItalic(hasSlopeVariationAxis, fontDescription, fontCreationContext);
-    FontPlatformData platformData(font.get(), size, syntheticBold, syntheticItalic, orientation, widthVariant, fontDescription.textRenderingMode(), this);
+    FontPlatformData platformData(font.get(), size, syntheticBold, syntheticItalic, orientation, widthVariant, fontDescription.textRenderingMode(), fontCreationContext.metricsOverrides(), this);
 
     platformData.updateSizeWithFontSizeAdjust(fontDescription.fontSizeAdjust(), fontDescription.computedSize());
     return platformData;

--- a/Source/WebCore/platform/graphics/coretext/FontPlatformDataCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontPlatformDataCoreText.cpp
@@ -69,8 +69,8 @@ FontPlatformDataAttributes::FontPlatformDataAttributes(const FontMetadata& metad
     , m_psName(psName)
     { }
 
-FontPlatformData::FontPlatformData(RetainPtr<CTFontRef>&& font, float size, bool syntheticBold, bool syntheticOblique, FontOrientation orientation, FontWidthVariant widthVariant, TextRenderingMode textRenderingMode, const FontCustomPlatformData* customPlatformData)
-    : FontPlatformData(WTF::move(font), FontMetadata { size, orientation, widthVariant, textRenderingMode, syntheticBold, syntheticOblique }, customPlatformData)
+FontPlatformData::FontPlatformData(RetainPtr<CTFontRef>&& font, float size, bool syntheticBold, bool syntheticOblique, FontOrientation orientation, FontWidthVariant widthVariant, TextRenderingMode textRenderingMode, const FontMetricsOverrides& metricsOverrides, const FontCustomPlatformData* customPlatformData)
+    : FontPlatformData(WTF::move(font), FontMetadata { size, orientation, widthVariant, textRenderingMode, syntheticBold, syntheticOblique, metricsOverrides }, customPlatformData)
 {
 }
 

--- a/Source/WebCore/platform/graphics/freetype/FontCacheFreeType.cpp
+++ b/Source/WebCore/platform/graphics/freetype/FontCacheFreeType.cpp
@@ -466,7 +466,7 @@ std::unique_ptr<FontPlatformData> FontCache::createFontPlatformData(const FontDe
 #endif
 
     auto size = fontDescription.adjustedSizeForFontFace(fontCreationContext.sizeAdjust());
-    FontPlatformData platformData(fontFace.get(), WTF::move(resultPattern), size, fixedWidth, syntheticBold, syntheticOblique, fontDescription.orientation());
+    FontPlatformData platformData(fontFace.get(), WTF::move(resultPattern), size, fixedWidth, syntheticBold, syntheticOblique, fontDescription.orientation(), fontCreationContext.metricsOverrides());
 
     platformData.updateSizeWithFontSizeAdjust(fontDescription.fontSizeAdjust(), fontDescription.computedSize());
     auto platformDataUniquePtr = makeUnique<FontPlatformData>(platformData);

--- a/Source/WebCore/platform/graphics/freetype/FontCustomPlatformDataFreeType.cpp
+++ b/Source/WebCore/platform/graphics/freetype/FontCustomPlatformDataFreeType.cpp
@@ -112,7 +112,7 @@ FontPlatformData FontCustomPlatformData::fontPlatformData(const FontDescription&
     bool syntheticItalic = computeSyntheticItalic(hasSlopeVariationAxis, description, fontCreationContext);
 
     auto size = description.adjustedSizeForFontFace(fontCreationContext.sizeAdjust());
-    FontPlatformData platformData(m_fontFace.get(), WTF::move(pattern), size, freeTypeFace->face_flags & FT_FACE_FLAG_FIXED_WIDTH, syntheticBold, syntheticItalic, description.orientation());
+    FontPlatformData platformData(m_fontFace.get(), WTF::move(pattern), size, freeTypeFace->face_flags & FT_FACE_FLAG_FIXED_WIDTH, syntheticBold, syntheticItalic, description.orientation(), fontCreationContext.metricsOverrides());
 
     platformData.updateSizeWithFontSizeAdjust(description.fontSizeAdjust(), description.computedSize());
     return platformData;

--- a/Source/WebCore/platform/graphics/freetype/FontPlatformDataFreeType.cpp
+++ b/Source/WebCore/platform/graphics/freetype/FontPlatformDataFreeType.cpp
@@ -116,8 +116,8 @@ static void setCairoFontOptionsFromFontConfigPattern(cairo_font_options_t* optio
 #endif
 }
 
-FontPlatformData::FontPlatformData(cairo_font_face_t* fontFace, RefPtr<FcPattern>&& pattern, float size, bool fixedWidth, bool syntheticBold, bool syntheticOblique, FontOrientation orientation, const FontCustomPlatformData* customPlatformData)
-    : FontPlatformData(size, syntheticBold, syntheticOblique, orientation, FontWidthVariant::RegularWidth, TextRenderingMode::Auto, customPlatformData)
+FontPlatformData::FontPlatformData(cairo_font_face_t* fontFace, RefPtr<FcPattern>&& pattern, float size, bool fixedWidth, bool syntheticBold, bool syntheticOblique, FontOrientation orientation, const FontMetricsOverrides& metricsOverrides, const FontCustomPlatformData* customPlatformData)
+    : FontPlatformData(size, syntheticBold, syntheticOblique, orientation, FontWidthVariant::RegularWidth, TextRenderingMode::Auto, metricsOverrides, customPlatformData)
 {
     m_pattern = WTF::move(pattern);
     m_fixedWidth = fixedWidth;
@@ -340,7 +340,7 @@ FontPlatformData FontPlatformData::create(const Attributes& data, const FontCust
         fontFace = adoptRef(cairo_ft_font_face_create_for_pattern(pattern));
     }
 
-    return FontPlatformData(fontFace.get(), pattern, data.m_metadata.pointSize, fixedWidth, data.m_metadata.isSyntheticBold, data.m_metadata.isSyntheticOblique, data.m_metadata.orientation, custom);
+    return FontPlatformData(fontFace.get(), pattern, data.m_metadata.pointSize, fixedWidth, data.m_metadata.isSyntheticBold, data.m_metadata.isSyntheticOblique, data.m_metadata.orientation, data.m_metadata.metricsOverrides, custom);
 }
 
 FontPlatformData::Attributes FontPlatformData::attributes() const

--- a/Source/WebCore/platform/graphics/freetype/SimpleFontDataFreeType.cpp
+++ b/Source/WebCore/platform/graphics/freetype/SimpleFontDataFreeType.cpp
@@ -207,6 +207,7 @@ RefPtr<Font> Font::platformCreateScaledFont(const FontDescription& fontDescripti
         m_platformData.syntheticBold(),
         m_platformData.syntheticOblique(),
         fontDescription.orientation(),
+        m_platformData.metricsOverrides(),
         m_platformData.customPlatformData()),
         origin(), IsInterstitial::No);
 }

--- a/Source/WebCore/platform/graphics/skia/FontCacheSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontCacheSkia.cpp
@@ -421,7 +421,7 @@ std::unique_ptr<FontPlatformData> FontCache::createFontPlatformData(const FontDe
     auto size = fontDescription.adjustedSizeForFontFace(fontCreationContext.sizeAdjust());
     auto features = computeFeatures(fontDescription, fontCreationContext);
     auto [syntheticBold, syntheticOblique] = computeSynthesisProperties(*typeface, fontDescription, options);
-    FontPlatformData platformData(WTF::move(typeface), size, syntheticBold, syntheticOblique, fontDescription.orientation(), fontDescription.widthVariant(), fontDescription.textRenderingMode(), WTF::move(features));
+    FontPlatformData platformData(WTF::move(typeface), size, syntheticBold, syntheticOblique, fontDescription.orientation(), fontDescription.widthVariant(), fontDescription.textRenderingMode(), WTF::move(features), fontCreationContext.metricsOverrides());
 
     platformData.updateSizeWithFontSizeAdjust(fontDescription.fontSizeAdjust(), fontDescription.computedSize());
     auto platformDataUniquePtr = makeUnique<FontPlatformData>(platformData);

--- a/Source/WebCore/platform/graphics/skia/FontCustomPlatformDataSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontCustomPlatformDataSkia.cpp
@@ -94,7 +94,7 @@ FontPlatformData FontCustomPlatformData::fontPlatformData(const FontDescription&
     auto size = description.adjustedSizeForFontFace(fontCreationContext.sizeAdjust());
     auto features = FontCache::computeFeatures(description, fontCreationContext);
 
-    FontPlatformData platformData(WTF::move(typeface), size, computeSyntheticBold(hasWeightVariationAxis, description, fontCreationContext), computeSyntheticItalic(hasSlopeVariationAxis, description, fontCreationContext), description.orientation(), description.widthVariant(), description.textRenderingMode(), WTF::move(features), this);
+    FontPlatformData platformData(WTF::move(typeface), size, computeSyntheticBold(hasWeightVariationAxis, description, fontCreationContext), computeSyntheticItalic(hasSlopeVariationAxis, description, fontCreationContext), description.orientation(), description.widthVariant(), description.textRenderingMode(), WTF::move(features), fontCreationContext.metricsOverrides(), this);
     platformData.updateSizeWithFontSizeAdjust(description.fontSizeAdjust(), description.computedSize());
     return platformData;
 }

--- a/Source/WebCore/platform/graphics/skia/FontPlatformDataSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontPlatformDataSkia.cpp
@@ -47,8 +47,8 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
 namespace WebCore {
 
-FontPlatformData::FontPlatformData(sk_sp<SkTypeface>&& typeface, float size, bool syntheticBold, bool syntheticOblique, FontOrientation orientation, FontWidthVariant widthVariant, TextRenderingMode textRenderingMode, Vector<hb_feature_t>&& features, const FontCustomPlatformData* customPlatformData)
-    : FontPlatformData(WTF::move(typeface), FontMetadata { size, orientation, widthVariant, textRenderingMode, syntheticBold, syntheticOblique }, WTF::move(features), customPlatformData)
+FontPlatformData::FontPlatformData(sk_sp<SkTypeface>&& typeface, float size, bool syntheticBold, bool syntheticOblique, FontOrientation orientation, FontWidthVariant widthVariant, TextRenderingMode textRenderingMode, Vector<hb_feature_t>&& features, const FontMetricsOverrides& metricsOverrides, const FontCustomPlatformData* customPlatformData)
+    : FontPlatformData(WTF::move(typeface), FontMetadata { size, orientation, widthVariant, textRenderingMode, syntheticBold, syntheticOblique, metricsOverrides }, WTF::move(features), customPlatformData)
 {
 }
 
@@ -193,7 +193,7 @@ bool FontPlatformData::isFixedPitch() const
 unsigned FontPlatformData::hash() const
 {
     // FIXME: do we need to consider m_features for the hash?
-    return computeHash(m_font.getTypeface()->uniqueID(), m_isHashTableDeletedValue, m_metadata.widthVariant, m_metadata.textRenderingMode, m_metadata.orientation, m_metadata.isSyntheticBold, m_metadata.isSyntheticOblique);
+    return computeHash(m_font.getTypeface()->uniqueID(), m_isHashTableDeletedValue, m_metadata.widthVariant, m_metadata.textRenderingMode, m_metadata.orientation, m_metadata.isSyntheticBold, m_metadata.isSyntheticOblique, m_metadata.metricsOverrides);
 }
 
 bool FontPlatformData::platformIsEqual(const FontPlatformData& other) const

--- a/Source/WebCore/platform/graphics/skia/FontSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontSkia.cpp
@@ -161,6 +161,7 @@ RefPtr<Font> Font::platformCreateScaledFont(const FontDescription&, float scaleF
         m_platformData.widthVariant(),
         m_platformData.textRenderingMode(),
         Vector<hb_feature_t> { m_platformData.features() },
+        m_platformData.metricsOverrides(),
         m_platformData.customPlatformData()),
         origin(), IsInterstitial::No);
 }
@@ -174,6 +175,7 @@ RefPtr<Font> Font::platformCreateHalfWidthFont() const
         FontWidthVariant::HalfWidth,
         m_platformData.textRenderingMode(),
         Vector<hb_feature_t> { m_platformData.features() },
+        m_platformData.metricsOverrides(),
         m_platformData.customPlatformData()),
         origin(), IsInterstitial::No);
 }

--- a/Source/WebCore/platform/graphics/win/FontPlatformDataWin.cpp
+++ b/Source/WebCore/platform/graphics/win/FontPlatformDataWin.cpp
@@ -36,8 +36,8 @@
 
 namespace WebCore {
 
-FontPlatformData::FontPlatformData(GDIObject<HFONT> font, float size, bool bold, bool oblique, const FontCustomPlatformData* customPlatformData)
-    : FontPlatformData(size, bold, oblique, FontOrientation::Horizontal, FontWidthVariant::RegularWidth, TextRenderingMode::Auto, customPlatformData)
+FontPlatformData::FontPlatformData(GDIObject<HFONT> font, float size, bool bold, bool oblique, const FontMetricsOverrides& metricsOverrides, const FontCustomPlatformData* customPlatformData)
+    : FontPlatformData(size, bold, oblique, FontOrientation::Horizontal, FontWidthVariant::RegularWidth, TextRenderingMode::Auto, metricsOverrides, customPlatformData)
 {
     m_hfont = SharedGDIObject<HFONT>::create(WTF::move(font));
     platformDataInit(m_hfont->get(), size);
@@ -68,7 +68,7 @@ FontPlatformData FontPlatformData::create(const Attributes& data, const FontCust
         wcscpy_s(logFont.lfFaceName, LF_FACESIZE, custom->name.wideCharacters().data());
 
     auto gdiFont = adoptGDIObject(CreateFontIndirect(&logFont));
-    return FontPlatformData(WTF::move(gdiFont), data.m_metadata.pointSize, data.m_metadata.isSyntheticBold, data.m_metadata.isSyntheticOblique, custom);
+    return FontPlatformData(WTF::move(gdiFont), data.m_metadata.pointSize, data.m_metadata.isSyntheticBold, data.m_metadata.isSyntheticOblique, data.m_metadata.metricsOverrides, custom);
 }
 
 FontPlatformData::Attributes FontPlatformData::attributes() const
@@ -84,7 +84,7 @@ std::optional<FontPlatformData> FontPlatformData::fromIPCData(const FontMetadata
     return WTF::switchOn(ipcData,
         [&] (const FontPlatformSerializedData& d) -> std::optional<FontPlatformData> {
             if (auto gdiFont = adoptGDIObject(CreateFontIndirect(&d.logFont)))
-                return FontPlatformData(WTF::move(gdiFont), metadata.pointSize, metadata.isSyntheticBold, metadata.isSyntheticOblique);
+                return FontPlatformData(WTF::move(gdiFont), metadata.pointSize, metadata.isSyntheticBold, metadata.isSyntheticOblique, metadata.metricsOverrides);
 
             return std::nullopt;
         },

--- a/Source/WebCore/platform/graphics/win/SimpleFontDataWin.cpp
+++ b/Source/WebCore/platform/graphics/win/SimpleFontDataWin.cpp
@@ -128,7 +128,7 @@ RefPtr<Font> Font::platformCreateScaledFont(const FontDescription&, float scaleF
     GetObject(m_platformData.hfont(), sizeof(LOGFONT), &winfont);
     winfont.lfHeight = -lroundf(scaledSize * cWindowsFontScaleFactor);
     auto hfont = adoptGDIObject(::CreateFontIndirect(&winfont));
-    return Font::create(FontPlatformData(WTF::move(hfont), scaledSize, m_platformData.syntheticBold(), m_platformData.syntheticOblique(), m_platformData.customPlatformData()), origin());
+    return Font::create(FontPlatformData(WTF::move(hfont), scaledSize, m_platformData.syntheticBold(), m_platformData.syntheticOblique(), m_platformData.metricsOverrides(), m_platformData.customPlatformData()), origin());
 }
 
 RefPtr<Font> Font::platformCreateHalfWidthFont() const

--- a/Source/WebCore/platform/graphics/win/cairo/FontCacheWinCairo.cpp
+++ b/Source/WebCore/platform/graphics/win/cairo/FontCacheWinCairo.cpp
@@ -38,7 +38,7 @@ GDIObject<HFONT> createGDIFont(const AtomString&, LONG, bool, int);
 LONG toGDIFontWeight(FontSelectionValue);
 bool isGDIFontWeightBold(LONG);
 
-std::unique_ptr<FontPlatformData> FontCache::createFontPlatformData(const FontDescription& fontDescription, const AtomString& family, const FontCreationContext&, OptionSet<FontLookupOptions> options)
+std::unique_ptr<FontPlatformData> FontCache::createFontPlatformData(const FontDescription& fontDescription, const AtomString& family, const FontCreationContext& fontCreationContext, OptionSet<FontLookupOptions> options)
 {
     LONG weight = adjustedGDIFontWeight(toGDIFontWeight(fontDescription.weight()), family);
     auto hfont = createGDIFont(family, weight, isItalic(fontDescription.fontStyleSlope()),
@@ -55,7 +55,7 @@ std::unique_ptr<FontPlatformData> FontCache::createFontPlatformData(const FontDe
     bool synthesizeItalic = !options.contains(FontLookupOptions::DisallowObliqueSynthesis)
         && isItalic(fontDescription.fontStyleSlope()) && !logFont.lfItalic;
 
-    auto result = makeUnique<FontPlatformData>(WTF::move(hfont), fontDescription.computedSize(), synthesizeBold, synthesizeItalic);
+    auto result = makeUnique<FontPlatformData>(WTF::move(hfont), fontDescription.computedSize(), synthesizeBold, synthesizeItalic, fontCreationContext.metricsOverrides());
 
     bool fontCreationFailed = !result->scaledFont();
 

--- a/Source/WebCore/platform/graphics/win/cairo/FontCustomPlatformDataWinCairo.cpp
+++ b/Source/WebCore/platform/graphics/win/cairo/FontCustomPlatformDataWinCairo.cpp
@@ -59,7 +59,7 @@ FontPlatformData FontCustomPlatformData::fontPlatformData(const FontDescription&
 
     cairo_font_face_t* fontFace = createCairoDWriteFontFace(hfont.get());
 
-    FontPlatformData fontPlatformData(WTF::move(hfont), fontFace, size, syntheticBold, syntheticItalic, this);
+    FontPlatformData fontPlatformData(WTF::move(hfont), fontFace, size, syntheticBold, syntheticItalic, fontCreationContext.metricsOverrides(), this);
 
     cairo_font_face_destroy(fontFace);
 

--- a/Source/WebCore/platform/graphics/win/cairo/FontPlatformDataWinCairo.cpp
+++ b/Source/WebCore/platform/graphics/win/cairo/FontPlatformDataWinCairo.cpp
@@ -100,8 +100,8 @@ void FontPlatformData::platformDataInit(HFONT font, float size)
     cairo_font_face_destroy(fontFace);
 }
 
-FontPlatformData::FontPlatformData(GDIObject<HFONT> font, cairo_font_face_t* fontFace, float size, bool bold, bool oblique, const FontCustomPlatformData* customPlatformData)
-    : FontPlatformData(size, bold, oblique, FontOrientation::Horizontal, FontWidthVariant::RegularWidth, TextRenderingMode::Auto, customPlatformData)
+FontPlatformData::FontPlatformData(GDIObject<HFONT> font, cairo_font_face_t* fontFace, float size, bool bold, bool oblique, const FontMetricsOverrides& metricsOverrides, const FontCustomPlatformData* customPlatformData)
+    : FontPlatformData(size, bold, oblique, FontOrientation::Horizontal, FontWidthVariant::RegularWidth, TextRenderingMode::Auto, metricsOverrides, customPlatformData)
 {
     m_hfont = SharedGDIObject<HFONT>::create(WTF::move(font));
 

--- a/Source/WebCore/style/values/fonts/StyleFontMetricsOverride.cpp
+++ b/Source/WebCore/style/values/fonts/StyleFontMetricsOverride.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2026 Taishi Eguchi
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleFontMetricsOverride.h"
+
+#include "CSSKeywordValue.h"
+#include "StylePrimitiveNumericTypes+DeprecatedCSSValueConversion.h"
+
+namespace WebCore {
+namespace Style {
+
+// MARK: - Conversion
+
+auto DeprecatedCSSValueConversion<FontMetricsOverride>::operator()(const CSSValue& value) -> std::optional<FontMetricsOverride>
+{
+    if (auto* keywordValue = dynamicDowncast<CSSKeywordValue>(value)) {
+        if (keywordValue->valueID() == CSSValueNormal)
+            return FontMetricsOverride { CSS::Keyword::Normal { } };
+    }
+
+    auto percentage = deprecatedToStyleFromCSSValue<Percentage<CSS::Nonnegative, float>>(value);
+    if (!percentage)
+        return std::nullopt;
+
+    return FontMetricsOverride { WTF::move(*percentage) };
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/fonts/StyleFontMetricsOverride.h
+++ b/Source/WebCore/style/values/fonts/StyleFontMetricsOverride.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2026 Taishi Eguchi
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/StylePrimitiveNumericTypes.h>
+
+namespace WebCore {
+namespace Style {
+
+// <font-metrics-override> = normal | <percentage [0,∞]>
+// https://drafts.csswg.org/css-fonts-4/#font-metrics-override-desc
+struct FontMetricsOverride : ValueOrKeyword<Percentage<CSS::Nonnegative, float>, CSS::Keyword::Normal> {
+    using Base::Base;
+
+    bool isNormal() const { return isKeyword(); }
+};
+
+// MARK: - Conversion
+
+template<> struct DeprecatedCSSValueConversion<FontMetricsOverride> {
+    auto operator()(const CSSValue&) -> std::optional<FontMetricsOverride>;
+};
+
+} // namespace Style
+} // namespace WebCore
+
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::FontMetricsOverride)

--- a/Source/WebKit/Shared/WebCoreFont.serialization.in
+++ b/Source/WebKit/Shared/WebCoreFont.serialization.in
@@ -51,6 +51,17 @@ enum class WebCore::TextRenderingMode : uint8_t {
     GeometricPrecision
 };
 
+header: <WebCore/FontMetricsOverrides.h>
+[CustomHeader] struct WebCore::FontMetricsOverride {
+    Markable<float> value;
+};
+
+[CustomHeader] struct WebCore::FontMetricsOverrides {
+    WebCore::FontMetricsOverride ascentOverride;
+    WebCore::FontMetricsOverride descentOverride;
+    WebCore::FontMetricsOverride lineGapOverride;
+};
+
 header: <WebCore/FontPlatformData.h>
 [CustomHeader] struct WebCore::FontMetadata {
     float pointSize;
@@ -59,6 +70,7 @@ header: <WebCore/FontPlatformData.h>
     WebCore::TextRenderingMode textRenderingMode;
     bool isSyntheticBold;
     bool isSyntheticOblique;
+    WebCore::FontMetricsOverrides metricsOverrides;
 }
 
 #if !USE(CORE_TEXT)


### PR DESCRIPTION
#### 5ee6c014d2b88cc267eacd872f63aa987bfca9ed
<pre>
[CSS Fonts] Apply @font-face metric override descriptors to font metrics
<a href="https://bugs.webkit.org/show_bug.cgi?id=219735">https://bugs.webkit.org/show_bug.cgi?id=219735</a>

Reviewed by Vitor Roriz.

This completes WebKit&apos;s implementation of the CSS Fonts 4 @font-face
ascent-override, descent-override, and line-gap-override descriptors.
316829@main added parser support, and 316933@main exposed the descriptors
through FontFace and CSSFontFaceDescriptors.

Convert each descriptor to a used-size factor and carry it through
FontCreationContext. Store the factors in FontPlatformData::FontMetadata during
construction, before the data can be used as a FontDataCache key. This makes
the overrides part of FontDataCache identity and applies them once during Font
construction without cloning a cached Font.

Font size adjustment reads cap height, zero width, ideogram width, or x-height,
while metric overrides change only ascent, descent, line gap, and line spacing.
Constructing FontPlatformData with the factors therefore does not affect the
adjusted size. Font applies the factors against the final FontPlatformData size.
Preserve the metadata through derived fonts, system fallback fonts, platform
reconstruction, and remote rendering.

Tests: fast/text/font-face-metric-overrides-cache.html
       imported/w3c/web-platform-tests/css/css-fonts/ascent-descent-override.html
       imported/w3c/web-platform-tests/css/css-fonts/line-gap-override.html
       imported/w3c/web-platform-tests/css/css-fonts/font-size-adjust-metrics-override.html
       imported/w3c/web-platform-tests/css/css-fonts/font-face-unicode-range-nbsp.html
       imported/w3c/web-platform-tests/css/css-font-loading/fontface-override-descriptors.html
       ipc/cache-font-null-palette-colors-crash.html
       ipc/move-to-image-buffer-cross-thread-font-crash.html

* LayoutTests/TestExpectations:
Removed expectations for the metric override tests that now pass.
* LayoutTests/fast/text/font-face-metric-overrides-cache-expected.txt: Added.
Added expected output, including the trailing blank line emitted after
TEST COMPLETE.
* LayoutTests/fast/text/font-face-metric-overrides-cache.html: Added.
Verified metric overrides across local font cache entries and URL fonts, and
that updating loaded descriptors invalidates cached font data.
* LayoutTests/ipc/cache-font-null-palette-colors-crash.html:
* LayoutTests/ipc/move-to-image-buffer-cross-thread-font-crash.html:
Added normal metric overrides to hand-written FontMetadata payloads.
* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
Added the new metric override types to the build.
* Source/WebCore/css/CSSFontFace.cpp:
(WebCore::CSSFontFace::setAscentOverride):
(WebCore::CSSFontFace::setDescentOverride):
(WebCore::CSSFontFace::setLineGapOverride):
Converted descriptor percentages to factors and invalidated clients when they
change.
(WebCore::CSSFontFace::font):
Passed metric overrides through FontCreationContext.
* Source/WebCore/css/CSSFontFace.h:
Stored the computed metric overrides.
* Source/WebCore/platform/graphics/Font.cpp:
(WebCore::Font::Font):
(WebCore::Font::applyFontMetricsOverrides):
Applied overrides against the effective FontPlatformData size after normal font
metrics initialization.
* Source/WebCore/platform/graphics/Font.h:
Declared metric override application.
* Source/WebCore/platform/graphics/FontCache.cpp:
(WebCore::FontCache::cachedFontPlatformData):
Disabled zero-bit empty keys for every platform.
* Source/WebCore/platform/graphics/FontCreationContext.h:
(WebCore::FontCreationContextRareData::create):
(WebCore::FontCreationContextRareData::metricsOverrides const):
(WebCore::FontCreationContextRareData::operator== const):
(WebCore::FontCreationContextRareData::FontCreationContextRareData):
(WebCore::FontCreationContext::FontCreationContext):
(WebCore::FontCreationContext::metricsOverrides const):
(WebCore::add):
Carried metric overrides through font creation, equality, and hashing.
* Source/WebCore/platform/graphics/FontMetricsOverrides.h: Added.
(WebCore::FontMetricsOverride::isNormal const):
(WebCore::FontMetricsOverrides::isNormal const):
(WebCore::add):
Defined the computed override representation and hashing, including normalized
signed zero.
* Source/WebCore/platform/graphics/FontPlatformData.cpp:
(WebCore::FontPlatformData::FontPlatformData):
* Source/WebCore/platform/graphics/FontPlatformData.h:
(WebCore::FontPlatformData::FontPlatformData):
(WebCore::FontPlatformData::metricsOverrides const):
Added metric overrides to FontMetadata and the platform data constructors,
making them part of FontPlatformData equality at construction.
* Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp:
(WebCore::FontCache::createFontPlatformData):
(WebCore::FontCache::systemFallbackForCharacterCluster):
Passed metric overrides through normal CoreText platform construction and
system fallback fonts.
* Source/WebCore/platform/graphics/cocoa/FontPlatformDataCocoa.mm:
(WebCore::FontPlatformData::hash const):
Included metric overrides in the Cocoa platform data hash.
* Source/WebCore/platform/graphics/coretext/FontCoreText.cpp:
(WebCore::createDerivativeFont):
(WebCore::Font::createFontWithoutSynthesizableFeatures const):
(WebCore::Font::platformCreateScaledFont const):
(WebCore::Font::platformCreateHalfWidthFont const):
Preserved metric overrides in CoreText derivative fonts.
* Source/WebCore/platform/graphics/coretext/FontCustomPlatformDataCoreText.cpp:
(WebCore::FontCustomPlatformData::fontPlatformData):
Passed metric overrides when constructing custom CoreText platform data.
* Source/WebCore/platform/graphics/coretext/FontPlatformDataCoreText.cpp:
(WebCore::FontPlatformData::FontPlatformData):
Accepted metric overrides in CoreText platform data.
* Source/WebCore/platform/graphics/freetype/FontCacheFreeType.cpp:
(WebCore::FontCache::createFontPlatformData):
Passed metric overrides when constructing FreeType platform data.
* Source/WebCore/platform/graphics/freetype/FontCustomPlatformDataFreeType.cpp:
(WebCore::FontCustomPlatformData::fontPlatformData):
Passed metric overrides when constructing custom FreeType platform data.
* Source/WebCore/platform/graphics/freetype/FontPlatformDataFreeType.cpp:
(WebCore::FontPlatformData::FontPlatformData):
(WebCore::FontPlatformData::create):
Preserved metric overrides when constructing and reconstructing FreeType
platform data.
* Source/WebCore/platform/graphics/freetype/SimpleFontDataFreeType.cpp:
(WebCore::Font::platformCreateScaledFont const):
Preserved metric overrides in scaled FreeType fonts.
* Source/WebCore/platform/graphics/skia/FontCacheSkia.cpp:
(WebCore::FontCache::createFontPlatformData):
Passed metric overrides when constructing Skia platform data.
* Source/WebCore/platform/graphics/skia/FontCustomPlatformDataSkia.cpp:
(WebCore::FontCustomPlatformData::fontPlatformData):
Passed metric overrides when constructing custom Skia platform data.
* Source/WebCore/platform/graphics/skia/FontPlatformDataSkia.cpp:
(WebCore::FontPlatformData::FontPlatformData):
(WebCore::FontPlatformData::hash const):
Accepted and hashed metric overrides in Skia platform data.
* Source/WebCore/platform/graphics/skia/FontSkia.cpp:
(WebCore::Font::platformCreateScaledFont const):
(WebCore::Font::platformCreateHalfWidthFont const):
Preserved metric overrides in Skia derivative fonts.
* Source/WebCore/platform/graphics/win/FontPlatformDataWin.cpp:
(WebCore::FontPlatformData::FontPlatformData):
(WebCore::FontPlatformData::create):
(WebCore::FontPlatformData::fromIPCData):
Preserved metric overrides when constructing and reconstructing Windows
platform data.
* Source/WebCore/platform/graphics/win/SimpleFontDataWin.cpp:
(WebCore::Font::platformCreateScaledFont const):
Preserved metric overrides in scaled Windows fonts.
* Source/WebCore/platform/graphics/win/cairo/FontCacheWinCairo.cpp:
(WebCore::FontCache::createFontPlatformData):
Passed metric overrides when constructing Windows Cairo platform data.
* Source/WebCore/platform/graphics/win/cairo/FontCustomPlatformDataWinCairo.cpp:
(WebCore::FontCustomPlatformData::fontPlatformData):
Passed metric overrides when constructing custom Windows Cairo platform data.
* Source/WebCore/platform/graphics/win/cairo/FontPlatformDataWinCairo.cpp:
(WebCore::FontPlatformData::FontPlatformData):
Accepted metric overrides in custom Windows Cairo platform data.
* Source/WebCore/style/values/fonts/StyleFontMetricsOverride.cpp: Added.
(WebCore::Style::DeprecatedCSSValueConversion&lt;FontMetricsOverride&gt;::operator()):
* Source/WebCore/style/values/fonts/StyleFontMetricsOverride.h: Added.
(WebCore::Style::FontMetricsOverride):
Added the shared normal-or-nonnegative-percentage descriptor value and its CSS
conversion.
* Source/WebKit/Shared/WebCoreFont.serialization.in:
Serialized metric overrides as part of FontMetadata.

Canonical link: <a href="https://commits.webkit.org/318680@main">https://commits.webkit.org/318680@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4165064ea203ba7f5186169a372b22992c65e761

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177737 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51675 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45469 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187346 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/140984 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179600 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52967 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51384 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138535 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96347 "2 flakes 5 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180693 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42058 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159283 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118999 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40720 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39085 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151126 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38779 "Passed tests") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43460 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43320 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189774 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51342 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158815 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147652 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39931 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52024 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35407 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147437 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42154 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124239 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/118680 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50532 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13756 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49928 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50168 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49990 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->