### PR TITLE
Add layout test for former heap-use-after-free caused by access key and select element.

### DIFF
--- a/LayoutTests/fast/forms/access-key-select-destroy-expected.txt
+++ b/LayoutTests/fast/forms/access-key-select-destroy-expected.txt
@@ -1,0 +1,1 @@
+If you see this text, the select element and its containing iframe were successfully removed without crashing.

--- a/LayoutTests/fast/forms/access-key-select-destroy.html
+++ b/LayoutTests/fast/forms/access-key-select-destroy.html
@@ -1,0 +1,42 @@
+
+<html>
+<head>
+<script>
+forceGC = () => {
+    for (let i = 0; i < 20; ++i) {
+        new ArrayBuffer(100 * 1024 * 1024);
+    }
+}
+async function magic(){
+    frame.remove();
+    document.body.innerHTML = '<p>If you see this text, the select element and its containing iframe were successfully removed without crashing.</p>';
+    forceGC();
+}
+function test()
+{
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+        if (navigator.userAgent.search(/\bMac OS X\b/) != -1)
+            modifiers = ["ctrlKey", "altKey"];
+        else
+            modifiers = ["altKey"];
+        eventSender.keyDown("a", modifiers);
+    }
+}
+</script>
+</head>
+<body onload="test()">
+<p>This test checks what happens if an access key causing a button or select element to be focused or blurred destroys the access key's node.</p>
+<p>This caused a crash on previous versions of WebKit .</p>
+<script>
+frame = document.body.appendChild(document.createElement('iframe'));
+frame.style = 'width: 100%; height: 100%; border: 0';
+outerContainer = frame.contentDocument.body.attachShadow({ mode: 'open' });
+outerContainer.innerHTML = `<select accesskey="a">SouthSea</select>
+<p>Made in the body</p>
+<input></input>`;
+outerContainer.childNodes[4].addEventListener('blur',magic);
+outerContainer.childNodes[4].focus();
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### 26fe0cc78166c2d803fdc561eb89504ae78477be
<pre>
Add layout test for former heap-use-after-free caused by access key and select element.
<a href="https://rdar.apple.com/88295539">rdar://88295539</a>

Reviewed by NOBODY (OOPS!).

<a href="https://commits.webkit.org/246619@main">https://commits.webkit.org/246619@main</a> fixed this bug by replacing a pointer in EventHandler to a RefPtr. Other additional changes, like moving accessKeyAction into HTMLElement and various uses of SaferCPP throughout the code mean I couldn&apos;t replicate the crash even after reverting that change.

* LayoutTests/fast/forms/access-key-select-destroy-expected.txt: Added.
* LayoutTests/fast/forms/access-key-select-destroy.html: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26fe0cc78166c2d803fdc561eb89504ae78477be

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173885 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47818 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41599 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183459 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131753 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49110 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47500 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135226 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95348 "1 flakes 4 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176843 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38658 "Found 1 new test failure: fast/forms/access-key-select-destroy.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156020 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115704 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37299 "4 new passes 1 failures") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35664 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31943 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147723 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35513 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185885 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39862 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144125 "Found 1 new test failure: compositing/color-matching/image-color-matching.html (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47485 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155575 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143983 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48164 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32130 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/113477 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38900 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46670 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10470 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46072 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46303 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46131 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->