### PR TITLE
[CMake] Call replace-webkit-additions-includes for WebKit headers

### DIFF
--- a/Source/WebKit/PlatformMac.cmake
+++ b/Source/WebKit/PlatformMac.cmake
@@ -164,6 +164,25 @@ list(APPEND WebKit_PRIVATE_LIBRARIES
     "-weak_framework PowerLog"
 )
 
+foreach (_header IN LISTS WebKit_PUBLIC_FRAMEWORK_HEADERS)
+    file(READ ${WEBKIT_DIR}/${_header} _contents)
+    # Only run headers through the replacement script if they actually contain
+    # a WKA import.
+    if (_contents MATCHES "#import <WebKitAdditions/.*\.h>")
+        get_filename_component(_name ${_header} NAME)
+        add_custom_command(
+            OUTPUT ${WebKit_HEADERS_DIR}/${_name}
+            COMMAND
+                env ${WEBKITADDITIONS_DEFINITIONS_FOR_HEADER_REPLACEMENT}
+                    ${WEBKIT_DIR}/mac/replace-webkit-additions-includes.py
+                    ${WebKitAdditions_FRAMEWORK_HEADERS_DIR} ${CMAKE_OSX_SYSROOT}
+                    ${WEBKIT_DIR}/${_header} ${WebKit_HEADERS_DIR}/${_name}
+            MAIN_DEPENDENCY ${WEBKIT_DIR}/${_header}
+            VERBATIM
+        )
+    endif ()
+endforeach ()
+
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -compatibility_version 1 -current_version ${WEBKIT_MAC_VERSION}")
 # -Wl,-u forces a symbol reference so -dead_strip_dylibs won't prune the weak framework.
 target_link_options(WebKit PRIVATE

--- a/Source/WebKit/mac/replace-webkit-additions-includes.py
+++ b/Source/WebKit/mac/replace-webkit-additions-includes.py
@@ -24,6 +24,7 @@
 # THE POSSIBILITY OF SUCH DAMAGE.
 #
 
+import argparse
 import os
 import re
 import sys
@@ -34,7 +35,7 @@ should_restrict_header_replacement_based_on_feature = True
 
 
 def read_content_from_webkit_additions(built_products_directory, sdk_root_directory, filename):
-    library_headers_folder_path = os.environ['WK_LIBRARY_HEADERS_FOLDER_PATH'].removeprefix('/')
+    library_headers_folder_path = os.environ.get('WK_LIBRARY_HEADERS_FOLDER_PATH', '').removeprefix('/')
     additions_path = os.path.join(library_headers_folder_path, "WebKitAdditions", filename)
     try:
         file_in_build_directory = open(os.path.join(built_products_directory, additions_path), "r")
@@ -55,28 +56,33 @@ def check_should_do_replacement(built_products_directory, sdk_root_directory):
 
 
 def main(argv=None):
-    if not argv:
-        argv = sys.argv
+    parser = argparse.ArgumentParser()
+    parser.add_argument('built_products_dir')
+    parser.add_argument('sdk_root_dir')
+    parser.add_argument('src', nargs='?')
+    parser.add_argument('dst', nargs='?')
+    args = parser.parse_args(argv)
 
-    if len(argv) != 3:
-        print("Usage: replace-webkit-additions-includes.py <built_products_directory> <sdk_root_directory>", file=sys.stderr)
-        return 1
+    if not args.src:
+        src = sys.stdin
+    else:
+        src = open(args.src, 'r')
 
-    built_products_directory = argv[1]
-    sdk_root_directory = argv[2]
+    if not args.dst:
+        dst = sys.stdout
+    else:
+        if os.path.exists(args.dst) and os.path.islink(args.dst):
+            # Migrate from a CMake build that used symlinks to source headers.
+            os.unlink(args.dst)
+        dst = open(args.dst, 'w')
 
-    if not len(built_products_directory):
-        print("(%s): built products directory unspecified" % argv[0], file=sys.stderr)
-        return 1
-
-    if not len(sdk_root_directory):
-        print("(%s): SDK root directory unspecified" % argv[0], file=sys.stderr)
-        return 1
+    built_products_directory = args.built_products_dir
+    sdk_root_directory = args.sdk_root_dir
 
     should_do_replacement = check_should_do_replacement(built_products_directory, sdk_root_directory)
 
     additions_import_pattern = re.compile(r"\#if 0 // API_WEBKIT_ADDITIONS_REPLACEMENT\n#import <WebKitAdditions/(.*)>\n#endif")
-    header_contents = sys.stdin.read()
+    header_contents = src.read()
     match = additions_import_pattern.search(header_contents)
     while match:
         if should_do_replacement:
@@ -84,8 +90,7 @@ def main(argv=None):
         else:
             header_contents = header_contents[:match.start()] + header_contents[match.end():]
         match = additions_import_pattern.search(header_contents)
-    sys.stdout.write(header_contents)
-    return 0
+    dst.write(header_contents)
 
 if __name__ == "__main__":
-    sys.exit(main(sys.argv))
+    main()

--- a/Source/cmake/WebKitCommon.cmake
+++ b/Source/cmake/WebKitCommon.cmake
@@ -309,6 +309,11 @@ if (NOT HAS_RUN_WEBKIT_COMMON)
     include(WebKitStaticAnalysis)
     include(WebKitFeatures)
 
+    if (USE_APPLE_INTERNAL_SDK)
+        list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../Internal/WebKit/WebKitAdditions/CMake")
+        include(WebKitAdditions)
+    endif ()
+
     include(OptionsCommon)
     include(Options${PORT})
 


### PR DESCRIPTION
#### b87df79901bf7227381364392ff322c237acccf1
<pre>
[CMake] Call replace-webkit-additions-includes for WebKit headers
<a href="https://bugs.webkit.org/show_bug.cgi?id=319141">https://bugs.webkit.org/show_bug.cgi?id=319141</a>
<a href="https://rdar.apple.com/181957548">rdar://181957548</a>

Reviewed by Richard Robinson.

WebKitAdditions has a CMake module which defines
WEBKITADDITIONS_DEFINITIONS_FOR_HEADER_REPLACEMENT. Load it, then use
replace-webkit-additions-includes.py as a custom command for public
headers which contain WKA stubs.

Rewrite the script to have fewer Xcode-isms, so it&apos;s easy to share
between Xcode and CMake.

* Source/WebKit/PlatformMac.cmake:
* Source/WebKit/mac/replace-webkit-additions-includes.py:
(read_content_from_webkit_additions):
(main):
* Source/cmake/WebKitCommon.cmake:

Canonical link: <a href="https://commits.webkit.org/316953@main">https://commits.webkit.org/316953@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ec9573554452f2cf0599db276550e379960c756

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173906 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47839 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41620 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183480 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/131774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8a372305-0152-49ef-8c5b-570f3449a012) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49131 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47521 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/135242 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/131774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2a648e5a-c966-4f7c-9677-239df01fbd90) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176864 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/38673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/156029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115720 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/965288f1-f6fd-41b3-8fc9-0f42f2404f8e) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/37314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/35678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31964 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/4539 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/147738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35522 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185906 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/35168 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/38960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/39876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/144139 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47506 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143999 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48185 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113502 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26444 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38911 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/120069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/210940 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46691 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10479 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54955 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46094 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46325 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46152 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->