### PR TITLE
[Text Extraction] Add more context before SVG icons without any relevant accessibility attributes

### DIFF
--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -38,6 +38,7 @@
 #include "Editing.h"
 #include "Editor.h"
 #include "ElementAncestorIteratorInlines.h"
+#include "ElementChildIteratorInlines.h"
 #include "ElementInlines.h"
 #include "EventHandler.h"
 #include "EventListenerMap.h"
@@ -67,6 +68,7 @@
 #include "JSNode.h"
 #include "LocalFrame.h"
 #include "NodeList.h"
+#include "NodeTraversal.h"
 #include "Page.h"
 #include "PlatformKeyboardEvent.h"
 #include "PlatformMouseEvent.h"
@@ -80,6 +82,9 @@
 #include "RenderLayerScrollableArea.h"
 #include "RenderObjectInlines.h"
 #include "RenderView.h"
+#include "SVGElementTypeHelpers.h"
+#include "SVGSVGElement.h"
+#include "SVGTitleElement.h"
 #include "Settings.h"
 #include "SimpleRange.h"
 #include "StaticRange.h"
@@ -692,6 +697,22 @@ static inline Variant<SkipExtraction, ItemData, URL, Editable> extractItemData(N
             .completedSource = completedSourceURL,
             .shortenedName = StringEntropyHelpers::lowEntropyLastPathComponent(completedSourceURL, "image"_s, mimeType),
             .altText = image->altText(),
+        } };
+    }
+
+    if (RefPtr svg = dynamicDowncast<SVGSVGElement>(element)) {
+        auto altText = normalizeText(element->attributeWithoutSynchronization(HTMLNames::aria_labelAttr));
+        if (altText.isEmpty()) {
+            for (Ref title : childrenOfType<SVGTitleElement>(*svg)) {
+                altText = normalizeText(title->textContent());
+                break;
+            }
+        }
+
+        return { ImageItemData {
+            .completedSource = { },
+            .shortenedName = { },
+            .altText = WTF::move(altText),
         } };
     }
 
@@ -2191,6 +2212,55 @@ static RefPtr<Element> closestLinkOrButtonAncestor(const Element& element)
     return nullptr;
 }
 
+static bool containsLetterOrDigit(StringView text)
+{
+    return text.contains([](auto character) {
+        return u_isalpha(character) || u_isdigit(character);
+    });
+}
+
+static String precedingRenderedTextLabel(const Element& element)
+{
+    static constexpr unsigned maximumPrecedingTextNodesToSearch = 16;
+    static constexpr unsigned maximumAdjacentTextLength = 40;
+
+    RefPtr stayWithin = element.document().documentElement();
+    unsigned examinedTextNodes = 0;
+    Vector<String> collectedInReverse;
+    for (RefPtr node = NodeTraversal::previous(element, stayWithin.get()); node; node = NodeTraversal::previous(*node, stayWithin.get())) {
+        RefPtr text = dynamicDowncast<Text>(*node);
+        if (!text || !text->renderer())
+            continue;
+
+        if (shouldTreatAsPasswordField(text->shadowHost()))
+            continue;
+
+        if (++examinedTextNodes > maximumPrecedingTextNodesToSearch)
+            break;
+
+        auto normalized = normalizeText(text->data());
+        if (normalized.isEmpty())
+            continue;
+
+        collectedInReverse.append(normalized);
+        if (containsLetterOrDigit(normalized))
+            break;
+    }
+
+    collectedInReverse.reverse();
+    if (collectedInReverse.isEmpty())
+        return { };
+
+    auto joined = makeStringByJoining(collectedInReverse, " "_s);
+    if (!containsLetterOrDigit(joined))
+        return { };
+
+    if (joined.length() > maximumAdjacentTextLength)
+        joined = makeString(StringView { joined }.left(maximumAdjacentTextLength - 3), "..."_s);
+
+    return joined;
+}
+
 static String textDescription(const Element& element, Vector<String>& stringsToValidate, bool isTargetElement = true)
 {
     StringBuilder description;
@@ -2205,30 +2275,35 @@ static String textDescription(const Element& element, Vector<String>& stringsToV
         description.append(tagName);
 
     auto needsParentContext = true;
+    auto hasAccessibleName = false;
 
     if (element.isLink()) {
         if (auto text = normalizeText(element.attributeWithoutSynchronization(HTMLNames::hrefAttr)); !text.isEmpty()) {
             description.append(makeString(" with href "_s, wrapWithDoubleQuotes(WTF::move(text))));
             stringsToValidate.append(WTF::move(text));
             needsParentContext = false;
+            hasAccessibleName = true;
         }
     }
 
     if (auto text = normalizeText(element.attributeWithoutSynchronization(HTMLNames::roleAttr)); !text.isEmpty() && text != tagName) {
         description.append(makeString(" with role "_s, wrapWithDoubleQuotes(WTF::move(text))));
         needsParentContext = false;
+        hasAccessibleName = true;
     }
 
     if (auto text = normalizedLabelText(element); !text.isEmpty()) {
         description.append(makeString(" labeled "_s, wrapWithDoubleQuotes(WTF::move(text))));
         stringsToValidate.append(WTF::move(text));
         needsParentContext = false;
+        hasAccessibleName = true;
     }
 
     if (auto text = normalizeText(element.attributeWithoutSynchronization(HTMLNames::titleAttr)); !text.isEmpty()) {
         description.append(makeString(" titled "_s, wrapWithDoubleQuotes(WTF::move(text))));
         stringsToValidate.append(WTF::move(text));
         needsParentContext = false;
+        hasAccessibleName = true;
     }
 
     if (auto text = element.attributeWithoutSynchronization(HTMLNames::typeAttr); !text.isEmpty() && text != tagName)
@@ -2238,6 +2313,7 @@ static String textDescription(const Element& element, Vector<String>& stringsToV
         description.append(makeString(" with placeholder "_s, wrapWithDoubleQuotes(WTF::move(text))));
         stringsToValidate.append(WTF::move(text));
         needsParentContext = false;
+        hasAccessibleName = true;
     }
 
     if (RefPtr input = dynamicDowncast<HTMLInputElement>(element)) {
@@ -2250,6 +2326,7 @@ static String textDescription(const Element& element, Vector<String>& stringsToV
                 description.append(makeString(" with value "_s, wrapWithDoubleQuotes(WTF::move(text))));
                 stringsToValidate.append(WTF::move(text));
                 needsParentContext = false;
+                hasAccessibleName = true;
             }
         }
     }
@@ -2286,6 +2363,19 @@ static String textDescription(const Element& element, Vector<String>& stringsToV
             auto ancestorDescription = textDescription(*ancestor, stringsToValidate, false);
             if (!ancestorDescription.isEmpty())
                 return makeString(WTF::move(elementDescription), " under "_s, WTF::move(ancestorDescription));
+        }
+    }
+
+    if (isTargetElement && !hasAccessibleName && (is<HTMLImageElement>(element) || element.isSVGElement())) {
+        bool hasImageAltText = false;
+        if (RefPtr image = dynamicDowncast<HTMLImageElement>(element))
+            hasImageAltText = !normalizeText(image->altText()).isEmpty();
+
+        if (!hasImageAltText) {
+            if (auto neighborText = precedingRenderedTextLabel(element); !neighborText.isEmpty()) {
+                stringsToValidate.append(neighborText);
+                return makeString(WTF::move(elementDescription), " after rendered text "_s, wrapWithDoubleQuotes(WTF::move(neighborText)));
+            }
         }
     }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm
@@ -365,6 +365,36 @@ TEST(TextExtractionTests, InteractionDebugDescription)
     }
 }
 
+TEST(TextExtractionTests, InteractionDescriptionUsesAdjacentTextForUnlabeledIcon)
+{
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [[configuration preferences] _setTextExtractionEnabled:YES];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration]);
+    [webView synchronouslyLoadHTMLString:@"<div><span>Full Name</span><svg width='16' height='16' class='pencil1' onclick=''></svg></div>"
+        "<div><span>Password</span><span>********</span><svg width='16' height='16' class='pencil2' onclick=''></svg></div>"];
+
+    RetainPtr debugText = [webView synchronouslyGetDebugText:nil];
+    RetainPtr nameIconID = extractNodeIdentifier(debugText, @"pencil1");
+    RetainPtr passwordIconID = extractNodeIdentifier(debugText, @"pencil2");
+    EXPECT_NOT_NULL(nameIconID);
+    EXPECT_NOT_NULL(passwordIconID);
+
+    NSError *error = nil;
+    NSString *description = nil;
+    RetainPtr interaction = adoptNS([[_WKTextExtractionInteraction alloc] initWithAction:_WKTextExtractionActionClick]);
+
+    [interaction setNodeIdentifier:nameIconID];
+    description = [interaction debugDescriptionInWebView:webView error:&error];
+    EXPECT_WK_STREQ("Click on svg with class “pencil1” after rendered text “Full Name”", description);
+    EXPECT_NULL(error);
+
+    [interaction setNodeIdentifier:passwordIconID];
+    description = [interaction debugDescriptionInWebView:webView error:&error];
+    EXPECT_WK_STREQ("Click on svg with class “pencil2” after rendered text “Password ********”", description);
+    EXPECT_NULL(error);
+}
+
 TEST(TextExtractionTests, InteractionDebugDescriptionWithStaleNodeIdentifier)
 {
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);


### PR DESCRIPTION
#### 3f30614bd4ead34b1686dc3ec0341678f7a5c02a
<pre>
[Text Extraction] Add more context before SVG icons without any relevant accessibility attributes
<a href="https://bugs.webkit.org/show_bug.cgi?id=319142">https://bugs.webkit.org/show_bug.cgi?id=319142</a>
<a href="https://rdar.apple.com/181959554">rdar://181959554</a>

Reviewed by Abrar Rahman Protyasha and Richard Robinson.

Make a couple of adjustments when handling SVG images during text extraction, to give agents more
context when reasoning about clickable icons with no accessibility attributes:

-   Surface them as `image` items (similar to the `img` element), but without a `src` attribute.
-   When producing an interaction description for an SVG, if there are no relevant accessibility
    attributes in any ancestor element or descendants, fall back to collecting text samples from
    immediately preceding rendered text.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::extractItemData):
(WebCore::TextExtraction::containsLetterOrDigit):
(WebCore::TextExtraction::precedingRenderedTextLabel):
(WebCore::TextExtraction::textDescription):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm:
(TestWebKitAPI::TEST(TextExtractionTests, InteractionDescriptionUsesAdjacentTextForUnlabeledIcon)):

Canonical link: <a href="https://commits.webkit.org/316956@main">https://commits.webkit.org/316956@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bea64d6778b787e15ea92966fbaf59aedff360e4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173911 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47844 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41625 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183485 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131779 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d4705b09-43ea-413e-a910-1cdc6470d9c3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175776 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49136 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47526 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135245 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176869 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38674 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156033 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115723 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37315 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35682 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31969 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147739 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35526 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185911 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38966 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39880 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144144 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47511 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144004 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38834 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48190 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113510 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38913 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120074 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46696 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10483 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46099 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46330 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46157 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->