### PR TITLE
CanvasRenderingContext2D: filtered drawing should not need to save states

### DIFF
--- a/LayoutTests/fast/canvas/canvas-filtered-drawing-after-stack-exhaustion-expected.html
+++ b/LayoutTests/fast/canvas/canvas-filtered-drawing-after-stack-exhaustion-expected.html
@@ -1,0 +1,13 @@
+<canvas width="300" height="300" id="canvas"></canvas>
+
+<script>
+  const context = canvas.getContext("2d");
+
+  context.filter = "drop-shadow(-5px -5px)";
+  context.fillStyle = "blue";
+  context.fillRect(100, 100, 100, 100);
+
+  context.filter = "drop-shadow(5px 5px)";
+  context.fillStyle = "green";
+  context.fillRect(200, 200, 50, 50);
+</script>

--- a/LayoutTests/fast/canvas/canvas-filtered-drawing-after-stack-exhaustion.html
+++ b/LayoutTests/fast/canvas/canvas-filtered-drawing-after-stack-exhaustion.html
@@ -1,0 +1,24 @@
+<!-- webkit-test-runner [ GraphicsContextFiltersEnabled=false ]-->
+<!DOCTYPE html>
+
+<title>When save stack is exhausted, filtered drawing should still use the last set filter</title>
+
+<canvas width="300" height="300" id="canvas"></canvas>
+
+<script>
+  const context = canvas.getContext("2d");
+
+  for (let i = 0; i < 20000; ++i)
+    context.save();
+
+  context.filter = "drop-shadow(-5px -5px)";
+  context.fillStyle = "blue";
+  context.fillRect(100, 100, 100, 100);
+
+  context.filter = "drop-shadow(5px 5px)";
+  context.fillStyle = "green";
+  context.fillRect(200, 200, 50, 50);
+
+  for (let i = 0; i < 20000; ++i)
+    context.restore();
+</script>

--- a/Source/WebCore/html/canvas/CanvasFilterContextSwitcher.cpp
+++ b/Source/WebCore/html/canvas/CanvasFilterContextSwitcher.cpp
@@ -44,25 +44,21 @@ std::unique_ptr<CanvasFilterContextSwitcher> CanvasFilterContextSwitcher::create
     if (!filter)
         return nullptr;
 
-    auto filterSwitcher = makeUnique<CanvasFilterContextSwitcher>(context);
-    auto targetSwitcher = CanvasLayerContextSwitcher::create(context, bounds, WTF::move(filter));
-    if (!targetSwitcher)
-        return nullptr;
-
-    context.modifiableState().targetSwitcher = WTF::move(targetSwitcher);
-    return filterSwitcher;
+    return makeUnique<CanvasFilterContextSwitcher>(context, bounds, WTF::move(filter));
 }
 
-CanvasFilterContextSwitcher::CanvasFilterContextSwitcher(CanvasRenderingContext2DBase& context)
+CanvasFilterContextSwitcher::CanvasFilterContextSwitcher(CanvasRenderingContext2DBase& context, const FloatRect& bounds, RefPtr<Filter>&& filter)
     : m_context(context)
+    , m_contextOldTargetSwitcher(context.state().targetSwitcher)
 {
-    context.save();
-    context.realizeSaves();
+    // Only use the new target switcher if it's non-null. Otherwise keep using the old one.
+    if (auto targetSwitcher = CanvasLayerContextSwitcher::create(context, bounds, WTF::move(filter)))
+        m_context->modifiableState().targetSwitcher = targetSwitcher;
 }
 
 CanvasFilterContextSwitcher::~CanvasFilterContextSwitcher()
 {
-    context()->restore();
+    m_context->modifiableState().targetSwitcher = WTF::move(m_contextOldTargetSwitcher);
 }
 
 FloatRect CanvasFilterContextSwitcher::expandedBounds() const

--- a/Source/WebCore/html/canvas/CanvasFilterContextSwitcher.h
+++ b/Source/WebCore/html/canvas/CanvasFilterContextSwitcher.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "Filter.h"
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakRef.h>
 
@@ -39,14 +40,15 @@ class CanvasFilterContextSwitcher {
 public:
     static std::unique_ptr<CanvasFilterContextSwitcher> create(CanvasRenderingContext2DBase&, const FloatRect& bounds);
 
-    CanvasFilterContextSwitcher(CanvasRenderingContext2DBase&);
+    CanvasFilterContextSwitcher(CanvasRenderingContext2DBase&, const FloatRect&, RefPtr<Filter>&&);
     ~CanvasFilterContextSwitcher();
 
     FloatRect expandedBounds() const;
 
 private:
     Ref<CanvasRenderingContext2DBase> context() const { return m_context.get(); }
-    WeakRef<CanvasRenderingContext2DBase> m_context;
+    const WeakRef<CanvasRenderingContext2DBase> m_context;
+    RefPtr<CanvasLayerContextSwitcher> m_contextOldTargetSwitcher;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### c5d6db573430acbf012085a24fb2368845e8158b
<pre>
CanvasRenderingContext2D: filtered drawing should not need to save states
<a href="https://rdar.apple.com/181410087">rdar://181410087</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=319036">https://bugs.webkit.org/show_bug.cgi?id=319036</a>

Reviewed by Simon Fraser.

CanvasRenderingContext2D limits the amount of state on the stack to MaxStackSize
(currently 16384). If the limit is reached, save() is a no-op and doesn&apos;t push new
states onto the stack. This is fine for most code, however it&apos;ll cause trouble for
CanvasFilterContextSwitcher as it requires a state save to change targetSwitcher:

std::unique_ptr&lt;CanvasFilterContextSwitcher&gt; CanvasFilterContextSwitcher::create(CanvasRenderingContext2DBase&amp; context, const FloatRect&amp; bounds)
{
    auto filter = [...];

    auto filterSwitcher = makeUnique&lt;CanvasFilterContextSwitcher&gt;(context);     &lt;-- (a)
    auto targetSwitcher = CanvasLayerContextSwitcher::create(context, bounds, WTF::move(filter)); &lt;-- (d)
    if (!targetSwitcher)
        return nullptr;

    context.modifiableState().targetSwitcher = WTF::move(targetSwitcher);       &lt;-- (c)
    return filterSwitcher;
}

CanvasFilterContextSwitcher::CanvasFilterContextSwitcher(CanvasRenderingContext2DBase&amp; context)
    : m_context(context)
{
    // (b)
    context.save();
    context.realizeSaves();
}

RefPtr&lt;CanvasLayerContextSwitcher&gt; CanvasLayerContextSwitcher::create(CanvasRenderingContext2DBase&amp; context, const FloatRect&amp; bounds, RefPtr&lt;Filter&gt;&amp;&amp; filter)
{
    ASSERT(!bounds.isEmpty());
    auto* effectiveDrawingContext = context.effectiveDrawingContext();  &lt;-- (e)
    if (!effectiveDrawingContext)
        return nullptr;

    auto targetSwitcher = GraphicsContextSwitcher::create(*effectiveDrawingContext, bounds, context.colorSpace(), WTF::move(filter));
    if (!targetSwitcher)
        return nullptr;

    return adoptRef(*new CanvasLayerContextSwitcher(context, bounds, WTF::move(targetSwitcher)));
}

When the CanvasFilterContextSwitcher is created (a), it saves the current state (b),
so it can change targetSwitcher later (c). But if the state stack is exhausted, then
no states are pushed on the stack. In that case, the CanvasLayerContextSwitcher
created in (d) holds the drawing context (e) from the current effectiveDrawingContext,
aka the drawing context from the targetSwitcher at the top of the stack. Then (c)
overwrites the top targetSwitcher with the newly created one in (d). If the old
targetSwitcher is only kept alive by the top state, then overwriting it would free it.
But the new targetSwitcher holds a reference to the drawingContext of the targetSwitcher
that we just freed.

This patch fixes this by eliminating the state save. Instead, CanvasFilterContextSwitcher
holds onto the old targetSwitcher in top of stack when it&apos;s created, then replace it with
the new one. On destruction, it&apos;ll put the old one back. This ensures filtered drawing
would work regardless of stack exhaustion.

Test: fast/canvas/canvas-filtered-drawing-after-stack-exhaustion.html

* LayoutTests/fast/canvas/canvas-filtered-drawing-after-stack-exhaustion-expected.html: Added.
* LayoutTests/fast/canvas/canvas-filtered-drawing-after-stack-exhaustion.html: Added.
* Source/WebCore/html/canvas/CanvasFilterContextSwitcher.cpp:
(WebCore::CanvasFilterContextSwitcher::create):
(WebCore::CanvasFilterContextSwitcher::CanvasFilterContextSwitcher):
(WebCore::CanvasFilterContextSwitcher::~CanvasFilterContextSwitcher):
* Source/WebCore/html/canvas/CanvasFilterContextSwitcher.h:

Canonical link: <a href="https://commits.webkit.org/317546@main">https://commits.webkit.org/317546@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c44f6dfcd362ee267ec24e2036646b685c46a72

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175267 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49199 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42980 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184852 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/133637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a25d2faf-aa85-47d7-8316-73a082446908) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177131 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50491 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48882 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136436 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/133637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0d33f8eb-3593-4dd2-aad5-5b2675ec203d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178224 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39859 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157197 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116914 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/affd95ff-c230-4458-87ab-919fdac06b81) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38500 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36872 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33325 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148923 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36690 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187273 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/40886 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41076 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145394 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48866 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156753 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145239 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39203 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49546 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33311 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115425 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40067 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121739 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48052 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11663 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47455 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47685 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47512 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->