### PR TITLE
Synchronize Font metadata representation (size, orientation, etc.)

### DIFF
--- a/Source/WebCore/platform/graphics/FontPlatformData.cpp
+++ b/Source/WebCore/platform/graphics/FontPlatformData.cpp
@@ -44,13 +44,14 @@ FontPlatformData::FontPlatformData(WTF::HashTableDeletedValueType)
 FontPlatformData::FontPlatformData() = default;
 
 FontPlatformData::FontPlatformData(float size, bool syntheticBold, bool syntheticOblique, FontOrientation orientation, FontWidthVariant widthVariant, TextRenderingMode textRenderingMode, const FontCustomPlatformData* customPlatformData)
-    : m_size(size)
-    , m_orientation(orientation)
-    , m_widthVariant(widthVariant)
-    , m_textRenderingMode(textRenderingMode)
+: m_metadata { size, orientation, widthVariant, textRenderingMode, syntheticBold, syntheticOblique }
+, m_customPlatformData(customPlatformData)
+{
+}
+
+FontPlatformData::FontPlatformData(const FontMetadata& metadata, const FontCustomPlatformData* customPlatformData)
+    : m_metadata(metadata)
     , m_customPlatformData(customPlatformData)
-    , m_syntheticBold(syntheticBold)
-    , m_syntheticOblique(syntheticOblique)
 {
 }
 
@@ -62,7 +63,7 @@ FontPlatformData& FontPlatformData::operator=(const FontPlatformData&) = default
 FontPlatformData FontPlatformData::cloneWithOrientation(const FontPlatformData& source, FontOrientation orientation)
 {
     FontPlatformData copy(source);
-    copy.m_orientation = orientation;
+    copy.m_metadata.orientation = orientation;
     return copy;
 }
 #endif
@@ -79,7 +80,7 @@ FontPlatformData FontPlatformData::cloneWithSize(const FontPlatformData& source,
 #if !USE(SKIA)
 void FontPlatformData::updateSize(float size)
 {
-    m_size = size;
+    m_metadata.pointSize = size;
 }
 #endif
 #endif

--- a/Source/WebCore/platform/graphics/FontPlatformData.h
+++ b/Source/WebCore/platform/graphics/FontPlatformData.h
@@ -91,69 +91,53 @@ class SkiaHarfBuzzFont;
 struct FontPlatformSerializedAttributes;
 #endif
 
+struct FontMetadata {
+    float pointSize = { 0.0 };
+    FontOrientation orientation = FontOrientation::Horizontal;
+    FontWidthVariant widthVariant = FontWidthVariant::RegularWidth;
+    TextRenderingMode textRenderingMode = TextRenderingMode::Auto;
+    bool isSyntheticBold = false;
+    bool isSyntheticOblique = false;
+
+    friend bool operator==(const FontMetadata&, const FontMetadata&) = default;
+};
+
 struct FontPlatformDataAttributes {
-    FontPlatformDataAttributes(float size, FontOrientation orientation, FontWidthVariant widthVariant, TextRenderingMode textRenderingMode, bool syntheticBold, bool syntheticOblique)
-        : m_size(size)
-        , m_orientation(orientation)
-        , m_widthVariant(widthVariant)
-        , m_textRenderingMode(textRenderingMode)
-        , m_syntheticBold(syntheticBold)
-        , m_syntheticOblique(syntheticOblique)
+    FontPlatformDataAttributes(const FontMetadata& metadata)
+        : m_metadata(metadata)
         { }
 
 #if USE(CORE_TEXT)
-    FontPlatformDataAttributes(float size, FontOrientation orientation, FontWidthVariant widthVariant, TextRenderingMode textRenderingMode, bool syntheticBold, bool syntheticOblique, RetainPtr<CFDictionaryRef> attributes, CTFontDescriptorOptions options, RetainPtr<CFStringRef> url, RetainPtr<CFStringRef> psName)
-        : m_size(size)
-        , m_orientation(orientation)
-        , m_widthVariant(widthVariant)
-        , m_textRenderingMode(textRenderingMode)
-        , m_syntheticBold(syntheticBold)
-        , m_syntheticOblique(syntheticOblique)
+    FontPlatformDataAttributes(const FontMetadata& metadata, RetainPtr<CFDictionaryRef> attributes, CTFontDescriptorOptions options, RetainPtr<CFStringRef> url, RetainPtr<CFStringRef> psName)
+        : m_metadata(metadata)
         , m_attributes(attributes)
         , m_options(options)
         , m_url(url)
         , m_psName(psName)
         { }
 
-    WEBCORE_EXPORT FontPlatformDataAttributes(float size, FontOrientation, FontWidthVariant, TextRenderingMode, bool syntheticBold, bool syntheticOblique, std::optional<FontPlatformSerializedAttributes>, CTFontDescriptorOptions, RetainPtr<CFStringRef> url, RetainPtr<CFStringRef> psName);
+    WEBCORE_EXPORT FontPlatformDataAttributes(const FontMetadata&, std::optional<FontPlatformSerializedAttributes>, CTFontDescriptorOptions, RetainPtr<CFStringRef> url, RetainPtr<CFStringRef> psName);
 
     WEBCORE_EXPORT std::optional<FontPlatformSerializedAttributes> serializableAttributes() const;
 #endif
 
 #if PLATFORM(WIN) && USE(CAIRO)
-    FontPlatformDataAttributes(float size, FontOrientation orientation, FontWidthVariant widthVariant, TextRenderingMode textRenderingMode, bool syntheticBold, bool syntheticOblique, LOGFONT font)
-        : m_size(size)
-        , m_orientation(orientation)
-        , m_widthVariant(widthVariant)
-        , m_textRenderingMode(textRenderingMode)
-        , m_syntheticBold(syntheticBold)
-        , m_syntheticOblique(syntheticOblique)
+    FontPlatformDataAttributes(const FontMetadata& metadata, LOGFONT font)
+        : m_metadata(metadata)
         , m_font(font)
         { }
 #endif
 
 #if USE(SKIA)
-    FontPlatformDataAttributes(float size, FontOrientation orientation, FontWidthVariant widthVariant, TextRenderingMode textRenderingMode, bool syntheticBold, bool syntheticOblique, SkString familyName, SkFontStyle style, Vector<hb_feature_t>&& features)
-        : m_size(size)
-        , m_orientation(orientation)
-        , m_widthVariant(widthVariant)
-        , m_textRenderingMode(textRenderingMode)
-        , m_syntheticBold(syntheticBold)
-        , m_syntheticOblique(syntheticOblique)
+    FontPlatformDataAttributes(const FontMetadata& metadata, SkString familyName, SkFontStyle style, Vector<hb_feature_t>&& features)
+        : m_metadata(metadata)
         , m_familyName(familyName)
         , m_style(style)
         , m_features(WTF::move(features))
         { }
 #endif
 
-    float m_size { 0 };
-
-    FontOrientation m_orientation { FontOrientation::Horizontal };
-    FontWidthVariant m_widthVariant { FontWidthVariant::RegularWidth };
-    TextRenderingMode m_textRenderingMode { TextRenderingMode::Auto };
-
-    bool m_syntheticBold { false };
-    bool m_syntheticOblique { false };
+    FontMetadata m_metadata;
 
 #if PLATFORM(WIN) && USE(CAIRO)
     LOGFONT m_font;
@@ -241,27 +225,18 @@ struct FontPlatformSerializedData {
     std::optional<FontPlatformSerializedAttributes> attributes;
 };
 
-struct FontMetadata {
-    double pointSize = { 0.0 };
-    WebCore::FontOrientation orientation = FontOrientation::Horizontal;
-    WebCore::FontWidthVariant widthVariant = FontWidthVariant::RegularWidth;
-    WebCore::TextRenderingMode textRenderingMode = TextRenderingMode::Auto;
-    bool syntheticBold = false;
-    bool syntheticOblique = false;
-};
-
 struct InstalledFont {
     struct SystemUIFont {
         SystemUIFontType systemUIFontType { SystemUIFontTypeNone };
         String language;
-        RetainPtr<CTFontRef> toCTFont(double pointSize) const;
+        RetainPtr<CTFontRef> toCTFont(float pointSize) const;
     };
 
     struct PostScriptFont {
         String postScriptName;
         CTFontDescriptorOptions fontDescriptorOptions;
         std::optional<FontPlatformSerializedAttributes> fontSerializedAttributes;
-        RetainPtr<CTFontRef> toCTFont(double pointSize) const;
+        RetainPtr<CTFontRef> toCTFont(float pointSize) const;
     };
 
     Variant<SystemUIFont, PostScriptFont> font;
@@ -332,9 +307,11 @@ public:
     FontPlatformData();
 
     FontPlatformData(float size, bool syntheticBold, bool syntheticOblique, FontOrientation = FontOrientation::Horizontal, FontWidthVariant = FontWidthVariant::RegularWidth, TextRenderingMode = TextRenderingMode::Auto, const FontCustomPlatformData* = nullptr);
+    FontPlatformData(const FontMetadata&, const FontCustomPlatformData* = nullptr);
 
 #if USE(CORE_TEXT)
     WEBCORE_EXPORT FontPlatformData(RetainPtr<CTFontRef>&&, float size, bool syntheticBold = false, bool syntheticOblique = false, FontOrientation = FontOrientation::Horizontal, FontWidthVariant = FontWidthVariant::RegularWidth, TextRenderingMode = TextRenderingMode::Auto, const FontCustomPlatformData* = nullptr);
+    WEBCORE_EXPORT FontPlatformData(RetainPtr<CTFontRef>&&, const FontMetadata&, const FontCustomPlatformData* = nullptr);
 #endif
 
 #if PLATFORM(WIN) && USE(CAIRO)
@@ -346,6 +323,7 @@ public:
     FontPlatformData(cairo_font_face_t*, RefPtr<FcPattern>&&, float size, bool fixedWidth, bool syntheticBold, bool syntheticOblique, FontOrientation, const FontCustomPlatformData* = nullptr);
 #elif USE(SKIA)
     WEBCORE_EXPORT FontPlatformData(sk_sp<SkTypeface>&&, float size, bool syntheticBold, bool syntheticOblique, FontOrientation, FontWidthVariant, TextRenderingMode, Vector<hb_feature_t>&&, const FontCustomPlatformData* = nullptr);
+    WEBCORE_EXPORT FontPlatformData(sk_sp<SkTypeface>&&, const FontMetadata&, Vector<hb_feature_t>&&, const FontCustomPlatformData* = nullptr);
 #endif
 
     using Attributes = FontPlatformDataAttributes;
@@ -367,13 +345,15 @@ public:
 
     using IPCData = Variant<FontPlatformSerializedData, CustomFontCreationData>;
 #if USE(CORE_TEXT)
-    WEBCORE_EXPORT FontPlatformData(float size, FontOrientation&&, FontWidthVariant&&, TextRenderingMode&&, bool syntheticBold, bool syntheticOblique, RetainPtr<CTFontRef>&&, RefPtr<FontCustomPlatformData>&&);
+    WEBCORE_EXPORT FontPlatformData(const FontMetadata&, RetainPtr<CTFontRef>&&, RefPtr<FontCustomPlatformData>&&);
 #elif USE(SKIA)
-    WEBCORE_EXPORT FontPlatformData(float size, FontOrientation&&, FontWidthVariant&&, TextRenderingMode&&, bool syntheticBold, bool syntheticOblique, RefPtr<FontCustomPlatformData>&&);
+    WEBCORE_EXPORT FontPlatformData(const FontMetadata&, RefPtr<FontCustomPlatformData>&&);
 #endif
 
-    WEBCORE_EXPORT static std::optional<FontPlatformData> fromIPCData(float size, FontOrientation&&, FontWidthVariant&&, TextRenderingMode&&, bool syntheticBold, bool syntheticOblique, FontPlatformData::IPCData&& toIPCData);
+#if !USE(CORE_TEXT)
+    WEBCORE_EXPORT static std::optional<FontPlatformData> fromIPCData(const FontMetadata&, FontPlatformData::IPCData&& toIPCData);
     WEBCORE_EXPORT IPCData toIPCData() const;
+#endif
 
 #if USE(CORE_TEXT)
     WEBCORE_EXPORT RetainPtr<CTFontRef> registeredFont() const; // Returns nullptr iff the font is not registered, such as web fonts (otherwise returns font()).
@@ -389,13 +369,14 @@ public:
 #endif
 
     bool isFixedPitch() const;
-    float size() const { return m_size; }
-    bool syntheticBold() const { return m_syntheticBold; }
-    bool syntheticOblique() const { return m_syntheticOblique; }
+    float size() const { return m_metadata.pointSize; }
+    bool syntheticBold() const { return m_metadata.isSyntheticBold; }
+    bool syntheticOblique() const { return m_metadata.isSyntheticOblique; }
     bool isColorBitmapFont() const { return m_isColorBitmapFont; }
-    FontOrientation orientation() const { return m_orientation; }
-    FontWidthVariant widthVariant() const { return m_widthVariant; }
-    TextRenderingMode textRenderingMode() const { return m_textRenderingMode; }
+    FontOrientation orientation() const { return m_metadata.orientation; }
+    FontWidthVariant widthVariant() const { return m_metadata.widthVariant; }
+    TextRenderingMode textRenderingMode() const { return m_metadata.textRenderingMode; }
+    const FontMetadata& metadata() const { return m_metadata; }
     bool isForTextCombine() const { return widthVariant() != FontWidthVariant::RegularWidth; } // Keep in sync with callers of FontDescription::setWidthVariant().
 
     String familyName() const;
@@ -425,14 +406,9 @@ public:
     bool operator==(const FontPlatformData& other) const
     {
         return platformIsEqual(other)
+            && m_metadata == other.m_metadata
             && m_isHashTableDeletedValue == other.m_isHashTableDeletedValue
-            && m_size == other.m_size
-            && m_syntheticBold == other.m_syntheticBold
-            && m_syntheticOblique == other.m_syntheticOblique
-            && m_isColorBitmapFont == other.m_isColorBitmapFont
-            && m_orientation == other.m_orientation
-            && m_widthVariant == other.m_widthVariant
-            && m_textRenderingMode == other.m_textRenderingMode;
+            && m_isColorBitmapFont == other.m_isColorBitmapFont;
     }
 
     bool isHashTableDeletedValue() const
@@ -502,18 +478,12 @@ private:
     RefPtr<FcPattern> m_pattern;
 #endif
 
-    float m_size { 0 };
-
-    FontOrientation m_orientation { FontOrientation::Horizontal };
-    FontWidthVariant m_widthVariant { FontWidthVariant::RegularWidth };
-    TextRenderingMode m_textRenderingMode { TextRenderingMode::Auto };
+    FontMetadata m_metadata;
 
     // This is conceptually const, but we can't make it actually const,
     // because FontPlatformData is used as a key in a HashMap.
     RefPtr<const FontCustomPlatformData> m_customPlatformData;
 
-    bool m_syntheticBold { false };
-    bool m_syntheticOblique { false };
     bool m_isColorBitmapFont { false };
     bool m_isHashTableDeletedValue { false };
 #if PLATFORM(COCOA)

--- a/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
@@ -601,7 +601,7 @@ static std::optional<SpecialCaseFontLookupResult> fontDescriptorWithFamilySpecia
         return { { adoptCF(CTFontDescriptorCreateLastResort()), FontTypeForPreparation::NonSystemFont } };
 
     if (equalLettersIgnoringASCIICase(family, "-apple-system-monospaced-numbers"_s)) {
-        auto systemFontDescriptor = UnrealizedCoreTextFont { adoptCF(CTFontDescriptorCreateForUIType(kCTFontUIFontSystem, size, nullptr)) };
+        auto systemFontDescriptor = UnrealizedCoreTextFont { adoptCF(CTFontDescriptorCreateForUIType(kCTFontUIFontSystem, size, fontDescription.computedLocale().string().createCFString().get())) };
         systemFontDescriptor.modify([](CFMutableDictionaryRef attributes) {
             int numberSpacingType = kNumberSpacingType;
             int monospacedNumbersSelector = kMonospacedNumbersSelector;

--- a/Source/WebCore/platform/graphics/cocoa/FontPlatformDataCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/FontPlatformDataCocoa.mm
@@ -37,7 +37,7 @@ namespace WebCore {
 unsigned FontPlatformData::hash() const
 {
     // FIXME: Hashing a CFHash is unfortunate here.
-    return computeHash(CFHash(m_font.get()), m_widthVariant, m_isHashTableDeletedValue, m_textRenderingMode, m_orientation, m_syntheticBold, m_syntheticOblique);
+    return computeHash(CFHash(m_font.get()), m_isHashTableDeletedValue, m_metadata.widthVariant, m_metadata.textRenderingMode, m_metadata.orientation, m_metadata.isSyntheticBold, m_metadata.isSyntheticOblique);
 }
 
 bool FontPlatformData::platformIsEqual(const FontPlatformData& other) const

--- a/Source/WebCore/platform/graphics/coretext/FontCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCoreText.cpp
@@ -1029,7 +1029,7 @@ std::optional<Ref<Font>> Font::fromIPCData(IPCFontData&& data)
 
             RetainPtr font = adoptCF(CTFontCreateWithFontDescriptor(fontDescriptor.get(), creationData.metadata.pointSize, nullptr));
 
-            return Font::create(FontPlatformData(creationData.metadata.pointSize, FontOrientation(creationData.metadata.orientation), FontWidthVariant(creationData.metadata.widthVariant), TextRenderingMode(creationData.metadata.textRenderingMode), creationData.metadata.syntheticBold, creationData.metadata.syntheticOblique, WTF::move(font), WTF::move(customPlatformData)));
+            return Font::create(FontPlatformData(creationData.metadata, WTF::move(font), WTF::move(customPlatformData)));
         }
     );
 }
@@ -1040,15 +1040,6 @@ std::optional<InstalledFont> Font::toSerializableInstalledFont() const
     if (!ctFont || m_platformData.creationData())
         return std::nullopt;
 
-    FontMetadata fontData = {
-        CTFontGetSize(ctFont.get()),
-        platformData().orientation(),
-        platformData().widthVariant(),
-        platformData().textRenderingMode(),
-        platformData().syntheticBold(),
-        platformData().syntheticOblique()
-    };
-
     SystemUIFontType fontType = CTFontGetUIFontType(ctFont.get());
     if (fontType != SystemUIFontTypeNone) {
         return InstalledFont {
@@ -1056,7 +1047,7 @@ std::optional<InstalledFont> Font::toSerializableInstalledFont() const
                 fontType,
                 adoptCF(checked_cf_cast<CFStringRef>(CTFontCopyAttribute(ctFont.get(), kCTFontDescriptorLanguageAttribute))).get()
             },
-            fontData
+            platformData().metadata()
         };
     }
 
@@ -1068,7 +1059,7 @@ std::optional<InstalledFont> Font::toSerializableInstalledFont() const
             CTFontDescriptorGetOptions(fontDescriptor.get()),
             FontPlatformSerializedAttributes::fromCF(attributes.get())
         },
-        fontData
+        platformData().metadata()
     };
 }
 
@@ -1083,16 +1074,7 @@ IPCFontData Font::toSerializableFont() const
     RetainPtr attributes = adoptCF(CTFontDescriptorCopyAttributes(fontDescriptor.get()));
 
     const auto& data = m_platformData.creationData();
-    FontMetadata fontData = {
-        CTFontGetSize(font.get()),
-        m_platformData.orientation(),
-        m_platformData.widthVariant(),
-        m_platformData.textRenderingMode(),
-        m_platformData.syntheticBold(),
-        m_platformData.syntheticOblique()
-    };
-
-    return { CustomFontCreationData { fontData, { data->fontFaceData->span() }, FontPlatformSerializedAttributes::fromCF(attributes.get()), data->itemInCollection } };
+    return { CustomFontCreationData { platformData().metadata(), { data->fontFaceData->span() }, FontPlatformSerializedAttributes::fromCF(attributes.get()), data->itemInCollection } };
 }
 
 #if ENABLE(MULTI_REPRESENTATION_HEIC)

--- a/Source/WebCore/platform/graphics/coretext/FontPlatformDataCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontPlatformDataCoreText.cpp
@@ -25,6 +25,7 @@
 
 #include "Font.h"
 #include "FontCustomPlatformData.h"
+#include "Logging.h"
 #include "SharedBuffer.h"
 #include <CoreText/CoreText.h>
 #include <WebCore/Font.h>
@@ -60,13 +61,8 @@ std::optional<FontPlatformSerializedAttributes> FontPlatformDataAttributes::seri
     return FontPlatformSerializedAttributes::fromCF(m_attributes.get());
 }
 
-FontPlatformDataAttributes::FontPlatformDataAttributes(float size, FontOrientation orientation, FontWidthVariant widthVariant, TextRenderingMode textRenderingMode, bool syntheticBold, bool syntheticOblique, std::optional<FontPlatformSerializedAttributes> attributes, CTFontDescriptorOptions options, RetainPtr<CFStringRef> url, RetainPtr<CFStringRef> psName)
-    : m_size(size)
-    , m_orientation(orientation)
-    , m_widthVariant(widthVariant)
-    , m_textRenderingMode(textRenderingMode)
-    , m_syntheticBold(syntheticBold)
-    , m_syntheticOblique(syntheticOblique)
+FontPlatformDataAttributes::FontPlatformDataAttributes(const FontMetadata& metadata, std::optional<FontPlatformSerializedAttributes> attributes, CTFontDescriptorOptions options, RetainPtr<CFStringRef> url, RetainPtr<CFStringRef> psName)
+    : m_metadata(metadata)
     , m_attributes(attributes ? attributes->toCFDictionary() : nullptr)
     , m_options(options)
     , m_url(url)
@@ -74,22 +70,27 @@ FontPlatformDataAttributes::FontPlatformDataAttributes(float size, FontOrientati
     { }
 
 FontPlatformData::FontPlatformData(RetainPtr<CTFontRef>&& font, float size, bool syntheticBold, bool syntheticOblique, FontOrientation orientation, FontWidthVariant widthVariant, TextRenderingMode textRenderingMode, const FontCustomPlatformData* customPlatformData)
-    : FontPlatformData(size, syntheticBold, syntheticOblique, orientation, widthVariant, textRenderingMode, customPlatformData)
+    : FontPlatformData(WTF::move(font), FontMetadata { size, orientation, widthVariant, textRenderingMode, syntheticBold, syntheticOblique }, customPlatformData)
+{
+}
+
+FontPlatformData::FontPlatformData(RetainPtr<CTFontRef>&& font, const FontMetadata& metadata, const FontCustomPlatformData* customPlatformData)
+    : FontPlatformData(metadata, customPlatformData)
 {
     ASSERT_ARG(font, font);
     m_font = WTF::move(font);
     m_isColorBitmapFont = CTFontGetSymbolicTraits(m_font.get()) & kCTFontColorGlyphsTrait;
     m_isSystemFont = WebCore::isSystemFont(m_font.get());
 
-    if (m_widthVariant != FontWidthVariant::RegularWidth) {
+    if (m_metadata.widthVariant != FontWidthVariant::RegularWidth) {
         // FIXME: Do something smarter than creating the CTFontRef twice <webkit.org/b/276635>
         int featureTypeValue = kTextSpacingType;
-        int featureSelectorValue = mapFontWidthVariantToCTFeatureSelector(m_widthVariant);
+        int featureSelectorValue = mapFontWidthVariantToCTFeatureSelector(m_metadata.widthVariant);
         RetainPtr<CTFontDescriptorRef> sourceDescriptor = adoptCF(CTFontCopyFontDescriptor(m_font.get()));
         RetainPtr<CFNumberRef> featureType = adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &featureTypeValue));
         RetainPtr<CFNumberRef> featureSelector = adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &featureSelectorValue));
         RetainPtr<CTFontDescriptorRef> newDescriptor = adoptCF(CTFontDescriptorCreateCopyWithFeature(sourceDescriptor.get(), featureType.get(), featureSelector.get()));
-        RetainPtr<CTFontRef> newFont = adoptCF(CTFontCreateWithFontDescriptor(newDescriptor.get(), m_size, 0));
+        RetainPtr<CTFontRef> newFont = adoptCF(CTFontCreateWithFontDescriptor(newDescriptor.get(), m_metadata.pointSize, 0));
 
         if (newFont)
             m_font = WTF::move(newFont);
@@ -146,11 +147,11 @@ FontPlatformData FontPlatformData::create(const Attributes& data, const FontCust
         RetainPtr baseFontDescriptor = custom->fontDescriptor.get();
         RELEASE_ASSERT(baseFontDescriptor);
         RetainPtr fontDescriptor = adoptCF(CTFontDescriptorCreateCopyWithAttributes(baseFontDescriptor.get(), data.m_attributes.get()));
-        ctFont = adoptCF(CTFontCreateWithFontDescriptor(fontDescriptor.get(), data.m_size, nullptr));
+        ctFont = adoptCF(CTFontCreateWithFontDescriptor(fontDescriptor.get(), data.m_metadata.pointSize, nullptr));
     } else
-        ctFont = createCTFont(data.m_attributes.get(), data.m_size, data.m_options, data.m_url.get(), data.m_psName.get());
+        ctFont = createCTFont(data.m_attributes.get(), data.m_metadata.pointSize, data.m_options, data.m_url.get(), data.m_psName.get());
 
-    return WebCore::FontPlatformData(ctFont.get(), data.m_size, data.m_syntheticBold, data.m_syntheticOblique, data.m_orientation, data.m_widthVariant, data.m_textRenderingMode, custom);
+    return WebCore::FontPlatformData(ctFont.get(), data.m_metadata, custom);
 }
 
 bool isSystemFont(CTFontRef font)
@@ -195,10 +196,10 @@ RefPtr<SharedBuffer> FontPlatformData::openTypeTable(uint32_t table) const
 String FontPlatformData::description() const
 {
     String fontDescription { adoptCF(CFCopyDescription(ctFont())).get() };
-    return makeString(fontDescription, ' ', m_size,
-        (m_syntheticBold ? " synthetic bold"_s : ""_s),
-        (m_syntheticOblique ? " synthetic oblique"_s : ""_s),
-        (m_orientation == FontOrientation::Vertical ? " vertical orientation"_s : ""_s));
+    return makeString(fontDescription, ' ', m_metadata.pointSize,
+        (m_metadata.isSyntheticBold ? " synthetic bold"_s : ""_s),
+        (m_metadata.isSyntheticOblique ? " synthetic oblique"_s : ""_s),
+        (m_metadata.orientation == FontOrientation::Vertical ? " vertical orientation"_s : ""_s));
 }
 
 #endif
@@ -219,14 +220,14 @@ FontPlatformData FontPlatformData::cloneWithSize(const FontPlatformData& source,
 
 void FontPlatformData::updateSize(float size)
 {
-    m_size = size;
+    m_metadata.pointSize = size;
     ASSERT(m_font.get());
-    m_font = adoptCF(CTFontCreateCopyWithAttributes(m_font.get(), m_size, nullptr, nullptr));
+    m_font = adoptCF(CTFontCreateCopyWithAttributes(m_font.get(), m_metadata.pointSize, nullptr, nullptr));
 }
 
 FontPlatformData::Attributes FontPlatformData::attributes() const
 {
-    Attributes result(m_size, m_orientation, m_widthVariant, m_textRenderingMode, m_syntheticBold, m_syntheticOblique);
+    Attributes result(m_metadata);
 
     auto fontDescriptor = adoptCF(CTFontCopyFontDescriptor(m_font.get()));
     result.m_attributes = adoptCF(CTFontDescriptorCopyAttributes(fontDescriptor.get()));
@@ -241,45 +242,13 @@ FontPlatformData::Attributes FontPlatformData::attributes() const
     return result;
 }
 
-FontPlatformData::FontPlatformData(float size, WebCore::FontOrientation&& orientation, WebCore::FontWidthVariant&& widthVariant, WebCore::TextRenderingMode&& textRenderingMode, bool syntheticBold, bool syntheticOblique, RetainPtr<CTFontRef>&& font, RefPtr<FontCustomPlatformData>&& customPlatformData)
+FontPlatformData::FontPlatformData(const FontMetadata& metadata, RetainPtr<CTFontRef>&& font, RefPtr<FontCustomPlatformData>&& customPlatformData)
     : m_font(font)
-    , m_size(size)
-    , m_orientation(orientation)
-    , m_widthVariant(widthVariant)
-    , m_textRenderingMode(textRenderingMode)
+    , m_metadata(metadata)
     , m_customPlatformData(customPlatformData)
-    , m_syntheticBold(syntheticBold)
-    , m_syntheticOblique(syntheticOblique)
 {
     m_isColorBitmapFont = CTFontGetSymbolicTraits(m_font.get()) & kCTFontColorGlyphsTrait;
     m_isSystemFont = WebCore::isSystemFont(m_font.get());
-}
-
-FontPlatformData::IPCData FontPlatformData::toIPCData() const
-{
-    RetainPtr font = ctFont();
-    RetainPtr fontDescriptor = adoptCF(CTFontCopyFontDescriptor(font.get()));
-    RetainPtr attributes = adoptCF(CTFontDescriptorCopyAttributes(fontDescriptor.get()));
-
-    const auto& data = creationData();
-    if (data) {
-        FontMetadata fontData = {
-            CTFontGetSize(font.get()),
-            orientation(),
-            widthVariant(),
-            textRenderingMode(),
-            syntheticBold(),
-            syntheticOblique()
-        };
-
-        return CustomFontCreationData { fontData, { data->fontFaceData->span() }, FontPlatformSerializedAttributes::fromCF(attributes.get()), data->itemInCollection };
-    }
-
-    auto options = CTFontDescriptorGetOptions(fontDescriptor.get());
-    RetainPtr referenceURL = adoptCF(checked_cf_cast<CFURLRef>(CTFontCopyAttribute(font.get(), kCTFontReferenceURLAttribute)));
-    RetainPtr urlString = retainPtr(CFURLGetString(referenceURL.get()));
-    RetainPtr postScriptName = adoptCF(CTFontCopyPostScriptName(font.get())).get();
-    return FontPlatformSerializedData { options, WTF::move(urlString), WTF::move(postScriptName), FontPlatformSerializedAttributes::fromCF(attributes.get()) };
 }
 
 #define EXTRACT_TYPED_VALUE(key, cfType, target) { \
@@ -533,12 +502,12 @@ RetainPtr<CFTypeRef> FontPlatformOpticalSize::toCF() const
     });
 }
 
-RetainPtr<CTFontRef> InstalledFont::SystemUIFont::toCTFont(double pointSize) const
+RetainPtr<CTFontRef> InstalledFont::SystemUIFont::toCTFont(float pointSize) const
 {
     return adoptCF(CTFontCreateUIFontForLanguage(static_cast<CTFontUIFontType>(systemUIFontType), pointSize, language.createCFString().get()));
 }
 
-RetainPtr<CTFontRef> InstalledFont::PostScriptFont::toCTFont(double pointSize) const
+RetainPtr<CTFontRef> InstalledFont::PostScriptFont::toCTFont(float pointSize) const
 {
     RetainPtr<CTFontDescriptorRef> fontDescriptor;
     if (fontSerializedAttributes)
@@ -547,8 +516,12 @@ RetainPtr<CTFontRef> InstalledFont::PostScriptFont::toCTFont(double pointSize) c
         fontDescriptor = adoptCF(CTFontDescriptorCreateWithNameAndSize(postScriptName.createCFString().get(), pointSize));
 
     RetainPtr font = adoptCF(CTFontCreateWithFontDescriptor(fontDescriptor.get(), pointSize, nullptr));
-    if (String(adoptCF(CTFontCopyPostScriptName(font.get())).get()) != postScriptName)
+    auto fontName = String(adoptCF(CTFontCopyPostScriptName(font.get())).get());
+    if (fontName != postScriptName) {
+        RELEASE_LOG_ERROR(Fonts, "Serialized font %{public}s reconstructed to %{public}s. Subbing system-ui; may result in garbled text.",
+            postScriptName.utf8().data(), fontName.utf8().data());
         font = adoptCF(CTFontCreateUIFontForLanguage(kCTFontUIFontSystem, pointSize, nullptr));
+    }
 
     return font;
 }
@@ -569,10 +542,10 @@ Ref<Font> InstalledFont::toFont() const
 {
     return WTF::switchOn(font,
         [this] (const SystemUIFont& systemFont) -> Ref<Font> {
-            return Font::create(FontPlatformData(systemFont.toCTFont(metadata.pointSize).get(), metadata.pointSize, metadata.syntheticBold, metadata.syntheticOblique, metadata.orientation, metadata.widthVariant, metadata.textRenderingMode));
+            return Font::create(FontPlatformData(systemFont.toCTFont(metadata.pointSize).get(), metadata));
         },
         [this] (const PostScriptFont& postScriptFont) -> Ref<Font> {
-            return Font::create(FontPlatformData(postScriptFont.toCTFont(metadata.pointSize).get(), metadata.pointSize, metadata.syntheticBold, metadata.syntheticOblique, metadata.orientation, metadata.widthVariant, metadata.textRenderingMode));
+            return Font::create(FontPlatformData(postScriptFont.toCTFont(metadata.pointSize).get(), metadata));
         }
     );
 }

--- a/Source/WebCore/platform/graphics/freetype/FontPlatformDataFreeType.cpp
+++ b/Source/WebCore/platform/graphics/freetype/FontPlatformDataFreeType.cpp
@@ -134,8 +134,8 @@ FontPlatformData::FontPlatformData(cairo_font_face_t* fontFace, RefPtr<FcPattern
 FontPlatformData FontPlatformData::cloneWithOrientation(const FontPlatformData& source, FontOrientation orientation)
 {
     FontPlatformData copy(source);
-    if (copy.m_scaledFont && copy.m_orientation != orientation) {
-        copy.m_orientation = orientation;
+    if (copy.m_scaledFont && copy.m_metadata.orientation != orientation) {
+        copy.m_metadata.orientation = orientation;
         copy.buildScaledFont(cairo_scaled_font_get_font_face(copy.m_scaledFont.get()));
     }
     return copy;
@@ -150,7 +150,7 @@ FontPlatformData FontPlatformData::cloneWithSize(const FontPlatformData& source,
 
 void FontPlatformData::updateSize(float size)
 {
-    m_size = size;
+    m_metadata.pointSize = size;
     // We need to reinitialize the instance, because the difference in size
     // necessitates a new scaled font instance.
     ASSERT(m_scaledFont.get());
@@ -239,17 +239,17 @@ void FontPlatformData::buildScaledFont(cairo_font_face_t* fontFace)
     // The matrix from FontConfig does not include the scale. Scaling a font with width zero size leads
     // to a failed cairo_scaled_font_t instantiations. Instead we scale the font to a very tiny
     // size and just abort rendering later on.
-    float realSize = m_size ? m_size : 1;
+    float realSize = m_metadata.pointSize ? m_metadata.pointSize : 1;
     cairo_matrix_scale(&fontMatrix, realSize, realSize);
 
     if (syntheticOblique()) {
         static const float syntheticObliqueSkew = -tanf(14 * acosf(0) / 90);
         static const cairo_matrix_t skew = {1, 0, syntheticObliqueSkew, 1, 0, 0};
         static const cairo_matrix_t verticalSkew = {1, -syntheticObliqueSkew, 0, 1, 0, 0};
-        cairo_matrix_multiply(&fontMatrix, m_orientation == FontOrientation::Vertical ? &verticalSkew : &skew, &fontMatrix);
+        cairo_matrix_multiply(&fontMatrix, m_metadata.orientation == FontOrientation::Vertical ? &verticalSkew : &skew, &fontMatrix);
     }
 
-    if (m_orientation == FontOrientation::Vertical) {
+    if (m_metadata.orientation == FontOrientation::Vertical) {
         // The resulting transformation matrix for vertical glyphs (V) is a
         // combination of rotation (R) and translation (T) applied on the
         // horizontal matrix (H). V = H . R . T, where R rotates by -90 degrees
@@ -340,15 +340,15 @@ FontPlatformData FontPlatformData::create(const Attributes& data, const FontCust
         fontFace = adoptRef(cairo_ft_font_face_create_for_pattern(pattern));
     }
 
-    return FontPlatformData(fontFace.get(), pattern, data.m_size, fixedWidth, data.m_syntheticBold, data.m_syntheticOblique, data.m_orientation, custom);
+    return FontPlatformData(fontFace.get(), pattern, data.m_metadata.pointSize, fixedWidth, data.m_metadata.isSyntheticBold, data.m_metadata.isSyntheticOblique, data.m_metadata.orientation, custom);
 }
 
 FontPlatformData::Attributes FontPlatformData::attributes() const
 {
-    return Attributes(m_size, m_orientation, m_widthVariant, m_textRenderingMode, m_syntheticBold, m_syntheticOblique);
+    return Attributes(m_metadata);
 }
 
-std::optional<FontPlatformData> FontPlatformData::fromIPCData(float, FontOrientation&&, FontWidthVariant&&, TextRenderingMode&&, bool, bool, IPCData&&)
+std::optional<FontPlatformData> FontPlatformData::fromIPCData(const FontMetadata&, IPCData&&)
 {
     ASSERT_NOT_REACHED();
     return std::nullopt;

--- a/Source/WebCore/platform/graphics/skia/FontPlatformDataSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontPlatformDataSkia.cpp
@@ -48,18 +48,23 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 namespace WebCore {
 
 FontPlatformData::FontPlatformData(sk_sp<SkTypeface>&& typeface, float size, bool syntheticBold, bool syntheticOblique, FontOrientation orientation, FontWidthVariant widthVariant, TextRenderingMode textRenderingMode, Vector<hb_feature_t>&& features, const FontCustomPlatformData* customPlatformData)
-    : FontPlatformData(size, syntheticBold, syntheticOblique, orientation, widthVariant, textRenderingMode, customPlatformData)
+    : FontPlatformData(WTF::move(typeface), FontMetadata { size, orientation, widthVariant, textRenderingMode, syntheticBold, syntheticOblique }, WTF::move(features), customPlatformData)
 {
-    m_font = SkFont(typeface, m_size);
+}
+
+FontPlatformData::FontPlatformData(sk_sp<SkTypeface>&& typeface, const FontMetadata& metadata, Vector<hb_feature_t>&& features, const FontCustomPlatformData* customPlatformData)
+    : FontPlatformData(metadata, customPlatformData)
+{
+    m_font = SkFont(typeface, m_metadata.pointSize);
     m_features = WTF::move(features);
 
     platformDataInit();
 }
 
-FontPlatformData::FontPlatformData(float size, FontOrientation&& orientation, FontWidthVariant&& widthVariant, TextRenderingMode&& textRenderingMode, bool syntheticBold, bool syntheticOblique, RefPtr<FontCustomPlatformData>&& customPlatformData)
-    : FontPlatformData(size, syntheticBold, syntheticOblique, orientation, widthVariant, textRenderingMode, customPlatformData.get())
+FontPlatformData::FontPlatformData(const FontMetadata& metadata, RefPtr<FontCustomPlatformData>&& customPlatformData)
+    : FontPlatformData(metadata, customPlatformData.get())
 {
-    m_font = SkFont(customPlatformData->m_typeface, m_size);
+    m_font = SkFont(customPlatformData->m_typeface, m_metadata.pointSize);
 
     platformDataInit();
 }
@@ -117,8 +122,8 @@ bool FontPlatformData::skiaTypefaceHasAnySupportedColorTable(const SkTypeface& t
 
 void FontPlatformData::platformDataInit()
 {
-    m_font.setEmbolden(m_syntheticBold);
-    m_font.setSkewX(m_syntheticOblique ? -SK_Scalar1 / 4 : 0);
+    m_font.setEmbolden(m_metadata.isSyntheticBold);
+    m_font.setSkewX(m_metadata.isSyntheticOblique ? -SK_Scalar1 / 4 : 0);
 
     bool useSubpixelPositioning = FontRenderOptions::singleton().useSubpixelPositioning();
 
@@ -143,19 +148,19 @@ void FontPlatformData::platformDataInit()
     m_isColorBitmapFont = m_hbFont->isColorBitmapFont();
 }
 
-std::optional<FontPlatformData> FontPlatformData::fromIPCData(float size, FontOrientation&& orientation, FontWidthVariant&& widthVariant, TextRenderingMode&& textRenderingMode, bool syntheticBold, bool syntheticOblique, IPCData&& ipcData)
+std::optional<FontPlatformData> FontPlatformData::fromIPCData(const FontMetadata& metadata, IPCData&& ipcData)
 {
     return WTF::switchOn(ipcData,
         [&] (const FontPlatformSerializedData& d) -> std::optional<FontPlatformData> {
             if (sk_sp<SkTypeface> typeface = SkTypeface::MakeDeserialize(SkMemoryStream::Make(d.typefaceData).get(), nullptr))
-                return FontPlatformData(WTF::move(typeface), size, syntheticBold, syntheticOblique, WTF::move(orientation), WTF::move(widthVariant), WTF::move(textRenderingMode), { });
+                return FontPlatformData(WTF::move(typeface), metadata, { });
 
             return std::nullopt;
         },
         [&] (CustomFontCreationData& d) -> std::optional<FontPlatformData> {
             auto fontFaceData = SharedBuffer::create(WTF::move(d.fontFaceData));
             if (RefPtr fontCustomPlatformData = FontCustomPlatformData::create(fontFaceData, d.itemInCollection))
-                return FontPlatformData(size, WTF::move(orientation), WTF::move(widthVariant), WTF::move(textRenderingMode), syntheticBold, syntheticOblique, WTF::move(fontCustomPlatformData));
+                return FontPlatformData(metadata, WTF::move(fontCustomPlatformData));
 
             return std::nullopt;
         }
@@ -178,7 +183,7 @@ bool FontPlatformData::isFixedPitch() const
 unsigned FontPlatformData::hash() const
 {
     // FIXME: do we need to consider m_features for the hash?
-    return computeHash(m_font.getTypeface()->uniqueID(), m_widthVariant, m_isHashTableDeletedValue, m_textRenderingMode, m_orientation, m_syntheticBold, m_syntheticOblique);
+    return computeHash(m_font.getTypeface()->uniqueID(), m_isHashTableDeletedValue, m_metadata.widthVariant, m_metadata.textRenderingMode, m_metadata.orientation, m_metadata.isSyntheticBold, m_metadata.isSyntheticOblique);
 }
 
 bool FontPlatformData::platformIsEqual(const FontPlatformData& other) const
@@ -229,10 +234,10 @@ FontPlatformData FontPlatformData::create(const Attributes& data, const FontCust
     Vector<hb_feature_t> features = data.m_features;
     if (custom) {
         sk_sp<SkTypeface> typeface = custom->m_typeface;
-        return { WTF::move(typeface), data.m_size, data.m_syntheticBold, data.m_syntheticOblique, data.m_orientation, data.m_widthVariant, data.m_textRenderingMode, WTF::move(features), custom };
+        return { WTF::move(typeface), data.m_metadata, WTF::move(features), custom };
     }
     sk_sp<SkTypeface> typeface = FontCache::forCurrentThread().fontManager().matchFamilyStyle(data.m_familyName.c_str(), data.m_style);
-    return { WTF::move(typeface), data.m_size, data.m_syntheticBold, data.m_syntheticOblique, data.m_orientation, data.m_widthVariant, data.m_textRenderingMode, WTF::move(features) };
+    return { WTF::move(typeface), data.m_metadata, WTF::move(features) };
 }
 
 FontPlatformData::Attributes FontPlatformData::attributes() const
@@ -241,7 +246,7 @@ FontPlatformData::Attributes FontPlatformData::attributes() const
     skFont().getTypeface()->getFamilyName(&familyName);
     SkFontStyle style = skFont().getTypeface()->fontStyle();
     Vector<hb_feature_t> features = m_features;
-    return { m_size, m_orientation, m_widthVariant, m_textRenderingMode, m_syntheticBold, m_syntheticOblique, familyName, style, WTF::move(features) };
+    return { m_metadata, familyName, style, WTF::move(features) };
 }
 
 hb_font_t* FontPlatformData::hbFont() const
@@ -262,8 +267,8 @@ HbUniquePtr<hb_font_t> FontPlatformData::createOpenTypeMathHarfBuzzFont() const
 
 void FontPlatformData::updateSize(float size)
 {
-    m_size = size;
-    m_font.setSize(m_size);
+    m_metadata.pointSize = size;
+    m_font.setSize(m_metadata.pointSize);
 }
 
 Vector<FontPlatformData::FontVariationAxis> FontPlatformData::variationAxes(ShouldLocalizeAxisNames) const

--- a/Source/WebCore/platform/graphics/win/FontPlatformDataWin.cpp
+++ b/Source/WebCore/platform/graphics/win/FontPlatformDataWin.cpp
@@ -68,30 +68,30 @@ FontPlatformData FontPlatformData::create(const Attributes& data, const FontCust
         wcscpy_s(logFont.lfFaceName, LF_FACESIZE, custom->name.wideCharacters().data());
 
     auto gdiFont = adoptGDIObject(CreateFontIndirect(&logFont));
-    return FontPlatformData(WTF::move(gdiFont), data.m_size, data.m_syntheticBold, data.m_syntheticOblique, custom);
+    return FontPlatformData(WTF::move(gdiFont), data.m_metadata.pointSize, data.m_metadata.isSyntheticBold, data.m_metadata.isSyntheticOblique, custom);
 }
 
 FontPlatformData::Attributes FontPlatformData::attributes() const
 {
-    Attributes result(m_size, m_orientation, m_widthVariant, m_textRenderingMode, m_syntheticBold, m_syntheticOblique);
+    Attributes result(m_metadata);
 
     GetObject(hfont(), sizeof(LOGFONT), &result.m_font);
     return result;
 }
 
-std::optional<FontPlatformData> FontPlatformData::fromIPCData(float size, FontOrientation&& orientation, FontWidthVariant&& widthVariant, TextRenderingMode&& textRenderingMode, bool syntheticBold, bool syntheticOblique, IPCData&& ipcData)
+std::optional<FontPlatformData> FontPlatformData::fromIPCData(const FontMetadata& metadata, IPCData&& ipcData)
 {
     return WTF::switchOn(ipcData,
         [&] (const FontPlatformSerializedData& d) -> std::optional<FontPlatformData> {
             if (auto gdiFont = adoptGDIObject(CreateFontIndirect(&d.logFont)))
-                return FontPlatformData(WTF::move(gdiFont), size, syntheticBold, syntheticOblique);
+                return FontPlatformData(WTF::move(gdiFont), metadata.pointSize, metadata.isSyntheticBold, metadata.isSyntheticOblique);
 
             return std::nullopt;
         },
         [&] (CustomFontCreationData& d) -> std::optional<FontPlatformData> {
             auto fontFaceData = SharedBuffer::create(WTF::move(d.fontFaceData));
             if (RefPtr fontCustomPlatformData = FontCustomPlatformData::create(fontFaceData, d.itemInCollection))
-                return FontPlatformData(size, syntheticBold, syntheticOblique, WTF::move(orientation), WTF::move(widthVariant), WTF::move(textRenderingMode), fontCustomPlatformData.get());
+                return FontPlatformData(metadata, fontCustomPlatformData.get());
 
             return std::nullopt;
         }

--- a/Source/WebKit/Shared/WebCoreFont.serialization.in
+++ b/Source/WebKit/Shared/WebCoreFont.serialization.in
@@ -51,28 +51,28 @@ enum class WebCore::TextRenderingMode : uint8_t {
     GeometricPrecision
 };
 
+header: <WebCore/FontPlatformData.h>
+[CustomHeader] struct WebCore::FontMetadata {
+    float pointSize;
+    WebCore::FontOrientation orientation;
+    WebCore::FontWidthVariant widthVariant;
+    WebCore::TextRenderingMode textRenderingMode;
+    bool isSyntheticBold;
+    bool isSyntheticOblique;
+}
+
 #if !USE(CORE_TEXT)
 using WebCore::FontPlatformData::IPCData = Variant<WebCore::FontPlatformSerializedData, WebCore::CustomFontCreationData>;
 
 [CreateUsing=fromIPCData] class WebCore::FontPlatformData {
-    float size();
-    WebCore::FontOrientation orientation();
-    WebCore::FontWidthVariant widthVariant();
-    WebCore::TextRenderingMode textRenderingMode();
-    bool syntheticBold();
-    bool syntheticOblique();
+    WebCore::FontMetadata metadata();
     WebCore::FontPlatformData::IPCData toIPCData();
 }
 #endif
 
 header: <WebCore/FontPlatformData.h>
 [CustomHeader] struct WebCore::FontPlatformDataAttributes {
-    float m_size;
-    WebCore::FontOrientation m_orientation;
-    WebCore::FontWidthVariant m_widthVariant;
-    WebCore::TextRenderingMode m_textRenderingMode;
-    bool m_syntheticBold;
-    bool m_syntheticOblique;
+    WebCore::FontMetadata m_metadata;
 #if PLATFORM(WIN) && USE(CAIRO)
     LOGFONT m_font;
 #endif
@@ -157,15 +157,6 @@ header: <WebCore/FontPlatformData.h>
     std::optional<WebCore::FontPlatformSerializedAttributes> attributes;
     String itemInCollection;
 };
-
-[CustomHeader] struct WebCore::FontMetadata {
-    double pointSize;
-    WebCore::FontOrientation orientation;
-    WebCore::FontWidthVariant widthVariant;
-    WebCore::TextRenderingMode textRenderingMode;
-    bool syntheticBold;
-    bool syntheticOblique;
-}
 
 using WebCore::SystemUIFontType = uint32_t;
 


### PR DESCRIPTION
#### a5831b78ade6e207c0cab878d354e6798b06e993
<pre>
Synchronize Font metadata representation (size, orientation, etc.)
<a href="https://bugs.webkit.org/show_bug.cgi?id=319132">https://bugs.webkit.org/show_bug.cgi?id=319132</a>
<a href="https://rdar.apple.com/182108081">rdar://182108081</a>

Reviewed by Alan Baradlay.

We&apos;re investigating a hard-to-reproduce bug where we are using the glyphIDs
of one system-ui font to render text using a different system-ui font. Since
this is a lookup error, the main thing to check is if the lookups on both
sides of IPC (CPU layout vs GPU draw) are using the same data. The bug is
sensitive to locale and hardware, which means paying special attention to
locale and sizing information.

Since six of the core lookup data parameters are duplicated in three (!)
different data structs, it&apos;s easy for these to get out of sync. And in fact,
they are out of sync, so this patch aims to clean this up, on the theory
that this might be causing the lookup mismatch.

A. Makes FontPlatformData, FontPlatformDataAttributes, and InstalledFont etc.
   all use the same FontMetadata struct, ensuring a consistent representation
   and streamlining parameter passing and data copying.

B. Aligns this FontMetadata struct with all other representations of font
   data in WebKit to use `float` rather than `double` for the size. This
   ensures that any numeric type conversions are consistent for all lookups.

C. Corrects Font::toSerializableInstalledFont() and Font::toSerializableFont()
   to use WebKit&apos;s size data rather than pulling it off the CT font object.
   These values are not guaranteed to match, so we should be consistent about
   which one we use for lookups.

D. Removes FontPlatformData::toIPCData() from CoreText which we would need to
   update also, except it&apos;s dead code that should have been removed already.

E. Adds logging to an error condition in InstalledFont::PostScriptFont::toCTFont
   in case we are somehow landing in this case. (We should log this error
   regardless.)

F. Adds a missing locale parameter to the -apple-system-monospaced-numbers font
   lookup, which seems unlikely to be the problem but fixing it just in case.

* Source/WebCore/platform/graphics/FontPlatformData.cpp:
(WebCore::FontPlatformData::FontPlatformData):
(WebCore::m_customPlatformData):
(WebCore::FontPlatformData::cloneWithOrientation):
(WebCore::FontPlatformData::updateSize):
* Source/WebCore/platform/graphics/FontPlatformData.h:
(WebCore::FontPlatformDataAttributes::FontPlatformDataAttributes):
(WebCore::FontPlatformData::size const):
(WebCore::FontPlatformData::syntheticBold const):
(WebCore::FontPlatformData::syntheticOblique const):
(WebCore::FontPlatformData::orientation const):
(WebCore::FontPlatformData::widthVariant const):
(WebCore::FontPlatformData::textRenderingMode const):
(WebCore::FontPlatformData::metadata const):
(WebCore::FontPlatformData::operator== const):
* Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp:
(WebCore::fontDescriptorWithFamilySpecialCase):
* Source/WebCore/platform/graphics/cocoa/FontPlatformDataCocoa.mm:
(WebCore::FontPlatformData::hash const):
* Source/WebCore/platform/graphics/coretext/FontCoreText.cpp:
(WebCore::Font::fromIPCData):
(WebCore::Font::toSerializableInstalledFont const):
(WebCore::Font::toSerializableFont const):
* Source/WebCore/platform/graphics/coretext/FontPlatformDataCoreText.cpp:
(WebCore::FontPlatformDataAttributes::FontPlatformDataAttributes):
(WebCore::FontPlatformData::FontPlatformData):
(WebCore::FontPlatformData::create):
(WebCore::FontPlatformData::description const):
(WebCore::FontPlatformData::updateSize):
(WebCore::FontPlatformData::attributes const):
(WebCore::InstalledFont::SystemUIFont::toCTFont const):
(WebCore::InstalledFont::PostScriptFont::toCTFont const):
(WebCore::InstalledFont::toFont const):
(WebCore::FontPlatformData::toIPCData const): Deleted.
* Source/WebCore/platform/graphics/freetype/FontPlatformDataFreeType.cpp:
(WebCore::FontPlatformData::cloneWithOrientation):
(WebCore::FontPlatformData::updateSize):
(WebCore::FontPlatformData::buildScaledFont):
(WebCore::FontPlatformData::create):
(WebCore::FontPlatformData::attributes const):
(WebCore::FontPlatformData::fromIPCData):
* Source/WebCore/platform/graphics/skia/FontPlatformDataSkia.cpp:
(WebCore::FontPlatformData::FontPlatformData):
(WebCore::FontPlatformData::platformDataInit):
(WebCore::FontPlatformData::fromIPCData):
(WebCore::FontPlatformData::hash const):
(WebCore::FontPlatformData::create):
(WebCore::FontPlatformData::attributes const):
(WebCore::FontPlatformData::updateSize):
* Source/WebCore/platform/graphics/win/FontPlatformDataWin.cpp:
(WebCore::FontPlatformData::create):
(WebCore::FontPlatformData::attributes const):
(WebCore::FontPlatformData::fromIPCData):
* Source/WebKit/Shared/WebCoreFont.serialization.in:

Canonical link: <a href="https://commits.webkit.org/317059@main">https://commits.webkit.org/317059@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/270da64ad879bb1d5ed6db70d30bf4991381b6fd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174245 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48178 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/41959 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/183819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/132113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176110 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49470 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47860 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/183819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/132113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177203 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/38966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/156326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/183819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/37606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/35976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32303 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/148030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/35819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/186245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/39431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/186245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/47845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/155881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/186245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/48524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114057 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26479 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/48524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/120443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47030 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/10781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/46433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/46664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/46491 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->