### PR TITLE
TestWebKitAPI binary should have a help output

### DIFF
--- a/Tools/TestWebKitAPI/Runner/TestRunner.swift
+++ b/Tools/TestWebKitAPI/Runner/TestRunner.swift
@@ -32,6 +32,7 @@ protocol TestRunner {
 
 struct TestRunnerConfiguration {
     let programName: String?
+    let help: Bool
     let pretty: Bool
     let listTests: Bool
     let filter: [String]
@@ -68,9 +69,65 @@ extension TestRunner.Configuration {
         self.skip = Self.option(arguments, for: "--skip")
         self.repetitions = Self.option(arguments, for: "--repetitions").first.flatMap { Int($0) }
 
+        self.help = Self.flag(arguments, for: "--help") || Self.flag(arguments, for: "-h")
         self.force = Self.flag(arguments, for: "--force")
         self.listTests = Self.flag(arguments, for: "--list-tests")
         self.pretty = Self.flag(arguments, for: "--pretty")
         self.parallel = Self.flag(arguments, for: "--parallel")
+    }
+}
+
+extension TestRunner.Configuration {
+    /// Human-readable usage describing every argument the runner understands when
+    /// launched directly.
+
+    /// Keep this in sync with `init(parsing:)` above and with the argument handling
+    /// in the runner.
+    var usage: String {
+        let invocation = programName.map { URL(fileURLWithPath: $0).lastPathComponent } ?? "TestWebKitAPI"
+
+        let base = """
+            OVERVIEW: Runs the TestWebKitAPI test suites (GoogleTest and Swift Testing).
+
+            USAGE: \(invocation) [options]
+
+            With no options, every test is run. Select a subset with --filter/--skip; both
+            may be given more than once. Tests are chosen by pattern only: bare test names
+            passed as positional arguments are ignored.
+
+            TEST SELECTION:
+              --filter <pattern>     Run only tests matching <pattern>; may be repeated.
+                                     GoogleTest patterns look like '<suite>.<test>' and accept
+                                     '*' wildcards; Swift Testing patterns are regular expressions.
+              --skip <pattern>       Skip tests matching <pattern>; may be repeated.
+              --force                Also run tests that are otherwise disabled.
+
+            EXECUTION:
+              --repetitions <count>  Run the selected tests <count> times.
+              --parallel             Allow tests to run in parallel where supported.
+              --list-tests           Print the selected test names without running them.
+              --pretty               Produce verbose, human-readable output.
+
+            GENERAL:
+              --help, -h             Print this help and exit.
+            """
+
+        #if WTF_PLATFORM_MAC
+        // These are consulted only in the UI process and are not parsed into this
+        // configuration; they are handled separately while setting up defaults.
+        let sectionSeparator = "\n\n"
+        let macOptions = """
+            macOS OPTIONS:
+              --remote-layer-tree    Use the remote layer tree drawing model.
+              --no-remote-layer-tree Disable the remote layer tree drawing model.
+              --use-gpu-process      Enable GPU process DOM rendering.
+              --no-use-gpu-process   Disable GPU process DOM rendering.
+              --site-isolation-enabled-by-default
+                                     Force site isolation on for every test.
+            """
+        return base + sectionSeparator + macOptions
+        #else
+        return base
+        #endif
     }
 }

--- a/Tools/TestWebKitAPI/Runner/TestWebKitAPI.swift
+++ b/Tools/TestWebKitAPI/Runner/TestWebKitAPI.swift
@@ -128,6 +128,11 @@ struct TestWebKitAPI {
 
         let configuration = instance.configure()
 
+        if configuration.help {
+            print(configuration.usage)
+            exit(EXIT_SUCCESS)
+        }
+
         let (googleTestsPassed, didRunGoogleTests) = try await instance.runGoogleTests(with: configuration)
 
         #if WTF_PLATFORM_MAC


### PR DESCRIPTION
#### 903ee1c8cb2d6151b4f2b171f92581b345e93ff7
<pre>
TestWebKitAPI binary should have a help output
<a href="https://bugs.webkit.org/show_bug.cgi?id=319148">https://bugs.webkit.org/show_bug.cgi?id=319148</a>
<a href="https://rdar.apple.com/181972000">rdar://181972000</a>

Reviewed by Richard Robinson.

The `run-api-tests` script is great at both documenting the various ways
to configure TWKAPI runs, and at exposing arguments to pass on these
customizations to the underlying binary.

However, debugging flows often consist of invoking the TWKAPI binary
directly. In these cases, the many ways to configure test runs are
difficult to discover without peeking at source code.

To alleviate this problem, we teach TWKAPI about `-h/--help` flags that
generate a handy output documenting the various accepted options.

* Tools/TestWebKitAPI/Runner/TestRunner.swift:
(TestRunner.usage):
* Tools/TestWebKitAPI/Runner/TestWebKitAPI.swift:
(TestWebKitAPI.main):

Canonical link: <a href="https://commits.webkit.org/316973@main">https://commits.webkit.org/316973@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/34f23a253a8d97a48e66e682c21c357a169b2147

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173937 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47870 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41651 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183511 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131805 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/abb43783-5be6-4ac4-b06f-da667a7ebb4c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175802 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49162 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47552 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135268 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95372 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1dff6f8f-7889-4783-a409-7f667e6d5d6a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176895 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38697 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156057 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115746 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/96f0d384-59ac-4f59-b878-874b3657f335) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37338 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35705 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31995 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147762 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35550 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185937 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39903 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144169 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47537 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144027 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48216 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32167 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113554 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26453 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38936 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46722 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10507 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46125 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46356 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46183 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->