### PR TITLE
TextTrackCueGeneric::isOrderedBefore is not a valid strict weak ordering

### DIFF
--- a/LayoutTests/media/track/text-track-generic-cue-ordering-expected.txt
+++ b/LayoutTests/media/track/text-track-generic-cue-ordering-expected.txt
@@ -1,0 +1,5 @@
+
+PASS isOrderedBefore is antisymmetric for equal-timing generic cues
+PASS isOrderedBefore orders equal-timing generic cues by line, not cue index
+PASS isOrderedBefore stays a strict weak ordering across many conflicting generic cues
+

--- a/LayoutTests/media/track/text-track-generic-cue-ordering.html
+++ b/LayoutTests/media/track/text-track-generic-cue-ordering.html
@@ -1,0 +1,113 @@
+<!doctype html>
+<html>
+<head>
+    <title>TextTrackCueGeneric::isOrderedBefore is a valid strict weak ordering</title>
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+// Regression test for TextTrackCueGeneric::isOrderedBefore.
+//
+// For two generic cues with equal start/end times, the comparator broke the
+// tie by cue index (via VTTCue::isOrderedBefore()) yet fell back to breaking
+// it by on-screen line. Those two orderings can disagree, so isOrderedBefore(a,
+// b) and isOrderedBefore(b, a) could both be true -- an asymmetric relation
+// that is not a strict weak ordering. That comparator is passed to std::sort()
+// in HTMLMediaElement::updateActiveTextTrackCues(), where an invalid ordering
+// is undefined behaviour. Rather than observe UB from script, we call the
+// comparator directly via internals and assert the properties it must satisfy.
+//
+// internals.createGenericCue() is the only way to mint a TextTrackCueGeneric
+// from script, and internals.cueIsOrderedBefore() exposes the comparator, so
+// these tests require internals.
+
+// Two generic cues sharing timing but differing in line, where the *first-added*
+// cue (lower cue index) has the *lower* line. The old comparator's cue-index
+// tiebreak and its line tiebreak then point in opposite directions.
+function makeConflictingCues(t) {
+    // A track is required so the cues have distinct cue indices (cueIndex() is
+    // the cue's position within its track's cue list).
+    const video = document.createElement("video");
+    document.body.appendChild(video);
+    t.add_cleanup(() => video.remove());
+    const tt = video.addTextTrack("captions", "test", "en");
+
+    const lowLine = internals.createGenericCue(0, 100, "low line, added first");
+    lowLine.line = 1;
+    tt.addCue(lowLine);            // cue index 0
+
+    const highLine = internals.createGenericCue(0, 100, "high line, added second");
+    highLine.line = 10;
+    tt.addCue(highLine);           // cue index 1
+
+    return { lowLine, highLine };
+}
+
+test(t => {
+    assert_true(!!window.internals, "test requires window.internals");
+    const { lowLine, highLine } = makeConflictingCues(t);
+
+    const lowBeforeHigh = internals.cueIsOrderedBefore(lowLine, highLine);
+    const highBeforeLow = internals.cueIsOrderedBefore(highLine, lowLine);
+
+    // Antisymmetry: a valid strict weak ordering can never order both a<b and
+    // b<a. The old code returned true for both directions here.
+    assert_false(lowBeforeHigh && highBeforeLow,
+        "isOrderedBefore must not order two generic cues before each other");
+}, "isOrderedBefore is antisymmetric for equal-timing generic cues");
+
+test(t => {
+    assert_true(!!window.internals, "test requires window.internals");
+    const { lowLine, highLine } = makeConflictingCues(t);
+
+    // Irreflexivity: no cue is ordered before itself.
+    assert_false(internals.cueIsOrderedBefore(lowLine, lowLine),
+        "a cue is not ordered before itself");
+
+    // The intended ordering: for equal-timing generic cues the higher line
+    // sorts first, independent of add order / cue index.
+    assert_true(internals.cueIsOrderedBefore(highLine, lowLine),
+        "higher-line generic cue is ordered before lower-line cue");
+    assert_false(internals.cueIsOrderedBefore(lowLine, highLine),
+        "lower-line generic cue is not ordered before higher-line cue");
+}, "isOrderedBefore orders equal-timing generic cues by line, not cue index");
+
+test(t => {
+    assert_true(!!window.internals, "test requires window.internals");
+
+    const video = document.createElement("video");
+    document.body.appendChild(video);
+    t.add_cleanup(() => video.remove());
+    const tt = video.addTextTrack("captions", "test", "en");
+
+    // A fully-conflicting fan: add order ascending and line ascending too, so
+    // the first-added cue (lowest cue index) has the lowest line. Every pair's
+    // cue-index tiebreak (lower index first) and line tiebreak (higher line
+    // first) then disagree. Verify the relation stays a strict weak ordering
+    // across all pairs (irreflexive + antisymmetric), which is what std::sort
+    // relies on.
+    const cues = [];
+    const LINES = [1, 2, 3, 4, 5, 6, 7, 8];
+    for (const line of LINES) {
+        const cue = internals.createGenericCue(0, 100, `line ${line}`);
+        cue.line = line;
+        tt.addCue(cue);
+        cues.push(cue);
+    }
+
+    for (let i = 0; i < cues.length; ++i) {
+        for (let j = 0; j < cues.length; ++j) {
+            const ab = internals.cueIsOrderedBefore(cues[i], cues[j]);
+            const ba = internals.cueIsOrderedBefore(cues[j], cues[i]);
+            if (i === j)
+                assert_false(ab, `cue ${i} must not be ordered before itself`);
+            assert_false(ab && ba,
+                `cues ${i} and ${j} must not both be ordered before each other`);
+        }
+    }
+}, "isOrderedBefore stays a strict weak ordering across many conflicting generic cues");
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/track/TextTrackCueGeneric.cpp
+++ b/Source/WebCore/html/track/TextTrackCueGeneric.cpp
@@ -150,17 +150,17 @@ bool TextTrackCueGeneric::cueContentsMatch(const TextTrackCue& otherTextTrackCue
 
 bool TextTrackCueGeneric::isOrderedBefore(const TextTrackCue* that) const
 {
-    if (VTTCue::isOrderedBefore(that))
-        return true;
-
     if (auto* thatCue = dynamicDowncast<TextTrackCueGeneric>(*that); thatCue && startTime() == that->startTime() && endTime() == that->endTime()) {
-        // Further order generic cues by their calculated line value.
+        // For generic cues with identical timing, order by their calculated line value. This tiebreak must be
+        // decided before falling back to VTTCue::isOrderedBefore(), which resolves the same case by cue index;
+        // consulting both would let isOrderedBefore(a, b) and isOrderedBefore(b, a) both be true, breaking the
+        // strict weak ordering required by the cue-sorting callers (e.g. HTMLMediaElement::updateActiveTextTrackCues).
         auto thisPosition = getPositionCoordinates();
         auto thatPosition = thatCue->getPositionCoordinates();
         return thisPosition.second > thatPosition.second || (thisPosition.second == thatPosition.second && thisPosition.first < thatPosition.first);
     }
 
-    return false;
+    return VTTCue::isOrderedBefore(that);
 }
 
 bool TextTrackCueGeneric::isPositionedAbove(const TextTrackCue* that) const

--- a/Source/WebCore/html/track/TextTrackCueGeneric.h
+++ b/Source/WebCore/html/track/TextTrackCueGeneric.h
@@ -67,7 +67,7 @@ public:
 private:
     TextTrackCueGeneric(Document&, const MediaTime& start, const MediaTime& end, const String&);
 
-    bool isOrderedBefore(const TextTrackCue*) const final;
+    WEBCORE_EXPORT bool isOrderedBefore(const TextTrackCue*) const final;
     bool isPositionedAbove(const TextTrackCue*) const final;
 
     RefPtr<VTTCueBox> createDisplayTree() final;

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -5155,6 +5155,14 @@ RefPtr<TextTrackCueGeneric> Internals::createGenericCue(double startTime, double
     return TextTrackCueGeneric::create(*document, MediaTime::createWithDouble(startTime), MediaTime::createWithDouble(endTime), text);
 }
 
+bool Internals::cueIsOrderedBefore(TextTrackCueGeneric& a, TextTrackCueGeneric& b)
+{
+    // isOrderedBefore() is public on TextTrackCue but a private override on
+    // TextTrackCueGeneric, so call it through a base reference (virtual
+    // dispatch still runs the generic override).
+    return static_cast<const TextTrackCue&>(a).isOrderedBefore(&b);
+}
+
 ExceptionOr<String> Internals::textTrackBCP47Language(TextTrack& track)
 {
     return String { track.validBCP47Language() };

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -893,6 +893,7 @@ public:
     String captionDisplayMode() const;
 #if ENABLE(VIDEO)
     RefPtr<TextTrackCueGeneric> createGenericCue(double startTime, double endTime, String text);
+    bool cueIsOrderedBefore(TextTrackCueGeneric&, TextTrackCueGeneric&);
     ExceptionOr<String> textTrackBCP47Language(TextTrack&);
     Ref<TimeRanges> createTimeRanges(Float32Array& startTimes, Float32Array& endTimes);
     double closestTimeToTimeRanges(double time, TimeRanges&);

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1069,6 +1069,7 @@ enum ContentsFormat {
     [Conditional=VIDEO] undefined setCaptionDisplayMode(DOMString mode);
     [Conditional=VIDEO] readonly attribute DOMString captionDisplayMode;
     [Conditional=VIDEO] TextTrackCueGeneric? createGenericCue(double startTime, double endTime, DOMString text);
+    [Conditional=VIDEO] boolean cueIsOrderedBefore(TextTrackCueGeneric a, TextTrackCueGeneric b);
     [Conditional=VIDEO] DOMString textTrackBCP47Language(TextTrack track);
 
     [Conditional=VIDEO] TimeRanges createTimeRanges(Float32Array startTimes, Float32Array


### PR DESCRIPTION
#### d944baa9d3594c71a303c34fb7bae9323a784ffa
<pre>
TextTrackCueGeneric::isOrderedBefore is not a valid strict weak ordering
<a href="https://bugs.webkit.org/show_bug.cgi?id=319151">https://bugs.webkit.org/show_bug.cgi?id=319151</a>
<a href="https://rdar.apple.com/181975502">rdar://181975502</a>

Reviewed by NOBODY (OOPS!).

TextTrackCueGeneric::isOrderedBefore() consulted VTTCue::isOrderedBefore()
first and only fell back to the line-position tiebreak when the base
comparator returned false. For two generic cues with equal start and end
times the base comparator breaks the tie by cue index, while the fallback
breaks it by on-screen line. Those two orderings can disagree, so both
isOrderedBefore(a, b) and isOrderedBefore(b, a) could return true. That is
an asymmetric relation, not a strict weak ordering.

The comparator is passed to std::ranges::sort() in
HTMLMediaElement::updateActiveTextTrackCues() whenever more than one cue is
active simultaneously, which is normal for in-band CEA-608/708 captions that
share timing but occupy different rows. Sorting with a comparator that
violates strict weak ordering is undefined behavior: it can abort under a
hardened/debug libc++ or silently misorder or read out of bounds otherwise.

Fix this by deciding the equal-(start, end) generic case by line first and
only falling back to VTTCue::isOrderedBefore() otherwise, mirroring the
already-consistent isPositionedAbove().

To make the comparator testable, expose it through internals: because the
override is private and TextTrackCueGeneric is final, the call is
devirtualized to the derived symbol, so it is marked WEBCORE_EXPORT so the
WebCoreTestSupport dylib can link against it.

* LayoutTests/media/track/text-track-generic-cue-ordering-expected.txt: Added.
* LayoutTests/media/track/text-track-generic-cue-ordering.html: Added.
* Source/WebCore/html/track/TextTrackCueGeneric.cpp:
(WebCore::TextTrackCueGeneric::isOrderedBefore const):
* Source/WebCore/html/track/TextTrackCueGeneric.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::cueIsOrderedBefore):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d944baa9d3594c71a303c34fb7bae9323a784ffa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173943 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47876 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41657 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183517 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131811 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3f17e7ad-1ac3-4c68-9e24-5f160c0e8f39) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175808 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49168 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47558 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135273 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95377 "1 flakes 3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/202ff3d6-5c08-41c8-9b59-7bf7d77aa11c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176901 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38702 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156063 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115751 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6633d816-2ae0-4456-a18e-70e3ccc13c3e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37343 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35711 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32001 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147767 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35556 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185943 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39002 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39909 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144174 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47543 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155618 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144032 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48222 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32173 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113565 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38942 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120106 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46728 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10513 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46131 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46362 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46189 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->