### PR TITLE
[WebVTT] Move WebVTTToken into the out-parameter in WebVTTTokenizer::emitToken instead of copying

### DIFF
--- a/Source/WebCore/html/track/WebVTTTokenizer.cpp
+++ b/Source/WebCore/html/track/WebVTTTokenizer.cpp
@@ -62,9 +62,9 @@ static void addNewClass(StringBuilder& classes, const StringBuilder& newClass)
     classes.append(newClass);
 }
 
-static bool emitToken(WebVTTToken& resultToken, const WebVTTToken& token)
+static bool emitToken(WebVTTToken& resultToken, WebVTTToken&& token)
 {
-    resultToken = token;
+    resultToken = WTF::move(token);
     return true;
 }
 


### PR DESCRIPTION
#### 5c1e6bce7262a1717c3e33b20e3af11b24935480
<pre>
[WebVTT] Move WebVTTToken into the out-parameter in WebVTTTokenizer::emitToken instead of copying
<a href="https://bugs.webkit.org/show_bug.cgi?id=319152">https://bugs.webkit.org/show_bug.cgi?id=319152</a>
<a href="https://rdar.apple.com/181975594">rdar://181975594</a>

Reviewed by Chris Dumez.

emitToken() took its source token by const reference and copy-assigned it
into the result out-parameter. Every one of its call sites passes a freshly
constructed temporary (WebVTTToken::StringToken(), StartTag(), EndTag(),
TimestampTag()), so the copy performed three needless atomic reference-count
bumps per emitted token (one String plus two AtomStrings) on a value that is
immediately discarded.

Take the token by rvalue reference and move-assign it instead. No behavior
change.

* Source/WebCore/html/track/WebVTTTokenizer.cpp:
(WebCore::emitToken):

Canonical link: <a href="https://commits.webkit.org/317021@main">https://commits.webkit.org/317021@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/24841cdc560defe331e5959a0f7aa68d58fab4c5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173941 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47874 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41655 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183515 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131809 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6d4f2e4e-9606-4e4e-a91e-a8aae6d354bf) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175806 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49166 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47556 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135271 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95374 "3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c2b6f7d9-0571-468f-91cc-2e41d36775a7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176899 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38701 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156059 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115749 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a0141fc4-ffb7-4e64-b18a-03979c429abe) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37342 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35708 "Found 1 new API test failure: TestWebKitAPI._WKDownload.DownloadMonitorCancel (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31999 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147766 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35552 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185941 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39000 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39906 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144172 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47541 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144030 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38861 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48220 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32169 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113563 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38940 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120104 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46726 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10509 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46129 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46360 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46187 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->