### PR TITLE
[WebVTT] A cue wrongly inherits a preceding line as its identifier across a REGION or STYLE block

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/support/ids-across-region-block.test
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/support/ids-across-region-block.test
@@ -1,0 +1,18 @@
+ids not carried across a region block
+<link rel="help" href="https://w3c.github.io/webvtt/#collect-a-webvtt-block">
+
+// A stray line that precedes a REGION block must not be remembered and
+// applied as the id of a later cue that has no id line of its own.
+assert_equals(cues.length, 1);
+assert_equals(cues[0].id, "");
+
+===
+WEBVTT
+
+not-an-id
+REGION
+id:r1
+lines:2
+
+00:00:00.000 --> 00:00:01.000
+text

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/support/ids-across-style-block.test
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/support/ids-across-style-block.test
@@ -1,0 +1,17 @@
+ids not carried across a style block
+<link rel="help" href="https://w3c.github.io/webvtt/#collect-a-webvtt-block">
+
+// A stray line that precedes a STYLE block must not be remembered and
+// applied as the id of a later cue that has no id line of its own.
+assert_equals(cues.length, 1);
+assert_equals(cues[0].id, "");
+
+===
+WEBVTT
+
+not-an-id
+STYLE
+::cue { color: lime }
+
+00:00:00.000 --> 00:00:01.000
+text

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/tests/ids-across-region-block-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/tests/ids-across-region-block-expected.txt
@@ -1,0 +1,3 @@
+
+PASS ids not carried across a region block
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/tests/ids-across-region-block.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/tests/ids-across-region-block.html
@@ -1,0 +1,42 @@
+<!doctype html><!-- webkit-test-runner [ captionDisplayMode=automatic ] -->
+<!-- DO NOT EDIT! This file and support/ids-across-region-block.vtt are generated. -->
+<!-- See /webvtt/parsing/file-parsing/README.md -->
+<meta charset=utf-8>
+<title>WebVTT parser test: ids not carried across a region block</title>
+<link rel="help" href="https://w3c.github.io/webvtt/#collect-a-webvtt-block">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id=log></div>
+<script>
+var t = async_test('ids not carried across a region block');
+t.step(function(){
+    var video = document.createElement('video');
+    var track = document.createElement('track');
+    assert_true('src' in track, 'track element not supported');
+    track.src = 'support/ids-across-region-block.vtt';
+    track['default'] = true;
+    track.kind = 'subtitles';
+    track.onload = this.step_func(trackLoaded);
+    track.onerror = this.step_func(trackError);
+    video.appendChild(track);
+    document.body.appendChild(video);
+});
+
+function trackLoaded(event) {
+    var track = event.target;
+    var video = track.parentNode;
+    var cues = video.textTracks[0].cues;
+    {
+// A stray line that precedes a REGION block must not be remembered and
+// applied as the id of a later cue that has no id line of its own.
+assert_equals(cues.length, 1);
+assert_equals(cues[0].id, "");
+
+    }
+    this.done();
+}
+
+function trackError(e) {
+    assert_unreached('got unexpected error event');
+}
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/tests/ids-across-style-block-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/tests/ids-across-style-block-expected.txt
@@ -1,0 +1,3 @@
+
+PASS ids not carried across a style block
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/tests/ids-across-style-block.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/tests/ids-across-style-block.html
@@ -1,0 +1,42 @@
+<!doctype html><!-- webkit-test-runner [ captionDisplayMode=automatic ] -->
+<!-- DO NOT EDIT! This file and support/ids-across-style-block.vtt are generated. -->
+<!-- See /webvtt/parsing/file-parsing/README.md -->
+<meta charset=utf-8>
+<title>WebVTT parser test: ids not carried across a style block</title>
+<link rel="help" href="https://w3c.github.io/webvtt/#collect-a-webvtt-block">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id=log></div>
+<script>
+var t = async_test('ids not carried across a style block');
+t.step(function(){
+    var video = document.createElement('video');
+    var track = document.createElement('track');
+    assert_true('src' in track, 'track element not supported');
+    track.src = 'support/ids-across-style-block.vtt';
+    track['default'] = true;
+    track.kind = 'subtitles';
+    track.onload = this.step_func(trackLoaded);
+    track.onerror = this.step_func(trackError);
+    video.appendChild(track);
+    document.body.appendChild(video);
+});
+
+function trackLoaded(event) {
+    var track = event.target;
+    var video = track.parentNode;
+    var cues = video.textTracks[0].cues;
+    {
+// A stray line that precedes a STYLE block must not be remembered and
+// applied as the id of a later cue that has no id line of its own.
+assert_equals(cues.length, 1);
+assert_equals(cues[0].id, "");
+
+    }
+    this.done();
+}
+
+function trackError(e) {
+    assert_unreached('got unexpected error event');
+}
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/tests/support/ids-across-region-block.vtt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/tests/support/ids-across-region-block.vtt
@@ -1,0 +1,9 @@
+WEBVTT
+
+not-an-id
+REGION
+id:r1
+lines:2
+
+00:00:00.000 --> 00:00:01.000
+text

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/tests/support/ids-across-style-block.vtt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/tests/support/ids-across-style-block.vtt
@@ -1,0 +1,8 @@
+WEBVTT
+
+not-an-id
+STYLE
+::cue { color: lime }
+
+00:00:00.000 --> 00:00:01.000
+text

--- a/Source/WebCore/html/track/WebVTTParser.cpp
+++ b/Source/WebCore/html/track/WebVTTParser.cpp
@@ -274,11 +274,17 @@ WebVTTParser::ParseState WebVTTParser::collectWebVTTBlock(const String& line)
 {
     // collect a WebVTT block parsing. (WebVTT parser algorithm step 14)
     
-    if (checkAndCreateRegion(line))
+    if (checkAndCreateRegion(line)) {
+        // Starting a region block supersedes any buffered line, so it must not
+        // linger and get applied as the id of a later cue that has no id line.
+        m_previousLine = emptyString();
         return Region;
-    
-    if (checkStyleSheet(line))
+    }
+
+    if (checkStyleSheet(line)) {
+        m_previousLine = emptyString();
         return Style;
+    }
 
     // Handle cue block.
     ParseState state = checkAndRecoverCue(line);


### PR DESCRIPTION
#### e289f76946d55f85c3ae899b7f1e841f042adbfd
<pre>
[WebVTT] A cue wrongly inherits a preceding line as its identifier across a REGION or STYLE block
<a href="https://bugs.webkit.org/show_bug.cgi?id=319155">https://bugs.webkit.org/show_bug.cgi?id=319155</a>
<a href="https://rdar.apple.com/181977285">rdar://181977285</a>

Reviewed by Eric Carlson.

WebVTTParser::collectWebVTTBlock() buffers a candidate cue-identifier line
in m_previousLine while collecting a WebVTT block. When the block then turns
out to be a region or style block, m_previousLine was left untouched, so the
stray line survived across the block and was later applied as the identifier
of the next cue that had no identifier of its own.

Per the &quot;collect a WebVTT block&quot; algorithm [1], a REGION/STYLE block is only
recognized when it is the first line of the block; a line preceding it makes
the whole block a no-op, and the following cue&apos;s identifier is the (empty)
buffer. Clear m_previousLine when a region or style block is started so the
buffered line is not carried over.

This matches Firefox on both cases and Chrome on the region case (Chrome has
a separate bug in the style case).

[1] <a href="https://w3c.github.io/webvtt/#collect-a-webvtt-block">https://w3c.github.io/webvtt/#collect-a-webvtt-block</a>

Tests: imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/tests/ids-across-region-block.html
 imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/tests/ids-across-style-block.html

* LayoutTests/imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/support/ids-across-region-block.test: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/support/ids-across-style-block.test: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/tests/ids-across-region-block-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/tests/ids-across-region-block.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/tests/ids-across-style-block-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/tests/ids-across-style-block.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/tests/support/ids-across-region-block.vtt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/tests/support/ids-across-style-block.vtt: Added.
* Source/WebCore/html/track/WebVTTParser.cpp:
(WebCore::WebVTTParser::collectWebVTTBlock):

Canonical link: <a href="https://commits.webkit.org/317811@main">https://commits.webkit.org/317811@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d67a545d9bb05c70c517d32a5fed422756db7f21

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173944 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47877 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41658 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183518 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131812 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7b2c31e8-bcc5-45e9-b6b1-992657ef2c1b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175809 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49169 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47559 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135274 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95378 "1 flakes 4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/37cda23b-cdf8-417c-9859-ff35e5ae7d5f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176902 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38704 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156064 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115752 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/18b2a5ac-cf14-4b16-99ef-c7b86937d19e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37345 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35713 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32002 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147769 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35557 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185944 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39004 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39911 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144175 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47544 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155619 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144033 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39387 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48223 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32174 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113571 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38943 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120107 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46729 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10518 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46132 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46363 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46190 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->