### PR TITLE
Compute visited link hashes with the URL parser

### DIFF
--- a/Source/WTF/wtf/URLParser.cpp
+++ b/Source/WTF/wtf/URLParser.cpp
@@ -1084,8 +1084,9 @@ ALWAYS_INLINE size_t URLParser::currentPosition(const CodePointIterator<Characte
     return iterator.codeUnitsSince(reinterpret_cast<const CharacterType*>(m_inputBegin));
 }
 
-URLParser::URLParser(String&& input, const URL& base, const URLTextEncoding* nonUTF8QueryEncoding)
-    : m_inputString(WTF::move(input))
+URLParser::URLParser(String&& input, const URL& base, const URLTextEncoding* nonUTF8QueryEncoding, ShouldConstructString shouldConstructString)
+    : m_shouldConstructString(shouldConstructString)
+    , m_inputString(WTF::move(input))
 {
     if (m_inputString.isNull()) {
         if (base.isValid() && !base.m_hasOpaquePath) {
@@ -1104,6 +1105,9 @@ URLParser::URLParser(String&& input, const URL& base, const URLTextEncoding* non
         m_inputBegin = characters.data();
         parse(characters, base, nonUTF8QueryEncoding);
     }
+
+    if (m_shouldConstructString == ShouldConstructString::No)
+        return;
 
     ASSERT(!m_url.m_isValid
         || m_didSeeSyntaxViolation == (m_url.string() != m_inputString)
@@ -2058,6 +2062,12 @@ void URLParser::parse(std::span<const CharacterType> input, const URL& base, con
         break;
     }
 
+    if (m_shouldConstructString == ShouldConstructString::No) [[unlikely]] {
+        // parseAndConsume() hashes m_asciiBuffer / m_inputString directly; skip the result String.
+        m_url.m_isValid = true;
+        return;
+    }
+
     if (!m_didSeeSyntaxViolation) [[likely]] {
         m_url.m_string = m_inputString;
         ASSERT(m_asciiBuffer.isEmpty());
@@ -2545,12 +2555,35 @@ URLParser::Latin1Buffer URLParser::percentDecode(std::span<const Latin1Character
 
 bool URLParser::needsNonSpecialDotSlash() const
 {
+    return needsNonSpecialDotSlash(m_url.m_string);
+}
+
+bool URLParser::needsNonSpecialDotSlash(StringView urlString) const
+{
     auto pathStart = m_url.m_hostEnd + m_url.m_portLength;
     return !m_urlIsSpecial
         && pathStart == m_url.m_schemeEnd + 1U
-        && pathStart + 1 < m_url.m_string.length()
-        && m_url.m_string[pathStart] == '/'
-        && m_url.m_string[pathStart + 1] == '/';
+        && pathStart + 1 < urlString.length()
+        && urlString[pathStart] == '/'
+        && urlString[pathStart + 1] == '/';
+}
+
+StringView URLParser::canonicalView(String& fixupStorage) const
+{
+    StringView view;
+    if (!m_url.m_string.isNull())
+        view = m_url.m_string; // failure() and base-copy paths set the string directly.
+    else if (!m_didSeeSyntaxViolation)
+        view = m_inputString;
+    else
+        view = m_asciiBuffer.span();
+
+    if (needsNonSpecialDotSlash(view)) [[unlikely]] {
+        auto pathStart = m_url.m_hostEnd + m_url.m_portLength;
+        fixupStorage = makeString(view.left(pathStart + 1), "./"_s, view.substring(pathStart + 1));
+        return fixupStorage;
+    }
+    return view;
 }
 
 void URLParser::addNonSpecialDotSlash()

--- a/Source/WTF/wtf/URLParser.h
+++ b/Source/WTF/wtf/URLParser.h
@@ -69,9 +69,25 @@ public:
     static std::optional<uint16_t> NODELETE defaultPortForProtocol(StringView);
     WTF_EXPORT_PRIVATE static std::optional<String> formURLDecode(StringView input);
 
+    // Resolves "input" against "base" using the full URL canonicalizer, then invokes "consumer"
+    // with the canonical URL characters as a StringView — without allocating the result String.
+    // The StringView is only valid for the duration of the consumer call.
+    template<typename Consumer>
+    static auto parseAndConsume(String&& input, const URL& base, const URLTextEncoding* encoding, NOESCAPE Consumer&& consumer)
+    {
+        URLParser parser(WTF::move(input), base, encoding, ShouldConstructString::No);
+        String fixupStorage;
+        return consumer(parser.canonicalView(fixupStorage));
+    }
+
 private:
-    URLParser(String&&, const URL& = { }, const URLTextEncoding* = nullptr);
+    enum class ShouldConstructString : bool { No, Yes };
+    WTF_EXPORT_PRIVATE URLParser(String&&, const URL& = { }, const URLTextEncoding* = nullptr, ShouldConstructString = ShouldConstructString::Yes);
     URL result() { return m_url; }
+
+    // Canonical URL characters left behind by parse(). Valid only while this URLParser is alive;
+    // "fixupStorage" backs the rare non-special "//" path and must outlive the returned view.
+    WTF_EXPORT_PRIVATE StringView canonicalView(String& fixupStorage) const LIFETIME_BOUND;
 
     friend class URL;
 
@@ -81,6 +97,7 @@ private:
     bool m_urlIsFile { false };
     bool m_hostHasPercentOrNonASCII { false };
     bool m_didSeeSyntaxViolation { false };
+    ShouldConstructString m_shouldConstructString { ShouldConstructString::Yes };
     String m_inputString;
     const void* m_inputBegin { nullptr };
 
@@ -131,6 +148,7 @@ private:
     char16_t parsedDataView(size_t position);
 
     bool NODELETE needsNonSpecialDotSlash() const;
+    bool NODELETE needsNonSpecialDotSlash(StringView) const;
     void addNonSpecialDotSlash();
 
     using IPv4Address = uint32_t;

--- a/Source/WebCore/platform/SharedStringHash.cpp
+++ b/Source/WebCore/platform/SharedStringHash.cpp
@@ -24,188 +24,13 @@
 #include "config.h"
 #include "SharedStringHash.h"
 
-#include <wtf/ASCIICType.h>
 #include <wtf/HashFunctions.h>
-#include <wtf/URL.h>
+#include <wtf/URLParser.h>
 #include <wtf/text/AtomString.h>
 #include <wtf/text/StringHash.h>
 #include <wtf/text/StringView.h>
 
 namespace WebCore {
-
-template <typename CharacterType>
-static inline size_t NODELETE findSlashDotDotSlash(std::span<const CharacterType> characters, size_t position)
-{
-    if (characters.size() < 4)
-        return notFound;
-    size_t loopLimit = characters.size() - 3;
-    for (size_t i = position; i < loopLimit; ++i) {
-        if (characters[i] == '/' && characters[i + 1] == '.' && characters[i + 2] == '.' && characters[i + 3] == '/')
-            return i;
-    }
-    return notFound;
-}
-
-template <typename CharacterType>
-static inline size_t NODELETE findSlashSlash(std::span<const CharacterType> characters, size_t position)
-{
-    if (characters.size() < 2)
-        return notFound;
-    size_t loopLimit = characters.size() - 1;
-    for (size_t i = position; i < loopLimit; ++i) {
-        if (characters[i] == '/' && characters[i + 1] == '/')
-            return i;
-    }
-    return notFound;
-}
-
-template <typename CharacterType>
-static inline size_t NODELETE findSlashDotSlash(std::span<const CharacterType> characters, size_t position)
-{
-    if (characters.size() < 3)
-        return notFound;
-    size_t loopLimit = characters.size() - 2;
-    for (size_t i = position; i < loopLimit; ++i) {
-        if (characters[i] == '/' && characters[i + 1] == '.' && characters[i + 2] == '/')
-            return i;
-    }
-    return notFound;
-}
-
-template <typename CharacterType>
-static inline bool NODELETE startsWithSchemeColonSlashSlash(std::span<const CharacterType> characters)
-{
-    if (!isASCIIAlpha(characters[0]))
-        return false;
-    size_t i = 1;
-    for (; i < characters.size(); ++i) {
-        auto character = characters[i];
-        if (character == ':')
-            break;
-        if (!isASCIIAlphanumeric(character) && character != '+' && character != '-' && character != '.')
-            return false;
-    }
-    return i + 2 < characters.size() && characters[i] == ':' && characters[i + 1] == '/' && characters[i + 2] == '/';
-}
-
-template <typename CharacterType>
-static inline void NODELETE squeezeOutNullCharacters(Vector<CharacterType, 512>& string)
-{
-    size_t size = string.size();
-    size_t i = 0;
-    for (i = 0; i < size; ++i) {
-        if (!string[i])
-            break;
-    }
-    if (i == size)
-        return;
-    size_t j = i;
-    for (++i; i < size; ++i) {
-        if (CharacterType character = string[i])
-            string[j++] = character;
-    }
-    ASSERT(j < size);
-    string.shrink(j);
-}
-
-template <typename CharacterType>
-static void NODELETE cleanSlashDotDotSlashes(Vector<CharacterType, 512>& path, size_t firstSlash)
-{
-    size_t slash = firstSlash;
-    do {
-        size_t previousSlash = slash ? reverseFind(path.span(), '/', slash - 1) : notFound;
-        // Don't remove the host, i.e. http://foo.org/../foo.html
-        if (previousSlash == notFound || (previousSlash > 3 && path[previousSlash - 2] == ':' && path[previousSlash - 1] == '/')) {
-            path[slash] = 0;
-            path[slash + 1] = 0;
-            path[slash + 2] = 0;
-        } else {
-            for (size_t i = previousSlash; i < slash + 3; ++i)
-                path[i] = 0;
-        }
-        slash += 3;
-    } while ((slash = findSlashDotDotSlash(path.span(), slash)) != notFound);
-    squeezeOutNullCharacters(path);
-}
-
-template <typename CharacterType>
-static void NODELETE mergeDoubleSlashes(Vector<CharacterType, 512>& path, size_t firstSlash)
-{
-    size_t refPos = find(path.span(), '#');
-    if (!refPos || refPos == notFound)
-        refPos = path.size();
-
-    size_t slash = firstSlash;
-    while (slash < refPos) {
-        if (!slash || path[slash - 1] != ':')
-            path[slash++] = 0;
-        else
-            slash += 2;
-        if ((slash = findSlashSlash(path.span(), slash)) == notFound)
-            break;
-    }
-    squeezeOutNullCharacters(path);
-}
-
-template <typename CharacterType>
-static void NODELETE cleanSlashDotSlashes(Vector<CharacterType, 512>& path, size_t firstSlash)
-{
-    size_t slash = firstSlash;
-    do {
-        path[slash] = 0;
-        path[slash + 1] = 0;
-        slash += 2;
-    } while ((slash = findSlashDotSlash(path.span(), slash)) != notFound);
-    squeezeOutNullCharacters(path);
-}
-
-template <typename CharacterType>
-static inline void NODELETE cleanPath(Vector<CharacterType, 512>& path)
-{
-    // FIXME: Should not do this in the query or anchor part of the URL.
-    size_t firstSlash = findSlashDotDotSlash(path.span(), 0);
-    if (firstSlash != notFound)
-        cleanSlashDotDotSlashes(path, firstSlash);
-
-    // FIXME: Should not do this in the query part.
-    firstSlash = findSlashSlash(path.span(), 0);
-    if (firstSlash != notFound)
-        mergeDoubleSlashes(path, firstSlash);
-
-    // FIXME: Should not do this in the query or anchor part.
-    firstSlash = findSlashDotSlash(path.span(), 0);
-    if (firstSlash != notFound)
-        cleanSlashDotSlashes(path, firstSlash);
-}
-
-template <typename CharacterType>
-static inline bool NODELETE matchLetter(CharacterType c, char lowercaseLetter)
-{
-    return (c | 0x20) == lowercaseLetter;
-}
-
-template <typename CharacterType>
-static inline bool NODELETE needsTrailingSlash(std::span<const CharacterType> characters)
-{
-    if (characters.size() < 6)
-        return false;
-    if (!matchLetter(characters[0], 'h') || !matchLetter(characters[1], 't') || !matchLetter(characters[2], 't') || !matchLetter(characters[3], 'p'))
-        return false;
-    if (!(characters[4] == ':' || (matchLetter(characters[4], 's') && characters[5] == ':')))
-        return false;
-
-    unsigned pos = characters[4] == ':' ? 5 : 6;
-
-    // Skip initial two slashes if present.
-    if (pos + 1 < characters.size() && characters[pos] == '/' && characters[pos + 1] == '/')
-        pos += 2;
-
-    // Find next slash.
-    while (pos < characters.size() && characters[pos] != '/')
-        ++pos;
-
-    return pos == characters.size();
-}
 
 template <typename CharacterType>
 static ALWAYS_INLINE SharedStringHash NODELETE computeSharedStringHashInline(std::span<const CharacterType> url)
@@ -225,58 +50,11 @@ SharedStringHash computeSharedStringHash(std::span<const char16_t> url)
     return computeSharedStringHashInline(url);
 }
 
-template <typename CharacterType>
-static ALWAYS_INLINE SharedStringHash computeSharedStringHashInline(const URL& base, std::span<const CharacterType> characters)
+SharedStringHash computeSharedStringHash(StringView url)
 {
-    if (characters.empty())
-        return 0;
-
-    // This is a poor man's completeURL. Faster with less memory allocation.
-    // FIXME: It's missing a lot of what completeURL does and a lot of what URL does.
-    // For example, it does not handle international domain names properly.
-
-    // FIXME: needsTrailingSlash does not properly return true for a URL that has no path, but does
-    // have a query or anchor.
-
-    if (startsWithSchemeColonSlashSlash(characters)) {
-        if (!needsTrailingSlash(characters))
-            return computeSharedStringHashInline(characters);
-
-        // FIXME: This is incorrect for URLs that have a query or anchor; the "/" needs to go at the
-        // end of the path, *before* the query or anchor.
-        SuperFastHash hasher;
-        hasher.addCharacters(characters);
-        hasher.addCharacter(static_cast<char16_t>('/'));
-        return AlreadyHashed::avoidDeletedValue(hasher.hash());
-    }
-
-    Vector<CharacterType, 512> buffer;
-    if (characters.size() >= 2 && characters[0] == '/' && characters[1] == '/') {
-        // Protocol-relative URL; inherit the scheme from the base URL.
-        append(buffer, base.protocol());
-        buffer.append(':');
-    } else {
-        switch (characters[0]) {
-        case '/':
-            append(buffer, StringView(base.string()).left(base.pathStart()));
-            break;
-        case '#':
-            append(buffer, StringView(base.string()).left(base.pathEnd()));
-            break;
-        default:
-            append(buffer, StringView(base.string()).left(base.pathAfterLastSlash()));
-            break;
-        }
-    }
-    buffer.append(characters);
-    cleanPath(buffer);
-    if (needsTrailingSlash(buffer.span())) {
-        // FIXME: This is incorrect for URLs that have a query or anchor; the "/" needs to go at the
-        // end of the path, *before* the query or anchor.
-        buffer.append('/');
-    }
-
-    return computeSharedStringHashInline(buffer.span());
+    if (url.isEmpty() || url.is8Bit())
+        return computeSharedStringHashInline(url.span8());
+    return computeSharedStringHashInline(url.span16());
 }
 
 SharedStringHash computeVisitedLinkHash(const URL& base, const AtomString& attributeURL)
@@ -284,11 +62,11 @@ SharedStringHash computeVisitedLinkHash(const URL& base, const AtomString& attri
     if (attributeURL.isEmpty())
         return 0;
 
-    if ((base.string().isEmpty() || base.string().is8Bit()) && attributeURL.is8Bit())
-        return computeSharedStringHashInline(base, attributeURL.span8());
-
-    auto upconvertedCharacters = StringView(attributeURL.string()).upconvertedCharacters();
-    return computeSharedStringHashInline(base, upconvertedCharacters.span());
+    // Resolve "attributeURL" against "base" using the real URL canonicalizer and hash the
+    // canonical characters directly out of the parser's buffer — no result String is allocated.
+    return WTF::URLParser::parseAndConsume(String { attributeURL.string() }, base, nullptr, [](StringView canonicalURL) {
+        return computeSharedStringHash(canonicalURL);
+    });
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/SharedStringHash.h
+++ b/Source/WebCore/platform/SharedStringHash.h
@@ -44,11 +44,12 @@ struct SharedStringHashHash {
 // Returns the hash of the string that will be used for visited link coloring.
 WEBCORE_EXPORT SharedStringHash NODELETE computeSharedStringHash(const String& url);
 WEBCORE_EXPORT SharedStringHash computeSharedStringHash(std::span<const char16_t> url);
+SharedStringHash computeSharedStringHash(StringView url);
 
 // Resolves the potentially relative URL "attributeURL" relative to the given
 // base URL, and returns the hash of the string that will be used for visited
 // link coloring. It will return the special value of 0 if attributeURL does not
 // look like a relative URL.
-SharedStringHash computeVisitedLinkHash(const URL& base, const AtomString& attributeURL);
+WEBCORE_EXPORT SharedStringHash computeVisitedLinkHash(const URL& base, const AtomString& attributeURL);
 
 } // namespace WebCore

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -257,6 +257,7 @@ if (ENABLE_WEBCORE)
         Tests/WebCore/ShareableBitmap.cpp
         Tests/WebCore/SharedBuffer.cpp
         Tests/WebCore/SharedBufferTest.cpp
+        Tests/WebCore/SharedStringHash.cpp
         Tests/WebCore/StyleGradient.cpp
         Tests/WebCore/TestPlatformStrategies.cpp
         Tests/WebCore/TextIterator.cpp

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -797,6 +797,7 @@
 				WebCore/ShareableBitmap.cpp,
 				WebCore/SharedBuffer.cpp,
 				WebCore/SharedBufferTest.cpp,
+				WebCore/SharedStringHash.cpp,
 				WebCore/SharedMemoryTests.cpp,
 				WebCore/SharedTimebaseTests.cpp,
 				WebCore/StaticRangeValidity.cpp,

--- a/Tools/TestWebKitAPI/Tests/WebCore/SharedStringHash.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/SharedStringHash.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "Helpers/Test.h"
+#include <WebCore/SharedStringHash.h>
+#include <wtf/URL.h>
+#include <wtf/text/AtomString.h>
+
+namespace TestWebKitAPI {
+
+using namespace WebCore;
+
+// computeVisitedLinkHash() must produce exactly the hash of the fully-resolved,
+// canonicalized URL — i.e. the same value the store side computes via
+// computeSharedStringHash(URL(base, relative).string()). This locks the
+// non-allocating parseAndConsume() path to the real URL canonicalizer.
+static void expectParity(ASCIILiteral baseString, ASCIILiteral relative)
+{
+    URL base { String { baseString } };
+    AtomString relativeAtom { String { relative } };
+
+    SharedStringHash viaVisitedLinkHash = computeVisitedLinkHash(base, relativeAtom);
+    SharedStringHash viaResolvedURL = computeSharedStringHash(URL(base, String { relative }).string());
+
+    EXPECT_EQ(viaVisitedLinkHash, viaResolvedURL) << "base=" << baseString.characters() << " relative=" << relative.characters();
+}
+
+TEST(SharedStringHash, VisitedLinkHashParity)
+{
+    // Already-absolute, already-canonical (no syntax violation, buffer untouched).
+    expectParity("https://example.com/"_s, "https://other.example/path?q=1#frag"_s);
+
+    // Relative path resolution (syntax violation -> canonical buffer path).
+    expectParity("https://example.com/dir/page.html"_s, "foo.html"_s);
+    expectParity("https://example.com/dir/page.html"_s, "../up.html"_s);
+    expectParity("https://example.com/a/b/c"_s, "./x/./y/../z"_s);
+
+    // Query-only and fragment-only relatives.
+    expectParity("https://example.com/dir/page.html?old=1"_s, "?new=2"_s);
+    expectParity("https://example.com/dir/page.html"_s, "#frag"_s);
+
+    // Protocol-relative.
+    expectParity("https://example.com/"_s, "//other.example/x"_s);
+
+    // needsTrailingSlash: absolute URL with empty path.
+    expectParity("https://example.com/x"_s, "https://example.com"_s);
+
+    // Previously-broken cases where the shadow resolver diverged from URL():
+    // "://" inside a relative reference, and mixed schemes.
+    expectParity("https://example.com/dir/"_s, "a://b/c"_s);
+    expectParity("https://example.com/dir/"_s, "path?x=a://b"_s);
+    expectParity("https://example.com/dir/"_s, "notascheme:relative"_s);
+
+    // Non-special scheme with an authority-less "//" path (dot-slash fixup path).
+    expectParity("data:text/plain,base"_s, "//foo/bar"_s);
+
+    // Uppercase host / percent-encoding (syntax violations that rewrite the buffer).
+    expectParity("https://example.com/"_s, "HTTPS://EXAMPLE.COM/PATH"_s);
+    expectParity("https://example.com/dir/"_s, "a b c.html"_s);
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### 2b251e25755cff9542a31377748ad0f2631dcd27
<pre>
Compute visited link hashes with the URL parser
<a href="https://bugs.webkit.org/show_bug.cgi?id=319158">https://bugs.webkit.org/show_bug.cgi?id=319158</a>

Reviewed by NOBODY (OOPS!).

computeVisitedLinkHash() used a hand-rolled URL parser that diverged
from the actual URL parser in many respects, e.g., does not work for
non-ASCII, leading or trailing whitespace, code points that will be
percent-encoded, and including the default port.

This adds URLParser::parseAndConsume(), which runs the URL parser but,
instead of adopting its buffer into a String, hands the output to a
consumer as a StringView. This allows computeVisitedLinkHash() to
continue to not allocate anything when the URL is already parsed and
serialized. It will however incur a heap allocation for a serialization
buffer in the other cases.

The one remaining divergence is when the document encoding is not UTF-8
and the URLs contain a query with non-ASCII code points.

Tested through existing coverage and a new API test.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b251e25755cff9542a31377748ad0f2631dcd27

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173949 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47882 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41663 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183523 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131817 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e5020aa0-b231-4e35-a0e6-6f91801f5747) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175814 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49174 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47564 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135280 "Found 1 new test failure: fast/block/float/float-in-float-painting.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95383 "3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f7deed81-4cbd-42da-bd1f-dc739add67ea) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176907 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38708 "Found 1 new test failure: fast/block/float/float-in-float-painting.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156070 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115758 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5f94cde8-28f3-4b11-a6c5-4339473feff7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37349 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35716 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32007 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/4580 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147773 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35563 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185949 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/35211 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39009 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39914 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144181 "Found 2 new test failures: compositing/framesets/composited-frame-alignment.html fast/block/float/float-in-float-painting.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47549 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144039 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48228 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32180 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113576 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38948 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120112 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/210983 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46734 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10521 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54966 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46137 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46368 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46195 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->