### PR TITLE
TextTrackList::getTrackById iterates via length()/item() instead of walking track vectors directly

### DIFF
--- a/Source/WebCore/html/track/TextTrackList.cpp
+++ b/Source/WebCore/html/track/TextTrackList.cpp
@@ -128,10 +128,14 @@ RefPtr<TextTrack> TextTrackList::getTrackById(const AtomString& id) const
     // The getTrackById(id) method must return the first TextTrack in the
     // TextTrackList object whose id IDL attribute would return a value equal
     // to the value of the id argument.
-    for (unsigned i = 0; i < length(); ++i) {
-        Ref track = *item(i);
-        if (track->id() == id)
-            return track;
+    // Iterate the member vectors in the same order as item(): element tracks,
+    // then addTextTrack() tracks, then in-band tracks.
+    for (auto* tracks : { &m_elementTracks, &m_addTrackTracks, &m_inbandTracks }) {
+        for (auto& trackBase : *tracks) {
+            Ref track = downcast<TextTrack>(trackBase);
+            if (track->id() == id)
+                return track;
+        }
     }
 
     // When no tracks match the given argument, the method must return null.
@@ -140,10 +144,12 @@ RefPtr<TextTrack> TextTrackList::getTrackById(const AtomString& id) const
 
 RefPtr<TextTrack> TextTrackList::getTrackById(TrackID id) const
 {
-    for (unsigned i = 0; i < length(); ++i) {
-        auto& track = *item(i);
-        if (track.trackId() == id)
-            return track;
+    for (auto* tracks : { &m_elementTracks, &m_addTrackTracks, &m_inbandTracks }) {
+        for (auto& trackBase : *tracks) {
+            Ref track = downcast<TextTrack>(trackBase);
+            if (track->trackId() == id)
+                return track;
+        }
     }
     return nullptr;
 }


### PR DESCRIPTION
#### 086bea30b60140e0fda95eef01c32fce1ce46779
<pre>
TextTrackList::getTrackById iterates via length()/item() instead of walking track vectors directly
<a href="https://bugs.webkit.org/show_bug.cgi?id=319159">https://bugs.webkit.org/show_bug.cgi?id=319159</a>
<a href="https://rdar.apple.com/181978691">rdar://181978691</a>

Reviewed by Jer Noble.

Both TextTrackList::getTrackById overloads looped `for (i = 0; i &lt; length();
++i) item(i)`, which recomputed length() and re-did the three-way index
arithmetic (plus a downcast) in item() on every iteration. Since these
lookups run inside SourceBuffer&apos;s per-segment-track loops, that cost
compounds during initialization segment processing.

Iterate the three member track vectors (m_elementTracks, m_addTrackTracks,
m_inbandTracks) directly, in the same element -&gt; addTrack -&gt; inband order
item() uses, so the &quot;first matching TextTrack&quot; semantics are preserved.
This matches the existing AudioTrackList and VideoTrackList implementations.

No change in behavior, so no new tests.

* Source/WebCore/html/track/TextTrackList.cpp:
(WebCore::TextTrackList::getTrackById const):

Canonical link: <a href="https://commits.webkit.org/316978@main">https://commits.webkit.org/316978@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad89d5958c5510388c6c55eb192b49d49373a187

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173950 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47883 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41664 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183524 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131818 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a015f49b-8aba-4982-af54-383455346c31) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175815 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49175 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47565 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135278 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1b96e9fa-a4ba-4b5d-8c41-30db6781c633) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176908 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38707 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156068 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115756 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/858ac465-fdf0-408b-9f2f-7fc039f4653a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37348 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35717 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32008 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147772 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35561 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185950 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39010 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39915 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144179 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47550 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144037 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38840 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48229 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32178 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113578 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38947 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120113 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46735 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10519 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46138 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46369 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46196 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->