### PR TITLE
[WTF] Use std::has_single_bit() instead of open-coded single-bit checks in EnumSet and SmallSet

### DIFF
--- a/Source/WTF/wtf/EnumSet.h
+++ b/Source/WTF/wtf/EnumSet.h
@@ -154,8 +154,7 @@ public:
 
     constexpr bool hasExactlyOneBitSet() const
     {
-        auto storage = m_storage;
-        return storage && !(storage & (storage - 1));
+        return std::has_single_bit(m_storage);
     }
 
     constexpr std::optional<E> toSingleValue() const

--- a/Source/WTF/wtf/SmallSet.h
+++ b/Source/WTF/wtf/SmallSet.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <bit>
 #include <limits>
 #include <wtf/Assertions.h>
 #include <wtf/FastMalloc.h>
@@ -48,7 +49,7 @@ class SmallSet {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(SmallSet);
     WTF_MAKE_NONCOPYABLE(SmallSet);
     static_assert(std::is_trivially_destructible<T>::value, "We currently don't support non-trivially destructible types.");
-    static_assert(!(SmallArraySize & (SmallArraySize - 1)), "Inline size must be a power of two.");
+    static_assert(std::has_single_bit(SmallArraySize), "Inline size must be a power of two.");
     static_assert(sizeof(T*) <= SmallArraySize * sizeof(T), "This class has not been tested for m_inline.buffer larger than m_inline.smallStorage");
 
 public:
@@ -144,7 +145,7 @@ public:
         // If we're more than 3/4ths full we grow.
         if (m_size * 4 >= m_capacity * 3) [[unlikely]] {
             grow(m_capacity * 2);
-            ASSERT(!(m_capacity & (m_capacity - 1)));
+            ASSERT(std::has_single_bit(m_capacity));
         }
 
         T* bucket = this->bucket(value);
@@ -276,7 +277,7 @@ private:
 
     inline T* bucketInBuffer(std::span<T> buffer, T target) const
     {
-        ASSERT(!(m_capacity & (m_capacity - 1)));
+        ASSERT(std::has_single_bit(m_capacity));
         unsigned bucket = Hash::hash(target) & (m_capacity - 1);
         unsigned index = 0;
         while (true) {


### PR DESCRIPTION
#### 4c450a7daaf8c2acf3935116f63147049729ab8b
<pre>
[WTF] Use std::has_single_bit() instead of open-coded single-bit checks in EnumSet and SmallSet
<a href="https://bugs.webkit.org/show_bug.cgi?id=319160">https://bugs.webkit.org/show_bug.cgi?id=319160</a>
<a href="https://rdar.apple.com/181980648">rdar://181980648</a>

Reviewed by Chris Dumez.

Replace open-coded `!(x &amp; (x - 1))` power-of-two/single-bit checks with
std::has_single_bit(), matching the sibling OptionSet::hasExactlyOneBitSet().

* Source/WTF/wtf/EnumSet.h:
(WTF::EnumSet::hasExactlyOneBitSet const):
* Source/WTF/wtf/SmallSet.h:

Canonical link: <a href="https://commits.webkit.org/317052@main">https://commits.webkit.org/317052@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5155fce359d3fa4dadbb6b2c068d59a1ca0e21c9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174183 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48116 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41897 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183757 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132051 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b2ae0b63-7e6f-4654-b8cc-8bfa9bc82b36) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49408 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47798 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135490 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7b3fea4e-9137-4893-a0c3-a5ec589f7615) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177141 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38916 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156276 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115968 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a1000800-5073-4f11-8099-0899299a1235) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37556 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35922 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32241 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/4786 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147980 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35769 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186183 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/35445 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39344 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40120 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144384 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47783 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144244 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38882 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48462 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32389 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113974 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39156 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120368 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/211218 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46968 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10731 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55045 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46371 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46602 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46429 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->