### PR TITLE
Find the caption cue nearest video's playhead from selection

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/FindController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/FindController.cpp
@@ -121,6 +121,40 @@ static std::optional<size_t> indexOfCursor(const Vector<FindMatch>& merged, cons
     return std::nullopt;
 }
 
+static size_t cueIndexNearestPlayhead(const Vector<FindMatch>& merged, size_t matchIndex, bool backwards)
+{
+    auto* cue = std::get_if<CueMatch>(&merged[matchIndex]);
+    if (!cue)
+        return matchIndex;
+    RefPtr media = cue->mediaElement.get();
+    if (!media)
+        return matchIndex;
+
+    auto isSameMediaCue = [&](size_t index) {
+        auto* candidate = std::get_if<CueMatch>(&merged[index]);
+        return candidate && candidate->mediaElement.get() == media.get();
+    };
+
+    double currentTime = media->currentTime();
+    size_t nearestIndex = matchIndex;
+
+    if (!backwards) {
+        for (size_t index = matchIndex; index < merged.size() && isSameMediaCue(index); ++index) {
+            nearestIndex = index;
+            if (std::get<CueMatch>(merged[index]).seekTime.toDouble() >= currentTime)
+                return index;
+        }
+        return nearestIndex;
+    }
+
+    for (size_t index = matchIndex + 1; index && isSameMediaCue(index - 1); --index) {
+        nearestIndex = index - 1;
+        if (std::get<CueMatch>(merged[index - 1]).seekTime.toDouble() <= currentTime)
+            return index - 1;
+    }
+    return nearestIndex;
+}
+
 static std::optional<size_t> indexClosestToSelection(const Vector<FindMatch>& merged, const std::optional<SimpleRange>& selection, bool backwards)
 {
     if (merged.isEmpty() || !selection)
@@ -138,13 +172,13 @@ static std::optional<size_t> indexClosestToSelection(const Vector<FindMatch>& me
     if (!backwards) {
         for (size_t matchIndex = 0; matchIndex < merged.size(); ++matchIndex) {
             if (auto position = positionOf(merged[matchIndex]); position && is_gteq(treeOrder<ComposedTree>(*position, anchor)))
-                return matchIndex;
+                return cueIndexNearestPlayhead(merged, matchIndex, backwards);
         }
         return std::nullopt;
     }
     for (size_t matchIndex = merged.size(); matchIndex > 0; --matchIndex) {
         if (auto position = positionOf(merged[matchIndex - 1]); position && is_lteq(treeOrder<ComposedTree>(*position, anchor)))
-            return matchIndex - 1;
+            return cueIndexNearestPlayhead(merged, matchIndex - 1, backwards);
     }
     return std::nullopt;
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FindInPage.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FindInPage.mm
@@ -45,6 +45,34 @@
 #import "UIKitSPIForTesting.h"
 #endif
 
+#if ENABLE(VIDEO) && (!PLATFORM(IOS_FAMILY) || HAVE(UIFINDINTERACTION))
+
+static RetainPtr<WKWebViewConfiguration> configurationWithFindInVideoEnabled()
+{
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    for (_WKFeature *feature in [WKPreferences _features]) {
+        if ([feature.key isEqualToString:@"FindInVideoEnabled"]) {
+            [[configuration preferences] _setEnabled:YES forFeature:feature];
+            break;
+        }
+    }
+    return configuration;
+}
+
+static double waitForVideoCurrentTimeNear(TestWKWebView *webView, double expectedTime)
+{
+    double currentTime = 0;
+    for (unsigned attempt = 0; attempt < 100; ++attempt) {
+        currentTime = [[webView objectByEvaluatingJavaScript:@"document.querySelector('video').currentTime"] doubleValue];
+        if (currentTime > expectedTime - 0.1 && currentTime < expectedTime + 0.1)
+            break;
+        [webView waitForNextPresentationUpdate];
+    }
+    return currentTime;
+}
+
+#endif // ENABLE(VIDEO) && (!PLATFORM(IOS_FAMILY) || HAVE(UIFINDINTERACTION))
+
 #if !PLATFORM(IOS_FAMILY)
 
 typedef enum : NSUInteger {
@@ -543,6 +571,129 @@ TEST(WebKit, FindTextInImageOverlay)
 
 #endif // ENABLE(IMAGE_ANALYSIS)
 
+#if ENABLE(VIDEO)
+
+TEST(WebKit, FindInPageVideoCaptionStepThroughCues)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 320, 500) configuration:configurationWithFindInVideoEnabled()]);
+    [webView loadTestPageNamed:@"video-with-caption-cues"];
+    [webView _test_waitForDidFinishNavigation];
+
+    // Drop the caret at the top so find-next steps through the merged list in document order.
+    [webView objectByEvaluatingJavaScript:
+        @"document.querySelector('video').currentTime = 0;"
+        "document.getSelection().setBaseAndExtent(document.body, 0, document.body, 0)"];
+
+    // The leading text match is first and doesn't seek the video.
+    findMatches(webView.get(), @"Birthday", noFindOptions, 1);
+    EXPECT_NEAR(waitForVideoCurrentTimeNear(webView.get(), 0.0), 0.0, 0.1);
+
+    // Find-next walks into the cue run, seeking to each cue in turn.
+    findMatches(webView.get(), @"Birthday", noFindOptions, 1);
+    EXPECT_NEAR(waitForVideoCurrentTimeNear(webView.get(), 1.0), 1.0, 0.1);
+    findMatches(webView.get(), @"Birthday", noFindOptions, 1);
+    EXPECT_NEAR(waitForVideoCurrentTimeNear(webView.get(), 2.0), 2.0, 0.1);
+    findMatches(webView.get(), @"Birthday", noFindOptions, 1);
+    EXPECT_NEAR(waitForVideoCurrentTimeNear(webView.get(), 3.0), 3.0, 0.1);
+
+    // The trailing text match is past the cues, so the playhead stays at the last cue.
+    findMatches(webView.get(), @"Birthday", noFindOptions, 1);
+    EXPECT_NEAR(waitForVideoCurrentTimeNear(webView.get(), 3.0), 3.0, 0.1);
+}
+
+TEST(WebKit, FindInPageVideoCaptionCueInSubframe)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 320, 500) configuration:configurationWithFindInVideoEnabled()]);
+
+    // Main-frame text followed by a caption cue on a video inside a same-origin subframe.
+    NSString *markup = @"<p>Birthday</p>"
+        "<iframe srcdoc=\"<video src='test.mp4'></video>"
+        "<script>const track = document.querySelector('video').addTextTrack('captions', 'English', 'en'); track.mode = 'showing'; track.addCue(new VTTCue(2, 3, 'Happy Birthday'));</script>\"></iframe>";
+    [webView loadHTMLString:markup baseURL:[NSBundle.test_resourcesBundle resourceURL]];
+    [webView _test_waitForDidFinishNavigation];
+
+    // Caret at the start of the main-frame text, then find-next steps into the subframe cue.
+    [webView objectByEvaluatingJavaScript:
+        @"let p = document.querySelector('p'); document.getSelection().setBaseAndExtent(p, 0, p, 0)"];
+
+    findMatches(webView.get(), @"Birthday", noFindOptions, 1);
+    findMatches(webView.get(), @"Birthday", noFindOptions, 1);
+
+    // Stepping into the subframe cue seeks that subframe's video to the cue start at 2s.
+    double currentTime = 0;
+    for (unsigned attempt = 0; attempt < 100; ++attempt) {
+        currentTime = [[webView objectByEvaluatingJavaScript:@"document.querySelector('iframe').contentDocument.querySelector('video').currentTime"] doubleValue];
+        if (currentTime > 1.9 && currentTime < 2.1)
+            break;
+        [webView waitForNextPresentationUpdate];
+    }
+    EXPECT_NEAR(currentTime, 2.0, 0.1);
+}
+
+static void seekAndPlaceCaretBeforeVideo(TestWKWebView *webView, double seekTime)
+{
+    [webView objectByEvaluatingJavaScript:[NSString stringWithFormat:
+        @"document.querySelector('video').currentTime = %f;"
+        "let p = document.querySelectorAll('p')[0]; document.getSelection().setBaseAndExtent(p, 1, p, 1)", seekTime]];
+}
+
+static void seekAndPlaceCaretAfterVideo(TestWKWebView *webView, double seekTime)
+{
+    [webView objectByEvaluatingJavaScript:[NSString stringWithFormat:
+        @"document.querySelector('video').currentTime = %f;"
+        "let p = document.querySelectorAll('p')[1]; document.getSelection().setBaseAndExtent(p, 0, p, 0)", seekTime]];
+}
+
+TEST(WebKit, FindInPageVideoCaptionNearestCueForward)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 320, 500) configuration:configurationWithFindInVideoEnabled()]);
+    [webView loadTestPageNamed:@"video-with-caption-cues"];
+    [webView _test_waitForDidFinishNavigation];
+
+    // Playhead at 1.5, forward seeks to the next cue at 2s.
+    seekAndPlaceCaretBeforeVideo(webView.get(), 1.5);
+    findMatches(webView.get(), @"Birthday", noFindOptions, 1);
+    EXPECT_NEAR(waitForVideoCurrentTimeNear(webView.get(), 2.0), 2.0, 0.1);
+}
+
+TEST(WebKit, FindInPageVideoCaptionNearestCueBackward)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 320, 500) configuration:configurationWithFindInVideoEnabled()]);
+    [webView loadTestPageNamed:@"video-with-caption-cues"];
+    [webView _test_waitForDidFinishNavigation];
+
+    // Playhead at 1.5, backward seeks to the previous cue at 1s.
+    seekAndPlaceCaretAfterVideo(webView.get(), 1.5);
+    findMatches(webView.get(), @"Birthday", backwardsFindOptions, 1);
+    EXPECT_NEAR(waitForVideoCurrentTimeNear(webView.get(), 1.0), 1.0, 0.1);
+}
+
+TEST(WebKit, FindInPageVideoCaptionNearestCuePastAllForward)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 320, 500) configuration:configurationWithFindInVideoEnabled()]);
+    [webView loadTestPageNamed:@"video-with-caption-cues"];
+    [webView _test_waitForDidFinishNavigation];
+
+    // Playhead past every cue, forward falls back to the last cue at 3s.
+    seekAndPlaceCaretBeforeVideo(webView.get(), 5.0);
+    findMatches(webView.get(), @"Birthday", noFindOptions, 1);
+    EXPECT_NEAR(waitForVideoCurrentTimeNear(webView.get(), 3.0), 3.0, 0.1);
+}
+
+TEST(WebKit, FindInPageVideoCaptionNearestCueBeforeAllBackward)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 320, 500) configuration:configurationWithFindInVideoEnabled()]);
+    [webView loadTestPageNamed:@"video-with-caption-cues"];
+    [webView _test_waitForDidFinishNavigation];
+
+    // Playhead before every cue, backward falls back to the first cue at 1s.
+    seekAndPlaceCaretAfterVideo(webView.get(), 0.0);
+    findMatches(webView.get(), @"Birthday", backwardsFindOptions, 1);
+    EXPECT_NEAR(waitForVideoCurrentTimeNear(webView.get(), 1.0), 1.0, 0.1);
+}
+
+#endif // ENABLE(VIDEO)
+
 #endif // !PLATFORM(IOS_FAMILY)
 
 #if HAVE(UIFINDINTERACTION)
@@ -665,18 +816,6 @@ TEST(WebKit, FindInPageFullWord)
 
 #if ENABLE(VIDEO)
 
-static RetainPtr<WKWebViewConfiguration> configurationWithFindInVideoEnabled()
-{
-    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    for (_WKFeature *feature in [WKPreferences _features]) {
-        if ([feature.key isEqualToString:@"FindInVideoEnabled"]) {
-            [[configuration preferences] _setEnabled:YES forFeature:feature];
-            break;
-        }
-    }
-    return configuration;
-}
-
 TEST(WebKit, FindInPageVideoCaptionCues)
 {
     RetainPtr webView = adoptNS([[FindInPageTestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configurationWithFindInVideoEnabled()]);
@@ -691,17 +830,9 @@ TEST(WebKit, FindInPageVideoCaptionCues)
 
 static double currentTimeAfterHighlighting(TestWKWebView *webView, UITextRange *range, double expectedTime)
 {
+    // Highlighting a cue seeks the video asynchronously.
     [webView decorateFoundTextRange:range inDocument:nil usingStyle:(UITextSearchFoundTextStyle)_UIFoundTextStyleHighlighted];
-
-    // Highlighting a cue seeks the video asynchronously. Poll until it reaches the expected time.
-    double currentTime = 0;
-    for (unsigned attempt = 0; attempt < 100; ++attempt) {
-        currentTime = [[webView objectByEvaluatingJavaScript:@"document.querySelector('video').currentTime"] doubleValue];
-        if (currentTime > expectedTime - 0.1 && currentTime < expectedTime + 0.1)
-            break;
-        [webView waitForNextPresentationUpdate];
-    }
-    return currentTime;
+    return waitForVideoCurrentTimeNear(webView, expectedTime);
 }
 
 TEST(WebKit, FindInPageVideoCaptionCueSeeksVideo)


### PR DESCRIPTION
#### 462ce69479bd73f3f956d26e627dfc494d2aa2f9
<pre>
Find the caption cue nearest video&apos;s playhead from selection
<a href="https://bugs.webkit.org/show_bug.cgi?id=319163">https://bugs.webkit.org/show_bug.cgi?id=319163</a>
<a href="https://rdar.apple.com/182001231">rdar://182001231</a>

Reviewed by Andy Estes.

When a find starts from a selection, all of a video&apos;s matching cues
share the media element&apos;s document position, so the closest match
always resolved to the run&apos;s first/last cue.
Instead, pick the cue nearest the video&apos;s playhead in the search direction.

Added additional find-in-video navigation coverage on macOS, covering
both the new behavior and stepping through interleaved page text and
caption cues.

* Source/WebKit/WebProcess/WebPage/FindController.cpp:
(WebKit::cueIndexNearestPlayhead):
(WebKit::indexClosestToSelection):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FindInPage.mm:
(configurationWithFindInVideoEnabled):
(waitForVideoCurrentTimeNear):
(TEST(WebKit, FindInPageVideoCaptionStepThroughCues)):
(TEST(WebKit, FindInPageVideoCaptionCueInSubframe)):
(seekAndPlaceCaretBeforeVideo):
(seekAndPlaceCaretAfterVideo):
(TEST(WebKit, FindInPageVideoCaptionNearestCueForward)):
(TEST(WebKit, FindInPageVideoCaptionNearestCueBackward)):
(TEST(WebKit, FindInPageVideoCaptionNearestCuePastAllForward)):
(TEST(WebKit, FindInPageVideoCaptionNearestCueBeforeAllBackward)):
(currentTimeAfterHighlighting):

Canonical link: <a href="https://commits.webkit.org/317168@main">https://commits.webkit.org/317168@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/614ee8487ae667f6958e5bba75dea63b6caf8c6a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174408 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48341 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42122 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183985 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132276 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176273 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49633 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48023 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135672 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177366 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39107 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156466 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116150 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37748 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36116 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32466 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148171 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35958 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186411 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39627 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40313 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144585 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48008 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144443 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38963 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48687 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32578 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114241 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39345 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120638 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47194 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10922 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46596 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46827 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46654 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->