### PR TITLE
REGRESSION (316928@main): WebCore audit-spi should be disabled on non-iOS embedded platforms

### DIFF
--- a/Source/WebCore/Configurations/WebCore.xcconfig
+++ b/Source/WebCore/Configurations/WebCore.xcconfig
@@ -212,6 +212,11 @@ TEXT_BASED_API_FILE = WebCore.tbd
 // WebCore does build with InstallAPI by default, and unlike other frameworks
 // in our stack, its API surface is fully discoverable through binary analysis.
 WK_DEFAULT_WK_AUDIT_SPI[sdk=iphoneos*] = $(WK_NOT_$(WK_ANY_SANITIZER_ENABLED));
+// Explicitly disable auditing on other embedded platforms, because some SDKs
+// fall back to reading settings for iOS.
+WK_DEFAULT_WK_AUDIT_SPI[sdk=appletvos*] = ;
+WK_DEFAULT_WK_AUDIT_SPI[sdk=watchos*] = ;
+WK_DEFAULT_WK_AUDIT_SPI[sdk=xros*] = ;
 WK_AUDIT_SPI_ALLOWLISTS = $(SRCROOT)/Configurations/AllowedSPI.toml $(SRCROOT)/Configurations/AllowedSPI-legacy.toml $(WK_AUDIT_SPI_ALLOWLISTS_$(USE_INTERNAL_SDK));
 WK_AUDIT_SPI_ALLOWLISTS_YES = $(WK_WEBKITADDITIONS_HEADERS_FOLDER_PATH)/AllowedSPI/AllowedSPI-WebCore.toml;
 


### PR DESCRIPTION
#### 8e83fc1c7d6a2f1cb346ea7bdc486deec61f2db7
<pre>
REGRESSION (316928@main): WebCore audit-spi should be disabled on non-iOS embedded platforms
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=319166">https://bugs.webkit.org/show_bug.cgi?id=319166</a>&gt;
&lt;<a href="https://rdar.apple.com/182004010">rdar://182004010</a>&gt;

Unreviewed build fix.

* Source/WebCore/Configurations/WebCore.xcconfig:
(WK_DEFAULT_WK_AUDIT_SPI):
- Explicitly clear for tvOS, visionOS and watchOS.

Canonical link: <a href="https://commits.webkit.org/316970@main">https://commits.webkit.org/316970@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/52805b0446c76f9dba7ea98ae120ae4857a2ea19

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173983 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47916 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41697 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183557 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131851 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f1687fbb-3ec4-4feb-bdb8-0408c89e8a5e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175848 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49208 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47598 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135305 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5de41181-6583-4e85-9c46-e2fb57d4187c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176941 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38735 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156096 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115783 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d10462a6-87a5-461c-a1c9-cc2dfa886f5e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37376 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35743 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32041 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147800 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35589 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185983 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39056 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39941 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144206 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47583 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144065 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48262 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32206 "Failed to checkout and rebase branch from PR 69182") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113648 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26451 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38974 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120146 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46768 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10549 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46171 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46402 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46229 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->