### PR TITLE
AX: REGRESSION(308698@main): Voice Control only labels top-left web elements when the page scale isn't 1 (e.g. on desktop-width pages)

### DIFF
--- a/LayoutTests/accessibility/ios-simulator/root-scroll-view-frame-not-scaled-by-page-scale-expected.txt
+++ b/LayoutTests/accessibility/ios-simulator/root-scroll-view-frame-not-scaled-by-page-scale-expected.txt
@@ -1,0 +1,10 @@
+This test ensures the root scroll view's accessibility frame size is NOT scaled by the page scale factor.
+The root scroll view represents the on-screen viewport, whose size does not change when the page is zoomed (only the content within it scales).
+PASS: accessibilityController.accessibleElementById('target').x !== initialTargetX === true
+PASS: root.width / initialRootWidth was equal or approximately equal to 1.
+PASS: root.height / initialRootHeight was equal or approximately equal to 1.
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Click me

--- a/LayoutTests/accessibility/ios-simulator/root-scroll-view-frame-not-scaled-by-page-scale.html
+++ b/LayoutTests/accessibility/ios-simulator/root-scroll-view-frame-not-scaled-by-page-scale.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+<style>
+body { margin: 0; }
+#target { position: absolute; top: 200px; left: 100px; width: 80px; height: 30px; }
+</style>
+</head>
+<body>
+
+<button id="target">Click me</button>
+
+<script>
+var output = "This test ensures the root scroll view's accessibility frame size is NOT scaled by the page scale factor.\n";
+output += "The root scroll view represents the on-screen viewport, whose size does not change when the page is zoomed (only the content within it scales).\n";
+
+var root, initialRootWidth, initialRootHeight, initialTargetX;
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    (async function() {
+        await waitForFrameGeometryReady();
+
+        root = accessibilityController.rootElement;
+        initialRootWidth = root.width;
+        initialRootHeight = root.height;
+
+        initialTargetX = accessibilityController.accessibleElementById("target").x;
+
+        await testRunner.setPageScaleFactor(2, 0, 0);
+
+        // Wait for the scaled geometry to propagate to accessibility (a content element's screen
+        // position shifts as the page zooms).
+        await waitFor(() => accessibilityController.accessibleElementById("target").x !== initialTargetX);
+
+        // Verify the page scale genuinely took effect (content element moved in screen space).
+        output += expect("accessibilityController.accessibleElementById('target').x !== initialTargetX", "true");
+
+        // The regression: the root viewport must be unchanged by page zoom. Before the fix its
+        // width/height were multiplied by the page scale factor (ratio ~= 2 here instead of ~= 1).
+        root = accessibilityController.rootElement;
+        output += expectNumber("root.width / initialRootWidth", 1, /* allowedVariance */ 0.05);
+        output += expectNumber("root.height / initialRootHeight", 1, /* allowedVariance */ 0.05);
+
+        debug(output);
+        finishJSTest();
+    })();
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -592,7 +592,19 @@ FloatRect AccessibilityObject::convertFrameToSpace(const FloatRect& frameRect, A
 
         auto geometry = rootScrollView->frameGeometry();
 
-        auto scaledRect = geometry.screenTransform.mapRect(FloatRect(snappedFrameRect));
+        // The top-level page scroll view's own frame is in view/device space (the viewport). Every other
+        // object's frame is content-space. screenTransform is the content->screen page-zoom scale, so
+        // applying it to the already-device-space viewport double-scales it (viewport * pageZoom),
+        // shrinking the frame that Voice Control, Switch Control, etc. clips its set of visible elements
+        // against. Skip the transform for the top page scroll view's own frame only.
+        //
+        // Guard on "no ancestor scroll view" -- NOT isRoot(), which is also true for local iframe roots under
+        // ACCESSIBILITY_LOCAL_FRAME -- so iframe scroll views (content-space elementRect) are still scaled.
+        // No-op at page zoom 1.0 (screenTransform is identity).
+        const bool isTopPageScrollViewOwnFrame = this == rootScrollView.get() && !parentAccessibilityScrollView;
+        auto scaledRect = isTopPageScrollViewOwnFrame
+            ? FloatRect(snappedFrameRect)
+            : geometry.screenTransform.mapRect(FloatRect(snappedFrameRect));
 
         auto screenPosition = geometry.screenPosition;
 


### PR DESCRIPTION
#### 6e24445681b2ec7c2594f591da532f9c22b5617c
<pre>
AX: REGRESSION(308698@main): Voice Control only labels top-left web elements when the page scale isn&apos;t 1 (e.g. on desktop-width pages)
<a href="https://bugs.webkit.org/show_bug.cgi?id=319170">https://bugs.webkit.org/show_bug.cgi?id=319170</a>
<a href="https://rdar.apple.com/181036467">rdar://181036467</a>

Reviewed by Chris Fleizach and Dominic Mazzoni.

On desktop-width pages that don&apos;t opt into mobile layout, Safari auto-fits the
content to the device width, so the page scale is &lt; 1 on load (e.g. ~0.39) with
no user zooming. In that state Voice Control &quot;show numbers&quot; only labelled elements
in the top-left of the web view (e.g. BitBucket, The Verge -- not mobile-optimized
sites like Wikipedia, whose page scale is 1).

Voice Control and other ATs clip candidates to each element&apos;s visible frame, intersected
against the web page&apos;s root scroll view frame. convertFrameToSpace() maps a
frame to screen space via screenTransform, the content-to-screen page-scale --
correct for element rects (content space), but the top page scroll view&apos;s own
frame from AccessibilityScrollView::elementRect() is already view/device space
(the viewport). Applying screenTransform double-scales it to viewport * pageScale
(e.g. 154x334 instead of 393x852), so on-screen elements outside that shrunken
rect were pruned.

Skip screenTransform for the top page scroll view&apos;s own frame.

* LayoutTests/accessibility/ios-simulator/root-scroll-view-frame-not-scaled-by-page-scale-expected.txt: Added.
* LayoutTests/accessibility/ios-simulator/root-scroll-view-frame-not-scaled-by-page-scale.html: Added.
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::convertFrameToSpace const):

Canonical link: <a href="https://commits.webkit.org/317042@main">https://commits.webkit.org/317042@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/40d91eea8e26afc241aa401e7b99772b9b223aa9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174008 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47941 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41722 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183582 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131876 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e419f3c7-d465-4de9-b333-cca4b34bc519) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175873 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49233 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47623 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135322 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95426 "5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/89567e0d-173e-4a7d-a38d-0e51c7dba05a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176966 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38753 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156114 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115800 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b447aec5-ed0f-43cb-bbe4-949401227370) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37394 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35762 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32066 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147818 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35607 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186008 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39088 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39960 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144224 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47608 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155669 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144083 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38875 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48287 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32224 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/held.https.any.sharedworker.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113685 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38992 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120171 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46793 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10568 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46196 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46427 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46254 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->