### PR TITLE
Web Inspector: Sources: show WebAssembly modules

### DIFF
--- a/LayoutTests/inspector/debugger/wasm/getScriptSource-expected.txt
+++ b/LayoutTests/inspector/debugger/wasm/getScriptSource-expected.txt
@@ -1,0 +1,35 @@
+Tests the script metadata and source reported for WebAssembly modules.
+
+
+== Running test suite: Debugger.getScriptSource.WebAssembly
+-- Running test case: Debugger.getScriptSource.WebAssembly.ModuleCreatedBeforeInspector
+PASS: Should discover a WebAssembly module that has not been instantiated.
+"inspector/debugger/wasm/<identifier>.wasm"
+PASS: WebAssembly scripts should not expose source content.
+
+-- Running test case: Debugger.getScriptSource.WebAssembly.SharedModule
+"inspector/debugger/wasm/<identifier>.wasm"
+PASS: WebAssembly scripts should not expose source content.
+PASS: Should report one script for multiple instances of the same module.
+
+-- Running test case: Debugger.getScriptSource.WebAssembly.DefaultURL
+"inspector/debugger/wasm/<identifier>.wasm"
+PASS: WebAssembly scripts should not expose source content.
+
+-- Running test case: Debugger.getScriptSource.WebAssembly.ModuleName
+"inspector/debugger/wasm/<identifier>.wasm"
+PASS: WebAssembly scripts should not expose source content.
+PASS: Should report the module name separately from its URL.
+
+-- Running test case: Debugger.getScriptSource.WebAssembly.StreamingURL
+"data:application/wasm;base64,AGFzbQEAAAABBwFgAn9/AX8DAgEABQMBAAEHEAIDYWRkAAAGbWVtb3J5AgAKCQEHACAAIAFqCwAaBG5hbWUAExJzdHJlYW1lZC1uYW1lLndhc20="
+PASS: WebAssembly scripts should not expose source content.
+PASS: Should report the WebAssembly module's real URL.
+PASS: Should report the module name separately from its URL.
+
+-- Running test case: Debugger.getScriptSource.WebAssembly.ModuleLoaderOpaqueURL
+"data:application/wasm;base64,AGFzbQEAAAABBwFgAn9/AX8DAgEABQMBAAEHEAIDYWRkAAAGbWVtb3J5AgAKCQEHACAAIAFqCwAfBG5hbWUAGBdtb2R1bGUtbG9hZGVyLW5hbWUud2FzbQ=="
+PASS: WebAssembly scripts should not expose source content.
+PASS: Should report the WebAssembly module's real URL.
+PASS: Should report the module name separately from its URL.
+

--- a/LayoutTests/inspector/debugger/wasm/getScriptSource.html
+++ b/LayoutTests/inspector/debugger/wasm/getScriptSource.html
@@ -1,0 +1,233 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../http/tests/inspector/resources/protocol-test.js"></script>
+<script src="../../../resources/wasm-builder.js"></script>
+<script src="resources/test-modules.js"></script>
+<script>
+function wasmDataURL(bytes)
+{
+    return "data:application/wasm;base64," + btoa(String.fromCharCode(...bytes));
+}
+
+let wasmInstances = new Set;
+let wasmModules = new Set;
+let wasmModuleNamespaces = new Set;
+function compileWasmBytes(bytes)
+{
+    let module = new WebAssembly.Module(bytes);
+    wasmModules.add(module);
+    return module;
+}
+
+function instantiateWasmModule(wasmModule, imports)
+{
+    let instance = new WebAssembly.Instance(wasmModule, imports);
+    wasmInstances.add(instance);
+    return instance;
+}
+
+function instantiateWasmBytes(bytes, imports)
+{
+    return instantiateWasmModule(compileWasmBytes(bytes), imports);
+}
+
+function instantiateWasm(bytes, {imports, streaming} = {})
+{
+    if (streaming) {
+        return WebAssembly.instantiateStreaming(fetch(wasmDataURL(bytes)), imports).then((result) => {
+            wasmInstances.add(result.instance);
+            return result;
+        });
+    }
+
+    return instantiateWasmBytes(bytes, imports);
+}
+
+function importWasmURL(url)
+{
+    return import(url).then((namespace) => {
+        wasmModuleNamespaces.add(namespace);
+        return namespace;
+    });
+}
+
+function importWasm(bytes)
+{
+    return importWasmURL(wasmDataURL(bytes));
+}
+
+let wasmModuleCreatedBeforeInspector = compileWasmBytes(createAddWasmBytes());
+
+function test()
+{
+    let webAssemblyScriptType = "webassembly";
+    let mainExecutionContextId = null;
+    let pendingDumpPromise = null;
+    let wasmScripts = [];
+    let debuggerEnabled;
+
+    function sanitizeWasmURL(url)
+    {
+        return sanitizeURL(url).replace(/\d+\.wasm$/, "<identifier>.wasm");
+    }
+
+    async function dump(script)
+    {
+        let {scriptSource} = await InspectorProtocol.awaitCommand({
+            method: "Debugger.getScriptSource",
+            params: {scriptId: script.scriptId},
+        });
+        ProtocolTest.assert(script.scriptType === webAssemblyScriptType, "Should be WebAssembly.");
+        ProtocolTest.assert(Number.isInteger(script.executionContextId), "Should identify the creating execution context.");
+        ProtocolTest.assert(script.executionContextId === mainExecutionContextId, "Should identify the execution context that created the WebAssembly module.");
+        ProtocolTest.assert(!script.endLine, "WebAssembly scripts should use a single logical line.");
+        ProtocolTest.assert(script.endColumn > script.startColumn, "WebAssembly scripts should report their bytecode range.");
+        ProtocolTest.log(JSON.stringify(sanitizeWasmURL(script.url)));
+        ProtocolTest.expectEqual(scriptSource, "", "WebAssembly scripts should not expose source content.");
+    }
+
+    InspectorProtocol.eventHandler["Debugger.scriptParsed"] = async function({params: script}) {
+        if (script.scriptType !== webAssemblyScriptType)
+            return;
+
+        wasmScripts.push(script);
+
+        if (!pendingDumpPromise)
+            return;
+
+        let dumpPromise = pendingDumpPromise;
+        pendingDumpPromise = null;
+
+        try {
+            await dump(script);
+            dumpPromise.resolve(script);
+        } catch (error) {
+            dumpPromise.reject(error);
+        }
+    };
+
+    async function evaluateAndDump(expression)
+    {
+        console.assert(!pendingDumpPromise);
+        let dumpPromise = Promise.withResolvers();
+        pendingDumpPromise = dumpPromise;
+
+        try {
+            let evaluationPromise = InspectorProtocol.awaitCommand({method: "Runtime.evaluate", params: {expression}}).then(async (response) => {
+                if (response.wasThrown)
+                    throw JSON.stringify(response);
+                if (response.result.className !== "Promise")
+                    return;
+
+                response = await InspectorProtocol.awaitCommand({
+                    method: "Runtime.awaitPromise",
+                    params: {promiseObjectId: response.result.objectId},
+                });
+                if (response.wasThrown)
+                    throw JSON.stringify(response);
+            });
+
+            let [script] = await Promise.all([dumpPromise.promise, evaluationPromise]);
+            return script;
+        } finally {
+            if (pendingDumpPromise === dumpPromise)
+                pendingDumpPromise = null;
+        }
+    }
+
+    InspectorProtocol.eventHandler["Runtime.executionContextCreated"] = function({params: {context}}) {
+        mainExecutionContextId ??= context.id;
+    };
+
+    debuggerEnabled = (async function() {
+        await InspectorProtocol.awaitCommand({method: "Runtime.enable", params: {}});
+        ProtocolTest.assert(Number.isInteger(mainExecutionContextId), "Should report the main execution context.");
+        await InspectorProtocol.awaitCommand({method: "Debugger.enable", params: {}});
+    })();
+
+    let suite = ProtocolTest.createAsyncSuite("Debugger.getScriptSource.WebAssembly");
+
+    suite.addTestCase({
+        name: "Debugger.getScriptSource.WebAssembly.ModuleCreatedBeforeInspector",
+        description: "A live WebAssembly module created but never instantiated before Web Inspector opens should be discovered when the Debugger is enabled.",
+        async test() {
+            await debuggerEnabled;
+
+            ProtocolTest.expectTrue(wasmScripts.length, "Should discover a WebAssembly module that has not been instantiated.");
+
+            for (let script of wasmScripts)
+                await dump(script);
+        }
+    });
+
+    suite.addTestCase({
+        name: "Debugger.getScriptSource.WebAssembly.SharedModule",
+        description: "Multiple instances of the same WebAssembly.Module should share one script.",
+        async test() {
+            await debuggerEnabled;
+
+            let previousScriptCount = wasmScripts.length;
+            await evaluateAndDump(`(() => {
+                let module = new WebAssembly.Module(createAddWasmBytes());
+                instantiateWasmModule(module);
+                instantiateWasmModule(module);
+            })()`);
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            ProtocolTest.expectEqual(wasmScripts.length, previousScriptCount + 1, "Should report one script for multiple instances of the same module.");
+        }
+    });
+
+    [
+        {
+            name: "DefaultURL",
+            description: "A WebAssembly module should use a URL derived from its frame when no response URL is available.",
+            expression: `instantiateWasm(createAddWasmBytes())`,
+        },
+        {
+            name: "ModuleName",
+            description: "A byte-created WebAssembly module should use its name section as a display name without replacing its unique URL.",
+            expression: `instantiateWasm(createNamedAddWasmBytes("named-math.wasm"))`,
+            expectedDisplayName: "named-math.wasm",
+        },
+        {
+            name: "StreamingURL",
+            description: "A streaming WebAssembly module should preserve its response URL while using its name section to label an opaque data URL.",
+            expression: `instantiateWasm(createNamedAddWasmBytes("streamed-name.wasm"), {streaming: true})`,
+            expectedURLPrefix: "data:application/wasm;base64,",
+            expectedDisplayName: "streamed-name.wasm",
+        },
+        {
+            name: "ModuleLoaderOpaqueURL",
+            description: "A WebAssembly module imported by the module loader should preserve its module URL while using its name section to label an opaque data URL.",
+            expression: `importWasm(createNamedAddWasmBytes("module-loader-name.wasm"))`,
+            expectedURLPrefix: "data:application/wasm;base64,",
+            expectedDisplayName: "module-loader-name.wasm",
+        },
+    ].forEach(function({name, description, expression, expectedURLPrefix, expectedURLSuffix, expectedDisplayName}) {
+        suite.addTestCase({
+            name: "Debugger.getScriptSource.WebAssembly." + name,
+            description,
+            async test() {
+                await debuggerEnabled;
+                let script = await evaluateAndDump(expression);
+                if (expectedURLPrefix)
+                    ProtocolTest.expectTrue(script.url.startsWith(expectedURLPrefix), "Should report the WebAssembly module's real URL.");
+                if (expectedURLSuffix)
+                    ProtocolTest.expectTrue(script.url.endsWith(expectedURLSuffix), "Should report the WebAssembly module's real URL.");
+                if (expectedDisplayName)
+                    ProtocolTest.expectEqual(script.displayName, expectedDisplayName, "Should report the module name separately from its URL.");
+                else if (expectedDisplayName === null)
+                    ProtocolTest.expectFalse("displayName" in script, "Should derive the display name from the real URL.");
+            },
+        });
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Tests the script metadata and source reported for WebAssembly modules.</p>
+</body>
+</html>

--- a/LayoutTests/inspector/debugger/wasm/resources/test-modules.js
+++ b/LayoutTests/inspector/debugger/wasm/resources/test-modules.js
@@ -1,0 +1,78 @@
+function encodeULEB(value)
+{
+    let result = [];
+    do {
+        let byte = value & 0x7f;
+        value >>>= 7;
+        result.push(byte | (value ? 0x80 : 0));
+    } while (value);
+    return result;
+}
+
+function encodeWasmName(name)
+{
+    let bytes = new TextEncoder().encode(name);
+    return [...encodeULEB(bytes.length), ...bytes];
+}
+
+function encodeNameMap(entries)
+{
+    let result = encodeULEB(entries.length);
+    for (let [index, name] of entries)
+        result.push(...encodeULEB(index), ...encodeWasmName(name));
+    return result;
+}
+
+function encodeNameSubsection(type, payload)
+{
+    return [type, ...encodeULEB(payload.length), ...payload];
+}
+
+function addNameSection(builder, {moduleName, functionNames = [], localNames = []})
+{
+    let bytes = [];
+    if (moduleName !== undefined)
+        bytes.push(...encodeNameSubsection(0, encodeWasmName(moduleName)));
+    if (functionNames.length)
+        bytes.push(...encodeNameSubsection(1, encodeNameMap(functionNames)));
+    if (localNames.length) {
+        let localNameMap = encodeULEB(localNames.length);
+        for (let [functionIndex, entries] of localNames)
+            localNameMap.push(...encodeULEB(functionIndex), ...encodeNameMap(entries));
+        bytes.push(...encodeNameSubsection(2, localNameMap));
+    }
+
+    let section = builder.Unknown("name");
+    for (let byte of bytes)
+        section = section.Byte(byte);
+    return section.End();
+}
+
+function createAddWasmBuilder()
+{
+    let builder = new Builder();
+    return builder.Type().End()
+        .Function().End()
+        .Memory().InitialMaxPages(1).End()
+        .Export()
+            .Function("add")
+            .Memory("memory", 0)
+            .End()
+        .Code()
+            .Function("add", {params: ["i32", "i32"], ret: "i32"})
+                .GetLocal(0)
+                .GetLocal(1)
+                .I32Add()
+                .End()
+            .End();
+}
+
+function createAddWasmBytes()
+{
+    return createAddWasmBuilder().WebAssembly().get();
+}
+
+function createNamedAddWasmBytes(moduleName)
+{
+    return addNameSection(createAddWasmBuilder(), {moduleName}).WebAssembly().get();
+}

--- a/LayoutTests/inspector/model/frame-extra-scripts-expected.txt
+++ b/LayoutTests/inspector/model/frame-extra-scripts-expected.txt
@@ -2,6 +2,7 @@ CONSOLE MESSAGE: dynamically added script element
 WI.Frame.extraScriptCollection.
 
 
+
 == Running test suite: WI.Frame.extraScriptCollection
 -- Running test case: FrameHasNoExtraScriptsYet
 PASS: Main frame should have no dynamic scripts.
@@ -10,4 +11,35 @@ PASS: Main frame should have no dynamic scripts.
 PASS: ExtraScriptAdded event fired.
 PASS: Script should identify as dynamic.
 PASS: Main frame should have 1 dynamic script.
+
+-- Running test case: AssociateDynamicJavaScriptWithChildFrame
+PASS: The child frames should have the same URL.
+PASS: The dynamic JavaScript script should belong to the second child frame.
+PASS: The first child frame should not contain the second child frame's dynamic JavaScript script.
+PASS: The second child frame should contain its dynamic JavaScript script.
+
+-- Running test case: AssociateJavaScriptWithChildFrame
+PASS: The JavaScript script should be associated with a Resource.
+PASS: The JavaScript script should belong to the first child frame.
+PASS: The resource-backed JavaScript script should not be an extra script.
+
+-- Running test case: AddWebAssemblyScriptToMainFrame
+PASS: The WebAssembly script should not be associated with a Resource.
+PASS: The WebAssembly script should belong to the main frame.
+PASS: The main frame should contain the WebAssembly script.
+PASS: The WebAssembly script should use its module name for display.
+
+-- Running test case: AddWebAssemblyScriptToChildFrame
+PASS: The child frames should have the same URL.
+PASS: The first WebAssembly script should belong to the first child frame.
+PASS: The main frame should not contain the first child frame's WebAssembly script.
+PASS: The first child frame should contain its WebAssembly script.
+PASS: The second child frame should not contain the first child frame's WebAssembly script.
+PASS: The first WebAssembly script should use its module name for display.
+PASS: The second WebAssembly script should belong to the second child frame.
+PASS: The main frame should not contain the second child frame's WebAssembly script.
+PASS: The first child frame should not contain the second child frame's WebAssembly script.
+PASS: The second child frame should contain its WebAssembly script.
+PASS: The second WebAssembly script should use its module name for display.
+PASS: Equal module names should not replace the scripts' unique URLs.
 

--- a/LayoutTests/inspector/model/frame-extra-scripts.html
+++ b/LayoutTests/inspector/model/frame-extra-scripts.html
@@ -2,6 +2,8 @@
 <html>
 <head>
 <script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script src="../../resources/wasm-builder.js"></script>
+<script src="../debugger/wasm/resources/test-modules.js"></script>
 <script>
 function triggerAddScriptElement() {
     let script = document.createElement("script");
@@ -9,11 +11,79 @@ function triggerAddScriptElement() {
     document.body.appendChild(script);
 }
 
+function loadScriptInFrame(frameName)
+{
+    let script = frames[frameName].document.createElement("script");
+    script.src = new URL("../../resources/wasm-builder.js?frame=" + frameName, location.href).href;
+    frames[frameName].document.head.appendChild(script);
+}
+
+function triggerAddScriptElementInFrame(frameName)
+{
+    let script = frames[frameName].document.createElement("script");
+    script.text = "window.dynamicScriptWasAdded = Boolean(true);";
+    frames[frameName].document.body.appendChild(script);
+}
+
+let wasmInstances = [];
+function instantiateWasmInFrame(frameName, moduleName)
+{
+    let targetWindow = frameName === undefined ? window : frames[frameName];
+    let module = new targetWindow.WebAssembly.Module(createNamedAddWasmBytes(moduleName));
+    wasmInstances.push(new targetWindow.WebAssembly.Instance(module));
+}
+
 function test()
 {
     let suite = InspectorTest.createAsyncSuite("WI.Frame.extraScriptCollection");
 
     let mainFrame = WI.networkManager.mainFrame;
+
+    async function targetForFrame(frame)
+    {
+        if (!WI.isSiteIsolationEnabled())
+            return WI.mainTarget;
+
+        let match = frame.id.match(/^frame-(\d+)\.(\d+)$/);
+        console.assert(match);
+        let targetIdentifier = `frame-${match[2]}-${match[1]}`;
+
+        while (true) {
+            let target = WI.targetManager.targetForIdentifier(targetIdentifier);
+            if (target)
+                return target;
+            await WI.targetManager.awaitEvent(WI.TargetManager.Event.TargetAdded);
+        }
+    }
+
+    function scriptsForAllTargets()
+    {
+        let scripts = [];
+        for (let target of WI.targets) {
+            if (target.hasDomain("Debugger"))
+                scripts.pushAll(WI.debuggerManager.dataForTarget(target).scripts);
+        }
+        return scripts;
+    }
+
+    async function evaluateAndAwaitScript(frame, expression, predicate)
+    {
+        let knownScripts = new Set(scriptsForAllTargets());
+        await InspectorTest.evaluateInPage(expression);
+
+        let targetData = WI.debuggerManager.dataForTarget(await targetForFrame(frame));
+        while (true) {
+            let script = targetData.scripts.find((script) => predicate(script) && !knownScripts.has(script));
+            if (script)
+                return script;
+            await WI.debuggerManager.awaitEvent(WI.DebuggerManager.Event.ScriptAdded);
+        }
+    }
+
+    function evaluateAndAwaitWebAssemblyScript(frame, expression)
+    {
+        return evaluateAndAwaitScript(frame, expression, (script) => script.sourceType === WI.Script.SourceType.WebAssembly);
+    }
 
     suite.addTestCase({
         name: "FrameHasNoExtraScriptsYet",
@@ -40,11 +110,85 @@ function test()
         }
     });
 
+    suite.addTestCase({
+        name: "AssociateDynamicJavaScriptWithChildFrame",
+        description: "A dynamic JavaScript script should belong to the exact child frame for its execution context.",
+        async test() {
+            let childFrames = Array.from(mainFrame.childFrameCollection);
+            let firstChildFrame = childFrames.find((frame) => frame.name === "first");
+            let secondChildFrame = childFrames.find((frame) => frame.name === "second");
+            InspectorTest.assert(firstChildFrame, "Should find the first child frame.");
+            InspectorTest.assert(secondChildFrame, "Should find the second child frame.");
+            InspectorTest.expectEqual(firstChildFrame.url, secondChildFrame.url, "The child frames should have the same URL.");
+
+            let script = await evaluateAndAwaitScript(secondChildFrame, "triggerAddScriptElementInFrame('second')", (script) => script.dynamicallyAddedScriptElement);
+            InspectorTest.expectEqual(script.parentFrame, secondChildFrame, "The dynamic JavaScript script should belong to the second child frame.");
+            InspectorTest.expectFalse(firstChildFrame.extraScriptCollection.has(script), "The first child frame should not contain the second child frame's dynamic JavaScript script.");
+            InspectorTest.expectTrue(secondChildFrame.extraScriptCollection.has(script), "The second child frame should contain its dynamic JavaScript script.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "AssociateJavaScriptWithChildFrame",
+        description: "A JavaScript script should belong to the child frame for its execution context.",
+        async test() {
+            let firstChildFrame = Array.from(mainFrame.childFrameCollection).find((frame) => frame.name === "first");
+            InspectorTest.assert(firstChildFrame, "Should find the first child frame.");
+
+            let script = await evaluateAndAwaitScript(firstChildFrame, "loadScriptInFrame('first')", (script) => script.url.includes("wasm-builder.js?frame=first"));
+            InspectorTest.expectNotNull(script.resource, "The JavaScript script should be associated with a Resource.");
+            InspectorTest.expectEqual(script.parentFrame, firstChildFrame, "The JavaScript script should belong to the first child frame.");
+            InspectorTest.expectFalse(firstChildFrame.extraScriptCollection.has(script), "The resource-backed JavaScript script should not be an extra script.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "AddWebAssemblyScriptToMainFrame",
+        description: "A WebAssembly script should belong to the main frame that created it.",
+        async test() {
+            let script = await evaluateAndAwaitWebAssemblyScript(mainFrame, "instantiateWasmInFrame(undefined, 'main-frame-math.wasm')");
+            InspectorTest.expectNull(script.resource, "The WebAssembly script should not be associated with a Resource.");
+            InspectorTest.expectEqual(script.parentFrame, mainFrame, "The WebAssembly script should belong to the main frame.");
+            InspectorTest.expectTrue(mainFrame.extraScriptCollection.has(script), "The main frame should contain the WebAssembly script.");
+            InspectorTest.expectEqual(script.displayName, "main-frame-math.wasm", "The WebAssembly script should use its module name for display.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "AddWebAssemblyScriptToChildFrame",
+        description: "A WebAssembly script should belong to the exact child frame that created it.",
+        async test() {
+            let childFrames = Array.from(mainFrame.childFrameCollection);
+            let firstChildFrame = childFrames.find((frame) => frame.name === "first");
+            let secondChildFrame = childFrames.find((frame) => frame.name === "second");
+            InspectorTest.assert(firstChildFrame, "Should find the first child frame.");
+            InspectorTest.assert(secondChildFrame, "Should find the second child frame.");
+            InspectorTest.expectEqual(firstChildFrame.url, secondChildFrame.url, "The child frames should have the same URL.");
+
+            let firstScript = await evaluateAndAwaitWebAssemblyScript(firstChildFrame, "instantiateWasmInFrame('first', 'shared-frame-math.wasm')");
+            InspectorTest.expectEqual(firstScript.parentFrame, firstChildFrame, "The first WebAssembly script should belong to the first child frame.");
+            InspectorTest.expectFalse(mainFrame.extraScriptCollection.has(firstScript), "The main frame should not contain the first child frame's WebAssembly script.");
+            InspectorTest.expectTrue(firstChildFrame.extraScriptCollection.has(firstScript), "The first child frame should contain its WebAssembly script.");
+            InspectorTest.expectFalse(secondChildFrame.extraScriptCollection.has(firstScript), "The second child frame should not contain the first child frame's WebAssembly script.");
+            InspectorTest.expectEqual(firstScript.displayName, "shared-frame-math.wasm", "The first WebAssembly script should use its module name for display.");
+
+            let secondScript = await evaluateAndAwaitWebAssemblyScript(secondChildFrame, "instantiateWasmInFrame('second', 'shared-frame-math.wasm')");
+            InspectorTest.expectEqual(secondScript.parentFrame, secondChildFrame, "The second WebAssembly script should belong to the second child frame.");
+            InspectorTest.expectFalse(mainFrame.extraScriptCollection.has(secondScript), "The main frame should not contain the second child frame's WebAssembly script.");
+            InspectorTest.expectFalse(firstChildFrame.extraScriptCollection.has(secondScript), "The first child frame should not contain the second child frame's WebAssembly script.");
+            InspectorTest.expectTrue(secondChildFrame.extraScriptCollection.has(secondScript), "The second child frame should contain its WebAssembly script.");
+            InspectorTest.expectEqual(secondScript.displayName, "shared-frame-math.wasm", "The second WebAssembly script should use its module name for display.");
+            InspectorTest.expectNotEqual(firstScript.url, secondScript.url, "Equal module names should not replace the scripts' unique URLs.");
+        }
+    });
+
     suite.runTestCasesAndFinish();
 }
 </script>
 </head>
 <body onload="runTest()">
 <p>WI.Frame.extraScriptCollection.</p>
+<iframe name="first" src="../page/resources/blank.html"></iframe>
+<iframe name="second" src="../page/resources/blank.html"></iframe>
 </body>
 </html>

--- a/LayoutTests/inspector/worker/debugger-getScriptSource-wasm-expected.txt
+++ b/LayoutTests/inspector/worker/debugger-getScriptSource-wasm-expected.txt
@@ -1,0 +1,15 @@
+Tests WebAssembly script discovery for instances created in a Worker before and after Web Inspector opens.
+
+
+== Running test suite: Worker.Debugger.WebAssembly
+-- Running test case: Worker.Debugger.WebAssembly.InstanceCreatedBeforeInspector
+PASS: The WebAssembly script should not replace the Worker's main script.
+PASS: The WebAssembly script should not be associated with the Worker script's Resource.
+PASS: The WebAssembly script should be listed separately under the Worker.
+"inspector/worker/resources/<identifier>.wasm"
+PASS: WebAssembly scripts should not expose source content.
+
+-- Running test case: Worker.Debugger.WebAssembly.InstanceCreatedAfterInspector
+"inspector/worker/resources/<identifier>.wasm"
+PASS: WebAssembly scripts should not expose source content.
+

--- a/LayoutTests/inspector/worker/debugger-getScriptSource-wasm.html
+++ b/LayoutTests/inspector/worker/debugger-getScriptSource-wasm.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script src="resources/worker-utilities.js"></script>
+<script>
+let workerPromise = Promise.withResolvers();
+let worker = new Worker("resources/worker-debugger-wasm.js");
+worker.addEventListener("message", ({data}) => {
+    if (data === "ready")
+        workerPromise.resolve();
+});
+worker.addEventListener("error", workerPromise.reject);
+
+async function test()
+{
+    function sanitizeWasmURL(url)
+    {
+        return sanitizeURL(url).replace(/\d+\.wasm$/, "<identifier>.wasm");
+    }
+
+    function findWasmScript(workerTarget, ignoredScripts)
+    {
+        return WI.debuggerManager.dataForTarget(workerTarget).scripts.find((script) => script.sourceType === WI.Script.SourceType.WebAssembly && !ignoredScripts.has(script));
+    }
+
+    async function awaitWasmScript(workerTarget, ignoredScripts = new Set)
+    {
+        while (true) {
+            let script = findWasmScript(workerTarget, ignoredScripts);
+            if (script)
+                return script;
+            await WI.debuggerManager.awaitEvent(WI.DebuggerManager.Event.ScriptAdded);
+        }
+    }
+
+    let workerTarget = await window.awaitTarget((target) => target instanceof WI.WorkerTarget && target.displayName.endsWith("worker-debugger-wasm.js"));
+
+    async function dump(script)
+    {
+        let {content} = await script.requestContent();
+        InspectorTest.assert(script.target === workerTarget, "Should belong to the Worker target.");
+        InspectorTest.assert(script.sourceType === WI.Script.SourceType.WebAssembly, "Should be WebAssembly.");
+        InspectorTest.log(JSON.stringify(sanitizeWasmURL(script.url)));
+        InspectorTest.expectEqual(content, "", "WebAssembly scripts should not expose source content.");
+    }
+
+    let suite = InspectorTest.createAsyncSuite("Worker.Debugger.WebAssembly");
+
+    suite.addTestCase({
+        name: "Worker.Debugger.WebAssembly.InstanceCreatedBeforeInspector",
+        description: "A live WebAssembly instance created in a Worker before Web Inspector opens should be discovered when the Worker debugger is enabled.",
+        async test() {
+            let script = await awaitWasmScript(workerTarget);
+            InspectorTest.expectFalse(script.isMainResource(), "The WebAssembly script should not replace the Worker's main script.");
+            InspectorTest.expectNull(script.resource, "The WebAssembly script should not be associated with the Worker script's Resource.");
+            InspectorTest.expectTrue(workerTarget.extraScriptCollection.has(script), "The WebAssembly script should be listed separately under the Worker.");
+            await dump(script);
+        },
+    });
+
+    suite.addTestCase({
+        name: "Worker.Debugger.WebAssembly.InstanceCreatedAfterInspector",
+        description: "A WebAssembly instance created in a Worker after Web Inspector opens should be reported to the Worker debugger.",
+        async test() {
+            let ignoredScripts = new Set(WI.debuggerManager.dataForTarget(workerTarget).scripts);
+            let [script] = await Promise.all([
+                awaitWasmScript(workerTarget, ignoredScripts),
+                InspectorTest.evaluateInPage("worker.postMessage('instantiate')"),
+            ]);
+            await dump(script);
+        },
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="testRunner.waitUntilDone(); workerPromise.promise.then(runTest)">
+<p>Tests WebAssembly script discovery for instances created in a Worker before and after Web Inspector opens.</p>
+</body>
+</html>

--- a/LayoutTests/inspector/worker/resources/worker-debugger-wasm.js
+++ b/LayoutTests/inspector/worker/resources/worker-debugger-wasm.js
@@ -1,0 +1,17 @@
+importScripts("../../../resources/wasm-builder.js", "../../debugger/wasm/resources/test-modules.js");
+
+let wasmBytes = createAddWasmBytes();
+let wasmInstances = [];
+
+function instantiateWasm(bytes)
+{
+    let wasmModule = new WebAssembly.Module(bytes);
+    wasmInstances.push(new WebAssembly.Instance(wasmModule));
+}
+
+instantiateWasm(wasmBytes);
+addEventListener("message", ({data}) => {
+    if (data === "instantiate")
+        instantiateWasm(wasmBytes);
+});
+postMessage("ready");

--- a/Source/JavaScriptCore/debugger/Debugger.cpp
+++ b/Source/JavaScriptCore/debugger/Debugger.cpp
@@ -28,16 +28,25 @@
 #include "HeapIterationScope.h"
 #include "JSAsyncFunctionGenerator.h"
 #include "JSCInlines.h"
+#include "JSWebAssemblyModule.h"
 #include "MarkedSpaceInlines.h"
+#include "MarkedVector.h"
 #include "Microtask.h"
+#include "SourceOrigin.h"
+#include "SourceProvider.h"
 #include "VMEntryScopeInlines.h"
 #include "VMTrapsInlines.h"
+#include "WasmModuleInformation.h"
+#include <atomic>
+#include <wtf/CheckedArithmetic.h>
 #include <wtf/ForbidHeapAllocation.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/RefPtr.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/URL.h>
 #include <wtf/Vector.h>
+#include <wtf/text/MakeString.h>
 #include <wtf/text/TextPosition.h>
 
 namespace JSC {
@@ -173,6 +182,9 @@ void Debugger::attach(JSGlobalObject* globalObject)
 
     // Call `sourceParsed` after iterating because it will execute JavaScript in Web Inspector.
     UncheckedKeyHashSet<RefPtr<SourceProvider>> sourceProviders;
+#if ENABLE(WEBASSEMBLY)
+    MarkedVector<JSWebAssemblyModule*> wasmModules;
+#endif
     {
         JSLockHolder locker(m_vm);
         HeapIterationScope iterationScope(m_vm.heap);
@@ -183,12 +195,22 @@ void Debugger::attach(JSGlobalObject* globalObject)
                     if (function->scope()->realm() == globalObject && function->executable()->isFunctionExecutable() && !function->isHostOrBuiltinFunction())
                         sourceProviders.add(uncheckedDowncast<FunctionExecutable>(function->executable())->source().provider());
                 }
+#if ENABLE(WEBASSEMBLY)
+                else if (auto* module = dynamicDowncast<JSWebAssemblyModule>(cell)) {
+                    if (module->realm() == globalObject)
+                        wasmModules.append(module);
+                }
+#endif
             }
             return IterationStatus::Continue;
         });
     }
     for (auto& sourceProvider : sourceProviders)
         sourceParsed(globalObject, sourceProvider.get(), -1, nullString());
+#if ENABLE(WEBASSEMBLY)
+    for (auto* module : wasmModules)
+        sourceParsed(globalObject, module);
+#endif
 }
 
 void Debugger::detach(JSGlobalObject* globalObject, ReasonForDetach reason)
@@ -324,8 +346,12 @@ void Debugger::removeObserver(Observer& observer, bool isBeingDestroyed)
 {
     m_observers.remove(&observer);
 
-    if (m_observers.isEmpty())
-        detachDebugger(isBeingDestroyed);
+    if (!m_observers.isEmpty())
+        return;
+
+    m_reportedSourceIDs.clear();
+
+    detachDebugger(isBeingDestroyed);
 }
 
 bool Debugger::canDispatchFunctionToObservers() const
@@ -354,6 +380,10 @@ void Debugger::sourceParsed(JSGlobalObject* globalObject, SourceProvider* source
     if (!canDispatchFunctionToObservers())
         return;
 
+    JSC::SourceID sourceID = sourceProvider->asID();
+    if (!m_reportedSourceIDs.add(sourceID).isNewEntry)
+        return;
+
     if (errorLine != -1) {
         auto sourceURL = sourceProvider->sourceURL();
         auto data = sourceProvider->source().toString();
@@ -363,8 +393,6 @@ void Debugger::sourceParsed(JSGlobalObject* globalObject, SourceProvider* source
         });
         return;
     }
-
-    JSC::SourceID sourceID = sourceProvider->asID();
 
     // FIXME: <https://webkit.org/b/162773> Web Inspector: Simplify Debugger::Script to use SourceProvider
     Debugger::Script script;
@@ -394,9 +422,54 @@ void Debugger::sourceParsed(JSGlobalObject* globalObject, SourceProvider* source
         script.endColumn = sourceLength - lastLineStart;
 
     dispatchFunctionToObservers([&] (Observer& observer) {
-        observer.didParseSource(sourceID, script);
+        observer.didParseSource(globalObject, sourceID, script);
     });
 }
+
+#if ENABLE(WEBASSEMBLY)
+
+void Debugger::sourceParsed(JSGlobalObject* globalObject, JSWebAssemblyModule* module)
+{
+    if (!canDispatchFunctionToObservers())
+        return;
+
+    Ref info = module->moduleInformation();
+
+    auto baseURL = sourceURLBase(globalObject);
+    auto url = Wasm::makeString(info->sourceURL);
+    if (url.isEmpty()) {
+        static std::atomic<uint64_t> nextWasmURLIdentifier { 0 };
+        auto identifier = ++nextWasmURLIdentifier;
+        URL resolvedURL(baseURL, makeString(identifier, ".wasm"_s));
+        if (resolvedURL.isValid())
+            url = resolvedURL.string();
+        else
+            url = makeString("webassembly:///"_s, identifier, ".wasm"_s);
+    }
+
+    Ref sourceProvider = StringSourceProvider::create(emptyString(), SourceOrigin { baseURL }, WTF::move(url), SourceTaintedOrigin::Untainted, TextPosition(), SourceProviderSourceType::WebAssembly);
+    SourceID sourceID = sourceProvider->asID();
+    if (!m_reportedSourceIDs.add(sourceID).isNewEntry)
+        return;
+
+    Debugger::Script script;
+    script.url = sourceProvider->sourceURL();
+    URL sourceURL { Wasm::makeString(info->sourceURL) };
+    if (info->sourceURL.isEmpty() || sourceURL.protocolIsBlob() || sourceURL.protocolIsData())
+        script.displayName = Wasm::makeString(info->nameSection().moduleName);
+    script.sourceProvider = WTF::move(sourceProvider);
+    script.isContentScript = isContentScript(globalObject);
+
+    const auto& functions = info->functions;
+    if (!functions.isEmpty())
+        script.endColumn = safeCast<int>(functions.last().end);
+
+    dispatchFunctionToObservers([&] (Observer& observer) {
+        observer.didParseSource(globalObject, sourceID, script);
+    });
+}
+
+#endif // ENABLE(WEBASSEMBLY)
 
 Seconds Debugger::willEvaluateScript()
 {

--- a/Source/JavaScriptCore/debugger/Debugger.h
+++ b/Source/JavaScriptCore/debugger/Debugger.h
@@ -32,6 +32,7 @@
 #include <wtf/Forward.h>
 #include <wtf/ListHashSet.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/URL.h>
 #include <wtf/text/TextPosition.h>
 
 namespace JSC {
@@ -47,6 +48,10 @@ class Microtask;
 class NativeExecutable;
 class SourceProvider;
 class VM;
+
+#if ENABLE(WEBASSEMBLY)
+class JSWebAssemblyModule;
+#endif
 
 enum class ProfilingReason : uint8_t;
 
@@ -146,6 +151,9 @@ public:
     void setSuppressAllPauses(bool suppress) { m_suppressAllPauses = suppress; }
 
     JS_EXPORT_PRIVATE virtual void sourceParsed(JSGlobalObject*, SourceProvider*, int errorLineNumber, const WTF::String& errorMessage);
+#if ENABLE(WEBASSEMBLY)
+    JS_EXPORT_PRIVATE virtual void sourceParsed(JSGlobalObject*, JSWebAssemblyModule*);
+#endif
 
     void exception(JSGlobalObject*, CallFrame*, JSValue exceptionValue, bool hasCatchHandler);
     void atStatement(CallFrame*);
@@ -189,6 +197,7 @@ public:
     struct Script {
         String url;
         String source;
+        String displayName;
         String sourceURL;
         String sourceMappingURL;
         RefPtr<SourceProvider> sourceProvider;
@@ -203,7 +212,7 @@ public:
     public:
         virtual ~Observer() { }
 
-        virtual void didParseSource(SourceID, const Debugger::Script&) { }
+        virtual void didParseSource(JSGlobalObject*, SourceID, const Debugger::Script&) { }
         virtual void failedToParseSource(const String& /* url */, const String& /* data */, int /* firstLine */, int /* errorLine */, const String& /* errorMessage */) { }
 
         virtual void didCreateNativeExecutable(NativeExecutable&) { }
@@ -270,6 +279,8 @@ protected:
 
     virtual bool isContentScript(JSGlobalObject*) const { return false; }
 
+    virtual URL sourceURLBase(JSGlobalObject*) const { return { }; }
+
     // NOTE: Currently all exceptions are reported at the API boundary through reportAPIException.
     // Until a time comes where an exception can be caused outside of the API (e.g. setTimeout
     // or some other async operation in a pure JSContext) we can ignore exceptions reported here.
@@ -326,6 +337,7 @@ private:
     VM& m_vm;
     UncheckedKeyHashSet<JSGlobalObject*> m_globalObjects;
     UncheckedKeyHashMap<SourceID, DebuggerParseData, WTF::IntHash<SourceID>, WTF::UnsignedWithZeroKeyHashTraits<SourceID>> m_parseDataMap;
+    UncheckedKeyHashSet<SourceID, WTF::IntHash<SourceID>, WTF::UnsignedWithZeroKeyHashTraits<SourceID>> m_reportedSourceIDs;
     UncheckedKeyHashMap<SourceID, BlackboxConfiguration, WTF::IntHash<SourceID>, WTF::UnsignedWithZeroKeyHashTraits<SourceID>> m_blackboxConfigurations;
     bool m_blackboxBreakpointEvaluations : 1;
 

--- a/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.cpp
@@ -89,6 +89,26 @@ static JSC::Debugger::BlackboxRange NODELETE blackboxRange(const JSC::Debugger::
     };
 }
 
+static Protocol::Debugger::ScriptType scriptTypeForScript(const JSC::Debugger::Script& script)
+{
+    if (!script.sourceProvider)
+        return Protocol::Debugger::ScriptType::Program;
+
+    switch (script.sourceProvider->sourceType()) {
+    case JSC::SourceProviderSourceType::Module:
+        return Protocol::Debugger::ScriptType::Module;
+    case JSC::SourceProviderSourceType::WebAssembly:
+        return Protocol::Debugger::ScriptType::WebAssembly;
+    case JSC::SourceProviderSourceType::Program:
+    case JSC::SourceProviderSourceType::JSON:
+    case JSC::SourceProviderSourceType::ImportMap:
+        return Protocol::Debugger::ScriptType::Program;
+    }
+
+    ASSERT_NOT_REACHED();
+    return Protocol::Debugger::ScriptType::Program;
+}
+
 static std::optional<JSC::Breakpoint::Action::Type> breakpointActionTypeForString(Protocol::ErrorString& errorString, const String& typeString)
 {
     auto type = Protocol::Helpers::parseEnumValueFromString<Protocol::Debugger::BreakpointAction::Type>(typeString);
@@ -633,6 +653,10 @@ void InspectorDebuggerAgent::didSetBreakpoint(ProtocolBreakpoint& protocolBreakp
 
 bool InspectorDebuggerAgent::resolveBreakpoint(const JSC::Debugger::Script& script, JSC::Breakpoint& debuggerBreakpoint)
 {
+    // FIXME: Support breakpoints in WebAssembly.
+    if (scriptTypeForScript(script) == Protocol::Debugger::ScriptType::WebAssembly)
+        return false;
+
     if (debuggerBreakpoint.lineNumber() < static_cast<unsigned>(script.startLine) || static_cast<unsigned>(script.endLine) < debuggerBreakpoint.lineNumber())
         return false;
 
@@ -1147,6 +1171,10 @@ Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Protocol::Debugger::Location>>> Inspec
     if (scriptIterator == m_scripts.end())
         return makeUnexpected("Missing script for scriptId in given start"_s);
 
+    // FIXME: Support breakpoints in WebAssembly.
+    if (scriptTypeForScript(scriptIterator->value) == Protocol::Debugger::ScriptType::WebAssembly)
+        return makeUnexpected("WebAssembly breakpoints are not supported"_s);
+
     auto protocolLocations = JSON::ArrayOf<Protocol::Debugger::Location>::create();
     m_debugger.forEachBreakpointLocation(startSourceID, scriptIterator->value.sourceProvider.get(), startLineNumber, startColumnNumber, endLineNumber, endColumnNumber, [&] (int lineNumber, int columnNumber) {
         auto protocolLocation = Protocol::Debugger::Location::create()
@@ -1511,6 +1539,10 @@ Protocol::ErrorStringOr<void> InspectorDebuggerAgent::setShouldBlackboxURL(const
 
 void InspectorDebuggerAgent::setBlackboxConfiguration(JSC::SourceID sourceID, const JSC::Debugger::Script& script)
 {
+    // FIXME: Support blackboxing in WebAssembly.
+    if (scriptTypeForScript(script) == Protocol::Debugger::ScriptType::WebAssembly)
+        return;
+
     JSC::Debugger::BlackboxConfiguration blackboxConfiguration;
 
     if (!m_pauseForInternalScripts && isWebKitInjectedScript(script.sourceURL)) {
@@ -1815,16 +1847,20 @@ JSC::JSObject* InspectorDebuggerAgent::debuggerScopeExtensionObject(JSC::Debugge
     return injectedScript.createCommandLineAPIObject(callFrame);
 }
 
-void InspectorDebuggerAgent::didParseSource(JSC::SourceID sourceID, const JSC::Debugger::Script& script)
+void InspectorDebuggerAgent::didParseSource(JSC::JSGlobalObject* globalObject, JSC::SourceID sourceID, const JSC::Debugger::Script& script)
 {
     String scriptIDStr = String::number(sourceID);
     bool hasSourceURL = !script.sourceURL.isEmpty();
     String sourceURL = script.sourceURL;
     String sourceMappingURL = sourceMapURLForScript(script);
 
-    m_frontendDispatcher->scriptParsed(scriptIDStr, script.url, script.startLine, script.startColumn, script.endLine, script.endColumn, script.isContentScript, sourceURL, sourceMappingURL, script.sourceProvider->sourceType() == JSC::SourceProviderSourceType::Module);
+    m_frontendDispatcher->scriptParsed(scriptIDStr, script.url, script.startLine, script.startColumn, script.endLine, script.endColumn, injectedScriptManager().injectedScriptIdFor(globalObject), scriptTypeForScript(script), script.isContentScript, sourceURL, sourceMappingURL, script.displayName);
 
     m_scripts.set(sourceID, script);
+
+    // FIXME: Support breakpoints and blackboxing in WebAssembly.
+    if (scriptTypeForScript(script) == Protocol::Debugger::ScriptType::WebAssembly)
+        return;
 
     String scriptURLForBreakpoints = hasSourceURL ? script.sourceURL : script.url;
     if (scriptURLForBreakpoints.isEmpty())

--- a/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.h
@@ -108,7 +108,7 @@ public:
     JSC::JSObject* debuggerScopeExtensionObject(JSC::Debugger&, JSC::JSGlobalObject*, JSC::DebuggerCallFrame&) final;
 
     // JSC::Debugger::Observer
-    void didParseSource(JSC::SourceID, const JSC::Debugger::Script&) final;
+    void didParseSource(JSC::JSGlobalObject*, JSC::SourceID, const JSC::Debugger::Script&) final;
     void failedToParseSource(const String& url, const String& data, int firstLine, int errorLine, const String& errorMessage) final;
     void didCreateNativeExecutable(JSC::NativeExecutable&) final;
     void willCallNativeExecutable(JSC::CallFrame*) final;

--- a/Source/JavaScriptCore/inspector/protocol/Debugger.json
+++ b/Source/JavaScriptCore/inspector/protocol/Debugger.json
@@ -20,6 +20,11 @@
             "description": "Unique script identifier."
         },
         {
+            "id": "ScriptType",
+            "type": "string",
+            "enum": ["program", "module", "webassembly"]
+        },
+        {
             "id": "CallFrameId",
             "type": "string",
             "description": "Call frame identifier."
@@ -31,7 +36,7 @@
             "properties": [
                 { "name": "scriptId", "$ref": "ScriptId", "description": "Script identifier as reported in the <code>Debugger.scriptParsed</code>." },
                 { "name": "lineNumber", "type": "integer", "description": "Line number in the script (0-based)." },
-                { "name": "columnNumber", "type": "integer", "optional": true, "description": "Column number in the script (0-based)." }
+                { "name": "columnNumber", "type": "integer", "optional": true, "description": "Column number in the script (0-based) or bytecode offset for WebAssembly modules (0-based)." }
             ]
         },
         {
@@ -376,11 +381,13 @@
                 { "name": "startLine", "type": "integer", "description": "Line offset of the script within the resource with given URL (for script tags)." },
                 { "name": "startColumn", "type": "integer", "description": "Column offset of the script within the resource with given URL." },
                 { "name": "endLine", "type": "integer", "description": "Last line of the script." },
-                { "name": "endColumn", "type": "integer", "description": "Length of the last line of the script." },
+                { "name": "endColumn", "type": "integer", "description": "Length of the last line of the script or the end bytecode offset for WebAssembly modules." },
+                { "name": "executionContextId", "$ref": "Runtime.ExecutionContextId", "description": "Identifier of the execution context in which this script was parsed." },
+                { "name": "scriptType", "$ref": "ScriptType", "description": "Type of script." },
                 { "name": "isContentScript", "type": "boolean", "optional": true, "description": "Determines whether this script is a user extension script." },
                 { "name": "sourceURL", "type": "string", "optional": true, "description": "sourceURL name of the script (if any)." },
                 { "name": "sourceMapURL", "type": "string", "optional": true, "description": "URL of source map associated with script (if any)." },
-                { "name": "module", "type": "boolean", "optional": true, "description": "True if this script was parsed as a module." }
+                { "name": "displayName", "type": "string", "optional": true, "description": "Human-readable name of the script." }
             ]
         },
         {

--- a/Source/JavaScriptCore/inspector/scripts/codegen/generator.py
+++ b/Source/JavaScriptCore/inspector/scripts/codegen/generator.py
@@ -45,7 +45,7 @@ def ucfirst(str):
     return str[:1].upper() + str[1:]
 
 
-_ALWAYS_SPECIALCASED_ENUM_VALUE_SUBSTRINGS = set(['2D', 'API', 'CSS', 'DOM', 'HTML', 'JIT', 'SRGB', 'XHR', 'XML', 'IOS', 'MacOS', 'JavaScript', 'ServiceWorker'])
+_ALWAYS_SPECIALCASED_ENUM_VALUE_SUBSTRINGS = set(['2D', 'API', 'CSS', 'DOM', 'HTML', 'JIT', 'SRGB', 'XHR', 'XML', 'IOS', 'MacOS', 'JavaScript', 'ServiceWorker', 'WebAssembly'])
 _ALWAYS_SPECIALCASED_ENUM_VALUE_LOOKUP_TABLE = dict([(s.upper(), s) for s in _ALWAYS_SPECIALCASED_ENUM_VALUE_SUBSTRINGS])
 
 _ENUM_IDENTIFIER_RENAME_MAP = {

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -3740,6 +3740,13 @@ private:
     {
         DollarVMAssertScope assertScope;
     }
+
+#if ENABLE(WEBASSEMBLY)
+    void sourceParsed(JSGlobalObject*, JSWebAssemblyModule*) final
+    {
+        DollarVMAssertScope assertScope;
+    }
+#endif
 };
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(DoNothingDebugger);

--- a/Source/JavaScriptCore/wasm/WasmModule.cpp
+++ b/Source/JavaScriptCore/wasm/WasmModule.cpp
@@ -40,11 +40,14 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace JSC { namespace Wasm {
 
-Module::Module(IPIntPlan& plan)
+Module::Module(IPIntPlan& plan, Name&& sourceURL)
     : m_moduleInformation(plan.takeModuleInformation())
     , m_ipintCallees(plan.takeCallees())
     , m_wasmToJSExitStubs(plan.takeWasmToJSExitStubs())
 {
+    if (!sourceURL.isEmpty())
+        m_moduleInformation->sourceURL = WTF::move(sourceURL);
+
 #if ENABLE(WEBASSEMBLY_DEBUGGER)
     if (Options::enableWasmDebugger()) [[unlikely]]
         Wasm::DebugServer::singleton().trackModule(*this);
@@ -64,19 +67,19 @@ Wasm::RTT const& Module::rttFromFunctionIndexSpace(FunctionSpaceIndex functionIn
     return m_moduleInformation->rtt(functionIndexSpace);
 }
 
-static Module::ValidationResult makeValidationResult(IPIntPlan& plan)
+static Module::ValidationResult makeValidationResult(IPIntPlan& plan, Name&& sourceURL = { })
 {
     ASSERT(!plan.hasWork());
     if (plan.failed())
         return std::unexpected<String>(plan.errorMessage());
-    return Module::ValidationResult(Module::create(plan));
+    return Module::ValidationResult(Module::create(plan, WTF::move(sourceURL)));
 }
 
-static Plan::CompletionTask makeValidationCallback(Module::AsyncValidationCallback&& callback)
+static Plan::CompletionTask makeValidationCallback(Name&& sourceURL, Module::AsyncValidationCallback&& callback)
 {
-    return createSharedTask<Plan::CallbackType>([callback = WTF::move(callback)] (Plan& plan) {
+    return createSharedTask<Plan::CallbackType>([sourceURL = WTF::move(sourceURL), callback = WTF::move(callback)] (Plan& plan) mutable {
         ASSERT(!plan.hasWork());
-        callback->run(makeValidationResult(static_cast<IPIntPlan&>(plan)));
+        callback->run(makeValidationResult(static_cast<IPIntPlan&>(plan), WTF::move(sourceURL)));
     });
 }
 
@@ -90,7 +93,12 @@ Module::ValidationResult Module::validateSync(VM& vm, Vector<uint8_t>&& source)
 
 void Module::validateAsync(VM& vm, Vector<uint8_t>&& source, Module::AsyncValidationCallback&& callback)
 {
-    Ref<Plan> plan = adoptRef(*new IPIntPlan(vm, WTF::move(source), CompilerMode::Validation, makeValidationCallback(WTF::move(callback))));
+    validateAsync(vm, WTF::move(source), { }, WTF::move(callback));
+}
+
+void Module::validateAsync(VM& vm, Vector<uint8_t>&& source, Name&& sourceURL, Module::AsyncValidationCallback&& callback)
+{
+    Ref<Plan> plan = adoptRef(*new IPIntPlan(vm, WTF::move(source), CompilerMode::Validation, makeValidationCallback(WTF::move(sourceURL), WTF::move(callback))));
     Wasm::ensureWorklist().enqueue(WTF::move(plan));
 }
 

--- a/Source/JavaScriptCore/wasm/WasmModule.h
+++ b/Source/JavaScriptCore/wasm/WasmModule.h
@@ -65,10 +65,11 @@ public:
 
     static ValidationResult validateSync(VM&, Vector<uint8_t>&& source);
     static void validateAsync(VM&, Vector<uint8_t>&& source, Module::AsyncValidationCallback&&);
+    static void validateAsync(VM&, Vector<uint8_t>&& source, Name&& sourceURL, Module::AsyncValidationCallback&&);
 
-    static Ref<Module> create(IPIntPlan& plan)
+    static Ref<Module> create(IPIntPlan& plan, Name&& sourceURL = { })
     {
-        return adoptRef(*new Module(plan));
+        return adoptRef(*new Module(plan, WTF::move(sourceURL)));
     }
 
     const Wasm::RTT& rttFromFunctionIndexSpace(FunctionSpaceIndex functionIndexSpace) const;
@@ -101,7 +102,7 @@ public:
 private:
     Ref<CalleeGroup> getOrCreateCalleeGroup(VM&, MemoryMode);
 
-    Module(IPIntPlan&);
+    Module(IPIntPlan&, Name&& sourceURL);
     const Ref<ModuleInformation> m_moduleInformation;
     RefPtr<CalleeGroup> m_calleeGroups[numberOfMemoryModes];
     const Ref<IPIntCallees> m_ipintCallees;

--- a/Source/JavaScriptCore/wasm/WasmModuleInformation.h
+++ b/Source/JavaScriptCore/wasm/WasmModuleInformation.h
@@ -220,6 +220,7 @@ struct ModuleInformation final : public ThreadSafeRefCounted<ModuleInformation> 
     std::optional<uint32_t> numberOfDataSegments;
     using ConstantExpressionAndSourceOffset = std::pair<Vector<uint8_t>, size_t>;
     Vector<ConstantExpressionAndSourceOffset> constantExpressions;
+    Name sourceURL;
     Name sourceMappingURL;
 #if ENABLE(WEBASSEMBLY_DEBUGGER)
     std::unique_ptr<Wasm::ModuleDebugInfo> debugInfo;

--- a/Source/JavaScriptCore/wasm/WasmStreamingCompiler.cpp
+++ b/Source/JavaScriptCore/wasm/WasmStreamingCompiler.cpp
@@ -50,14 +50,7 @@ StreamingCompiler::StreamingCompiler(VM& vm, CompilerMode compilerMode, JSGlobal
     , m_parser(m_info.get(), *this)
     , m_source(source)
 {
-#if ENABLE(WEBASSEMBLY_DEBUGGER)
-    if (Options::enableWasmDebugger()) [[unlikely]] {
-        if (!wasmSourceURL.isEmpty())
-            m_info->debugInfo->sourceURL = WTF::move(wasmSourceURL);
-    }
-#else
-    UNUSED_PARAM(wasmSourceURL);
-#endif
+    m_info->sourceURL = Name(byteCast<char8_t>(wasmSourceURL.utf8().span()));
     Vector<JSCell*> dependencies;
     dependencies.append(globalObject);
     if (importObject)

--- a/Source/JavaScriptCore/wasm/debugger/WasmModuleDebugInfo.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmModuleDebugInfo.cpp
@@ -95,9 +95,10 @@ String ModuleDebugInfo::debugName() const
 
     StringBuilder result;
 
-    if (!sourceURL.isEmpty()) {
+    if (!moduleInfo->sourceURL.isEmpty()) {
         // LLDB normalizes "//" -> "/" in library names (FileSpec treats them as paths),
         // so we strip the URL scheme and store only "host/path" to avoid mangling.
+        auto sourceURL = makeString(moduleInfo->sourceURL);
         URL url { sourceURL };
         if (url.isValid() && !url.host().isEmpty())
             result.append(makeString(url.host(), url.path()));

--- a/Source/JavaScriptCore/wasm/debugger/WasmModuleDebugInfo.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmModuleDebugInfo.h
@@ -74,7 +74,6 @@ public:
     Ref<ModuleInformation> moduleInfo;
     uint32_t id { 0 };
     Vector<uint8_t> source;
-    String sourceURL;
     using FunctionIndexToData = UncheckedKeyHashMap<size_t, FunctionDebugInfo, DefaultHash<size_t>, WTF::UnsignedWithZeroKeyHashTraits<size_t>>;
     FunctionIndexToData functionIndexToData;
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssembly.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssembly.cpp
@@ -295,7 +295,12 @@ static void compileAndInstantiate(VM& vm, JSGlobalObject* globalObject, JSPromis
         dependencies.append(importObject);
     dependencies.append(moduleKeyCell);
     auto weakTicket = vm.deferredWorkTimer->addPendingWork(DeferredWorkTimer::WorkType::ImminentlyScheduled, vm, promise, WTF::move(dependencies));
-    Wasm::Module::validateAsync(vm, WTF::move(source), createSharedTask<Wasm::Module::CallbackType>([weakTicket = WTF::move(weakTicket), importObject, sourceProvider = WTF::move(sourceProvider), compileOptions = WTF::move(compileOptions), resolveKind, creationMode, &vm] (Wasm::Module::ValidationResult&& result) mutable {
+    Wasm::Name sourceURL;
+    if (creationMode == Wasm::CreationMode::FromModuleLoader && sourceProvider) {
+        auto sourceURLString = sourceProvider->sourceOrigin().url().string();
+        sourceURL = Wasm::Name(byteCast<char8_t>(sourceURLString.utf8().span()));
+    }
+    Wasm::Module::validateAsync(vm, WTF::move(source), WTF::move(sourceURL), createSharedTask<Wasm::Module::CallbackType>([weakTicket = WTF::move(weakTicket), importObject, sourceProvider = WTF::move(sourceProvider), compileOptions = WTF::move(compileOptions), resolveKind, creationMode, &vm] (Wasm::Module::ValidationResult&& result) mutable {
         vm.deferredWorkTimer->scheduleWorkSoonIfActive(weakTicket, [importObject, sourceProvider = WTF::move(sourceProvider), compileOptions = WTF::move(compileOptions), result = WTF::move(result), resolveKind, creationMode, &vm](DeferredWorkTimer::Ticket& ticket) mutable {
             auto* promise = uncheckedDowncast<JSPromise>(ticket.target());
             auto& deps = ticket.dependencies();

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyModule.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyModule.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(WEBASSEMBLY)
 
+#include "Debugger.h"
 #include "JSCInlines.h"
 #include "JSWebAssemblyCompileError.h"
 #include "JSWebAssemblyLinkError.h"
@@ -47,6 +48,8 @@ JSWebAssemblyModule* JSWebAssemblyModule::create(VM& vm, Structure* structure, R
 {
     auto* module = new (NotNull, allocateCell<JSWebAssemblyModule>(vm)) JSWebAssemblyModule(vm, structure, WTF::move(result));
     module->finishCreation(vm);
+    if (auto* debugger = module->realm()->debugger()) [[unlikely]]
+        debugger->sourceParsed(module->realm(), module);
     return module;
 }
 

--- a/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
@@ -636,7 +636,8 @@ static void handleResponseOnStreamingAction(JSC::JSGlobalObject* globalObject, J
         }
     }
 
-    auto compiler = JSC::Wasm::StreamingCompiler::create(vm, compilerMode, globalObject, promise, importObject, WTF::move(compileOptions), JSC::makeSource("handleResponseOnStreamingAction"_s, JSC::SourceOrigin(), JSC::SourceTaintedOrigin::Untainted), inputResponse->url());
+    String wasmSourceURL = inputResponse->url();
+    auto compiler = JSC::Wasm::StreamingCompiler::create(vm, compilerMode, globalObject, promise, importObject, WTF::move(compileOptions), JSC::makeSource("handleResponseOnStreamingAction"_s, JSC::SourceOrigin(), JSC::SourceTaintedOrigin::Untainted), WTF::move(wasmSourceURL));
 
     if (inputResponse->isBodyReceivedByChunk()) {
         inputResponse->consumeBodyReceivedByChunk([vmPtr = &vm, compiler = WTF::move(compiler)](auto&& result) mutable {

--- a/Source/WebCore/inspector/FrameDebugger.cpp
+++ b/Source/WebCore/inspector/FrameDebugger.cpp
@@ -150,6 +150,13 @@ bool FrameDebugger::isContentScript(JSGlobalObject* state) const
     return &currentWorld(*state) != &mainThreadNormalWorldSingleton() || JSC::Debugger::isContentScript(state);
 }
 
+URL FrameDebugger::sourceURLBase(JSGlobalObject* state) const
+{
+    if (RefPtr context = uncheckedDowncast<JSDOMGlobalObject>(state)->scriptExecutionContext())
+        return context->url();
+    return { };
+}
+
 void FrameDebugger::reportException(JSGlobalObject* state, JSC::Exception* exception) const
 {
     JSC::Debugger::reportException(state, exception);

--- a/Source/WebCore/inspector/FrameDebugger.h
+++ b/Source/WebCore/inspector/FrameDebugger.h
@@ -49,6 +49,7 @@ private:
     void didContinue(JSC::JSGlobalObject*) final;
     void runEventLoopWhilePaused() final;
     bool isContentScript(JSC::JSGlobalObject*) const final;
+    URL sourceURLBase(JSC::JSGlobalObject*) const final;
     void reportException(JSC::JSGlobalObject*, JSC::Exception*) const final;
 
     void runEventLoopWhilePausedInternal();

--- a/Source/WebCore/inspector/PageDebugger.cpp
+++ b/Source/WebCore/inspector/PageDebugger.cpp
@@ -149,6 +149,13 @@ bool PageDebugger::isContentScript(JSGlobalObject* state) const
     return &currentWorld(*state) != &mainThreadNormalWorldSingleton() || JSC::Debugger::isContentScript(state);
 }
 
+URL PageDebugger::sourceURLBase(JSGlobalObject* state) const
+{
+    if (RefPtr context = uncheckedDowncast<JSDOMGlobalObject>(state)->scriptExecutionContext())
+        return context->url();
+    return { };
+}
+
 void PageDebugger::reportException(JSGlobalObject* state, JSC::Exception* exception) const
 {
     JSC::Debugger::reportException(state, exception);

--- a/Source/WebCore/inspector/PageDebugger.h
+++ b/Source/WebCore/inspector/PageDebugger.h
@@ -52,6 +52,7 @@ private:
     void didContinue(JSC::JSGlobalObject*) final;
     void runEventLoopWhilePaused() final;
     bool isContentScript(JSC::JSGlobalObject*) const final;
+    URL sourceURLBase(JSC::JSGlobalObject*) const final;
     void reportException(JSC::JSGlobalObject*, JSC::Exception*) const final;
 
     void runEventLoopWhilePausedInternal();

--- a/Source/WebCore/inspector/WorkerDebugger.cpp
+++ b/Source/WebCore/inspector/WorkerDebugger.cpp
@@ -53,6 +53,11 @@ WorkerDebugger::WorkerDebugger(WorkerOrWorkletGlobalScope& context)
 {
 }
 
+URL WorkerDebugger::sourceURLBase(JSC::JSGlobalObject*) const
+{
+    return protect(m_globalScope)->url();
+}
+
 void WorkerDebugger::attachDebugger()
 {
     JSC::Debugger::attachDebugger();

--- a/Source/WebCore/inspector/WorkerDebugger.h
+++ b/Source/WebCore/inspector/WorkerDebugger.h
@@ -51,6 +51,7 @@ private:
     void detachDebugger(bool isBeingDestroyed) final;
     void recompileAllJSFunctions() final;
     void runEventLoopWhilePaused() final;
+    URL sourceURLBase(JSC::JSGlobalObject*) const final;
     void reportException(JSC::JSGlobalObject*, JSC::Exception*) const final;
 
     WeakRef<WorkerOrWorkletGlobalScope> m_globalScope;

--- a/Source/WebCore/inspector/agents/frame/FrameRuntimeAgent.cpp
+++ b/Source/WebCore/inspector/agents/frame/FrameRuntimeAgent.cpp
@@ -33,6 +33,7 @@
 #include "FrameConsoleClient.h"
 #include "FrameLoader.h"
 #include "FrameLoaderStateMachine.h"
+#include "InspectorIdentifierRegistry.h"
 #include "InstrumentingAgents.h"
 #include "JSDOMWindowCustom.h"
 #include "JSExecState.h"
@@ -40,6 +41,7 @@
 #include "LocalFrame.h"
 #include "LocalFrameInlines.h"
 #include "Page.h"
+#include "ProcessIdentifier.h"
 #include "RuntimeAgentUtilities.h"
 #include "ScriptController.h"
 #include "SecurityOrigin.h"
@@ -166,7 +168,7 @@ void FrameRuntimeAgent::unmuteConsole()
 
 String FrameRuntimeAgent::frameIdForProtocol() const
 {
-    return makeString("frame-"_s, m_frameIdentifier.toUInt64());
+    return IdentifierRegistry::protocolFrameId(m_frameIdentifier, Process::identifier());
 }
 
 void FrameRuntimeAgent::reportExecutionContextCreation()

--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -1451,6 +1451,7 @@ localizedStrings["Resource Size"] = "Resource Size";
 localizedStrings["Resource Type"] = "Resource Type";
 localizedStrings["Resource does not have timing data"] = "Resource does not have timing data";
 localizedStrings["Resource failed to load."] = "Resource failed to load.";
+localizedStrings["Resource has binary content."] = "Resource has binary content.";
 /* An error message shown when there is no cached content for a HTTP 304 Not Modified resource response. */
 localizedStrings["Resource has no cached content. @ Resource Preview"] = "Resource has no cached content.";
 localizedStrings["Resource has no content."] = "Resource has no content.";

--- a/Source/WebInspectorUI/UserInterface/Controllers/DebuggerManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/DebuggerManager.js
@@ -48,6 +48,7 @@ WI.DebuggerManager = class DebuggerManager extends WI.Object
         WI.auditManager.addEventListener(WI.AuditManager.Event.TestCompleted, this._handleAuditManagerTestCompleted, this);
 
         WI.targetManager.addEventListener(WI.TargetManager.Event.TargetRemoved, this._targetRemoved, this);
+        WI.networkManager.addEventListener(WI.NetworkManager.Event.FrameWasRemoved, this._frameWasRemoved, this);
 
         WI.settings.blackboxBreakpointEvaluations.addEventListener(WI.Setting.Event.Changed, this._handleBlackboxBreakpointEvaluationsChange, this);
 
@@ -1105,10 +1106,11 @@ WI.DebuggerManager = class DebuggerManager extends WI.Object
         InspectorFrontendHost.beep();
     }
 
-    scriptDidParse(target, scriptIdentifier, url, startLine, startColumn, endLine, endColumn, isModule, isContentScript, sourceURL, sourceMapURL)
+    scriptDidParse(target, scriptIdentifier, url, startLine, startColumn, endLine, endColumn, executionContextId, scriptType, isContentScript, sourceURL, sourceMapURL, displayName)
     {
-        // Don't add the script again if it is already known.
         let targetData = this.dataForTarget(target);
+
+        // COMPATIBILITY (macOS X.Y, iOS X.Y): Older backends could report the same script more than once.
         let existingScript = targetData.scriptForIdentifier(scriptIdentifier);
         if (existingScript) {
             console.assert(existingScript.url === (url || null));
@@ -1123,10 +1125,14 @@ WI.DebuggerManager = class DebuggerManager extends WI.Object
             return;
 
         let range = new WI.TextRange(startLine, startColumn, endLine, endColumn);
-        let sourceType = isModule ? WI.Script.SourceType.Module : WI.Script.SourceType.Program;
-        let script = new WI.Script(target, scriptIdentifier, range, url, sourceType, isContentScript, sourceURL, sourceMapURL);
+
+        let parentFrame = this._frameForExecutionContext(target, executionContextId);
+        let script = new WI.Script(target, scriptIdentifier, range, url, scriptType, isContentScript, sourceURL, sourceMapURL, parentFrame, displayName);
 
         targetData.addScript(script);
+
+        if (!script.resource && script.sourceType === WI.Script.SourceType.WebAssembly)
+            script.parentFrame?.addExtraScript(script);
 
         // FIXME: <https://webkit.org/b/164427> Web Inspector: WorkerTarget's mainResource should be a Resource not a Script
         // We make the main resource of a WorkerTarget the Script instead of the Resource
@@ -1190,6 +1196,24 @@ WI.DebuggerManager = class DebuggerManager extends WI.Object
     }
 
     // Private
+
+    _frameForExecutionContext(target, executionContextId)
+    {
+        if (!executionContextId)
+            return null;
+
+        if (target instanceof WI.FrameTarget) {
+            let executionContext = target.executionContextList.contexts.find((executionContext) => executionContext.id === executionContextId);
+            return executionContext?.frame || null;
+        }
+
+        for (let frame of WI.networkManager.frames) {
+            if (frame.executionContextList.contexts.some((executionContext) => executionContext.target === target && executionContext.id === executionContextId))
+                return frame;
+        }
+
+        return null;
+    }
 
     _sourceCodeLocationFromPayload(target, payload)
     {
@@ -1672,11 +1696,25 @@ WI.DebuggerManager = class DebuggerManager extends WI.Object
     _targetRemoved(event)
     {
         let wasPaused = this.paused;
+        let {target} = event.data;
 
-        this._targetDebuggerDataMap.delete(event.data.target);
+        target.extraScriptCollection.clear();
+        for (let frame of WI.networkManager.frames) {
+            for (let script of Array.from(frame.extraScriptCollection)) {
+                if (script.target === target)
+                    frame.extraScriptCollection.remove(script);
+            }
+        }
+
+        this._targetDebuggerDataMap.delete(target);
 
         if (!this.paused && wasPaused)
             this.dispatchEventToListeners(WI.DebuggerManager.Event.Resumed);
+    }
+
+    _frameWasRemoved(event)
+    {
+        event.data.frame.extraScriptCollection.clear();
     }
 
     _handleBlackboxBreakpointEvaluationsChange(event)

--- a/Source/WebInspectorUI/UserInterface/Controllers/NetworkManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/NetworkManager.js
@@ -1202,7 +1202,7 @@ WI.NetworkManager = class NetworkManager extends WI.Object
 
         let type = WI.ExecutionContext.typeFromPayload(payload);
         let target = frame.mainResource.target;
-        let executionContext = new WI.ExecutionContext(target, payload.id, type, payload.name, frame);
+        let executionContext = new WI.ExecutionContext(target, payload.id, type, payload.name, payload.frameId);
         frame.addExecutionContext(executionContext);
     }
 

--- a/Source/WebInspectorUI/UserInterface/Models/ExecutionContext.js
+++ b/Source/WebInspectorUI/UserInterface/Models/ExecutionContext.js
@@ -25,20 +25,19 @@
 
 WI.ExecutionContext = class ExecutionContext
 {
-    constructor(target, id, type, name, frame)
+    constructor(target, id, type, name, frameId)
     {
         console.assert(target instanceof WI.Target);
         console.assert(typeof id === "number" || id === WI.RuntimeManager.TopLevelExecutionContextIdentifier);
         console.assert(Object.values(WI.ExecutionContext.Type).includes(type));
         console.assert(!name || typeof name === "string");
-        // Frame is required unless: (1) it's a top-level context, or (2) target is a FrameTarget (site isolation).
-        console.assert(frame instanceof WI.Frame || id === WI.RuntimeManager.TopLevelExecutionContextIdentifier || target instanceof WI.FrameTarget);
+        console.assert(typeof frameId === "string" || id === WI.RuntimeManager.TopLevelExecutionContextIdentifier || target instanceof WI.FrameTarget);
 
         this._target = target;
         this._id = id;
         this._type = type || WI.ExecutionContext.Type.Internal;
         this._name = name || "";
-        this._frame = frame || null;
+        this._frameId = frameId || null;
     }
 
     // Static
@@ -68,7 +67,11 @@ WI.ExecutionContext = class ExecutionContext
     get id() { return this._id; }
     get type() { return this._type; }
     get name() { return this._name; }
-    get frame() { return this._frame; }
+
+    get frame()
+    {
+        return this._frameId ? WI.networkManager.frameForIdentifier(this._frameId) : null;
+    }
 };
 
 WI.ExecutionContext.Type = {

--- a/Source/WebInspectorUI/UserInterface/Models/Script.js
+++ b/Source/WebInspectorUI/UserInterface/Models/Script.js
@@ -25,7 +25,7 @@
 
 WI.Script = class Script extends WI.SourceCode
 {
-    constructor(target, id, range, url, sourceType, injected, sourceURL, sourceMapURL)
+    constructor(target, id, range, url, sourceType, injected, sourceURL, sourceMapURL, parentFrame, displayName)
     {
         super(url);
 
@@ -35,10 +35,12 @@ WI.Script = class Script extends WI.SourceCode
         this._target = target;
         this._id = id || null;
         this._range = range || null;
-        this._sourceType = sourceType || WI.Script.SourceType.Program;
+        this._sourceType = sourceType;
         this._sourceURL = sourceURL || null;
         this._sourceMappingURL = sourceMapURL || null;
         this._injected = injected || false;
+        this._parentFrame = parentFrame || null;
+        this._displayName = displayName || null;
         this._dynamicallyAddedScriptElement = false;
         this._scriptSyntaxTree = null;
 
@@ -51,9 +53,10 @@ WI.Script = class Script extends WI.SourceCode
             console.assert(this._resource.isMainResource());
             let documentResource = this._resource;
             this._resource = null;
+            this._parentFrame ||= documentResource.parentFrame;
             this._dynamicallyAddedScriptElement = true;
-            documentResource.parentFrame.addExtraScript(this);
-            this._dynamicallyAddedScriptElementNumber = documentResource.parentFrame.extraScriptCollection.size;
+            this._parentFrame.addExtraScript(this);
+            this._dynamicallyAddedScriptElementNumber = this._parentFrame.extraScriptCollection.size;
         } else if (this._resource)
             this._resource.associateWithScript(this);
 
@@ -74,6 +77,17 @@ WI.Script = class Script extends WI.SourceCode
             WI.Script._uniqueDisplayNameNumbersForRootTargetMap.delete(target);
     }
 
+    static isWebAssembly(sourceCode)
+    {
+        if (sourceCode instanceof WI.SourceMapResource)
+            sourceCode = sourceCode.sourceMap.originalSourceCode;
+
+        if (sourceCode instanceof WI.Script)
+            return sourceCode.sourceType === WI.Script.SourceType.WebAssembly;
+
+        return sourceCode instanceof WI.Resource && (sourceCode.mimeTypeComponents.type === "application/wasm" || sourceCode.scripts.some((script) => script.sourceType === WI.Script.SourceType.WebAssembly));
+    }
+
     // Public
 
     get target() { return this._target; }
@@ -83,6 +97,7 @@ WI.Script = class Script extends WI.SourceCode
     get sourceURL() { return this._sourceURL; }
     get sourceMappingURL() { return this._sourceMappingURL; }
     get injected() { return this._injected; }
+    get parentFrame() { return this._parentFrame; }
 
     get contentIdentifier()
     {
@@ -108,7 +123,14 @@ WI.Script = class Script extends WI.SourceCode
 
     get mimeType()
     {
-        return this._resource ? this._resource.mimeType : "text/javascript";
+        return this._resource?.mimeType || this.syntheticMIMEType;
+    }
+
+    get syntheticMIMEType()
+    {
+        if (this._sourceType === WI.Script.SourceType.WebAssembly)
+            return "application/wasm";
+        return "text/javascript";
     }
 
     get isScript()
@@ -116,8 +138,19 @@ WI.Script = class Script extends WI.SourceCode
         return true;
     }
 
+    get supportsScriptBlackboxing()
+    {
+        // FIXME: Support blackboxing in WebAssembly.
+        if (this._sourceType === WI.Script.SourceType.WebAssembly)
+            return false;
+        return super.supportsScriptBlackboxing;
+    }
+
     get displayName()
     {
+        if (this._displayName)
+            return this._displayName;
+
         if (isWebInspectorBootstrapScript(this._sourceURL || this._url)) {
             console.assert(WI.NetworkManager.supportsBootstrapScript());
             return WI.UIString("Inspector Bootstrap Script");
@@ -187,7 +220,7 @@ WI.Script = class Script extends WI.SourceCode
     {
         console.assert(target instanceof WI.Target, target);
 
-        return this._url === target.name;
+        return this._sourceType !== WI.Script.SourceType.WebAssembly && this._url === target.name;
     }
 
     isMainResource()
@@ -305,6 +338,11 @@ WI.Script = class Script extends WI.SourceCode
 
     _resolveResource()
     {
+        // FIXME: Associate WebAssembly scripts with a `WI.Resource` once the backend reports enough
+        // information to uniquely identify it.
+        if (this._sourceType === WI.Script.SourceType.WebAssembly)
+            return null;
+
         // FIXME: We should be able to associate a Script with a Resource through identifiers,
         // we shouldn't need to lookup by URL, which is not safe with frames, where there might
         // be multiple resources with the same URL.
@@ -315,7 +353,7 @@ WI.Script = class Script extends WI.SourceCode
             return null;
 
         let isOtherTarget = this._target && this._target !== WI.mainTarget;
-        let resolver = isOtherTarget ? this._target.resourceCollection : WI.networkManager;
+        let resolver = this._parentFrame || (isOtherTarget ? this._target.resourceCollection : WI.networkManager);
 
         let filters = [
             (item) => item.type === WI.Resource.Type.Document || item.type === WI.Resource.Type.Script,
@@ -378,8 +416,9 @@ WI.Script = class Script extends WI.SourceCode
 };
 
 WI.Script.SourceType = {
-    Program: "script-source-type-program",
-    Module: "script-source-type-module",
+    Program: "program",
+    Module: "module",
+    WebAssembly: "webassembly",
 };
 
 WI.Script.TypeIdentifier = "script";

--- a/Source/WebInspectorUI/UserInterface/Protocol/DebuggerObserver.js
+++ b/Source/WebInspectorUI/UserInterface/Protocol/DebuggerObserver.js
@@ -29,7 +29,7 @@ WI.DebuggerObserver = class DebuggerObserver extends InspectorBackend.Dispatcher
     {
         super(target);
 
-        this._legacyScriptParsed = this._target.hasEvent("Debugger.scriptParsed", "hasSourceURL");
+        this._legacyScriptParsed = !this._target.hasEvent("Debugger.scriptParsed", "scriptType");
     }
 
     // Events defined by the "Debugger" domain.
@@ -39,9 +39,19 @@ WI.DebuggerObserver = class DebuggerObserver extends InspectorBackend.Dispatcher
         WI.debuggerManager.globalObjectCleared(this._target);
     }
 
-    scriptParsed(scriptId, url, startLine, startColumn, endLine, endColumn, isContentScript, sourceURL, sourceMapURL, isModule)
+    scriptParsed(scriptId, url, startLine, startColumn, endLine, endColumn, executionContextId, scriptType, isContentScript, sourceURL, sourceMapURL, displayName)
     {
-        WI.debuggerManager.scriptDidParse(this._target, scriptId, url, startLine, startColumn, endLine, endColumn, isModule, isContentScript, sourceURL, sourceMapURL);
+        if (this._legacyScriptParsed) {
+            // COMPATIBILITY (macOS X.Y, iOS X.Y): Older backends report `module` instead of `scriptType`.
+            let isModule = sourceURL;
+            sourceMapURL = isContentScript;
+            sourceURL = scriptType;
+            isContentScript = executionContextId;
+            executionContextId = undefined;
+            scriptType = isModule ? InspectorBackend.Enum.Debugger.ScriptType.Module : InspectorBackend.Enum.Debugger.ScriptType.Program;
+        }
+
+        WI.debuggerManager.scriptDidParse(this._target, scriptId, url, startLine, startColumn, endLine, endColumn, executionContextId, scriptType, isContentScript, sourceURL, sourceMapURL, displayName);
     }
 
     scriptFailedToParse(url, scriptSource, startLine, errorLine, errorMessage)

--- a/Source/WebInspectorUI/UserInterface/Protocol/RuntimeObserver.js
+++ b/Source/WebInspectorUI/UserInterface/Protocol/RuntimeObserver.js
@@ -31,7 +31,7 @@ WI.RuntimeObserver = class RuntimeObserver extends InspectorBackend.Dispatcher
     {
         if (this._target instanceof WI.FrameTarget) {
             let type = WI.ExecutionContext.typeFromPayload(contextPayload);
-            let executionContext = new WI.ExecutionContext(this._target, contextPayload.id, type, contextPayload.name);
+            let executionContext = new WI.ExecutionContext(this._target, contextPayload.id, type, contextPayload.name, contextPayload.frameId);
             this._target.addExecutionContext(executionContext);
             return;
         }

--- a/Source/WebInspectorUI/UserInterface/Views/FrameTreeElement.js
+++ b/Source/WebInspectorUI/UserInterface/Views/FrameTreeElement.js
@@ -41,6 +41,7 @@ WI.FrameTreeElement = class FrameTreeElement extends WI.ResourceTreeElement
         frame.addEventListener(WI.Frame.Event.ExtraScriptAdded, this._extraScriptAdded, this);
         frame.addEventListener(WI.Frame.Event.ChildFrameWasAdded, this._childFrameWasAdded, this);
         frame.addEventListener(WI.Frame.Event.ChildFrameWasRemoved, this._childFrameWasRemoved, this);
+        frame.extraScriptCollection.addEventListener(WI.Collection.Event.ItemRemoved, this._collectionItemWasRemoved, this);
 
         this.shouldRefreshChildren = true;
         this.folderSettingsKey = this._frame.url.hash;
@@ -174,7 +175,7 @@ WI.FrameTreeElement = class FrameTreeElement extends WI.ResourceTreeElement
         }
 
         for (let extraScript of this._frame.extraScriptCollection) {
-            if (extraScript.sourceURL || extraScript.sourceMappingURL)
+            if (extraScript.sourceURL || extraScript.sourceMappingURL || extraScript.sourceType === WI.Script.SourceType.WebAssembly)
                 this.addChildForRepresentedObject(extraScript);
         }
 
@@ -240,10 +241,15 @@ WI.FrameTreeElement = class FrameTreeElement extends WI.ResourceTreeElement
         this.removeChildForRepresentedObject(event.data.resource);
     }
 
+    _collectionItemWasRemoved(event)
+    {
+        this.removeChildForRepresentedObject(event.data.item);
+    }
+
     _extraScriptAdded(event)
     {
         let extraScript = event.data.script;
-        if (extraScript.sourceURL || extraScript.sourceMappingURL)
+        if (extraScript.sourceURL || extraScript.sourceMappingURL || extraScript.sourceType === WI.Script.SourceType.WebAssembly)
             this.addRepresentedObjectToNewChildQueue(extraScript);
     }
 

--- a/Source/WebInspectorUI/UserInterface/Views/OpenResourceDialog.js
+++ b/Source/WebInspectorUI/UserInterface/Views/OpenResourceDialog.js
@@ -452,7 +452,7 @@ WI.OpenResourceDialog = class OpenResourceDialog extends WI.Dialog
     _scriptAdded(event)
     {
         let {script} = event.data;
-        if (script.resource || script.target === WI.mainTarget)
+        if (script.resource || script.dynamicallyAddedScriptElement)
             return;
 
         this._addResource(script);
@@ -461,7 +461,7 @@ WI.OpenResourceDialog = class OpenResourceDialog extends WI.Dialog
     _scriptRemoved(event)
     {
         let {script} = event.data;
-        if (script.resource || script.target === WI.mainTarget)
+        if (script.resource || script.dynamicallyAddedScriptElement)
             return;
 
         this._removeResource(script);

--- a/Source/WebInspectorUI/UserInterface/Views/ScriptContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ScriptContentView.js
@@ -39,9 +39,9 @@ WI.ScriptContentView = class ScriptContentView extends WI.ContentView
 
         this._script = script;
 
-        // This view is only for standalone Scripts with no corresponding Resource. All other Scripts
-        // should be handled by TextResourceContentView via the Resource.
-        console.assert(!script.resource);
+        // WebAssembly Resources use ScriptContentView so the debugger's source content is shown instead
+        // of the Resource's raw binary response.
+        console.assert(!script.resource || script.sourceType === WI.Script.SourceType.WebAssembly);
         // FIXME: <https://webkit.org/b/298909> Frame target inline scripts have non-zero start positions
         // because they are <script> blocks inside HTML, but frame targets lack a Network agent so there
         // is no Document resource to display through TextResourceContentView. This is blocked on the
@@ -240,6 +240,12 @@ WI.ScriptContentView = class ScriptContentView extends WI.ContentView
 
     _contentDidPopulate(event)
     {
+        if (this._script.sourceType === WI.Script.SourceType.WebAssembly && !this._textEditor.string) {
+            this.removeAllSubviews();
+            this.element.appendChild(WI.createMessageTextView(WI.UIString("Resource has binary content.")));
+            return;
+        }
+
         let isLocalScript = this._script instanceof WI.LocalScript;
 
         this._prettyPrintButtonNavigationItem.enabled = this._textEditor.canBeFormatted();

--- a/Source/WebInspectorUI/UserInterface/Views/SourceCodeTextEditor.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SourceCodeTextEditor.js
@@ -558,10 +558,8 @@ WI.SourceCodeTextEditor = class SourceCodeTextEditor extends WI.TextEditor
         if (this._contentPopulated)
             return;
 
-        if (this._sourceCode instanceof WI.Resource)
+        if (this._sourceCode instanceof WI.Resource || this._sourceCode instanceof WI.Script)
             this.mimeType = this._sourceCode.syntheticMIMEType;
-        else if (this._sourceCode instanceof WI.Script)
-            this.mimeType = "text/javascript";
         else if (this._sourceCode instanceof WI.CSSStyleSheet)
             this.mimeType = "text/css";
 
@@ -1295,10 +1293,15 @@ WI.SourceCodeTextEditor = class SourceCodeTextEditor extends WI.TextEditor
         if (this._sourceCode instanceof WI.Resource) {
             if (this._sourceCode.localResourceOverride)
                 return false;
+            // FIXME: Support breakpoints and stepping in WebAssembly.
+            if (this._sourceCode.mimeTypeComponents.type === "application/wasm")
+                return false;
             return this._sourceCode.type === WI.Resource.Type.Document || this._sourceCode.type === WI.Resource.Type.Script;
         }
-        if (this._sourceCode instanceof WI.Script)
-            return !(this._sourceCode instanceof WI.LocalScript);
+        if (this._sourceCode instanceof WI.Script) {
+            // FIXME: Support breakpoints and stepping in WebAssembly.
+            return !(this._sourceCode instanceof WI.LocalScript) && this._sourceCode.sourceType !== WI.Script.SourceType.WebAssembly;
+        }
         return false;
     }
 

--- a/Source/WebInspectorUI/UserInterface/Views/SourcesNavigationSidebarPanel.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SourcesNavigationSidebarPanel.js
@@ -326,6 +326,7 @@ WI.SourcesNavigationSidebarPanel = class SourcesNavigationSidebarPanel extends W
         WI.Target.addEventListener(WI.Target.Event.ResourceAdded, this._handleResourceAdded, this);
 
         WI.networkManager.addEventListener(WI.NetworkManager.Event.FrameWasAdded, this._handleFrameWasAdded, this);
+        WI.networkManager.addEventListener(WI.NetworkManager.Event.FrameWasRemoved, this._handleFrameWasRemoved, this);
 
         if (WI.NetworkManager.supportsBootstrapScript()) {
             WI.networkManager.addEventListener(WI.NetworkManager.Event.BootstrapScriptCreated, this._handleBootstrapScriptCreated, this);
@@ -495,6 +496,7 @@ WI.SourcesNavigationSidebarPanel = class SourcesNavigationSidebarPanel extends W
         WI.Target.removeEventListener(WI.Target.Event.ResourceAdded, this._handleResourceAdded, this);
 
         WI.networkManager.removeEventListener(WI.NetworkManager.Event.FrameWasAdded, this._handleFrameWasAdded, this);
+        WI.networkManager.removeEventListener(WI.NetworkManager.Event.FrameWasRemoved, this._handleFrameWasRemoved, this);
 
         if (WI.NetworkManager.supportsBootstrapScript()) {
             WI.networkManager.removeEventListener(WI.NetworkManager.Event.BootstrapScriptCreated, this._handleBootstrapScriptCreated, this);
@@ -1278,6 +1280,31 @@ WI.SourcesNavigationSidebarPanel = class SourcesNavigationSidebarPanel extends W
         // If the script URL matches a resource we can assume it is part of that resource and does not need added.
         if (script.resource || script.dynamicallyAddedScriptElement)
             return;
+
+        if (script.parentFrame) {
+            if (WI.settings.resourceGroupingMode.value === WI.Resource.GroupingMode.Path) {
+                let origin = this._originForURLComponents(script.urlComponents, script.parentFrame?.securityOrigin);
+                let originTreeElement = this._originTreeElementMap.get(origin);
+                if (!originTreeElement) {
+                    let representedObject = origin === script.parentFrame?.urlComponents.origin ? script.parentFrame : null;
+                    originTreeElement = new WI.OriginTreeElement(origin, representedObject, {hasChildren: true});
+                    this._originTreeElementMap.set(origin, originTreeElement);
+
+                    let index = insertionIndexForObjectInListSortedByFunction(originTreeElement, this._resourcesTreeOutline.children, this._boundCompareTreeElements);
+                    this._resourcesTreeOutline.insertChild(originTreeElement, index);
+                }
+
+                let subpath = script.urlComponents.origin ? script.urlComponents.path : null;
+                let parentTreeElement = originTreeElement.createFoldersAsNeededForSubpath(subpath, this._boundCompareTreeElements);
+                let scriptTreeElement = new WI.ScriptTreeElement(script);
+                let index = insertionIndexForObjectInListSortedByFunction(scriptTreeElement, parentTreeElement.children, this._boundCompareTreeElements);
+                parentTreeElement.insertChild(scriptTreeElement, index);
+            }
+
+            this._addBreakpointsForSourceCode(script);
+            this._addIssuesForSourceCode(script);
+            return;
+        }
 
         let scriptTreeElement = new WI.ScriptTreeElement(script);
 
@@ -2450,6 +2477,12 @@ WI.SourcesNavigationSidebarPanel = class SourcesNavigationSidebarPanel extends W
         this._addResourcesRecursivelyForFrame(frame);
     }
 
+    _handleFrameWasRemoved(event)
+    {
+        if (WI.settings.resourceGroupingMode.value === WI.Resource.GroupingMode.Path)
+            this._handleResourceGroupingModeChanged();
+    }
+
     _handleBootstrapScriptCreated(event)
     {
         this._addLocalOverride(event.data.bootstrapScript);
@@ -2502,7 +2535,7 @@ WI.SourcesNavigationSidebarPanel = class SourcesNavigationSidebarPanel extends W
         let parentTreeElement = scriptTreeElement.parent;
         parentTreeElement.removeChild(scriptTreeElement);
 
-        if (parentTreeElement instanceof WI.FolderTreeElement || parentTreeElement instanceof WI.OriginTreeElement) {
+        if (parentTreeElement.representedObject instanceof WI.ScriptCollection) {
             parentTreeElement.representedObject.remove(script);
 
             if (!parentTreeElement.children.length)
@@ -2521,6 +2554,11 @@ WI.SourcesNavigationSidebarPanel = class SourcesNavigationSidebarPanel extends W
                 continue;
 
             this._breakpointsTreeOutline.removeChild(treeElement, suppressOnDeselect, suppressSelectSibling);
+        }
+
+        if (WI.settings.resourceGroupingMode.value === WI.Resource.GroupingMode.Path) {
+            this._handleResourceGroupingModeChanged();
+            return;
         }
 
         if (this._extensionScriptsFolderTreeElement) {
@@ -2843,6 +2881,9 @@ WI.SourcesNavigationSidebarPanel = class SourcesNavigationSidebarPanel extends W
         let workerTreeElement = this._workerTargetTreeElementMap.take(target);
         if (workerTreeElement)
             workerTreeElement.parent.removeChild(workerTreeElement);
+
+        if (target instanceof WI.FrameTarget)
+            this._handleResourceGroupingModeChanged();
 
         let callStackTreeElement = this._findCallStackTargetTreeElement(target);
         console.assert(callStackTreeElement);


### PR DESCRIPTION
#### 14549e6b85926dcf5f87f114d2d688b73053f2f1
<pre>
Web Inspector: Sources: show WebAssembly modules
<a href="https://bugs.webkit.org/show_bug.cgi?id=319168">https://bugs.webkit.org/show_bug.cgi?id=319168</a>

Reviewed by Yusuke Suzuki.

* Source/JavaScriptCore/wasm/WasmModule.h:
(JSC::Wasm::Module::validateAsync):
(JSC::Wasm::Module::create):
(JSC::Wasm::Module::Module):
* Source/JavaScriptCore/wasm/WasmModule.cpp:
(JSC::Wasm::Module::Module):
(JSC::Wasm::makeValidationResult):
(JSC::Wasm::makeValidationCallback):
(JSC::Wasm::Module::validateAsync):
* Source/JavaScriptCore/wasm/WasmModuleInformation.h:
* Source/JavaScriptCore/wasm/WasmStreamingCompiler.cpp:
(JSC::Wasm::StreamingCompiler::StreamingCompiler):
* Source/JavaScriptCore/wasm/debugger/WasmModuleDebugInfo.h:
* Source/JavaScriptCore/wasm/debugger/WasmModuleDebugInfo.cpp:
(JSC::Wasm::ModuleDebugInfo::debugName const):
* Source/JavaScriptCore/wasm/js/JSWebAssembly.cpp:
(JSC::compileAndInstantiate):
Store the URL of streamed modules and module-loader for showing in Web Inspector.

* Source/JavaScriptCore/wasm/js/JSWebAssemblyModule.cpp:
(JSC::JSWebAssemblyModule::create):
* Source/JavaScriptCore/debugger/Debugger.h:
(JSC::Debugger::sourceParsed):
(JSC::Debugger::Observer::didParseSource):
(JSC::Debugger::sourceURLBase const): Added.
* Source/JavaScriptCore/debugger/Debugger.cpp:
(JSC::Debugger::attach):
(JSC::Debugger::removeObserver):
(JSC::Debugger::sourceParsed):
* Source/JavaScriptCore/tools/JSDollarVM.cpp:
(JSC::DoNothingDebugger::sourceParsed): Added.
Add instrumentation whenever a `WebAssembly.Module` is created.
Use the standard WebAssembly module name subsection as an optional/fallback display name.
Drive-by: deduplicate all parsed scripts by `SourceID`.

* Source/JavaScriptCore/inspector/protocol/Debugger.json:
* Source/JavaScriptCore/inspector/scripts/codegen/generator.py:
(ucfirst):
* Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.h:
(Inspector::InspectorDebuggerAgent::didParseSource):
* Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.cpp:
(Inspector::scriptTypeForScript): Added.
(Inspector::InspectorDebuggerAgent::resolveBreakpoint):
(Inspector::InspectorDebuggerAgent::getBreakpointLocations):
(Inspector::InspectorDebuggerAgent::setBlackboxConfiguration):
(Inspector::InspectorDebuggerAgent::didParseSource):
Report script type, execution context, and display name for each `WebAssembly.Module`.
Disable unsupported WebAssembly debugger features (e.g. breakpoints, blackboxing, etc.).

* Source/WebCore/bindings/js/JSDOMGlobalObject.cpp:
(WebCore::handleResponseOnStreamingAction):
Forward the final response URL to the streaming compiler so it can be stored with the module.

* Source/WebCore/inspector/FrameDebugger.h:
(WebCore::FrameDebugger::sourceURLBase const): Added.
* Source/WebCore/inspector/FrameDebugger.cpp:
(WebCore::FrameDebugger::sourceURLBase const): Added.
* Source/WebCore/inspector/PageDebugger.h:
(WebCore::PageDebugger::sourceURLBase const): Added.
* Source/WebCore/inspector/PageDebugger.cpp:
(WebCore::PageDebugger::sourceURLBase const): Added.
* Source/WebCore/inspector/WorkerDebugger.h:
(WebCore::WorkerDebugger::sourceURLBase const): Added.
* Source/WebCore/inspector/WorkerDebugger.cpp:
(WebCore::WorkerDebugger::sourceURLBase const): Added.
Use the document or `Worker` URL as the base for modules instantiated directly from bytes.

* Source/WebCore/inspector/agents/frame/FrameRuntimeAgent.cpp:
(WebCore::FrameRuntimeAgent::frameIdForProtocol const):
Use process-qualified identifiers so execution contexts can be associated with site-isolated frames.

* Source/WebInspectorUI/UserInterface/Protocol/DebuggerObserver.js:
(WI.DebuggerObserver):
(WI.DebuggerObserver.prototype.scriptParsed):
* Source/WebInspectorUI/UserInterface/Protocol/RuntimeObserver.js:
(WI.RuntimeObserver.prototype.executionContextCreated):
* Source/WebInspectorUI/UserInterface/Controllers/DebuggerManager.js:
(WI.DebuggerManager):
(WI.DebuggerManager.prototype.scriptDidParse):
(WI.DebuggerManager.prototype._frameForExecutionContext): Added.
(WI.DebuggerManager.prototype._targetRemoved):
(WI.DebuggerManager.prototype._frameWasRemoved): Added.
Convert the legacy `module` parameter from older backends into a `Debugger.ScriptType` enum.
Associate every `WI.Script` reported with a `WI.ExecutionContext` to its owner `WI.Frame`.
Keep WebAssembly module `WI.Script` that cannot map to a `WI.Resource` in &quot;Extra Scripts&quot;.

* Source/WebInspectorUI/UserInterface/Models/Script.js:
(WI.Script):
(WI.Script.isWebAssembly): Added.
(WI.Script.prototype.get parentFrame): Added.
(WI.Script.prototype.get mimeType):
(WI.Script.prototype.get syntheticMIMEType): Added.
(WI.Script.prototype.get supportsScriptBlackboxing): Added.
(WI.Script.prototype.get displayName):
(WI.Script.prototype.couldBeMainResource):
(WI.Script.prototype._resolveResource):
Give WebAssembly `WI.Script` a MIME of `application/wasm`.
Resolve a matching `WI.Resource` without allowing WebAssembly `WI.Script` to replace a main resource.

* Source/WebInspectorUI/UserInterface/Views/FrameTreeElement.js:
(WI.FrameTreeElement):
(WI.FrameTreeElement.prototype.onpopulate):
(WI.FrameTreeElement.prototype._collectionItemWasRemoved): Added.
(WI.FrameTreeElement.prototype._extraScriptAdded):
* Source/WebInspectorUI/UserInterface/Views/OpenResourceDialog.js:
(WI.OpenResourceDialog.prototype._scriptAdded):
(WI.OpenResourceDialog.prototype._scriptRemoved):
* Source/WebInspectorUI/UserInterface/Views/SourcesNavigationSidebarPanel.js:
(WI.SourcesNavigationSidebarPanel):
(WI.SourcesNavigationSidebarPanel.prototype.closed):
(WI.SourcesNavigationSidebarPanel.prototype._addScript):
(WI.SourcesNavigationSidebarPanel.prototype._handleFrameWasRemoved): Added.
(WI.SourcesNavigationSidebarPanel.prototype._handleDebuggerScriptRemoved):
(WI.SourcesNavigationSidebarPanel.prototype._handleDebuggerScriptsCleared):
(WI.SourcesNavigationSidebarPanel.prototype._handleTargetRemoved):
Show WebAssembly `WI.Script` without a `WI.Resource` under the parent `WI.Frame` and/or `Worker`.

* Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js:
* Source/WebInspectorUI/UserInterface/Views/ScriptContentView.js:
(WI.ScriptContentView):
(WI.ScriptContentView.prototype._contentDidPopulate):
* Source/WebInspectorUI/UserInterface/Views/SourceCodeTextEditor.js:
(WI.SourceCodeTextEditor.prototype._prepareEditorForInitialContent):
(WI.SourceCodeTextEditor.prototype.get _supportsDebugging):
Show binary WebAssembly `WI.Script` without treating their contents as editable source text.

* LayoutTests/inspector/debugger/wasm/getScriptSource.html: Added.
* LayoutTests/inspector/debugger/wasm/getScriptSource-expected.txt: Added.
* LayoutTests/inspector/debugger/wasm/resources/test-modules.js: Added.
* LayoutTests/inspector/model/frame-extra-scripts.html:
* LayoutTests/inspector/model/frame-extra-scripts-expected.txt:
* LayoutTests/inspector/worker/debugger-getScriptSource-wasm.html: Added.
* LayoutTests/inspector/worker/debugger-getScriptSource-wasm-expected.txt: Added.
* LayoutTests/inspector/worker/resources/worker-debugger-wasm.js: Added.

Canonical link: <a href="https://commits.webkit.org/317891@main">https://commits.webkit.org/317891@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba75207ff304c2732dc0a8ebf7ead1492f13ab59

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176627 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50564 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44356 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186229 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/139368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178490 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51857 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50250 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137584 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/139368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179583 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41088 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158369 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118058 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39743 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38105 "Passed tests") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/23 "Found 5 new JSC stress test failures: wasm.yaml/wasm/stress/type-index-abstract-heap-types-concrete-vs-abstract.js.wasm-aggressive-inline, wasm.yaml/wasm/stress/type-index-abstract-heap-types-concrete-vs-abstract.js.wasm-eager, wasm.yaml/wasm/stress/type-index-abstract-heap-types-globals-and-tables.js.wasm-aggressive-inline, wasm.yaml/wasm/stress/type-index-abstract-heap-types-globals-and-tables.js.wasm-eager, wasm.yaml/wasm/stress/type-index-abstract-heap-types-nulls-and-casts.js.wasm-aggressive-inline (failure)") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/6876 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150155 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37867 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34697 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/37898 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42304 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42322 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188653 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50231 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/157912 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146643 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39443 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50914 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146451 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41215 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123120 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117226 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49419 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12846 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48818 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49054 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48879 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->