### PR TITLE
WebGL2: drawElements with UNSIGNED_INT indices crashes when element array buffer size is not a multiple of 4

### DIFF
--- a/LayoutTests/webgl/webgl2-draw-elements-unaligned-buffer-nocrash-expected.txt
+++ b/LayoutTests/webgl/webgl2-draw-elements-unaligned-buffer-nocrash-expected.txt
@@ -1,0 +1,3 @@
+PASS if no crash.
+
+

--- a/LayoutTests/webgl/webgl2-draw-elements-unaligned-buffer-nocrash.html
+++ b/LayoutTests/webgl/webgl2-draw-elements-unaligned-buffer-nocrash.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>PASS if no crash.</p>
+<canvas id="canvas" width="1" height="1"></canvas>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+const canvas = document.getElementById('canvas');
+const gl = canvas.getContext('webgl2');
+
+const vs = gl.createShader(gl.VERTEX_SHADER);
+gl.shaderSource(vs, `#version 300 es\nvoid main() {}`);
+gl.compileShader(vs);
+
+const fs = gl.createShader(gl.FRAGMENT_SHADER);
+gl.shaderSource(fs, `#version 300 es\nprecision mediump float;\nout vec4 c;\nvoid main() { c = vec4(0); }`);
+gl.compileShader(fs);
+
+const program = gl.createProgram();
+gl.attachShader(program, vs);
+gl.attachShader(program, fs);
+gl.linkProgram(program);
+gl.useProgram(program);
+
+// 53 bytes is intentionally not a multiple of 4 (sizeof UNSIGNED_INT).
+// drawElements with UNSIGNED_INT must not crash when processing the buffer
+// for primitive restart index ranges.
+const ibo = gl.createBuffer();
+gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, ibo);
+gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, 53, gl.STATIC_DRAW);
+gl.drawElements(gl.POINTS, 3, gl.UNSIGNED_INT, 4);
+gl.finish();
+
+setTimeout(() => {
+    if (window.testRunner)
+        testRunner.notifyDone();
+}, 300);
+</script>
+</body>
+</html>

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/BufferMtl.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/BufferMtl.mm
@@ -478,7 +478,8 @@ template <typename T>
 static std::vector<DrawIndexRange> CalculateDrawIndexRanges(angle::Span<const uint8_t> data)
 {
     std::vector<DrawIndexRange> result;
-    angle::Span<const T> elements = angle::reinterpret_span<const T>(data);
+    angle::Span<const T> elements =
+        angle::reinterpret_span<const T>(data.first(data.size() - data.size() % sizeof(T)));
     constexpr T restartMarker     = std::numeric_limits<T>::max();
     const auto begin              = elements.cbegin();
     const auto end                = elements.cend();


### PR DESCRIPTION
#### 98d7962dd25c6dfa50d334389d385817308171b3
<pre>
WebGL2: drawElements with UNSIGNED_INT indices crashes when element array buffer size is not a multiple of 4
<a href="https://bugs.webkit.org/show_bug.cgi?id=319175">https://bugs.webkit.org/show_bug.cgi?id=319175</a>
<a href="https://rdar.apple.com/181799978">rdar://181799978</a>

Reviewed by Dan Glastonbury.

CalculateDrawIndexRanges&lt;T&gt; passes the raw buffer byte span directly to angle::reinterpret_span&lt;const T&gt;, which asserts that the span size is a multiple of sizeof(T). When a WebGL2
drawElements call is made with UNSIGNED_INT indices against a buffer whose size is not a multiple of 4, this assertion fires and aborts the GPU process.

Fix: truncate the span to floor(size / sizeof(T)) * sizeof(T) bytes before calling reinterpret_span. The trailing partial bytes cannot form a complete index and are correctly
ignored.

Test: webgl/webgl2-draw-elements-unaligned-buffer-nocrash.html

* LayoutTests/webgl/webgl2-draw-elements-unaligned-buffer-nocrash-expected.txt: Added.
* LayoutTests/webgl/webgl2-draw-elements-unaligned-buffer-nocrash.html: Added.
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/BufferMtl.mm:
(rx::CalculateDrawIndexRanges):

Canonical link: <a href="https://commits.webkit.org/317110@main">https://commits.webkit.org/317110@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/83ca6401d3e6717cc4a54b6b40ec0c942b077a4e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174025 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47958 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41739 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183599 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131893 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ba33af34-f91e-4ebb-8076-3635f8c65027) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49250 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47640 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135337 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95440 "4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6a6c94d7-73c2-490d-b5a2-3c376a6ed431) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176983 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38768 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156128 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115815 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/13ee1cbb-e461-4ffa-a6c4-53372d4ffca3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37409 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35776 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32083 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147833 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35621 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186025 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39975 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144238 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47625 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155683 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144097 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38923 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48304 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32238 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113715 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39006 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46810 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10582 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46213 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46444 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46271 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->