### PR TITLE
[iOS] debug editing/selection/ios/select-text-by-long-press-with-hardware-keyboard.html is timing out

### DIFF
--- a/LayoutTests/editing/selection/ios/select-text-by-long-press-with-hardware-keyboard.html
+++ b/LayoutTests/editing/selection/ios/select-text-by-long-press-with-hardware-keyboard.html
@@ -24,7 +24,7 @@ description("Verifies that long-pressing non-editable text while a separate edit
 
 addEventListener("load", async () => {
     const input = document.querySelector("input");
-    await UIHelper.activateElementAndWaitForInputSession(input);
+    await UIHelper.activateElementAndWaitForInputSessionStart(input);
 
     window.focusedElementWasInput = document.activeElement === input;
     shouldBeTrue("focusedElementWasInput");


### PR DESCRIPTION
#### 5049e8b1e79709e2588926ab14a70d1968bfbbae
<pre>
[iOS] debug editing/selection/ios/select-text-by-long-press-with-hardware-keyboard.html is timing out
<a href="https://bugs.webkit.org/show_bug.cgi?id=319181">https://bugs.webkit.org/show_bug.cgi?id=319181</a>
<a href="https://rdar.apple.com/181955233">rdar://181955233</a>

Reviewed by Richard Robinson.

After 316922@main, this is one of the tests that needed
to use the new helper activateAndWaitForInputSessionStartAt
to fix the timeout issue.

In this case, use activateElementAndWaitForInputSessionStart
which calls activateAndWaitForInputSessionStartAt.

* LayoutTests/editing/selection/ios/select-text-by-long-press-with-hardware-keyboard.html:

Canonical link: <a href="https://commits.webkit.org/317060@main">https://commits.webkit.org/317060@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c283906883fc045a0d6a8b02105361d8d302e9d7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174043 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47976 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41757 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183617 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131911 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dd59f96c-a205-49a9-8ced-cee8d63542b7) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49268 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47658 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135351 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95454 "2 flakes 3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9c6740e8-2e5e-4cea-aa7f-1a95545740fc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177001 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38781 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156141 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115829 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/73ee2601-95a9-4a79-abd4-f0694c5b5889) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37422 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35790 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32101 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147846 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35634 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186043 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39989 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144252 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47643 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155696 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144111 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48322 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32251 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113746 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26480 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39020 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46828 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10595 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46231 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46462 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46289 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->