### PR TITLE
Scroll To Text Fragment: simplify MIME-type gate and add mixed-case coverage

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/resources/text-html-mixed-case.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/resources/text-html-mixed-case.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<style>
+  p {
+    position: absolute;
+    top: 200vh;
+  }
+</style>
+<p>
+  target
+</p>

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/resources/text-html-mixed-case.html.headers
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/resources/text-html-mixed-case.html.headers
@@ -1,0 +1,1 @@
+Content-Type: Text/HTML; charset=UTF-8

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/text-directive-mime-type-parameter-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/text-directive-mime-type-parameter-expected.txt
@@ -1,3 +1,4 @@
 
 PASS Text directive allowed in text/html with a charset parameter
+PASS Text directive allowed in text/html served with mixed-case MIME type
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/text-directive-mime-type-parameter.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/text-directive-mime-type-parameter.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<title>Allow text fragments when the MIME type has a parameter</title>
+<title>Allow text fragments when the MIME type has a parameter or mixed case</title>
 <meta charset=utf-8>
 <link rel="help" href="https://wicg.github.io/scroll-to-text-fragment/#text-directive-allowing-mime-type">
 <script src="/resources/testharness.js"></script>
@@ -13,7 +13,8 @@
 // A "text directive allowing MIME type" is one whose essence is "text/html" or
 // "text/plain". The essence must be compared after stripping any MIME type
 // parameter, so a document served as e.g. "text/html; charset=utf-8" must still
-// process text directives.
+// process text directives. The comparison is also ASCII case-insensitive, so a
+// document served as e.g. "Text/HTML" must be treated the same as "text/html".
 
 function rAF(win) {
   return new Promise((resolve) => {
@@ -42,4 +43,17 @@ promise_test(async function (t) {
 
   popup.close();
 }, 'Text directive allowed in text/html with a charset parameter');
+
+promise_test(async function (t) {
+  // resources/text-html-mixed-case.html is served as "Text/HTML; charset=UTF-8".
+  const popup = await openPopup(`resources/text-html-mixed-case.html#:~:text=target`);
+
+  // rAF twice in case there is any asynchronicity in scrolling to the target.
+  await rAF(popup);
+  await rAF(popup);
+
+  assert_true(popup.scrollY > 0, 'scrolled to fragment');
+
+  popup.close();
+}, 'Text directive allowed in text/html served with mixed-case MIME type');
 </script>

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -3150,7 +3150,7 @@ bool LocalFrameView::scrollToTextFragment(IsRetry isRetry)
     if (!parsedContentType)
         return false;
     auto mimeType = parsedContentType->mimeType();
-    if (!equalLettersIgnoringASCIICase(mimeType, "text/html"_s) && !equalLettersIgnoringASCIICase(mimeType, "text/plain"_s))
+    if (mimeType != "text/html"_s && mimeType != "text/plain"_s)
         return false;
 
     // Block text fragments in cross-origin window.open() popups


### PR DESCRIPTION
#### 0f1cee1acd25f51b59c7c5d529ebfbb588da465b
<pre>
Scroll To Text Fragment: simplify MIME-type gate and add mixed-case coverage
<a href="https://bugs.webkit.org/show_bug.cgi?id=319182">https://bugs.webkit.org/show_bug.cgi?id=319182</a>
<a href="https://rdar.apple.com/182030528">rdar://182030528</a>

Reviewed by Anne van Kesteren.

Follow-up to 316976@main. ParsedContentType::mimeType() already returns an
ASCII-lowercased essence (setContentType() calls convertToASCIILowercase()),
so the equalLettersIgnoringASCIICase() comparisons in scrollToTextFragment()
were redundant. Compare the parsed MIME type directly against the lowercase
literals &quot;text/html&quot; and &quot;text/plain&quot;, and note in a comment that the string
is already lowercased.

Also add WPT coverage for a document served with a mixed-case Content-Type
(&quot;Text/HTML; charset=UTF-8&quot;) to pin the case-insensitive normalization.

* LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/resources/text-html-mixed-case.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/resources/text-html-mixed-case.html.headers: Added.
* LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/text-directive-mime-type-parameter-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/text-directive-mime-type-parameter.html:
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::scrollToTextFragment):

Canonical link: <a href="https://commits.webkit.org/316990@main">https://commits.webkit.org/316990@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0897d94f48a08314df587f8f0406a1992b77ec32

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174049 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47982 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41763 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183623 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131917 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/29a5d871-cd3a-4648-b61b-f1c83a9f7d2e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175914 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49274 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47664 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135357 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4ec2715f-d07d-4d9b-9531-d0a6df3c8060) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177007 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38786 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156147 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115835 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2a90fcd2-dd75-429f-a598-faf61dd02257) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37427 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35796 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32107 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147851 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35640 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186049 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39147 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39995 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144258 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47649 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155702 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144118 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38846 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48328 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32257 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113764 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39026 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120213 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46834 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10601 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46237 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46468 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46295 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->