### PR TITLE
[JSC] AsyncFromSyncIterator does not close correctly when the sync iterator yields a rejected value promise

### DIFF
--- a/JSTests/stress/async-from-sync-iterator-close-on-rejection-throwing-return.js
+++ b/JSTests/stress/async-from-sync-iterator-close-on-rejection-throwing-return.js
@@ -1,0 +1,122 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}, expected ${expected}`);
+}
+
+// When the sync iterator yields a rejected value promise, AsyncFromSyncIteratorContinuation
+// performs IteratorClose(syncIteratorRecord, ThrowCompletion(error)). Any exception thrown
+// while getting or calling the return method must be discarded and the promise must be
+// rejected with the original rejection reason (ECMA-262 IteratorClose steps 3-6).
+
+// return() throws.
+{
+    let state = "pending";
+    const syncIterable = {
+        [Symbol.iterator]() {
+            return {
+                next() { return { value: Promise.reject(new Error("original")), done: false }; },
+                return() { throw new Error("close error"); }
+            };
+        }
+    };
+    (async () => {
+        try {
+            for await (const x of syncIterable) {}
+            state = "fulfilled";
+        } catch (e) {
+            state = e.message;
+        }
+    })();
+    drainMicrotasks();
+    shouldBe(state, "original");
+}
+
+// 'return' getter throws.
+{
+    let state = "pending";
+    const syncIterable = {
+        [Symbol.iterator]() {
+            return {
+                next() { return { value: Promise.reject(new Error("original")), done: false }; },
+                get return() { throw new Error("getter error"); }
+            };
+        }
+    };
+    (async () => {
+        try {
+            for await (const x of syncIterable) {}
+            state = "fulfilled";
+        } catch (e) {
+            state = e.message;
+        }
+    })();
+    drainMicrotasks();
+    shouldBe(state, "original");
+}
+
+// 'return' is non-callable: the GetMethod TypeError is also discarded.
+{
+    let state = "pending";
+    const syncIterable = {
+        [Symbol.iterator]() {
+            return {
+                next() { return { value: Promise.reject(new Error("original")), done: false }; },
+                return: 42
+            };
+        }
+    };
+    (async () => {
+        try {
+            for await (const x of syncIterable) {}
+            state = "fulfilled";
+        } catch (e) {
+            state = e.message;
+        }
+    })();
+    drainMicrotasks();
+    shouldBe(state, "original");
+}
+
+// return() returns normally: iterator is closed exactly once, original reason preserved.
+{
+    let state = "pending";
+    let returnCount = 0;
+    const syncIterable = {
+        [Symbol.iterator]() {
+            return {
+                next() { return { value: Promise.reject(new Error("original")), done: false }; },
+                return() { returnCount++; return { done: true }; }
+            };
+        }
+    };
+    (async () => {
+        try {
+            for await (const x of syncIterable) {}
+            state = "fulfilled";
+        } catch (e) {
+            state = e.message;
+        }
+    })();
+    drainMicrotasks();
+    shouldBe(state, "original");
+    shouldBe(returnCount, 1);
+}
+
+// Same via async generator yield* delegation.
+{
+    let state = "pending";
+    const syncIterable = {
+        [Symbol.iterator]() {
+            return {
+                next() { return { value: Promise.reject(new Error("original")), done: false }; },
+                return() { throw new Error("close error"); }
+            };
+        }
+    };
+    async function* gen() { yield* syncIterable; }
+    gen().next().then(
+        () => { state = "fulfilled"; },
+        (e) => { state = e.message; });
+    drainMicrotasks();
+    shouldBe(state, "original");
+}

--- a/Source/JavaScriptCore/runtime/JSMicrotask.cpp
+++ b/Source/JavaScriptCore/runtime/JSMicrotask.cpp
@@ -303,27 +303,13 @@ static void asyncFromSyncIteratorContinueOrDone(JSGlobalObject* globalObject, VM
     case JSPromise::Status::Rejected: {
         JSValue syncIterator = contextObject->getDirect(vm, vm.propertyNames->builtinNames().syncIteratorPrivateName());
         if (syncIterator.isObject()) {
-            JSValue returnMethod;
-            JSValue error;
-            {
-                auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-                returnMethod = asObject(syncIterator)->get(globalObject, vm.propertyNames->returnKeyword);
-                if (catchScope.exception()) [[unlikely]] {
-                    error = catchScope.exception()->value();
-                    if (!catchScope.clearExceptionExceptTermination()) [[unlikely]] {
-                        scope.release();
-                        return;
-                    }
-                }
-            }
-            if (error) [[unlikely]] {
-                promise->reject(vm, error);
-                return;
-            }
-            if (returnMethod.isCallable()) {
+            auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+            JSValue returnMethod = asObject(syncIterator)->get(globalObject, vm.propertyNames->returnKeyword);
+            if (!catchScope.exception() && returnMethod.isCallable())
                 callMicrotask(globalObject, returnMethod, syncIterator, dynamicCastToCell(returnMethod), "return is not a function"_s, nullptr);
-                if (scope.exception()) [[unlikely]]
-                    return;
+            if (!catchScope.clearExceptionExceptTermination()) [[unlikely]] {
+                scope.release();
+                return;
             }
         }
         scope.release();


### PR DESCRIPTION
#### 8490d02c5dcc8461ce5d8161717d292d8085a596
<pre>
[JSC] AsyncFromSyncIterator does not close correctly when the sync iterator yields a rejected value promise
<a href="https://bugs.webkit.org/show_bug.cgi?id=319185">https://bugs.webkit.org/show_bug.cgi?id=319185</a>

Reviewed by Yusuke Suzuki.

Per IteratorClose[1] invoked with a throw completion, any exception thrown
while getting or calling the return method must be discarded so the outer
completion (the original rejection reason) is preserved. JSC was letting a
throwing return() propagate (leaving the promise pending with an uncaught
exception) and letting a throwing return getter reject the promise with the
getter&apos;s exception instead of the original reason.

    const it = {
        [Symbol.iterator]: () =&gt; ({
            next: () =&gt; ({ value: Promise.reject(new Error(&quot;original&quot;)), done: false }),
            return() { throw new Error(&quot;close error&quot;); }
        })
    };
    (async () =&gt; { for await (const _ of it) {} })(); // never settled before

[1]: <a href="https://tc39.es/ecma262/#sec-iteratorclose">https://tc39.es/ecma262/#sec-iteratorclose</a>

Test: JSTests/stress/async-from-sync-iterator-close-on-rejection-throwing-return.js

* JSTests/stress/async-from-sync-iterator-close-on-rejection-throwing-return.js: Added.
(shouldBe):
(const.syncIterable.Symbol.iterator.return.get return):
(throw.new.Error.async drainMicrotasks):
(async drainMicrotasks):
(async gen):
(throw.new.Error):
* Source/JavaScriptCore/runtime/JSMicrotask.cpp:
(JSC::asyncFromSyncIteratorContinueOrDone):

Canonical link: <a href="https://commits.webkit.org/317012@main">https://commits.webkit.org/317012@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/911f51092ac6ce1a3638aa693376bd5aa316105c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174124 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48057 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41838 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183698 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131992 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49349 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47739 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135423 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177082 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38852 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/156215 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115901 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37493 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35863 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32182 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/4725 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147917 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35708 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186124 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/35386 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39253 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40061 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144324 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47724 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144184 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38855 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48403 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32325 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113897 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39096 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120297 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/211159 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46909 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10670 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55030 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46312 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46543 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46370 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->