### PR TITLE
ReadableStream byte-source tee: BYOB close steps target the wrong branch

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/tee.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/tee.any-expected.txt
@@ -16,6 +16,7 @@ PASS ReadableStream teeing with byte source: erroring the original should immedi
 PASS ReadableStream teeing with byte source: erroring the original should error pending reads from default reader
 PASS ReadableStream teeing with byte source: erroring the original should error pending reads from BYOB reader
 PASS ReadableStream teeing with byte source: canceling branch1 should finish when branch2 reads until end of stream
+PASS ReadableStream teeing with byte source: canceling branch1 should finish when branch2 reads with a BYOB reader until end of stream
 PASS ReadableStream teeing with byte source: canceling branch1 should finish when original stream errors
 PASS ReadableStream teeing with byte source: should not pull any chunks if no branches are reading
 PASS ReadableStream teeing with byte source: should only pull enough to fill the emptiest queue

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/tee.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/tee.any.js
@@ -351,6 +351,39 @@ promise_test(async () => {
 
 }, 'ReadableStream teeing with byte source: canceling branch1 should finish when branch2 reads until end of stream');
 
+promise_test(async () => {
+
+  let controller;
+  const rs = new ReadableStream({
+    type: 'bytes',
+    start(c) {
+      controller = c;
+    }
+  });
+
+  const [branch1, branch2] = rs.tee();
+  const reader1 = branch1.getReader({ mode: 'byob' });
+  const reader2 = branch2.getReader({ mode: 'byob' });
+  const cancelPromise = reader1.cancel();
+
+  controller.enqueue(new Uint8Array([0x01]));
+
+  const read2 = await reader2.read(new Uint8Array(1));
+  assert_equals(read2.done, false, 'first read() from branch2 should not be done');
+  assert_typed_array_equals(read2.value, new Uint8Array([0x01]), 'first read() from branch2');
+
+  controller.close();
+
+  const read2b = await reader2.read(new Uint8Array(1));
+  assert_equals(read2b.done, true, 'second read() from branch2 should be done');
+
+  await Promise.all([
+    reader2.closed,
+    cancelPromise
+  ]);
+
+}, 'ReadableStream teeing with byte source: canceling branch1 should finish when branch2 reads with a BYOB reader until end of stream');
+
 promise_test(async t => {
 
   let controller;

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/tee.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/tee.any.serviceworker-expected.txt
@@ -16,6 +16,7 @@ PASS ReadableStream teeing with byte source: erroring the original should immedi
 PASS ReadableStream teeing with byte source: erroring the original should error pending reads from default reader
 PASS ReadableStream teeing with byte source: erroring the original should error pending reads from BYOB reader
 PASS ReadableStream teeing with byte source: canceling branch1 should finish when branch2 reads until end of stream
+PASS ReadableStream teeing with byte source: canceling branch1 should finish when branch2 reads with a BYOB reader until end of stream
 PASS ReadableStream teeing with byte source: canceling branch1 should finish when original stream errors
 PASS ReadableStream teeing with byte source: should not pull any chunks if no branches are reading
 PASS ReadableStream teeing with byte source: should only pull enough to fill the emptiest queue

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/tee.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/tee.any.sharedworker-expected.txt
@@ -16,6 +16,7 @@ PASS ReadableStream teeing with byte source: erroring the original should immedi
 PASS ReadableStream teeing with byte source: erroring the original should error pending reads from default reader
 PASS ReadableStream teeing with byte source: erroring the original should error pending reads from BYOB reader
 PASS ReadableStream teeing with byte source: canceling branch1 should finish when branch2 reads until end of stream
+PASS ReadableStream teeing with byte source: canceling branch1 should finish when branch2 reads with a BYOB reader until end of stream
 PASS ReadableStream teeing with byte source: canceling branch1 should finish when original stream errors
 PASS ReadableStream teeing with byte source: should not pull any chunks if no branches are reading
 PASS ReadableStream teeing with byte source: should only pull enough to fill the emptiest queue

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/tee.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/tee.any.worker-expected.txt
@@ -16,6 +16,7 @@ PASS ReadableStream teeing with byte source: erroring the original should immedi
 PASS ReadableStream teeing with byte source: erroring the original should error pending reads from default reader
 PASS ReadableStream teeing with byte source: erroring the original should error pending reads from BYOB reader
 PASS ReadableStream teeing with byte source: canceling branch1 should finish when branch2 reads until end of stream
+PASS ReadableStream teeing with byte source: canceling branch1 should finish when branch2 reads with a BYOB reader until end of stream
 PASS ReadableStream teeing with byte source: canceling branch1 should finish when original stream errors
 PASS ReadableStream teeing with byte source: should not pull any chunks if no branches are reading
 PASS ReadableStream teeing with byte source: should only pull enough to fill the emptiest queue

--- a/Source/WebCore/Modules/streams/StreamTeeUtilities.cpp
+++ b/Source/WebCore/Modules/streams/StreamTeeUtilities.cpp
@@ -570,12 +570,15 @@ private:
         bool byobCanceled = m_forBranch2 ? m_state->canceled2() : m_state->canceled1();
         bool otherCanceled = m_forBranch2 ? m_state->canceled1() : m_state->canceled2();
 
-        bool shouldStopSteps = false;
-        if (!byobCanceled && branch1)
-            shouldStopSteps = !branch1->controller()->close(*globalObject, ReadableByteStreamController::ShouldThrowOnError::No);
+        RefPtr byobBranch = m_forBranch2 ? branch2 : branch1;
+        RefPtr otherBranch = m_forBranch2 ? branch1 : branch2;
 
-        if (!otherCanceled && branch2)
-            shouldStopSteps |= !branch2->controller()->close(*globalObject, ReadableByteStreamController::ShouldThrowOnError::No);
+        bool shouldStopSteps = false;
+        if (!byobCanceled && byobBranch)
+            shouldStopSteps = !byobBranch->controller()->close(*globalObject, ReadableByteStreamController::ShouldThrowOnError::No);
+
+        if (!otherCanceled && otherBranch)
+            shouldStopSteps |= !otherBranch->controller()->close(*globalObject, ReadableByteStreamController::ShouldThrowOnError::No);
 
         if (shouldStopSteps)
             return;
@@ -591,10 +594,10 @@ private:
             Ref chunk = chunkResult.releaseReturnValue();
             ASSERT(!chunk->byteLength());
 
-            if (!byobCanceled && branch1)
-                protect(branch1->controller())->respondWithNewView(*globalObject, chunk);
-            if (!otherCanceled && branch2 && branch2->controller()->hasPendingPullIntos())
-                protect(branch2->controller())->respond(*globalObject, 0);
+            if (!byobCanceled && byobBranch)
+                protect(byobBranch->controller())->respondWithNewView(*globalObject, chunk);
+            if (!otherCanceled && otherBranch && otherBranch->controller()->hasPendingPullIntos())
+                protect(otherBranch->controller())->respond(*globalObject, 0);
         }
 
         if (!byobCanceled || !otherCanceled)


### PR DESCRIPTION
#### c2c736166c9aee873409f5fef1b2ffc635131f3a
<pre>
ReadableStream byte-source tee: BYOB close steps target the wrong branch
<a href="https://bugs.webkit.org/show_bug.cgi?id=319189">https://bugs.webkit.org/show_bug.cgi?id=319189</a>
<a href="https://rdar.apple.com/182035805">rdar://182035805</a>

Reviewed by Youenn Fablet.

In byteStreamTee(), TeeBYOBReadRequest::runCloseSteps() correctly derived
byobCanceled/otherCanceled from m_forBranch2, but then performed the actual
close(), respondWithNewView(), and respond() calls against hardcoded branch1
and branch2 instead of the byobBranch/otherBranch pair implied by m_forBranch2
(as runChunkStepsInMicrotask() already does, and as the spec requires).

When a byte stream is teed and branch2 is drained through a BYOB reader while
branch1 has been canceled, the read-into request runs with m_forBranch2 == true.
The close steps then operated on branch1 (byobBranch should be branch2): they
skipped closing branch2 and, on end-of-stream, called
ReadableByteStreamControllerRespondWithNewView() on the canceled branch1, which
has no pending pull-into. That trips the RELEASE_ASSERT inside
respondWithNewView() and crashes the WebContent process:

      ReadableByteStreamController::respondWithNewView(...)
        TeeBYOBReadRequest::runCloseSteps(JSC::JSValue)
        ReadableByteStreamController::pullInto(...)
        ReadableStreamBYOBReader::read(...)
        pullWithBYOBReader(..., forBranch2=true)
        pull2Steps(...)

Route all four operations through byobBranch/otherBranch locals, matching the
chunk-steps path and the WHATWG &quot;readable byte stream tee&quot; close steps.

The new test (canceling branch1 while branch2 reads with a BYOB reader until
end of stream) crashes reliably without this change and passes with it.

* LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/tee.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/tee.any.js:
(promise_test.async let):
(promise_test):
* LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/tee.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/tee.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/tee.any.worker-expected.txt:
* Source/WebCore/Modules/streams/StreamTeeUtilities.cpp:

Canonical link: <a href="https://commits.webkit.org/317296@main">https://commits.webkit.org/317296@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3595f2ec728b8fda2a532ecf103cc87706946410

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174057 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47990 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41771 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183631 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131925 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8886a5c7-e155-4e5f-9dfa-c6d448dbf26c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175922 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49282 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47672 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135365 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95467 "4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b4c2106c-68a3-4b54-b30e-e9dac77f9e17) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177015 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38795 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156155 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115843 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cf07cc69-952d-4125-ae2f-08b3e49be2cd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37436 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35804 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32115 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147860 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35648 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186057 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39159 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40003 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144266 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47657 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144126 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39040 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48336 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32265 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113781 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39033 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120221 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46842 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10609 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46245 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46476 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/46303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->