### PR TITLE
[EvaluationTimeZoom] Convert custom properties to use evaluation time zoom

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/custom-property-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/custom-property-expected.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  display: inline-block;
+}
+.container {
+  background-color: black;
+  height: 20px;
+}
+.container-zoom {
+  background-color: black;
+  height: 40px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="width: 100px;"></div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="width: 100px;"></div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container-zoom" style="width: 200px;"></div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container-zoom" style="width: 200px;"></div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/custom-property.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/custom-property.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Zoom applies to custom properties</title>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+<link rel="match" href="reference/custom-property-ref.html">
+<style>
+@property --test {
+  syntax: "<length-percentage>";
+  inherits: false;
+  initial-value: 0px;
+}
+
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  --test: 100px;
+  display: inline-block;
+}
+.container {
+  background-color: black;
+  height: 20px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="--test: 100px; width: var(--test); zoom: 1;"></div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="--test: inherit; width: var(--test); zoom: 1;"></div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="--test: 100px; width: var(--test); zoom: 2;"></div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="--test: inherit; width: var(--test); zoom: 2;"></div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/custom-property-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/custom-property-ref.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  display: inline-block;
+}
+.container {
+  background-color: black;
+  height: 20px;
+}
+.container-zoom {
+  background-color: black;
+  height: 40px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="width: 100px;"></div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="width: 100px;"></div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container-zoom" style="width: 200px;"></div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container-zoom" style="width: 200px;"></div>
+  </div>
+</div>
+</body>
+</html>

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -464,9 +464,9 @@ std::pair<RefPtr<CSSValue>, CSSCustomPropertySyntax::Type> consumeCustomProperty
         case CSSCustomPropertySyntax::Type::CustomIdent:
             return consumeCustomIdent(range, state);
         case CSSCustomPropertySyntax::Type::Length:
-            return CSSPrimitiveValueResolver<CSS::Length<>>::consumeAndResolve(range, state);
+            return CSSPrimitiveValueResolver<CSS::Length<CSS::AllUnzoomed>>::consumeAndResolve(range, state);
         case CSSCustomPropertySyntax::Type::LengthPercentage:
-            return CSSPrimitiveValueResolver<CSS::LengthPercentage<>>::consumeAndResolve(range, state);
+            return CSSPrimitiveValueResolver<CSS::LengthPercentage<CSS::AllUnzoomed>>::consumeAndResolve(range, state);
         case CSSCustomPropertySyntax::Type::Percentage:
             return CSSPrimitiveValueResolver<CSS::Percentage<>>::consumeAndResolve(range, state);
         case CSSCustomPropertySyntax::Type::Integer:
@@ -544,9 +544,9 @@ std::optional<Variant<Ref<const Style::CustomProperty>, CSSWideKeyword>> consume
     auto resolveSyntaxValue = [&, syntaxType = syntaxType](const CSSValue& value) -> std::optional<Style::CustomProperty::Value> {
         switch (syntaxType) {
         case CSSCustomPropertySyntax::Type::LengthPercentage:
-            return Style::toStyleFromCSSValue<Style::LengthPercentage<>>(builderState, downcast<CSSPrimitiveValue>(value));
+            return Style::toStyleFromCSSValue<Style::LengthPercentage<CSS::AllUnzoomed>>(builderState, downcast<CSSPrimitiveValue>(value));
         case CSSCustomPropertySyntax::Type::Length:
-            return Style::toStyleFromCSSValue<Style::Length<>>(builderState, downcast<CSSPrimitiveValue>(value));
+            return Style::toStyleFromCSSValue<Style::Length<CSS::AllUnzoomed>>(builderState, downcast<CSSPrimitiveValue>(value));
         case CSSCustomPropertySyntax::Type::Integer:
         case CSSCustomPropertySyntax::Type::Number:
             return Style::toStyleFromCSSValue<Style::Number<>>(builderState, downcast<CSSPrimitiveValue>(value));

--- a/Source/WebCore/style/StyleCustomProperty.h
+++ b/Source/WebCore/style/StyleCustomProperty.h
@@ -55,8 +55,8 @@ public:
     struct GuaranteedInvalid { };
 
     using Value = Variant<
-        LengthPercentage<>,
-        Length<>,
+        LengthPercentage<CSS::AllUnzoomed>,
+        Length<CSS::AllUnzoomed>,
         Number<>,
         Percentage<>,
         Angle<>,

--- a/Source/WebCore/style/StyleInterpolation.cpp
+++ b/Source/WebCore/style/StyleInterpolation.cpp
@@ -196,9 +196,9 @@ static void interpolateCustomProperty(const AtomString& customProperty, Style::C
 static bool syntaxValuesRequireInterpolationForAccumulativeIteration(const CustomProperty::Value& a, const CustomProperty::Value& b, bool isList)
 {
     return WTF::switchOn(a,
-        [b, isList](const LengthPercentage<>& aLengthPercentage) {
-            ASSERT(std::holds_alternative<LengthPercentage<>>(b));
-            return !isList && Style::requiresInterpolationForAccumulativeIteration(aLengthPercentage, std::get<LengthPercentage<>>(b));
+        [b, isList](const LengthPercentage<CSS::AllUnzoomed>& aLengthPercentage) {
+            ASSERT(std::holds_alternative<LengthPercentage<CSS::AllUnzoomed>>(b));
+            return !isList && Style::requiresInterpolationForAccumulativeIteration(aLengthPercentage, std::get<LengthPercentage<CSS::AllUnzoomed>>(b));
         },
         [](const RefPtr<TransformOperation>&) {
             return true;


### PR DESCRIPTION
#### 02fc1f62790178b79ac3ea22f439cf83ca686ec1
<pre>
[EvaluationTimeZoom] Convert custom properties to use evaluation time zoom
<a href="https://bugs.webkit.org/show_bug.cgi?id=319194">https://bugs.webkit.org/show_bug.cgi?id=319194</a>

Reviewed by Alan Baradlay.

Makes custom properties work with evaluation time zoom by using the appropriate
unzoomed range modifier.

This also fixes an issue with zoom being doubly applied when using custom properties.

Tests: imported/w3c/web-platform-tests/css/css-viewport/zoom/custom-property.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/custom-property-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/custom-property.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/custom-property-ref.html: Added.
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
* Source/WebCore/style/StyleCustomProperty.h:
* Source/WebCore/style/StyleInterpolation.cpp:

Canonical link: <a href="https://commits.webkit.org/317000@main">https://commits.webkit.org/317000@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25e91cb1fa0df693f06c1113df382eb1a3ba8099

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174072 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48005 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41786 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183646 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131940 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175937 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49297 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47687 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135378 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177030 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38807 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156168 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115856 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37448 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35816 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32130 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147872 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35661 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186072 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39182 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40015 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144279 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47672 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155723 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144139 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38849 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48351 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32278 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113810 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39046 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120236 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46857 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10623 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46260 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46491 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46318 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->