### PR TITLE
[GLib] Add FrameInfo API

### DIFF
--- a/Source/WebKit/PlatformGTK.cmake
+++ b/Source/WebKit/PlatformGTK.cmake
@@ -161,6 +161,7 @@ set(WebKitGTK_HEADER_TEMPLATES
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitFileChooserRequest.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitFindController.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitFormSubmissionRequest.h.in
+    ${WEBKIT_DIR}/UIProcess/API/glib/WebKitFrameInfo.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitGeolocationManager.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitGeolocationPermissionRequest.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitHitTestResult.h.in

--- a/Source/WebKit/PlatformWPE.cmake
+++ b/Source/WebKit/PlatformWPE.cmake
@@ -183,6 +183,7 @@ set(WPE_API_HEADER_TEMPLATES
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitFileChooserRequest.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitFindController.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitFormSubmissionRequest.h.in
+    ${WEBKIT_DIR}/UIProcess/API/glib/WebKitFrameInfo.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitGeolocationManager.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitGeolocationPermissionRequest.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitHitTestResult.h.in

--- a/Source/WebKit/SourcesGTK.txt
+++ b/Source/WebKit/SourcesGTK.txt
@@ -148,6 +148,7 @@ UIProcess/API/glib/WebKitFileChooserRequest.cpp @no-unify
 UIProcess/API/glib/WebKitFindController.cpp @no-unify
 UIProcess/API/glib/WebKitFormClient.cpp @no-unify
 UIProcess/API/glib/WebKitFormSubmissionRequest.cpp @no-unify
+UIProcess/API/glib/WebKitFrameInfo.cpp @no-unify
 UIProcess/API/glib/WebKitGeolocationManager.cpp @no-unify
 UIProcess/API/glib/WebKitGeolocationPermissionRequest.cpp @no-unify
 UIProcess/API/glib/WebKitIconLoadingClient.cpp @no-unify

--- a/Source/WebKit/SourcesWPE.txt
+++ b/Source/WebKit/SourcesWPE.txt
@@ -152,6 +152,7 @@ UIProcess/API/glib/WebKitFileChooserRequest.cpp @no-unify
 UIProcess/API/glib/WebKitFindController.cpp @no-unify
 UIProcess/API/glib/WebKitFormClient.cpp @no-unify
 UIProcess/API/glib/WebKitFormSubmissionRequest.cpp @no-unify
+UIProcess/API/glib/WebKitFrameInfo.cpp @no-unify
 UIProcess/API/glib/WebKitGeolocationManager.cpp @no-unify
 UIProcess/API/glib/WebKitGeolocationPermissionRequest.cpp @no-unify
 UIProcess/API/glib/WebKitIconLoadingClient.cpp @no-unify

--- a/Source/WebKit/UIProcess/API/glib/WebKitAutocleanups.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitAutocleanups.h.in
@@ -88,6 +88,7 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitWebInspector, g_object_unref)
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitApplicationInfo, webkit_application_info_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitCredential, webkit_credential_free)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitFrameInfo, webkit_frame_info_free)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitITPFirstParty, webkit_itp_first_party_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitITPThirdParty, webkit_itp_third_party_unref)
 #if !ENABLE(2022_GLIB_API)

--- a/Source/WebKit/UIProcess/API/glib/WebKitFrameInfo.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitFrameInfo.cpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2026 Tau Gärtli
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+#include "WebKitFrameInfo.h"
+
+#include "APIFrameInfo.h"
+#include "WebKitFrameInfoPrivate.h"
+
+/**
+ * WebKitFrameInfo:
+ *
+ * Information about a frame on a webpage.
+ *
+ * Since: 2.42
+ */
+struct _WebKitFrameInfo {
+    _WebKitFrameInfo(API::FrameInfo* info)
+        : info(info)
+    {
+    }
+
+    _WebKitFrameInfo(WebKitFrameInfo* frameInfo)
+        : info(frameInfo->info)
+    {
+    }
+
+    RefPtr<API::FrameInfo> info;
+};
+
+G_DEFINE_BOXED_TYPE(WebKitFrameInfo, webkit_frame_info, webkit_frame_info_copy, webkit_frame_info_free)
+
+WebKitFrameInfo* webkitFrameInfoCreate(API::FrameInfo* frameInfo)
+{
+    WebKitFrameInfo* info = static_cast<WebKitFrameInfo*>(fastZeroedMalloc(sizeof(WebKitFrameInfo)));
+    new (info) WebKitFrameInfo(frameInfo);
+    return info;
+}
+
+/**
+ * webkit_frame_info_copy:
+ * @info: a #WebKitFrameInfo
+ *
+ * Make a copy of @info.
+ *
+ * Returns: (transfer full): A copy of passed in #WebKitFrameInfo
+ *
+ * Since: 2.54
+ */
+WebKitFrameInfo* webkit_frame_info_copy(WebKitFrameInfo* info)
+{
+    g_return_val_if_fail(info, nullptr);
+
+    WebKitFrameInfo* copy = static_cast<WebKitFrameInfo*>(fastZeroedMalloc(sizeof(WebKitFrameInfo)));
+    new (copy) WebKitFrameInfo(info);
+    return copy;
+}
+
+/**
+ * webkit_frame_info_free:
+ * @info: a #WebKitFrameInfo
+ *
+ * Free the #WebKitFrameInfo
+ *
+ * Since: 2.54
+ */
+void webkit_frame_info_free(WebKitFrameInfo* info)
+{
+    g_return_if_fail(info);
+
+    info->~WebKitFrameInfo();
+    fastFree(info);
+}
+
+/**
+ * webkit_frame_info_is_main_frame:
+ * @info: a #WebKitFrameInfo
+ *
+ * Whether or not this frame is the web site's main frame or a subframe.
+ *
+ * Since: 2.54
+ */
+gboolean
+webkit_frame_info_is_main_frame(WebKitFrameInfo* info)
+{
+    g_return_val_if_fail(info, FALSE);
+
+    return info->info->isMainFrame();
+}

--- a/Source/WebKit/UIProcess/API/glib/WebKitFrameInfo.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitFrameInfo.h.in
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Igalia S.L.
+ * Copyright (C) 2026 Tau Gärtli
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -17,29 +17,29 @@
  * Boston, MA 02110-1301, USA.
  */
 
+@API_SINGLE_HEADER_CHECK@
+
 #pragma once
 
-#include "APINavigationAction.h"
-#include "WebKitNavigationAction.h"
-#include <wtf/glib/GRefPtr.h>
-#include <wtf/text/CString.h>
+#include <glib-object.h>
+#include <@API_INCLUDE_PREFIX@/WebKitDefines.h>
 
-struct _WebKitNavigationAction {
-    _WebKitNavigationAction(Ref<API::NavigationAction>&& action)
-        : action(WTF::move(action))
-    {
-    }
+G_BEGIN_DECLS
 
-    _WebKitNavigationAction(WebKitNavigationAction* navigation)
-        : action(navigation->action)
-    {
-    }
+#define WEBKIT_TYPE_FRAME_INFO (webkit_frame_info_get_type())
 
-    RefPtr<API::NavigationAction> action;
-    GRefPtr<WebKitURIRequest> request;
-    std::optional<CString> frameName;
-    WebKitFrameInfo* sourceFrame;
-    WebKitFrameInfo* targetFrame;
-};
+typedef struct _WebKitFrameInfo WebKitFrameInfo;
 
-WebKitNavigationAction* webkitNavigationActionCreate(Ref<API::NavigationAction>&&);
+WEBKIT_API GType
+webkit_frame_info_get_type            (void);
+
+WEBKIT_API WebKitFrameInfo *
+webkit_frame_info_copy                (WebKitFrameInfo *info);
+
+WEBKIT_API void
+webkit_frame_info_free                (WebKitFrameInfo *info);
+
+WEBKIT_API gboolean
+webkit_frame_info_is_main_frame       (WebKitFrameInfo *info);
+
+G_END_DECLS

--- a/Source/WebKit/UIProcess/API/glib/WebKitFrameInfoPrivate.h
+++ b/Source/WebKit/UIProcess/API/glib/WebKitFrameInfoPrivate.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Igalia S.L.
+ * Copyright (C) 2026 Tau Gärtli
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -19,27 +19,12 @@
 
 #pragma once
 
-#include "APINavigationAction.h"
-#include "WebKitNavigationAction.h"
-#include <wtf/glib/GRefPtr.h>
-#include <wtf/text/CString.h>
+#include "WebKitFrameInfo.h"
 
-struct _WebKitNavigationAction {
-    _WebKitNavigationAction(Ref<API::NavigationAction>&& action)
-        : action(WTF::move(action))
-    {
-    }
-
-    _WebKitNavigationAction(WebKitNavigationAction* navigation)
-        : action(navigation->action)
-    {
-    }
-
-    RefPtr<API::NavigationAction> action;
-    GRefPtr<WebKitURIRequest> request;
-    std::optional<CString> frameName;
-    WebKitFrameInfo* sourceFrame;
-    WebKitFrameInfo* targetFrame;
+namespace API {
+class FrameInfo;
 };
 
-WebKitNavigationAction* webkitNavigationActionCreate(Ref<API::NavigationAction>&&);
+typedef struct _WebKitFrameInfo WebKitFrameInfo;
+
+WebKitFrameInfo* webkitFrameInfoCreate(API::FrameInfo*);

--- a/Source/WebKit/UIProcess/API/glib/WebKitNavigationAction.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitNavigationAction.cpp
@@ -20,6 +20,7 @@
 #include "config.h"
 #include "WebKitNavigationAction.h"
 
+#include "WebKitFrameInfoPrivate.h"
 #include "WebKitNavigationActionPrivate.h"
 #include "WebKitPrivate.h"
 #include "WebKitURIRequestPrivate.h"
@@ -72,6 +73,10 @@ void webkit_navigation_action_free(WebKitNavigationAction* navigation)
 {
     g_return_if_fail(navigation);
 
+    if (auto sourceFrame = navigation->sourceFrame)
+        webkit_frame_info_free(sourceFrame);
+    if (auto targetFrame = navigation->targetFrame)
+        webkit_frame_info_free(targetFrame);
     navigation->~WebKitNavigationAction();
     fastFree(navigation);
 }
@@ -208,4 +213,45 @@ const char* webkit_navigation_action_get_frame_name(WebKitNavigationAction* navi
             navigation->frameName = CString();
     }
     return navigation->frameName->data();
+}
+
+/**
+ * webkit_navigation_action_get_source_frame:
+ * @navigation: a #WebKitNavigationAction
+ *
+ * The frame that requested the navigation.
+ *
+ * Returns: (transfer none) (nullable): a #WebKitFrameInfo or %NULL
+ *
+ * Since: 2.54
+ */
+WebKitFrameInfo* webkit_navigation_action_get_source_frame(WebKitNavigationAction* navigation)
+{
+    g_return_val_if_fail(navigation, nullptr);
+    if (!navigation->sourceFrame) {
+        if (auto sourceFrame = navigation->action->sourceFrame())
+            navigation->sourceFrame = webkitFrameInfoCreate(sourceFrame);
+    }
+    return navigation->sourceFrame;
+}
+
+/**
+ * webkit_navigation_action_get_target_frame:
+ * @navigation: a #WebKitNavigationAction
+ *
+ * The frame in which to display the new content or %NULL
+ * if the target of the navigation is a new window.
+ *
+ * Returns: (transfer none) (nullable): a #WebKitFrameInfo or %NULL
+ *
+ * Since: 2.54
+ */
+WebKitFrameInfo* webkit_navigation_action_get_target_frame(WebKitNavigationAction* navigation)
+{
+    g_return_val_if_fail(navigation, nullptr);
+    if (!navigation->targetFrame) {
+        if (auto targetFrame = navigation->action->targetFrame())
+            navigation->targetFrame = webkitFrameInfoCreate(targetFrame);
+    }
+    return navigation->targetFrame;
 }

--- a/Source/WebKit/UIProcess/API/glib/WebKitNavigationAction.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitNavigationAction.h.in
@@ -24,6 +24,7 @@
 
 #include <glib-object.h>
 #include <@API_INCLUDE_PREFIX@/WebKitDefines.h>
+#include <@API_INCLUDE_PREFIX@/WebKitFrameInfo.h>
 #include <@API_INCLUDE_PREFIX@/WebKitURIRequest.h>
 
 G_BEGIN_DECLS
@@ -82,6 +83,12 @@ webkit_navigation_action_is_redirect         (WebKitNavigationAction *navigation
 
 WEBKIT_API const char *
 webkit_navigation_action_get_frame_name      (WebKitNavigationAction *navigation);
+
+WEBKIT_API WebKitFrameInfo *
+webkit_navigation_action_get_source_frame    (WebKitNavigationAction *navigation);
+
+WEBKIT_API WebKitFrameInfo *
+webkit_navigation_action_get_target_frame    (WebKitNavigationAction *navigation);
 
 G_END_DECLS
 

--- a/Source/WebKit/UIProcess/API/glib/webkit.h.in
+++ b/Source/WebKit/UIProcess/API/glib/webkit.h.in
@@ -70,6 +70,7 @@
 #endif
 #include <@API_INCLUDE_PREFIX@/WebKitFindController.h>
 #include <@API_INCLUDE_PREFIX@/WebKitFormSubmissionRequest.h>
+#include <@API_INCLUDE_PREFIX@/WebKitFrameInfo.h>
 #include <@API_INCLUDE_PREFIX@/WebKitGeolocationManager.h>
 #include <@API_INCLUDE_PREFIX@/WebKitGeolocationPermissionRequest.h>
 #include <@API_INCLUDE_PREFIX@/WebKitHitTestResult.h>


### PR DESCRIPTION
#### 6e736ce74c3064915e01526bc16366bafeec0495
<pre>
[GLib] Add FrameInfo API

<a href="https://bugs.webkit.org/show_bug.cgi?id=319164">https://bugs.webkit.org/show_bug.cgi?id=319164</a>

* Source/WebKit/PlatformGTK.cmake:
* Source/WebKit/PlatformWPE.cmake:
* Source/WebKit/SourcesGTK.txt:
* Source/WebKit/SourcesWPE.txt:
* Source/WebKit/UIProcess/API/glib/WebKitAutocleanups.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitFrameInfo.cpp: Added.
(_WebKitFrameInfo::_WebKitFrameInfo):
(webkitFrameInfoCreate):
(webkit_frame_info_copy):
(webkit_frame_info_free):
(webkit_frame_info_is_main_frame):
* Source/WebKit/UIProcess/API/glib/WebKitFrameInfo.h.in: Copied from Source/WebKit/UIProcess/API/glib/WebKitNavigationActionPrivate.h.
* Source/WebKit/UIProcess/API/glib/WebKitFrameInfoPrivate.h: Copied from Source/WebKit/UIProcess/API/glib/WebKitNavigationActionPrivate.h.
* Source/WebKit/UIProcess/API/glib/WebKitNavigationAction.cpp:
(webkit_navigation_action_free):
(webkit_navigation_action_get_source_frame):
(webkit_navigation_action_get_target_frame):
* Source/WebKit/UIProcess/API/glib/WebKitNavigationAction.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitNavigationActionPrivate.h:
* Source/WebKit/UIProcess/API/glib/webkit.h.in:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e736ce74c3064915e01526bc16366bafeec0495

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174085 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48018 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41799 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183659 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131953 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49310 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47700 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135389 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95492 "1 flakes 3 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177043 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38821 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156181 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115867 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37462 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35828 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32143 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147886 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35674 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186085 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39197 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40027 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144290 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47685 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144150 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48364 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32291 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/113827 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39062 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120250 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46870 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10636 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46273 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46504 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46331 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->