### PR TITLE
[EvaluationTimeZoom] Convert media/container queries to use unzoomed lengths

### DIFF
--- a/Source/WebCore/css/query/ContainerQueryFeatures.cpp
+++ b/Source/WebCore/css/query/ContainerQueryFeatures.cpp
@@ -51,18 +51,12 @@
 #include "StyleCustomPropertyRegistry.h"
 #include "StylePrimitiveNumericTypes+Conversions.h"
 #include "StylePrimitiveNumericTypes+Evaluation.h"
+#include "StyleZoomPrimitivesInlines.h"
 #include <wtf/NeverDestroyed.h>
 
 namespace WebCore::CQ {
 
 using namespace MQ;
-
-static LayoutUnit NODELETE unscaledSizeForPrincipleBox(const Style::PreferredSize& computedSize, LayoutUnit usedSize, UsesSVGZoomRulesForLength usesSVGZoomRulesForLength, float usedZoom)
-{
-    if (usesSVGZoomRulesForLength == UsesSVGZoomRulesForLength::Yes || !computedSize.isFixed())
-        return usedSize;
-    return LayoutUnit { usedSize / usedZoom };
-}
 
 struct SizeFeatureSchema : public FeatureSchema {
     SizeFeatureSchema(const AtomString& name, Type type, ValueType valueType, OptionSet<MediaQueryDynamicDependency> dependencies, FixedVector<CSSValueID>&& valueIdentifiers = { })
@@ -101,10 +95,7 @@ struct WidthFeatureSchema : public SizeFeatureSchema {
 
     EvaluationResult evaluate(const MQ::Feature& feature, const RenderBox& renderer, const CSSToLengthConversionData& conversionData) const override
     {
-        CheckedRef renderStyle = renderer.style();
-        auto usesSVGZoomRulesForLength = renderStyle->useSVGZoomRulesForLength() ? UsesSVGZoomRulesForLength::Yes : UsesSVGZoomRulesForLength::No;
-
-        auto width = unscaledSizeForPrincipleBox(renderStyle->width(), renderer.contentBoxWidth(), usesSVGZoomRulesForLength, renderStyle->usedZoom());
+        auto width = Style::adjustForAbsoluteZoom(renderer.contentBoxWidth(), renderer);
         return evaluateLengthFeature(feature, width, conversionData);
     }
 };
@@ -119,10 +110,7 @@ struct HeightFeatureSchema : public SizeFeatureSchema {
 
     EvaluationResult evaluate(const MQ::Feature& feature, const RenderBox& renderer, const CSSToLengthConversionData& conversionData) const override
     {
-        CheckedRef renderStyle = renderer.style();
-        auto usesSVGZoomRulesForLength = renderStyle->useSVGZoomRulesForLength() ? UsesSVGZoomRulesForLength::Yes : UsesSVGZoomRulesForLength::No;
-
-        auto height = unscaledSizeForPrincipleBox(renderStyle->height(), renderer.contentBoxHeight(), usesSVGZoomRulesForLength, renderStyle->usedZoom());
+        auto height = Style::adjustForAbsoluteZoom(renderer.contentBoxHeight(), renderer);
         return evaluateLengthFeature(feature, height, conversionData);
     }
 };
@@ -137,10 +125,7 @@ struct InlineSizeFeatureSchema : public SizeFeatureSchema {
 
     EvaluationResult evaluate(const MQ::Feature& feature, const RenderBox& renderer, const CSSToLengthConversionData& conversionData) const override
     {
-        CheckedRef renderStyle = renderer.style();
-        auto usesSVGZoomRulesForLength = renderStyle->useSVGZoomRulesForLength() ? UsesSVGZoomRulesForLength::Yes : UsesSVGZoomRulesForLength::No;
-
-        auto logicalWidth = unscaledSizeForPrincipleBox(renderStyle->logicalWidth(), renderer.contentBoxLogicalWidth(), usesSVGZoomRulesForLength, renderStyle->usedZoom());
+        auto logicalWidth = Style::adjustForAbsoluteZoom(renderer.contentBoxLogicalWidth(), renderer);
         return evaluateLengthFeature(feature, logicalWidth, conversionData);
     }
 };
@@ -155,10 +140,7 @@ struct BlockSizeFeatureSchema : public SizeFeatureSchema {
 
     EvaluationResult evaluate(const MQ::Feature& feature, const RenderBox& renderer, const CSSToLengthConversionData& conversionData) const override
     {
-        CheckedRef renderStyle = renderer.style();
-        auto usesSVGZoomRulesForLength = renderStyle->useSVGZoomRulesForLength() ? UsesSVGZoomRulesForLength::Yes : UsesSVGZoomRulesForLength::No;
-
-        auto logicalHeight = unscaledSizeForPrincipleBox(renderStyle->logicalHeight(), renderer.contentBoxLogicalHeight(), usesSVGZoomRulesForLength, renderStyle->usedZoom());
+        auto logicalHeight = Style::adjustForAbsoluteZoom(renderer.contentBoxLogicalHeight(), renderer);
         return evaluateLengthFeature(feature, logicalHeight, conversionData);
     }
 };
@@ -204,7 +186,7 @@ struct StyleRangeValue {
 // Evaluates the (already substituted) computed value of a <style-range-value> into one of
 // <number>, <length>, <percentage>, <angle>, <time>, <frequency> or <resolution>, computed
 // with respect to the query container. Returns nullopt if it doesn't parse as a single value.
-static std::optional<StyleRangeValue> evaluateStyleRangeValue(const Vector<CSSParserToken>& tokens, const FeatureEvaluationContext& context)
+static std::optional<StyleRangeValue> evaluateStyleRangeValue(const Vector<CSSParserToken>& tokens, const FeatureEvaluationContext& context, const Style::ComputedStyle& style)
 {
     using namespace CSSPropertyParserHelpers;
 
@@ -231,9 +213,9 @@ static std::optional<StyleRangeValue> evaluateStyleRangeValue(const Vector<CSSPa
     }
     // overrideParserMode matches MQ::consumeValue's <length> parsing so quirky/quirks-mode lengths behave
     // identically here. See the FIXME there.
-    if (auto subrange = range; auto value = MetaConsumer<CSS::Length<>>::consume(subrange, parserState, { .overrideParserMode = HTMLStandardMode })) {
+    if (auto subrange = range; auto value = MetaConsumer<CSS::Length<CSS::AllUnzoomed>>::consume(subrange, parserState, { .overrideParserMode = HTMLStandardMode })) {
         if (isFullyConsumed(subrange))
-            return StyleRangeValue { StyleRangeCategory::Length, Style::evaluate<double>(Style::toStyle(*value, conversionData), Style::ZoomNeeded { }) };
+            return StyleRangeValue { StyleRangeCategory::Length, Style::evaluate<double>(Style::toStyle(*value, conversionData), style.usedZoomForLength()) };
     }
     if (auto subrange = range; auto value = MetaConsumer<CSS::Percentage<>>::consume(subrange, parserState)) {
         if (isFullyConsumed(subrange))
@@ -380,7 +362,7 @@ struct StyleFeatureSchema : public FeatureSchema {
             }
             if (!customProperty || customProperty->isGuaranteedInvalid())
                 return { };
-            return evaluateStyleRangeValue(customProperty->tokens(), context);
+            return evaluateStyleRangeValue(customProperty->tokens(), context, style);
         };
 
         auto center = resolveOperand(feature.subject, feature.name);

--- a/Source/WebCore/css/query/GenericMediaQueryEvaluator.cpp
+++ b/Source/WebCore/css/query/GenericMediaQueryEvaluator.cpp
@@ -35,7 +35,7 @@
 namespace WebCore {
 namespace MQ {
 
-static std::optional<LayoutUnit> resolveLength(const Value& value, const CSSToLengthConversionData& conversionData)
+static std::optional<LayoutUnit> resolveLength(const Value& value, const CSSToLengthConversionData& conversionData, Style::ZoomFactor zoom)
 {
     return WTF::switchOn(value,
         [&](const CSS::Integer<>& integer) -> std::optional<LayoutUnit> {
@@ -50,8 +50,8 @@ static std::optional<LayoutUnit> resolveLength(const Value& value, const CSSToLe
                 return 0_lu;
             return { };
         },
-        [&](const CSS::Length<>& length) -> std::optional<LayoutUnit> {
-            return Style::evaluate<LayoutUnit>(Style::toStyle(length, conversionData), Style::ZoomNeeded { });
+        [&](const CSS::Length<CSS::AllUnzoomed>& length) -> std::optional<LayoutUnit> {
+            return Style::evaluate<LayoutUnit>(Style::toStyle(length, conversionData), zoom);
         },
         [](const auto&) -> std::optional<LayoutUnit> {
             return std::nullopt;
@@ -126,17 +126,17 @@ static CSSValueID resolveIdent(const Value& value)
 }
 
 enum class Side : uint8_t { Left, Right };
-static EvaluationResult evaluateLengthComparison(LayoutUnit size, const std::optional<Comparison>& comparison, Side side, const CSSToLengthConversionData& conversionData)
+static EvaluationResult evaluateLengthComparison(LayoutUnit unzoomedSize, const std::optional<Comparison>& comparison, Side side, const CSSToLengthConversionData& conversionData)
 {
     if (!comparison)
         return EvaluationResult::True;
 
-    auto expressionSize = resolveLength(*comparison->value, conversionData);
+    auto expressionSize = resolveLength(*comparison->value, conversionData, Style::ZoomFactor::none());
     if (!expressionSize)
         return EvaluationResult::Unknown;
 
-    auto left = side == Side::Left ? *expressionSize : size;
-    auto right = side == Side::Left ? size : *expressionSize;
+    auto left = side == Side::Left ? *expressionSize : unzoomedSize;
+    auto right = side == Side::Left ? unzoomedSize : *expressionSize;
 
     return toEvaluationResult(compare(comparison->op, left, right));
 };
@@ -180,13 +180,13 @@ static EvaluationResult evaluateResolutionComparison(float resolution, const std
     return toEvaluationResult(compare(comparison->op, left, right));
 };
 
-EvaluationResult evaluateLengthFeature(const Feature& feature, LayoutUnit length, const CSSToLengthConversionData& conversionData)
+EvaluationResult evaluateLengthFeature(const Feature& feature, LayoutUnit unzoomedLength, const CSSToLengthConversionData& conversionData)
 {
     if (!feature.leftComparison && !feature.rightComparison)
-        return toEvaluationResult(!!length);
+        return toEvaluationResult(!!unzoomedLength);
 
-    auto leftResult = evaluateLengthComparison(length, feature.leftComparison, Side::Left, conversionData);
-    auto rightResult = evaluateLengthComparison(length, feature.rightComparison, Side::Right, conversionData);
+    auto leftResult = evaluateLengthComparison(unzoomedLength, feature.leftComparison, Side::Left, conversionData);
+    auto rightResult = evaluateLengthComparison(unzoomedLength, feature.rightComparison, Side::Right, conversionData);
 
     return leftResult & rightResult;
 };

--- a/Source/WebCore/css/query/GenericMediaQueryParser.cpp
+++ b/Source/WebCore/css/query/GenericMediaQueryParser.cpp
@@ -112,7 +112,7 @@ static std::optional<Value> consumeValue(CSSParserTokenRange& range, const Media
     if (auto value = MetaConsumer<CSS::Number<>>::consume(range, parserState))
         return Value { WTF::move(*value) };
     // FIXME: Figure out and document why overrideParserMode is explicitly set to HTMLStandardMode here.
-    if (auto value = MetaConsumer<CSS::Length<>>::consume(range, parserState, { .overrideParserMode = HTMLStandardMode }))
+    if (auto value = MetaConsumer<CSS::Length<CSS::AllUnzoomed>>::consume(range, parserState, { .overrideParserMode = HTMLStandardMode }))
         return Value { WTF::move(*value) };
     if (auto value = MetaConsumer<CSS::Resolution<>>::consume(range, parserState))
         return Value { WTF::move(*value) };
@@ -296,7 +296,7 @@ bool FeatureParser::validateFeatureAgainstSchema(Feature& feature, const Feature
                         }
                     );
                 }
-                return WTF::holdsAlternative<CSS::Length<>>(*value);
+                return WTF::holdsAlternative<CSS::Length<CSS::AllUnzoomed>>(*value);
 
             case FeatureSchema::ValueType::Resolution:
                 return WTF::holdsAlternative<CSS::Resolution<>>(*value);

--- a/Source/WebCore/css/query/GenericMediaQueryTypes.h
+++ b/Source/WebCore/css/query/GenericMediaQueryTypes.h
@@ -81,7 +81,7 @@ struct FeatureSchema;
 using Value = Variant<
     CSS::Integer<>,
     CSS::Number<>,
-    CSS::Length<>,
+    CSS::Length<CSS::AllUnzoomed>,
     CSS::Resolution<>,
     CSS::Ratio,
     CSS::Keyword,


### PR DESCRIPTION
#### 8fb376678408a7822702039d48e4948b5dfc4ea5
<pre>
[EvaluationTimeZoom] Convert media/container queries to use unzoomed lengths
<a href="https://bugs.webkit.org/show_bug.cgi?id=319197">https://bugs.webkit.org/show_bug.cgi?id=319197</a>

Reviewed by Alan Baradlay.

Switch media/container queries to use unzoomed lengths and simplify using
existing unzooming helpers.

* Source/WebCore/css/query/ContainerQueryFeatures.cpp:
* Source/WebCore/css/query/GenericMediaQueryEvaluator.cpp:
* Source/WebCore/css/query/GenericMediaQueryParser.cpp:
* Source/WebCore/css/query/GenericMediaQueryTypes.h:

Canonical link: <a href="https://commits.webkit.org/317069@main">https://commits.webkit.org/317069@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50a9aaafc8310a37d7c3f991e382449d68754d6a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174232 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48165 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41946 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183806 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132100 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176097 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49457 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47847 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135530 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177190 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38959 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156319 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116008 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37599 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/35968 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32290 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148023 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35812 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186232 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39415 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40165 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144434 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47832 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144293 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38895 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48511 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32432 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114039 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39199 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120428 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47017 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10774 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46420 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46651 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46478 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->