### PR TITLE
WebSpeechSynthesisWrapper crashes on voice change notification

### DIFF
--- a/Source/WebCore/platform/cocoa/PlatformSpeechSynthesizerCocoa.mm
+++ b/Source/WebCore/platform/cocoa/PlatformSpeechSynthesizerCocoa.mm
@@ -101,6 +101,12 @@ static float getAVSpeechUtteranceMaximumSpeechRate()
 
 #if HAVE(AVSPEECHSYNTHESIS_VOICES_CHANGE_NOTIFICATION)
 
+- (void)dealloc
+{
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:RetainPtr { AVSpeechSynthesisAvailableVoicesDidChangeNotification }.get() object:nil];
+    [super dealloc];
+}
+
 - (void)availableVoicesDidChange
 {
     // AVFoundation may post AVSpeechSynthesisAvailableVoicesDidChangeNotification from a


### PR DESCRIPTION
#### 1b953e1a0f16b1bd079b1e48cdc348ce42eaadc9
<pre>
WebSpeechSynthesisWrapper crashes on voice change notification
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=308938">https://bugs.webkit.org/show_bug.cgi?id=308938</a>&gt;
&lt;<a href="https://rdar.apple.com/171479344">rdar://171479344</a>&gt;

Reviewed by Ryosuke Niwa.

This is a merge-back of the safari-7624-branch fix.  The
`-availableVoicesDidChange` main-thread hop and null-check that the
original fix added already landed independently on `main` in
312522@main (Bug 313950, <a href="https://rdar.apple.com/173555693">rdar://173555693</a>) via `ensureOnMainThread`.
This merge-back therefore preserves `main`&apos;s existing
`-availableVoicesDidChange` and applies only the remaining `-dealloc`
change from the original fix.

`WebSpeechSynthesisWrapper` registers as an observer for
`AVSpeechSynthesisAvailableVoicesDidChangeNotification` but never
removed itself.  Add `-dealloc` to call `-removeObserver:name:object:`
on `NSNotificationCenter`.  While Foundation stores observers as
zeroing weak references that auto-invalidate when the observer is
deallocated, it is best practice to remove the registration promptly.

No new tests since no change in behavior.

* Source/WebCore/platform/cocoa/PlatformSpeechSynthesizerCocoa.mm:
(-[WebSpeechSynthesisWrapper dealloc]): Add.

Originally-landed-as: 305413.387@safari-7624-branch (4627c5152694). <a href="https://rdar.apple.com/171479344">rdar://171479344</a>
Canonical link: <a href="https://commits.webkit.org/317002@main">https://commits.webkit.org/317002@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0fcc7a564df7aa0ba641c82a84acc7f9679993f9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174096 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48029 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41810 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183670 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131964 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/79ba9cbb-daae-4fc4-9fcb-6c4516c66287) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175961 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49321 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47711 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135397 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b4748eba-7450-4043-8a76-f19ed3807e2a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177054 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38828 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156188 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115875 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bf6b6c5d-314f-4327-a0d6-0af782657729) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37469 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/35837 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32154 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/147893 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35681 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186096 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39211 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40036 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144299 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47696 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144159 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48375 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32298 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113846 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26462 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39067 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120262 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46881 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10643 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46284 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46515 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46342 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->