### PR TITLE
[LBSE] Clip the SVG child-paint loop once per container instead of once per shape

### DIFF
--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -1056,7 +1056,7 @@ private:
     bool appendChildrenInDOMOrderForSVG(RenderElement& parent, LayoutSize ancestorOffset, bool& anyNonZeroZIndex);
     const Vector<SVGPaintOrderLayerItem>& childrenInDOMOrderForSVG();
     void paintChildrenInDOMOrderForSVG(GraphicsContext&, const LayerPaintingInfo&, OptionSet<PaintLayerFlag>, const LayerFragments&, OptionSet<PaintBehavior>, RenderObject*, std::optional<WTF::Range<unsigned>> svgPaintOrderItemRange);
-    void paintNonLayerChildForFragmentsForSVG(RenderElement&, const LayoutSize& accumulatedAncestorOffset, PaintPhase, const LayerFragments&, GraphicsContext&, const LayerPaintingInfo&, OptionSet<PaintBehavior>, RenderObject*, const LayoutPoint& containerBaseOffset, bool isSVGRoot);
+    void paintNonLayerChildForFragmentsForSVG(RenderElement&, const LayoutSize& accumulatedAncestorOffset, PaintPhase, const LayerFragments&, GraphicsContext&, const LayerPaintingInfo&, OptionSet<PaintBehavior>, RenderObject*, const LayoutPoint& containerBaseOffset, bool isSVGRoot, bool sharedClipApplied);
     void paintRendererByApplyingTransformForSVG(GraphicsContext&, CheckedRef<RenderElement>, const LayoutSize& positionOffset, const LayerPaintingInfo&, OptionSet<PaintLayerFlag>, OptionSet<PaintBehavior>, RenderObject*, const LayoutSize& nominalPreTranslation = { });
     void paintSubtreeWithinTransformScopeForSVG(GraphicsContext&, RenderElement& container, const LayoutPoint& paintOffset, const LayerPaintingInfo&, OptionSet<PaintLayerFlag>, OptionSet<PaintBehavior>, RenderObject*);
     HitLayer hitTestChildrenInDOMOrderForSVG(RenderLayer* rootLayer, const HitTestRequest&, HitTestResult&, const LayoutRect& hitTestRect, const HitTestLocation&, const HitTestingTransformState*, double* zOffsetForDescendants);

--- a/Source/WebCore/rendering/RenderLayerSVGAdditions.cpp
+++ b/Source/WebCore/rendering/RenderLayerSVGAdditions.cpp
@@ -403,7 +403,7 @@ const Vector<SVGPaintOrderLayerItem>& RenderLayer::childrenInDOMOrderForSVG()
 
 void RenderLayer::paintNonLayerChildForFragmentsForSVG(RenderElement& childRenderer, const LayoutSize& accumulatedAncestorOffset,
     PaintPhase phase, const LayerFragments& layerFragments, GraphicsContext& context, const LayerPaintingInfo& paintingInfo,
-    OptionSet<PaintBehavior> paintBehavior, RenderObject* subtreePaintRootForRenderer, const LayoutPoint& containerBaseOffset, bool isSVGRoot)
+    OptionSet<PaintBehavior> paintBehavior, RenderObject* subtreePaintRootForRenderer, const LayoutPoint& containerBaseOffset, bool isSVGRoot, bool sharedClipApplied)
 {
     LayoutPoint svgRootScrollAdjustment;
     if (isSVGRoot)
@@ -416,9 +416,15 @@ void RenderLayer::paintNonLayerChildForFragmentsForSVG(RenderElement& childRende
         if (!collectingEventRegion && (!fragment.shouldPaintContent || fragment.dirtyForegroundRect().isEmpty()))
             continue;
 
-        GraphicsContextStateSaver stateSaver(context, false);
-        RegionContextStateSaver regionContextStateSaver(paintingInfo.regionContext);
-        clipToRect(context, stateSaver, regionContextStateSaver, paintingInfo, paintBehavior, fragment.dirtyForegroundRect());
+        // Re-clip per shape only when the caller has not already applied a shared clip around the
+        // whole child loop (see paintChildrenInDOMOrderForSVG).
+        std::optional<GraphicsContextStateSaver> stateSaver;
+        std::optional<RegionContextStateSaver> regionContextStateSaver;
+        if (!sharedClipApplied) {
+            stateSaver.emplace(context, false);
+            regionContextStateSaver.emplace(paintingInfo.regionContext);
+            clipToRect(context, *stateSaver, *regionContextStateSaver, paintingInfo, paintBehavior, fragment.dirtyForegroundRect());
+        }
 
         PaintInfo paintInfo(context, fragment.dirtyForegroundRect().rect(),
             phase, paintBehavior, subtreePaintRootForRenderer,
@@ -473,6 +479,25 @@ void RenderLayer::paintChildrenInDOMOrderForSVG(GraphicsContext& context, const 
         endIndex = std::min<size_t>(svgPaintOrderItemRange->end(), allChildren.size());
     }
 
+    // Every non-layer child clips the context to the same fragment dirty-foreground rect, one
+    // CGContextSaveGState + CGContextClipToRect per shape. With a single paintable fragment and no
+    // child owning a layer, apply that clip once and share it across all children. Skip resource
+    // layers (marker/mask/pattern), whose content paints in its own coordinate system where this
+    // fragment rect is the wrong clip.
+    bool hasChildLayers = beginIndex < endIndex && std::ranges::any_of(allChildren.subspan(beginIndex, endIndex - beginIndex), [](auto& child) {
+        return !!child.layer.get();
+    });
+    std::optional<GraphicsContextStateSaver> sharedClipSaver;
+    std::optional<RegionContextStateSaver> sharedRegionSaver;
+    if (!hasChildLayers && layerFragments.size() == 1 && layerFragments[0].shouldPaintContent && !isPaintingResourceLayerForSVG()) {
+        auto dirtyForegroundRect = layerFragments[0].dirtyForegroundRect();
+        if (!dirtyForegroundRect.isEmpty()) {
+            sharedClipSaver.emplace(context, false);
+            sharedRegionSaver.emplace(paintingInfo.regionContext);
+            clipToRect(context, *sharedClipSaver, *sharedRegionSaver, paintingInfo, paintBehavior, dirtyForegroundRect);
+        }
+    }
+
     for (size_t index = beginIndex; index < endIndex; ++index) {
         auto& childToPaint = allChildren[index];
         if (CheckedPtr childLayer = childToPaint.layer.get()) {
@@ -514,9 +539,14 @@ void RenderLayer::paintChildrenInDOMOrderForSVG(GraphicsContext& context, const 
                 if (!fragment.shouldPaintContent || fragment.dirtyForegroundRect().isEmpty())
                     continue;
 
-                GraphicsContextStateSaver stateSaver(context, false);
-                RegionContextStateSaver regionContextStateSaver(paintingInfo.regionContext);
-                clipToRect(context, stateSaver, regionContextStateSaver, paintingInfo, paintBehavior, fragment.dirtyForegroundRect());
+                // Re-clip per shape only when no shared clip was applied before the loop (multiple fragments, or child layers present).
+                std::optional<GraphicsContextStateSaver> stateSaver;
+                std::optional<RegionContextStateSaver> regionContextStateSaver;
+                if (!sharedClipSaver) {
+                    stateSaver.emplace(context, false);
+                    regionContextStateSaver.emplace(paintingInfo.regionContext);
+                    clipToRect(context, *stateSaver, *regionContextStateSaver, paintingInfo, paintBehavior, fragment.dirtyForegroundRect());
+                }
 
                 // nominalCorrection is applied inside the scope, so TransformPaintScope concatenates it
                 // onto the CTM and inverse-maps paintDirtyRect through it together. The leaf
@@ -534,13 +564,13 @@ void RenderLayer::paintChildrenInDOMOrderForSVG(GraphicsContext& context, const 
         // EventRegion phase separately for non-layer children when collecting the event region.
         if (paintFlags.contains(PaintLayerFlag::CollectingEventRegion)) {
             paintNonLayerChildForFragmentsForSVG(childRenderer.get(), childToPaint.accumulatedAncestorOffset,
-                PaintPhase::EventRegion, layerFragments, context, paintingInfo, paintBehavior, subtreePaintRootForRenderer, containerBaseOffset, isSVGRoot);
+                PaintPhase::EventRegion, layerFragments, context, paintingInfo, paintBehavior, subtreePaintRootForRenderer, containerBaseOffset, isSVGRoot, sharedClipSaver.has_value());
             continue;
         }
 
         for (auto phase : childToPaint.phasesToPaint) {
             paintNonLayerChildForFragmentsForSVG(childRenderer.get(), childToPaint.accumulatedAncestorOffset,
-                phase, layerFragments, context, paintingInfo, paintBehavior, subtreePaintRootForRenderer, containerBaseOffset, isSVGRoot);
+                phase, layerFragments, context, paintingInfo, paintBehavior, subtreePaintRootForRenderer, containerBaseOffset, isSVGRoot, sharedClipSaver.has_value());
         }
     }
 }


### PR DESCRIPTION
#### 4f7f297bd72c384b62959578b03b62182ef4a130
<pre>
[LBSE] Clip the SVG child-paint loop once per container instead of once per shape
<a href="https://bugs.webkit.org/show_bug.cgi?id=319203">https://bugs.webkit.org/show_bug.cgi?id=319203</a>

Reviewed by Rob Buis.

When painting SVG, paintChildrenInDOMOrderForSVG() set up a clip rectangle
for every child shape before drawing it. Each shape did its own save, clip,
and restore, even though the clip rectangle was the same for all of them.

When there is only one region to clip to and no child draws on its own
layer, we now set that clip up a single time and let every child share it.
Both transformed and non-transformed children use the shared clip, so the
extra per-shape save and clip are gone.

Covered by existing tests under LBSE.

* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderLayerSVGAdditions.cpp:
(WebCore::RenderLayer::paintNonLayerChildForFragmentsForSVG):
(WebCore::RenderLayer::paintChildrenInDOMOrderForSVG):

Canonical link: <a href="https://commits.webkit.org/317036@main">https://commits.webkit.org/317036@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9fc220ccd83f56a2e6b9473fb5cc473c665270dc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174105 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48038 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41819 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183679 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131973 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175970 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49330 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47720 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135404 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95505 "4 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177063 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38837 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156198 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115882 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37478 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35845 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32163 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147902 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35691 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186105 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39224 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40044 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144306 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47705 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144166 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48384 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32308 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113856 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26471 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39077 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120273 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46890 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10653 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46293 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46524 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46351 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->