### PR TITLE
[Text Extraction] Append a `clickable` token next to images, SVGs and other containers that look visually clickable

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt
@@ -11,7 +11,8 @@ root
             'This button does nothing' […]
             input uid=… […] placeholder='Enter text here'
             uid=… role=button 'Clickable Div' […]
-            uid=… 'Clickable Div 2' […]
+            uid=… clickable 'Clickable Div 2' […]
+            image uid=… […] clickable
         section label='ARIA Labeling Examples'
             'Name Field' […]
             'Description' […]

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-basic.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-basic.html
@@ -72,6 +72,9 @@ canvas {
         <input type="text" class="focusable" placeholder="Enter text here" onfocus="this.style.backgroundColor='yellow'" onblur="this.style.backgroundColor=''" aria-required="true" aria-invalid="false" />
         <div class="interactive" tabindex="0"  role="button" onclick="this.textContent = 'Clicked!'" onkeydown="if(event.key==='Enter') this.click()" aria-pressed="false">Clickable Div</div>
         <div class="clickable">Clickable Div 2</div>
+        <svg style="cursor: pointer;" width="16" height="16" onclick="console.log('svg clicked')">
+            <path d="M3 13 L11 5 L13 7 L5 15 Z" fill="black"></path>
+        </svg>
     </section>
     <section id="section2" aria-label="ARIA Labeling Examples">
         <div id="label1">Name Field</div>

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -575,6 +575,8 @@ static bool NODELETE shouldTreatAsPasswordField(const Element* element)
 
 enum class FallbackPolicy : bool { Skip, Extract };
 
+static bool looksVisuallyClickable(const RenderObject&);
+
 static inline Variant<SkipExtraction, ItemData, URL, Editable> extractItemData(Node& node, FallbackPolicy policy, TraversalContext& context)
 {
     CheckedPtr renderer = node.renderer();
@@ -950,7 +952,7 @@ static bool looksVisuallyClickable(const RenderObject& renderer)
     if (style->pointerEvents() == PointerEvents::None)
         return false;
 
-    if (!hasVisuallyDistinctStyling(protect(style)))
+    if (!hasVisuallyDistinctStyling(protect(style)) && !renderer.isRenderReplaced())
         return false;
 
     CheckedPtr parent = renderer.parent();
@@ -1241,8 +1243,10 @@ static inline void extractRecursive(Node& node, Item& parentItem, TraversalConte
         context.onlyCollectTextAndLinksCount++;
     }
 
-    if (auto* renderer = node.renderer(); renderer && item)
+    if (CheckedPtr renderer = node.renderer(); renderer && item) {
         item->hasLineThrough = renderer->style().textDecorationLineInEffect().hasLineThrough();
+        item->isVisuallyClickable = looksVisuallyClickable(*renderer);
+    }
 
     if (item)
         item->visualBlockContainerNumber = context.currentVisualBlockContainerNumber();

--- a/Source/WebCore/page/text-extraction/TextExtractionTypes.h
+++ b/Source/WebCore/page/text-extraction/TextExtractionTypes.h
@@ -226,6 +226,7 @@ struct Item {
     unsigned enclosingBlockNumber { 0 };
     unsigned visualBlockContainerNumber { 0 };
     bool hasLineThrough { false };
+    bool isVisuallyClickable { false };
 
     template<typename T> bool hasData() const
     {

--- a/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
@@ -1635,10 +1635,14 @@ static void addPartsForItem(const TextExtraction::Item& item, std::optional<Node
                     parts.append("-"_s);
                 }
             } else {
+                bool isGenericContainer = containerString.isEmpty();
                 if (!containerString.isEmpty())
                     parts.append(WTF::move(containerString));
 
                 parts.appendVector(partsForItem(item, aggregator, includeRectForParentItem));
+
+                if (isGenericContainer && item.isVisuallyClickable)
+                    parts.append("clickable"_s);
             }
             aggregator.addResult(line, WTF::move(parts));
         },
@@ -1976,6 +1980,9 @@ static void addPartsForItem(const TextExtraction::Item& item, std::optional<Node
 
                 if (!imageData.altText.isEmpty())
                     parts.append(makeString("alt="_s, quoteValue(escapeString(imageData.altText), streamlined)));
+
+                if (item.isVisuallyClickable)
+                    parts.append("clickable"_s);
             }
 
             aggregator.addResult(line, WTF::move(parts));

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -5038,6 +5038,7 @@ header: <WebCore/TextExtractionTypes.h>
     unsigned enclosingBlockNumber;
     unsigned visualBlockContainerNumber;
     bool hasLineThrough;
+    bool isVisuallyClickable;
 };
 
 header: <WebCore/TextExtractionTypes.h>


### PR DESCRIPTION
#### 7c094a16ad8e0d53fcd6ad7966243f928032f540
<pre>
[Text Extraction] Append a `clickable` token next to images, SVGs and other containers that look visually clickable
<a href="https://bugs.webkit.org/show_bug.cgi?id=319201">https://bugs.webkit.org/show_bug.cgi?id=319201</a>
<a href="https://rdar.apple.com/182054863">rdar://182054863</a>

Reviewed by Richard Robinson.

Leverage the existing `looksVisuallyClickable` heuristic to append a `clickable` token next to
extracted elements — in particular, images and `svg` elements that might not seem immediately
interactive to an agent.

* LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-basic.html:
* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::extractRecursive):
* Source/WebCore/page/text-extraction/TextExtractionTypes.h:
* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
(WebKit::addPartsForItem):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/317016@main">https://commits.webkit.org/317016@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5beca5cb3053d566bd70b8c2e5cd5c4b986d2f1c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174133 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48066 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41847 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183707 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132001 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5c206de5-d401-4cf3-a02d-ec4d583ff3e5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175998 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49358 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47748 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135432 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95530 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0784744e-16b6-41cf-a797-209271d264b5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177091 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38864 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156225 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115910 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4697881e-3a00-475f-a040-ba4aef74d5fc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37505 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35873 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32191 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147929 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35718 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186133 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39268 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40071 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144333 "Found 1 new test failure: compositing/framesets/composited-frame-alignment.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47733 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155780 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144193 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38858 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48412 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32336 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113908 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39104 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120308 "Found 119 new failures in b3/B3Value.h, b3/testb3_7.cpp, WebProcess/Network/WebResourceLoader.cpp, UIProcess/WebProcessPool.cpp, Shared/Cocoa/WKNSArray.mm, Shared/SessionState.cpp, NetworkProcess/NetworkResourceLoadParameters.cpp, WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm, WebProcess/WebPage/WebPage.cpp, WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm ...") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46918 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10680 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46321 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46552 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46379 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->