### PR TITLE
Add iteration bounds to SVGSMILElement interval-resolution loops to prevent potential hangs

### DIFF
--- a/Source/WebCore/svg/animation/SVGSMILElement.cpp
+++ b/Source/WebCore/svg/animation/SVGSMILElement.cpp
@@ -865,7 +865,18 @@ void SVGSMILElement::resolveInterval(bool first, SMILTime& beginResult, SMILTime
     // See the pseudocode in http://www.w3.org/TR/SMIL3/smil-timing.html#q90.
     SMILTime beginAfter = first ? -std::numeric_limits<double>::infinity() : m_intervalEnd;
     SMILTime lastIntervalTempEnd = std::numeric_limits<double>::infinity();
+
+    // Defensively bound the walk: a malformed or non-advancing begin/end list must never spin
+    // here indefinitely. Falling out leaves the interval unresolved.
+    size_t currentIteration = 0;
+    // Allow 4x the begin-time count for end-time refinement retries, but never fewer than 1M
+    // iterations so small/empty lists driven by dynamic or event-based times aren't capped early.
+    size_t maxIterations = std::max<size_t>(m_beginTimes.size() * 4, 1000000);
     while (true) {
+        if (currentIteration++ >= maxIterations) [[unlikely]] {
+            ASSERT_NOT_REACHED();
+            break;
+        }
         bool equalsMinimumOK = !first || m_intervalEnd > m_intervalBegin;
         SMILTime tempBegin = findInstanceTime(Begin, beginAfter, equalsMinimumOK);
         if (tempBegin.isUnresolved())
@@ -1013,7 +1024,17 @@ void SVGSMILElement::seekToIntervalCorrespondingToTime(SMILTime elapsed)
     ASSERT(elapsed >= m_intervalBegin);
 
     // Manually seek from interval to interval, just as if the animation would run regulary.
+    // Defensively bound the walk so a non-advancing interval list can't spin here indefinitely.
+    // Falling out simply stops seeking at the current interval.
+    size_t currentIteration = 0;
+    // Allow 4x the begin-time count for end-time refinement retries, but never fewer than 1M
+    // iterations so small/empty lists driven by dynamic or event-based times aren't capped early.
+    size_t maxIterations = std::max<size_t>(m_beginTimes.size() * 4, 1000000);
     while (true) {
+        if (currentIteration++ >= maxIterations) [[unlikely]] {
+            ASSERT_NOT_REACHED();
+            return;
+        }
         // Figure out the next value in the begin time list after the current interval begin.
         SMILTime nextBegin = findInstanceTime(Begin, m_intervalBegin, false);
 


### PR DESCRIPTION
#### 37384dc63e5df1d8d5e2a6609b3998ae351ce2b5
<pre>
Add iteration bounds to SVGSMILElement interval-resolution loops to prevent potential hangs
<a href="https://bugs.webkit.org/show_bug.cgi?id=319207">https://bugs.webkit.org/show_bug.cgi?id=319207</a>
<a href="https://rdar.apple.com/182059570">rdar://182059570</a>

Reviewed by Taher Ali.

Merge: <a href="https://chromium-review.googlesource.com/c/chromium/src/+/1937067">https://chromium-review.googlesource.com/c/chromium/src/+/1937067</a>

SVGSMILElement::resolveInterval() and seekToIntervalCorrespondingToTime()
each drive an unbounded `while (true)` loop whose termination depends
entirely on the begin/end instance-time lists advancing on every pass.
A malformed or non-advancing time list can therefore spin these loops
indefinitely, pinning the main thread (see the equivalent Blink hang,
crbug.com/1021630).

Defensively bound both walks with an iteration cap of
max(m_beginTimes.size() * 4, 1000000) -- matching Blink&apos;s kMaxIterations
-- then ASSERT_NOT_REACHED() and fall out gracefully on overflow:
resolveInterval() leaves the interval unresolved and
seekToIntervalCorrespondingToTime() stops seeking at the current
interval.

The cap is deliberately loose so no valid content can ever reach it:
  - m_beginTimes.size() * 4 scales the bound with the actual input. A
    legitimate walk advances about one iteration per begin instance time,
    plus a small constant multiple for the end-time refinement retries;
    4x leaves headroom over that.
  - 1000000 is an absolute floor. When the begin list is small or empty,
    size * 4 would be tiny (or 0) and could false-positive on walks
    driven by dynamically-added or event-based instance times that are
    not reflected in m_beginTimes.size(). The 1M floor guarantees a large
    ceiling regardless of list size.

No behavior change for valid animations; no new tests since the bound is
unreachable by well-formed timing input.

* Source/WebCore/svg/animation/SVGSMILElement.cpp:
(WebCore::SVGSMILElement::resolveInterval):
(WebCore::SVGSMILElement::seekToIntervalCorrespondingToTime):

Canonical link: <a href="https://commits.webkit.org/317014@main">https://commits.webkit.org/317014@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b854028c59696d35250e11250d4e61e9d931acd3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174118 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48051 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41832 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183692 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131986 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a13ba211-4cd7-4f01-906a-85e44b6ca97f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175983 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49343 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47733 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135418 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ae0bc4c9-930d-4173-9ca7-9e7dff998c2e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177076 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38849 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156210 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115896 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1063ea10-63df-4127-814c-281e4ee00983) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37490 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35858 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32176 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147914 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35703 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186118 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39245 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40056 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144319 "Found 1 new test failure: compositing/color-matching/image-color-matching.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47718 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144179 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38856 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48397 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32320 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113887 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39089 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120290 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46903 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10665 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46306 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46537 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46364 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->