### PR TITLE
[JSC] `Strong<T>` should be pointer-sized

### DIFF
--- a/Source/JavaScriptCore/heap/Handle.h
+++ b/Source/JavaScriptCore/heap/Handle.h
@@ -115,8 +115,6 @@ public:
         setSlot(o.slot());
     }
 
-    virtual ~Handle() = default;
-
     void swap(Handle& other) { HandleBase::swap(other); }
 
     ExternalType get() const { return HandleTypes<T>::getFromSlot(this->slot()); }

--- a/Source/JavaScriptCore/heap/Strong.h
+++ b/Source/JavaScriptCore/heap/Strong.h
@@ -97,7 +97,7 @@ public:
     {
     }
 
-    ~Strong() override
+    ~Strong()
     {
         clear();
     }
@@ -152,6 +152,11 @@ template<class T> inline void swap(Strong<T>& a, Strong<T>& b)
 {
     a.swap(b);
 }
+
+#if !ENABLE(REFTRACKER)
+// Handle has no virtual methods, so a Strong is just its slot pointer.
+static_assert(sizeof(Strong<Unknown>) == sizeof(HandleSlot));
+#endif
 
 } // namespace JSC
 


### PR DESCRIPTION
#### 904ba517118749e7b0e97ded812b7b64d8b7d534
<pre>
[JSC] `Strong&lt;T&gt;` should be pointer-sized
<a href="https://bugs.webkit.org/show_bug.cgi?id=319210">https://bugs.webkit.org/show_bug.cgi?id=319210</a>

Reviewed by Yusuke Suzuki.

284791@main added `virtual ~Handle() = default;` while introducing
StrongRefTracker, doubling sizeof(Strong&lt;T&gt;) from 8 to 16 bytes everywhere.
Strong&lt;T&gt; is final and the only subclass of Handle&lt;T&gt;, and nothing deletes
through a Handle&lt;T&gt;*, so the virtual destructor is unnecessary.

RefTracker does not rely on it either: the Vector interaction is handled by
the ENABLE(REFTRACKER)-guarded VectorTraits flags added in the same commit.

Verified on a Debug build that JSC_enableStrongRefTracker=1 still works,
including through Vector&lt;Strong&lt;JSPromise&gt;&gt; reallocations.

Also add a static_assert so Strong&lt;T&gt; stays pointer-sized.

* Source/JavaScriptCore/heap/Handle.h:
* Source/JavaScriptCore/heap/Strong.h:

Canonical link: <a href="https://commits.webkit.org/317117@main">https://commits.webkit.org/317117@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0fbfa4c8d37663af742e22beef56d21594cacc01

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174123 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48056 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41837 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183697 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131991 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49348 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47738 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135426 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95521 "1 flakes 5 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177081 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38855 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156217 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115904 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37496 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35864 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32181 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/4727 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147920 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35710 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186123 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/35385 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39261 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40062 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144325 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47723 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144185 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38925 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48402 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32327 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113894 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39094 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120296 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/211158 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46908 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10672 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55029 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46311 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46542 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46369 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->