### PR TITLE
Remove the dead NeedsVP9FullRangeFlagQuirk

### DIFF
--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -681,35 +681,6 @@ void MediaSource::streamEndedWithError(std::optional<EndOfStreamError> error)
     });
 }
 
-static ContentType addVP9FullRangeVideoFlagToContentType(const ContentType& type)
-{
-    auto countPeriods = [] (const String& codec) {
-        unsigned count = 0;
-        unsigned position = 0;
-
-        while (codec.find('.', position) != notFound) {
-            ++count;
-            ++position;
-        }
-
-        return count;
-    };
-
-    for (auto codec : type.codecs()) {
-        if (!codec.startsWith("vp09"_s) || countPeriods(codec) != 7)
-            continue;
-
-        auto rawType = type.raw();
-        auto position = rawType.find(codec);
-        ASSERT(position != notFound);
-        if (position == notFound)
-            continue;
-
-        return ContentType(makeStringByInserting(rawType, ".00"_s, position + codec.length()));
-    }
-    return type;
-}
-
 ExceptionOr<Ref<SourceBuffer>> MediaSource::addSourceBuffer(const String& type)
 {
     DEBUG_LOG(LOGIDENTIFIER, type);
@@ -742,9 +713,6 @@ ExceptionOr<Ref<SourceBuffer>> MediaSource::addSourceBuffer(const String& type)
 
     // 5. Create a new SourceBuffer object and associated resources.
     ContentType contentType(type);
-    if (document && document->quirks().needsVP9FullRangeFlagQuirk())
-        contentType = addVP9FullRangeVideoFlagToContentType(contentType);
-
     auto sourceBufferPrivate = createSourceBufferPrivate(contentType);
 
     if (sourceBufferPrivate.hasException()) {
@@ -999,8 +967,6 @@ bool MediaSource::isTypeSupported(ScriptExecutionContext& context, const String&
 
     ContentType contentType(type);
     RefPtr document = dynamicDowncast<Document>(context);
-    if (document && document->quirks().needsVP9FullRangeFlagQuirk())
-        contentType = addVP9FullRangeVideoFlagToContentType(contentType);
 
     String codecs = contentType.parameter("codecs"_s);
 
@@ -1262,16 +1228,14 @@ Vector<PlatformTimeRanges> MediaSource::activeRanges() const
     });
 }
 
-ExceptionOr<Ref<SourceBufferPrivate>> MediaSource::createSourceBufferPrivate(const ContentType& incomingType)
+ExceptionOr<Ref<SourceBufferPrivate>> MediaSource::createSourceBufferPrivate(const ContentType& type)
 {
-    ContentType type { incomingType };
-
-    RefPtr document = dynamicDowncast<Document>(scriptExecutionContext());
-    if (document && document->quirks().needsVP9FullRangeFlagQuirk())
-        type = addVP9FullRangeVideoFlagToContentType(incomingType);
-
     ASSERT(isOpen());
     Ref msp = *m_private;
+
+#if ENABLE(MEDIA_RECORDER_WEBM)
+    RefPtr document = dynamicDowncast<Document>(scriptExecutionContext());
+#endif
 
     RefPtr<SourceBufferPrivate> sourceBufferPrivate;
     MediaSourceConfiguration configuration = {

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1625,14 +1625,6 @@ Quirks::StorageAccessResult Quirks::triggerOptionalStorageAccessQuirk(Element& e
     return Quirks::StorageAccessResult::ShouldNotCancelEvent;
 }
 
-// youtube.com rdar://66242343
-bool Quirks::needsVP9FullRangeFlagQuirk() const
-{
-    QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
-
-    return m_quirksData.quirkIsEnabled(QuirksData::SiteSpecificQuirk::NeedsVP9FullRangeFlagQuirk);
-}
-
 // facebook.com: rdar://67273166
 // forbes.com:
 // reddit.com: rdar://80550715
@@ -4033,8 +4025,6 @@ static void handleYouTubeQuirks(QuirksData& quirksData, const URL& quirksURL, co
         QuirksData::SiteSpecificQuirk::HasBrokenEncryptedMediaAPISupportQuirk,
         // youtube.com rdar://135886305
         QuirksData::SiteSpecificQuirk::NeedsScrollbarWidthThinDisabledQuirk,
-        // youtube.com rdar://66242343
-        QuirksData::SiteSpecificQuirk::NeedsVP9FullRangeFlagQuirk,
 #if PLATFORM(COCOA)
         QuirksData::SiteSpecificQuirk::NeedsYouTubeCaptionQuirk,
 #endif

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -207,8 +207,6 @@ public:
     void setSubFrameDomainsForStorageAccessQuirk(Vector<RegistrableDomain>&& domains) { m_subFrameDomainsForStorageAccessQuirk = WTF::move(domains); }
     const Vector<RegistrableDomain>& subFrameDomainsForStorageAccessQuirk() const LIFETIME_BOUND { return m_subFrameDomainsForStorageAccessQuirk; }
 
-    bool needsVP9FullRangeFlagQuirk() const;
-
     bool requiresUserGestureToPauseInPictureInPicture() const;
     bool requiresUserGestureToLoadInPictureInPicture() const;
     bool requiresUserGestureToPlayInFullscreen() const;

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -133,7 +133,6 @@ struct QuirksData {
         NeedsSeekingSupportDisabledQuirk,
         NeedsSuppressPostLayoutBoundaryEventsQuirk,
         NeedsTikTokOverflowingContentQuirk,
-        NeedsVP9FullRangeFlagQuirk,
         NeedsVideoShouldMaintainAspectRatioQuirk,
         NeedsWebKitMediaTextTrackDisplayQuirk,
 #if PLATFORM(COCOA)


### PR DESCRIPTION
#### 1a91592d550067571bf491412e36dd1dd036a4d4
<pre>
Remove the dead NeedsVP9FullRangeFlagQuirk
<a href="https://bugs.webkit.org/show_bug.cgi?id=319212">https://bugs.webkit.org/show_bug.cgi?id=319212</a>
<a href="https://rdar.apple.com/182066464">rdar://182066464</a>

Reviewed by Jean-Yves Avenard.

NeedsVP9FullRangeFlagQuirk (youtube.com, <a href="https://rdar.apple.com/66242343">rdar://66242343</a>) was meant to
complete a &quot;vp09&quot; codec string that carried the optional fields but omitted
the trailing videoFullRangeFlag, appending &quot;.00&quot; so that the
mutually-inclusive optional group parsed. It has never done so, and it is
no longer needed either way.

It never applied because countPeriods() in
addVP9FullRangeVideoFlagToContentType() advanced its scan cursor by a
single position after each match (++position) instead of moving past the
index the &apos;.&apos; was found at. String::find(&apos;.&apos;, position) returns the
absolute index of the next match at or after position, so the same period
was re-counted on every iteration until the cursor walked past it,
inflating the count: &quot;vp09.00.41.08.01.01.01.00&quot; (7 periods) counts as 23,
so the required `countPeriods(codec) != 7` check never matched and the
quirk was a no-op from its introduction in 227853@main.

It is also moot: youtube.com serves WebKit the complete 9-field form,
verified in Safari as &quot;vp09.02.51.10.01.09.16.09.00&quot;, which already carries
videoFullRangeFlag. That has 8 periods rather than the 7 the quirk keyed on,
so a repaired countPeriods() would skip it, and parseVPCodecParameters()
accepts it unmodified. HDR VP9 (PQ/bt2020) plays at 2560x1440@60 in Safari
today with the quirk inert.

Eight years without a report of the underlying problem and no remaining
codec string to complete, so remove the quirk rather than repair it. This
is not a behavior change, and no new test is needed: rejection of the
8-field form is already covered by
platform/mac/media/media-source/is-type-supported-vp9-codec-check.html.

createSourceBufferPrivate() no longer needs to copy its ContentType
argument, and its Document lookup is now only used by the
MEDIA_RECORDER_WEBM Matroska quirk, so it moves inside that guard.

* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::addVP9FullRangeVideoFlagToContentType): Deleted.
(WebCore::MediaSource::addSourceBuffer):
(WebCore::MediaSource::isTypeSupported):
(WebCore::MediaSource::createSourceBufferPrivate):
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::needsVP9FullRangeFlagQuirk const): Deleted.
(WebCore::handleYouTubeQuirks):
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/QuirksData.h:

Canonical link: <a href="https://commits.webkit.org/318943@main">https://commits.webkit.org/318943@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/22bbe926b443ec9475db2f67d29a3ef622b8b928

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179787 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53726 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47525 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189620 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144098 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/25bc7f9a-3b13-4189-9a4a-740cf21ad3fe) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181650 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55020 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53438 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140239 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e698d8ab-6f34-40c1-bead-ba95a4d61228) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182744 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43847 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160974 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120690 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/be9456fe-b4c5-4228-8ace-a6fedaffd4e0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42517 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40840 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152918 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40495 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1073 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46332 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45087 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191841 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53396 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149520 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40084 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54077 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37112 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149254 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43907 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126349 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121381 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52594 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15485 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51979 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52220 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52040 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->