### PR TITLE
[iOS] Placard may show incorrect route name during wireless playback

### DIFF
--- a/LayoutTests/media/wireless-playback-media-player/route-name-expected.txt
+++ b/LayoutTests/media/wireless-playback-media-player/route-name-expected.txt
@@ -1,0 +1,14 @@
+
+Test that the AirPlay placard title is populated with the MediaDeviceRoute's routeName.
+
+EXPECTED (video.remote.state == 'disconnected') OK
+RUN(video.src = findMediaFile('video', '../content/test'))
+EVENT(canplaythrough)
+RUN(video.play())
+EVENT(playing)
+EXPECTED (route.routeName.length > 0 == 'true') OK
+RUN(internals.mockMediaDeviceRouteController.activateRoute(route))
+EVENT(connect)
+EXPECTED (placardTitleText() === route.routeName == 'true') OK
+END OF TEST
+

--- a/LayoutTests/media/wireless-playback-media-player/route-name-fallback-expected.txt
+++ b/LayoutTests/media/wireless-playback-media-player/route-name-fallback-expected.txt
@@ -1,0 +1,14 @@
+
+Test that the AirPlay placard title falls back to "AirPlay" when the MediaDeviceRoute has no routeName.
+
+EXPECTED (video.remote.state == 'disconnected') OK
+RUN(video.src = findMediaFile('video', '../content/test'))
+EVENT(canplaythrough)
+RUN(video.play())
+EVENT(playing)
+EXPECTED (route.routeName == '') OK
+RUN(internals.mockMediaDeviceRouteController.activateRoute(route))
+EVENT(connect)
+EXPECTED (placardTitleText() == 'AirPlay') OK
+END OF TEST
+

--- a/LayoutTests/media/wireless-playback-media-player/route-name-fallback.html
+++ b/LayoutTests/media/wireless-playback-media-player/route-name-fallback.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html><!-- webkit-test-runner [ WirelessPlaybackMediaPlayerEnabled=true ] -->
+<html>
+    <head>
+        <meta charset='UTF-8'>
+        <script src='../media-file.js'></script>
+        <script src='../video-test.js'></script>
+        <script>
+            var route;
+            var video;
+
+            function placardTitleText()
+            {
+                const node = internals.shadowRoot(video).querySelector('.placard .title');
+                return node ? node.innerText : null;
+            }
+
+            async function start()
+            {
+                if (window.internals)
+                    internals.mockMediaDeviceRouteController.enabled = true;
+
+                video = document.getElementsByTagName('video')[0];
+                testExpected('video.remote.state', 'disconnected');
+
+                run(`video.src = findMediaFile('video', '../content/test')`);
+                await waitFor(video, 'canplaythrough');
+
+                run(`video.play()`)
+                await waitFor(video, 'playing');
+
+                const connectPromise = waitFor(video.remote, 'connect');
+                route = internals.mockMediaDeviceRouteController.createMockMediaDeviceRoute();
+                route.deviceName = 'test';
+                testExpected('route.routeName', '');
+                run(`internals.mockMediaDeviceRouteController.activateRoute(route)`);
+                await connectPromise;
+
+                // With no route name, the placard title falls back to the localized "AirPlay".
+                await testExpectedEventually('placardTitleText() === "AirPlay"', true);
+                endTest();
+            }
+        </script>
+    </head>
+    <body onload='start()'>
+        <video controls></video>
+        <p>Test that the AirPlay placard title falls back to "AirPlay" when the MediaDeviceRoute has no routeName.</p>
+    </body>
+</html>

--- a/LayoutTests/media/wireless-playback-media-player/route-name.html
+++ b/LayoutTests/media/wireless-playback-media-player/route-name.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html><!-- webkit-test-runner [ WirelessPlaybackMediaPlayerEnabled=true ] -->
+<html>
+    <head>
+        <meta charset='UTF-8'>
+        <script src='../media-file.js'></script>
+        <script src='../video-test.js'></script>
+        <script>
+            var route;
+            var video;
+
+            function placardTitleText()
+            {
+                const node = internals.shadowRoot(video).querySelector('.placard .title');
+                return node ? node.innerText : null;
+            }
+
+            async function start()
+            {
+                if (window.internals)
+                    internals.mockMediaDeviceRouteController.enabled = true;
+
+                video = document.getElementsByTagName('video')[0];
+                testExpected('video.remote.state', 'disconnected');
+
+                run(`video.src = findMediaFile('video', '../content/test')`);
+                await waitFor(video, 'canplaythrough');
+
+                run(`video.play()`)
+                await waitFor(video, 'playing');
+
+                const connectPromise = waitFor(video.remote, 'connect');
+                route = internals.mockMediaDeviceRouteController.createMockMediaDeviceRoute();
+                route.deviceName = 'test';
+                route.protocolTypeIdentifier = 'public.mpeg-4';
+                testExpected('route.routeName.length > 0', true);
+                run(`internals.mockMediaDeviceRouteController.activateRoute(route)`);
+                await connectPromise;
+
+                // Wait for the AirPlay placard to appear, then verify it shows the route name
+                // from the first update (rather than briefly falling back to "AirPlay").
+                while (placardTitleText() === null)
+                    await new Promise(requestAnimationFrame);
+                testExpected('placardTitleText() === route.routeName', true);
+                endTest();
+            }
+        </script>
+    </head>
+    <body onload='start()'>
+        <video controls></video>
+        <p>Test that the AirPlay placard title is populated with the MediaDeviceRoute's routeName.</p>
+    </body>
+</html>

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
@@ -380,6 +380,23 @@ String MediaControlsHost::externalDeviceDisplayName() const
 #endif
 }
 
+String MediaControlsHost::externalDeviceRouteName() const
+{
+#if ENABLE(WIRELESS_PLAYBACK_TARGET)
+    RefPtr player = m_mediaElement->player();
+    if (!player) {
+        LOG(Media, "MediaControlsHost::externalDeviceRouteName - returning \"\" because player is NULL");
+        return emptyString();
+    }
+
+    String name = player->wirelessPlaybackRouteName();
+    LOG(Media, "MediaControlsHost::externalDeviceRouteName - returning \"%s\"", name.utf8().data());
+    return name;
+#else
+    return emptyString();
+#endif
+}
+
 auto MediaControlsHost::externalDeviceType() const -> DeviceType
 {
 #if !ENABLE(WIRELESS_PLAYBACK_TARGET)

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.h
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.h
@@ -120,6 +120,7 @@ public:
     void requiresTextTrackRepresentationChanged();
 
     String externalDeviceDisplayName() const;
+    String externalDeviceRouteName() const;
 
     enum class DeviceType { None, Airplay, Tvout };
     DeviceType externalDeviceType() const;

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.idl
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.idl
@@ -72,6 +72,7 @@ enum DeviceType {
     readonly attribute boolean isAVExperienceControllerFullscreenEnabled;
 
     readonly attribute DOMString externalDeviceDisplayName;
+    readonly attribute DOMString externalDeviceRouteName;
     readonly attribute DeviceType externalDeviceType;
 
     attribute boolean controlsDependOnPageScaleFactor;

--- a/Source/WebCore/Modules/modern-media-controls/controls/placard.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/placard.js
@@ -76,6 +76,12 @@ class Placard extends LayoutItem
         this._container.children = children;
     }
     
+    set title(title)
+    {
+        this._titleNode = !!title ? new LayoutNode(`<div class="title">${title}</div>`) : null;
+        this.needsLayout = true;
+    }
+    
     set description(description)
     {
         this._descriptionNode = !!description ? new LayoutNode(`<div class="description">${description}</div>`) : null;

--- a/Source/WebCore/Modules/modern-media-controls/media/placard-support.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/placard-support.js
@@ -95,19 +95,23 @@ class PlacardSupport extends MediaControllerSupport
 
     _updateAirPlayPlacard()
     {
-        var deviceName = "";
-        
         if (!this.mediaController.host)
             return;
-        
+
+        var deviceName = "";
+        var routeName = UIString("AirPlay");
+
         switch(this.mediaController.host.externalDeviceType) {
             case 'airplay':
                 deviceName = UIString("This video is playing on \u201C%s\u201D.", escapeHTML(this.mediaController.host.externalDeviceDisplayName) || UIString("Apple TV"));
+                if (this.mediaController.host.externalDeviceRouteName)
+                    routeName = escapeHTML(this.mediaController.host.externalDeviceRouteName);
                 break;
             case 'tvout':
                 deviceName = UIString("This video is playing on the TV.");
                 break;
         }
+        this.mediaController.controls.airplayPlacard.title = routeName;
         this.mediaController.controls.airplayPlacard.description = deviceName;
     }
 

--- a/Source/WebCore/platform/audio/ios/MediaDeviceRoute.h
+++ b/Source/WebCore/platform/audio/ios/MediaDeviceRoute.h
@@ -113,6 +113,7 @@ public:
 
     const WTF::UUID& identifier() const LIFETIME_BOUND { return m_identifier; }
     String deviceName() const;
+    String routeName() const;
     WebMediaDevicePlatformRoute *platformRoute() const;
 
     void loadURL(const URL&, CompletionHandler<void(const MediaDeviceRouteLoadURLResult&)>&&);

--- a/Source/WebCore/platform/audio/ios/MediaDeviceRoute.mm
+++ b/Source/WebCore/platform/audio/ios/MediaDeviceRoute.mm
@@ -235,6 +235,11 @@ String MediaDeviceRoute::deviceName() const
     return [m_platformRoute routeDisplayName];
 }
 
+String MediaDeviceRoute::routeName() const
+{
+    return [m_platformRoute protocolType].localizedDescription;
+}
+
 WebMediaDevicePlatformRoute *MediaDeviceRoute::platformRoute() const
 {
     return m_platformRoute.get();

--- a/Source/WebCore/platform/graphics/MediaPlaybackTarget.h
+++ b/Source/WebCore/platform/graphics/MediaPlaybackTarget.h
@@ -44,6 +44,7 @@ public:
 
     virtual bool hasActiveRoute() const = 0;
     virtual String deviceName() const = 0;
+    virtual String routeName() const = 0;
     virtual bool supportsRemoteVideoPlayback() const = 0;
 
     virtual bool operator==(const MediaPlaybackTarget& other) const { return this == &other; }

--- a/Source/WebCore/platform/graphics/MediaPlaybackTargetWirelessPlayback.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlaybackTargetWirelessPlayback.cpp
@@ -74,6 +74,13 @@ String MediaPlaybackTargetWirelessPlayback::deviceName() const
     return { };
 }
 
+String MediaPlaybackTargetWirelessPlayback::routeName() const
+{
+    if (RefPtr route = m_route)
+        return route->routeName();
+    return { };
+}
+
 bool MediaPlaybackTargetWirelessPlayback::operator==(const MediaPlaybackTarget& other) const
 {
     RefPtr otherWirelessPlaybackTarget = dynamicDowncast<MediaPlaybackTargetWirelessPlayback>(other);

--- a/Source/WebCore/platform/graphics/MediaPlaybackTargetWirelessPlayback.h
+++ b/Source/WebCore/platform/graphics/MediaPlaybackTargetWirelessPlayback.h
@@ -53,6 +53,7 @@ private:
 
     // MediaPlaybackTarget
     String deviceName() const final;
+    String routeName() const final;
     bool hasActiveRoute() const final { return m_hasActiveRoute; }
     bool supportsRemoteVideoPlayback() const final { return hasActiveRoute(); }
     bool operator==(const MediaPlaybackTarget&) const final;

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -1312,6 +1312,11 @@ String MediaPlayer::wirelessPlaybackTargetName() const
     return protect(m_private)->wirelessPlaybackTargetName();
 }
 
+String MediaPlayer::wirelessPlaybackRouteName() const
+{
+    return protect(m_private)->wirelessPlaybackRouteName();
+}
+
 MediaPlayer::WirelessPlaybackTargetType MediaPlayer::wirelessPlaybackTargetType() const
 {
     return protect(m_private)->wirelessPlaybackTargetType();

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -589,6 +589,7 @@ public:
     WirelessPlaybackTargetType wirelessPlaybackTargetType() const;
 
     String wirelessPlaybackTargetName() const;
+    String wirelessPlaybackRouteName() const;
 
     bool wirelessVideoPlaybackDisabled() const;
     void setWirelessVideoPlaybackDisabled(bool);

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
@@ -224,6 +224,7 @@ public:
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
 
     virtual String wirelessPlaybackTargetName() const { return emptyString(); }
+    virtual String wirelessPlaybackRouteName() const { return emptyString(); }
     virtual MediaPlayer::WirelessPlaybackTargetType wirelessPlaybackTargetType() const { return MediaPlayer::WirelessPlaybackTargetType::TargetTypeNone; }
 
     virtual bool wirelessVideoPlaybackDisabled() const { return true; }

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp
@@ -129,6 +129,13 @@ String MediaPlayerPrivateWirelessPlayback::wirelessPlaybackTargetName() const
     return { };
 }
 
+String MediaPlayerPrivateWirelessPlayback::wirelessPlaybackRouteName() const
+{
+    if (RefPtr playbackTarget = m_playbackTarget)
+        return playbackTarget->routeName();
+    return { };
+}
+
 MediaPlayer::WirelessPlaybackTargetType MediaPlayerPrivateWirelessPlayback::wirelessPlaybackTargetType() const
 {
     RefPtr playbackTarget = m_playbackTarget;

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.h
@@ -104,6 +104,7 @@ private:
     DestinationColorSpace colorSpace() final { return DestinationColorSpace::SRGB(); }
     static OptionSet<MediaPlaybackTargetType> playbackTargetTypes();
     String wirelessPlaybackTargetName() const final;
+    String wirelessPlaybackRouteName() const final;
     MediaPlayer::WirelessPlaybackTargetType wirelessPlaybackTargetType() const final;
     bool wirelessVideoPlaybackDisabled() const final { return !m_allowsWirelessVideoPlayback; }
     void setWirelessVideoPlaybackDisabled(bool disabled) final { m_allowsWirelessVideoPlayback = !disabled; }

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlaybackTargetCocoa.h
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlaybackTargetCocoa.h
@@ -58,6 +58,7 @@ private:
 
     // MediaPlaybackTarget
     String deviceName() const final;
+    String routeName() const final;
     bool hasActiveRoute() const final;
 
     RetainPtr<AVOutputContext> m_outputContext;

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlaybackTargetCocoa.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlaybackTargetCocoa.mm
@@ -61,6 +61,11 @@ String MediaPlaybackTargetCocoa::deviceName() const
     return [outputDeviceNames componentsJoinedByString:@" + "];
 }
 
+String MediaPlaybackTargetCocoa::routeName() const
+{
+    return { };
+}
+
 bool MediaPlaybackTargetCocoa::hasActiveRoute() const
 {
     if ([m_outputContext supportsMultipleOutputDevices]) {

--- a/Source/WebCore/platform/mock/MediaPlaybackTargetMock.h
+++ b/Source/WebCore/platform/mock/MediaPlaybackTargetMock.h
@@ -54,6 +54,7 @@ private:
 
     // MediaPlaybackTarget
     String deviceName() const final { return m_mockDeviceName; }
+    String routeName() const final { return { }; }
     bool hasActiveRoute() const final { return !m_mockDeviceName.isEmpty(); }
     bool supportsRemoteVideoPlayback() const final { return !m_mockDeviceName.isEmpty(); }
 

--- a/Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.h
+++ b/Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.h
@@ -49,6 +49,7 @@ extern NSErrorDomain const WebMockMediaDeviceRouteErrorDomain;
 @interface WebMockMediaDeviceRoute : NSObject <AVPlaybackControl, WebMediaDevicePlatformRoute>
 @property (nonatomic, nullable, setter=setURLCallback:) WebCore::MockMediaDeviceRouteURLCallback* urlCallback;
 @property (copy) NSString *routeDisplayName;
+@property (copy) UTType *protocolType;
 @property (nonatomic, getter=isReady) BOOL ready;
 @property (nonatomic, strong, nullable) NSError *error;
 @property (nonatomic) CMTimeRange timeRange;

--- a/Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.mm
+++ b/Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.mm
@@ -75,6 +75,7 @@ NSErrorDomain const WebMockMediaDeviceRouteErrorDomain = @"WebMockMediaDeviceRou
 @synthesize volume;
 @synthesize metadata;
 @synthesize routeDisplayName;
+@synthesize protocolType;
 
 - (void)seekToPosition:(CMTime)position tolerance:(CMTime)tolerance
 {

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
@@ -830,6 +830,7 @@ void RemoteMediaPlayerProxy::mediaPlayerCurrentPlaybackTargetIsWirelessChanged(b
 {
     RefPtr player = m_player;
     m_cachedState.wirelessPlaybackTargetName = player->wirelessPlaybackTargetName();
+    m_cachedState.wirelessPlaybackRouteName = player->wirelessPlaybackRouteName();
     m_cachedState.wirelessPlaybackTargetType = player->wirelessPlaybackTargetType();
     sendCachedState();
     protect(m_webProcessConnection)->send(Messages::MediaPlayerPrivateRemote::CurrentPlaybackTargetIsWirelessChanged(isCurrentPlaybackTargetWireless), m_id);

--- a/Source/WebKit/Platform/cocoa/MediaPlaybackTargetContextSerialized.h
+++ b/Source/WebKit/Platform/cocoa/MediaPlaybackTargetContextSerialized.h
@@ -44,6 +44,7 @@ public:
     explicit MediaPlaybackTargetContextSerialized(const WebCore::MediaPlaybackTarget&);
 
     String deviceName() const { return m_deviceName; }
+    String routeName() const { return m_routeName; }
     bool hasActiveRoute() const { return m_hasActiveRoute; }
     bool supportsRemoteVideoPlayback() const { return m_supportsRemoteVideoPlayback; }
 
@@ -54,16 +55,17 @@ public:
     WebCore::MediaPlaybackTargetMockState mockState() const { return m_state; }
 #if HAVE(WK_SECURE_CODING_AVOUTPUTCONTEXT)
     CoreIPCAVOutputContext context() const { return m_context; }
-    MediaPlaybackTargetContextSerialized(String&&, bool, bool, WebCore::MediaPlaybackTargetType, WebCore::MediaPlaybackTargetMockState, CoreIPCAVOutputContext&&, std::optional<WTF::UUID>&&);
+    MediaPlaybackTargetContextSerialized(String&&, String&&, bool, bool, WebCore::MediaPlaybackTargetType, WebCore::MediaPlaybackTargetMockState, CoreIPCAVOutputContext&&, std::optional<WTF::UUID>&&);
 #else
     String contextID() const { return m_contextID; }
     String contextType() const { return m_contextType; }
-    MediaPlaybackTargetContextSerialized(String&&, bool, bool, WebCore::MediaPlaybackTargetType, WebCore::MediaPlaybackTargetMockState, String&&, String&&, std::optional<WTF::UUID>&&);
+    MediaPlaybackTargetContextSerialized(String&&, String&&, bool, bool, WebCore::MediaPlaybackTargetType, WebCore::MediaPlaybackTargetMockState, String&&, String&&, std::optional<WTF::UUID>&&);
 #endif
     const std::optional<WTF::UUID>& identifier() const LIFETIME_BOUND { return m_identifier; }
 
 private:
     String m_deviceName;
+    String m_routeName;
     bool m_hasActiveRoute { false };
     bool m_supportsRemoteVideoPlayback { false };
     // This should be const, however IPC's Decoder's handling doesn't allow for const member.

--- a/Source/WebKit/Platform/cocoa/MediaPlaybackTargetContextSerialized.mm
+++ b/Source/WebKit/Platform/cocoa/MediaPlaybackTargetContextSerialized.mm
@@ -46,6 +46,7 @@ using namespace WebCore;
 
 MediaPlaybackTargetContextSerialized::MediaPlaybackTargetContextSerialized(const MediaPlaybackTarget& target)
     : m_deviceName { target.deviceName() }
+    , m_routeName { target.routeName() }
     , m_hasActiveRoute { target.hasActiveRoute() }
     , m_supportsRemoteVideoPlayback { target.supportsRemoteVideoPlayback() }
     , m_targetType { is<MediaPlaybackTargetSerialized>(target) ? downcast<MediaPlaybackTargetSerialized>(target).context().targetType() : target.type() }
@@ -80,8 +81,9 @@ MediaPlaybackTargetContextSerialized::MediaPlaybackTargetContextSerialized(const
 }
 
 #if HAVE(WK_SECURE_CODING_AVOUTPUTCONTEXT)
-MediaPlaybackTargetContextSerialized::MediaPlaybackTargetContextSerialized(String&& deviceName, bool hasActiveRoute, bool supportsRemoteVideoPlayback, MediaPlaybackTargetType targetType, MediaPlaybackTargetMockState state, CoreIPCAVOutputContext&& context, std::optional<WTF::UUID>&& identifier)
+MediaPlaybackTargetContextSerialized::MediaPlaybackTargetContextSerialized(String&& deviceName, String&& routeName, bool hasActiveRoute, bool supportsRemoteVideoPlayback, MediaPlaybackTargetType targetType, MediaPlaybackTargetMockState state, CoreIPCAVOutputContext&& context, std::optional<WTF::UUID>&& identifier)
     : m_deviceName { WTF::move(deviceName) }
+    , m_routeName { WTF::move(routeName) }
     , m_hasActiveRoute { hasActiveRoute }
     , m_supportsRemoteVideoPlayback { supportsRemoteVideoPlayback }
     , m_targetType { targetType }
@@ -91,8 +93,9 @@ MediaPlaybackTargetContextSerialized::MediaPlaybackTargetContextSerialized(Strin
 {
 }
 #else
-MediaPlaybackTargetContextSerialized::MediaPlaybackTargetContextSerialized(String&& deviceName, bool hasActiveRoute, bool supportsRemoteVideoPlayback, MediaPlaybackTargetType targetType, MediaPlaybackTargetMockState state, String&& contextID, String&& contextType, std::optional<WTF::UUID>&& identifier)
+MediaPlaybackTargetContextSerialized::MediaPlaybackTargetContextSerialized(String&& deviceName, String&& routeName, bool hasActiveRoute, bool supportsRemoteVideoPlayback, MediaPlaybackTargetType targetType, MediaPlaybackTargetMockState state, String&& contextID, String&& contextType, std::optional<WTF::UUID>&& identifier)
     : m_deviceName(WTF::move(deviceName))
+    , m_routeName(WTF::move(routeName))
     , m_hasActiveRoute(hasActiveRoute)
     , m_supportsRemoteVideoPlayback(supportsRemoteVideoPlayback)
     , m_targetType(targetType)

--- a/Source/WebKit/Platform/cocoa/MediaPlaybackTargetContextSerialized.serialization.in
+++ b/Source/WebKit/Platform/cocoa/MediaPlaybackTargetContextSerialized.serialization.in
@@ -41,6 +41,7 @@ header: <WebCore/MediaPlaybackTarget.h>
 header: "MediaPlaybackTargetContextSerialized.h"
 [CustomHeader] class WebKit::MediaPlaybackTargetContextSerialized {
     String deviceName();
+    String routeName();
     bool hasActiveRoute();
     bool supportsRemoteVideoPlayback();
     WebCore::MediaPlaybackTargetType targetType();

--- a/Source/WebKit/Platform/cocoa/MediaPlaybackTargetSerialized.h
+++ b/Source/WebKit/Platform/cocoa/MediaPlaybackTargetSerialized.h
@@ -46,6 +46,7 @@ private:
     // MediaPlaybackTarget
     Type targetType() const final { return m_context.targetType(); }
     String deviceName() const final { return m_context.deviceName(); }
+    String routeName() const final { return m_context.routeName(); }
     bool hasActiveRoute() const final { return m_context.hasActiveRoute(); }
     bool supportsRemoteVideoPlayback() const final { return m_context.supportsRemoteVideoPlayback(); }
 

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
@@ -626,6 +626,7 @@ void MediaPlayerPrivateRemote::updateCachedState(RemoteMediaPlayerState&& state)
     m_cachedState.movieLoadType = state.movieLoadType;
     m_cachedState.wirelessPlaybackTargetType = state.wirelessPlaybackTargetType;
     m_cachedState.wirelessPlaybackTargetName = state.wirelessPlaybackTargetName;
+    m_cachedState.wirelessPlaybackRouteName = state.wirelessPlaybackRouteName;
 
     m_cachedState.startDate = state.startDate;
     m_cachedState.startTime = state.startTime;
@@ -1225,6 +1226,11 @@ bool MediaPlayerPrivateRemote::hasAvailableVideoFrame() const
 String MediaPlayerPrivateRemote::wirelessPlaybackTargetName() const
 {
     return m_cachedState.wirelessPlaybackTargetName;
+}
+
+String MediaPlayerPrivateRemote::wirelessPlaybackRouteName() const
+{
+    return m_cachedState.wirelessPlaybackRouteName;
 }
 
 MediaPlayer::WirelessPlaybackTargetType MediaPlayerPrivateRemote::wirelessPlaybackTargetType() const

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
@@ -360,6 +360,7 @@ private:
 
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
     String wirelessPlaybackTargetName() const final;
+    String wirelessPlaybackRouteName() const final;
     WebCore::MediaPlayer::WirelessPlaybackTargetType wirelessPlaybackTargetType() const final;
 
     bool wirelessVideoPlaybackDisabled() const final;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerState.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerState.h
@@ -44,6 +44,7 @@ struct RemoteMediaPlayerState {
     MediaTime startTime;
     String languageOfPrimaryAudioTrack;
     String wirelessPlaybackTargetName;
+    String wirelessPlaybackRouteName;
     std::optional<WebCore::PlatformTimeRanges> bufferedRanges;
     WebCore::MediaPlayerEnums::NetworkState networkState { WebCore::MediaPlayerEnums::NetworkState::Empty };
     WebCore::MediaPlayerEnums::MovieLoadType movieLoadType { WebCore::MediaPlayerEnums::MovieLoadType::Unknown };

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerState.serialization.in
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerState.serialization.in
@@ -29,6 +29,7 @@ struct WebKit::RemoteMediaPlayerState {
     MediaTime startTime;
     String languageOfPrimaryAudioTrack;
     String wirelessPlaybackTargetName;
+    String wirelessPlaybackRouteName;
     std::optional<WebCore::PlatformTimeRanges> bufferedRanges;
     WebCore::MediaPlayerNetworkState networkState;
     WebCore::MediaPlayerMovieLoadType movieLoadType;


### PR DESCRIPTION
#### eb017c5dbb25ecbe522514bd2cfedf1b2a1892bb
<pre>
[iOS] Placard may show incorrect route name during wireless playback
<a href="https://bugs.webkit.org/show_bug.cgi?id=319214">https://bugs.webkit.org/show_bug.cgi?id=319214</a>
<a href="https://rdar.apple.com/182073085">rdar://182073085</a>

Reviewed by Jer Noble.

The placard used for wireless playback was hardcoded to display &quot;AirPlay&quot;, but when using
AVSystemRouting the route may have a different name. Updated the placard to show the correct name
based on the MediaDeviceRoute.

Tests: media/wireless-playback-media-player/route-name-fallback.html
       media/wireless-playback-media-player/route-name.html

* LayoutTests/media/wireless-playback-media-player/route-name-expected.txt: Added.
* LayoutTests/media/wireless-playback-media-player/route-name-fallback-expected.txt: Added.
* LayoutTests/media/wireless-playback-media-player/route-name-fallback.html: Added.
* LayoutTests/media/wireless-playback-media-player/route-name.html: Added.
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp:
(WebCore::MediaControlsHost::externalDeviceDisplayName const):
(WebCore::MediaControlsHost::externalDeviceRouteName const):
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.h:
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.idl:
* Source/WebCore/Modules/modern-media-controls/controls/placard.js:
* Source/WebCore/Modules/modern-media-controls/media/placard-support.js:
(PlacardSupport.prototype._updateAirPlayPlacard):
(PlacardSupport):
* Source/WebCore/platform/audio/ios/MediaDeviceRoute.h:
* Source/WebCore/platform/audio/ios/MediaDeviceRoute.mm:
(WebCore::MediaDeviceRoute::routeName const):
* Source/WebCore/platform/graphics/MediaPlaybackTarget.h:
* Source/WebCore/platform/graphics/MediaPlaybackTargetWirelessPlayback.cpp:
(WebCore::MediaPlaybackTargetWirelessPlayback::routeName const):
* Source/WebCore/platform/graphics/MediaPlaybackTargetWirelessPlayback.h:
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::MediaPlayer::wirelessPlaybackRouteName const):
* Source/WebCore/platform/graphics/MediaPlayer.h:
* Source/WebCore/platform/graphics/MediaPlayerPrivate.h:
(WebCore::MediaPlayerPrivateInterface::wirelessPlaybackRouteName const):
* Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp:
(WebCore::MediaPlayerPrivateWirelessPlayback::wirelessPlaybackRouteName const):
* Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.h:
* Source/WebCore/platform/graphics/avfoundation/MediaPlaybackTargetCocoa.h:
* Source/WebCore/platform/graphics/avfoundation/MediaPlaybackTargetCocoa.mm:
(WebCore::MediaPlaybackTargetCocoa::routeName const):
* Source/WebCore/platform/mock/MediaPlaybackTargetMock.h:
* Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.h:
* Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.mm:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp:
(WebKit::RemoteMediaPlayerProxy::mediaPlayerCurrentPlaybackTargetIsWirelessChanged):
* Source/WebKit/Platform/cocoa/MediaPlaybackTargetContextSerialized.h:
(WebKit::MediaPlaybackTargetContextSerialized::routeName const):
* Source/WebKit/Platform/cocoa/MediaPlaybackTargetContextSerialized.mm:
(WebKit::MediaPlaybackTargetContextSerialized::MediaPlaybackTargetContextSerialized):
* Source/WebKit/Platform/cocoa/MediaPlaybackTargetContextSerialized.serialization.in:
* Source/WebKit/Platform/cocoa/MediaPlaybackTargetSerialized.h:
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::updateCachedState):
(WebKit::MediaPlayerPrivateRemote::wirelessPlaybackRouteName const):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerState.h:
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerState.serialization.in:

Canonical link: <a href="https://commits.webkit.org/317107@main">https://commits.webkit.org/317107@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b2eeaf10f7c9d999ea85aaca944c532712f1f4c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174135 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48068 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41849 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183709 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132003 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a99ec4df-136e-4426-bc6b-bd988f4db876) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176000 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49360 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47750 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135433 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95533 "1 flakes 3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/de054306-a8cf-4f7f-9c89-fe2d985374b9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177093 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38866 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156227 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115911 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2d20296c-51ae-4d03-9683-9855d325405c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37507 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35875 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32193 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147931 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35720 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186135 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39273 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40073 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144335 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47735 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155782 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144195 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38919 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48414 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32338 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113910 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39106 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120311 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46920 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10682 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46323 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46554 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46381 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->