### PR TITLE
isUserVisibleURL() inspects the wrong bytes for %-escapes and "xn--"

### DIFF
--- a/Source/WTF/wtf/cocoa/NSURLExtras.mm
+++ b/Source/WTF/wtf/cocoa/NSURLExtras.mm
@@ -29,6 +29,7 @@
 #import "config.h"
 #import "NSURLExtras.h"
 
+#import <wtf/IndexedRange.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/StdLibExtras.h>
 #import <wtf/URL.h>
@@ -334,15 +335,15 @@ BOOL isUserVisibleURL(NSString *string)
 
     // Check for control characters, %-escape sequences that are non-ASCII, and xn--: these
     // are the things that might lead the userVisibleString function to actually change the string.
-    for (auto character : characters) {
+    for (auto [i, character] : indexedRange(characters)) {
         // Control characters, including space, will be escaped by userVisibleString.
         if (character <= 0x20 || character == 0x7F)
             return NO;
         // Escape sequences that expand to non-ASCII characters may be converted to non-escaped UTF-8 sequences.
-        if (character == '%' && isASCIIHexDigit(characters[0]) && isASCIIHexDigit(characters[1]) && !isASCII(toASCIIHexValue(characters[0], characters[1])))
+        if (character == '%' && i + 2 < characters.size() && isASCIIHexDigit(characters[i + 1]) && isASCIIHexDigit(characters[i + 2]) && !isASCII(toASCIIHexValue(characters[i + 1], characters[i + 2])))
             return NO;
         // If "xn--" appears, then we might need to run the IDN algorithm if it's a host name.
-        if (isASCIIAlphaCaselessEqual(character, 'x') && isASCIIAlphaCaselessEqual(characters[0], 'n') && characters[1] == '-' && characters[2] == '-')
+        if (isASCIIAlphaCaselessEqual(character, 'x') && i + 3 < characters.size() && isASCIIAlphaCaselessEqual(characters[i + 1], 'n') && characters[i + 2] == '-' && characters[i + 3] == '-')
             return NO;
     }
 

--- a/Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm
@@ -399,5 +399,17 @@ TEST(URLExtras, URLByRemovingUserInfo)
     EXPECT_STREQ("https://foo.github.io/upload/test.zip", url2.string().utf8().data());
 }
 
+// isUserVisibleURL() is a fast-path guard that must return YES only when
+// userVisibleString() is guaranteed to leave the URL unchanged.
+TEST(URLExtras, IsUserVisibleURL)
+{
+    EXPECT_TRUE(WTF::isUserVisibleURL(@"http://webkit.org/path"));
+
+    EXPECT_STRNE("http://example.com/%E2%82%AC", userVisibleString(literalURL("http://example.com/%E2%82%AC")));
+    EXPECT_FALSE(WTF::isUserVisibleURL(@"http://example.com/%E2%82%AC"));
+
+    EXPECT_FALSE(WTF::isUserVisibleURL(@"http://xn--nxasmq6b.com/"));
+}
+
 } // namespace TestWebKitAPI
 


### PR DESCRIPTION
#### 94eeb1642d1c7d5be84d5147bed2809641508a73
<pre>
isUserVisibleURL() inspects the wrong bytes for %-escapes and &quot;xn--&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=319223">https://bugs.webkit.org/show_bug.cgi?id=319223</a>
<a href="https://rdar.apple.com/181625207">rdar://181625207</a>

Reviewed by Darin Adler.

isUserVisibleURL() is a fast-path guard that returns YES only when
userVisibleString() is guaranteed to leave a URL unchanged; callers use
it to skip IDN / percent-escape normalization. When 286606@main
rewrote its scanning loop from a pointer that advanced each iteration
(`while (auto character = *characters++)`) into a range-for over a fixed
span, the look-ahead accesses were left as the literal indices
characters[0], characters[1] and characters[2]. Those now always refer
to the first few bytes of the string instead of the bytes following the
current character.

As a result, a percent-escape that expands to a non-ASCII byte, or an
&quot;xn--&quot; IDN sequence, is only detected when it happens to sit at the very
start of the string. For any URL where the triggering sequence appears
later (e.g. &quot;<a href="http://example.com/%E2%82%AC&quot">http://example.com/%E2%82%AC&quot</a>; or &quot;<a href="http://xn--nxasmq6b.com/&quot">http://xn--nxasmq6b.com/&quot</a>;)
the function wrongly returns YES, so the required normalization is
skipped.

Fix the look-ahead to be position-relative and bounds-checked, using
indexedRange() to iterate the span with its index. The explicit
`i + 2 &lt; size` / `i + 3 &lt; size` guards also make the accesses safe by
construction rather than relying on short-circuit evaluation.

Test: URLExtras.IsUserVisibleURL

* Source/WTF/wtf/cocoa/NSURLExtras.mm:
(WTF::isUserVisibleURL):
* Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm:
(TestWebKitAPI::TEST(URLExtras, IsUserVisibleURL)):

Canonical link: <a href="https://commits.webkit.org/317086@main">https://commits.webkit.org/317086@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f935bb87da71f27b9b027b659a514fae4aa92e8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174153 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48086 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41867 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183727 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132021 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0575df65-e00c-4161-ba0e-59a71cb0f9f8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176018 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49378 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47768 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135451 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95549 "4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/eafd45eb-082d-4b80-a992-566d3518b5a2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177111 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38884 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156245 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115929 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/97b09806-37a9-4f6a-99a6-2785dd7a8d12) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37525 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35892 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32211 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/4755 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147949 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35738 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186153 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/35415 "Built successfully and passed tests") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39296 "Found 119 new failures in b3/B3Value.h, b3/testb3_7.cpp, WebProcess/Network/WebResourceLoader.cpp, UIProcess/WebProcessPool.cpp, Shared/Cocoa/WKNSArray.mm, Shared/SessionState.cpp, NetworkProcess/NetworkResourceLoadParameters.cpp, WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm, WebProcess/WebPage/WebPage.cpp, WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm ...") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40090 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144354 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47753 "Built successfully") | | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144214 "1 api test failed or timed out") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38905 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48432 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32356 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113933 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39124 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120331 "Found 1059 new failures in b3/B3Value.h, b3/testb3_7.cpp, WebProcess/Network/WebResourceLoader.cpp, jit/OperationResult.h, UIProcess/WebProcessPool.cpp, testing/MockMediaSessionCoordinator.cpp, Shared/Cocoa/WKNSArray.mm, heap/WeakSet.h, API/tests/Regress141275.mm, Shared/SessionState.cpp ...") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/211188 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46938 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10700 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55037 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46341 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46572 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46399 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->