### PR TITLE
hasEntitlementValueInArray() may leak value returned by SecTaskCopyValueForEntitlement()

### DIFF
--- a/Source/WTF/wtf/cocoa/Entitlements.mm
+++ b/Source/WTF/wtf/cocoa/Entitlements.mm
@@ -87,7 +87,7 @@ bool hasEntitlementValueInArray(audit_token_t token, ASCIILiteral entitlement, A
         return false;
 
     auto string = entitlement.createCFString();
-    RetainPtr array = adoptCF(dynamic_cf_cast<CFArrayRef>(SecTaskCopyValueForEntitlement(secTaskForToken.get(), string.get(), nullptr)));
+    RetainPtr array = dynamic_cf_cast<CFArrayRef>(adoptCF(SecTaskCopyValueForEntitlement(secTaskForToken.get(), string.get(), nullptr)));
     if (!array)
         return false;
 

--- a/Source/WebKit/Shared/cf/CoreIPCSecTrust.mm
+++ b/Source/WebKit/Shared/cf/CoreIPCSecTrust.mm
@@ -263,7 +263,7 @@ CoreIPCSecTrust::CoreIPCSecTrust(SecTrustRef trust)
     {
         // FIXME: The Security framework API is missing the `CF_RETURNS_RETAINED` annotation (rdar://161546781).
         CFErrorRef rawError = NULL;
-        cfDictionary = adoptCF(dynamic_cf_cast<CFDictionaryRef>(SecTrustCopyPropertyListRepresentation(trust, &rawError)));
+        cfDictionary = dynamic_cf_cast<CFDictionaryRef>(adoptCF(SecTrustCopyPropertyListRepresentation(trust, &rawError)));
         SUPPRESS_RETAINPTR_CTOR_ADOPT error = adoptCF(rawError);
     }
     if (!cfDictionary || error)

--- a/Source/WebKit/Shared/mac/ScrollingAccelerationCurveMac.mm
+++ b/Source/WebKit/Shared/mac/ScrollingAccelerationCurveMac.mm
@@ -113,21 +113,21 @@ static std::optional<ScrollingAccelerationCurve> fromIOHIDDevice(IOHIDEventSende
         return std::nullopt;
     }
 
-    auto curves = adoptCF(dynamic_cf_cast<CFArrayRef>(IOHIDServiceClientCopyProperty(ioHIDService.get(), CFSTR(kHIDScrollAccelParametricCurvesKey))));
+    auto curves = dynamic_cf_cast<CFArrayRef>(adoptCF(IOHIDServiceClientCopyProperty(ioHIDService.get(), CFSTR(kHIDScrollAccelParametricCurvesKey))));
     if (!curves) {
         RELEASE_LOG(ScrollAnimations, "ScrollingAccelerationCurve::fromIOHIDDevice failed to look up curves");
         return std::nullopt;
     }
 
     auto readFixedPointServiceKey = [&] (CFStringRef key) -> std::optional<float> {
-        auto valueCF = adoptCF(dynamic_cf_cast<CFNumberRef>(IOHIDServiceClientCopyProperty(ioHIDService.get(), key)));
+        auto valueCF = dynamic_cf_cast<CFNumberRef>(adoptCF(IOHIDServiceClientCopyProperty(ioHIDService.get(), key)));
         if (!valueCF)
             return std::nullopt;
         return fromFixedPoint([(NSNumber *)valueCF.get() floatValue]);
     };
 
     auto scrollAcceleration = [&] () -> std::optional<float> {
-        if (auto scrollAccelerationType = adoptCF(dynamic_cf_cast<CFStringRef>(IOHIDServiceClientCopyProperty(ioHIDService.get(), CFSTR("HIDScrollAccelerationType"))))) {
+        if (auto scrollAccelerationType = dynamic_cf_cast<CFStringRef>(adoptCF(IOHIDServiceClientCopyProperty(ioHIDService.get(), CFSTR("HIDScrollAccelerationType"))))) {
             if (auto acceleration = readFixedPointServiceKey(scrollAccelerationType.get()))
                 return acceleration;
         }
@@ -153,7 +153,7 @@ static std::optional<ScrollingAccelerationCurve> fromIOHIDDevice(IOHIDEventSende
 
     static CFStringRef dispatchFrameRateKey = CFSTR("ScrollMomentumDispatchRate");
     static constexpr float defaultDispatchFrameRate = 60;
-    auto frameRateCF = adoptCF(dynamic_cf_cast<CFNumberRef>(IOHIDServiceClientCopyProperty(ioHIDService.get(), dispatchFrameRateKey)));
+    auto frameRateCF = dynamic_cf_cast<CFNumberRef>(adoptCF(IOHIDServiceClientCopyProperty(ioHIDService.get(), dispatchFrameRateKey)));
     float frameRate = frameRateCF ? fromCFNumber(frameRateCF.get()) : defaultDispatchFrameRate;
 
     return fromIOHIDCurveArrayWithAcceleration((NSArray *)curves.get(), *scrollAcceleration, *resolution, frameRate);

--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -3164,6 +3164,34 @@ def check_auto_with_adopt(clean_lines, line_number, file_state, error):
         error(line_number, 'runtime/auto_with_adopt', 4, "Use '%s' instead of 'auto' with '%s()'." % (smart_ptr, adopt_func))
 
 
+def check_adopt_of_dynamic_cast(clean_lines, line_number, file_state, error):
+    """Looks for 'adoptCF(dynamic_cf_cast<>(...))' and 'adoptNS(dynamic_objc_cast<>(...))'.
+
+    These patterns leak the value returned by the inner CF/NS 'Copy'/'Create'
+    function on a type mismatch: dynamic_cf_cast<>()/dynamic_objc_cast<>() return
+    nullptr when the type does not match, so adoptCF(nullptr)/adoptNS(nullptr)
+    silently drops the reference instead of releasing the original value. The
+    adopt should be applied to the value *before* the cast, e.g.
+    'dynamic_cf_cast<CFArrayRef>(adoptCF(...))', which relies on the
+    RetainPtr<>&& overload of dynamic_cf_cast<>() to release on mismatch.
+
+    Args:
+      clean_lines: A CleansedLines instance containing the file.
+      line_number: The number of the line to check.
+      file_state: A _FileState instance which maintains information about
+                  the state of things in the file.
+      error: The function to call with any errors found.
+    """
+
+    line = clean_lines.elided[line_number]  # Get rid of comments and strings.
+
+    matched = search(r'\b(adoptCF|adoptNS)\s*\(\s*(dynamic_cf_cast|dynamic_objc_cast)\b', line)
+    if matched:
+        adopt_func = matched.group(1)
+        cast_func = matched.group(2)
+        error(line_number, 'runtime/adopt_dynamic_cast', 4, "Adopt the value before casting, e.g. '%s<>(%s(...))', otherwise the value leaks on type mismatch." % (cast_func, adopt_func))
+
+
 def check_lock_guard(clean_lines, line_number, file_state, error):
     """Looks for use of 'std::lock_guard<>' which should be replaced with 'WTF::Locker'.
 
@@ -3992,6 +4020,7 @@ def check_style(clean_lines, line_number, file_extension, class_state, file_stat
     check_wtf_os_object_ptr(clean_lines, line_number, file_state, error)
     check_wtf_xpc_object_ptr(clean_lines, line_number, file_state, error)
     check_auto_with_adopt(clean_lines, line_number, file_state, error)
+    check_adopt_of_dynamic_cast(clean_lines, line_number, file_state, error)
     check_lock_guard(clean_lines, line_number, file_state, error)
     check_log(clean_lines, line_number, file_state, error)
     check_ctype_functions(clean_lines, line_number, file_state, error)
@@ -5286,6 +5315,7 @@ class CppChecker(object):
         'runtime/unsafe_get_ptr',
         'runtime/unsigned',
         'runtime/virtual',
+        'runtime/adopt_dynamic_cast',
         'runtime/auto_with_adopt',
         'runtime/js_cast',
         'runtime/js_dynamic_cast',

--- a/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
@@ -6207,6 +6207,28 @@ class WebKitStyleTest(CppStyleTestBase):
             "  [runtime/auto_with_adopt] [4]",
             'foo.cpp')
 
+    def test_adopt_of_dynamic_cast(self):
+        self.assert_lint(
+            'RetainPtr array = adoptCF(dynamic_cf_cast<CFArrayRef>(SecTaskCopyValueForEntitlement(task, key, nullptr)));',
+            "Adopt the value before casting, e.g. 'dynamic_cf_cast<>(adoptCF(...))', otherwise the value leaks on type mismatch."
+            "  [runtime/adopt_dynamic_cast] [4]",
+            'foo.mm')
+        self.assert_lint(
+            'RetainPtr value = adoptNS(dynamic_objc_cast<NSString>([obj copyValue]));',
+            "Adopt the value before casting, e.g. 'dynamic_objc_cast<>(adoptNS(...))', otherwise the value leaks on type mismatch."
+            "  [runtime/adopt_dynamic_cast] [4]",
+            'foo.mm')
+        # The correct pattern (adopt before cast) should not be flagged.
+        self.assert_lint(
+            'RetainPtr array = dynamic_cf_cast<CFArrayRef>(adoptCF(SecTaskCopyValueForEntitlement(task, key, nullptr)));',
+            '',
+            'foo.mm')
+        # adoptCF of a plain Copy function (no cast) is fine.
+        self.assert_lint(
+            'RetainPtr context = adoptCF(CGBitmapContextCreate(0, 0, 0, 0, 0, 0, 0));',
+            '',
+            'foo.cpp')
+
     def test_wtf_make_unique(self):
         self.assert_lint(
              'std::unique_ptr<Foo> foo = WTF::makeUnique<Foo>();',


### PR DESCRIPTION
#### ee722e07de6f38964e138a6cc80e484f26c10238
<pre>
hasEntitlementValueInArray() may leak value returned by SecTaskCopyValueForEntitlement()
<a href="https://bugs.webkit.org/show_bug.cgi?id=319224">https://bugs.webkit.org/show_bug.cgi?id=319224</a>

Reviewed by David Kilzer.

hasEntitlementValueInArray() may leak value returned by
SecTaskCopyValueForEntitlement() if its type is not CFArrayRef, since
`dynamic_cf_cast&lt;CFArrayRef&gt;()` would return nullptr in this case,
rendering the `adoptCF()` useless.

Fix the issue by adopting the value returned by
SecTaskCopyValueForEntitlement() *before* passing it to
dynamic_cf_cast&lt;&gt;(), so that the RetainPtr&lt;&gt;&amp;&amp; overload of
dynamic_cf_cast&lt;&gt;() releases the value on type mismatch instead of the
`adoptCF()` silently dropping a nullptr.

Also fixed the same bug pattern in other parts of the codebase, where a
value returned by a CF &quot;Copy&quot; function (SecTrustCopyPropertyListRepresentation()
and IOHIDServiceClientCopyProperty()) was wrapped as
adoptCF(dynamic_cf_cast&lt;&gt;(...)) and would leak on type mismatch.

* Source/WTF/wtf/cocoa/Entitlements.mm:
(WTF::hasEntitlementValueInArray):
* Source/WebKit/Shared/cf/CoreIPCSecTrust.mm:
(WebKit::CoreIPCSecTrust::CoreIPCSecTrust):
* Source/WebKit/Shared/mac/ScrollingAccelerationCurveMac.mm:
(WebKit::fromIOHIDDevice):
* Tools/Scripts/webkitpy/style/checkers/cpp.py:
(check_adopt_of_dynamic_cast):
(check_style):
(CppChecker):
* Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py:
(WebKitStyleTest.test_adopt_of_dynamic_cast):

Canonical link: <a href="https://commits.webkit.org/317102@main">https://commits.webkit.org/317102@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d6e15c80ac982f34c313e05ca018553b1e53103

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174204 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48137 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41918 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183778 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132072 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176069 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49429 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47819 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135503 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177162 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38934 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156294 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115981 "Passed tests") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/173525 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37574 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35944 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32262 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/4804 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147998 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35787 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186204 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/35466 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39376 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40141 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144407 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47804 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144266 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38916 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48483 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32407 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114006 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39173 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120394 "Found 1059 new failures in b3/B3Value.h, b3/testb3_7.cpp, WebProcess/Network/WebResourceLoader.cpp, jit/OperationResult.h, UIProcess/WebProcessPool.cpp, testing/MockMediaSessionCoordinator.cpp, Shared/Cocoa/WKNSArray.mm, heap/WeakSet.h, API/tests/Regress141275.mm, Shared/SessionState.cpp ...") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/211239 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46989 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10749 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55048 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46392 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46623 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46450 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->