### PR TITLE
Fix bad assertions in ListHashSetLink::insertAfter() and ListHashSetLink::insertBefore()

### DIFF
--- a/Source/WTF/wtf/ListHashSet.h
+++ b/Source/WTF/wtf/ListHashSet.h
@@ -262,8 +262,8 @@ inline void ListHashSetLink::unlink()
 
 inline void ListHashSetLink::insertAfter(ListHashSetLink* prev)
 {
-    ASSERT(m_prev = this);
-    ASSERT(m_next = this);
+    ASSERT(m_prev == this);
+    ASSERT(m_next == this);
 
     m_prev = prev;
     m_next = prev->m_next;
@@ -274,8 +274,8 @@ inline void ListHashSetLink::insertAfter(ListHashSetLink* prev)
 
 inline void ListHashSetLink::insertBefore(ListHashSetLink* next)
 {
-    ASSERT(m_prev = this);
-    ASSERT(m_next = this);
+    ASSERT(m_prev == this);
+    ASSERT(m_next == this);
 
     m_prev = next->m_prev;
     m_next = next;


### PR DESCRIPTION
#### bbfcb3eda714c09be1ed79a150e1a437d59a15a5
<pre>
Fix bad assertions in ListHashSetLink::insertAfter() and ListHashSetLink::insertBefore()
<a href="https://bugs.webkit.org/show_bug.cgi?id=319225">https://bugs.webkit.org/show_bug.cgi?id=319225</a>

Reviewed by Darin Adler.

They were using `=` and doing an assignment instad of doing a comparison
using `==`.

* Source/WTF/wtf/ListHashSet.h:
(WTF::ListHashSetLink::insertAfter):
(WTF::ListHashSetLink::insertBefore):

Canonical link: <a href="https://commits.webkit.org/317092@main">https://commits.webkit.org/317092@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/405a985d91a74e02962fec0ff10f29b08642ed35

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174154 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48087 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41868 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183728 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132022 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b4962a86-e225-4e31-a5e3-13be6911bea1) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49379 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47769 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135459 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95552 "4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5e53fed5-5cf4-4103-a3cf-9d473c7848bd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177112 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38890 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156249 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115937 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b0ddb2fc-db18-48ce-98f8-e0d2595cfc9b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37531 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35896 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32212 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/4759 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147955 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35742 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186154 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/35416 "Built successfully and passed tests") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39298 "Found 67 new failures in rendering/FlexLayoutUtils.cpp, rendering/FlexLayoutUtils.h") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40093 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144359 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47754 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144218 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38906 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48433 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32360 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113938 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39127 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120404 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/211189 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46939 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10704 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55038 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46342 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46573 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46400 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->