### PR TITLE
[AppKit Gestures] Unable to grab scroll bar in Safari

### DIFF
--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -1998,7 +1998,8 @@ std::optional<RemoteFrameGeometryTransformer> EventHandler::geometryTransformerF
 static Scrollbar* scrollbarForMouseEvent(const MouseEventWithHitTestResults& mouseEvent, LocalFrameView* view)
 {
     if (view) {
-        if (auto* scrollbar = view->scrollbarAtPoint(flooredIntPoint(mouseEvent.event().position())))
+        const auto tolerance = mouseEvent.event().inputSource() == MouseEventInputSource::Automation ? ScrollbarHitTestTolerance::Expanded : ScrollbarHitTestTolerance::None;
+        if (auto* scrollbar = view->scrollbarAtPoint(flooredIntPoint(mouseEvent.event().position()), tolerance))
             return scrollbar;
     }
     return mouseEvent.scrollbar();

--- a/Source/WebCore/platform/ScrollTypes.h
+++ b/Source/WebCore/platform/ScrollTypes.h
@@ -307,6 +307,11 @@ enum class ScrollbarStyle : uint8_t {
     Overlay
 };
 
+enum class ScrollbarHitTestTolerance : uint8_t {
+    None,
+    Expanded
+};
+
 enum class ScrollbarOverlayStyle : uint8_t {
     Default,
     Dark,

--- a/Source/WebCore/platform/ScrollView.cpp
+++ b/Source/WebCore/platform/ScrollView.cpp
@@ -1232,19 +1232,36 @@ void ScrollView::setScrollbarsSuppressed(bool suppressed, bool repaintOnUnsuppre
     }
 }
 
-Scrollbar* ScrollView::scrollbarAtPoint(const IntPoint& windowPoint)
+Scrollbar* ScrollView::scrollbarAtPoint(const IntPoint& windowPoint, ScrollbarHitTestTolerance tolerance)
 {
     if (platformWidget())
-        return 0;
+        return nullptr;
 
     // convertFromContainingWindow doesn't do what it sounds like it does. We need it here just to get this
     // point into the right coordinates if this is the ScrollView of a sub-frame.
-    IntPoint convertedPoint = convertFromContainingWindow(windowPoint);
-    if (m_horizontalScrollbar && protect(m_horizontalScrollbar)->shouldParticipateInHitTesting() && protect(m_horizontalScrollbar)->frameRect().contains(convertedPoint))
-        return m_horizontalScrollbar.get();
-    if (m_verticalScrollbar && protect(m_verticalScrollbar)->shouldParticipateInHitTesting() && protect(m_verticalScrollbar)->frameRect().contains(convertedPoint))
-        return m_verticalScrollbar.get();
-    return 0;
+    const auto convertedPoint = convertFromContainingWindow(windowPoint);
+
+    if (RefPtr scrollbar = m_horizontalScrollbar; scrollbar && scrollbar->shouldParticipateInHitTesting()) {
+        auto hitRect = scrollbar->frameRect();
+
+        if (tolerance == ScrollbarHitTestTolerance::Expanded)
+            hitRect.inflateY(scrollbar->expandedHitTestToleranceThreshold());
+
+        if (hitRect.contains(convertedPoint))
+            return m_horizontalScrollbar;
+    }
+
+    if (RefPtr scrollbar = m_verticalScrollbar; scrollbar && scrollbar->shouldParticipateInHitTesting()) {
+        auto hitRect = scrollbar->frameRect();
+
+        if (tolerance == ScrollbarHitTestTolerance::Expanded)
+            hitRect.inflateX(scrollbar->expandedHitTestToleranceThreshold());
+
+        if (hitRect.contains(convertedPoint))
+            return m_verticalScrollbar;
+    }
+
+    return nullptr;
 }
 
 IntPoint ScrollView::convertChildToSelf(const Widget* child, IntPoint point) const

--- a/Source/WebCore/platform/ScrollView.h
+++ b/Source/WebCore/platform/ScrollView.h
@@ -379,7 +379,7 @@ public:
     void clipRectChanged() final;
 
     // For platforms that need to hit test scrollbars from within the engine's event handlers (like Win32).
-    Scrollbar* scrollbarAtPoint(const IntPoint& windowPoint);
+    Scrollbar* scrollbarAtPoint(const IntPoint& windowPoint, ScrollbarHitTestTolerance = ScrollbarHitTestTolerance::None);
 
     IntPoint convertChildToSelf(const Widget*, IntPoint) const;
     FloatPoint convertChildToSelf(const Widget*, FloatPoint) const;

--- a/Source/WebCore/platform/Scrollbar.cpp
+++ b/Source/WebCore/platform/Scrollbar.cpp
@@ -420,7 +420,8 @@ bool Scrollbar::mouseUp(const PlatformMouseEvent& mouseEvent)
 
 bool Scrollbar::mouseDown(const PlatformMouseEvent& evt)
 {
-    ScrollbarPart pressedPart = theme().hitTest(*this, flooredIntPoint(evt.position()));
+    const auto tolerance = evt.inputSource() == MouseEventInputSource::Automation ? ScrollbarHitTestTolerance::Expanded : ScrollbarHitTestTolerance::None;
+    ScrollbarPart pressedPart = theme().hitTest(*this, flooredIntPoint(evt.position()), tolerance);
     auto action = theme().handleMousePressEvent(*this, evt, pressedPart);
     if (action == ScrollbarButtonPressAction::None)
         return true;
@@ -464,6 +465,16 @@ void Scrollbar::setEnabled(bool e)
 bool Scrollbar::isOverlayScrollbar() const
 {
     return theme().usesOverlayScrollbars();
+}
+
+int Scrollbar::expandedHitTestToleranceThreshold() const
+{
+#if PLATFORM(MAC)
+    // Match AppKit.
+    return isOverlayScrollbar() ? 20 : 10;
+#else
+    return 0;
+#endif
 }
 
 bool Scrollbar::isMockScrollbar() const

--- a/Source/WebCore/platform/Scrollbar.h
+++ b/Source/WebCore/platform/Scrollbar.h
@@ -97,6 +97,7 @@ public:
 
     virtual bool isOverlayScrollbar() const;
     bool shouldParticipateInHitTesting();
+    int expandedHitTestToleranceThreshold() const;
     virtual bool isHiddenByStyle() const;
 
     bool isWindowActive() const;

--- a/Source/WebCore/platform/ScrollbarTheme.h
+++ b/Source/WebCore/platform/ScrollbarTheme.h
@@ -51,7 +51,7 @@ public:
     virtual void updateEnabledState(Scrollbar&) { }
 
     virtual bool paint(Scrollbar&, GraphicsContext&, const IntRect& /*damageRect*/) { return false; }
-    virtual ScrollbarPart hitTest(Scrollbar&, const IntPoint&) { return NoPart; }
+    virtual ScrollbarPart hitTest(Scrollbar&, const IntPoint&, ScrollbarHitTestTolerance = ScrollbarHitTestTolerance::None) { return NoPart; }
     
     virtual int scrollbarThickness(ScrollbarWidth = ScrollbarWidth::Auto, OverlayScrollbarSizeRelevancy = OverlayScrollbarSizeRelevancy::IncludeOverlayScrollbarSize) { return 0; }
 

--- a/Source/WebCore/platform/ScrollbarThemeComposite.cpp
+++ b/Source/WebCore/platform/ScrollbarThemeComposite.cpp
@@ -109,7 +109,7 @@ bool ScrollbarThemeComposite::paint(Scrollbar& scrollbar, GraphicsContext& graph
     return true;
 }
 
-ScrollbarPart ScrollbarThemeComposite::hitTest(Scrollbar& scrollbar, const IntPoint& position)
+ScrollbarPart ScrollbarThemeComposite::hitTest(Scrollbar& scrollbar, const IntPoint& position, ScrollbarHitTestTolerance tolerance)
 {
     ScrollbarPart result = NoPart;
     if (!scrollbar.enabled())
@@ -117,7 +117,20 @@ ScrollbarPart ScrollbarThemeComposite::hitTest(Scrollbar& scrollbar, const IntPo
 
     IntPoint testPosition = scrollbar.convertFromContainingWindow(position);
     testPosition.move(scrollbar.x(), scrollbar.y());
-    
+
+    if (tolerance == ScrollbarHitTestTolerance::Expanded) {
+        // With expanded granularity, a point can land just off the scrollbar and miss it entirely.
+        // In this case, it therefore needs to have its cross-axis be mapped to an eligible location on the scrollbar.
+        //
+        // Note that since maxX()/maxY() are exclusive (frameRect().contains() treats them as outside),
+        // the -1 is needed to land on the last position still inside the bar.
+        const auto bar = scrollbar.frameRect();
+        if (scrollbar.orientation() == ScrollbarOrientation::Vertical)
+            testPosition.setX(std::clamp(testPosition.x(), bar.x(), bar.maxX() - 1));
+        else
+            testPosition.setY(std::clamp(testPosition.y(), bar.y(), bar.maxY() - 1));
+    }
+
     if (!scrollbar.frameRect().contains(testPosition))
         return NoPart;
 

--- a/Source/WebCore/platform/ScrollbarThemeComposite.h
+++ b/Source/WebCore/platform/ScrollbarThemeComposite.h
@@ -38,7 +38,7 @@ class ScrollbarThemeComposite : public ScrollbarTheme {
 public:
     // Implement ScrollbarTheme interface
     bool paint(Scrollbar&, GraphicsContext&, const IntRect& damageRect) override;
-    ScrollbarPart hitTest(Scrollbar&, const IntPoint&) override;
+    ScrollbarPart hitTest(Scrollbar&, const IntPoint&, ScrollbarHitTestTolerance) override;
     void invalidatePart(Scrollbar&, ScrollbarPart) override;
     int thumbPosition(Scrollbar&) override;
     int thumbLength(Scrollbar&) override;

--- a/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
+++ b/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
@@ -698,15 +698,18 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
         return NO;
 
     NSPoint locationInView = [webView convertPoint:[event locationInWindow] fromView:nil];
-    if (viewImpl->isTextSelectedAtPoint(locationInView)) {
-        WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(RefPtr { _page.get() }->logIdentifier(), "deferral: not deferring; text already selected at %@", NSStringFromPoint(locationInView));
+
+    const auto isInScrollbar = [self _isPointInScrollbar:locationInView];
+
+    if (!isInScrollbar && viewImpl->isTextSelectedAtPoint(locationInView)) {
+        WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG_DEBUG(RefPtr { _page.get() }->logIdentifier(), "deferral: not deferring; text already selected at %@", NSStringFromPoint(locationInView));
         return NO;
     }
 
-    WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(RefPtr { _page.get() }->logIdentifier(), "deferral: deferring; awaiting position info at %@", NSStringFromPoint(locationInView));
+    WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG_DEBUG(RefPtr { _page.get() }->logIdentifier(), "deferral: deferring; awaiting position info at %@", NSStringFromPoint(locationInView));
 
     WebKit::InteractionInformationRequest request { WebCore::IntPoint { locationInView } };
-    [self doAfterPositionInformationUpdate:[weakSelf = WeakObjCPtr<WKAppKitGestureController>(self), weakDeferring = WeakObjCPtr<WKDeferringGestureRecognizer>(deferringGestureRecognizer)](const auto &info) {
+    [self doAfterPositionInformationUpdate:[weakSelf = WeakObjCPtr<WKAppKitGestureController>(self), weakDeferring = WeakObjCPtr<WKDeferringGestureRecognizer>(deferringGestureRecognizer), isInScrollbar](const auto &info) {
         RetainPtr strongSelf = weakSelf.get();
         RetainPtr strongDeferring = weakDeferring.get();
         if (!strongSelf || !strongDeferring)
@@ -714,21 +717,28 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
 
         auto deferralState = [strongDeferring state];
         if (deferralState != NSGestureRecognizerStatePossible) {
-            WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(RefPtr { strongSelf->_page.get() }->logIdentifier(),
+            WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG_DEBUG(RefPtr { strongSelf->_page.get() }->logIdentifier(),
                 "deferral: position info arrived after deferring gesture exited Possible (state=%ld); skipping resolution", static_cast<long>(deferralState));
             return;
         }
 
         auto shouldPreventGestures = [&] {
+            // An event over a scrollbar should drive the scrollbar, not select text; prevent the deferred
+            // text-selection gestures so the mouse-tracking -> `Scrollbar::mouseDown` path wins.
+            if (isInScrollbar) {
+                WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG_DEBUG(RefPtr { strongSelf->_page.get() }->logIdentifier(), "deferral resolved: over scrollbar; preventing text-selection gestures");
+                return true;
+            }
+
             if (strongDeferring == strongSelf->_dragDeferringGestureRecognizer) {
                 auto isDraggable = representsDraggableElement(info);
-                WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(RefPtr { strongSelf->_page.get() }->logIdentifier(), "deferral resolved: isDraggable=%d (link=%d image=%d attachment=%d dhtml=%d color=%d prefersDrag=%d)", isDraggable, info.isLink, info.isImage, info.isAttachment, info.isDHTMLDraggable, info.isColorInput, info.prefersDraggingOverTextSelection);
+                WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG_DEBUG(RefPtr { strongSelf->_page.get() }->logIdentifier(), "deferral resolved: isDraggable=%d (link=%d image=%d attachment=%d dhtml=%d color=%d prefersDrag=%d)", isDraggable, info.isLink, info.isImage, info.isAttachment, info.isDHTMLDraggable, info.isColorInput, info.prefersDraggingOverTextSelection);
                 return isDraggable;
             }
 
             if (strongDeferring == strongSelf->_secondaryClickDeferringGestureRecognizer) {
                 bool isSelectable = info.isSelectable();
-                WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(RefPtr { strongSelf->_page.get() }->logIdentifier(), "Resolved deferral: isSelectable=%d", isSelectable);
+                WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG_DEBUG(RefPtr { strongSelf->_page.get() }->logIdentifier(), "Resolved deferral: isSelectable=%d", isSelectable);
                 return !isSelectable;
             }
 
@@ -857,6 +867,12 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     _hasValidPositionInformation = _positionInformation.canBeValid;
 
     [self _invokeAndRemovePendingHandlersValidForCurrentPositionInformation];
+}
+
+- (BOOL)_isPointInScrollbar:(NSPoint)locationInViewCoordinates
+{
+    CheckedPtr viewImpl = _viewImpl.get();
+    return viewImpl && viewImpl->isPointInScrollbar(locationInViewCoordinates);
 }
 
 - (BOOL)_secondaryClickShouldBeginAtLocation:(NSPoint)locationInViewCoordinates
@@ -1507,6 +1523,14 @@ static inline bool isSamePair(NSGestureRecognizer *a, NSGestureRecognizer *b, NS
             return YES;
         if (gestureRecognizer != _panGestureRecognizer)
             return NO;
+    }
+
+    // An event over a scrollbar is a scrollbar interaction; only the mouse-tracking gesture (which drives
+    // `Scrollbar::mouseDown` -> thumb drag) should handle it. The AppKit text-selection/context-menu gestures
+    // are handled separately in the deferral delegate.
+    if ([self _isPointInScrollbar:locationInViewCoordinates] && gestureRecognizer != _mouseTrackingGestureRecognizer) {
+        WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG_DEBUG(RefPtr { _page.get() }->logIdentifier(), "Denying gesture over scrollbar: %@", gestureLogDescription(gestureRecognizer));
+        return NO;
     }
 
     if (gestureRecognizer == _doubleClickGestureRecognizer)

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift
@@ -614,6 +614,30 @@ extension AppKitGesturesTests.Basic {
         #expect(selection == expected)
     }
 
+    @Test(arguments: [6, 8], [Duration.seconds(0.1), .seconds(0.5), .seconds(1.0)])
+    func scrollingOnScrollBarChangesScrollPosition(inset: Int, pressAndWait: Duration) async throws {
+        let html = """
+            <body style="width: 100%; height: 2000px; margin: 0; background: repeating-linear-gradient(to bottom, blue 0 50px, white 50px 100px);">
+            </body>
+            """
+
+        try await page.load(html: html).wait()
+
+        let topOfScrollBarInWindowCoordinates = NSPoint(x: window.frame.maxX - CGFloat(inset), y: window.frame.maxY - 160)
+        let start = screenBounds(ofPointInWindowCoordinates: topOfScrollBarInWindowCoordinates)
+        let end = CGPoint(x: start.x, y: start.y + 200)
+
+        await recap.play { composer in
+            composer._wk_drag(withStart: start, end: end, duration: .seconds(1.0), pressAndWait: pressAndWait)
+        }
+
+        try await Task.sleep(for: .seconds(1))
+
+        let finalScrollPosition = try await page.callJavaScript(JavaScriptMessages.ScrollPosition())
+        #expect(finalScrollPosition.x == 0)
+        #expect(finalScrollPosition.y > 0)
+    }
+
     @Test(arguments: [true, false])
     func scrollingChangesScrollPosition(scrollOnImage: Bool) async throws {
         let image = scrollOnImage ? #"<img id="img" src="400x400-green.png" style="display: block; margin: 50px;">"# : ""


### PR DESCRIPTION
#### 8b21bb68c6fbc325572bb23189e9948b14dd740d
<pre>
[AppKit Gestures] Unable to grab scroll bar in Safari
<a href="https://bugs.webkit.org/show_bug.cgi?id=319227">https://bugs.webkit.org/show_bug.cgi?id=319227</a>
<a href="https://rdar.apple.com/181274217">rdar://181274217</a>

Reviewed by Abrar Rahman Protyasha.

Clicking and dragging to grab the scroll bar in Safari wasn&apos;t working for three reasons:

1. AppKit&apos;s internal mechanism prevented any gestures reaching WKAppKitGestureController in the
first place in the case where the click&apos;s location was very close to the window edge. Fix this
by telling AppKit if a point is located atop WebKit&apos;s custom scrollbar.

2. In the case where the click&apos;s location was close or near the inner edge of the scrollbar, the
scrollbar hit testing threshold range was too narrow. Fix this by expanding the range where applicable.

3. In WKAppKitGestureController, other gestures were preventing the mouse tracking gesture when
clicking over the scrollbar in some cases. Fix this by preventing all gestures when the click is
above the scrollbar (except the mouse tracking one).

Test: Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift

* Source/WebCore/page/EventHandler.cpp:
(WebCore::scrollbarForMouseEvent):
* Source/WebCore/platform/ScrollTypes.h:
* Source/WebCore/platform/ScrollView.cpp:
(WebCore::ScrollView::scrollbarAtPoint):
* Source/WebCore/platform/ScrollView.h:
* Source/WebCore/platform/Scrollbar.cpp:
(WebCore::Scrollbar::mouseDown):
(WebCore::Scrollbar::expandedHitTestToleranceThreshold const):
* Source/WebCore/platform/Scrollbar.h:
* Source/WebCore/platform/ScrollbarTheme.h:
(WebCore::ScrollbarTheme::hitTest):
* Source/WebCore/platform/ScrollbarThemeComposite.cpp:
(WebCore::ScrollbarThemeComposite::hitTest):
* Source/WebCore/platform/ScrollbarThemeComposite.h:

Fix (2).

* Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm:
(-[WKAppKitGestureController deferringGestureRecognizer:shouldDeferGesturesForEventThatWillBeginAction:]):
(-[WKAppKitGestureController _isPointOverScrollbar:]):
(-[WKAppKitGestureController gestureRecognizerShouldBegin:]):

Fix (3).

* Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift:
(AppKitGesturesTests.scrollingOnScrollBarChangesScrollPosition(_:pressAndWait:)):

A test, with parameterized combinations for all the potential failure cases that were a result
of any of the three failing issues.

Canonical link: <a href="https://commits.webkit.org/317197@main">https://commits.webkit.org/317197@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d8cbdf1bd8e67094921dab09c681f13dc5dc382

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174582 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48515 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/42296 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184159 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/132450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7d50b974-9f84-4c19-9ebd-257127e9dfbb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176447 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49807 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48198 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/135842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/132450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f7177ce6-eac8-4864-87b9-90f06cb3d6cd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177540 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/39263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/156627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116320 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9e67503d-c30b-414e-8be9-b4ade7efb9e4) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/37904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32640 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/148327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/36119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186587 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/39857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/144752 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48182 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/156182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144612 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38975 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48861 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39497 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/120855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47368 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/11085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46770 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47001 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46828 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->