### PR TITLE
UUID::parse fails to reject a leading '+' in the third segment

### DIFF
--- a/Source/WTF/wtf/UUID.cpp
+++ b/Source/WTF/wtf/UUID.cpp
@@ -125,7 +125,7 @@ std::optional<UUID> UUID::parse(StringView value)
         return { };
 
     // parseInteger may accept integers starting with +, let's check this beforehand.
-    if (value[0] == '+' || value[9] == '+'  || value[19] == '+' || value[24] == '+')
+    if (value[0] == '+' || value[9] == '+'  || value[14] == '+' || value[19] == '+' || value[24] == '+')
         return { };
 
     auto firstValue = parseInteger<uint64_t>(value.left(8), 16);

--- a/Tools/TestWebKitAPI/Tests/WTF/UUID.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/UUID.cpp
@@ -86,6 +86,24 @@ TEST(WTF, TestUUIDVersion4Parsing)
     EXPECT_EQ(parseAndStringifyUUID(testAd12), testAd12.convertToASCIILowercase());
 }
 
+// parseInteger() silently accepts a single leading '+', so UUID::parse() must
+// explicitly reject a '+' at the start of every segment. The five segments
+// begin at indices 0, 9, 14, 19 and 24. Note that parseVersion4() cannot
+// exercise the index-14 case: a leading '+' there consumes a character slot,
+// leaving only 3 hex digits, so the version nibble can never be 4 and the
+// version check rejects it before the '+' would matter. parse() must be
+// tested directly.
+TEST(WTF, UUIDParseRejectsLeadingPlusInEachSegment)
+{
+    EXPECT_FALSE(!!WTF::UUID::parse("+1234567-89ab-cdef-0123-456789abcdef"_s)); // index 0
+    EXPECT_FALSE(!!WTF::UUID::parse("01234567-+9ab-cdef-0123-456789abcdef"_s)); // index 9
+    EXPECT_FALSE(!!WTF::UUID::parse("01234567-89ab-+def-0123-456789abcdef"_s)); // index 14
+    EXPECT_FALSE(!!WTF::UUID::parse("01234567-89ab-cdef-+123-456789abcdef"_s)); // index 19
+    EXPECT_FALSE(!!WTF::UUID::parse("01234567-89ab-cdef-0123-+56789abcdef"_s)); // index 24
+
+    EXPECT_TRUE(!!WTF::UUID::parse("01234567-89ab-cdef-0123-456789abcdef"_s));
+}
+
 TEST(WTF, TestUUIDVersion4MakeString)
 {
     String testNormal = "12345678-9abc-4de0-89ab-0123456789ab"_s;


### PR DESCRIPTION
#### fac50442561859ce96263a686864803d53965d4a
<pre>
UUID::parse fails to reject a leading &apos;+&apos; in the third segment
<a href="https://bugs.webkit.org/show_bug.cgi?id=319229">https://bugs.webkit.org/show_bug.cgi?id=319229</a>

Reviewed by Darin Adler and Yusuke Suzuki.

parseInteger() silently accepts a single leading &apos;+&apos;, so UUID::parse()
guards against a &apos;+&apos; at the start of each segment before delegating to
it. The five segments begin at indices 0, 9, 14, 19 and 24, but the
guard checked only 0, 9, 19 and 24 -- the third segment (index 14) was
omitted.

As a result a malformed string such as
&quot;01234567-89ab-+def-0123-456789abcdef&quot; was accepted and aliased to the
canonical &quot;01234567-89ab-0def-0123-456789abcdef&quot;, so two distinct
strings mapped to a single UUID identity. Add the missing index-14
check.

This gap could not be caught through parseVersion4(): a leading &apos;+&apos; at
index 14 consumes a character slot, leaving only 3 hex digits, so the
version nibble can never be 4 and the version check rejects the input
before the &apos;+&apos; would matter. The new test therefore exercises parse()
directly.

Test: WTF.UUIDParseRejectsLeadingPlusInEachSegment

* Source/WTF/wtf/UUID.cpp:
(WTF::UUID::parse):
* Tools/TestWebKitAPI/Tests/WTF/UUID.cpp:
(TEST(WTF, UUIDParseRejectsLeadingPlusInEachSegment)):

Canonical link: <a href="https://commits.webkit.org/317089@main">https://commits.webkit.org/317089@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7017083fa4a746cef47b8e5dfe82e90f2006b0fd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174159 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48092 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41873 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183733 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132027 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b5df07e8-2b26-426a-872b-8da273ec1921) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176024 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49384 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47774 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135456 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95555 "2 flakes 4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9ef925b3-c1ba-4dd8-8a4d-52d8873e45ba) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177117 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38888 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156260 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115934 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/50c66df7-646d-4a22-9854-1fd2b7d7f79c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37529 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35899 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32217 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/4770 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147953 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35753 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186159 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/35421 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39306 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40096 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144360 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47759 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144225 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38907 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48438 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32372 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113945 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39128 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120339 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/211194 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46944 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10715 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55040 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46347 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46578 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46405 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->