### PR TITLE
[LBSE] Cache the SVG transform origin on RenderSVGModelObject

### DIFF
--- a/LayoutTests/svg/transforms/change-transform-origin-with-transform-attribute-expected.html
+++ b/LayoutTests/svg/transforms/change-transform-origin-with-transform-attribute-expected.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body>
+    <div style="position: absolute; left: 25px; top: 25px; width: 100px; height: 100px; background: green;"></div>
+</body>
+</html>

--- a/LayoutTests/svg/transforms/change-transform-origin-with-transform-attribute.html
+++ b/LayoutTests/svg/transforms/change-transform-origin-with-transform-attribute.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+
+<!--
+Verify that changing the SVG transform-origin CSS property works when the element's transform comes
+from the SVG 'transform' presentation attribute. This exercises the LBSE non-layered paint path,
+which caches the transform origin keyed on the reference box (RenderSVGModelObject). Regression
+test for a stale-cache bug: the cached origin must be dropped before RenderLayerModelObject::
+styleDidChange() rebuilds m_localTransform, otherwise the shape keeps rotating/scaling about the
+previous origin after a transform-origin change that does not trigger layout.
+
+The green 100x100 rectangle should appear at 25,25.
+-->
+
+<body>
+  <svg style="position: absolute; top: 0px; left: 0px;">
+      <rect id="rect" width="50px" height="50px" x="50" y="50" fill="green" transform="scale(2, 2)" style="transform-box: fill-box;"/>
+  </svg>
+
+  <script>
+      document.getElementById('rect').style.transformOrigin = "50% 50%";
+  </script>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderLayerModelObject.cpp
+++ b/Source/WebCore/rendering/RenderLayerModelObject.cpp
@@ -461,7 +461,8 @@ void RenderLayerModelObject::applySVGTransform(TransformationMatrix& transform, 
         || !style.rotate().isNone()
         || !style.translate().isNone()
         || !style.scale().isNone();
-    bool hasSVGTransform = !svgTransform.isIdentity() || preApplySVGTransformMatrix || postApplySVGTransformMatrix || supplementalTransform;
+    bool hasSupplementalOrExternalTransformMatrix = preApplySVGTransformMatrix || postApplySVGTransformMatrix || supplementalTransform;
+    bool hasSVGTransform = !svgTransform.isIdentity() || hasSupplementalOrExternalTransformMatrix;
 
     // Common case: 'viewBox' set on outermost <svg> element -> 'preApplySVGTransformMatrix'
     // passed by RenderSVGViewportContainer::applyTransform(), the anonymous single child
@@ -485,8 +486,16 @@ void RenderLayerModelObject::applySVGTransform(TransformationMatrix& transform, 
     };
 
     FloatPoint3D originTranslate;
-    if (options.contains(Style::TransformResolverOption::TransformOrigin) && affectedByTransformOrigin())
-        originTranslate = transformResolver.computeTransformOrigin(boundingBox);
+    if (options.contains(Style::TransformResolverOption::TransformOrigin) && affectedByTransformOrigin()) {
+        // For a plain SVG transform-attribute shape (no CSS transform and no supplemental
+        // or external matrix) the transform origin depends only on the style and the reference box,
+        // both of which are stable while the shape is only animated by its transform.
+        std::optional<FloatPoint3D> cached;
+        if (!hasCSSTransform && !hasSupplementalOrExternalTransformMatrix)
+            cached = cachedTransformOriginForReferenceBox(style, boundingBox);
+
+        originTranslate = cached ? cached.value() : transformResolver.computeTransformOrigin(boundingBox);
+    }
 
     transformResolver.applyTransformOrigin(originTranslate);
 

--- a/Source/WebCore/rendering/RenderLayerModelObject.h
+++ b/Source/WebCore/rendering/RenderLayerModelObject.h
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include <WebCore/FloatPoint3D.h>
 #include <WebCore/PaintPhase.h>
 #include <WebCore/RenderElement.h>
 #include <wtf/OptionSet.h>
@@ -109,6 +110,8 @@ public:
     void applySVGTransform(TransformationMatrix&, const SVGGraphicsElement&, const Style::ComputedStyle&, const FloatRect& boundingBox, const std::optional<AffineTransform>& preApplySVGTransformMatrix, const std::optional<AffineTransform>& postApplySVGTransformMatrix, OptionSet<Style::TransformResolverOption>) const;
     void updateHasSVGTransformFlags();
     virtual bool needsHasSVGTransformFlags() const { ASSERT_NOT_REACHED(); return false; }
+
+    virtual std::optional<FloatPoint3D> cachedTransformOriginForReferenceBox(const Style::ComputedStyle&, const FloatRect&) const { return std::nullopt; }
 
     enum class SVGAttributeChangeRepaintMode : bool {
         // Issue a full repaint at the new position from inside the function.

--- a/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
@@ -171,6 +171,12 @@ void RenderSVGModelObject::styleDidChange(Style::Difference diff, const Style::C
 {
     RenderLayerModelObject::styleDidChange(diff, oldStyle);
 
+    // Invalidate cached transform origin when relevant styles change.
+    if (!oldStyle
+        || oldStyle->transformOrigin() != style().transformOrigin()
+        || oldStyle->usedZoomForLength().value != style().usedZoomForLength().value)
+        invalidateCachedTransformOrigin();
+
     // Invalidate cached visual overflow rect when relevant styles change.
     if (oldStyle && diff >= Style::DifferenceResult::Repaint) {
         auto visualOverflowStyleChanged = [](const Style::ComputedStyle& newStyle, const Style::ComputedStyle& oldStyle) {
@@ -212,6 +218,15 @@ void RenderSVGModelObject::styleDidChange(Style::Difference diff, const Style::C
     bool hasSVGMask = false;
     if (hasSVGMask && hasLayer() && style().usedVisibility() != Visibility::Visible)
         layer()->setHasVisibleContent();
+}
+
+std::optional<FloatPoint3D> RenderSVGModelObject::cachedTransformOriginForReferenceBox(const Style::ComputedStyle& style, const FloatRect& referenceBox) const
+{
+    if (!m_cachedTransformOrigin || m_cachedTransformOriginBox != referenceBox) {
+        m_cachedTransformOrigin = Style::TransformResolver::computeTransformOrigin(style, referenceBox);
+        m_cachedTransformOriginBox = referenceBox;
+    }
+    return m_cachedTransformOrigin;
 }
 
 void RenderSVGModelObject::mapAbsoluteToLocalPoint(OptionSet<MapCoordinatesMode> mode, TransformState& transformState) const

--- a/Source/WebCore/rendering/svg/RenderSVGModelObject.h
+++ b/Source/WebCore/rendering/svg/RenderSVGModelObject.h
@@ -31,6 +31,7 @@
 
 #pragma once
 
+#include <WebCore/FloatPoint3D.h>
 #include <WebCore/RenderBox.h>
 #include <WebCore/RenderLayerModelObject.h>
 #include <WebCore/SVGBoundingBoxComputation.h>
@@ -100,6 +101,9 @@ public:
 
     void invalidateCachedVisualOverflowRect() override { m_cachedVisualOverflowRect = std::nullopt; }
 
+    std::optional<FloatPoint3D> cachedTransformOriginForReferenceBox(const Style::ComputedStyle&, const FloatRect& referenceBox) const override;
+    void invalidateCachedTransformOrigin() const { m_cachedTransformOrigin = std::nullopt; }
+
 protected:
     RenderSVGModelObject(Type, Document&, Style::ComputedStyle&&, OptionSet<SVGModelObjectFlag> = { });
     RenderSVGModelObject(Type, SVGElement&, Style::ComputedStyle&&, OptionSet<SVGModelObjectFlag> = { });
@@ -132,6 +136,9 @@ private:
 
     LayoutRect m_layoutRect;
     std::optional<AffineTransform> m_localTransform;
+
+    mutable std::optional<FloatPoint3D> m_cachedTransformOrigin;
+    mutable FloatRect m_cachedTransformOriginBox;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### a61f5be9e63a0e2a62a436809340e1950f1b9b04
<pre>
[LBSE] Cache the SVG transform origin on RenderSVGModelObject
<a href="https://bugs.webkit.org/show_bug.cgi?id=319228">https://bugs.webkit.org/show_bug.cgi?id=319228</a>

Reviewed by Rob Buis.

applySVGTransform() calls computeTransformOrigin() for every non-layered SVG shape on every
transform flush. The origin only depends on the transform-origin style and the transform
reference box, so it stays the same as long as those do not change. Sampling MotionMark/Suits
at high, fixed complexity showed computeTransformOrigin costs ~1% of the WebProcess main thread.

Cache the origin on RenderSVGModelObject keyed on the reference box. A different box forces a
recompute, and styleDidChange() drops the cache for transform-origin or transform-box changes,
where the box is the same but the origin differs. The cache is only used on the plain SVG
transform path (no CSS transform and no pre, post or supplemental matrix). Viewport containers
and CSS-transformed renderers keep computing it directly. The optimization scope could be expanded
in future.

Added a new test to cover an edge case caused by a missing cache invalidation during development,
that lacked test coverage so far. The rest of the change is covered by existing tests.

Test: svg/transforms/change-transform-origin-with-transform-attribute.html

* LayoutTests/svg/transforms/change-transform-origin-with-transform-attribute-expected.html: Added.
* LayoutTests/svg/transforms/change-transform-origin-with-transform-attribute.html: Added.
* Source/WebCore/rendering/RenderLayerModelObject.cpp:
(WebCore::RenderLayerModelObject::applySVGTransform const):
* Source/WebCore/rendering/RenderLayerModelObject.h:
(WebCore::RenderLayerModelObject::cachedTransformOriginForReferenceBox const):
* Source/WebCore/rendering/svg/RenderSVGModelObject.cpp:
(WebCore::RenderSVGModelObject::styleDidChange):
(WebCore::RenderSVGModelObject::cachedTransformOriginForReferenceBox const):
* Source/WebCore/rendering/svg/RenderSVGModelObject.h:
(WebCore::RenderSVGModelObject::invalidateCachedTransformOrigin const):

Canonical link: <a href="https://commits.webkit.org/317077@main">https://commits.webkit.org/317077@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/88a41ee152fed4ceed328ab9c891aeb57f8753f2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174267 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48200 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/41981 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183841 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/132135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176132 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49492 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47882 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/135557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/132135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177225 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38986 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/156348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/116035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/37626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/35996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32325 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/148050 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/35841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186267 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/39458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/144462 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47867 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/155903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144319 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38896 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48546 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114079 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39224 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/120468 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47052 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/10805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46455 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46686 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46513 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->