### PR TITLE
pairIntHash extracts the wrong bits of the 64-bit product, degrading hash distribution

### DIFF
--- a/Source/WTF/wtf/HashFunctions.h
+++ b/Source/WTF/wtf/HashFunctions.h
@@ -64,7 +64,7 @@ namespace WTF {
         uint64_t longRandom = 19248658165952622LL; // A random 64-bit value.
 
         uint64_t product = longRandom * (shortRandom1 * key1 + shortRandom2 * key2);
-        unsigned highBits = static_cast<unsigned>(product >> (sizeof(uint64_t) - sizeof(unsigned)));
+        unsigned highBits = static_cast<unsigned>(product >> ((sizeof(uint64_t) - sizeof(unsigned)) * 8));
         return highBits;
     }
 


### PR DESCRIPTION
#### b420bd34107467e3dcf8e9e5c05d2a042b97cfdb
<pre>
pairIntHash extracts the wrong bits of the 64-bit product, degrading hash distribution
<a href="https://bugs.webkit.org/show_bug.cgi?id=319230">https://bugs.webkit.org/show_bug.cgi?id=319230</a>

Reviewed by Darin Adler and Yusuke Suzuki.

pairIntHash() implements the multiplicative hashing scheme from
opendatastructures.org, whose final step folds the 2w-bit product down
to the high w bits (w = 32, the width of unsigned). It did this with:
```
      product &gt;&gt; (sizeof(uint64_t) - sizeof(unsigned))
```
sizeof() returns a byte count, but &gt;&gt; shifts by bits, so this evaluated
to `product &gt;&gt; 4` rather than the intended `product &gt;&gt; 32`. The result
(named highBits) was therefore bits [4, 36) of the product -- mostly the
poorly-mixed low bits that multiplicative hashing deliberately discards,
instead of the well-mixed high 32 bits [32, 64).

This does not affect correctness: the hash remains deterministic, so
HashMap/HashSet stay correct. But it worsens bit-mixing and raises
collision rates for tables keyed on integer std::pair/tuple values
(PairHash, and the DefaultHash for std::pair), which is especially
noticeable for clustered small-integer keys.

Multiply the byte-width difference by 8 to shift by the correct number
of bits.

* Source/WTF/wtf/HashFunctions.h:
(WTF::pairIntHash):

Canonical link: <a href="https://commits.webkit.org/317095@main">https://commits.webkit.org/317095@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/45e0eb61b0a05db98767b2db3484bf07b8f5879f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174161 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48094 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41875 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183735 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132029 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/20a10013-6e63-4658-a2cf-a08d0f7c95dc) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49386 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47776 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135473 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95557 "3 flakes 3 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/913e175e-1f5b-48cf-a5a3-3aedaaa67f44) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177119 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38893 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156258 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115951 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ca60cda9-aded-42bb-a0fc-39287e5923c2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37534 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35904 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32219 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/4768 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147958 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35751 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186161 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/35423 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39310 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40101 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144367 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47761 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144227 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38908 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48440 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32370 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113947 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39137 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120341 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/211196 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46946 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10713 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55041 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46349 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46580 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46407 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->