### PR TITLE
generate-bindings-all.pl misses supplemental dependency changes that preserve list size

### DIFF
--- a/Source/WebCore/bindings/scripts/generate-bindings-all.pl
+++ b/Source/WebCore/bindings/scripts/generate-bindings-all.pl
@@ -123,9 +123,10 @@ buildDirectoryCache();
 
 my @idlFilesToUpdate = grep &{sub {
     my $absPath = Cwd::abs_path($_) || $_;
-    if (defined($oldSupplements{$absPath})
-        && @{$oldSupplements{$absPath}} ne @{$newSupplements{$absPath} or []}) {
-        # Re-process the IDL file if its supplemental dependencies were added or removed
+    my $oldSupplement = $oldSupplements{$absPath};
+    if (defined($oldSupplement)
+        && join("\0", @$oldSupplement) ne join("\0", @{$newSupplements{$absPath} || []})) {
+        # Re-process the IDL file if its supplemental dependencies were added, removed, or changed.
         return 1;
     }
     my ($filename, $dirs, $suffix) = fileparse($_, '.idl');


### PR DESCRIPTION
#### 15327146e8a258e27b3315e080e9009f1bb38928
<pre>
generate-bindings-all.pl misses supplemental dependency changes that preserve list size
<a href="https://bugs.webkit.org/show_bug.cgi?id=319233">https://bugs.webkit.org/show_bug.cgi?id=319233</a>

Reviewed by Darin Adler.

When deciding whether an IDL file must be re-processed, generate-bindings-all.pl
compares the file&apos;s previous set of supplemental dependencies against the current
set. The comparison was written as:
```
      @{$oldSupplements{$absPath}} ne @{$newSupplements{$absPath} or []}
```
`ne` is a string operator, so both arrays are evaluated in scalar context, i.e.
their element counts. This only compares the *number* of supplemental
dependencies, not their contents. As a result, a supplement set that changes to a
different set of the same size -- for example [A.idl] becoming [B.idl] -- is not
detected as a change. Because the subsequent mtime-based check only inspects the
files still present in the new supplement set, the stale JS*.cpp/.h for that
interface is never regenerated, producing incorrect bindings until an unrelated
change forces a rebuild.

Compare the lists by contents instead. The supplement lists are already stored
sorted (see readSupplementalDependencyFile), so joining each with a NUL separator,
a byte that cannot appear in a filesystem path, yields an order-stable,
collision-free comparison that correctly detects additions, removals, and
same-size swaps. Also switch the deref fallback from `or []` to `|| []` for
correct precedence.

* Source/WebCore/bindings/scripts/generate-bindings-all.pl:

Canonical link: <a href="https://commits.webkit.org/317093@main">https://commits.webkit.org/317093@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/77a85c66029c425db8f70cf10de6e0e371e7e2b9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174164 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48097 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41878 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183738 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132032 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0485ec36-5ee3-4957-9635-3115efd1e808) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176029 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49389 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47779 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135460 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95559 "4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1272caae-3444-40dd-87c0-ccdf279dfcad) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177122 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38892 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156253 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115938 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37533 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35905 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32222 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147957 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35746 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186164 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39428 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40102 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144364 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47764 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144223 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38910 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48443 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32365 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113950 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39134 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120346 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46949 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10708 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46352 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46583 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46410 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->