### PR TITLE
Broken interpolation in duplicate-extended-attribute error message in CodeGenerator.pm

### DIFF
--- a/Source/WebCore/bindings/scripts/CodeGenerator.pm
+++ b/Source/WebCore/bindings/scripts/CodeGenerator.pm
@@ -354,7 +354,7 @@ sub MergeExtendedAttributesFromSupplemental
         # Handle case that the attribute already has a extented attribute with this key.
         if ($property->extendedAttributes->{$extendedAttributeName}) {
             if (!$idlAttributes->{$extendedAttributeName}->{"supportsConjunction"}) {
-                die "Duplicate non-mergeable extended attribute ($extendedAttributeName) found when merging extended attributes for ${property->name}";
+                die "Duplicate non-mergeable extended attribute ($extendedAttributeName) found when merging extended attributes for " . $property->name;
             }
             $property->extendedAttributes->{$extendedAttributeName} = $property->extendedAttributes->{$extendedAttributeName} . "&" . $supplementalExtendedAttributes->{$extendedAttributeName};
         } else {


### PR DESCRIPTION
#### 2898162c8c2a3c2bbcd3538f10d5740d6b6a4e03
<pre>
Broken interpolation in duplicate-extended-attribute error message in CodeGenerator.pm
<a href="https://bugs.webkit.org/show_bug.cgi?id=319234">https://bugs.webkit.org/show_bug.cgi?id=319234</a>

Reviewed by Darin Adler.

MergeExtendedAttributesFromSupplemental dies when a supplemental interface
(partial or mixin via includes) supplies a duplicate, non-mergeable extended
attribute. The diagnostic was written as:
```
      die &quot;... when merging extended attributes for ${property-&gt;name}&quot;;
```
In a double-quoted string, ${property-&gt;name} is not a method call. Perl parses
${ ... } as a symbolic-reference/block dereference and attempts to resolve
`name` as a method on the bareword package `property`, so instead of the
intended message the generator dies with an unrelated:
```
      Can&apos;t locate object method &quot;name&quot; via package &quot;property&quot;
```
which masks the real cause (which property actually carried the conflicting
extended attribute). Build the message with string concatenation so
$property-&gt;name is invoked as a method.

Like the message it replaces, this only fires on an error path, but that is
precisely when a clear diagnostic matters. All callers pass an IDLAttribute,
IDLOperation, IDLConstant, or IDLDictionaryMember, each of which provides a
`name` accessor.

* Source/WebCore/bindings/scripts/CodeGenerator.pm:
(MergeExtendedAttributesFromSupplemental):

Canonical link: <a href="https://commits.webkit.org/317094@main">https://commits.webkit.org/317094@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/315fa44d6adcf3ba0f8996f4e6353f76f43327ca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174165 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48098 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41879 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183739 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132033 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b29ac4f9-a498-45fe-a435-7c187c39c459) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176030 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49390 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47780 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135461 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95561 "1 flakes 4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f34b2acc-2789-45d4-8005-4f14738863a8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177123 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38895 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156254 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115939 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fc398ff9-5282-484a-a589-22a57032c73e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37536 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35906 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32223 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147960 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35747 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186165 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39316 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40103 "Found 1 new test failure: imported/w3c/web-platform-tests/html/cross-origin-opener-policy/resource-popup.https.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144365 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47765 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144224 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38911 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48444 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32366 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113951 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39135 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120347 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46950 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10709 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46353 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46584 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46411 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->