### PR TITLE
[JSC] `Array#indexOf` / `includes` should not take the slow path for rope elements with mismatched length

### DIFF
--- a/JSTests/microbenchmarks/array-includes-string-rope-before-match.js
+++ b/JSTests/microbenchmarks/array-includes-string-rope-before-match.js
@@ -1,0 +1,21 @@
+function makeRope(a, b) {
+    return a + b;
+}
+noInline(makeRope);
+
+var array = [
+    undefined, undefined, undefined, undefined,
+    undefined, undefined, undefined, undefined,
+    makeRope('he', 'y'),
+    '',
+];
+
+function test(array) {
+    return array.includes('');
+}
+noInline(test);
+
+for (var i = 0; i < 1e6; ++i) {
+    if (!test(array))
+        throw new Error("bad");
+}

--- a/JSTests/microbenchmarks/array-indexof-string-rope-before-match.js
+++ b/JSTests/microbenchmarks/array-indexof-string-rope-before-match.js
@@ -1,0 +1,21 @@
+function makeRope(a, b) {
+    return a + b;
+}
+noInline(makeRope);
+
+var array = [
+    undefined, undefined, undefined, undefined,
+    undefined, undefined, undefined, undefined,
+    makeRope('he', 'y'),
+    '',
+];
+
+function test(array) {
+    return array.indexOf('', 1);
+}
+noInline(test);
+
+for (var i = 0; i < 1e6; ++i) {
+    if (test(array) !== 9)
+        throw new Error("bad");
+}

--- a/JSTests/stress/array-index-of-string-rope-elements-16bit.js
+++ b/JSTests/stress/array-index-of-string-rope-elements-16bit.js
@@ -1,0 +1,31 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected: ' + expected);
+}
+
+function makeRope(a, b) {
+    return a + b;
+}
+noInline(makeRope);
+
+function indexOfValue(array, value) {
+    return array.indexOf(value);
+}
+noInline(indexOfValue);
+
+for (var i = 0; i < 2e5; ++i) {
+    var array = [
+        makeRope('あい', 'う'),
+        makeRope('か', 'き'),
+        'あいう',
+        '',
+    ];
+    shouldBe(indexOfValue(array, ''), 3);
+    shouldBe(indexOfValue(array, 'あいう'), 0);
+    shouldBe(indexOfValue(array, 'かき'), 1);
+    shouldBe(indexOfValue(array, 'あいか'), -1);
+
+    var mixed = [makeRope('あい', 'う'), makeRope('ab', 'cd'), 'x'];
+    shouldBe(indexOfValue(mixed, 'x'), 2);
+    shouldBe(indexOfValue(mixed, 'abcd'), 1);
+}

--- a/JSTests/stress/array-index-of-string-rope-elements-from-index.js
+++ b/JSTests/stress/array-index-of-string-rope-elements-from-index.js
@@ -1,0 +1,27 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected: ' + expected);
+}
+
+function makeRope(a, b) {
+    return a + b;
+}
+noInline(makeRope);
+
+function indexOfValueFrom(array, value, from) {
+    return array.indexOf(value, from);
+}
+noInline(indexOfValueFrom);
+
+for (var i = 0; i < 2e5; ++i) {
+    var array = [
+        makeRope('ab', 'cd'),
+        makeRope('zz', 'zz'),
+        makeRope('ab', 'cd'),
+    ];
+    shouldBe(indexOfValueFrom(array, 'abcd', 0), 0);
+    shouldBe(indexOfValueFrom(array, 'abcd', 1), 2);
+    shouldBe(indexOfValueFrom(array, 'abcd', -1), 2);
+    shouldBe(indexOfValueFrom(array, 'zzzz', 2), -1);
+    shouldBe(indexOfValueFrom(array, 'zzzz', 1), 1);
+}

--- a/JSTests/stress/array-index-of-string-rope-elements-holes.js
+++ b/JSTests/stress/array-index-of-string-rope-elements-holes.js
@@ -1,0 +1,22 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected: ' + expected);
+}
+
+function makeRope(a, b) {
+    return a + b;
+}
+noInline(makeRope);
+
+function indexOfValue(array, value) {
+    return array.indexOf(value);
+}
+noInline(indexOfValue);
+
+for (var i = 0; i < 2e5; ++i) {
+    var holey = [makeRope('ab', 'cd')];
+    holey[3] = '';
+    shouldBe(indexOfValue(holey, ''), 3);
+    shouldBe(indexOfValue(holey, 'abcd'), 0);
+    shouldBe(indexOfValue(holey, undefined), -1);
+}

--- a/JSTests/stress/array-index-of-string-rope-elements-rescan.js
+++ b/JSTests/stress/array-index-of-string-rope-elements-rescan.js
@@ -1,0 +1,28 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected: ' + expected);
+}
+
+function makeRope(a, b) {
+    return a + b;
+}
+noInline(makeRope);
+
+function indexOfValue(array, value) {
+    return array.indexOf(value);
+}
+noInline(indexOfValue);
+
+function includesValue(array, value) {
+    return array.includes(value);
+}
+noInline(includesValue);
+
+for (var i = 0; i < 2e5; ++i) {
+    var array = [makeRope('zz', 'zz'), 'abcd', makeRope('ab', 'cd')];
+    shouldBe(indexOfValue(array, 'abcd'), 1);
+    shouldBe(includesValue(array, 'abcd'), true);
+
+    var array2 = [makeRope('ab', 'cd'), 'abcd'];
+    shouldBe(indexOfValue(array2, 'abcd'), 0);
+}

--- a/JSTests/stress/array-index-of-string-rope-elements.js
+++ b/JSTests/stress/array-index-of-string-rope-elements.js
@@ -1,0 +1,43 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected: ' + expected);
+}
+
+function makeRope(a, b) {
+    return a + b;
+}
+noInline(makeRope);
+
+function indexOfValue(array, value) {
+    return array.indexOf(value);
+}
+noInline(indexOfValue);
+
+function includesValue(array, value) {
+    return array.includes(value);
+}
+noInline(includesValue);
+
+for (var i = 0; i < 2e5; ++i) {
+    var array = [
+        makeRope('ab', 'cd'),
+        makeRope('wx', 'yz'),
+        'hello',
+        undefined,
+        makeRope('a', 'b'),
+        '',
+    ];
+
+    shouldBe(indexOfValue(array, ''), 5);
+    shouldBe(indexOfValue(array, 'ab'), 4);
+    shouldBe(includesValue(array, ''), true);
+
+    shouldBe(indexOfValue(array, 'abcd'), 0);
+    shouldBe(indexOfValue(array, 'wxyz'), 1);
+    shouldBe(indexOfValue(array, 'xyzw'), -1);
+    shouldBe(includesValue(array, 'wxyz'), true);
+    shouldBe(includesValue(array, 'xyzw'), false);
+
+    shouldBe(indexOfValue(array, 'hello'), 2);
+    shouldBe(indexOfValue(array, undefined), 3);
+}

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -10550,17 +10550,18 @@ void SpeculativeJIT::compileArrayIndexOfOrArrayIncludes(Node* node)
             falseCase.append(branchIfNotCell(leftStringGPR));
             falseCase.append(branchIfNotString(leftStringGPR));
 
-            loadPtr(Address(leftStringGPR, JSString::offsetOfValue()), leftStringGPR);
-
-            slowCase.append(branchIfRopeStringImpl(leftStringGPR));
-
-            load32(Address(leftStringGPR, StringImpl::lengthMemoryOffset()), compareLengthGPR);
+            loadPtr(Address(leftStringGPR, JSString::offsetOfValue()), leftCharGPR);
             loadPtr(Address(searchElementGPR, JSString::offsetOfValue()), rightStringGPR);
-            falseCase.append(branch32(
-                NotEqual,
-                Address(rightStringGPR, StringImpl::lengthMemoryOffset()),
-                compareLengthGPR
-            ));
+
+            auto notRopeElement = branchIfNotRopeStringImpl(leftCharGPR);
+            load32(Address(leftStringGPR, JSRopeString::offsetOfLength()), compareLengthGPR);
+            falseCase.append(branch32(NotEqual, Address(rightStringGPR, StringImpl::lengthMemoryOffset()), compareLengthGPR));
+            slowCase.append(jump());
+            notRopeElement.link(this);
+
+            move(leftCharGPR, leftStringGPR);
+            load32(Address(leftStringGPR, StringImpl::lengthMemoryOffset()), compareLengthGPR);
+            falseCase.append(branch32(NotEqual, Address(rightStringGPR, StringImpl::lengthMemoryOffset()), compareLengthGPR));
 
             trueCase.append(branchTest32(Zero, compareLengthGPR));
 

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -8714,7 +8714,8 @@ IGNORE_CLANG_WARNINGS_END
             LBasicBlock fastCheckElementCell = m_out.newBlock();
             LBasicBlock fastCheckElementString = m_out.newBlock();
             LBasicBlock fastPath = m_out.newBlock();
-            LBasicBlock slowCheckElementRope = m_out.newBlock();
+            LBasicBlock checkElementRope = m_out.newBlock();
+            LBasicBlock ropeElementLengthCheck = m_out.newBlock();
             LBasicBlock compareStringLengths = m_out.newBlock();
             LBasicBlock slowCheckElement8Bit = m_out.newBlock();
             LBasicBlock checkNonEmpty = m_out.newBlock();
@@ -8800,12 +8801,12 @@ IGNORE_CLANG_WARNINGS_END
             m_out.appendTo(fastCheckElementString, fastPath);
             m_out.branch(isString(element), usually(fastPath), rarely(loopNext));
 
-            m_out.appendTo(fastPath, slowCheckElementRope);
+            m_out.appendTo(fastPath, checkElementRope);
             ValueFromBlock foundResult = isArrayIncludes ? m_out.anchor(m_out.constBool(true)) : m_out.anchor(index);
-            m_out.branch(m_out.equal(element, searchElement), rarely(continuation), usually(slowCheckElementRope));
+            m_out.branch(m_out.equal(element, searchElement), rarely(continuation), usually(checkElementRope));
 
-            m_out.appendTo(slowCheckElementRope, compareStringLengths);
-            m_out.branch(isRopeString(element), rarely(slowCase), usually(compareStringLengths));
+            m_out.appendTo(checkElementRope, compareStringLengths);
+            m_out.branch(isRopeString(element), rarely(ropeElementLengthCheck), usually(compareStringLengths));
 
             m_out.appendTo(compareStringLengths, slowCheckElement8Bit);
             LValue elementImpl = m_out.loadPtr(element, m_heaps.JSString_value);
@@ -8862,10 +8863,15 @@ IGNORE_CLANG_WARNINGS_END
             m_out.appendTo(compareWordsTail, compareWordsTailLoad);
             m_out.branch(m_out.isNull(compareWordsLoopIndexInLoop), unsure(continuation), unsure(compareWordsTailLoad));
 
-            m_out.appendTo(compareWordsTailLoad, loopNext);
+            m_out.appendTo(compareWordsTailLoad, ropeElementLengthCheck);
             LValue elementTailWord = m_out.load64(TypedPointer(m_heaps.characters8.atAnyIndex(), elementData));
             LValue searchElementTailWord = m_out.load64(TypedPointer(m_heaps.characters8.atAnyIndex(), searchElementData));
             m_out.branch(m_out.notEqual(elementTailWord, searchElementTailWord), unsure(loopNext), unsure(continuation));
+
+            m_out.appendTo(ropeElementLengthCheck, loopNext);
+            m_out.branch(
+                m_out.notEqual(m_out.load32NonNegative(element, m_heaps.JSRopeString_length), m_out.load32(searchElementImpl, m_heaps.StringImpl_length)),
+                usually(loopNext), rarely(slowCase));
 
             m_out.appendTo(loopNext,  notFound);
             LValue nextIndex = m_out.add(index, m_out.intPtrOne);


### PR DESCRIPTION
#### a84e1b4694055dfe89ceb1106d8850405421aa7f
<pre>
[JSC] `Array#indexOf` / `includes` should not take the slow path for rope elements with mismatched length
<a href="https://bugs.webkit.org/show_bug.cgi?id=319237">https://bugs.webkit.org/show_bug.cgi?id=319237</a>

Reviewed by Yusuke Suzuki.

A rope stores its length inline, so the fast path can compare lengths and skip
rope elements without resolving them, instead of bailing out to the slow path
at the first rope element. The slow path is now only entered when a rope&apos;s
length matches the search element. This avoids the operation call for scans
stepping over freshly created ropes, e.g. RegExp matches arrays whose captures
are substring ropes.

                                                    baseline                  patched

array-indexof-string-rope-before-match        11.8110+-0.5658     ^      8.2470+-0.2127        ^ definitely 1.4322x faster
array-includes-string-rope-before-match       13.2017+-0.3347     ^      9.1412+-0.4073        ^ definitely 1.4442x faster

Tests: JSTests/microbenchmarks/array-includes-string-rope-before-match.js
       JSTests/microbenchmarks/array-indexof-string-rope-before-match.js
       JSTests/stress/array-index-of-string-rope-elements-16bit.js
       JSTests/stress/array-index-of-string-rope-elements-from-index.js
       JSTests/stress/array-index-of-string-rope-elements-holes.js
       JSTests/stress/array-index-of-string-rope-elements-rescan.js
       JSTests/stress/array-index-of-string-rope-elements.js

* JSTests/microbenchmarks/array-includes-string-rope-before-match.js: Added.
(makeRope):
(test):
* JSTests/microbenchmarks/array-indexof-string-rope-before-match.js: Added.
(makeRope):
(test):
* JSTests/stress/array-index-of-string-rope-elements-16bit.js: Added.
(shouldBe):
(makeRope):
(indexOfValue):
* JSTests/stress/array-index-of-string-rope-elements-from-index.js: Added.
(shouldBe):
(makeRope):
(indexOfValueFrom):
* JSTests/stress/array-index-of-string-rope-elements-holes.js: Added.
(shouldBe):
(makeRope):
(indexOfValue):
* JSTests/stress/array-index-of-string-rope-elements-rescan.js: Added.
(shouldBe):
(makeRope):
(indexOfValue):
(includesValue):
* JSTests/stress/array-index-of-string-rope-elements.js: Added.
(shouldBe):
(makeRope):
(indexOfValue):
(includesValue):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileArrayIndexOfOrArrayIncludes):

Canonical link: <a href="https://commits.webkit.org/317465@main">https://commits.webkit.org/317465@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38fb4085dc8671b40c43ad72a98ba17b110901e2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175028 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48961 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42742 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184609 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132936 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50253 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48644 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136221 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96106 "2 flakes 4 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177986 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39663 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157019 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116700 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38304 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36692 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33086 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5528 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148727 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36511 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187033 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/36290 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/40754 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40894 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145167 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48628 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145022 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39145 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49308 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33132 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/held.https.any.sharedworker.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115126 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39885 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121454 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/212120 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47814 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11484 "Passed tests") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55331 "Found 12 jsc stress test failures: stress/promise-prototype-catch-on-non-promise.js.default, stress/regexp-dot-star-enclosure-contains-capturing-terms-out-of-stack.js.bytecode-cache, stress/regexp-prototype-symbol-search-on-non-regexp.js.default, stress/regexp-prototype-test-on-non-regexp.js.default, stress/string-replace-regexp-with-own-property.js.default ..., JSC test binary failure: testapi") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47217 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47447 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47274 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->