### PR TITLE
NotificationData::direction is serialized uninitialized when a NotificationPayload has no options

### DIFF
--- a/Source/WebCore/Modules/notifications/NotificationData.h
+++ b/Source/WebCore/Modules/notifications/NotificationData.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <WebCore/NotificationDirection.h>
 #include <WebCore/ScriptExecutionContextIdentifier.h>
 #include <optional>
 #include <pal/SessionID.h>
@@ -37,8 +38,6 @@
 OBJC_CLASS NSDictionary;
 
 namespace WebCore {
-
-enum class NotificationDirection : uint8_t;
 
 static constexpr Seconds silentPushTimeoutForProduction { 30_s };
 static constexpr Seconds silentPushTimeoutForTesting { 1_s };
@@ -60,7 +59,7 @@ struct NotificationData {
     String iconURL;
     String tag;
     String language;
-    WebCore::NotificationDirection direction;
+    NotificationDirection direction { NotificationDirection::Auto };
     String originString;
     URL serviceWorkerRegistrationURL;
     WTF::UUID notificationID { WTF::UUID::createVersion4() };


### PR DESCRIPTION
#### 5fc32e9843cb1070e514c2d27ce40142269c169d
<pre>
NotificationData::direction is serialized uninitialized when a NotificationPayload has no options
<a href="https://bugs.webkit.org/show_bug.cgi?id=319238">https://bugs.webkit.org/show_bug.cgi?id=319238</a>
<a href="https://rdar.apple.com/182085034">rdar://182085034</a>

Reviewed by Chris Dumez.

NotificationData::direction had no default member initializer, so when
NotificationPayload::toNotificationData() runs with no options, it stays
indeterminate and is then serialized over IPC (undefined behavior, and
possibly an out-of-range NotificationDirection).

Initialize it explicitly to NotificationDirection::Auto, and drop the
redundant WebCore:: qualifier since the struct is already in the WebCore
namespace.

Since the initializer now references the NotificationDirection::Auto
enumerator, the enum can no longer be an incomplete forward declaration.
Include &lt;WebCore/NotificationDirection.h&gt; and remove the forward
declaration so the enumerator is visible.

* Source/WebCore/Modules/notifications/NotificationData.h:

Canonical link: <a href="https://commits.webkit.org/317160@main">https://commits.webkit.org/317160@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d1d14f123151971be6755afaa06d6b797557ae6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174395 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48328 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42109 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183974 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132263 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/404ee179-b733-414c-98f2-41ebf32c4027) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176260 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49620 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48010 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135661 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f8610661-6092-4974-b817-3a4403bb9470) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177353 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39099 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156455 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116139 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c3a4b669-af07-49c4-8c61-1745f989959a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37740 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36104 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32453 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148163 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35947 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186398 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39611 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40301 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144574 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47995 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144432 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38956 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48674 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32567 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114221 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39332 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120620 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47180 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10911 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46583 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46814 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46641 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->