### PR TITLE
[animation-triggers] add parsing support for the `timeline-trigger-activation-range` shorthand

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/parsing/timeline-trigger-entry-range-shorthand.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/parsing/timeline-trigger-entry-range-shorthand.tentative-expected.txt
@@ -1,68 +1,68 @@
 
-FAIL e.style['timeline-trigger-activation-range'] = "normal" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-activation-range'] = "normal normal" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-activation-range'] = "cover" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-activation-range'] = "contain" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-activation-range'] = "entry" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-activation-range'] = "entry-crossing" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-activation-range'] = "exit" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-activation-range'] = "exit-crossing" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-activation-range'] = "entry, exit" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-activation-range'] = "entry 0% entry 100%" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-activation-range'] = "entry-crossing 0% entry-crossing 100%" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-activation-range'] = "exit 0% exit 100%" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-activation-range'] = "exit-crossing 0% exit-crossing 100%" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-activation-range'] = "cover 0% cover 100%" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-activation-range'] = "contain 0% contain 100%" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-activation-range'] = "entry calc(10% - 10%) entry calc(50% + 50%)" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-activation-range'] = "cover 50%" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-activation-range'] = "contain 50%" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-activation-range'] = "entry 50%" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-activation-range'] = "entry-crossing 50%" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-activation-range'] = "exit 50%" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-activation-range'] = "exit-crossing 50%" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-activation-range'] = "entry 50px exit 100px" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-activation-range'] = "exit calc(10% + 50px)" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-activation-range'] = "entry 50% exit 50%" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-activation-range'] = "cover 50% entry 50%, contain 50% exit 50%" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-activation-range'] = "50% exit 50%" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-activation-range'] = "normal 100px" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-activation-range'] = "100px" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-activation-range'] = "100px normal" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-activation-range'] = "10% normal" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL Property timeline-trigger-activation-range value 'normal' assert_true: timeline-trigger-activation-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-activation-range value 'normal normal' assert_true: timeline-trigger-activation-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-activation-range value 'cover' assert_true: timeline-trigger-activation-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-activation-range value 'contain' assert_true: timeline-trigger-activation-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-activation-range value 'entry' assert_true: timeline-trigger-activation-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-activation-range value 'entry-crossing' assert_true: timeline-trigger-activation-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-activation-range value 'exit' assert_true: timeline-trigger-activation-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-activation-range value 'exit-crossing' assert_true: timeline-trigger-activation-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-activation-range value 'entry, exit' assert_true: timeline-trigger-activation-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-activation-range value 'entry 0% entry 100%' assert_true: timeline-trigger-activation-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-activation-range value 'entry-crossing 0% entry-crossing 100%' assert_true: timeline-trigger-activation-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-activation-range value 'exit 0% exit 100%' assert_true: timeline-trigger-activation-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-activation-range value 'exit-crossing 0% exit-crossing 100%' assert_true: timeline-trigger-activation-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-activation-range value 'cover 0% cover 100%' assert_true: timeline-trigger-activation-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-activation-range value 'contain 0% contain 100%' assert_true: timeline-trigger-activation-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-activation-range value 'entry calc(10% - 10%) entry calc(50% + 50%)' assert_true: timeline-trigger-activation-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-activation-range value 'cover 50%' assert_true: timeline-trigger-activation-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-activation-range value 'contain 50%' assert_true: timeline-trigger-activation-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-activation-range value 'entry 50%' assert_true: timeline-trigger-activation-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-activation-range value 'entry-crossing 50%' assert_true: timeline-trigger-activation-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-activation-range value 'exit 50%' assert_true: timeline-trigger-activation-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-activation-range value 'exit-crossing 50%' assert_true: timeline-trigger-activation-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-activation-range value 'entry 50px exit 100px' assert_true: timeline-trigger-activation-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-activation-range value 'exit calc(10% + 50px)' assert_true: timeline-trigger-activation-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-activation-range value 'entry 50% exit 50%' assert_true: timeline-trigger-activation-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-activation-range value 'cover 50% entry 50%, contain 50% exit 50%' assert_true: timeline-trigger-activation-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-activation-range value 'entry 10em exit 20em' assert_true: timeline-trigger-activation-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-activation-range value '10em exit 20em' assert_true: timeline-trigger-activation-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-activation-range value 'normal 100px' assert_true: timeline-trigger-activation-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-activation-range value '100px' assert_true: timeline-trigger-activation-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-activation-range value '100px normal' assert_true: timeline-trigger-activation-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-activation-range value '10% normal' assert_true: timeline-trigger-activation-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-activation-range value '10% calc(70% + 10% * sign(100em - 1px))' assert_true: timeline-trigger-activation-range doesn't seem to be supported in the computed style expected true got false
+PASS e.style['timeline-trigger-activation-range'] = "normal" should set the property value
+PASS e.style['timeline-trigger-activation-range'] = "normal normal" should set the property value
+PASS e.style['timeline-trigger-activation-range'] = "cover" should set the property value
+PASS e.style['timeline-trigger-activation-range'] = "contain" should set the property value
+PASS e.style['timeline-trigger-activation-range'] = "entry" should set the property value
+PASS e.style['timeline-trigger-activation-range'] = "entry-crossing" should set the property value
+PASS e.style['timeline-trigger-activation-range'] = "exit" should set the property value
+PASS e.style['timeline-trigger-activation-range'] = "exit-crossing" should set the property value
+PASS e.style['timeline-trigger-activation-range'] = "entry, exit" should set the property value
+PASS e.style['timeline-trigger-activation-range'] = "entry 0% entry 100%" should set the property value
+PASS e.style['timeline-trigger-activation-range'] = "entry-crossing 0% entry-crossing 100%" should set the property value
+PASS e.style['timeline-trigger-activation-range'] = "exit 0% exit 100%" should set the property value
+PASS e.style['timeline-trigger-activation-range'] = "exit-crossing 0% exit-crossing 100%" should set the property value
+PASS e.style['timeline-trigger-activation-range'] = "cover 0% cover 100%" should set the property value
+PASS e.style['timeline-trigger-activation-range'] = "contain 0% contain 100%" should set the property value
+FAIL e.style['timeline-trigger-activation-range'] = "entry calc(10% - 10%) entry calc(50% + 50%)" should set the property value assert_equals: serialization should be canonical expected "entry" but got "entry calc(0%) entry calc(100%)"
+PASS e.style['timeline-trigger-activation-range'] = "cover 50%" should set the property value
+PASS e.style['timeline-trigger-activation-range'] = "contain 50%" should set the property value
+PASS e.style['timeline-trigger-activation-range'] = "entry 50%" should set the property value
+PASS e.style['timeline-trigger-activation-range'] = "entry-crossing 50%" should set the property value
+PASS e.style['timeline-trigger-activation-range'] = "exit 50%" should set the property value
+PASS e.style['timeline-trigger-activation-range'] = "exit-crossing 50%" should set the property value
+PASS e.style['timeline-trigger-activation-range'] = "entry 50px exit 100px" should set the property value
+PASS e.style['timeline-trigger-activation-range'] = "exit calc(10% + 50px)" should set the property value
+PASS e.style['timeline-trigger-activation-range'] = "entry 50% exit 50%" should set the property value
+PASS e.style['timeline-trigger-activation-range'] = "cover 50% entry 50%, contain 50% exit 50%" should set the property value
+PASS e.style['timeline-trigger-activation-range'] = "50% exit 50%" should set the property value
+PASS e.style['timeline-trigger-activation-range'] = "normal 100px" should set the property value
+PASS e.style['timeline-trigger-activation-range'] = "100px" should set the property value
+PASS e.style['timeline-trigger-activation-range'] = "100px normal" should set the property value
+PASS e.style['timeline-trigger-activation-range'] = "10% normal" should set the property value
+PASS Property timeline-trigger-activation-range value 'normal'
+PASS Property timeline-trigger-activation-range value 'normal normal'
+PASS Property timeline-trigger-activation-range value 'cover'
+PASS Property timeline-trigger-activation-range value 'contain'
+PASS Property timeline-trigger-activation-range value 'entry'
+PASS Property timeline-trigger-activation-range value 'entry-crossing'
+PASS Property timeline-trigger-activation-range value 'exit'
+PASS Property timeline-trigger-activation-range value 'exit-crossing'
+PASS Property timeline-trigger-activation-range value 'entry, exit'
+PASS Property timeline-trigger-activation-range value 'entry 0% entry 100%'
+PASS Property timeline-trigger-activation-range value 'entry-crossing 0% entry-crossing 100%'
+PASS Property timeline-trigger-activation-range value 'exit 0% exit 100%'
+PASS Property timeline-trigger-activation-range value 'exit-crossing 0% exit-crossing 100%'
+PASS Property timeline-trigger-activation-range value 'cover 0% cover 100%'
+PASS Property timeline-trigger-activation-range value 'contain 0% contain 100%'
+PASS Property timeline-trigger-activation-range value 'entry calc(10% - 10%) entry calc(50% + 50%)'
+PASS Property timeline-trigger-activation-range value 'cover 50%'
+PASS Property timeline-trigger-activation-range value 'contain 50%'
+PASS Property timeline-trigger-activation-range value 'entry 50%'
+PASS Property timeline-trigger-activation-range value 'entry-crossing 50%'
+PASS Property timeline-trigger-activation-range value 'exit 50%'
+PASS Property timeline-trigger-activation-range value 'exit-crossing 50%'
+PASS Property timeline-trigger-activation-range value 'entry 50px exit 100px'
+PASS Property timeline-trigger-activation-range value 'exit calc(10% + 50px)'
+PASS Property timeline-trigger-activation-range value 'entry 50% exit 50%'
+PASS Property timeline-trigger-activation-range value 'cover 50% entry 50%, contain 50% exit 50%'
+PASS Property timeline-trigger-activation-range value 'entry 10em exit 20em'
+PASS Property timeline-trigger-activation-range value '10em exit 20em'
+PASS Property timeline-trigger-activation-range value 'normal 100px'
+PASS Property timeline-trigger-activation-range value '100px'
+PASS Property timeline-trigger-activation-range value '100px normal'
+PASS Property timeline-trigger-activation-range value '10% normal'
+PASS Property timeline-trigger-activation-range value '10% calc(70% + 10% * sign(100em - 1px))'
 PASS e.style['timeline-trigger-activation-range'] = "entry 50% 0s" should not set the property value
 PASS e.style['timeline-trigger-activation-range'] = "0s entry 50%" should not set the property value
 PASS e.style['timeline-trigger-activation-range'] = "1s" should not set the property value
@@ -86,46 +86,46 @@ PASS e.style['timeline-trigger-activation-range'] = "thing 100px" should not set
 PASS e.style['timeline-trigger-activation-range'] = "100% thing" should not set the property value
 PASS e.style['timeline-trigger-activation-range'] = "normal foo normal 100%" should not set the property value
 PASS e.style['timeline-trigger-activation-range'] = "normal normal 100%" should not set the property value
-FAIL e.style['timeline-trigger-activation-range'] = "normal" should set timeline-trigger-activation-range-end assert_equals: timeline-trigger-activation-range-end should be canonical expected "normal" but got ""
-FAIL e.style['timeline-trigger-activation-range'] = "normal" should set timeline-trigger-activation-range-start assert_equals: timeline-trigger-activation-range-start should be canonical expected "normal" but got ""
-FAIL e.style['timeline-trigger-activation-range'] = "normal" should not set unrelated longhands assert_true: expected true got false
-FAIL e.style['timeline-trigger-activation-range'] = "normal normal" should set timeline-trigger-activation-range-end assert_equals: timeline-trigger-activation-range-end should be canonical expected "normal" but got ""
-FAIL e.style['timeline-trigger-activation-range'] = "normal normal" should set timeline-trigger-activation-range-start assert_equals: timeline-trigger-activation-range-start should be canonical expected "normal" but got ""
-FAIL e.style['timeline-trigger-activation-range'] = "normal normal" should not set unrelated longhands assert_true: expected true got false
-FAIL e.style['timeline-trigger-activation-range'] = "normal entry 100%" should set timeline-trigger-activation-range-end assert_equals: timeline-trigger-activation-range-end should be canonical expected "entry" but got ""
-FAIL e.style['timeline-trigger-activation-range'] = "normal entry 100%" should set timeline-trigger-activation-range-start assert_equals: timeline-trigger-activation-range-start should be canonical expected "normal" but got ""
-FAIL e.style['timeline-trigger-activation-range'] = "normal entry 100%" should not set unrelated longhands assert_true: expected true got false
-FAIL e.style['timeline-trigger-activation-range'] = "normal entry 10%" should set timeline-trigger-activation-range-end assert_equals: timeline-trigger-activation-range-end should be canonical expected "entry 10%" but got ""
-FAIL e.style['timeline-trigger-activation-range'] = "normal entry 10%" should set timeline-trigger-activation-range-start assert_equals: timeline-trigger-activation-range-start should be canonical expected "normal" but got ""
-FAIL e.style['timeline-trigger-activation-range'] = "normal entry 10%" should not set unrelated longhands assert_true: expected true got false
-FAIL e.style['timeline-trigger-activation-range'] = "cover" should set timeline-trigger-activation-range-end assert_equals: timeline-trigger-activation-range-end should be canonical expected "cover" but got ""
-FAIL e.style['timeline-trigger-activation-range'] = "cover" should set timeline-trigger-activation-range-start assert_equals: timeline-trigger-activation-range-start should be canonical expected "cover" but got ""
-FAIL e.style['timeline-trigger-activation-range'] = "cover" should not set unrelated longhands assert_true: expected true got false
-FAIL e.style['timeline-trigger-activation-range'] = "contain" should set timeline-trigger-activation-range-end assert_equals: timeline-trigger-activation-range-end should be canonical expected "contain" but got ""
-FAIL e.style['timeline-trigger-activation-range'] = "contain" should set timeline-trigger-activation-range-start assert_equals: timeline-trigger-activation-range-start should be canonical expected "contain" but got ""
-FAIL e.style['timeline-trigger-activation-range'] = "contain" should not set unrelated longhands assert_true: expected true got false
-FAIL e.style['timeline-trigger-activation-range'] = "contain 100% contain 0%" should set timeline-trigger-activation-range-end assert_equals: timeline-trigger-activation-range-end should be canonical expected "contain 0%" but got ""
-FAIL e.style['timeline-trigger-activation-range'] = "contain 100% contain 0%" should set timeline-trigger-activation-range-start assert_equals: timeline-trigger-activation-range-start should be canonical expected "contain 100%" but got ""
-FAIL e.style['timeline-trigger-activation-range'] = "contain 100% contain 0%" should not set unrelated longhands assert_true: expected true got false
-FAIL e.style['timeline-trigger-activation-range'] = "entry 10% exit 20%" should set timeline-trigger-activation-range-end assert_equals: timeline-trigger-activation-range-end should be canonical expected "exit 20%" but got ""
-FAIL e.style['timeline-trigger-activation-range'] = "entry 10% exit 20%" should set timeline-trigger-activation-range-start assert_equals: timeline-trigger-activation-range-start should be canonical expected "entry 10%" but got ""
-FAIL e.style['timeline-trigger-activation-range'] = "entry 10% exit 20%" should not set unrelated longhands assert_true: expected true got false
-FAIL e.style['timeline-trigger-activation-range'] = "entry calc(10% + 10px) exit 20px" should set timeline-trigger-activation-range-end assert_equals: timeline-trigger-activation-range-end should be canonical expected "exit 20px" but got ""
-FAIL e.style['timeline-trigger-activation-range'] = "entry calc(10% + 10px) exit 20px" should set timeline-trigger-activation-range-start assert_equals: timeline-trigger-activation-range-start should be canonical expected "entry calc(10% + 10px)" but got ""
-FAIL e.style['timeline-trigger-activation-range'] = "entry calc(10% + 10px) exit 20px" should not set unrelated longhands assert_true: expected true got false
-FAIL e.style['timeline-trigger-activation-range'] = "entry, exit" should set timeline-trigger-activation-range-end assert_equals: timeline-trigger-activation-range-end should be canonical expected "entry, exit" but got ""
-FAIL e.style['timeline-trigger-activation-range'] = "entry, exit" should set timeline-trigger-activation-range-start assert_equals: timeline-trigger-activation-range-start should be canonical expected "entry, exit" but got ""
-FAIL e.style['timeline-trigger-activation-range'] = "entry, exit" should not set unrelated longhands assert_true: expected true got false
-FAIL e.style['timeline-trigger-activation-range'] = "entry 0%, exit" should set timeline-trigger-activation-range-end assert_equals: timeline-trigger-activation-range-end should be canonical expected "entry, exit" but got ""
-FAIL e.style['timeline-trigger-activation-range'] = "entry 0%, exit" should set timeline-trigger-activation-range-start assert_equals: timeline-trigger-activation-range-start should be canonical expected "entry, exit" but got ""
-FAIL e.style['timeline-trigger-activation-range'] = "entry 0%, exit" should not set unrelated longhands assert_true: expected true got false
-FAIL e.style['timeline-trigger-activation-range'] = "exit calc(10% + 50px)" should set timeline-trigger-activation-range-end assert_equals: timeline-trigger-activation-range-end should be canonical expected "exit" but got ""
-FAIL e.style['timeline-trigger-activation-range'] = "exit calc(10% + 50px)" should set timeline-trigger-activation-range-start assert_equals: timeline-trigger-activation-range-start should be canonical expected "exit calc(10% + 50px)" but got ""
-FAIL e.style['timeline-trigger-activation-range'] = "exit calc(10% + 50px)" should not set unrelated longhands assert_true: expected true got false
-FAIL e.style['timeline-trigger-activation-range'] = "100px" should set timeline-trigger-activation-range-end assert_equals: timeline-trigger-activation-range-end should be canonical expected "normal" but got ""
-FAIL e.style['timeline-trigger-activation-range'] = "100px" should set timeline-trigger-activation-range-start assert_equals: timeline-trigger-activation-range-start should be canonical expected "100px" but got ""
-FAIL e.style['timeline-trigger-activation-range'] = "100px" should not set unrelated longhands assert_true: expected true got false
-FAIL e.style['timeline-trigger-activation-range'] = "10%" should set timeline-trigger-activation-range-end assert_equals: timeline-trigger-activation-range-end should be canonical expected "normal" but got ""
-FAIL e.style['timeline-trigger-activation-range'] = "10%" should set timeline-trigger-activation-range-start assert_equals: timeline-trigger-activation-range-start should be canonical expected "10%" but got ""
-FAIL e.style['timeline-trigger-activation-range'] = "10%" should not set unrelated longhands assert_true: expected true got false
+PASS e.style['timeline-trigger-activation-range'] = "normal" should set timeline-trigger-activation-range-end
+PASS e.style['timeline-trigger-activation-range'] = "normal" should set timeline-trigger-activation-range-start
+PASS e.style['timeline-trigger-activation-range'] = "normal" should not set unrelated longhands
+PASS e.style['timeline-trigger-activation-range'] = "normal normal" should set timeline-trigger-activation-range-end
+PASS e.style['timeline-trigger-activation-range'] = "normal normal" should set timeline-trigger-activation-range-start
+PASS e.style['timeline-trigger-activation-range'] = "normal normal" should not set unrelated longhands
+PASS e.style['timeline-trigger-activation-range'] = "normal entry 100%" should set timeline-trigger-activation-range-end
+PASS e.style['timeline-trigger-activation-range'] = "normal entry 100%" should set timeline-trigger-activation-range-start
+PASS e.style['timeline-trigger-activation-range'] = "normal entry 100%" should not set unrelated longhands
+PASS e.style['timeline-trigger-activation-range'] = "normal entry 10%" should set timeline-trigger-activation-range-end
+PASS e.style['timeline-trigger-activation-range'] = "normal entry 10%" should set timeline-trigger-activation-range-start
+PASS e.style['timeline-trigger-activation-range'] = "normal entry 10%" should not set unrelated longhands
+PASS e.style['timeline-trigger-activation-range'] = "cover" should set timeline-trigger-activation-range-end
+PASS e.style['timeline-trigger-activation-range'] = "cover" should set timeline-trigger-activation-range-start
+PASS e.style['timeline-trigger-activation-range'] = "cover" should not set unrelated longhands
+PASS e.style['timeline-trigger-activation-range'] = "contain" should set timeline-trigger-activation-range-end
+PASS e.style['timeline-trigger-activation-range'] = "contain" should set timeline-trigger-activation-range-start
+PASS e.style['timeline-trigger-activation-range'] = "contain" should not set unrelated longhands
+PASS e.style['timeline-trigger-activation-range'] = "contain 100% contain 0%" should set timeline-trigger-activation-range-end
+PASS e.style['timeline-trigger-activation-range'] = "contain 100% contain 0%" should set timeline-trigger-activation-range-start
+PASS e.style['timeline-trigger-activation-range'] = "contain 100% contain 0%" should not set unrelated longhands
+PASS e.style['timeline-trigger-activation-range'] = "entry 10% exit 20%" should set timeline-trigger-activation-range-end
+PASS e.style['timeline-trigger-activation-range'] = "entry 10% exit 20%" should set timeline-trigger-activation-range-start
+PASS e.style['timeline-trigger-activation-range'] = "entry 10% exit 20%" should not set unrelated longhands
+PASS e.style['timeline-trigger-activation-range'] = "entry calc(10% + 10px) exit 20px" should set timeline-trigger-activation-range-end
+PASS e.style['timeline-trigger-activation-range'] = "entry calc(10% + 10px) exit 20px" should set timeline-trigger-activation-range-start
+PASS e.style['timeline-trigger-activation-range'] = "entry calc(10% + 10px) exit 20px" should not set unrelated longhands
+PASS e.style['timeline-trigger-activation-range'] = "entry, exit" should set timeline-trigger-activation-range-end
+PASS e.style['timeline-trigger-activation-range'] = "entry, exit" should set timeline-trigger-activation-range-start
+PASS e.style['timeline-trigger-activation-range'] = "entry, exit" should not set unrelated longhands
+PASS e.style['timeline-trigger-activation-range'] = "entry 0%, exit" should set timeline-trigger-activation-range-end
+PASS e.style['timeline-trigger-activation-range'] = "entry 0%, exit" should set timeline-trigger-activation-range-start
+PASS e.style['timeline-trigger-activation-range'] = "entry 0%, exit" should not set unrelated longhands
+PASS e.style['timeline-trigger-activation-range'] = "exit calc(10% + 50px)" should set timeline-trigger-activation-range-end
+PASS e.style['timeline-trigger-activation-range'] = "exit calc(10% + 50px)" should set timeline-trigger-activation-range-start
+PASS e.style['timeline-trigger-activation-range'] = "exit calc(10% + 50px)" should not set unrelated longhands
+PASS e.style['timeline-trigger-activation-range'] = "100px" should set timeline-trigger-activation-range-end
+PASS e.style['timeline-trigger-activation-range'] = "100px" should set timeline-trigger-activation-range-start
+PASS e.style['timeline-trigger-activation-range'] = "100px" should not set unrelated longhands
+PASS e.style['timeline-trigger-activation-range'] = "10%" should set timeline-trigger-activation-range-end
+PASS e.style['timeline-trigger-activation-range'] = "10%" should set timeline-trigger-activation-range-start
+PASS e.style['timeline-trigger-activation-range'] = "10%" should not set unrelated longhands
 

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -13268,6 +13268,24 @@
                 "url": "https://drafts.csswg.org/animation-triggers-1/#timeline-trigger-source"
             }
         },
+        "timeline-trigger-activation-range": {
+            "codegen-properties": {
+                "longhands": [
+                    "timeline-trigger-activation-range-start",
+                    "timeline-trigger-activation-range-end"
+                ],
+                "coordinated-value-list-property": true,
+                "separator": ",",
+                "parser-function": "consumeTimelineTriggerActivationRangeShorthand",
+                "parser-grammar-unused": "[ <'timeline-trigger-activation-range-start'> <'timeline-trigger-activation-range-end'>? ]#",
+                "parser-grammar-unused-reason": "Needs support for shorthand grammars.",
+                "settings-flag": "animationTriggersEnabled"
+            },
+            "specification": {
+                "category": "animation-triggers",
+                "url": "https://drafts.csswg.org/animation-triggers-1/#propdef-timeline-trigger-activation-range"
+            }
+        },
         "timeline-trigger-activation-range-start": {
             "animation-type": "not animatable",
             "initial": "normal",

--- a/Source/WebCore/css/ShorthandSerializer.cpp
+++ b/Source/WebCore/css/ShorthandSerializer.cpp
@@ -450,6 +450,7 @@ String ShorthandSerializer::serialize()
     case CSSPropertyViewTimeline:
         return serializeCoordinatingListPropertyGroup();
     case CSSPropertyAnimationRange:
+    case CSSPropertyTimelineTriggerActivationRange:
         return serializeAnimationRange();
     default:
         ASSERT_NOT_REACHED();

--- a/Source/WebCore/css/parser/CSSPropertyParserCustom.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserCustom.h
@@ -172,6 +172,7 @@ public:
     static bool consumeContainerShorthand(CSSParserTokenRange&, PropertyParserState&, const StylePropertyShorthand&, PropertyParserResult&);
     static bool consumeContainIntrinsicSizeShorthand(CSSParserTokenRange&, PropertyParserState&, const StylePropertyShorthand&, PropertyParserResult&);
     static bool consumeAnimationRangeShorthand(CSSParserTokenRange&, PropertyParserState&, const StylePropertyShorthand&, PropertyParserResult&);
+    static bool consumeTimelineTriggerActivationRangeShorthand(CSSParserTokenRange&, PropertyParserState&, const StylePropertyShorthand&, PropertyParserResult&);
     static bool consumeScrollTimelineShorthand(CSSParserTokenRange&, PropertyParserState&, const StylePropertyShorthand&, PropertyParserResult&);
     static bool consumeViewTimelineShorthand(CSSParserTokenRange&, PropertyParserState&, const StylePropertyShorthand&, PropertyParserResult&);
     static bool consumeLineClampShorthand(CSSParserTokenRange&, PropertyParserState&, const StylePropertyShorthand&, PropertyParserResult&);
@@ -2078,7 +2079,7 @@ inline bool PropertyParserCustom::consumeWhiteSpaceShorthand(CSSParserTokenRange
     return true;
 }
 
-inline bool PropertyParserCustom::consumeAnimationRangeShorthand(CSSParserTokenRange& range, PropertyParserState& state, const StylePropertyShorthand&, PropertyParserResult& result)
+inline bool PropertyParserCustom::consumeAnimationRangeShorthand(CSSParserTokenRange& range, PropertyParserState& state, const StylePropertyShorthand& shorthand, PropertyParserResult& result)
 {
     CSSValueListBuilder startList;
     CSSValueListBuilder endList;
@@ -2119,9 +2120,15 @@ inline bool PropertyParserCustom::consumeAnimationRangeShorthand(CSSParserTokenR
     if (!range.atEnd())
         return false;
 
-    result.addPropertyForCurrentShorthand(state, CSSPropertyAnimationRangeStart, CSSValueList::createCommaSeparated(WTF::move(startList)));
-    result.addPropertyForCurrentShorthand(state, CSSPropertyAnimationRangeEnd, CSSValueList::createCommaSeparated(WTF::move(endList)));
+    ASSERT(shorthand.properties().size() == 2);
+    result.addPropertyForCurrentShorthand(state, shorthand.properties()[0], CSSValueList::createCommaSeparated(WTF::move(startList)));
+    result.addPropertyForCurrentShorthand(state, shorthand.properties()[1], CSSValueList::createCommaSeparated(WTF::move(endList)));
     return true;
+}
+
+inline bool PropertyParserCustom::consumeTimelineTriggerActivationRangeShorthand(CSSParserTokenRange& range, PropertyParserState& state, const StylePropertyShorthand& shorthand, PropertyParserResult& result)
+{
+    return consumeAnimationRangeShorthand(range, state, shorthand, result);
 }
 
 inline bool PropertyParserCustom::consumeScrollTimelineShorthand(CSSParserTokenRange& range, PropertyParserState& state, const StylePropertyShorthand&, PropertyParserResult& result)

--- a/Source/WebCore/style/StyleExtractorCustom.h
+++ b/Source/WebCore/style/StyleExtractorCustom.h
@@ -169,6 +169,7 @@ public:
     static RefPtr<CSSValue> extractTextDecorationSkipShorthand(ExtractorState&);
     static RefPtr<CSSValue> extractTextDecorationShorthand(ExtractorState&);
     static RefPtr<CSSValue> extractTextWrapShorthand(ExtractorState&);
+    static RefPtr<CSSValue> extractTimelineTriggerActivationRangeShorthand(ExtractorState&);
     static RefPtr<CSSValue> extractTransformOriginShorthand(ExtractorState&);
     static RefPtr<CSSValue> extractTransitionShorthand(ExtractorState&);
     static RefPtr<CSSValue> extractViewTimelineShorthand(ExtractorState&);
@@ -266,6 +267,7 @@ public:
     static void extractTextDecorationSkipShorthandSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
     static void extractTextDecorationShorthandSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
     static void extractTextWrapShorthandSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
+    static void extractTimelineTriggerActivationRangeShorthandSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
     static void extractTransformOriginShorthandSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
     static void extractTransitionShorthandSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
     static void extractViewTimelineShorthandSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
@@ -2710,6 +2712,23 @@ inline void ExtractorCustom::extractAnimationRangeShorthandSerialization(Extract
         builder.append(convertAnimationRange(state, value)->cssText(context));
     };
     return extractCoordinatedValueListSerialization<CSSPropertyAnimationRange>(state, builder, context, state.style.animations(), mapper);
+}
+
+inline RefPtr<CSSValue> ExtractorCustom::extractTimelineTriggerActivationRangeShorthand(ExtractorState& state)
+{
+    auto mapper = [](auto& state, const auto& value, const std::optional<TimelineTrigger>&, const auto&) -> Ref<CSSValue> {
+        return convertAnimationRange(state, value);
+    };
+    return extractCoordinatedValueListValue<CSSPropertyTimelineTriggerActivationRange>(state, state.style.timelineTriggers(), mapper);
+}
+
+inline void ExtractorCustom::extractTimelineTriggerActivationRangeShorthandSerialization(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context)
+{
+    auto mapper = [&](auto& state, auto& builder, const auto& context, const auto& value, const std::optional<TimelineTrigger>&, const auto&) {
+        // FIXME: Do this more efficiently without creating and destroying a CSSValue object.
+        builder.append(convertAnimationRange(state, value)->cssText(context));
+    };
+    return extractCoordinatedValueListSerialization<CSSPropertyTimelineTriggerActivationRange>(state, builder, context, state.style.timelineTriggers(), mapper);
 }
 
 inline RefPtr<CSSValue> ExtractorCustom::extractBackgroundShorthand(ExtractorState& state)

--- a/Source/WebCore/style/values/animation-triggers/StyleTimelineTrigger.h
+++ b/Source/WebCore/style/values/animation-triggers/StyleTimelineTrigger.h
@@ -46,6 +46,10 @@ namespace Style {
     macro(TimelineTrigger, TimelineTriggerActiveRangeEnd, SingleAnimationRangeEnd, activeRangeEnd, ActiveRangeEnd) \
 \
 
+#define FOR_EACH_TIMELINE_TRIGGER_SHORTHAND(macro) \
+    macro(TimelineTrigger, TimelineTriggerActivationRange, SingleAnimationRange, activationRange, ActivationRange) \
+\
+
 #define FOR_EACH_TIMELINE_TRIGGER_PROPERTY(macro) \
     FOR_EACH_TIMELINE_TRIGGER_REFERENCE(macro) \
 \
@@ -69,6 +73,16 @@ struct TimelineTrigger {
     static SingleAnimationRangeEnd initialActiveRangeEnd() { return CSS::Keyword::Normal { }; }
 
     FOR_EACH_TIMELINE_TRIGGER_REFERENCE(DECLARE_COORDINATED_VALUE_LIST_GETTER_AND_SETTERS_REFERENCE)
+
+    // Support for the `timeline-trigger-activation-range` shorthand.
+    static SingleAnimationRange initialActivationRange() { return { initialActivationRangeStart(), initialActivationRangeEnd() }; }
+    SingleAnimationRange activationRange() const { return { activationRangeStart(), activationRangeEnd() }; }
+    void setActivationRange(SingleAnimationRange&& activationRange) { setActivationRangeStart(WTF::move(activationRange.start)); setActivationRangeEnd(WTF::move(activationRange.end)); }
+    void fillActivationRange(SingleAnimationRange&& activationRange) { fillActivationRangeStart(WTF::move(activationRange.start)); fillActivationRangeEnd(WTF::move(activationRange.end)); }
+    void clearActivationRange() { clearActivationRangeStart(); clearActivationRangeEnd(); }
+    bool isActivationRangeUnset() const { return isActivationRangeStartUnset() && isActivationRangeEndUnset(); }
+    bool isActivationRangeSet() const { return isActivationRangeStartSet() || isActivationRangeEndSet(); }
+    bool isActivationRangeFilled() const { return isActivationRangeStartFilled() || isActivationRangeEndFilled(); }
 
     bool operator==(const TimelineTrigger&) const = default;
 
@@ -106,6 +120,7 @@ private:
 };
 
 FOR_EACH_TIMELINE_TRIGGER_REFERENCE(DECLARE_COORDINATED_VALUE_LIST_PROPERTY_ACCESSOR_REFERENCE)
+FOR_EACH_TIMELINE_TRIGGER_SHORTHAND(DECLARE_COORDINATED_VALUE_LIST_PROPERTY_ACCESSOR_SHORTHAND)
 
 // MARK: - Logging
 
@@ -113,6 +128,7 @@ TextStream& operator<<(TextStream&, const TimelineTrigger&);
 
 #undef FOR_EACH_TIMELINE_TRIGGER_REFERENCE
 #undef FOR_EACH_TIMELINE_TRIGGER_PROPERTY
+#undef FOR_EACH_TIMELINE_TRIGGER_SHORTHAND
 
 } // namespace Style
 } // namespace WebCore


### PR DESCRIPTION
#### ef6ba36394db2dfa43b2f4b4ccc8ec2a2867752b
<pre>
[animation-triggers] add parsing support for the `timeline-trigger-activation-range` shorthand
<a href="https://bugs.webkit.org/show_bug.cgi?id=319239">https://bugs.webkit.org/show_bug.cgi?id=319239</a>
<a href="https://rdar.apple.com/182085495">rdar://182085495</a>

Reviewed by Sam Weinig.

The animation-triggers spec adds a new shorthand property: `timeline-trigger-activation-range`.

* LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/ShorthandSerializer.cpp:
(WebCore::ShorthandSerializer::serialize):
* Source/WebCore/css/parser/CSSPropertyParserCustom.h:
(WebCore::CSS::PropertyParserCustom::consumeTimelineTriggerActivationRangeShorthand):
* Source/WebCore/style/StyleExtractorCustom.h:
(WebCore::Style::ExtractorCustom::extractTimelineTriggerActivationRangeShorthand):
(WebCore::Style::ExtractorCustom::extractTimelineTriggerActivationRangeShorthandSerialization):
* Source/WebCore/style/values/animation-triggers/StyleTimelineTrigger.h:
(WebCore::Style::TimelineTrigger::initialActivationRange):
(WebCore::Style::TimelineTrigger::activationRange const):
(WebCore::Style::TimelineTrigger::setActivationRange):
(WebCore::Style::TimelineTrigger::fillActivationRange):
(WebCore::Style::TimelineTrigger::clearActivationRange):
(WebCore::Style::TimelineTrigger::isActivationRangeUnset const):
(WebCore::Style::TimelineTrigger::isActivationRangeSet const):
(WebCore::Style::TimelineTrigger::isActivationRangeFilled const):

Canonical link: <a href="https://commits.webkit.org/317194@main">https://commits.webkit.org/317194@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a78aa1a33c7d01ed88289f7c2324af02f0f7cc04

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174241 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48174 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41955 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183815 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132109 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/81ad6d0a-ebe2-4faa-b4df-8a58da2c663f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176106 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49466 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47856 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135535 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95621 "3 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177199 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38965 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156323 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116013 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8b0c5cdf-02cc-48fe-a8b6-67c6f3c32101) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37605 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35973 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32299 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148029 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35816 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186241 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39426 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40170 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144438 "Found 1 new test failure: compositing/framesets/composited-frame-alignment.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47841 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144296 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48520 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32436 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114051 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26533 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39202 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120439 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47026 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10778 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46429 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46660 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46487 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->