### PR TITLE
[AppKit Gestures] Refactor WKAppKitGestureController conformance to NSGestureRecognizerDelegate

### DIFF
--- a/Source/WebKit/Modules/Internal/module.modulemap
+++ b/Source/WebKit/Modules/Internal/module.modulemap
@@ -41,6 +41,18 @@ module WebKit_Internal [system] {
         export *
     }
 
+    module InteractionInformationRequest {
+        requires cplusplus20
+        header "../../Shared/Cocoa/InteractionInformationRequest.h"
+        export *
+    }
+
+    module InteractionInformationAtPosition {
+        requires cplusplus20
+        header "../../Shared/Cocoa/InteractionInformationAtPosition.h"
+        export *
+    }
+
     module HistoryClient {
         requires cplusplus20
         header "../../UIProcess/API/APIHistoryClient.h"

--- a/Source/WebKit/UIProcess/mac/WKAppKitGestureController+NSGestureRecognizerDelegate.swift
+++ b/Source/WebKit/UIProcess/mac/WKAppKitGestureController+NSGestureRecognizerDelegate.swift
@@ -1,0 +1,346 @@
+// Copyright (C) 2026 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#if HAVE_APPKIT_GESTURES_SUPPORT
+
+import Foundation
+import WebKit_Internal
+import AppKit
+private import CxxStdlib
+private import WebCore_Private
+import struct Swift.String
+
+extension WKAppKitGestureController {
+    private func positionInformationRequestIsValid(at locationInViewCoordinates: NSPoint, radius: Int) -> Bool {
+        let request = WebKit.InteractionInformationRequest(.init(locationInViewCoordinates))
+        return hasValidPositionInformation && positionInformation.request.isApproximatelyValidForRequest(request, Int32(radius))
+    }
+
+    private static func representsDraggableElement(_ info: WebKit.InteractionInformationAtPosition) -> Bool {
+        info.isLink
+            || info.isImage
+            || info.isAttachment
+            || info.isDHTMLDraggable
+            || info.isColorInput
+            || info.prefersDraggingOverTextSelection
+    }
+
+    fileprivate func secondaryClickShouldBegin(at locationInViewCoordinates: NSPoint) -> Bool {
+        let request = WebKit.InteractionInformationRequest(.init(locationInViewCoordinates))
+
+        let requestIsValid = hasValidPositionInformation && positionInformation.request.isValidForRequest(request)
+        let isSelectable = positionInformation.isSelectable()
+        let isOverSelectableText = positionInformation.isOverSelectableText
+
+        // The secondary click owns selectable points that are not over actual text (e.g. the page
+        // background). Over a run of selectable text, the text selection manager should win so that a
+        // long press selects a word instead of synthesizing a context menu.
+        let shouldBegin = requestIsValid && isSelectable && !isOverSelectableText
+
+        if !requestIsValid {
+            _invalidateCurrentPositionInformation()
+        }
+
+        return shouldBegin
+    }
+
+    fileprivate func dragPressShouldBegin(at locationInViewCoordinates: NSPoint) -> Bool {
+        guard let dragPressGestureRecognizer else {
+            preconditionFailure("precondition violated: dragPressGestureRecognizer has not been created yet.")
+        }
+
+        let radius = Int(dragPressGestureRecognizer.allowableMovement.rounded(.up))
+
+        // FIXME: Migrate to requestDragStart: IPC for an authoritative decision.
+        // The heuristic below approximates DragController::draggableElement() by consulting the same element-type and style signals.
+        let isDraggable = Self.representsDraggableElement(positionInformation)
+        let requestIsValid = positionInformationRequestIsValid(at: locationInViewCoordinates, radius: radius)
+        let shouldDrag = requestIsValid && isDraggable
+
+        Logger.viewGestures.log(
+            "\(#function) Drag-press shouldBegin -> \(shouldDrag) (hasInfo=\(self.hasValidPositionInformation) link=\(self.positionInformation.isLink) image=\(self.positionInformation.isImage) attachment=\(self.positionInformation.isAttachment) dhtml=\(self.positionInformation.isDHTMLDraggable) color=\(self.positionInformation.isColorInput) prefersDrag=\(self.positionInformation.prefersDraggingOverTextSelection) radius=\(radius))"
+        )
+
+        if !requestIsValid {
+            _invalidateCurrentPositionInformation()
+        }
+
+        return shouldDrag
+    }
+
+    fileprivate func panShouldBegin(at locationInViewCoordinates: NSPoint) -> Bool {
+        let panPositionInformationToleranceRadius = 15
+        let requestIsValid = positionInformationRequestIsValid(at: locationInViewCoordinates, radius: panPositionInformationToleranceRadius)
+
+        // FIXME: (rdar://181964604) Because of this logic, vertically scrolling over these elements likely will not work.
+        let prefersInteraction = positionInformation.isRangeInput || positionInformation.isARIASlider
+        let yieldToContent = requestIsValid && prefersInteraction
+
+        Logger.viewGestures.log(
+            "\(#function) Pan shouldBegin -> \(!yieldToContent) (hasInfo=\(self.hasValidPositionInformation) valid=\(requestIsValid) prefersInteraction=\(prefersInteraction))"
+        )
+
+        return !yieldToContent
+    }
+
+    fileprivate func isScrollOrZoomGestureRecognizer(_ gesture: NSGestureRecognizer) -> Bool {
+        gesture == panGestureRecognizer || gesture.isBuiltInScrollViewPan || gesture is NSMagnificationGestureRecognizer
+    }
+}
+
+@objc(NSGestureRecognizerDelegate)
+@implementation
+extension WKAppKitGestureController {
+    @objc(gestureRecognizer:shouldRecognizeSimultaneouslyWithGestureRecognizer:)
+    func gestureRecognizer(
+        _ gestureRecognizer: NSGestureRecognizer,
+        shouldRecognizeSimultaneouslyWith otherGestureRecognizer: NSGestureRecognizer
+    ) -> Bool {
+        Logger.viewGestures.debug(
+            "\(#function) Gesture: \(Self.loggingDescription(for: gestureRecognizer)), Other gesture: \(Self.loggingDescription(for: otherGestureRecognizer))"
+        )
+
+        if isSamePair(gestureRecognizer, otherGestureRecognizer, singleClickGestureRecognizer, panGestureRecognizer) {
+            return true
+        }
+
+        if gestureRecognizer is WKDeferringGestureRecognizer || otherGestureRecognizer is WKDeferringGestureRecognizer {
+            return true
+        }
+
+        if isSamePair(gestureRecognizer, otherGestureRecognizer, mouseTrackingGestureRecognizer, singleClickGestureRecognizer) {
+            return true
+        }
+
+        if isSamePair(gestureRecognizer, otherGestureRecognizer, dragPressGestureRecognizer, singleClickGestureRecognizer) {
+            return true
+        }
+
+        if isSamePair(gestureRecognizer, otherGestureRecognizer, dragPressGestureRecognizer, mouseTrackingGestureRecognizer) {
+            return true
+        }
+
+        if gestureRecognizer == singleClickGestureRecognizer
+            && otherGestureRecognizer.isBuiltInScrollViewPan
+            && otherGestureRecognizer.view is NSScrollView
+        {
+            return true
+        }
+
+        guard let webView else {
+            return false
+        }
+
+        // Allow the single click or mouse tracking GRs to be simultaneously
+        // recognized with any of those from the text selection manager.
+        for gestureForFailureRequirements in webView.textSelectionManager?.gesturesForFailureRequirements ?? [] {
+            if isSamePair(gestureRecognizer, otherGestureRecognizer, singleClickGestureRecognizer, gestureForFailureRequirements) {
+                return true
+            }
+
+            if isSamePair(gestureRecognizer, otherGestureRecognizer, mouseTrackingGestureRecognizer, gestureForFailureRequirements) {
+                return true
+            }
+        }
+
+        return false
+    }
+
+    @objc(gestureRecognizer:shouldBeRequiredToFailByGestureRecognizer:)
+    func gestureRecognizer(
+        _ gestureRecognizer: NSGestureRecognizer,
+        shouldBeRequiredToFailBy otherGestureRecognizer: NSGestureRecognizer
+    ) -> Bool {
+        Logger.viewGestures.debug(
+            "\(#function) Gesture: \(Self.loggingDescription(for: gestureRecognizer)), Other gesture: \(Self.loggingDescription(for: otherGestureRecognizer))"
+        )
+
+        guard let webView else {
+            return false
+        }
+
+        if let deferringGestureRecognizer = gestureRecognizer as? WKDeferringGestureRecognizer {
+            return deferringGestureRecognizer.shouldDefer(otherGestureRecognizer)
+        }
+
+        // Fail any gestures from the text selection manager if the secondary click GR handles them.
+        let failForTextSelection = webView.textSelectionManager?.gesturesForFailureRequirements
+            .contains { gestureForFailureRequirements in
+                gestureRecognizer === secondaryClickGestureRecognizer && otherGestureRecognizer === gestureForFailureRequirements
+            }
+
+        if let failForTextSelection, failForTextSelection {
+            return true
+        }
+
+        return false
+    }
+
+    @objc(gestureRecognizer:shouldRequireFailureOfGestureRecognizer:)
+    func gestureRecognizer(
+        _ gestureRecognizer: NSGestureRecognizer,
+        shouldRequireFailureOf otherGestureRecognizer: NSGestureRecognizer
+    ) -> Bool {
+        Logger.viewGestures.debug(
+            "\(#function) Gesture: \(Self.loggingDescription(for: gestureRecognizer)), Other gesture: \(Self.loggingDescription(for: otherGestureRecognizer))"
+        )
+
+        guard webView != nil else {
+            return false
+        }
+
+        if gestureRecognizer === singleClickGestureRecognizer && otherGestureRecognizer === doubleClickGestureRecognizer {
+            return true
+        }
+
+        if gestureRecognizer === mouseTrackingGestureRecognizer && otherGestureRecognizer === panGestureRecognizer {
+            let panCanScroll = panGestureRecognizerCanScroll()
+            Logger.viewGestures.debug("\(#function) Mouse tracking requires pan to fail: \(panCanScroll)")
+            return panCanScroll
+        }
+
+        return false
+    }
+
+    @objc(gestureRecognizerShouldBegin:)
+    func gestureRecognizerShouldBegin(_ gestureRecognizer: NSGestureRecognizer) -> Bool {
+        Logger.viewGestures.debug("\(#function) Gesture: \(Self.loggingDescription(for: gestureRecognizer))")
+
+        guard let webView, let impl = webView._impl() else {
+            return false
+        }
+
+        let locationInViewCoordinates = gestureRecognizer.location(in: webView)
+
+        // While catching a decelerating scroll, only select gestures are allowed to begin:
+        // - single click, so it can reset the interruption state
+        // - pan, so it can continue with successive scrolls
+        if caughtDeceleratingScroll {
+            if gestureRecognizer === singleClickGestureRecognizer {
+                return true
+            }
+            if gestureRecognizer !== panGestureRecognizer {
+                return false
+            }
+        }
+
+        if gestureRecognizer === doubleClickGestureRecognizer {
+            return impl.allowsMagnification()
+        }
+
+        if gestureRecognizer === secondaryClickGestureRecognizer {
+            return secondaryClickShouldBegin(at: locationInViewCoordinates)
+        }
+
+        if gestureRecognizer === dragPressGestureRecognizer {
+            return dragPressShouldBegin(at: locationInViewCoordinates)
+        }
+
+        if gestureRecognizer === panGestureRecognizer {
+            return panShouldBegin(at: locationInViewCoordinates)
+        }
+
+        if gestureRecognizer === singleClickGestureRecognizer {
+            return !impl.isTextSelectedAtPoint(locationInViewCoordinates)
+        }
+
+        if gestureRecognizer === mouseTrackingGestureRecognizer {
+            return !impl.isTextSelectedAtPoint(locationInViewCoordinates)
+        }
+
+        return true
+    }
+
+    // swift-format-ignore: NoLeadingUnderscores
+    @objc(_gestureRecognizer:canPreventGestureRecognizer:)
+    func _gestureRecognizer(
+        _ preventingGestureRecognizer: NSGestureRecognizer?,
+        canPrevent preventedGestureRecognizer: NSGestureRecognizer?
+    ) -> Bool {
+        guard let preventingGestureRecognizer, let preventedGestureRecognizer else {
+            return false
+        }
+
+        Logger.viewGestures.debug(
+            "\(#function) Preventing gesture: \(Self.loggingDescription(for: preventingGestureRecognizer)), Prevented gesture: \(Self.loggingDescription(for: preventedGestureRecognizer))"
+        )
+
+        guard let webView else {
+            return false
+        }
+
+        // None of our gesture recognizers may prevent an enclosing scroll view's pan (or any other
+        // scroll/zoom) gesture, so that a scroll can always be handed off to the enclosing scroll view
+        // e.g. a scroll over a draggable <img> in a non-scrollable web view.
+        if isScrollOrZoomGestureRecognizer(preventedGestureRecognizer) {
+            return false
+        }
+
+        let isOurClickGesture =
+            preventingGestureRecognizer === singleClickGestureRecognizer
+            || preventingGestureRecognizer === secondaryClickGestureRecognizer
+            || preventingGestureRecognizer === mouseTrackingGestureRecognizer
+            || preventingGestureRecognizer === dragPressGestureRecognizer
+
+        guard isOurClickGesture else {
+            return true
+        }
+
+        // Don't let other click gestures prevent the secondary click GR; it must be allowed to fire its
+        // press timer (0.72s) without being short-circuited by gestures that recognize earlier
+        // (e.g. single click and mouse-tracking, which both transition to Began at mouse-down).
+        if preventedGestureRecognizer === secondaryClickGestureRecognizer {
+            return false
+        }
+
+        // Don't let our click gestures prevent text selection manager gestures;
+        // they should be allowed to recognize simultaneously (per shouldRecognizeSimultaneouslyWithGestureRecognizer:).
+        let preventsTextSelection = webView.textSelectionManager?.gesturesForFailureRequirements
+            .contains { textSelectionGesture in
+                preventedGestureRecognizer === textSelectionGesture
+            }
+
+        if let preventsTextSelection, preventsTextSelection {
+            return false
+        }
+
+        return true
+    }
+}
+
+private func isSamePair(_ a: NSGestureRecognizer?, _ b: NSGestureRecognizer?, _ x: NSGestureRecognizer?, _ y: NSGestureRecognizer?) -> Bool
+{
+    (a === x && b === y) || (b === x && a === y)
+}
+
+extension NSGestureRecognizer {
+    fileprivate var isBuiltInScrollViewPan: Bool {
+        guard let scrollViewPanGestureClass = NSClassFromString("NSScrollViewPanGestureRecognizer") else {
+            assertionFailure("Class 'NSScrollViewPanGestureRecognizer' not found")
+            return false
+        }
+        return isKind(of: scrollViewPanGestureClass)
+    }
+}
+
+#endif // HAVE_APPKIT_GESTURES_SUPPORT

--- a/Source/WebKit/UIProcess/mac/WKAppKitGestureController.h
+++ b/Source/WebKit/UIProcess/mac/WKAppKitGestureController.h
@@ -30,6 +30,7 @@
 #if HAVE(APPKIT_GESTURES_SUPPORT)
 
 #import <AppKit/NSGestureRecognizer.h>
+#import <AppKit/NSGestureRecognizer_Private.h>
 #import <wtf/Forward.h>
 #import <wtf/ObjectIdentifier.h>
 #import <wtf/Vector.h>
@@ -57,7 +58,7 @@ OBJC_CLASS WKWebView;
 NS_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 NS_SWIFT_UI_ACTOR
-@interface WKAppKitGestureController : NSObject <NSGestureRecognizerDelegate>
+@interface WKAppKitGestureController : NSObject
 
 - (instancetype)initWithPage:(std::reference_wrapper<WebKit::WebPageProxy>)page viewImpl:(std::reference_wrapper<WebKit::WebViewImpl>)viewImpl;
 - (void)enableGesturesIfNeeded;
@@ -89,9 +90,23 @@ NS_SWIFT_UI_ACTOR
 
 // Exposed for Swift
 @property (nonatomic, readonly, nullable) WKWebView *webView;
+@property (nonatomic, readonly) BOOL hasValidPositionInformation;
+@property (nonatomic, readonly) BOOL caughtDeceleratingScroll;
+@property (nonatomic, readonly) WebKit::InteractionInformationAtPosition positionInformation;
 @property (nonatomic, strong, nullable) NSPanGestureRecognizer *panGestureRecognizer;
+@property (nonatomic, strong, nullable) NSPressGestureRecognizer *singleClickGestureRecognizer;
+@property (nonatomic, strong, nullable) NSPressGestureRecognizer *mouseTrackingGestureRecognizer;
+@property (nonatomic, strong, nullable) NSPressGestureRecognizer *dragPressGestureRecognizer;
+@property (nonatomic, strong, nullable) NSPressGestureRecognizer *secondaryClickGestureRecognizer;
+@property (nonatomic, strong, nullable) NSClickGestureRecognizer *doubleClickGestureRecognizer;
 - (void)configureForScrolling:(NSPanGestureRecognizer *)gesture;
 - (void)panGestureRecognized:(NSGestureRecognizer *)gesture;
+- (BOOL)panGestureRecognizerCanScroll;
+- (void)_invalidateCurrentPositionInformation;
+
+@end
+
+@interface WKAppKitGestureController (NSGestureRecognizerDelegate) <NSGestureRecognizerDelegatePrivate>
 
 @end
 

--- a/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
+++ b/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
@@ -212,15 +212,38 @@ static NSString *gestureLogDescription(NSGestureRecognizer *gesture)
     return webView.getAutoreleased();
 }
 
-- (NSPanGestureRecognizer *)panGestureRecognizer
+- (BOOL)hasValidPositionInformation
 {
-    return _panGestureRecognizer.get();
+    return _hasValidPositionInformation;
 }
 
-- (void)setPanGestureRecognizer:(NSPanGestureRecognizer *)recognizer
+- (BOOL)caughtDeceleratingScroll
 {
-    _panGestureRecognizer = recognizer;
+    return _caughtDeceleratingScroll;
 }
+
+- (WebKit::InteractionInformationAtPosition)positionInformation
+{
+    return _positionInformation;
+}
+
+#define GESTURE_RECOGNIZER_GETTER_SETTER(type, name, getter, setter) \
+- (type *)getter \
+{ \
+    return name.get(); \
+} \
+\
+- (void)setter:(type *)recognizer \
+{ \
+    name = recognizer; \
+} \
+
+GESTURE_RECOGNIZER_GETTER_SETTER(NSPanGestureRecognizer, _panGestureRecognizer, panGestureRecognizer, setPanGestureRecognizer)
+GESTURE_RECOGNIZER_GETTER_SETTER(NSPressGestureRecognizer, _singleClickGestureRecognizer, singleClickGestureRecognizer, setSingleClickGestureRecognizer)
+GESTURE_RECOGNIZER_GETTER_SETTER(NSPressGestureRecognizer, _mouseTrackingGestureRecognizer, mouseTrackingGestureRecognizer, setMouseTrackingGestureRecognizer)
+GESTURE_RECOGNIZER_GETTER_SETTER(NSPressGestureRecognizer, _dragPressGestureRecognizer, dragPressGestureRecognizer, setDragPressGestureRecognizer)
+GESTURE_RECOGNIZER_GETTER_SETTER(NSPressGestureRecognizer, _secondaryClickGestureRecognizer, secondaryClickGestureRecognizer, setSecondaryClickGestureRecognizer)
+GESTURE_RECOGNIZER_GETTER_SETTER(NSClickGestureRecognizer, _doubleClickGestureRecognizer, doubleClickGestureRecognizer, setDoubleClickGestureRecognizer)
 
 - (void)setUpGestureRecognizers
 {
@@ -859,82 +882,6 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     [self _invokeAndRemovePendingHandlersValidForCurrentPositionInformation];
 }
 
-- (BOOL)_secondaryClickShouldBeginAtLocation:(NSPoint)locationInViewCoordinates
-{
-    WebKit::InteractionInformationRequest request { WebCore::IntPoint { locationInViewCoordinates } };
-
-    bool requestIsValid = _hasValidPositionInformation && _positionInformation.request.isValidForRequest(request);
-    bool isSelectable = _positionInformation.isSelectable();
-    bool isOverSelectableText = _positionInformation.isOverSelectableText;
-
-    // The secondary click owns selectable points that are not over actual text (e.g. the page
-    // background). Over a run of selectable text, the text selection manager should win so that a
-    // long press selects a word instead of synthesizing a context menu.
-    bool shouldBegin = requestIsValid && isSelectable && !isOverSelectableText;
-
-    if (!requestIsValid)
-        [self _invalidateCurrentPositionInformation];
-
-    return shouldBegin;
-}
-
-- (BOOL)_positionInformationRequestIsValidAtLocation:(NSPoint)locationInViewCoordinates withRadius:(NSInteger)radius
-{
-    WebKit::InteractionInformationRequest request { WebCore::IntPoint { locationInViewCoordinates } };
-    return _hasValidPositionInformation && _positionInformation.request.isApproximatelyValidForRequest(request, radius);
-}
-
-- (BOOL)_dragPressShouldBeginAtLocation:(NSPoint)locationInViewCoordinates
-{
-    int radius = static_cast<int>(std::ceil([_dragPressGestureRecognizer allowableMovement]));
-
-    // FIXME: Migrate to requestDragStart: IPC for an authoritative decision.
-    // The heuristic below approximates DragController::draggableElement() by consulting the same element-type and style signals.
-    bool isDraggable = representsDraggableElement(_positionInformation);
-    bool requestIsValid = [self _positionInformationRequestIsValidAtLocation:locationInViewCoordinates withRadius:radius];
-    bool shouldDrag = requestIsValid && isDraggable;
-
-    WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(
-        RefPtr { _page.get() }->logIdentifier(),
-        "Drag-press shouldBegin → %d (hasInfo=%d link=%d image=%d attachment=%d dhtml=%d color=%d prefersDrag=%d radius=%d)",
-        shouldDrag,
-        _hasValidPositionInformation,
-        _positionInformation.isLink,
-        _positionInformation.isImage,
-        _positionInformation.isAttachment,
-        _positionInformation.isDHTMLDraggable,
-        _positionInformation.isColorInput,
-        _positionInformation.prefersDraggingOverTextSelection,
-        radius
-    );
-
-    if (!requestIsValid)
-        [self _invalidateCurrentPositionInformation];
-
-    return shouldDrag;
-}
-
-- (BOOL)_panShouldBeginAtLocation:(NSPoint)locationInViewCoordinates
-{
-    static constexpr int panPositionInformationToleranceRadius = 15;
-    bool requestIsValid = [self _positionInformationRequestIsValidAtLocation:locationInViewCoordinates withRadius:panPositionInformationToleranceRadius];
-
-    // FIXME: (rdar://181964604) Because of this logic, vertically scrolling over these elements likely will not work.
-    bool prefersInteraction = _positionInformation.isRangeInput || _positionInformation.isARIASlider;
-    bool yieldToContent = requestIsValid && prefersInteraction;
-
-    WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(
-        RefPtr { _page.get() }->logIdentifier(),
-        "Pan shouldBegin → %d (hasInfo=%d valid=%d prefersInteraction=%d)",
-        !yieldToContent,
-        _hasValidPositionInformation,
-        requestIsValid,
-        prefersInteraction
-    );
-
-    return !yieldToContent;
-}
-
 #pragma mark - Drag Handling
 
 - (void)dragPressGestureRecognized:(NSGestureRecognizer *)gesture
@@ -1378,203 +1325,6 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     [self _invalidateCurrentPositionInformation];
     _lastOutstandingPositionInformationRequest.reset();
     _pendingPositionInformationHandlers.clear();
-}
-
-#pragma mark - NSGestureRecognizerDelegate
-
-static BOOL isBuiltInScrollViewPanGestureRecognizer(NSGestureRecognizer *recognizer)
-{
-    static Class scrollViewPanGestureClass = NSClassFromString(@"NSScrollViewPanGestureRecognizer");
-    return [recognizer isKindOfClass:scrollViewPanGestureClass];
-}
-
-static inline bool isSamePair(NSGestureRecognizer *a, NSGestureRecognizer *b, NSGestureRecognizer *x, NSGestureRecognizer *y)
-{
-    return (a == x && b == y) || (b == x && a == y);
-}
-
-- (BOOL)gestureRecognizer:(NSGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(NSGestureRecognizer *)otherGestureRecognizer
-{
-    WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG_DEBUG(RefPtr { _page.get() }->logIdentifier(), "Gesture: %@, Other gesture: %@", gestureLogDescription(gestureRecognizer), gestureLogDescription(otherGestureRecognizer));
-
-    if (isSamePair(gestureRecognizer, otherGestureRecognizer, _singleClickGestureRecognizer.get(), _panGestureRecognizer.get()))
-        return YES;
-
-    if ([gestureRecognizer isKindOfClass:WKDeferringGestureRecognizer.class] || [otherGestureRecognizer isKindOfClass:WKDeferringGestureRecognizer.class])
-        return YES;
-
-    if (isSamePair(gestureRecognizer, otherGestureRecognizer, _mouseTrackingGestureRecognizer.get(), _singleClickGestureRecognizer.get()))
-        return YES;
-
-    if (isSamePair(gestureRecognizer, otherGestureRecognizer, _dragPressGestureRecognizer.get(), _singleClickGestureRecognizer.get()))
-        return YES;
-
-    if (isSamePair(gestureRecognizer, otherGestureRecognizer, _dragPressGestureRecognizer.get(), _mouseTrackingGestureRecognizer.get()))
-        return YES;
-
-    if (gestureRecognizer == _singleClickGestureRecognizer
-        && isBuiltInScrollViewPanGestureRecognizer(otherGestureRecognizer)
-        && [otherGestureRecognizer.view isKindOfClass:NSScrollView.class])
-        return YES;
-
-    CheckedPtr viewImpl = _viewImpl.get();
-    if (!viewImpl)
-        return NO;
-
-    RetainPtr webView = viewImpl->view();
-    if (!webView)
-        return NO;
-
-    // Allow the single click or mouse tracking GRs to be simultaneously
-    // recognized with any of those from the text selection manager.
-    for (NSGestureRecognizer *gestureForFailureRequirements in [[webView textSelectionManager] gesturesForFailureRequirements]) {
-        if (isSamePair(gestureRecognizer, otherGestureRecognizer, _singleClickGestureRecognizer.get(), gestureForFailureRequirements))
-            return YES;
-        if (isSamePair(gestureRecognizer, otherGestureRecognizer, _mouseTrackingGestureRecognizer.get(), gestureForFailureRequirements))
-            return YES;
-    }
-
-    return NO;
-}
-
-- (BOOL)gestureRecognizer:(NSGestureRecognizer *)gestureRecognizer shouldBeRequiredToFailByGestureRecognizer:(NSGestureRecognizer *)otherGestureRecognizer
-{
-    WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG_DEBUG(RefPtr { _page.get() }->logIdentifier(), "Gesture: %@, Other gesture: %@", gestureLogDescription(gestureRecognizer), gestureLogDescription(otherGestureRecognizer));
-
-    CheckedPtr viewImpl = _viewImpl.get();
-    if (!viewImpl)
-        return NO;
-
-    RetainPtr webView = viewImpl->view();
-    if (!webView)
-        return NO;
-
-    if ([gestureRecognizer isKindOfClass:WKDeferringGestureRecognizer.class])
-        return [(WKDeferringGestureRecognizer *)gestureRecognizer shouldDeferGestureRecognizer:otherGestureRecognizer];
-
-    // Fail any gestures from the text selection manager if the secondary click GR handles them.
-    for (NSGestureRecognizer *gestureForFailureRequirements in [[webView textSelectionManager] gesturesForFailureRequirements]) {
-        if (gestureRecognizer == _secondaryClickGestureRecognizer && otherGestureRecognizer == gestureForFailureRequirements)
-            return YES;
-    }
-
-    return NO;
-}
-
-- (BOOL)gestureRecognizer:(NSGestureRecognizer *)gestureRecognizer shouldRequireFailureOfGestureRecognizer:(NSGestureRecognizer *)otherGestureRecognizer
-{
-    WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG_DEBUG(RefPtr { _page.get() }->logIdentifier(), "Gesture: %@, Other gesture: %@", gestureLogDescription(gestureRecognizer), gestureLogDescription(otherGestureRecognizer));
-
-    CheckedPtr viewImpl = _viewImpl.get();
-    if (!viewImpl)
-        return NO;
-
-    RetainPtr webView = viewImpl->view();
-    if (!webView)
-        return NO;
-
-    if (gestureRecognizer == _singleClickGestureRecognizer && otherGestureRecognizer == _doubleClickGestureRecognizer)
-        return YES;
-
-    if (gestureRecognizer == _mouseTrackingGestureRecognizer && otherGestureRecognizer == _panGestureRecognizer) {
-        bool panCanScroll = [self panGestureRecognizerCanScroll];
-        WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG_DEBUG(RefPtr { _page.get() }->logIdentifier(), "Mouse tracking requires pan to fail: %d", panCanScroll);
-        return panCanScroll;
-    }
-
-    return NO;
-}
-
-- (BOOL)gestureRecognizerShouldBegin:(NSGestureRecognizer *)gestureRecognizer
-{
-    WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG_DEBUG(RefPtr { _page.get() }->logIdentifier(), "Gesture: %@", gestureLogDescription(gestureRecognizer));
-
-    CheckedPtr viewImpl = _viewImpl.get();
-    if (!viewImpl)
-        return NO;
-
-    RetainPtr webView = viewImpl->view();
-    if (!webView)
-        return NO;
-
-    NSPoint locationInViewCoordinates = [gestureRecognizer locationInView:webView];
-
-    // While catching a decelerating scroll, only select gestures are allowed to begin:
-    // - single click, so it can reset the interruption state
-    // - pan, so it can continue with successive scrolls
-    if (_caughtDeceleratingScroll) {
-        if (gestureRecognizer == _singleClickGestureRecognizer)
-            return YES;
-        if (gestureRecognizer != _panGestureRecognizer)
-            return NO;
-    }
-
-    if (gestureRecognizer == _doubleClickGestureRecognizer)
-        return viewImpl->allowsMagnification();
-
-    if (gestureRecognizer == _secondaryClickGestureRecognizer)
-        return [self _secondaryClickShouldBeginAtLocation:locationInViewCoordinates];
-
-    if (gestureRecognizer == _dragPressGestureRecognizer)
-        return [self _dragPressShouldBeginAtLocation:locationInViewCoordinates];
-
-    if (gestureRecognizer == _panGestureRecognizer)
-        return [self _panShouldBeginAtLocation:locationInViewCoordinates];
-
-    if (gestureRecognizer == _singleClickGestureRecognizer)
-        return !viewImpl->isTextSelectedAtPoint(locationInViewCoordinates);
-
-    if (gestureRecognizer == _mouseTrackingGestureRecognizer)
-        return !viewImpl->isTextSelectedAtPoint(locationInViewCoordinates);
-
-    return YES;
-}
-
-- (BOOL)_isScrollOrZoomGestureRecognizer:(NSGestureRecognizer *)gesture
-{
-    return gesture == _panGestureRecognizer || isBuiltInScrollViewPanGestureRecognizer(gesture) || [gesture isKindOfClass:[NSMagnificationGestureRecognizer class]];
-}
-
-- (BOOL)_gestureRecognizer:(NSGestureRecognizer *)preventingGestureRecognizer canPreventGestureRecognizer:(NSGestureRecognizer *)preventedGestureRecognizer
-{
-    WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG_DEBUG(RefPtr { _page.get() }->logIdentifier(), "Preventing gesture: %@, Prevented gesture: %@", gestureLogDescription(preventingGestureRecognizer), gestureLogDescription(preventedGestureRecognizer));
-
-    CheckedPtr viewImpl = _viewImpl.get();
-    if (!viewImpl)
-        return NO;
-
-    RetainPtr webView = viewImpl->view();
-    if (!webView)
-        return NO;
-
-    // None of our gesture recognizers may prevent an enclosing scroll view's pan (or any other
-    // scroll/zoom) gesture, so that a scroll can always be handed off to the enclosing scroll view
-    // e.g. a scroll over a draggable <img> in a non-scrollable web view.
-    if ([self _isScrollOrZoomGestureRecognizer:preventedGestureRecognizer])
-        return NO;
-
-    bool isOurClickGesture = preventingGestureRecognizer == _singleClickGestureRecognizer
-        || preventingGestureRecognizer == _secondaryClickGestureRecognizer
-        || preventingGestureRecognizer == _mouseTrackingGestureRecognizer
-        || preventingGestureRecognizer == _dragPressGestureRecognizer;
-
-    if (!isOurClickGesture)
-        return YES;
-
-    // Don't let other click gestures prevent the secondary click GR; it must be allowed to fire its
-    // press timer (0.72s) without being short-circuited by gestures that recognize earlier
-    // (e.g. single click and mouse-tracking, which both transition to Began at mouse-down).
-    if (preventedGestureRecognizer == _secondaryClickGestureRecognizer)
-        return NO;
-
-    // Don't let our click gestures prevent text selection manager gestures;
-    // they should be allowed to recognize simultaneously (per shouldRecognizeSimultaneouslyWithGestureRecognizer:).
-    for (NSGestureRecognizer *textSelectionGesture in [[webView textSelectionManager] gesturesForFailureRequirements]) {
-        if (preventedGestureRecognizer == textSelectionGesture)
-            return NO;
-    }
-
-    return YES;
 }
 
 @end

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 55;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -189,6 +189,7 @@
 		076E884E1A13CADF005E90FC /* APIContextMenuClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 076E884D1A13CADF005E90FC /* APIContextMenuClient.h */; };
 		0772811D21234FF600C8EF2E /* UserMediaPermissionRequestManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A410F4319AF7B27002EBAB5 /* UserMediaPermissionRequestManager.h */; };
 		077FD1A02CC7569200C5D9E0 /* WKIntelligenceReplacementTextEffectCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077FD19F2CC7569200C5D9E0 /* WKIntelligenceReplacementTextEffectCoordinator.swift */; };
+		078060EB3004E61300707833 /* WKAppKitGestureController+NSGestureRecognizerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 078060EA3004E61300707833 /* WKAppKitGestureController+NSGestureRecognizerDelegate.swift */; };
 		0785E8002CBCDFFD00F68126 /* PlatformIntelligenceTextEffectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0785E7FF2CBCDFFD00F68126 /* PlatformIntelligenceTextEffectView.swift */; };
 		078B04442CF1149200B453A6 /* URLSchemeHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 078B04432CF1149200B453A6 /* URLSchemeHandler.swift */; };
 		078B04462CF1154B00B453A6 /* WebPage+Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 078B04452CF1154B00B453A6 /* WebPage+Configuration.swift */; };
@@ -3504,6 +3505,7 @@
 		0779D7BC2EA8101800C389D5 /* RemoteMediaSessionProxy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteMediaSessionProxy.cpp; sourceTree = "<group>"; };
 		077BA570260E8F630072F19F /* MediaSessionCoordinatorProxyPrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MediaSessionCoordinatorProxyPrivate.h; sourceTree = "<group>"; };
 		077FD19F2CC7569200C5D9E0 /* WKIntelligenceReplacementTextEffectCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKIntelligenceReplacementTextEffectCoordinator.swift; sourceTree = "<group>"; };
+		078060EA3004E61300707833 /* WKAppKitGestureController+NSGestureRecognizerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WKAppKitGestureController+NSGestureRecognizerDelegate.swift"; sourceTree = "<group>"; };
 		0785E7FF2CBCDFFD00F68126 /* PlatformIntelligenceTextEffectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformIntelligenceTextEffectView.swift; sourceTree = "<group>"; };
 		078B04432CF1149200B453A6 /* URLSchemeHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSchemeHandler.swift; sourceTree = "<group>"; };
 		078B04452CF1154B00B453A6 /* WebPage+Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WebPage+Configuration.swift"; sourceTree = "<group>"; };
@@ -3821,6 +3823,7 @@
 		118502622673B0DA00A6425E /* XRDeviceProxy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = XRDeviceProxy.cpp; sourceTree = "<group>"; };
 		118502632673B0DA00A6425E /* XRDeviceIdentifier.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = XRDeviceIdentifier.h; sourceTree = "<group>"; };
 		118502652673B0DA00A6425E /* XRDeviceInfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = XRDeviceInfo.h; sourceTree = "<group>"; };
+		17CF2486D8134D6FB486C07A /* WKWebView+TextExtraction.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "WKWebView+TextExtraction.mm"; sourceTree = "<group>"; };
 		1A002D3E196B329400B9AD44 /* _WKSessionState.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKSessionState.mm; sourceTree = "<group>"; };
 		1A002D3F196B329400B9AD44 /* _WKSessionState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKSessionState.h; sourceTree = "<group>"; };
 		1A002D42196B337000B9AD44 /* _WKSessionStateInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKSessionStateInternal.h; sourceTree = "<group>"; };
@@ -3862,7 +3865,6 @@
 		1A334DEC16DE8F88006A8E38 /* StorageAreaMapMessages.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StorageAreaMapMessages.h; sourceTree = "<group>"; };
 		1A3C887F18A5ABAE00C4C962 /* WKPreferencesInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKPreferencesInternal.h; sourceTree = "<group>"; };
 		1A3CC16418906ACF001E6ED8 /* WKWebView.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebView.mm; sourceTree = "<group>"; };
-		17CF2486D8134D6FB486C07A /* WKWebView+TextExtraction.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "WKWebView+TextExtraction.mm"; sourceTree = "<group>"; };
 		1A3CC16518906ACF001E6ED8 /* WKWebView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKWebView.h; sourceTree = "<group>"; };
 		1A3CC16818907EB0001E6ED8 /* WKProcessPoolInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKProcessPoolInternal.h; sourceTree = "<group>"; };
 		1A3D610413A7F03A00F95D4E /* ArgumentCoders.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ArgumentCoders.cpp; sourceTree = "<group>"; };
@@ -6891,8 +6893,6 @@
 		5CFECB031E1ED1C800F88504 /* LegacyCustomProtocolManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LegacyCustomProtocolManager.cpp; sourceTree = "<group>"; };
 		5CFFD8472DEF511B00C421F5 /* SwiftDemoLogo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDemoLogo.swift; sourceTree = "<group>"; };
 		5DAD73F1116FF90C00EE5396 /* BaseTarget.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = BaseTarget.xcconfig; sourceTree = "<group>"; };
-		5E55104100000000000A0001 /* SessionHistoryTraversalQueue.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = SessionHistoryTraversalQueue.cpp; sourceTree = "<group>"; };
-		5E55104100000000000A0002 /* SessionHistoryTraversalQueue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SessionHistoryTraversalQueue.h; sourceTree = "<group>"; };
 		5EB592AB2DC2049A0058664B /* BidiStorage.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = BidiStorage.json; sourceTree = "<group>"; };
 		5EEC724B2DC1B30700D012DD /* BidiStorageAgent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = BidiStorageAgent.cpp; sourceTree = "<group>"; };
 		5EEC724D2DC1B31300D012DD /* BidiStorageAgent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BidiStorageAgent.h; sourceTree = "<group>"; };
@@ -17046,6 +17046,7 @@
 				0FD07E4F28A3413700B38C81 /* WebViewImpl.mm */,
 				868160CD18763D4B0021E79D /* WindowServerConnection.h */,
 				868160CF187645370021E79D /* WindowServerConnection.mm */,
+				078060EA3004E61300707833 /* WKAppKitGestureController+NSGestureRecognizerDelegate.swift */,
 				336E07462EBCC1C100B4D635 /* WKAppKitGestureController.h */,
 				336E07472EBCC1C100B4D635 /* WKAppKitGestureController.mm */,
 				073B19992FEFB66B00BD5D69 /* WKAppKitGestureController.swift */,
@@ -22477,6 +22478,7 @@
 				9356F2DF2152B72300E6D5DF /* WebSWOriginStore.cpp in Sources */,
 				9356F2E12152B76600E6D5DF /* WebSWServerConnection.cpp in Sources */,
 				9356F2E02152B75200E6D5DF /* WebSWServerToContextConnection.cpp in Sources */,
+				078060EB3004E61300707833 /* WKAppKitGestureController+NSGestureRecognizerDelegate.swift in Sources */,
 				073B199A2FEFB66B00BD5D69 /* WKAppKitGestureController.swift in Sources */,
 				A190E9422F3DB703009615AD /* WKAVContentSource.mm in Sources */,
 				C6A4CA0C2252899800169289 /* WKBundlePageMac.mm in Sources */,


### PR DESCRIPTION
#### a00d7402b18bc5e028bd85481cd0025205aa9852
<pre>
[AppKit Gestures] Refactor WKAppKitGestureController conformance to NSGestureRecognizerDelegate
<a href="https://bugs.webkit.org/show_bug.cgi?id=319240">https://bugs.webkit.org/show_bug.cgi?id=319240</a>
<a href="https://rdar.apple.com/182086968">rdar://182086968</a>

Reviewed by NOBODY (OOPS!).

Refactor into a separate file.

Also convert to Swift to work towards converting more of WKAppKitGestureController.

* Source/WebKit/Modules/Internal/module.modulemap:
* Source/WebKit/UIProcess/mac/WKAppKitGestureController+NSGestureRecognizerDelegate.swift: Added.
(WKAppKitGestureController.positionInformationRequestIsValid(at:radius:)):
(WKAppKitGestureController.representsDraggableElement(_:)):
(WKAppKitGestureController.secondaryClickShouldBegin(at:)):
(WKAppKitGestureController.dragPressShouldBegin(at:)):
(WKAppKitGestureController.panShouldBegin(at:)):
(WKAppKitGestureController.isScrollOrZoomGestureRecognizer(_:)):
(WKAppKitGestureController.gestureRecognizerShouldBegin(_:)):
(isSamePair(_:_:_:_:)):
(NSGestureRecognizer.isBuiltInScrollViewPan):
* Source/WebKit/UIProcess/mac/WKAppKitGestureController.h:
* Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm:
(-[WKAppKitGestureController hasValidPositionInformation]):
(-[WKAppKitGestureController caughtDeceleratingScroll]):
(-[WKAppKitGestureController positionInformation]):
(-[WKAppKitGestureController panGestureRecognizer]): Deleted.
(-[WKAppKitGestureController setPanGestureRecognizer:]): Deleted.
(-[WKAppKitGestureController _secondaryClickShouldBeginAtLocation:]): Deleted.
(-[WKAppKitGestureController _positionInformationRequestIsValidAtLocation:withRadius:]): Deleted.
(-[WKAppKitGestureController _dragPressShouldBeginAtLocation:]): Deleted.
(-[WKAppKitGestureController _panShouldBeginAtLocation:]): Deleted.
(isBuiltInScrollViewPanGestureRecognizer): Deleted.
(isSamePair): Deleted.
(-[WKAppKitGestureController gestureRecognizer:shouldRecognizeSimultaneouslyWithGestureRecognizer:]): Deleted.
(-[WKAppKitGestureController gestureRecognizer:shouldBeRequiredToFailByGestureRecognizer:]): Deleted.
(-[WKAppKitGestureController gestureRecognizer:shouldRequireFailureOfGestureRecognizer:]): Deleted.
(-[WKAppKitGestureController gestureRecognizerShouldBegin:]): Deleted.
(-[WKAppKitGestureController _isScrollOrZoomGestureRecognizer:]): Deleted.
(-[WKAppKitGestureController _gestureRecognizer:canPreventGestureRecognizer:]): Deleted.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a00d7402b18bc5e028bd85481cd0025205aa9852

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174186 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48119 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41900 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183760 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132054 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/35a3e598-e389-42b4-bb86-13317859c0a5) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49411 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47801 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135482 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95576 "2 flakes 4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8762ccac-8a22-4ceb-8b06-bc82f68f138a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177144 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38913 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156273 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115960 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e8044514-ced0-430e-b219-367a0a80fe1c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37553 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35924 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32244 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147977 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35766 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186186 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39348 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40122 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144387 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47786 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144247 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48465 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32386 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113977 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39151 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120371 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46971 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10728 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46374 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46605 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46432 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->