### PR TITLE
After two runs of a SMIL SVG animation, an SVG item doesn't re-appear

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/scripted/onhover-syncbases-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/scripted/onhover-syncbases-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Check if onhover events reset correctly when triggered multiple times assert_equals: expected "rgb(0, 255, 0)" but got "rgb(255, 0, 0)"
+PASS Check if onhover events reset correctly when triggered multiple times
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/syncbases-with-tangled-dependencies-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/syncbases-with-tangled-dependencies-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Syncbases with tangled dependencies
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/syncbases-with-tangled-dependencies.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/syncbases-with-tangled-dependencies.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<title>Syncbases with tangled dependencies</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<svg viewBox="0 0 500 200" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="100%" fill="none">
+    <animate id="minani" attributeName="x" fill="freeze" begin="min.click" dur="100ms" values="0; 0"/>
+    <animate id="maxani" attributeName="x" fill="freeze" begin="max.click" dur="100ms" values="0; 0"/>
+  </rect>
+  <rect id="min" width="100" height="100" fill="green">
+    <set attributeName="height" fill="freeze" begin="minani.begin" to="0"/>
+    <set attributeName="height" fill="freeze" begin="maxani.begin+0.1s" to="100"/>
+  </rect>
+  <rect id="max" x="110" width="100" height="100" fill="blue"/>
+</svg>
+<script>
+  async_test(t => {
+    let clicks = 3;
+    let min = document.querySelector("#min");
+    let max = document.querySelector("#max");
+    // Remove the visible squares once the test is finished (passes or fails).
+    t.add_cleanup(() => document.querySelector("svg").remove());
+    function round() {
+      clicks--;
+      if (clicks == 0) {
+        t.step_timeout(t.step_func_done(() => {
+          assert_equals(window.getComputedStyle(min, null).height, "100px");
+        }), 500);
+      } else
+        t.step_timeout(round, 250);
+      min.dispatchEvent(new Event("click"));
+      t.step_timeout(() => max.dispatchEvent(new Event("click")), 130);
+    }
+    t.step_timeout(round, 250);
+  });
+</script>

--- a/LayoutTests/svg/animations/restarted-interval-does-not-flash-end-value-expected.txt
+++ b/LayoutTests/svg/animations/restarted-interval-does-not-flash-end-value-expected.txt
@@ -1,0 +1,3 @@
+
+PASS SMIL: a restarting animation must not flash its previous interval's end value
+

--- a/LayoutTests/svg/animations/restarted-interval-does-not-flash-end-value.html
+++ b/LayoutTests/svg/animations/restarted-interval-does-not-flash-end-value.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<title>SMIL: a restarting animation must not flash its previous interval's end value</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<!--
+  Regression test for https://bugs.webkit.org/show_bug.cgi?id=196596
+
+  #mover animates x from 0 to 300 and restarts back-to-back at t=1s (begin="0s;1s", dur="1s", so
+  its second interval begins exactly when the first ends). #holder is a lower-priority animation
+  that freezes x at 100 and wins the sandwich until #mover restarts. When #mover's second interval
+  begins at 1s it becomes the highest-priority (latest begin) contributor and must show the START
+  of that interval (~0), NOT the END/destination of its previous interval (300).
+
+  The bug computed the animation percent against the previous interval (which had just ended, so
+  percent clamped to 1 -> the destination value 300) before checkRestart() advanced to the new
+  interval, so the crossover frame briefly applied 300 for ~1-2 frames before correcting. Because
+  the restart is an Active->Active transition, no beginEvent fires; the flash is observed by
+  sampling x across the crossover. See the follow-up fix that moved the percent computation to
+  after the interval is resolved.
+-->
+<svg id="svg" width="400" height="120" xmlns="http://www.w3.org/2000/svg">
+  <rect id="target" x="0" y="0" width="20" height="20" fill="green">
+    <animate id="holder" attributeName="x" begin="0.5s" dur="0.1s" values="100;100" fill="freeze"/>
+    <animate id="mover" attributeName="x" begin="0s;1s" dur="1s" values="0;300" fill="freeze"/>
+  </rect>
+</svg>
+<script>
+async_test(t => {
+  const svg = document.getElementById("svg");
+  const target = document.getElementById("target");
+  let sampledCrossover = false;
+
+  function frame() {
+    const ct = svg.getCurrentTime();
+    const x = target.x.animVal.value;
+
+    // Just after the back-to-back restart at 1s, x must be near the new interval's start (0), not
+    // the previous interval's end (300). The buggy code applied 300 for the crossover frame(s).
+    if (ct >= 1.0 && ct <= 1.2) {
+      sampledCrossover = true;
+      assert_less_than(x, 150,
+        `x=${x.toFixed(1)} at t=${ct.toFixed(3)}s: the restart frame flashed the previous interval's end value (300)`);
+    }
+
+    if (ct > 1.3) {
+      assert_true(sampledCrossover, "sampled at least one frame just after the restart");
+      t.done();
+      return;
+    }
+    requestAnimationFrame(t.step_func(frame));
+  }
+  requestAnimationFrame(t.step_func(frame));
+});
+</script>

--- a/Source/WebCore/svg/animation/SMILTimeContainer.cpp
+++ b/Source/WebCore/svg/animation/SMILTimeContainer.cpp
@@ -276,6 +276,14 @@ void SMILTimeContainer::updateAnimations(SMILTime elapsed, bool seekToTime)
     SMILTime earliestFireTime = SMILTime::unresolved();
 
     for (auto& animations : copyToVector(m_scheduledAnimations.values())) {
+        // Advance every animation's current interval to `elapsed` before sorting. An animation
+        // whose interval only restarts at (or before) the current time -- e.g. a sync-base
+        // dependent that just gained a new, later begin time -- must be sorted using that new
+        // interval, otherwise a lower-priority animation could incorrectly win the sandwich and
+        // its result would be applied last.
+        for (Ref animation : animations)
+            animation->updateIntervalForProgress(elapsed, seekToTime);
+
         // Sort according to priority. Elements with later begin time have higher priority.
         // In case of a tie, document order decides.
         // FIXME: This should also consider timing relationships between the elements. Dependents
@@ -283,8 +291,7 @@ void SMILTimeContainer::updateAnimations(SMILTime elapsed, bool seekToTime)
         sortByPriority(animations, elapsed);
 
         RefPtr<SVGSMILElement> firstAnimation;
-        for (auto& weakAnimation : animations) {
-            Ref animation = weakAnimation.get();
+        for (Ref animation : animations) {
             ASSERT(animation->timeContainer() == this);
             ASSERT(animation->targetElement());
             ASSERT(animation->hasValidAttributeName());

--- a/Source/WebCore/svg/animation/SVGSMILElement.cpp
+++ b/Source/WebCore/svg/animation/SVGSMILElement.cpp
@@ -239,6 +239,7 @@ void SVGSMILElement::reset()
     stopAnimation(protect(targetElement()).get());
 
     m_activeState = Inactive;
+    m_previousActiveState = Inactive;
     m_isWaitingForFirstInterval = true;
     m_intervalBegin = SMILTime::unresolved();
     m_intervalEnd = SMILTime::unresolved();
@@ -1008,7 +1009,7 @@ void SVGSMILElement::checkRestart(SMILTime elapsed)
         if (restart != RestartAlways)
             return;
         SMILTime nextBegin = findInstanceTime(Begin, m_intervalBegin, false);
-        if (nextBegin < m_intervalEnd) { 
+        if (nextBegin < m_intervalEnd) {
             m_intervalEnd = nextBegin;
             notifyDependentsIntervalChanged();
         }
@@ -1134,21 +1135,69 @@ bool SVGSMILElement::isContributing(SMILTime elapsed) const
     return (m_activeState == Active && (fill() == FillFreeze || elapsed <= m_intervalBegin + repeatingDuration())) || m_activeState == Frozen;
 }
     
+void SVGSMILElement::updateIntervalForProgress(SMILTime elapsed, bool seekToTime)
+{
+    ASSERT(m_timeContainer);
+
+    if (!m_conditionsConnected)
+        connectConditions();
+
+    // Remember the state at the start of the frame so progress() can fire begin/end events for
+    // whatever transition happens now.
+    m_previousActiveState = m_activeState;
+
+    if (!m_intervalBegin.isFinite()) {
+        m_progressDisposition = ProgressDisposition::NotContributing;
+        return;
+    }
+
+    // The interval hasn't begun yet: keep the current (frozen or inactive) state.
+    if (elapsed < m_intervalBegin) {
+        m_progressDisposition = ProgressDisposition::BeforeInterval;
+        return;
+    }
+
+    m_previousIntervalBegin = m_intervalBegin;
+
+    if (m_isWaitingForFirstInterval) {
+        m_isWaitingForFirstInterval = false;
+        resolveFirstInterval();
+    }
+
+    if (seekToTime) {
+        seekToIntervalCorrespondingToTime(elapsed);
+        if (elapsed < m_intervalBegin) {
+            // elapsed is not within an interval.
+            m_progressDisposition = ProgressDisposition::NotContributing;
+            return;
+        }
+    }
+
+    // Resolve the current interval before progress() computes the animation percent. checkRestart()
+    // may end the current interval and start a new one; computing the percent afterwards (in
+    // progress(), against the resolved interval) ensures a just-restarted interval yields ~0 rather
+    // than the previous interval's end value. See https://bugs.webkit.org/show_bug.cgi?id=196596
+    checkRestart(elapsed);
+
+    m_activeState = determineActiveState(elapsed);
+    m_progressDisposition = ProgressDisposition::Resolved;
+}
+
 bool SVGSMILElement::progress(SMILTime elapsed, SVGSMILElement& firstAnimation, bool seekToTime)
 {
     ASSERT(m_timeContainer);
     ASSERT(m_isWaitingForFirstInterval || m_intervalBegin.isFinite());
 
-    if (!m_conditionsConnected)
-        connectConditions();
-
-    if (!m_intervalBegin.isFinite()) {
-        ASSERT(m_activeState == Inactive);
-        m_nextProgressTime = SMILTime::unresolved();
+    // The interval and active state for this frame were resolved by updateIntervalForProgress(),
+    // which runs for every scheduled animation before they are sorted by priority.
+    switch (m_progressDisposition) {
+    case ProgressDisposition::NotContributing:
+        // Either the interval is unresolved (m_intervalBegin is unresolved) or a seek landed before
+        // the interval began; in both cases m_intervalBegin is the next time worth revisiting.
+        m_nextProgressTime = m_intervalBegin;
         return false;
-    }
 
-    if (elapsed < m_intervalBegin) {
+    case ProgressDisposition::BeforeInterval: {
         ASSERT(m_activeState != Active);
         bool isFrozen = (m_activeState == Frozen);
         if (isFrozen) {
@@ -1161,29 +1210,22 @@ bool SVGSMILElement::progress(SMILTime elapsed, SVGSMILElement& firstAnimation, 
         return isFrozen;
     }
 
-    m_previousIntervalBegin = m_intervalBegin;
-
-    if (m_isWaitingForFirstInterval) {
-        m_isWaitingForFirstInterval = false;
-        resolveFirstInterval();
+    case ProgressDisposition::Resolved:
+        break;
     }
 
-    // This call may obtain a new interval -- never call calculateAnimationPercentAndRepeat() before!
-    if (seekToTime) {
-        seekToIntervalCorrespondingToTime(elapsed);
-        if (elapsed < m_intervalBegin) {
-            // elapsed is not within an interval.
-            m_nextProgressTime = m_intervalBegin;
-            return false;
-        }
-    }
-
+    // Compute the percent/repeat against the interval resolved by updateIntervalForProgress().
     unsigned repeat = 0;
-    float percent = calculateAnimationPercentAndRepeat(elapsed, repeat);
-    checkRestart(elapsed);
+    float percent = 0;
+    if (elapsed < m_intervalBegin) {
+        // checkRestart() advanced us to an interval that begins in the future (a gap between
+        // intervals); a frozen element holds its last value until that interval begins.
+        percent = m_lastPercent;
+        repeat = m_lastRepeat;
+    } else
+        percent = calculateAnimationPercentAndRepeat(elapsed, repeat);
 
-    ActiveState oldActiveState = m_activeState;
-    m_activeState = determineActiveState(elapsed);
+    ActiveState oldActiveState = m_previousActiveState;
     bool animationIsContributing = isContributing(elapsed);
 
     if (animationIsContributing) {

--- a/Source/WebCore/svg/animation/SVGSMILElement.h
+++ b/Source/WebCore/svg/animation/SVGSMILElement.h
@@ -84,6 +84,7 @@ public:
     SMILTime simpleDuration() const;
 
     void seekToIntervalCorrespondingToTime(SMILTime elapsed);
+    void updateIntervalForProgress(SMILTime elapsed, bool seekToTime);
     bool progress(SMILTime elapsed, SVGSMILElement& firstAnimation, bool seekToTime);
     SMILTime NODELETE nextProgressTime() const;
 
@@ -208,6 +209,14 @@ private:
     ActiveState m_activeState { Inactive };
     float m_lastPercent { 0 };
     unsigned m_lastRepeat { 0 };
+
+    // How updateIntervalForProgress() resolved the current interval for this frame, and the active
+    // state at the start of the frame; progress() consumes both (after the animations have been
+    // sorted by priority) to apply the value and fire begin/end events. NotContributing covers both
+    // an unresolved interval and a seek that landed before the interval began.
+    enum class ProgressDisposition : uint8_t { NotContributing, BeforeInterval, Resolved };
+    ProgressDisposition m_progressDisposition { ProgressDisposition::NotContributing };
+    ActiveState m_previousActiveState { Inactive };
 
     SMILTime m_nextProgressTime { 0 };
 


### PR DESCRIPTION
#### 1e92d3b75ea2374dd1343c066f82dbe719d80bec
<pre>
After two runs of a SMIL SVG animation, an SVG item doesn&apos;t re-appear
<a href="https://bugs.webkit.org/show_bug.cgi?id=196596">https://bugs.webkit.org/show_bug.cgi?id=196596</a>
<a href="https://rdar.apple.com/49631053">rdar://49631053</a>

Reviewed by Nikolas Zimmermann.

When several SMIL animations target the same element/attribute (a &quot;sandwich&quot;),
SMILTimeContainer::updateAnimations() sorts them by priority and applies their results in that
order, so the highest-priority (latest begin time) animation wins. The priority sort ran before
each animation&apos;s progress() advanced its current interval to the current time. An animation whose
interval only restarts at (or before) the current time — e.g. a sync-base dependent that just
gained a new, later begin time — was therefore sorted using its stale, earlier interval begin,
lost the sandwich to a lower-priority animation, and its result was overwritten. This is why, after
toggling minimize/maximize twice, the element failed to re-appear.

Fix this by resolving every scheduled animation&apos;s current interval (and active state) up front, in
a new updateIntervalForProgress() pass that runs before the priority sort, and having progress()
apply the value and fire events against that already-resolved state. progress() is now driven by a
ProgressDisposition recorded during that pass, which preserves each of the original early-outs via
two dispositions: NotContributing (an unresolved interval, or a seek landing before the interval)
and BeforeInterval (an interval not yet begun). The remaining Resolved disposition still fires
begin/end events for an interval that ends into a frozen state mid-frame.

The animation percent is now computed in progress(), after the interval has been resolved, rather
than before checkRestart(). Previously, on the frame an interval restarted, the percent was
computed against the just-ended interval (clamping to 1, i.e. the destination value), so the
restarting animation briefly painted its end value for one frame before correcting. Computing the
percent against the resolved interval yields ~0 (the interval&apos;s start) on that frame.

Tests: imported/w3c/web-platform-tests/svg/animations/syncbases-with-tangled-dependencies.html
       svg/animations/restarted-interval-does-not-flash-end-value.html

* LayoutTests/imported/w3c/web-platform-tests/svg/animations/scripted/onhover-syncbases-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/syncbases-with-tangled-dependencies-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/syncbases-with-tangled-dependencies.html: Added.
* LayoutTests/svg/animations/restarted-interval-does-not-flash-end-value-expected.txt: Added.
* LayoutTests/svg/animations/restarted-interval-does-not-flash-end-value.html: Added.
* Source/WebCore/svg/animation/SMILTimeContainer.cpp:
(WebCore::SMILTimeContainer::updateAnimations):
* Source/WebCore/svg/animation/SVGSMILElement.cpp:
(WebCore::SVGSMILElement::reset):
(WebCore::SVGSMILElement::checkRestart):
(WebCore::SVGSMILElement::updateIntervalForProgress):
(WebCore::SVGSMILElement::progress):
* Source/WebCore/svg/animation/SVGSMILElement.h:

Canonical link: <a href="https://commits.webkit.org/317272@main">https://commits.webkit.org/317272@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e4e1a2fe5125b53253d7a564c474b15964a43b4c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174701 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48634 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42415 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184280 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132569 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176566 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49926 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48317 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135937 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177659 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39371 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156724 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116415 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38012 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36388 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32759 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148435 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36216 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186706 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/40110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40586 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144861 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48301 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156280 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144721 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39019 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48981 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32837 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114760 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39594 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121081 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47487 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11184 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46889 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47120 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46947 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->