### PR TITLE
Web Inspector: removing a DOM breakpoint deletes sibling breakpoints that share the same URL

### DIFF
--- a/LayoutTests/inspector/dom-debugger/dom-breakpoints-expected.txt
+++ b/LayoutTests/inspector/dom-debugger/dom-breakpoints-expected.txt
@@ -18,6 +18,16 @@ Removing all breakpoints for #multiple-breakpoints-test...
 PASS: Should remove all breakpoints.
 -- Running test teardown.
 
+-- Running test case: DOMBreakpoint.RemoveDoesNotEvictSiblingSharingURL
+Adding "subtree-modified:1,HTML,1,BODY,1,DIV,2,DIV" DOM Breakpoint...
+Adding "subtree-modified:1,HTML,1,BODY,1,DIV,3,DIV" DOM Breakpoint...
+PASS: First breakpoint URL should match document URL.
+PASS: Second breakpoint URL should match document URL.
+Removing the first breakpoint...
+PASS: URL map should still contain the sibling breakpoint after removing its sibling.
+PASS: Remaining URL-mapped breakpoint should be the sibling that was not removed.
+-- Running test teardown.
+
 -- Running test case: DOMBreakpoint.SetBreakpointWithInvalidNodeId
 Setting breakpoint...
 PASS: Should produce an exception.

--- a/LayoutTests/inspector/dom-debugger/dom-breakpoints.html
+++ b/LayoutTests/inspector/dom-debugger/dom-breakpoints.html
@@ -44,6 +44,34 @@ function test()
     });
 
     suite.addTestCase({
+        name: "DOMBreakpoint.RemoveDoesNotEvictSiblingSharingURL",
+        description: "Removing one DOM breakpoint should not evict sibling breakpoints that share the same URL from the URL map.",
+        async test() {
+            let url = WI.networkManager.mainFrame.url;
+
+            let node1 = await InspectorTest.DOMBreakpoint.awaitQuerySelector("#sibling-shared-url-test-1");
+            let node2 = await InspectorTest.DOMBreakpoint.awaitQuerySelector("#sibling-shared-url-test-2");
+
+            let breakpoint1 = await InspectorTest.DOMBreakpoint.createBreakpoint(node1, WI.DOMBreakpoint.Type.SubtreeModified);
+            let breakpoint2 = await InspectorTest.DOMBreakpoint.createBreakpoint(node2, WI.DOMBreakpoint.Type.SubtreeModified);
+
+            InspectorTest.expectEqual(breakpoint1.url, url, "First breakpoint URL should match document URL.");
+            InspectorTest.expectEqual(breakpoint2.url, url, "Second breakpoint URL should match document URL.");
+
+            InspectorTest.log("Removing the first breakpoint...");
+            WI.domDebuggerManager.removeDOMBreakpoint(breakpoint1);
+
+            // The URL map is what re-resolves breakpoints to nodes after a navigation. Removing the
+            // first breakpoint must not evict its sibling (which shares the document URL) from the map.
+            let remainingForURL = WI.domDebuggerManager._domBreakpointURLMap.get(url);
+            remainingForURL = remainingForURL ? Array.from(remainingForURL) : [];
+            InspectorTest.expectEqual(remainingForURL.length, 1, "URL map should still contain the sibling breakpoint after removing its sibling.");
+            InspectorTest.expectEqual(remainingForURL[0], breakpoint2, "Remaining URL-mapped breakpoint should be the sibling that was not removed.");
+        },
+        teardown: InspectorTest.DOMBreakpoint.teardown,
+    });
+
+    suite.addTestCase({
         name: "DOMBreakpoint.SetBreakpointWithInvalidNodeId",
         description: "Check that setting a breakpoint for a nonexistant node returns an error.",
         async test() {
@@ -100,6 +128,8 @@ function test()
 <div id="test-container" style="display: none">
     <div id="basic-test"></div>
     <div id="remove-all-breakpoints-for-node-test"></div>
+    <div id="sibling-shared-url-test-1"></div>
+    <div id="sibling-shared-url-test-2"></div>
 </div>
 </body>
 </html>

--- a/Source/WebInspectorUI/UserInterface/Controllers/DOMDebuggerManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/DOMDebuggerManager.js
@@ -287,7 +287,7 @@ WI.DOMDebuggerManager = class DOMDebuggerManager extends WI.Object
         breakpoint.disabled = true;
         breakpoint.clearActions();
 
-        this._domBreakpointURLMap.delete(breakpoint.url);
+        this._domBreakpointURLMap.delete(breakpoint.url, breakpoint);
 
         if (breakpoint.domNode) {
             if (breakpoint.domNode.frame) {


### PR DESCRIPTION
#### 16b731767043e9593b5a3589cc716612547a5c17
<pre>
Web Inspector: removing a DOM breakpoint deletes sibling breakpoints that share the same URL
<a href="https://bugs.webkit.org/show_bug.cgi?id=319243">https://bugs.webkit.org/show_bug.cgi?id=319243</a>
<a href="https://rdar.apple.com/182090330">rdar://182090330</a>

Reviewed by Devin Rousso.

`_domBreakpointURLMap` is a `Multimap` keyed by frame URL, so every DOM
breakpoint on a page is stored under the same key. `removeDOMBreakpoint`
called `_domBreakpointURLMap.delete(breakpoint.url)` with a single
argument, which `Multimap.delete` treats as &quot;remove the entire key&quot; —
evicting every sibling breakpoint sharing that URL from the map.

The surviving breakpoints stayed attached for the current page, but the
URL map is what re-resolves breakpoints to nodes on navigation (via
`_speculativelyResolveDOMBreakpointsForURL` and `_nodeInserted`), so
after a reload the siblings silently failed to re-resolve and stopped
breaking.

Pass the breakpoint as the second argument so only that value is
removed, matching the two-arg `_domBreakpointFrameIdentifierMap.delete`
form used just below.

* LayoutTests/inspector/dom-debugger/dom-breakpoints-expected.txt:
* LayoutTests/inspector/dom-debugger/dom-breakpoints.html:
* Source/WebInspectorUI/UserInterface/Controllers/DOMDebuggerManager.js:
(WI.DOMDebuggerManager.prototype.removeDOMBreakpoint):

Canonical link: <a href="https://commits.webkit.org/317054@main">https://commits.webkit.org/317054@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c630726117e262c656d411e46a9c63c081737d0e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174196 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48129 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41910 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183770 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132064 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8b04b6d0-a556-4c5d-9ec8-fe877be652e8) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49421 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47811 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135494 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9aaba2e0-3487-46cc-9a66-950ddac70854) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177154 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38923 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156283 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115972 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5580a8f0-f37a-432c-b8ef-c470207f0965) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37563 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35934 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32254 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147987 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35776 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186196 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39364 "Found 1026 new failures in b3/testb3_7.cpp, b3/B3Value.h, WebProcess/Network/WebResourceLoader.cpp, jit/OperationResult.h, UIProcess/WebProcessPool.cpp, Shared/Cocoa/WKNSArray.mm, heap/WeakSet.h, API/tests/Regress141275.mm, Shared/SessionState.cpp, NetworkProcess/NetworkResourceLoadParameters.cpp ...") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40132 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144399 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47796 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155838 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144258 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38885 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48475 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32396 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113993 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39163 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120383 "Found 119 new failures in b3/B3Value.h, b3/testb3_7.cpp, WebProcess/Network/WebResourceLoader.cpp, UIProcess/WebProcessPool.cpp, Shared/Cocoa/WKNSArray.mm, Shared/SessionState.cpp, NetworkProcess/NetworkResourceLoadParameters.cpp, WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm, WebProcess/WebPage/WebPage.cpp, WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm ...") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46981 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10738 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46384 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46615 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46442 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->