### PR TITLE
REGRESSION(316802@main) : imported/blink/fast/backgrounds/bug420029.html constantly crashing in Debug

### DIFF
--- a/Source/WebCore/platform/graphics/CrossfadeGeneratedImage.cpp
+++ b/Source/WebCore/platform/graphics/CrossfadeGeneratedImage.cpp
@@ -46,6 +46,10 @@ static void drawCrossfadeSubimage(GraphicsContext& context, Image& image, Compos
 {
     FloatSize imageSize = image.size();
 
+    // A zero-sized image would produce a non-finite scale below, poisoning the CTM.
+    if (imageSize.isEmpty())
+        return;
+
     // SVGImage resets the opacity when painting, so we have to use transparency layers to accurately paint one at a given opacity.
     bool useTransparencyLayer = image.drawsSVGImage();
 
@@ -93,7 +97,7 @@ ImageDrawResult CrossfadeGeneratedImage::draw(GraphicsContext& context, const Fl
     context.setCompositeOperation(options.compositeOperator(), options.blendMode());
     context.clip(dstRect);
     context.translate(dstRect.location());
-    if (dstRect.size() != srcRect.size())
+    if (dstRect.size() != srcRect.size() && !srcRect.isEmpty())
         context.scale(dstRect.size() / srcRect.size());
     context.translate(-srcRect.location());
     


### PR DESCRIPTION
#### e9ba1c28e0567333b945e857e56c451268661409
<pre>
REGRESSION(316802@main) : imported/blink/fast/backgrounds/bug420029.html constantly crashing in Debug
<a href="https://bugs.webkit.org/show_bug.cgi?id=319242">https://bugs.webkit.org/show_bug.cgi?id=319242</a>

Reviewed by Carlos Garcia Campos.

CrossfadeGeneratedImage computed its scale factor with an unguarded
FloatSize / FloatSize division. When a cross-fade source image has an
empty size, the divisor is zero and the resulting non-finite scale
poisons the CTM, so every image drawn afterwards is recorded under a
NaN/inf transform.

This was harmless until the recording started using an SkBBHFactory,
whose bounds pass maps each op&apos;s transform and aborts in Skia&apos;s
computeFastBounds() when the rectangle is not sorted.

Skip the scale when the source image or srcRect is empty, keeping the
transform finite.

Covered by imported/blink/fast/backgrounds/bug420029.html

* Source/WebCore/platform/graphics/CrossfadeGeneratedImage.cpp:
(WebCore::drawCrossfadeSubimage):
(WebCore::CrossfadeGeneratedImage::draw):

Canonical link: <a href="https://commits.webkit.org/317040@main">https://commits.webkit.org/317040@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b09b7d969535e64d7fb2f1bf814413431c6a0aed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174198 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48131 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41912 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183772 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132066 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176063 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49423 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47813 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135495 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177156 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38928 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156288 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115973 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37568 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35937 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32256 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147992 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35781 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186198 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/39398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40135 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144401 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47798 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144260 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38873 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48477 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32401 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113997 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39167 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120387 "Found 1059 new failures in b3/testb3_7.cpp, b3/B3Value.h, WebProcess/Network/WebResourceLoader.cpp, jit/OperationResult.h, UIProcess/WebProcessPool.cpp, testing/MockMediaSessionCoordinator.cpp, Shared/Cocoa/WKNSArray.mm, heap/WeakSet.h, API/tests/Regress141275.mm, Shared/SessionState.cpp ...") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46983 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10743 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46386 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46617 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46444 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->