### PR TITLE
Improve `ScrollingTreeCoordinated` layer hit testing

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -4319,7 +4319,6 @@ imported/w3c/web-platform-tests/css/css-scroll-snap/snap-at-user-scroll-end.html
 imported/w3c/web-platform-tests/css/css-transforms/scroll-preserve-3d.html [ Skip ]
 imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-scroll-within.html [ Skip ]
-imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-touch-scroll.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/popovers/popover-self-invoke.html [ Skip ]
 imported/w3c/web-platform-tests/uievents/order-of-events/mouse-events/wheel-scrolling.html [ Skip ]
 
@@ -4770,7 +4769,6 @@ webkit.org/b/204115 imported/w3c/web-platform-tests/pointerevents/pointerevent_s
 webkit.org/b/204115 imported/w3c/web-platform-tests/pointerevents/pointerevent_setpointercapture_to_same_element_twice.html?touch [ Skip ]
 webkit.org/b/204115 imported/w3c/web-platform-tests/pointerevents/pointerevent_pointerrawupdate_changes_pointer_capture.https.html [ Skip ]
 
-imported/w3c/web-platform-tests/pointerevents/pointerevent_hit_test_scroll_visible_descendant.html [ Skip ]
 imported/w3c/web-platform-tests/pointerevents/pointer-events-none-skip-scroll-in-iframe.html [ Skip ]
 imported/w3c/web-platform-tests/pointerevents/pointer-events-none-skip-scroll-will-change-in-iframe.html [ Skip ]
 imported/w3c/web-platform-tests/pointerevents/pointerevent_attributes.html?pen [ Skip ]

--- a/Source/WebCore/page/scrolling/coordinated/ScrollingTreeCoordinated.cpp
+++ b/Source/WebCore/page/scrolling/coordinated/ScrollingTreeCoordinated.cpp
@@ -112,56 +112,185 @@ void ScrollingTreeCoordinated::didCompletePlatformRenderingUpdate()
     renderingUpdateComplete();
 }
 
-static bool traverseDescendantLayersAtPoint(const Ref<CoordinatedPlatformLayer>& parent, const FloatPoint& point, const Function<bool(const Ref<CoordinatedPlatformLayer>&, const FloatPoint&)>& function)
+using LayerAndPoint = std::pair<Ref<CoordinatedPlatformLayer>, FloatPoint>;
+
+static void collectDescendantLayersAtPoint(Vector<LayerAndPoint, 16>& layersAtPoint, const Ref<CoordinatedPlatformLayer>& parent, const FloatPoint& point, const std::function<bool(const Ref<CoordinatedPlatformLayer>&, const FloatPoint&)>& transformedPointFunction)
 {
-    assertIsHeld(parent->lock());
-    for (auto& child : parent->children() | std::views::reverse) {
-        Locker childLocker { child->lock() };
-        FloatPoint transformedPoint(point);
-        if (child->transform().isInvertible()) {
-            float originX = child->anchorPoint().x() * child->size().width();
-            float originY = child->anchorPoint().y() * child->size().height();
-            auto transform = *(TransformationMatrix()
-                .translate3d(originX + child->position().x() - parent->boundsOrigin().x(), originY + child->position().y() - parent->boundsOrigin().y(), child->anchorPoint().z())
-                .multiply(child->transform())
-                .translate3d(-originX, -originY, -child->anchorPoint().z()).inverse());
-            auto pointInChildSpace = transform.projectPoint(point);
-            transformedPoint.set(pointInChildSpace.x(), pointInChildSpace.y());
+    Vector<Ref<CoordinatedPlatformLayer>> children;
+    FloatPoint parentBoundsOrigin;
+    {
+        Locker parentLocker { parent->lock() };
+
+        if (parent->masksToBounds() && !parent->bounds().contains(point))
+            return;
+
+        if (RefPtr mask = parent->mask()) {
+            Locker maskLocker { mask->lock() };
+            if (!mask->bounds().contains(point))
+                return;
         }
-        if (traverseDescendantLayersAtPoint(child, transformedPoint, function))
-            return true;
+
+        children = parent->children();
+        parentBoundsOrigin = parent->boundsOrigin();
     }
 
-    if (parent->bounds().contains(point) && parent->eventRegion().contains(roundedIntPoint(point))) {
-        if (function(parent, point))
-            return true;
+    for (auto& layer : children) {
+        FloatPoint transformedPoint;
+        bool handlesEvent;
+        bool hasChildren;
+        {
+            Locker layerLocker { layer->lock() };
+
+            if (!layer->transform().isInvertible())
+                continue;
+
+            float originX = layer->anchorPoint().x() * layer->size().width();
+            float originY = layer->anchorPoint().y() * layer->size().height();
+
+            auto transform = TransformationMatrix()
+                .translate3d(originX + layer->position().x() - parentBoundsOrigin.x(), originY + layer->position().y() - parentBoundsOrigin.y(), layer->anchorPoint().z())
+                .multiply(layer->transform())
+                .translate3d(-originX, -originY, -layer->anchorPoint().z())
+                .inverse()
+                .value();
+
+            transformedPoint = transform.projectPoint(point);
+
+            handlesEvent = [&] {
+                assertIsHeld(layer->lock());
+                if (layer->bounds().isEmpty())
+                    return false;
+                if (!layer->bounds().contains(transformedPoint))
+                    return false;
+                if (transformedPointFunction)
+                    return transformedPointFunction(layer, transformedPoint);
+                return true;
+            }();
+
+            hasChildren = !layer->children().isEmpty();
+        }
+
+        if (handlesEvent)
+            layersAtPoint.append({ layer, transformedPoint });
+
+        if (hasChildren)
+            collectDescendantLayersAtPoint(layersAtPoint, layer, transformedPoint, transformedPointFunction);
     }
+}
+
+static bool layerEventRegionContainsPoint(const Ref<CoordinatedPlatformLayer>& layer, const FloatPoint& localPoint)
+{
+    assertIsHeld(layer->lock());
+    // Scrolling changes boundsOrigin on the scroll container layer, but we computed its event region ignoring scroll position, so factor out bounds origin.
+    auto originRelativePoint = localPoint - toFloatSize(layer->boundsOrigin());
+    return layer->eventRegion().contains(roundedIntPoint(originRelativePoint));
+}
+
+static Vector<LayerAndPoint, 16> layersAtPointToCheckForScrolling(const Ref<CoordinatedPlatformLayer>& parent, const FloatPoint& point, bool& hasAnyNonInteractiveScrollingLayers)
+{
+    Vector<LayerAndPoint, 16> layersAtPoint;
+    collectDescendantLayersAtPoint(layersAtPoint, parent, point, [&] (auto layer, auto transformedPoint) {
+        assertIsHeld(layer->lock());
+        if (layerEventRegionContainsPoint(layer, transformedPoint))
+            return true;
+        if (layer->scrollingNodeID()) {
+            hasAnyNonInteractiveScrollingLayers = true;
+            return true;
+        }
+        return false;
+    });
+    // Hit-test front to back.
+    layersAtPoint.reverse();
+    return layersAtPoint;
+}
+
+static bool isScrolledBy(const ScrollingTree& tree, ScrollingNodeID scrollingNodeID, const RefPtr<CoordinatedPlatformLayer>& hitLayer)
+{
+    for (auto layer = hitLayer; layer;) {
+        Locker layerLocker { layer->lock() };
+
+        auto nodeID = layer->scrollingNodeID();
+        if (nodeID == scrollingNodeID)
+            return true;
+
+        RefPtr scrollingNode = tree.nodeForID(nodeID);
+        if (RefPtr proxyNode = dynamicDowncast<ScrollingTreeOverflowScrollProxyNode>(scrollingNode)) {
+            auto actingOverflowScrollingNodeID = proxyNode->overflowScrollingNodeID();
+            if (actingOverflowScrollingNodeID == scrollingNodeID)
+                return true;
+        }
+
+        if (RefPtr positionedNode = dynamicDowncast<ScrollingTreePositionedNode>(scrollingNode)) {
+            if (positionedNode->relatedOverflowScrollingNodes().contains(scrollingNodeID))
+                return false;
+        }
+
+        layer = layer->parent();
+    }
+
     return false;
 }
 
 RefPtr<ScrollingTreeNode> ScrollingTreeCoordinated::scrollingNodeForPoint(FloatPoint point)
 {
-    auto* rootScrollingNode = rootNode();
+    RefPtr rootScrollingNode = rootNode();
     if (!rootScrollingNode)
         return nullptr;
 
-    Locker layerLocker { m_layerHitTestMutex };
+    Locker locker { m_layerHitTestMutex };
 
-    auto rootContentsLayer = static_cast<ScrollingTreeFrameScrollingNodeCoordinated*>(rootScrollingNode)->rootContentsLayer();
-    Locker rootContentsLayerLocker { rootContentsLayer->lock() };
+    auto rootContentsLayer = static_cast<ScrollingTreeFrameScrollingNodeCoordinated*>(rootScrollingNode.get())->rootContentsLayer();
+    FloatPoint scrollOrigin = rootScrollingNode->scrollOrigin();
+    auto pointInContentsLayer = point;
+    pointInContentsLayer.moveBy(scrollOrigin);
 
-    RefPtr<ScrollingTreeNode> result = rootScrollingNode;
-    traverseDescendantLayersAtPoint(Ref { *rootContentsLayer }, point, [&](const Ref<CoordinatedPlatformLayer>& layer, const FloatPoint&) {
-        assertIsHeld(layer->lock());
-        if (!layer->scrollingNodeID())
-            return false;
-        auto* scrollingNode = nodeForID(layer->scrollingNodeID());
-        if (is<ScrollingTreeScrollingNode>(scrollingNode))
-            result = scrollingNode;
-        return true;
-    });
+    bool hasAnyNonInteractiveScrollingLayers = false;
+    auto layersAtPoint = layersAtPointToCheckForScrolling(*rootContentsLayer, pointInContentsLayer, hasAnyNonInteractiveScrollingLayers);
 
-    return result;
+    RefPtr<CoordinatedPlatformLayer> frontmostInteractiveLayer;
+    for (size_t i = 0; i < layersAtPoint.size(); ++i) {
+        auto [layer, transformedPoint] = layersAtPoint[i];
+
+        {
+            Locker layerLocker { layer->lock() };
+            if (!layerEventRegionContainsPoint(layer, transformedPoint))
+                continue;
+        }
+
+        if (!frontmostInteractiveLayer)
+            frontmostInteractiveLayer = layer.get();
+
+        auto scrollingNodeForLayer = [&] (auto layer, auto point) -> RefPtr<ScrollingTreeNode> {
+            UNUSED_PARAM(point);
+            std::optional<ScrollingNodeID> nodeID;
+            {
+                Locker layerLocker { layer->lock() };
+                nodeID = layer->scrollingNodeID();
+            }
+            RefPtr scrollingNode = nodeForID(nodeID);
+            if (!is<ScrollingTreeScrollingNode>(scrollingNode))
+                return nullptr;
+            ASSERT(frontmostInteractiveLayer);
+            if (isScrolledBy(*this, *nodeID, frontmostInteractiveLayer.get()))
+                return scrollingNode;
+            return nullptr;
+        };
+
+        if (RefPtr scrollingNode = scrollingNodeForLayer(layer, transformedPoint))
+            return scrollingNode;
+
+        // This layer may be scrolled by some other layer further back which may itself be non-interactive.
+        if (hasAnyNonInteractiveScrollingLayers) {
+            for (size_t j = i + 1; j < layersAtPoint.size(); ++j) {
+                auto [behindLayer, behindPoint] = layersAtPoint[j];
+                if (RefPtr scrollingNode = scrollingNodeForLayer(behindLayer, behindPoint))
+                    return scrollingNode;
+            }
+        }
+        // FIXME: Hit-test scroll indicator layers.
+    }
+
+    return rootScrollingNode;
 }
 
 #if HAVE(DISPLAY_LINK)
@@ -188,16 +317,21 @@ OptionSet<EventListenerRegionType> ScrollingTreeCoordinated::eventListenerRegion
 
     Locker locker { m_layerHitTestMutex };
 
-    Ref rootContentsLayer = *static_cast<ScrollingTreeFrameScrollingNodeCoordinated*>(rootScrollingNode.get())->rootContentsLayer();
-    Locker rootContentsLayerLocker { rootContentsLayer->lock() };
+    auto rootContentsLayer = static_cast<ScrollingTreeFrameScrollingNodeCoordinated*>(rootScrollingNode.get())->rootContentsLayer();
 
-    OptionSet<EventListenerRegionType> result;
-    traverseDescendantLayersAtPoint(rootContentsLayer, point, [&](const Ref<CoordinatedPlatformLayer>& layer, const FloatPoint& point) {
+    Vector<LayerAndPoint, 16> layersAtPoint;
+    collectDescendantLayersAtPoint(layersAtPoint, *rootContentsLayer, point, [&] (auto layer, auto transformedPoint) {
         assertIsHeld(layer->lock());
-        result = layer->eventRegion().eventListenerRegionTypesForPoint(roundedIntPoint(point));
-        return true;
+        return layerEventRegionContainsPoint(layer, transformedPoint);
     });
-    return result;
+
+    if (layersAtPoint.isEmpty())
+        return { };
+
+    auto [hitLayer, transformedPoint] = layersAtPoint.last();
+
+    Locker hitLayerLocker { hitLayer->lock() };
+    return hitLayer->eventRegion().eventListenerRegionTypesForPoint(roundedIntPoint(transformedPoint));
 }
 #endif
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
@@ -359,6 +359,12 @@ void CoordinatedPlatformLayer::setMasksToBounds(bool masksToBounds)
     notifyCompositionRequired();
 }
 
+bool CoordinatedPlatformLayer::masksToBounds() const
+{
+    assertIsHeld(m_lock);
+    return m_masksToBounds;
+}
+
 void CoordinatedPlatformLayer::setPreserves3D(bool preserves3D)
 {
     assertIsHeld(m_lock);
@@ -661,6 +667,12 @@ void CoordinatedPlatformLayer::setMask(CoordinatedPlatformLayer* mask)
     notifyCompositionRequired();
 }
 
+CoordinatedPlatformLayer* CoordinatedPlatformLayer::mask() const
+{
+    assertIsHeld(m_lock);
+    return m_mask;
+}
+
 void CoordinatedPlatformLayer::setReplica(CoordinatedPlatformLayer* replica)
 {
     assertIsHeld(m_lock);
@@ -722,15 +734,48 @@ void CoordinatedPlatformLayer::setAnimations(const TextureMapperAnimations& anim
     notifyCompositionRequired();
 }
 
+RefPtr<CoordinatedPlatformLayer> CoordinatedPlatformLayer::parent() const
+{
+    assertIsHeld(m_lock);
+    return m_parent;
+}
+
 void CoordinatedPlatformLayer::setChildren(Vector<Ref<CoordinatedPlatformLayer>>&& children)
 {
     assertIsHeld(m_lock);
     if (m_children == children)
         return;
 
+    while (!m_children.isEmpty()) {
+        auto child = m_children.takeLast();
+        Locker childLocker { child->m_lock };
+        child->m_parent = nullptr;
+    }
+
     m_children = WTF::move(children);
+
+    for (auto& child : m_children) {
+        Locker childLocker { child->m_lock };
+        child->removeFromParent();
+        child->m_parent = this;
+    }
+
     m_pendingChanges.add(Change::Children);
     notifyCompositionRequired();
+}
+
+void CoordinatedPlatformLayer::removeFromParent()
+{
+    assertIsHeld(m_lock);
+    RefPtr parent = std::exchange(m_parent, nullptr);
+    if (!parent)
+        return;
+
+    Locker parentLocker { parent->m_lock };
+
+    parent->m_children.removeFirstMatching([this](auto& layer) {
+        return layer.ptr() == this;
+    });
 }
 
 const Vector<Ref<CoordinatedPlatformLayer>>& CoordinatedPlatformLayer::children() const

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
@@ -37,6 +37,7 @@
 #include <wtf/EnumSet.h>
 #include <wtf/Lock.h>
 #include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 
 #if USE(SKIA)
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
@@ -67,7 +68,7 @@ class PaintingEngine;
 }
 #endif
 
-class CoordinatedPlatformLayer : public ThreadSafeRefCounted<CoordinatedPlatformLayer> {
+class CoordinatedPlatformLayer : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<CoordinatedPlatformLayer> {
 public:
     // FIXME: remove this client when a subclass is added for the WebProcess.
     class Client {
@@ -146,6 +147,7 @@ public:
 
     void setDrawsContent(bool) WTF_REQUIRES_LOCK(m_lock);
     void setMasksToBounds(bool) WTF_REQUIRES_LOCK(m_lock);
+    bool masksToBounds() const WTF_REQUIRES_LOCK(m_lock);
     void setPreserves3D(bool) WTF_REQUIRES_LOCK(m_lock);
     void setBackfaceVisibility(bool) WTF_REQUIRES_LOCK(m_lock);
     void setOpacity(float) WTF_REQUIRES_LOCK(m_lock);
@@ -172,6 +174,7 @@ public:
 
     void setFilters(const FilterOperations&) WTF_REQUIRES_LOCK(m_lock);
     void setMask(CoordinatedPlatformLayer*) WTF_REQUIRES_LOCK(m_lock);
+    CoordinatedPlatformLayer* mask() const WTF_REQUIRES_LOCK(m_lock);
     void setReplica(CoordinatedPlatformLayer*) WTF_REQUIRES_LOCK(m_lock);
     void setBackdrop(CoordinatedPlatformLayer*) WTF_REQUIRES_LOCK(m_lock);
     void notifyBackdropFiltersChanged() WTF_REQUIRES_LOCK(m_lock);
@@ -179,6 +182,8 @@ public:
     void setIsBackdropRoot(bool) WTF_REQUIRES_LOCK(m_lock);
 
     void setAnimations(const TextureMapperAnimations&) WTF_REQUIRES_LOCK(m_lock);
+
+    RefPtr<CoordinatedPlatformLayer> parent() const WTF_REQUIRES_LOCK(m_lock);
 
     void setChildren(Vector<Ref<CoordinatedPlatformLayer>>&&) WTF_REQUIRES_LOCK(m_lock);
     const Vector<Ref<CoordinatedPlatformLayer>>& children() const WTF_REQUIRES_LOCK(m_lock);
@@ -217,6 +222,8 @@ public:
 
 private:
     explicit CoordinatedPlatformLayer(Client*);
+
+    void removeFromParent();
 
     void notifyCompositionRequired();
 
@@ -338,6 +345,7 @@ private:
     FloatRoundedRect m_backdropRect WTF_GUARDED_BY_LOCK(m_lock);
     bool m_isBackdropRoot WTF_GUARDED_BY_LOCK(m_lock) { false };
     TextureMapperAnimations m_animations WTF_GUARDED_BY_LOCK(m_lock);
+    ThreadSafeWeakPtr<CoordinatedPlatformLayer> m_parent WTF_GUARDED_BY_LOCK(m_lock);
     Vector<Ref<CoordinatedPlatformLayer>> m_children WTF_GUARDED_BY_LOCK(m_lock);
     EventRegion m_eventRegion WTF_GUARDED_BY_LOCK(m_lock);
     Color m_debugBorderColor WTF_GUARDED_BY_LOCK(m_lock);


### PR DESCRIPTION
#### 10bb43f2800676df37a1c6cee6fe646e330858f9
<pre>
Improve `ScrollingTreeCoordinated` layer hit testing
<a href="https://bugs.webkit.org/show_bug.cgi?id=320449">https://bugs.webkit.org/show_bug.cgi?id=320449</a>

Reviewed by Carlos Garcia Campos.

Current implementation walks the layer tree and returns the first layer
it encounters that has a scrolling node, with no check that this layer
is actually the one visually on top at the hit point. As a result, a
scrolling node can be chosen even when it&apos;s covered by an unrelated
element positioned on top of it.

This patch mirrors the `ScrollingTreeMac` implementation as closely as
possible: layers at the hit point are collected front-to-back, and a
candidate scrolling node is only accepted once `isScrolledBy()` confirms
it&apos;s actually an ancestor of the frontmost interactive layer with a
fallback to layers further back for the case where the frontmost layer
is itself non-interactive.

* Source/WebCore/page/scrolling/coordinated/ScrollingTreeCoordinated.cpp:
(WebCore::collectDescendantLayersAtPoint):
Walks the layer tree under a given point and builds a flat list of every
layer whose bounds contain the point.
(WebCore::isScrolledBy):
Given a candidate scrolling node and the actual frontmost hit layer,
walks up the frontmost layer&apos;s ancestor chain checking whether that
scrolling node owns it.
(WebCore::ScrollingTreeCoordinated::scrollingNodeForPoint):
Collects all candidate layers front-to-back, remembers the first
(&quot;frontmost&quot;) one that is interactive, and for each candidate checks
whether its scrolling node is confirmed by `isScrolledBy()` against that
frontmost layer. If the frontmost interactive layer itself isn&apos;t
scrollable, falls back to checking layers further behind it.
(WebCore::ScrollingTreeCoordinated::eventListenerRegionTypesForPoint const):
(WebCore::traverseDescendantLayersAtPoint): Deleted.
(WebCore::layersAtPointToCheckForScrolling):
(WebCore::layerEventRegionContainsPoint):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp:
(WebCore::CoordinatedPlatformLayer::setChildren):
(WebCore::CoordinatedPlatformLayer::removeFromParent):
(WebCore::CoordinatedPlatformLayer::masksToBounds const):
(WebCore::CoordinatedPlatformLayer::mask const):
(WebCore::CoordinatedPlatformLayer::parent const):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h:
(WebCore::CoordinatedPlatformLayer::parent const):
* LayoutTests/platform/glib/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/318342@main">https://commits.webkit.org/318342@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3217da804461620b2cd9c130105dda6eecbe592e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177969 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51907 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45701 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187579 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179832 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53200 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51616 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/138723 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180925 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42267 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/159478 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119186 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40930 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/39288 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151335 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38970 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36040 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44500 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43523 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190008 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51574 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/147857 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52256 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35600 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/147638 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42350 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124509 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118979 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50764 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13950 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50160 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50400 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50222 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->