### PR TITLE
AVVideoCaptureSource should skip packed-Bayer ProRes RAW formats when generating capture presets

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cf/CoreVideoSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cf/CoreVideoSPI.h
@@ -42,6 +42,12 @@ enum {
     kCVPixelFormatType_AGX_30RGBLE_8A_BiPlanar          = '&b38', // FIXME: Use kCVPixelFormatType_Lossless_30RGBLE_8A_BiPlanar
 };
 
+// Private packed-Bayer sensor format. The public versatile counterpart is
+// kCVPixelFormatType_96VersatileBayerPacked12 ('btp2').
+enum {
+    kCVPixelFormatType_96BayerPacked12_BGGR = 'bgp2', // Bayer 12-bit little-endian, packed 12-bits per component in 96-bits, ordered B G G R.
+};
+
 #if !HAVE(CVPIXELFORMATTYPE_30RGBLE_8A_BIPLANAR)
 enum {
     kCVPixelFormatType_30RGBLE_8A_BiPlanar = 'b3a8',

--- a/Source/WebCore/platform/mediastream/cocoa/AVVideoCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/cocoa/AVVideoCaptureSource.mm
@@ -48,6 +48,7 @@
 #import <algorithm>
 #import <objc/runtime.h>
 #import <pal/avfoundation/MediaTimeAVFoundation.h>
+#import <pal/spi/cf/CoreVideoSPI.h>
 #import <pal/spi/cocoa/AVFoundationSPI.h>
 #import <wtf/NeverDestroyed.h>
 #import <wtf/Scope.h>
@@ -473,8 +474,14 @@ void AVVideoCaptureSource::commitConfiguration()
     if (!m_beginConfigurationCount || --m_beginConfigurationCount > 0)
         return;
 
-    if (m_session)
+    if (!m_session)
+        return;
+
+    @try {
         [m_session commitConfiguration];
+    } @catch (NSException *exception) {
+        ERROR_LOG_IF_POSSIBLE(LOGIDENTIFIER, "error calling -commitConfiguration ", [[exception name] UTF8String], ", reason : ", exception.reason);
+    }
 }
 
 void AVVideoCaptureSource::settingsDidChange(OptionSet<RealtimeMediaSourceSettings::Flag> settings)
@@ -1521,6 +1528,11 @@ void AVVideoCaptureSource::generatePresets()
 {
     Vector<VideoPreset> presets;
     for (AVCaptureDeviceFormat* format in [device() formats]) {
+
+        // Skip packed-Bayer ProRes RAW sensor formats as they are not currently supported.
+        auto mediaSubType = PAL::CMFormatDescriptionGetMediaSubType(format.formatDescription);
+        if (mediaSubType == kCVPixelFormatType_96VersatileBayerPacked12 || mediaSubType == kCVPixelFormatType_96BayerPacked12_BGGR)
+            continue;
 
         CMVideoDimensions dimensions = PAL::CMVideoFormatDescriptionGetDimensions(format.formatDescription);
         IntSize size = { dimensions.width, dimensions.height };


### PR DESCRIPTION
#### 5d438a89c9c8bf0f021fabe4cb953656f3f8a431
<pre>
AVVideoCaptureSource should skip packed-Bayer ProRes RAW formats when generating capture presets
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=319249">https://bugs.webkit.org/show_bug.cgi?id=319249</a>&gt;
&lt;<a href="https://rdar.apple.com/161777392">rdar://161777392</a>&gt;

Reviewed by Eric Carlson and Youenn Fablet.

Skip packed-Bayer ProRes RAW formats when generating presets before
the resolution de-duplication since they are not currently supported.

* Source/WebCore/PAL/pal/spi/cf/CoreVideoSPI.h:
- Declare kCVPixelFormatType_96BayerPacked12_BGGR for public-SDK builds.
* Source/WebCore/platform/mediastream/cocoa/AVVideoCaptureSource.mm:
(WebCore::AVVideoCaptureSource::commitConfiguration):
- Wrap -commitConfiguration in @try/@catch so a commit-time
  exception is logged instead of aborting the GPU process.
(WebCore::AVVideoCaptureSource::generatePresets):
- Ignore the packed-Bayer ProRes RAW formats.

Canonical link: <a href="https://commits.webkit.org/317085@main">https://commits.webkit.org/317085@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b57d00a9bb09e74f93ed82b0c99569100d4a70a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174254 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48187 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41968 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183828 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132122 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1f1177a3-ac5f-4b88-a04b-4cb89b23223c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176119 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49479 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47869 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135542 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/39a56035-39cb-4639-b6d9-4454430caf90) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177212 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38975 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156337 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116020 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fecb780e-150e-43d8-9648-69cd38fb6f57) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37615 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35985 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32312 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148039 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35830 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186254 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39443 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40182 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144450 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47854 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144308 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48533 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32450 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114066 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26493 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39210 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120453 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47039 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10793 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46442 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46673 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46500 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->