### PR TITLE
REGRESSION(315356@main): Data race on CoordinatedSceneState::m_layers between the main and scrolling threads

### DIFF
--- a/LayoutTests/compositing/scrolling/layer-churn-during-async-scroll-crash-expected.txt
+++ b/LayoutTests/compositing/scrolling/layer-churn-during-async-scroll-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS: did not crash

--- a/LayoutTests/compositing/scrolling/layer-churn-during-async-scroll-crash.html
+++ b/LayoutTests/compositing/scrolling/layer-churn-during-async-scroll-crash.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+body { margin: 0; height: 40000px; }
+/* A fixed, composited layer the scrolling thread must reposition on every
+   display refresh while scrolling. That reposition is what runs
+   CoordinatedSceneState::flushPendingState() on the scrolling thread. */
+#fixed { position: fixed; top: 0; left: 0; width: 40px; height: 40px; background: green; will-change: transform; }
+.box { position: absolute; left: 0; width: 30px; height: 30px; background: blue; will-change: transform; }
+</style>
+</head>
+<body>
+<div id="fixed"></div>
+<div id="base"></div>
+<div id="churn"></div>
+<pre id="result">FAIL: did not finish</pre>
+<script>
+// This is a probabilistic regression test for a data race in
+// CoordinatedSceneState: the main thread mutates m_layers in addLayer()/
+// removeLayer() while the scrolling thread iterates it in flushPendingState().
+//
+// Reproducing it needs THREE things to overlap, all set up below:
+//   1. hasRecentActivity() must stay true so the scrolling thread keeps
+//      ticking -- kept alive with a wheel event every frame (eventSender).
+//      (No 'wheel' listener / background-attachment:fixed here: those add
+//      synchronous scrolling reasons and disable scrolling-thread layer
+//      updates via canUpdateLayersOnScrollingThread().)
+//   2. The main thread's rendering update must overrun the ~half-frame sync
+//      timeout so the scrolling thread DESYNCS and commits layer positions
+//      itself, concurrently with the main thread -- forced by churning a lot
+//      of composited layers per frame (slow compositing update).
+//   3. addLayer()/removeLayer() must run during that slow update -- the churn
+//      itself provides them.
+// Needs a Debug (asserts) build on a scrolling-thread port (GTK/WPE). On other
+// ports it simply passes.
+
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+// Keep m_layers large so the scrolling thread's iteration stays open longer.
+const base = document.getElementById('base');
+for (let i = 0; i < 200; i++) {
+    const b = document.createElement('div');
+    b.className = 'box';
+    b.style.top = (i * 31) + 'px';
+    base.appendChild(b);
+}
+
+const churn = document.getElementById('churn');
+const PER_FRAME = 150;
+const DURATION_MS = 8000;
+let previousGeneration = [];
+
+function churnLayers()
+{
+    for (const box of previousGeneration)
+        box.remove();               // detachLayer -> removeLayer
+    const generation = [];
+    for (let i = 0; i < PER_FRAME; i++) {
+        const b = document.createElement('div');
+        b.className = 'box';
+        b.style.top = (i * 31) + 'px';
+        churn.appendChild(b);       // attachLayer -> addLayer
+        generation.push(b);
+    }
+    previousGeneration = generation;
+}
+
+const start = performance.now();
+let direction = -1;
+
+function tick()
+{
+    // Wheel event every frame keeps hasProcessedWheelEventsRecently() true and
+    // scrolls the frame, so the scrolling thread repositions #fixed each refresh.
+    if (window.eventSender) {
+        eventSender.mouseScrollBy(0, direction * 40);
+        if (window.pageYOffset <= 0 || window.pageYOffset >= 39000)
+            direction = -direction;
+    }
+
+    churnLayers();
+
+    if (performance.now() - start < DURATION_MS) {
+        requestAnimationFrame(tick);
+        return;
+    }
+
+    for (const box of previousGeneration)
+        box.remove();
+    previousGeneration = [];
+    document.getElementById('result').textContent = "PASS: did not crash";
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+requestAnimationFrame(tick);
+</script>
+</body>
+</html>

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedSceneState.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedSceneState.cpp
@@ -64,14 +64,20 @@ void CoordinatedSceneState::setRootLayerChildren(Vector<Ref<CoordinatedPlatformL
 void CoordinatedSceneState::addLayer(CoordinatedPlatformLayer& layer)
 {
     ASSERT(isMainRunLoop());
-    m_layers.add(layer);
+    {
+        Locker locker { m_layersLock };
+        m_layers.add(layer);
+    }
     m_didChangeLayers = true;
 }
 
 void CoordinatedSceneState::removeLayer(CoordinatedPlatformLayer& layer)
 {
     ASSERT(isMainRunLoop());
-    m_layers.remove(layer);
+    {
+        Locker locker { m_layersLock };
+        m_layers.remove(layer);
+    }
     m_layersToRemove.add(layer);
     m_didChangeLayers = true;
 }
@@ -83,7 +89,10 @@ bool CoordinatedSceneState::flush()
     bool didChangeLayers = m_didChangeLayers.exchange(false);
     if (didChangeLayers) {
         Locker pendingLayersLock { m_pendingLayersLock };
-        m_pendingLayers = m_layers;
+        {
+            Locker locker { m_layersLock };
+            m_pendingLayers = m_layers;
+        }
         if (m_pendingLayersToRemove.isEmpty())
             m_pendingLayersToRemove = WTF::move(m_layersToRemove);
         else
@@ -98,7 +107,8 @@ bool CoordinatedSceneState::flush()
 void CoordinatedSceneState::flushPendingState()
 {
     Locker stateLock { m_stateLock };
-    for (auto& layer : m_layers)
+    Locker layersLock { m_layersLock };
+    for (Ref layer : m_layers)
         layer->flushPendingState();
 }
 
@@ -150,10 +160,13 @@ void CoordinatedSceneState::invalidate()
 {
     ASSERT(isMainRunLoop());
     // Root layer doesn't have client nor backing stores to invalidate.
-    while (!m_layers.isEmpty()) {
-        auto layer = m_layers.takeAny();
-        layer->invalidateClient();
+    HashSet<Ref<CoordinatedPlatformLayer>> layers;
+    {
+        Locker locker { m_layersLock };
+        layers = WTF::move(m_layers);
     }
+    for (Ref layer : layers)
+        layer->invalidateClient();
 
     Locker pendingLayersLock { m_pendingLayersLock };
     m_pendingLayers = { };

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedSceneState.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedSceneState.h
@@ -74,7 +74,8 @@ private:
     void commitPendingLayers();
 
     const Ref<WebCore::CoordinatedPlatformLayer> m_rootLayer;
-    HashSet<Ref<WebCore::CoordinatedPlatformLayer>> m_layers;
+    Lock m_layersLock;
+    HashSet<Ref<WebCore::CoordinatedPlatformLayer>> m_layers WTF_GUARDED_BY_LOCK(m_layersLock);
     HashSet<Ref<WebCore::CoordinatedPlatformLayer>> m_layersToRemove;
     Lock m_pendingLayersLock;
     HashSet<Ref<WebCore::CoordinatedPlatformLayer>> m_pendingLayers WTF_GUARDED_BY_LOCK(m_pendingLayersLock);


### PR DESCRIPTION
#### 6c291d01ba2f455787d406fc7dfb584172bdcd57
<pre>
REGRESSION(315356@main): Data race on CoordinatedSceneState::m_layers between the main and scrolling threads
<a href="https://bugs.webkit.org/show_bug.cgi?id=319255">https://bugs.webkit.org/show_bug.cgi?id=319255</a>

Reviewed by Carlos Garcia Campos.

Before 315356@main, m_layers was only used from the main thread, so it was
accessed without a lock. That change started iterating it in flushPendingState(),
which can also run on the scrolling thread: when the main thread&apos;s rendering
update overruns the scrolling tree&apos;s synchronization timeout, the scrolling
thread commits layer positions concurrently and its iteration races the
main-thread mutations in addLayer(), removeLayer() and invalidate(), corrupting
the hash table.

Protect m_layers with a dedicated lock, taken by the mutators and by
flushPendingState(). The state lock keeps guarding only the pending and
compositing state flushes, so adding or removing layers on the main thread does
not block the compositor thread.

Test: compositing/scrolling/layer-churn-during-async-scroll-crash.html

* LayoutTests/compositing/scrolling/layer-churn-during-async-scroll-crash-expected.txt: Added.
* LayoutTests/compositing/scrolling/layer-churn-during-async-scroll-crash.html: Added.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedSceneState.cpp:
(WebKit::CoordinatedSceneState::addLayer):
(WebKit::CoordinatedSceneState::removeLayer):
(WebKit::CoordinatedSceneState::flush):
(WebKit::CoordinatedSceneState::flushPendingState):
(WebKit::CoordinatedSceneState::invalidate):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedSceneState.h:

Canonical link: <a href="https://commits.webkit.org/317141@main">https://commits.webkit.org/317141@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cdd7c293a81fd25f4e9173c792a1d77805e8ce4c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174464 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48397 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42178 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184041 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132332 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49689 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48080 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135725 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177422 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39163 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/156523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116203 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37804 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32522 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/148227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36015 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186467 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/39697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144641 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48064 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156077 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144499 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48743 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114323 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26514 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39399 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/120708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47250 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10979 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46652 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46883 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46710 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->