### PR TITLE
Fix Safer CPP warnings in FlexLayoutUtils

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/NoDeleteCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoDeleteCheckerExpectations
@@ -155,8 +155,6 @@ rendering/LayerOverlapMap.cpp
 rendering/NinePieceImagePainter.cpp
 rendering/OutlinePainter.cpp
 rendering/RegionContext.cpp
-rendering/RenderBox.cpp
-rendering/RenderFlexibleBox.cpp
 rendering/RenderFrameSet.cpp
 rendering/RenderGeometryMap.cpp
 rendering/RenderLayerCompositor.cpp

--- a/Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations
@@ -27,7 +27,6 @@ platform/graphics/TextRunIterator.h
 [ iOS ] platform/ios/DeviceMotionClientIOS.h
 [ iOS ] platform/ios/DeviceOrientationClientIOS.h
 rendering/BackgroundPainter.h
-rendering/FlexLayoutUtils.h
 rendering/GlyphDisplayListCache.cpp
 rendering/GridTrackSizingAlgorithm.h
 rendering/InlineBoxPainter.h

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -293,7 +293,6 @@ rendering/ContentfulPaintChecker.cpp
 rendering/CounterNode.cpp
 rendering/EllipsisBoxPainter.cpp
 rendering/FixedTableLayout.cpp
-rendering/FlexLayoutUtils.cpp
 rendering/FloatingObjects.cpp
 rendering/GridTrackSizingAlgorithm.cpp
 rendering/HitTestResult.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -62,7 +62,6 @@ rendering/AutoTableLayout.cpp
 rendering/BackgroundPainter.cpp
 rendering/CounterNode.cpp
 rendering/FixedTableLayout.cpp
-rendering/FlexLayoutUtils.cpp
 rendering/GridLayoutFunctions.cpp
 rendering/GridTrackSizingAlgorithm.cpp
 rendering/HitTestResult.cpp

--- a/Source/WebCore/rendering/FlexLayoutUtils.cpp
+++ b/Source/WebCore/rendering/FlexLayoutUtils.cpp
@@ -286,7 +286,8 @@ Overflow FlexLayoutUtils::crossAxisOverflowForFlexItem(const RenderBox& flexItem
 
 OverflowAlignment FlexLayoutUtils::overflowAlignmentForFlexItem(const RenderBox& flexItem) const
 {
-    return flexItem.style().alignSelf().resolve(&flexBox().style()).overflow();
+    CheckedRef containerStyle = flexBox().style();
+    return flexItem.style().alignSelf().resolve(containerStyle.ptr()).overflow();
 }
 
 bool FlexLayoutUtils::hasAutoMarginsInCrossAxis(const RenderBox& flexItem) const
@@ -349,7 +350,8 @@ bool FlexLayoutUtils::canResolveFullyConstrainedLogicalHeight(const RenderFlexib
     // stretched yet - its height is 0 at that point and computeLogicalHeight would give
     // a wrong answer. This happens when the nested out-of-flow flex is laid out as part of the
     // anector flex's main-axis sizing, before the stretch phase sets the final cross size.
-    return flexBox.hasFullyConstrainedLogicalHeight() && flexBox.containingBlock()->hasDefiniteLogicalHeight();
+    CheckedPtr containingBlock = flexBox.containingBlock();
+    return flexBox.hasFullyConstrainedLogicalHeight() && containingBlock->hasDefiniteLogicalHeight();
 }
 
 bool FlexLayoutUtils::flexItemHasComputableAspectRatio(const RenderBox& flexItem) const
@@ -607,7 +609,8 @@ Style::FlexBasis FlexLayoutUtils::flexBasisForFlexItem(const RenderBox& flexItem
 
 ItemPosition FlexLayoutUtils::alignmentForFlexItem(const RenderBox& flexItem) const
 {
-    auto align = flexItem.style().alignSelf().resolve(&flexBox().style()).position();
+    CheckedRef containerStyle = flexBox().style();
+    auto align = flexItem.style().alignSelf().resolve(containerStyle.ptr()).position();
     if (align == ItemPosition::Normal)
         align = ItemPosition::Stretch;
 
@@ -644,8 +647,8 @@ ItemPosition FlexLayoutUtils::alignmentForFlexItem(const RenderBox& flexItem) co
 
 bool FlexLayoutUtils::hasStretchedFlexItemWithAspectRatio() const
 {
-    for (auto& flexItem : childrenOfType<RenderBox>(flexBox())) {
-        if (flexItem.isOutOfFlowPositioned() || flexItem.isExcludedFromNormalLayout())
+    for (CheckedRef flexItem : childrenOfType<RenderBox>(flexBox())) {
+        if (flexItem->isOutOfFlowPositioned() || flexItem->isExcludedFromNormalLayout())
             continue;
         if (!flexItemHasAspectRatio(flexItem))
             continue;

--- a/Source/WebCore/rendering/FlexLayoutUtils.h
+++ b/Source/WebCore/rendering/FlexLayoutUtils.h
@@ -27,6 +27,7 @@
 
 #include <WebCore/LayoutUnit.h>
 #include <optional>
+#include <wtf/CheckedRef.h>
 
 namespace WebCore {
 
@@ -110,8 +111,8 @@ public:
 
     FlowDirection crossAxisDirection() const;
     FlowDirection transformedBlockFlowDirection() const;
-    bool isHorizontalFlow() const;
-    bool isColumnFlow() const;
+    bool NODELETE isHorizontalFlow() const;
+    bool NODELETE isColumnFlow() const;
     bool isColumnOrRowReverse() const;
     bool isWrapReverse() const;
     bool isMultiline() const;
@@ -143,7 +144,7 @@ public:
 private:
     const RenderFlexibleBox& flexBox() const LIFETIME_BOUND { return m_flexBox; }
 
-    const RenderFlexibleBox& m_flexBox;
+    const CheckedRef<const RenderFlexibleBox> m_flexBox;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 8ce5104a519df1e3c748d78d5fbcf29ec3feed48
<pre>
Fix Safer CPP warnings in FlexLayoutUtils
<a href="https://bugs.webkit.org/show_bug.cgi?id=319257">https://bugs.webkit.org/show_bug.cgi?id=319257</a>
&lt;<a href="https://rdar.apple.com/problem/182105989">rdar://problem/182105989</a>&gt;

Reviewed by Antti Koivisto.

* Source/WebCore/SaferCPPExpectations/NoDeleteCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations:
* Source/WebCore/rendering/FlexLayoutUtils.cpp:
(WebCore::FlexLayoutUtils::overflowAlignmentForFlexItem const):
(WebCore::FlexLayoutUtils::canResolveFullyConstrainedLogicalHeight):
(WebCore::FlexLayoutUtils::alignmentForFlexItem const):
(WebCore::FlexLayoutUtils::hasStretchedFlexItemWithAspectRatio const):
* Source/WebCore/rendering/FlexLayoutUtils.h:

Canonical link: <a href="https://commits.webkit.org/317065@main">https://commits.webkit.org/317065@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff4adacdabb0cf6c6f2a8a60ee547971b3976f65

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174230 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48163 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41944 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183804 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132098 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9c3879cd-03e4-4c94-bf9a-7348a308e287) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176095 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49455 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47845 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135524 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/00fc7fcf-55e5-48de-b1b7-60216521d961) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177188 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38955 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156313 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116002 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/93979a07-6be8-429e-82f8-c588f4a58bd0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37595 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35965 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32288 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148019 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35806 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186230 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39412 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40162 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144429 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47830 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144288 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38892 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48509 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32426 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114037 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39193 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120426 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47015 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10768 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46418 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46649 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46476 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->