### PR TITLE
Sync custom elements tests

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/element-internals-aria-element-reflection-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/element-internals-aria-element-reflection-expected.txt
@@ -12,6 +12,7 @@ Labelled by from IDL attribute
 PASS Getting previously-unset ARIA element reflection properties on ElementInternals should return null.
 PASS Getting ARIA element reflection properties on ElementInternals should return the value that was set.
 PASS Setting ARIA element reflection properties to an empty array should work as expected.
+PASS Reading an ARIA element reflection array property that was set to an empty array, on an ElementInternals with no previously cached value, should return an empty array.
 PASS Setting ARIA element reflection properties on ElementInternals to null should delete any previous value, and not crash
 PASS Setting ariaLabelledByElements on ElementInternals should change the accessible name of the custom element
 PASS Setting aria-labelledby or ariaLabelledByElements on the custom element should supersede the value of ariaLabelledByElements on ElementInternals

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/element-internals-aria-element-reflection.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/element-internals-aria-element-reflection.html
@@ -88,6 +88,14 @@
     }, "Setting ARIA element reflection properties to an empty array should work as expected.");
 
     test(t => {
+      for (const [property, id] of array_properties) {
+        const custom = document.createElement('custom-element');
+        custom.i[property] = [];
+        assert_array_equals(custom.i[property], []);
+      }
+    }, "Reading an ARIA element reflection array property that was set to an empty array, on an ElementInternals with no previously cached value, should return an empty array.");
+
+    test(t => {
       const custom = document.getElementById('custom1');
       for (const [property, id] of element_properties) {
         const related = document.getElementById(id);

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-NotSupportedError.html

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/htmlconstructor/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/htmlconstructor/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/htmlconstructor/WEB_FEATURES.yml

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/parser/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/parser/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/parser/WEB_FEATURES.yml

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/perform-microtask-checkpoint-before-construction.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/perform-microtask-checkpoint-before-construction.html
@@ -43,49 +43,64 @@ window.onload = () => {
     return window;
 }
 
+function flatten_records_list(recordsList)
+{
+    // MutationObserver callback batching is not deterministic across runs.
+    // Flatten callback batches so assertions focus on mutation semantics.
+    assert_true(Array.isArray(recordsList));
+    const flattened = [];
+    for (const records of recordsList) {
+        assert_true(Array.isArray(records));
+        flattened.push(...records);
+    }
+    return flattened;
+}
+
 promise_test(async function () {
     const contentWindow = await construct_custom_element_in_parser(this, '<b><some-element></b>');
     const contentDocument = contentWindow.document;
 
-    let recordsList = contentWindow.recordsListInConstructor;
-    assert_true(Array.isArray(recordsList));
-    assert_equals(recordsList.length, 1);
-    assert_true(Array.isArray(recordsList[0]));
-    assert_equals(recordsList[0].length, 1);
-    let record = recordsList[0][0];
-    assert_equals(record.type, 'childList');
-    assert_equals(record.target, contentDocument.body);
-    assert_equals(record.previousSibling, contentDocument.querySelector('script'));
-    assert_equals(record.nextSibling, null);
-    assert_equals(record.removedNodes.length, 0);
-    assert_equals(record.addedNodes.length, 1);
-    assert_equals(record.addedNodes[0], contentDocument.querySelector('b'));
+    const constructorRecords =
+        flatten_records_list(contentWindow.recordsListInConstructor);
+    const script = contentDocument.querySelector('script');
+    const bElement = contentDocument.querySelector('b');
+    const someElement = contentDocument.querySelector('some-element');
+    const isBInsertionRecord = (candidate) =>
+        candidate.type === 'childList' &&
+        candidate.target === contentDocument.body &&
+        candidate.previousSibling === script &&
+        candidate.nextSibling === null &&
+        candidate.removedNodes.length === 0 &&
+        candidate.addedNodes.length === 1 &&
+        candidate.addedNodes[0] === bElement;
+    const isSomeElementInsertionRecord = (candidate) =>
+        candidate.type === 'childList' &&
+        candidate.target === bElement &&
+        candidate.previousSibling === null &&
+        candidate.nextSibling === null &&
+        candidate.removedNodes.length === 0 &&
+        candidate.addedNodes.length === 1 &&
+        candidate.addedNodes[0] === someElement;
 
-    recordsList = contentWindow.recordsListInDOMContentLoaded;
-    assert_true(Array.isArray(recordsList));
-    assert_equals(recordsList.length, 2);
-    assert_true(Array.isArray(recordsList[1]));
-    assert_equals(recordsList[1].length, 1);
-    record = recordsList[1][0];
-    assert_equals(record.type, 'childList');
-    assert_equals(record.target, contentDocument.querySelector('b'));
-    assert_equals(record.previousSibling, null);
-    assert_equals(record.nextSibling, null);
-    assert_equals(record.removedNodes.length, 0);
-    assert_equals(record.addedNodes.length, 1);
-    assert_equals(record.addedNodes[0], contentDocument.querySelector('some-element'));
+    assert_equals(constructorRecords.length, 1);
+    assert_true(isBInsertionRecord(constructorRecords[0]),
+        'first mutation record must be the <b> insertion into document.body');
+
+    const allRecords =
+        flatten_records_list(contentWindow.recordsListInDOMContentLoaded);
+    assert_equals(allRecords.length, 2);
+    assert_true(isSomeElementInsertionRecord(allRecords[1]),
+        'second mutation record must be the <some-element> insertion into <b>');
 }, 'HTML parser must perform a microtask checkpoint before constructing a custom element');
 
 promise_test(async function () {
     const contentWindow = await construct_custom_element_in_parser(this, '<b><i>hello</b><some-element>');
     const contentDocument = contentWindow.document;
-    let recordsList = contentWindow.recordsListInConstructor;
-    assert_true(Array.isArray(recordsList));
-    assert_equals(recordsList.length, 1);
-    assert_true(Array.isArray(recordsList[0]));
-    assert_equals(recordsList[0].length, 4);
 
-    let record = recordsList[0][0];
+    const constructorRecords = flatten_records_list(contentWindow.recordsListInConstructor);
+    assert_equals(constructorRecords.length, 4);
+
+    let record = constructorRecords[0];
     assert_equals(record.type, 'childList');
     assert_equals(record.target, contentDocument.body);
     assert_equals(record.previousSibling, contentDocument.querySelector('script'));
@@ -94,7 +109,7 @@ promise_test(async function () {
     assert_equals(record.addedNodes.length, 1);
     assert_equals(record.addedNodes[0], contentDocument.querySelector('b'));
 
-    record = recordsList[0][1];
+    record = constructorRecords[1];
     assert_equals(record.type, 'childList');
     assert_equals(record.target, contentDocument.querySelector('b'));
     assert_equals(record.previousSibling, null);
@@ -103,7 +118,7 @@ promise_test(async function () {
     assert_equals(record.addedNodes.length, 1);
     assert_equals(record.addedNodes[0], contentDocument.querySelector('i'));
 
-    record = recordsList[0][2];
+    record = constructorRecords[2];
     assert_equals(record.type, 'childList');
     assert_equals(record.target, contentDocument.querySelector('i'));
     assert_equals(record.previousSibling, null);
@@ -113,29 +128,29 @@ promise_test(async function () {
     assert_equals(record.addedNodes[0].nodeType, Node.TEXT_NODE);
     assert_equals(record.addedNodes[0].data, "hello");
 
-    record = recordsList[0][3];
+    const secondI = contentDocument.querySelectorAll('i')[1];
+    record = constructorRecords[3];
     assert_equals(record.type, 'childList');
     assert_equals(record.target, contentDocument.body);
     assert_equals(record.previousSibling, contentDocument.querySelector('b'));
     assert_equals(record.nextSibling, null);
     assert_equals(record.removedNodes.length, 0);
     assert_equals(record.addedNodes.length, 1);
-    assert_equals(record.addedNodes[0], contentDocument.querySelectorAll('i')[1]);
+    assert_equals(record.addedNodes[0], secondI);
 
-    recordsList = contentWindow.recordsListInDOMContentLoaded;
-    assert_true(Array.isArray(recordsList));
-    assert_equals(recordsList.length, 2);
-    assert_true(Array.isArray(recordsList[1]));
-    assert_equals(recordsList[1].length, 1);
-
-    record = recordsList[1][0];
-    assert_equals(record.type, 'childList');
-    assert_equals(record.target, contentDocument.querySelectorAll('i')[1]);
-    assert_equals(record.previousSibling, null);
-    assert_equals(record.nextSibling, null);
-    assert_equals(record.removedNodes.length, 0);
-    assert_equals(record.addedNodes.length, 1);
-    assert_equals(record.addedNodes[0], contentDocument.querySelector('some-element'));
+    const allRecords = flatten_records_list(contentWindow.recordsListInDOMContentLoaded);
+    assert_equals(allRecords.length, 5);
+    const someElement = contentDocument.querySelector('some-element');
+    const isSomeElementInsertionRecord = (candidate) =>
+        candidate.type === 'childList' &&
+        candidate.target === secondI &&
+        candidate.previousSibling === null &&
+        candidate.nextSibling === null &&
+        candidate.removedNodes.length === 0 &&
+        candidate.addedNodes.length === 1 &&
+        candidate.addedNodes[0] === someElement;
+    assert_true(isSomeElementInsertionRecord(allRecords[4]),
+        'last mutation record must be the <some-element> insertion into the second <i>');
 }, 'HTML parser must perform a microtask checkpoint before constructing a custom element during the adoption agency algorithm');
 
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/reactions/customized-builtins/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/reactions/customized-builtins/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/reactions/customized-builtins/HTMLAreaElement.html

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/reactions/resources/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/reactions/resources/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/reactions/resources/reactions.js

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/reactions/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/reactions/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/reactions/Animation.html

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/Element-innerHTML-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/Element-innerHTML-expected.txt
@@ -6,6 +6,7 @@ PASS innerHTML on an inserted element should continue to use the scoped registry
 FAIL nested descendants in innerHTML should use the null registry when the container element has null registry assert_equals: expected null but got object "[object CustomElementRegistry]"
 FAIL insertAdjacentHTML should use the element's registry even when the registry is null assert_equals: expected null but got object "[object CustomElementRegistry]"
 FAIL createContextualFragment on a range inside a template should use null registry even when the template has a scoped registry assert_equals: expected null but got object "[object CustomElementRegistry]"
+PASS innerHTML on a template with a scoped registry should use the scoped registry of the document
 PASS createContextualFragment on a range inside an element with scoped registry should use the scoped registry of the element
 PASS insertAdjacentHTML with beforebegin should use the containing scope's registry
 PASS insertAdjacentHTML with afterend should use the containing scope's registry

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/Element-innerHTML.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/Element-innerHTML.html
@@ -165,6 +165,22 @@ test((test) => {
     class ScopedNewElement extends HTMLElement { };
     registry.define('new-element', ScopedNewElement);
 
+    const template = document.createElement('template', {customElementRegistry: registry});
+    assert_equals(template.customElementRegistry, registry);
+
+    template.innerHTML = '<new-element><new-element></new-element></new-element>';
+    const outer_element = template.content.querySelector('new-element');
+    const inner_element = outer_element.querySelector('new-element');
+    document.body.append(outer_element);
+    assert_equals(outer_element.customElementRegistry, document.customElementRegistry);
+    assert_equals(inner_element.customElementRegistry, document.customElementRegistry);
+}, 'innerHTML on a template with a scoped registry should use the scoped registry of the document');
+
+test((test) => {
+    const registry = new CustomElementRegistry;
+    class ScopedNewElement extends HTMLElement { };
+    registry.define('new-element', ScopedNewElement);
+
     const div = document.createElement('div', {customElementRegistry: registry});
     assert_equals(div.customElementRegistry, registry);
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/element-mutation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/element-mutation-expected.txt
@@ -14,5 +14,4 @@ FAIL An element with scoped registry should not change its registry when run pre
 FAIL An element with scoped registry should not change its registry when run prepend into another shadow tree with different scoped registry. assert_equals: expected object "[object CustomElementRegistry]" but got object "[object CustomElementRegistry]"
 PASS A freshly created element should preserve global registry after prepend into and removal from a scoped shadow root.
 PASS A freshly created element should preserve global registry when run prepend between scoped shadow roots.
-PASS Declarative shadow DOM with shadowrootcustomelementregistry attribute without registry initialized should remain null registry after adoption.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/element-mutation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/element-mutation.html
@@ -20,15 +20,6 @@
     </div>
 </div>
 
-<template id="template">
-    <div id="template-host-1">
-        <template shadowrootmode="open" shadowrootclonable><x-foo></x-foo></template>
-    </div>
-    <div id="template-host-2">
-        <template shadowrootmode="open" shadowrootclonable shadowrootcustomelementregistry><x-foo></x-foo></template>
-    </div>
-</template>
-
 <script>
 
 function runTests(mutation, mutationName) {
@@ -111,14 +102,6 @@ function runTests(mutation, mutationName) {
 runTests(function (parent, child) { parent.append(child); }, "append");
 runTests(function (parent, child) { parent.appendChild(child); }, "appendChild");
 runTests(function (parent, child) { parent.prepend(child); }, "prepend");
-
-test(() => {
-    customElements.define('x-foo', class extends HTMLElement {});
-    const template = document.getElementById('template');
-    document.body.append(template.content.cloneNode(true));
-    assert_equals(document.querySelector('#template-host-1').shadowRoot.querySelector('x-foo').customElementRegistry, customElements);
-    assert_equals(document.querySelector('#template-host-2').shadowRoot.querySelector('x-foo').customElementRegistry, null);
-}, "Declarative shadow DOM with shadowrootcustomelementregistry attribute without registry initialized should remain null registry after adoption.")
 
 </script>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-append-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-append-expected.txt
@@ -9,4 +9,10 @@ PASS Inserting a node from another document with global registry results in the 
 PASS Inserting a node from another document with null registry results in the custom element registry to be set and upgraded.
 PASS Inserting a node cloned from a template with null registry into a scoped shadow root should set global registry
 PASS adoptNode then inserting into a scoped shadow root should preserve global registry
+PASS Declarative shadow DOM without shadowrootcustomelementregistry attribute without registry initialized should gain effective global registry after adoption.
+FAIL Declarative shadow DOM with shadowrootcustomelementregistry attribute without registry initialized should remain null registry after adoption. assert_equals: expected null but got object "[object CustomElementRegistry]"
+FAIL Null registry element should gain effective global registry of global registry from its parent upon adoption. assert_true: expected true got false
+PASS Null registry element should gain effective global registry of null from its parent upon adoption.
+FAIL Null registry element should gain effective global registry of scoped registry from its parent upon adoption. assert_equals: expected null but got object "[object CustomElementRegistry]"
+FAIL Global registry element should gain effective global registry of scoped registry from its parent upon adoption. assert_equals: expected object "[object CustomElementRegistry]" but got object "[object CustomElementRegistry]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-append.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-append.html
@@ -6,7 +6,21 @@
 <script src="/resources/testharnessreport.js"></script>
 </head>
 <body>
+
+<template id="template-1">
+    <div id="template-host-1">
+        <template shadowrootmode="open" shadowrootclonable><x-foo><x-foo></x-foo></x-foo></template>
+    </div>
+</template>
+
+<template id="template-2">
+    <div id="template-host-2">
+        <template shadowrootmode="open" shadowrootclonable shadowrootcustomelementregistry><x-foo><x-foo></x-foo></x-foo></template>
+    </div>
+</template>
+
 <script>
+class XFoo extends HTMLElement {}
 
 test(() => {
     assert_equals((new Document).createElement('a-b').customElementRegistry, null);
@@ -155,6 +169,77 @@ test((test) => {
         'Element adopted then appended into scoped shadow root should keep global registry');
 }, 'adoptNode then inserting into a scoped shadow root should preserve global registry');
 
+test(t => {
+    const template = document.getElementById('template-1');
+    const clone = template.content.cloneNode(true);
+    const [doc, win] = makeIframe(t);
+    doc.body.appendChild(clone);
+    const host1shadow = doc.querySelector('#template-host-1').shadowRoot;
+    assert_equals(host1shadow.customElementRegistry, win.customElements);
+}, "Declarative shadow DOM without shadowrootcustomelementregistry attribute without registry initialized should gain effective global registry after adoption.")
+
+test(t => {
+    const template = document.getElementById('template-2');
+    const clone = template.content.cloneNode(true);
+    const [doc, win] = makeIframe(t);
+    doc.body.append(clone);
+    const host2shadow = doc.querySelector('#template-host-2').shadowRoot;
+    assert_equals(host2shadow.customElementRegistry, null);
+}, "Declarative shadow DOM with shadowrootcustomelementregistry attribute without registry initialized should remain null registry after adoption.")
+
+test(t => {
+    const template = document.getElementById('template-1');
+    const clone = template.content.cloneNode(true);
+    const [doc, win] = makeIframe(t);
+    win.customElements.define('x-foo', XFoo);
+    doc.body.append(clone);
+    const host1shadow = doc.querySelector('#template-host-1').shadowRoot;
+    assert_equals(host1shadow.querySelector('x-foo').customElementRegistry, win.customElements);
+    assert_true(host1shadow.querySelector('x-foo') instanceof XFoo);
+    assert_equals(host1shadow.querySelector('x-foo').querySelector('x-foo').customElementRegistry, win.customElements);
+    assert_true(host1shadow.querySelector('x-foo').querySelector('x-foo') instanceof XFoo);
+}, "Null registry element should gain effective global registry of global registry from its parent upon adoption.")
+
+test(t => {
+    const template = document.getElementById('template-2');
+    const clone = template.content.cloneNode(true);
+    const [doc, win] = makeIframe(t);
+    win.customElements.define('x-foo', XFoo);
+    doc.body.append(clone);
+    const host2shadow = doc.querySelector('#template-host-2').shadowRoot;
+    assert_equals(host2shadow.querySelector('x-foo').customElementRegistry, null);
+    assert_false(host2shadow.querySelector('x-foo') instanceof XFoo);
+    assert_equals(host2shadow.querySelector('x-foo').querySelector('x-foo').customElementRegistry, null);
+    assert_false(host2shadow.querySelector('x-foo').querySelector('x-foo') instanceof XFoo);
+}, "Null registry element should gain effective global registry of null from its parent upon adoption.")
+
+test(t => {
+    const template = document.getElementById('template-2');
+    const clone = template.content.cloneNode(true);
+    const registry = new CustomElementRegistry;
+    registry.initialize(clone.querySelector('#template-host-2').shadowRoot);
+    clone.querySelector('#template-host-2').shadowRoot.appendChild(document.createElement('new-foo', {customElementRegistry: null}));
+    clone.querySelector('#template-host-2').shadowRoot.querySelector('x-foo').appendChild(document.createElement('new-foo', {customElementRegistry: null}));
+    const [doc, win] = makeIframe(t);
+    doc.body.append(clone);
+    const host2shadow = doc.querySelector('#template-host-2').shadowRoot;
+    assert_equals(host2shadow.querySelector('new-foo').customElementRegistry, null);
+    assert_equals(host2shadow.querySelector('x-foo').querySelector('new-foo').customElementRegistry, null);
+}, "Null registry element should gain effective global registry of scoped registry from its parent upon adoption.")
+
+test(t => {
+    const template = document.getElementById('template-2');
+    const clone = template.content.cloneNode(true);
+    const registry = new CustomElementRegistry;
+    registry.initialize(clone.querySelector('#template-host-2').shadowRoot);
+    clone.querySelector('#template-host-2').shadowRoot.appendChild(document.createElement('new-foo'));
+    clone.querySelector('#template-host-2').shadowRoot.querySelector('x-foo').appendChild(document.createElement('new-foo'));
+    const [doc, win] = makeIframe(t);
+    doc.body.append(clone);
+    const host2shadow = doc.querySelector('#template-host-2').shadowRoot;
+    assert_equals(host2shadow.querySelector('new-foo').customElementRegistry, win.customElements);
+    assert_equals(host2shadow.querySelector('x-foo').querySelector('new-foo').customElementRegistry, win.customElements);
+}, "Global registry element should gain effective global registry of scoped registry from its parent upon adoption.")
 </script>
 </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-effective-global-registry-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-effective-global-registry-expected.txt
@@ -1,0 +1,68 @@
+
+PASS Null registry element with element parent without custom element registry attribute (null registry) appended to new document
+PASS Null registry element with element parent without custom element registry attribute (global registry) appended to new document
+FAIL Null registry element with element parent without custom element registry attribute (scoped registry) appended to new document assert_equals: expected null but got object "[object CustomElementRegistry]"
+PASS Null registry element with declarative shadow root parent without custom element registry attribute appended to new document
+FAIL Null registry element with declarative shadow root parent with custom element registry attribute (null registry) appended to new document assert_equals: expected null but got object "[object CustomElementRegistry]"
+FAIL Null registry element with declarative shadow root parent with custom element registry attribute (global registry) appended to new document assert_equals: expected object "[object CustomElementRegistry]" but got null
+FAIL Null registry element with declarative shadow root parent with custom element registry attribute (scoped registry) appended to new document assert_equals: expected object "[object CustomElementRegistry]" but got object "[object CustomElementRegistry]"
+FAIL Null registry element with imperative shadow root parent (null registry) appended to new document assert_equals: expected object "[object CustomElementRegistry]" but got null
+FAIL Null registry element with imperative shadow root parent (global registry) appended to new document assert_equals: expected object "[object CustomElementRegistry]" but got null
+FAIL Null registry element with imperative shadow root parent (scoped registry) appended to new document assert_equals: expected null but got object "[object CustomElementRegistry]"
+PASS Global registry element with element parent without custom element registry attribute (null registry) appended to new document
+PASS Global registry element with element parent without custom element registry attribute (global registry) appended to new document
+PASS Global registry element with element parent without custom element registry attribute (scoped registry) appended to new document
+PASS Global registry element with declarative shadow root parent without custom element registry attribute appended to new document
+FAIL Global registry element with declarative shadow root parent with custom element registry attribute (null registry) appended to new document assert_equals: expected object "[object CustomElementRegistry]" but got object "[object CustomElementRegistry]"
+FAIL Global registry element with declarative shadow root parent with custom element registry attribute (global registry) appended to new document assert_equals: expected object "[object CustomElementRegistry]" but got object "[object CustomElementRegistry]"
+FAIL Global registry element with declarative shadow root parent with custom element registry attribute (scoped registry) appended to new document assert_equals: expected object "[object CustomElementRegistry]" but got object "[object CustomElementRegistry]"
+FAIL Global registry element with imperative shadow root parent (null registry) appended to new document assert_equals: expected object "[object CustomElementRegistry]" but got object "[object CustomElementRegistry]"
+FAIL Global registry element with imperative shadow root parent (global registry) appended to new document assert_equals: expected object "[object CustomElementRegistry]" but got null
+FAIL Global registry element with imperative shadow root parent (scoped registry) appended to new document assert_equals: expected object "[object CustomElementRegistry]" but got object "[object CustomElementRegistry]"
+PASS Scoped registry element with element parent without custom element registry attribute (null registry) appended to new document
+PASS Scoped registry element with element parent without custom element registry attribute (global registry) appended to new document
+PASS Scoped registry element with element parent without custom element registry attribute (scoped registry) appended to new document
+PASS Scoped registry element with declarative shadow root parent without custom element registry attribute appended to new document
+FAIL Scoped registry element with declarative shadow root parent with custom element registry attribute (null registry) appended to new document assert_equals: expected null but got object "[object CustomElementRegistry]"
+PASS Scoped registry element with declarative shadow root parent with custom element registry attribute (global registry) appended to new document
+FAIL Scoped registry element with declarative shadow root parent with custom element registry attribute (scoped registry) appended to new document assert_equals: expected object "[object CustomElementRegistry]" but got object "[object CustomElementRegistry]"
+PASS Scoped registry element with imperative shadow root parent (null registry) appended to new document
+PASS Scoped registry element with imperative shadow root parent (global registry) appended to new document
+PASS Scoped registry element with imperative shadow root parent (scoped registry) appended to new document
+PASS Null registry element with element parent without custom element registry attribute (null registry) adopted by new document
+PASS Null registry element with element parent without custom element registry attribute (global registry) adopted by new document
+FAIL Null registry element with element parent without custom element registry attribute (scoped registry) adopted by new document assert_equals: expected null but got object "[object CustomElementRegistry]"
+FAIL Null registry element with declarative shadow root parent without custom element registry attribute adopted by new document assert_equals: expected object "[object CustomElementRegistry]" but got null
+FAIL Null registry element with declarative shadow root parent with custom element registry attribute (null registry) adopted by new document assert_equals: expected null but got object "[object CustomElementRegistry]"
+FAIL Null registry element with declarative shadow root parent with custom element registry attribute (global registry) adopted by new document assert_equals: expected object "[object CustomElementRegistry]" but got null
+FAIL Null registry element with declarative shadow root parent with custom element registry attribute (scoped registry) adopted by new document assert_equals: expected object "[object CustomElementRegistry]" but got object "[object CustomElementRegistry]"
+FAIL Null registry element with imperative shadow root parent (null registry) adopted by new document assert_equals: expected object "[object CustomElementRegistry]" but got null
+FAIL Null registry element with imperative shadow root parent (global registry) adopted by new document assert_equals: expected object "[object CustomElementRegistry]" but got null
+FAIL Null registry element with imperative shadow root parent (scoped registry) adopted by new document assert_equals: expected null but got object "[object CustomElementRegistry]"
+PASS Global registry element with element parent without custom element registry attribute (null registry) adopted by new document
+PASS Global registry element with element parent without custom element registry attribute (global registry) adopted by new document
+PASS Global registry element with element parent without custom element registry attribute (scoped registry) adopted by new document
+FAIL Global registry element with declarative shadow root parent without custom element registry attribute adopted by new document assert_equals: expected object "[object CustomElementRegistry]" but got null
+FAIL Global registry element with declarative shadow root parent with custom element registry attribute (null registry) adopted by new document assert_equals: expected object "[object CustomElementRegistry]" but got object "[object CustomElementRegistry]"
+FAIL Global registry element with declarative shadow root parent with custom element registry attribute (global registry) adopted by new document assert_equals: expected object "[object CustomElementRegistry]" but got object "[object CustomElementRegistry]"
+FAIL Global registry element with declarative shadow root parent with custom element registry attribute (scoped registry) adopted by new document assert_equals: expected object "[object CustomElementRegistry]" but got object "[object CustomElementRegistry]"
+FAIL Global registry element with imperative shadow root parent (null registry) adopted by new document assert_equals: expected object "[object CustomElementRegistry]" but got object "[object CustomElementRegistry]"
+FAIL Global registry element with imperative shadow root parent (global registry) adopted by new document assert_equals: expected object "[object CustomElementRegistry]" but got null
+FAIL Global registry element with imperative shadow root parent (scoped registry) adopted by new document assert_equals: expected object "[object CustomElementRegistry]" but got object "[object CustomElementRegistry]"
+PASS Scoped registry element with element parent without custom element registry attribute (null registry) adopted by new document
+PASS Scoped registry element with element parent without custom element registry attribute (global registry) adopted by new document
+PASS Scoped registry element with element parent without custom element registry attribute (scoped registry) adopted by new document
+PASS Scoped registry element with declarative shadow root parent without custom element registry attribute adopted by new document
+FAIL Scoped registry element with declarative shadow root parent with custom element registry attribute (null registry) adopted by new document assert_equals: expected null but got object "[object CustomElementRegistry]"
+PASS Scoped registry element with declarative shadow root parent with custom element registry attribute (global registry) adopted by new document
+FAIL Scoped registry element with declarative shadow root parent with custom element registry attribute (scoped registry) adopted by new document assert_equals: expected object "[object CustomElementRegistry]" but got object "[object CustomElementRegistry]"
+PASS Scoped registry element with imperative shadow root parent (null registry) adopted by new document
+PASS Scoped registry element with imperative shadow root parent (global registry) adopted by new document
+PASS Scoped registry element with imperative shadow root parent (scoped registry) adopted by new document
+PASS Null registry element with exclusive DocumentFragment parent appended to new document
+PASS Global registry element with exclusive DocumentFragment parent appended to new document
+PASS Scoped registry element with exclusive DocumentFragment parent appended to new document
+PASS Null registry element with exclusive DocumentFragment parent adopted by new document
+PASS Global registry element with exclusive DocumentFragment parent adopted by new document
+PASS Scoped registry element with exclusive DocumentFragment parent adopted by new document
+

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-effective-global-registry.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-effective-global-registry.html
@@ -1,0 +1,320 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="author" title="Jayson Chen" href="mailto:jaysonchen@microsoft.com">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+
+<template id="template-1">
+    <div id="template-host-1">
+        <template shadowrootmode="open" shadowrootclonable></template>
+    </div>
+</template>
+
+<template id="template-2">
+    <div id="template-host-2">
+        <template shadowrootmode="open" shadowrootclonable shadowrootcustomelementregistry></template>
+    </div>
+</template>
+<script>
+
+const scopedRegistry = new CustomElementRegistry;
+
+// Parent creation helpers
+function createParentElementWithoutRegistryAttribute(registry) {
+    const host = document.createElement('div');
+    host.append(document.createElement('div', {customElementRegistry: registry}));
+    return host;
+}
+
+function createParentDeclarativeShadowRootWithoutRegistryAttribute() {
+    const template = document.getElementById('template-1');
+    const clone = template.content.cloneNode(true);
+    document.body.append(clone);
+    return document.querySelector('#template-host-1');
+}
+
+function createParentDeclarativeShadowRootWithRegistryAttribute(registry) {
+    const template = document.getElementById('template-2');
+    const clone = template.content.cloneNode(true);
+    document.body.append(clone);
+    const shadowRoot = document.querySelector('#template-host-2').shadowRoot;
+    if (registry !== null) {
+        registry.initialize(shadowRoot);
+    }
+    return shadowRoot.host;
+}
+
+function createParentImperativeShadowRoot(registry) {
+    const host = document.createElement('div');
+    host.attachShadow({mode: 'open', customElementRegistry: registry});
+    return host;
+}
+
+// Child creation helpers
+function appendToElementOrShadowRoot(host, element) {
+    if (host.shadowRoot instanceof ShadowRoot) {
+        host.shadowRoot.appendChild(element);
+    } else {
+        host.firstElementChild.appendChild(element);
+    }
+    return host;
+}
+
+function addNullRegistryChild(host) {
+    appendToElementOrShadowRoot(host, document.createElement('a-b', {customElementRegistry: null}));
+    return host;
+}
+
+function addGlobalRegistryChild(host) {
+    appendToElementOrShadowRoot(host, document.createElement('a-b', {customElementRegistry: customElements}));
+    return host;
+}
+
+function addScopedRegistryChild(host) {
+    appendToElementOrShadowRoot(host, document.createElement('a-b', {customElementRegistry: scopedRegistry}));
+    return host;
+}
+
+// Operations
+function appendToNewDocument(node, test) {
+    const iframe = document.createElement('iframe');
+    document.body.appendChild(iframe);
+    test.add_cleanup(() => iframe.remove());
+    iframe.contentDocument.body.appendChild(node);
+    return [iframe.contentWindow, node];
+}
+
+function adoptedByNewDocument(node, test) {
+    const iframe = document.createElement('iframe');
+    document.body.appendChild(iframe);
+    test.add_cleanup(() => iframe.remove());
+    iframe.contentDocument.adoptNode(node);
+    return [iframe.contentWindow, node];
+}
+
+function runTest(operation, operationName) {
+    // Null registry child tests
+    test(test => {
+        const [win, host] = operation(addNullRegistryChild(createParentElementWithoutRegistryAttribute(null)), test);
+        assert_equals(host.querySelector('a-b').customElementRegistry, win.customElements);
+        assert_equals(host.firstElementChild.customElementRegistry, win.customElements);
+    },  'Null registry element with element parent without custom element registry attribute (null registry) ' + operationName);
+
+    test(test => {
+        const [win, host] = operation(addNullRegistryChild(createParentElementWithoutRegistryAttribute(customElements)), test);
+        assert_equals(host.querySelector('a-b').customElementRegistry, win.customElements);
+        assert_equals(host.firstElementChild.customElementRegistry, win.customElements);
+    },  'Null registry element with element parent without custom element registry attribute (global registry) ' + operationName);
+
+    test(test => {
+        const [win, host] = operation(addNullRegistryChild(createParentElementWithoutRegistryAttribute(scopedRegistry)), test);
+        assert_equals(host.querySelector('a-b').customElementRegistry, null);
+        assert_equals(host.firstElementChild.customElementRegistry, scopedRegistry);
+    },  'Null registry element with element parent without custom element registry attribute (scoped registry) ' + operationName);
+
+    test(test => {
+        const [win, host] = operation(addNullRegistryChild(createParentDeclarativeShadowRootWithoutRegistryAttribute()), test);
+        assert_equals(host.shadowRoot.querySelector('a-b').customElementRegistry, win.customElements);
+        assert_equals(host.shadowRoot.customElementRegistry, win.customElements);
+    },  'Null registry element with declarative shadow root parent without custom element registry attribute ' + operationName);
+
+    test(test => {
+        const [win, host] = operation(addNullRegistryChild(createParentDeclarativeShadowRootWithRegistryAttribute(null)), test);
+        assert_equals(host.shadowRoot.querySelector('a-b').customElementRegistry, null);
+        assert_equals(host.shadowRoot.customElementRegistry, null);
+    },  'Null registry element with declarative shadow root parent with custom element registry attribute (null registry) ' + operationName);
+
+    test(test => {
+        const [win, host] = operation(addNullRegistryChild(createParentDeclarativeShadowRootWithRegistryAttribute(customElements)), test);
+        assert_equals(host.shadowRoot.querySelector('a-b').customElementRegistry, win.customElements);
+        assert_equals(host.shadowRoot.customElementRegistry, win.customElements);
+    },  'Null registry element with declarative shadow root parent with custom element registry attribute (global registry) ' + operationName);
+
+    test(test => {
+        const [win, host] = operation(addNullRegistryChild(createParentDeclarativeShadowRootWithRegistryAttribute(scopedRegistry)), test);
+        assert_equals(host.shadowRoot.querySelector('a-b').customElementRegistry, null);
+        assert_equals(host.shadowRoot.customElementRegistry, scopedRegistry);
+    },  'Null registry element with declarative shadow root parent with custom element registry attribute (scoped registry) ' + operationName);
+
+    test(test => {
+        const [win, host] = operation(addNullRegistryChild(createParentImperativeShadowRoot(null)), test);
+        assert_equals(host.shadowRoot.querySelector('a-b').customElementRegistry, win.customElements);
+        assert_equals(host.shadowRoot.customElementRegistry, win.customElements);
+    },  'Null registry element with imperative shadow root parent (null registry) ' + operationName);
+
+    test(test => {
+        const [win, host] = operation(addNullRegistryChild(createParentImperativeShadowRoot(customElements)), test);
+        assert_equals(host.shadowRoot.querySelector('a-b').customElementRegistry, win.customElements);
+        assert_equals(host.shadowRoot.customElementRegistry, win.customElements);
+    },  'Null registry element with imperative shadow root parent (global registry) ' + operationName);
+
+    test(test => {
+        const [win, host] = operation(addNullRegistryChild(createParentImperativeShadowRoot(scopedRegistry)), test);
+        assert_equals(host.shadowRoot.querySelector('a-b').customElementRegistry, null);
+        assert_equals(host.shadowRoot.customElementRegistry, scopedRegistry);
+    },  'Null registry element with imperative shadow root parent (scoped registry) ' + operationName);
+
+    // Global registry child tests
+    test(test => {
+        const [win, host] = operation(addGlobalRegistryChild(createParentElementWithoutRegistryAttribute(null)), test);
+        assert_equals(host.querySelector('a-b').customElementRegistry, win.customElements);
+        assert_equals(host.firstElementChild.customElementRegistry, win.customElements);
+    },  'Global registry element with element parent without custom element registry attribute (null registry) ' + operationName);
+
+    test(test => {
+        const [win, host] = operation(addGlobalRegistryChild(createParentElementWithoutRegistryAttribute(customElements)), test);
+        assert_equals(host.querySelector('a-b').customElementRegistry, win.customElements);
+        assert_equals(host.firstElementChild.customElementRegistry, win.customElements);
+    },  'Global registry element with element parent without custom element registry attribute (global registry) ' + operationName);
+
+    test(test => {
+        const [win, host] = operation(addGlobalRegistryChild(createParentElementWithoutRegistryAttribute(scopedRegistry)), test);
+        assert_equals(host.querySelector('a-b').customElementRegistry, win.customElements);
+        assert_equals(host.firstElementChild.customElementRegistry, scopedRegistry);
+    },  'Global registry element with element parent without custom element registry attribute (scoped registry) ' + operationName);
+
+    test(test => {
+        const [win, host] = operation(addGlobalRegistryChild(createParentDeclarativeShadowRootWithoutRegistryAttribute()), test);
+        assert_equals(host.shadowRoot.querySelector('a-b').customElementRegistry, win.customElements);
+        assert_equals(host.shadowRoot.customElementRegistry, win.customElements);
+    },  'Global registry element with declarative shadow root parent without custom element registry attribute ' + operationName);
+
+    test(test => {
+        const [win, host] = operation(addGlobalRegistryChild(createParentDeclarativeShadowRootWithRegistryAttribute(null)), test);
+        assert_equals(host.shadowRoot.querySelector('a-b').customElementRegistry, win.customElements);
+        assert_equals(host.shadowRoot.customElementRegistry, null);
+    },  'Global registry element with declarative shadow root parent with custom element registry attribute (null registry) ' + operationName);
+
+    test(test => {
+        const [win, host] = operation(addGlobalRegistryChild(createParentDeclarativeShadowRootWithRegistryAttribute(customElements)), test);
+        assert_equals(host.shadowRoot.querySelector('a-b').customElementRegistry, win.customElements);
+        assert_equals(host.shadowRoot.customElementRegistry, win.customElements);
+    },  'Global registry element with declarative shadow root parent with custom element registry attribute (global registry) ' + operationName);
+
+    test(test => {
+        const [win, host] = operation(addGlobalRegistryChild(createParentDeclarativeShadowRootWithRegistryAttribute(scopedRegistry)), test);
+        assert_equals(host.shadowRoot.querySelector('a-b').customElementRegistry, win.customElements);
+        assert_equals(host.shadowRoot.customElementRegistry, scopedRegistry);
+    },  'Global registry element with declarative shadow root parent with custom element registry attribute (scoped registry) ' + operationName);
+
+    test(test => {
+        const [win, host] = operation(addGlobalRegistryChild(createParentImperativeShadowRoot(null)), test);
+        assert_equals(host.shadowRoot.querySelector('a-b').customElementRegistry, win.customElements);
+        assert_equals(host.shadowRoot.customElementRegistry, win.customElements);
+    },  'Global registry element with imperative shadow root parent (null registry) ' + operationName);
+
+    test(test => {
+        const [win, host] = operation(addGlobalRegistryChild(createParentImperativeShadowRoot(customElements)), test);
+        assert_equals(host.shadowRoot.querySelector('a-b').customElementRegistry, win.customElements);
+        assert_equals(host.shadowRoot.customElementRegistry, win.customElements);
+    },  'Global registry element with imperative shadow root parent (global registry) ' + operationName);
+
+    test(test => {
+        const [win, host] = operation(addGlobalRegistryChild(createParentImperativeShadowRoot(scopedRegistry)), test);
+        assert_equals(host.shadowRoot.querySelector('a-b').customElementRegistry, win.customElements);
+        assert_equals(host.shadowRoot.customElementRegistry, scopedRegistry);
+    },  'Global registry element with imperative shadow root parent (scoped registry) ' + operationName);
+
+    // Scoped registry child tests
+    test(test => {
+        const [win, host] = operation(addScopedRegistryChild(createParentElementWithoutRegistryAttribute(null)), test);
+        assert_equals(host.querySelector('a-b').customElementRegistry, scopedRegistry);
+        assert_equals(host.firstElementChild.customElementRegistry, win.customElements);
+    },  'Scoped registry element with element parent without custom element registry attribute (null registry) ' + operationName);
+
+    test(test => {
+        const [win, host] = operation(addScopedRegistryChild(createParentElementWithoutRegistryAttribute(customElements)), test);
+        assert_equals(host.querySelector('a-b').customElementRegistry, scopedRegistry);
+        assert_equals(host.firstElementChild.customElementRegistry, win.customElements);
+    },  'Scoped registry element with element parent without custom element registry attribute (global registry) ' + operationName);
+
+    test(test => {
+        const [win, host] = operation(addScopedRegistryChild(createParentElementWithoutRegistryAttribute(scopedRegistry)), test);
+        assert_equals(host.querySelector('a-b').customElementRegistry, scopedRegistry);
+        assert_equals(host.firstElementChild.customElementRegistry, scopedRegistry);
+    },  'Scoped registry element with element parent without custom element registry attribute (scoped registry) ' + operationName);
+
+    test(test => {
+        const [win, host] = operation(addScopedRegistryChild(createParentDeclarativeShadowRootWithoutRegistryAttribute()), test);
+        assert_equals(host.shadowRoot.querySelector('a-b').customElementRegistry, scopedRegistry);
+        assert_equals(host.shadowRoot.customElementRegistry, win.customElements);
+    },  'Scoped registry element with declarative shadow root parent without custom element registry attribute ' + operationName);
+
+    test(test => {
+        const [win, host] = operation(addScopedRegistryChild(createParentDeclarativeShadowRootWithRegistryAttribute(null)), test);
+        assert_equals(host.shadowRoot.querySelector('a-b').customElementRegistry, scopedRegistry);
+        assert_equals(host.shadowRoot.customElementRegistry, null);
+    },  'Scoped registry element with declarative shadow root parent with custom element registry attribute (null registry) ' + operationName);
+
+    test(test => {
+        const [win, host] = operation(addScopedRegistryChild(createParentDeclarativeShadowRootWithRegistryAttribute(customElements)), test);
+        assert_equals(host.shadowRoot.querySelector('a-b').customElementRegistry, scopedRegistry);
+        assert_equals(host.shadowRoot.customElementRegistry, win.customElements);
+    },  'Scoped registry element with declarative shadow root parent with custom element registry attribute (global registry) ' + operationName);
+
+    test(test => {
+        const [win, host] = operation(addScopedRegistryChild(createParentDeclarativeShadowRootWithRegistryAttribute(scopedRegistry)), test);
+        assert_equals(host.shadowRoot.querySelector('a-b').customElementRegistry, scopedRegistry);
+        assert_equals(host.shadowRoot.customElementRegistry, scopedRegistry);
+    },  'Scoped registry element with declarative shadow root parent with custom element registry attribute (scoped registry) ' + operationName);
+
+    test(test => {
+        const [win, host] = operation(addScopedRegistryChild(createParentImperativeShadowRoot(null)), test);
+        assert_equals(host.shadowRoot.querySelector('a-b').customElementRegistry, scopedRegistry);
+        assert_equals(host.shadowRoot.customElementRegistry, win.customElements);
+    },  'Scoped registry element with imperative shadow root parent (null registry) ' + operationName);
+
+    test(test => {
+        const [win, host] = operation(addScopedRegistryChild(createParentImperativeShadowRoot(customElements)), test);
+        assert_equals(host.shadowRoot.querySelector('a-b').customElementRegistry, scopedRegistry);
+        assert_equals(host.shadowRoot.customElementRegistry, win.customElements);
+    },  'Scoped registry element with imperative shadow root parent (global registry) ' + operationName);
+
+    test(test => {
+        const [win, host] = operation(addScopedRegistryChild(createParentImperativeShadowRoot(scopedRegistry)), test);
+        assert_equals(host.shadowRoot.querySelector('a-b').customElementRegistry, scopedRegistry);
+        assert_equals(host.shadowRoot.customElementRegistry, scopedRegistry);
+    },  'Scoped registry element with imperative shadow root parent (scoped registry) ' + operationName);
+}
+
+runTest(appendToNewDocument, 'appended to new document');
+runTest(adoptedByNewDocument, 'adopted by new document');
+
+// A child whose parent is an exclusive DocumentFragment node (a DocumentFragment that
+// is not a shadow root) uses the new document's custom element registry directly, rather
+// than looking up the registry via its parent.
+function runExclusiveDocumentFragmentTest(operation, operationName) {
+    test(test => {
+        const fragment = document.createDocumentFragment();
+        const child = document.createElement('a-b', {customElementRegistry: null});
+        fragment.append(child);
+        const [win] = operation(fragment, test);
+        assert_equals(child.customElementRegistry, win.customElements);
+    },  'Null registry element with exclusive DocumentFragment parent ' + operationName);
+
+    test(test => {
+        const fragment = document.createDocumentFragment();
+        const child = document.createElement('a-b', {customElementRegistry: customElements});
+        fragment.append(child);
+        const [win] = operation(fragment, test);
+        assert_equals(child.customElementRegistry, win.customElements);
+    },  'Global registry element with exclusive DocumentFragment parent ' + operationName);
+
+    test(test => {
+        const fragment = document.createDocumentFragment();
+        const child = document.createElement('a-b', {customElementRegistry: scopedRegistry});
+        fragment.append(child);
+        const [win] = operation(fragment, test);
+        assert_equals(child.customElementRegistry, scopedRegistry);
+    },  'Scoped registry element with exclusive DocumentFragment parent ' + operationName);
+}
+
+runExclusiveDocumentFragmentTest(appendToNewDocument, 'appended to new document');
+runExclusiveDocumentFragmentTest(adoptedByNewDocument, 'adopted by new document');
+
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/Construct.html
@@ -43,9 +41,10 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/pseudo-class-defined.window.js
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-custom-element-registry-customelementregistry-attribute-in-xhtml.xhtml
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-custom-element-registry-customelementregistry-attribute.html
-/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-append-does-not-upgrade.html
+/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-append.html
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-define-upgrade-criteria.html
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-define-upgrade-order.html
+/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-effective-global-registry.html
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-initialize-upgrades.html
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-initialize.html
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-registry-define-get-etc.html

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/resources/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/resources/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/resources/custom-elements-helpers.js

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/state/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/state/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/state/ElementInternals-states.html

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/upgrading/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/upgrading/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/upgrading/Document-importNode-customized-builtins.html

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/CustomElementRegistry-constructor-and-callbacks-are-held-strongly.html


### PR DESCRIPTION
#### 5cda5f6c19bd6a8c06890885867c0a032cb80e1e
<pre>
Sync custom elements tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=319258">https://bugs.webkit.org/show_bug.cgi?id=319258</a>

Reviewed by Tim Nguyen.

Update custom elements tests as of ca2cd19351859f7a15e536d0cf655fcaefe8e4d2.

* LayoutTests/imported/w3c/web-platform-tests/custom-elements/element-internals-aria-element-reflection-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/element-internals-aria-element-reflection.html:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/htmlconstructor/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/parser/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/perform-microtask-checkpoint-before-construction.html:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/reactions/customized-builtins/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/reactions/resources/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/reactions/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/Element-innerHTML-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/Element-innerHTML.html:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/element-mutation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/element-mutation.html:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-append-expected.txt: Renamed from LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-append-does-not-upgrade-expected.txt.
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-append.html: Renamed from LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-append-does-not-upgrade.html.
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-effective-global-registry-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-effective-global-registry.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/resources/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/state/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/upgrading/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/317082@main">https://commits.webkit.org/317082@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/32eb30fb7340db64613410417ed940b40c642ba1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174246 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48179 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41960 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183820 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132114 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/880f3bde-cfc5-4ff5-8733-81a9caa126ff) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49471 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47861 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135536 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3d0641c5-20ce-4e45-ae73-00dd8c0d35f1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177204 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38968 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156327 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116014 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6c6c00e7-57bb-4fd9-ba66-6e8f7ece3f38) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37608 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35977 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32304 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148032 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35820 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186246 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40174 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144441 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47846 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155882 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144299 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38900 "") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48525 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32440 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114058 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26492 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39204 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47031 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10782 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46434 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46665 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46492 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->