### PR TITLE
[EvaluationTimeZoom] Convert remaining font related uses to use unzoomed lengths

### DIFF
--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp
@@ -364,7 +364,7 @@ static std::optional<UnresolvedFontSize> consumeFontSizeUnresolved(CSSParserToke
 
     auto rangeCopy = range;
 
-    auto lengthPercentage = MetaConsumer<CSS::LengthPercentage<CSS::Nonnegative>>::consume(rangeCopy, state);
+    auto lengthPercentage = MetaConsumer<CSS::LengthPercentage<CSS::NonnegativeUnzoomed>>::consume(rangeCopy, state);
     if (!lengthPercentage)
         return std::nullopt;
 
@@ -382,7 +382,7 @@ static std::optional<UnresolvedFontLineHeight> consumeLineHeightUnresolved(CSSPa
     using Consumer = MetaConsumer<
         CSS::Keyword::Normal,
         CSS::Number<CSS::Nonnegative>,
-        CSS::LengthPercentage<CSS::Nonnegative>
+        CSS::LengthPercentage<CSS::NonnegativeUnzoomed>
     >;
 
     return Consumer::consume(range, state,

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.h
@@ -79,10 +79,10 @@ using UnresolvedFontWidthPercentage = CSS::Percentage<CSS::Nonnegative>;
 using UnresolvedFontWidth = Variant<CSSValueID, UnresolvedFontWidthPercentage>;
 
 // <absolute-size> | <relative-size> | <length-percentage [0,∞]>
-using UnresolvedFontSize = Variant<CSSValueID, CSS::LengthPercentage<CSS::Nonnegative>>;
+using UnresolvedFontSize = Variant<CSSValueID, CSS::LengthPercentage<CSS::NonnegativeUnzoomed>>;
 
 // normal | <number [0,∞]> | <length-percentage [0,∞]>
-using UnresolvedFontLineHeight = Variant<CSSValueID, CSS::Number<CSS::Nonnegative>, CSS::LengthPercentage<CSS::Nonnegative>>;
+using UnresolvedFontLineHeight = Variant<CSSValueID, CSS::Number<CSS::Nonnegative>, CSS::LengthPercentage<CSS::NonnegativeUnzoomed>>;
 
 // [ <family-name> | <generic-family> ]#
 using UnresolvedFontFamilyName = Variant<CSSValueID, AtomString>;

--- a/Source/WebCore/editing/ApplyStyleCommand.cpp
+++ b/Source/WebCore/editing/ApplyStyleCommand.cpp
@@ -1520,7 +1520,7 @@ float ApplyStyleCommand::computedFontSize(Node* node)
     RefPtr value = dynamicDowncast<CSSPrimitiveValue>(Style::Extractor(node).propertyValue(CSSPropertyFontSize));
     if (!value)
         return 0;
-    return Style::deprecatedToStyleFromCSSValue<Style::Length<CSS::Nonnegative, float>>(*value)->resolveZoom(Style::ZoomNeeded { });
+    return Style::deprecatedToStyleFromCSSValue<Style::Length<CSS::NonnegativeUnzoomed, float>>(*value)->resolveZoom(Style::ZoomFactor::none());
 }
 
 void ApplyStyleCommand::joinChildTextNodes(Node* node, const Position& start, const Position& end)

--- a/Source/WebCore/editing/EditingStyle.cpp
+++ b/Source/WebCore/editing/EditingStyle.cpp
@@ -638,7 +638,7 @@ void EditingStyle::extractFontSizeDelta()
     if (!primitiveValue->isPx())
         return;
 
-    m_fontSizeDelta = Style::deprecatedToStyleFromCSSValue<Style::Length<CSS::All, float>>(*primitiveValue)->resolveZoom(Style::ZoomNeeded { });
+    m_fontSizeDelta = Style::deprecatedToStyleFromCSSValue<Style::Length<CSS::AllUnzoomed, float>>(*primitiveValue)->resolveZoom(Style::ZoomFactor::none());
     mutableStyle->removeProperty(CSSPropertyWebkitFontSizeDelta);
 }
 
@@ -2120,7 +2120,7 @@ static bool NODELETE isCSSValueLength(CSSPrimitiveValue& value)
 int legacyFontSizeFromCSSValue(Document& document, CSSValue& value, bool shouldUseFixedFontDefaultSize, LegacyFontSizeMode mode)
 {
     if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value); primitiveValue && isCSSValueLength(*primitiveValue)) {
-        int pixelFontSize = Style::deprecatedToStyleFromCSSValue<Style::Length<CSS::Nonnegative, int>>(*primitiveValue)->resolveZoom(Style::ZoomNeeded { });
+        int pixelFontSize = Style::deprecatedToStyleFromCSSValue<Style::Length<CSS::NonnegativeUnzoomed, int>>(*primitiveValue)->resolveZoom(Style::ZoomFactor::none());
         int legacyFontSize = Style::legacyFontSizeForPixelSize(pixelFontSize, shouldUseFixedFontDefaultSize, document);
         // Use legacy font size only if pixel value matches exactly to that of legacy font size.
         int cssPrimitiveEquivalent = legacyFontSize - 1 + CSSValueXSmall;

--- a/Source/WebCore/editing/cocoa/NodeHTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/NodeHTMLConverter.mm
@@ -650,7 +650,7 @@ String HTMLConverterCaches::propertyValueForNode(Node& node, CSSPropertyID prope
 static inline bool floatValueFromPrimitiveValue(CSSPrimitiveValue& primitiveValue, float& result)
 {
     if (primitiveValue.isFontIndependentLength()) {
-        result = WebCore::Style::deprecatedToStyleFromCSSValue<WebCore::Style::Length<CSS::All, float>>(primitiveValue)->resolveZoom(WebCore::Style::ZoomNeeded { });
+        result = WebCore::Style::deprecatedToStyleFromCSSValue<WebCore::Style::Length<CSS::AllUnzoomed, float>>(primitiveValue)->resolveZoom(WebCore::Style::ZoomFactor::none());
         return true;
     }
     return false;

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -3273,7 +3273,7 @@ void CanvasRenderingContext2DBase::setLetterSpacing(const String& letterSpacing)
     auto parserContext = CSSParserContext { HTMLStandardMode };
     auto parserState = CSS::PropertyParserState { .context = parserContext, .pool = protect(canvasBase())->scriptExecutionContext()->cssValuePool() };
 
-    auto parsedValue = CSSPropertyParserHelpers::MetaConsumer<CSS::Length<>>::consume(tokenRange, parserState);
+    auto parsedValue = CSSPropertyParserHelpers::MetaConsumer<CSS::Length<CSS::AllUnzoomed>>::consume(tokenRange, parserState);
     if (!parsedValue)
         return;
     auto rawLength = parsedValue->raw();
@@ -3301,7 +3301,7 @@ void CanvasRenderingContext2DBase::setWordSpacing(const String& wordSpacing)
     auto parserContext = CSSParserContext { HTMLStandardMode };
     auto parserState = CSS::PropertyParserState { .context = parserContext, .pool = protect(canvasBase())->scriptExecutionContext()->cssValuePool() };
 
-    auto parsedValue = CSSPropertyParserHelpers::MetaConsumer<CSS::Length<>>::consume(tokenRange, parserState);
+    auto parsedValue = CSSPropertyParserHelpers::MetaConsumer<CSS::Length<CSS::AllUnzoomed>>::consume(tokenRange, parserState);
     if (!parsedValue)
         return;
     auto rawLength = parsedValue->raw();

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -678,11 +678,11 @@ inline void BuilderCustom::applyValueFontSize(BuilderState& builderState, CSSVal
 
         auto conversionData = builderState.cssToLengthConversionData().copyForFontSize();
 
-        using StyleType = LengthPercentage<CSS::Nonnegative, float>;
+        using StyleType = LengthPercentage<CSS::NonnegativeUnzoomed, float>;
 
-        auto handleLength = [](const auto& length) -> float { return length.resolveZoom(ZoomNeeded { }); };
+        auto handleLength = [](const auto& length) -> float { return length.resolveZoom(ZoomFactor::none()); };
         auto handlePercentage = [&](const auto& percentage) -> float { return percentage.value * parentSize / 100.0f; };
-        auto handleCalc = [&](const auto& calc) -> float { return calc.evaluate(parentSize, ZoomNeeded { }); };
+        auto handleCalc = [&](const auto& calc) -> float { return calc.evaluate(parentSize, ZoomFactor::none()); };
 
         size =  WTF::switchOn(*primitiveValue,
             [&](const CSSPrimitiveValue::Calc& calc) -> float {

--- a/Source/WebCore/style/StyleExtractorCustom.h
+++ b/Source/WebCore/style/StyleExtractorCustom.h
@@ -779,12 +779,12 @@ template<> struct PropertyExtractorAdaptor<CSSPropertyLineHeight> {
                 // for how high to be in pixels does include things like minimum font size and the zoom factor.
                 // On the other hand, since font-size doesn't include the zoom factor, we really can't do
                 // that here either.
-                return functor(Length<CSS::Nonnegative> { percentage.value * state.style.fontDescription().computedSize() / 100 });
+                return functor(Length<CSS::NonnegativeUnzoomed> { percentage.value * state.style.fontDescription().computedSizeForRangeZoomOption(CSS::RangeZoomOptions::Unzoomed) / 100 });
             },
             [&](const LineHeight::Calc& calc) {
-                // FIXME: We pass 1.0f here to get the unzoomed value but it really is not clear why we are even
-                // evaluating calc here. We should probably revisit this and figure out another way to do this.
-                return functor(Length<CSS::Nonnegative> { evaluate<float>(calc, 0.0f, Style::ZoomFactor { 1.0f }) });
+                // FIXME: We pass ZoomFactor::none() but it really is not clear why we are even evaluating calc
+                // here. We should probably revisit this and figure out another way to do this.
+                return functor(Length<CSS::NonnegativeUnzoomed> { evaluate<float>(calc, 0.0f, ZoomFactor::none()) });
             }
         );
     }
@@ -803,7 +803,7 @@ template<> struct PropertyExtractorAdaptor<CSSPropertyFontFamily> {
 template<> struct PropertyExtractorAdaptor<CSSPropertyFontSize> {
     template<typename F> decltype(auto) computedValue(ExtractorState& state, F&& functor) const
     {
-        return functor(Length<CSS::Nonnegative> { state.style.fontDescription().computedSize() });
+        return functor(Length<CSS::NonnegativeUnzoomed> { state.style.fontDescription().computedSizeForRangeZoomOption(CSS::RangeZoomOptions::Unzoomed) });
     }
 };
 
@@ -2957,7 +2957,7 @@ inline RefPtr<CSSValue> ExtractorCustom::extractFontShorthand(ExtractorState& st
     if (!propertiesResetByShorthandAreExpressible())
         return computedFont;
 
-    computedFont->size = createCSSValue(state.pool, state.style, Length<> { description.computedSize() });
+    computedFont->size = createCSSValue(state.pool, state.style, Length<CSS::AllUnzoomed> { description.computedSizeForRangeZoomOption(CSS::RangeZoomOptions::Unzoomed) });
 
     auto computedLineHeight = ExtractorGenerated::extractValue(state, CSSPropertyLineHeight);
     if (computedLineHeight && !isValueID(*computedLineHeight, CSSValueNormal))

--- a/Source/WebCore/style/StyleResolveForFont.cpp
+++ b/Source/WebCore/style/StyleResolveForFont.cpp
@@ -252,9 +252,9 @@ static ResolvedFontSize fontSizeFromUnresolvedFontSize(const CSSPropertyParserHe
             ASSERT_NOT_REACHED();
             return { .size = 0.0f, .keyword = CSSValueInvalid };
         },
-        [&](const CSS::LengthPercentage<CSS::Nonnegative>& lengthPercentage) -> ResolvedFontSize {
+        [&](const CSS::LengthPercentage<CSS::NonnegativeUnzoomed>& lengthPercentage) -> ResolvedFontSize {
             return WTF::switchOn(lengthPercentage,
-                [&](const CSS::LengthPercentage<CSS::Nonnegative>::Raw& lengthPercentage) -> ResolvedFontSize {
+                [&](const CSS::LengthPercentage<CSS::NonnegativeUnzoomed>::Raw& lengthPercentage) -> ResolvedFontSize {
                     return CSS::switchOnUnitType(lengthPercentage.unit,
                         [&](CSS::PercentageUnit) -> ResolvedFontSize {
                             return {
@@ -281,13 +281,13 @@ static ResolvedFontSize fontSizeFromUnresolvedFontSize(const CSSPropertyParserHe
                         }
                     );
                 },
-                [&](const CSS::LengthPercentage<CSS::Nonnegative>::Calc& calc) -> ResolvedFontSize {
+                [&](const CSS::LengthPercentage<CSS::NonnegativeUnzoomed>::Calc& calc) -> ResolvedFontSize {
                     // FIXME: Figure out correct behavior when conversion data is required.
                     if (requiresConversionData(calc))
                         return { .size = 0.0f, .keyword = CSSValueInvalid };
 
                     return {
-                        .size = Style::evaluate<float>(Style::toStyleNoConversionDataRequired(calc), parentSize, Style::ZoomNeeded { }),
+                        .size = Style::evaluate<float>(Style::toStyleNoConversionDataRequired(calc), parentSize, Style::ZoomFactor::none()),
                         .keyword = CSSValueInvalid
                     };
                 }

--- a/Source/WebCore/style/computed/StyleComputedStyleProperties+SettersCustomInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleProperties+SettersCustomInlines.h
@@ -138,7 +138,7 @@ inline void ComputedStyleProperties::setFontSize(float size)
 
     auto description = fontDescription();
     description.setSpecifiedSize(size);
-    description.setComputedSize(size);
+    description.setComputedSize(size, description.usedZoomFactor());
     setFontDescription(WTF::move(description));
 
     // Whenever the font size changes, letter-spacing and word-spacing, which are dependent on font-size, must be re-synchronized.


### PR DESCRIPTION
#### 3231b507df562bd14ce7499b9b3c151136936bbe
<pre>
[EvaluationTimeZoom] Convert remaining font related uses to use unzoomed lengths
<a href="https://bugs.webkit.org/show_bug.cgi?id=319259">https://bugs.webkit.org/show_bug.cgi?id=319259</a>

Reviewed by Darin Adler and Alan Baradlay.

Switches to using unzoomed length for font related cases.

For uses of deprecatedToStyleFromCSSValue() or when passing no
conversion data it is fine a no-op to change to passing no zoom
factor explicitly.

To allow the unzoomed value to be accessed at computed value time
during animations, ComputedStyleProperties::setFontSize was fixed
to ensure the usedZoom was maintained when setting the size.

* Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.h:
* Source/WebCore/editing/ApplyStyleCommand.cpp:
* Source/WebCore/editing/EditingStyle.cpp:
* Source/WebCore/editing/cocoa/NodeHTMLConverter.mm:
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
* Source/WebCore/style/StyleBuilderCustom.h:
* Source/WebCore/style/StyleExtractorCustom.h:
* Source/WebCore/style/StyleResolveForFont.cpp:
* Source/WebCore/style/computed/StyleComputedStyleProperties+SettersCustomInlines.h:

Canonical link: <a href="https://commits.webkit.org/317244@main">https://commits.webkit.org/317244@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/87b10ce3da8b1c564e9c0fe83950d4e432292b72

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174501 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48434 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42215 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184078 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132369 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176366 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49726 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48117 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135766 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95808 "1 flakes 4 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177459 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39200 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156559 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116244 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37841 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36208 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32559 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148264 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36051 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186504 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39744 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40405 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144678 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48101 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144536 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39007 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48780 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32671 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39432 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120753 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47287 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11015 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46689 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46920 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46747 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->