### PR TITLE
Cleanup StyleBuilderCustom.h a bit

### DIFF
--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -68,151 +68,42 @@
 namespace WebCore {
 namespace Style {
 
-#define DECLARE_PROPERTY_CUSTOM_HANDLERS(property) \
-    static void applyInherit##property(BuilderState&); \
-    static void applyInitial##property(BuilderState&); \
-    static void applyValue##property(BuilderState&, CSSValue&)
+template<typename T>
+decltype(auto) forwardInheritedValue(T&& value)
+{
+    if constexpr (std::is_lvalue_reference_v<T>)
+        return std::remove_cvref_t<T>(value);
+    else
+        return std::forward<T>(value);
+}
 
-template<typename T> inline T forwardInheritedValue(T&& value) { return std::forward<T>(value); }
-template<auto R, typename V> inline Length<R, V> forwardInheritedValue(const Length<R, V>& value) { auto copy = value; return copy; }
-inline AccentColor forwardInheritedValue(const AccentColor& value) { auto copy = value; return copy; }
-inline AnchorNames forwardInheritedValue(const AnchorNames& value) { auto copy = value; return copy; }
-inline AppleColorFilter forwardInheritedValue(const AppleColorFilter& value) { auto copy = value; return copy; }
-inline AspectRatio forwardInheritedValue(const AspectRatio& value) { auto copy = value; return copy; }
-inline BackgroundSize forwardInheritedValue(const BackgroundSize& value) { auto copy = value; return copy; }
-inline BlockEllipsis forwardInheritedValue(const BlockEllipsis& value) { auto copy = value; return copy; }
-inline BlockStepSize forwardInheritedValue(const BlockStepSize& value) { auto copy = value; return copy; }
-inline BorderImageSource forwardInheritedValue(const BorderImageSource& value) { auto copy = value; return copy; }
-inline BorderImageSlice forwardInheritedValue(const BorderImageSlice& value) { auto copy = value; return copy; }
-inline BorderImageWidth forwardInheritedValue(const BorderImageWidth& value) { auto copy = value; return copy; }
-inline BorderImageOutset forwardInheritedValue(const BorderImageOutset& value) { auto copy = value; return copy; }
-inline BorderImageRepeat forwardInheritedValue(const BorderImageRepeat& value) { auto copy = value; return copy; }
-inline BorderRadiusValue forwardInheritedValue(const BorderRadiusValue& value) { auto copy = value; return copy; }
-inline BoxShadows forwardInheritedValue(const BoxShadows& value) { auto copy = value; return copy; }
-inline CaretColor forwardInheritedValue(const CaretColor& value) { auto copy = value; return copy; }
-inline ContainIntrinsicSize forwardInheritedValue(const ContainIntrinsicSize& value) { auto copy = value; return copy; }
-inline ContainerNames forwardInheritedValue(const ContainerNames& value) { auto copy = value; return copy; }
-inline CounterIncrement forwardInheritedValue(const CounterIncrement& value) { auto copy = value; return copy; }
-inline CounterReset forwardInheritedValue(const CounterReset& value) { auto copy = value; return copy; }
-inline CounterSet forwardInheritedValue(const CounterSet& value) { auto copy = value; return copy; }
-inline Content forwardInheritedValue(const Content& value) { auto copy = value; return copy; }
-inline WebCore::Color forwardInheritedValue(const WebCore::Color& value) { auto copy = value; return copy; }
-inline Color forwardInheritedValue(const Color& value) { auto copy = value; return copy; }
-inline EasingFunction forwardInheritedValue(const EasingFunction& value) { auto copy = value; return copy; }
-inline GapGutter forwardInheritedValue(const GapGutter& value) { auto copy = value; return copy; }
-inline FontFamilies forwardInheritedValue(const FontFamilies& value) { auto copy = value; return copy; }
-inline ScrollMarginEdge forwardInheritedValue(const ScrollMarginEdge& value) { auto copy = value; return copy; }
-inline ScrollPaddingEdge forwardInheritedValue(const ScrollPaddingEdge& value) { auto copy = value; return copy; }
-inline LineWidth forwardInheritedValue(const LineWidth& value) { auto copy = value; return copy; }
-inline MaskBorderSource forwardInheritedValue(const MaskBorderSource& value) { auto copy = value; return copy; }
-inline MaskBorderSlice forwardInheritedValue(const MaskBorderSlice& value) { auto copy = value; return copy; }
-inline MaskBorderWidth forwardInheritedValue(const MaskBorderWidth& value) { auto copy = value; return copy; }
-inline MaskBorderOutset forwardInheritedValue(const MaskBorderOutset& value) { auto copy = value; return copy; }
-inline MaskBorderRepeat forwardInheritedValue(const MaskBorderRepeat& value) { auto copy = value; return copy; }
-inline MarginEdge forwardInheritedValue(const MarginEdge& value) { auto copy = value; return copy; }
-inline PaddingEdge forwardInheritedValue(const PaddingEdge& value) { auto copy = value; return copy; }
-inline ImageOrNone forwardInheritedValue(const ImageOrNone& value) { auto copy = value; return copy; }
-inline InsetEdge forwardInheritedValue(const InsetEdge& value) { auto copy = value; return copy; }
-inline Perspective forwardInheritedValue(const Perspective& value) { auto copy = value; return copy; }
-inline Quotes forwardInheritedValue(const Quotes& value) { auto copy = value; return copy; }
-inline Rotate forwardInheritedValue(const Rotate& value) { auto copy = value; return copy; }
-inline Scale forwardInheritedValue(const Scale& value) { auto copy = value; return copy; }
-inline Translate forwardInheritedValue(const Translate& value) { auto copy = value; return copy; }
-inline PreferredSize forwardInheritedValue(const PreferredSize& value) { auto copy = value; return copy; }
-inline MinimumSize forwardInheritedValue(const MinimumSize& value) { auto copy = value; return copy; }
-inline MaximumSize forwardInheritedValue(const MaximumSize& value) { auto copy = value; return copy; }
-inline Filter forwardInheritedValue(const Filter& value) { auto copy = value; return copy; }
-inline FlexBasis forwardInheritedValue(const FlexBasis& value) { auto copy = value; return copy; }
-inline DynamicRangeLimit forwardInheritedValue(const DynamicRangeLimit& value) { auto copy = value; return copy; }
-inline Clip forwardInheritedValue(const Clip& value) { auto copy = value; return copy; }
-inline ClipPath forwardInheritedValue(const ClipPath& value) { auto copy = value; return copy; }
-inline CornerShapeValue forwardInheritedValue(const CornerShapeValue& value) { auto copy = value; return copy; }
-inline GridPosition forwardInheritedValue(const GridPosition& value) { auto copy = value; return copy; }
-inline GridTemplateAreas forwardInheritedValue(const GridTemplateAreas& value) { auto copy = value; return copy; }
-inline GridTemplateList forwardInheritedValue(const GridTemplateList& value) { auto copy = value; return copy; }
-inline GridTrackSizes forwardInheritedValue(const GridTrackSizes& value) { auto copy = value; return copy; }
-inline HyphenateCharacter forwardInheritedValue(const HyphenateCharacter& value) { auto copy = value; return copy; }
-inline FlowTolerance forwardInheritedValue(const FlowTolerance& value) { auto copy = value; return copy; }
-inline LetterSpacing forwardInheritedValue(const LetterSpacing& value) { auto copy = value; return copy; }
-inline LineHeight forwardInheritedValue(const LineHeight& value) { auto copy = value; return copy; }
-inline ListStyleType forwardInheritedValue(const ListStyleType& value) { auto copy = value; return copy; }
-inline NameScope forwardInheritedValue(const NameScope& value) { auto copy = value; return copy; }
-inline OffsetAnchor forwardInheritedValue(const OffsetAnchor& value) { auto copy = value; return copy; }
-inline OffsetDistance forwardInheritedValue(const OffsetDistance& value) { auto copy = value; return copy; }
-inline OffsetPath forwardInheritedValue(const OffsetPath& value) { auto copy = value; return copy; }
-inline OffsetPosition forwardInheritedValue(const OffsetPosition& value) { auto copy = value; return copy; }
-inline OffsetRotate forwardInheritedValue(const OffsetRotate& value) { auto copy = value; return copy; }
-inline ObjectViewBox forwardInheritedValue(const ObjectViewBox& value) { auto copy = value; return copy; }
-inline OutlineOffset forwardInheritedValue(const OutlineOffset& value) { auto copy = value; return copy; }
-inline OverflowClipMargin forwardInheritedValue(const OverflowClipMargin& value) { auto copy = value; return copy; }
-inline Position forwardInheritedValue(const Position& value) { auto copy = value; return copy; }
-inline PositionAnchor forwardInheritedValue(const PositionAnchor& value) { auto copy = value; return copy; }
-inline PositionTryFallbacks forwardInheritedValue(const PositionTryFallbacks& value) { auto copy = value; return copy; }
-inline PositionX forwardInheritedValue(const PositionX& value) { auto copy = value; return copy; }
-inline PositionY forwardInheritedValue(const PositionY& value) { auto copy = value; return copy; }
-inline RepeatStyle forwardInheritedValue(const RepeatStyle& value) { auto copy = value; return copy; }
-inline SVGBaselineShift forwardInheritedValue(const SVGBaselineShift& value) { auto copy = value; return copy; }
-inline SVGCenterCoordinateComponent forwardInheritedValue(const SVGCenterCoordinateComponent& value) { auto copy = value; return copy; }
-inline SVGCoordinateComponent forwardInheritedValue(const SVGCoordinateComponent& value) { auto copy = value; return copy; }
-inline SVGMarkerResource forwardInheritedValue(const SVGMarkerResource& value) { auto copy = value; return copy; }
-inline SVGPathData forwardInheritedValue(const SVGPathData& value) { auto copy = value; return copy; }
-inline SVGPaint forwardInheritedValue(const SVGPaint& value) { auto copy = value; return copy; }
-inline SVGRadius forwardInheritedValue(const SVGRadius& value) { auto copy = value; return copy; }
-inline SVGRadiusComponent forwardInheritedValue(const SVGRadiusComponent& value) { auto copy = value; return copy; }
-inline SVGStrokeDasharray forwardInheritedValue(const SVGStrokeDasharray& value) { auto copy = value; return copy; }
-inline SVGStrokeDashoffset forwardInheritedValue(const SVGStrokeDashoffset& value) { auto copy = value; return copy; }
-inline ScrollSnapAlign forwardInheritedValue(const ScrollSnapAlign& value) { auto copy = value; return copy; }
-inline ScrollSnapType forwardInheritedValue(const ScrollSnapType& value) { auto copy = value; return copy; }
-inline ScrollbarColor forwardInheritedValue(const ScrollbarColor& value) { auto copy = value; return copy; }
-inline ScrollbarGutter forwardInheritedValue(const ScrollbarGutter& value) { auto copy = value; return copy; }
-inline ContainerType forwardInheritedValue(const ContainerType& value) { auto copy = value; return copy; }
-inline ShapeMargin forwardInheritedValue(const ShapeMargin& value) { auto copy = value; return copy; }
-inline ShapeOutside forwardInheritedValue(const ShapeOutside& value) { auto copy = value; return copy; }
-inline SingleAnimationName forwardInheritedValue(const SingleAnimationName& value) { auto copy = value; return copy; }
-inline SingleAnimationRangeStart forwardInheritedValue(const SingleAnimationRangeStart& value) { auto copy = value; return copy; }
-inline SingleAnimationRangeEnd forwardInheritedValue(const SingleAnimationRangeEnd& value) { auto copy = value; return copy; }
-inline SingleAnimationRange forwardInheritedValue(const SingleAnimationRange& value) { auto copy = value; return copy; }
-inline SingleAnimationTimeline forwardInheritedValue(const SingleAnimationTimeline& value) { auto copy = value; return copy; }
-inline SingleTransitionProperty forwardInheritedValue(const SingleTransitionProperty& value) { auto copy = value; return copy; }
-inline StrokeWidth forwardInheritedValue(const StrokeWidth& value) { auto copy = value; return copy; }
-inline TabSize forwardInheritedValue(const TabSize& value) { auto copy = value; return copy; }
-inline TextDecorationLine forwardInheritedValue(const TextDecorationLine& value) { auto copy = value; return copy; }
-inline TextDecorationThickness forwardInheritedValue(const TextDecorationThickness& value) { auto copy = value; return copy; }
-inline TextEmphasisStyle forwardInheritedValue(const TextEmphasisStyle& value) { auto copy = value; return copy; }
-inline TextIndent forwardInheritedValue(const TextIndent& value) { auto copy = value; return copy; }
-inline TextShadows forwardInheritedValue(const TextShadows& value) { auto copy = value; return copy; }
-inline TextUnderlineOffset forwardInheritedValue(const TextUnderlineOffset& value) { auto copy = value; return copy; }
-inline URL forwardInheritedValue(const URL& value) { auto copy = value; return copy; }
-inline FixedVector<PositionTryFallback> forwardInheritedValue(const FixedVector<PositionTryFallback>& value) { auto copy = value; return copy; }
-inline ProgressTimelineName forwardInheritedValue(const ProgressTimelineName& value) { auto copy = value; return copy; }
-inline ScrollTimelines forwardInheritedValue(const ScrollTimelines& value) { auto copy = value; return copy; }
-inline TimelineTriggerName forwardInheritedValue(const TimelineTriggerName& value) { auto copy = value; return copy; }
-inline Transform forwardInheritedValue(const Transform& value) { auto copy = value; return copy; }
-inline VerticalAlign forwardInheritedValue(const VerticalAlign& value) { auto copy = value; return copy; }
-inline ViewTimelineInsetItem forwardInheritedValue(const ViewTimelineInsetItem& value) { auto copy = value; return copy; }
-inline ViewTimelines forwardInheritedValue(const ViewTimelines& value) { auto copy = value; return copy; }
-inline ViewTransitionClasses forwardInheritedValue(const ViewTransitionClasses& value) { auto copy = value; return copy; }
-inline ViewTransitionName forwardInheritedValue(const ViewTransitionName& value) { auto copy = value; return copy; }
-inline WebkitBoxReflect forwardInheritedValue(const WebkitBoxReflect& value) { auto copy = value; return copy; }
-inline WebkitInitialLetter forwardInheritedValue(const WebkitInitialLetter& value) { auto copy = value; return copy; }
-inline WebkitLineClamp forwardInheritedValue(const WebkitLineClamp& value) { auto copy = value; return copy; }
-inline WebkitLineGrid forwardInheritedValue(const WebkitLineGrid& value) { auto copy = value; return copy; }
-inline WebkitMarqueeIncrement forwardInheritedValue(const WebkitMarqueeIncrement& value) { auto copy = value; return copy; }
-inline WillChange forwardInheritedValue(const WillChange& value) { auto copy = value; return copy; }
-inline WordSpacing forwardInheritedValue(const WordSpacing& value) { auto copy = value; return copy; }
-
-// Note that we assume the CSS parser only allows valid CSSValue types.
 class BuilderCustom {
 public:
-    // Custom handling of inherit, initial and value setting.
-    DECLARE_PROPERTY_CUSTOM_HANDLERS(FontFamily);
-    DECLARE_PROPERTY_CUSTOM_HANDLERS(FontSize);
-    DECLARE_PROPERTY_CUSTOM_HANDLERS(LetterSpacing);
+    static void applyInheritFontFamily(BuilderState&);
+    static void applyInitialFontFamily(BuilderState&);
+    static void applyValueFontFamily(BuilderState&, CSSValue&);
+
+    static void applyInheritFontSize(BuilderState&);
+    static void applyInitialFontSize(BuilderState&);
+    static void applyValueFontSize(BuilderState&, CSSValue&);
+
+    static void applyInheritLetterSpacing(BuilderState&);
+    static void applyInitialLetterSpacing(BuilderState&);
+    static void applyValueLetterSpacing(BuilderState&, CSSValue&);
+
 #if ENABLE(TEXT_AUTOSIZING)
-    DECLARE_PROPERTY_CUSTOM_HANDLERS(LineHeight);
+    static void applyInheritLineHeight(BuilderState&);
+    static void applyInitialLineHeight(BuilderState&);
+    static void applyValueLineHeight(BuilderState&, CSSValue&);
 #endif
-    DECLARE_PROPERTY_CUSTOM_HANDLERS(WordSpacing);
-    DECLARE_PROPERTY_CUSTOM_HANDLERS(Zoom);
+
+    static void applyInheritWordSpacing(BuilderState&);
+    static void applyInitialWordSpacing(BuilderState&);
+    static void applyValueWordSpacing(BuilderState&, CSSValue&);
+
+    static void applyInheritZoom(BuilderState&);
+    static void applyInitialZoom(BuilderState&);
+    static void applyValueZoom(BuilderState&, CSSValue&);
 
     // Custom handling of initial setting only.
     static void applyInitialBorderTopWidth(BuilderState&);
@@ -236,12 +127,6 @@ public:
 
 private:
     static void resetUsedZoom(BuilderState&);
-
-    enum CounterBehavior { Increment, Reset, Set };
-    template<CounterBehavior>
-    static void applyInheritCounter(BuilderState&);
-    template<CounterBehavior>
-    static void applyValueCounter(BuilderState&, CSSValue&);
 
     static float largerFontSize(float size);
     static float smallerFontSize(float size);


### PR DESCRIPTION
#### 9100d1e997f262cad49c831df7c479d98ced8062
<pre>
Cleanup StyleBuilderCustom.h a bit
<a href="https://bugs.webkit.org/show_bug.cgi?id=319268">https://bugs.webkit.org/show_bug.cgi?id=319268</a>

Reviewed by Alan Baradlay.

- Replaces `forwardInheritedValue` overloads with a single generic version.
- Removes macro for forward declaring custom function sets.
- Removes forward declaration of functions that don&apos;t exist.

* Source/WebCore/style/StyleBuilderCustom.h:

Canonical link: <a href="https://commits.webkit.org/317083@main">https://commits.webkit.org/317083@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/02d36b3582f464dad06f851898de15adc337874c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174242 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48175 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41956 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183816 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132110 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176107 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49467 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47857 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135532 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177200 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38963 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156324 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116010 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37603 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35974 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32300 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148027 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35817 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186242 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/39471 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40171 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144440 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47842 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144298 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38902 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48521 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32437 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/115896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39203 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120440 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47027 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10779 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46430 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46661 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46488 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->