### PR TITLE
Inset box-shadow spread renders uneven thickness at fractional zoom

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/box-shadow-inset-spread-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/box-shadow-inset-spread-expected.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Inset box-shadow 1px spread stays even under fractional zoom</title>
+<style>
+  body { margin: 0; }
+  .box {
+    margin: 9.6px;
+    width: 120px; height: 72px;
+    box-shadow: inset 0 0 0 1px green;
+    background: white;
+  }
+</style>
+<div class="box"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/box-shadow-inset-spread.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/box-shadow-inset-spread.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Inset box-shadow 1px spread stays even under fractional zoom</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds/#box-shadow">
+<link rel="match" href="reference/box-shadow-inset-spread-ref.html">
+<style>
+  body { margin: 0; }
+  .zoom { zoom: 1.2; }
+  .box {
+    margin: 8px;
+    width: 100px; height: 60px;
+    box-shadow: inset 0 0 0 1px green;
+    background: white;
+  }
+</style>
+<div class="zoom"><div class="box"></div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/box-shadow-inset-spread-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/box-shadow-inset-spread-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Inset box-shadow 1px spread stays even under fractional zoom</title>
+<style>
+  body { margin: 0; }
+  .box {
+    margin: 9.6px;
+    width: 120px; height: 72px;
+    box-shadow: inset 0 0 0 1px green;
+    background: white;
+  }
+</style>
+<div class="box"></div>

--- a/Source/WebCore/rendering/BorderShape.cpp
+++ b/Source/WebCore/rendering/BorderShape.cpp
@@ -557,9 +557,36 @@ void BorderShape::fillRectWithInnerHoleShape(GraphicsContext& context, const Lay
         return;
     }
 
-    auto innerSnapped = m_innerEdgeRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
+    auto innerSnapped = snappedInnerEdgeRectForPainting(deviceScaleFactor);
     ASSERT(innerSnapped.isRenderable());
     context.fillRectWithRoundedHole(outerSnapped, innerSnapped, color);
+}
+
+FloatRoundedRect BorderShape::snappedInnerEdgeRectForPainting(float deviceScaleFactor) const
+{
+    // Derive the inner rect from the already-snapped outer rect, insetting each side by the width
+    // rounded to whole device pixels, so the gap (border/spread thickness) is equal on every side
+    // regardless of sub-pixel position.
+    auto outerSnapped = m_borderRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
+    auto outerRect = outerSnapped.rect();
+
+    auto topWidth = roundToDevicePixel(m_borderWidths.top(), deviceScaleFactor);
+    auto rightWidth = roundToDevicePixel(m_borderWidths.right(), deviceScaleFactor);
+    auto bottomWidth = roundToDevicePixel(m_borderWidths.bottom(), deviceScaleFactor);
+    auto leftWidth = roundToDevicePixel(m_borderWidths.left(), deviceScaleFactor);
+
+    FloatRect innerRect {
+        outerRect.x() + leftWidth,
+        outerRect.y() + topWidth,
+        std::max(0.0f, outerRect.width() - leftWidth - rightWidth),
+        std::max(0.0f, outerRect.height() - topWidth - bottomWidth),
+    };
+
+    auto innerSnapped = m_innerEdgeRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
+    innerSnapped.setRect(innerRect);
+    if (!innerSnapped.isRenderable())
+        innerSnapped.adjustRadii();
+    return innerSnapped;
 }
 
 LayoutRoundedRect BorderShape::computeInnerEdgeRoundedRect(const LayoutRoundedRect& borderRoundedRect, const RectEdges<LayoutUnit>& borderWidths)

--- a/Source/WebCore/rendering/BorderShape.h
+++ b/Source/WebCore/rendering/BorderShape.h
@@ -130,6 +130,9 @@ public:
 private:
     static LayoutRoundedRect computeInnerEdgeRoundedRect(const LayoutRoundedRect& borderRoundedRect, const RectEdges<LayoutUnit>& borderWidths);
 
+    // Insets the snapped outer rect by device-rounded widths so opposite sides stay equal thickness.
+    FloatRoundedRect snappedInnerEdgeRectForPainting(float deviceScaleFactor) const;
+
     // True if any corner uses a non-`round` shape (curvature != 1), so the shape
     bool hasNonRoundCornerShape() const;
 


### PR DESCRIPTION
#### cbf44125e63ae2079d99d27f049cd7b70a3b3f89
<pre>
Inset box-shadow spread renders uneven thickness at fractional zoom
<a href="https://bugs.webkit.org/show_bug.cgi?id=306014">https://bugs.webkit.org/show_bug.cgi?id=306014</a>
<a href="https://rdar.apple.com/169167365">rdar://169167365</a>

Reviewed by Simon Fraser.

An inset box-shadow used as a 1px rule (e.g. `box-shadow: inset 0 0 0 1px`)
rendered thicker on some sides than others at fractional zoom, because the
outer border box and the inner hole were snapped to device pixels
independently and a fractional-width spread rounded up on one side and down
on the other.

Derive the snapped inner rect from the already-snapped outer rect, insetting
each side by the width rounded to whole device pixels, so the thickness is
uniform on all four sides regardless of sub-pixel position.

* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/box-shadow-inset-spread-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/box-shadow-inset-spread.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/box-shadow-inset-spread-ref.html: Added.
* Source/WebCore/rendering/BorderShape.cpp:
(WebCore::BorderShape::fillRectWithInnerHoleShape const):
(WebCore::BorderShape::snappedInnerEdgeRectForPainting const):
* Source/WebCore/rendering/BorderShape.h:

Canonical link: <a href="https://commits.webkit.org/317080@main">https://commits.webkit.org/317080@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/097fba9aed305bdcdede12de8c276f4d326d87f8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174250 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48183 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41964 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183824 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132118 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/30c7d0bc-97a2-4123-8648-60f87efb6986) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176115 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49475 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47865 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135538 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7e9c2d21-4a04-4ac5-bce6-821c6e39a311) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177208 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38976 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156330 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116016 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f8629058-907c-4de7-af6d-1fb9e1371c72) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37616 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35981 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32308 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148040 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35823 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186250 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/39472 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40178 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144449 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47850 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155885 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144302 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38898 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48529 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32443 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114062 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39213 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120449 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47035 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10786 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46438 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46669 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46496 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->