### PR TITLE
Web Inspector: stylesheet resource cache is never invalidated when a resource is added or changes type

### DIFF
--- a/LayoutTests/inspector/css/clear-stylesheets-for-resource-invalidates-cache-expected.txt
+++ b/LayoutTests/inspector/css/clear-stylesheets-for-resource-invalidates-cache-expected.txt
@@ -1,0 +1,17 @@
+Tests that CSSManager evicts its frame+URL stylesheet cache when a stylesheet resource changes, so stale stylesheets are not returned.
+
+
+== Running test suite: CSSManager.clearStyleSheetsForResourceInvalidatesCache
+-- Running test case: FoundStyleSheetResource
+PASS: Should find the external.css stylesheet resource.
+PASS: Resource type should be StyleSheet.
+
+-- Running test case: PrimeCache
+PASS: Lookup should resolve to a stylesheet.
+
+-- Running test case: SecondLookupHitsCache
+PASS: Repeat lookup should be served from cache (no re-fetch).
+
+-- Running test case: TypeChangeInvalidatesCache
+PASS: Lookup after TypeDidChange should re-fetch (cache invalidated).
+

--- a/LayoutTests/inspector/css/clear-stylesheets-for-resource-invalidates-cache.html
+++ b/LayoutTests/inspector/css/clear-stylesheets-for-resource-invalidates-cache.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<link rel="stylesheet" href="resources/external.css">
+<script>
+function test()
+{
+    let mainFrame = WI.networkManager.mainFrame;
+
+    // Find the external.css stylesheet resource in the main frame.
+    let styleSheetResource = null;
+    for (let resource of Array.from(mainFrame.resourceCollectionForType(WI.Resource.Type.StyleSheet))) {
+        if (resource.url.endsWith("resources/external.css")) {
+            styleSheetResource = resource;
+            break;
+        }
+    }
+
+    // A cache miss in CSSMan._lookupStyleSheet routes to _fetchInfoForAllStyleSheets
+    // (which sends CSS.getAllStyleSheets); a cache hit returns synchronously without it.
+    // Counting fetches lets us observe, without poking private map state, that
+    // _clearStyleSheetsForResource actually evicts the frame+URL cache entry.
+    let fetchCount = 0;
+    let originalFetch = WI.cssManager._fetchInfoForAllStyleSheets;
+    WI.cssManager._fetchInfoForAllStyleSheets = function(callback) {
+        ++fetchCount;
+        return originalFetch.call(this, callback);
+    };
+
+    function lookup() {
+        return new Promise((resolve) => WI.cssManager._lookupStyleSheetForResource(styleSheetResource, resolve));
+    }
+
+    let suite = InspectorTest.createAsyncSuite("CSSManager.clearStyleSheetsForResourceInvalidatesCache");
+
+    suite.addTestCase({
+        name: "FoundStyleSheetResource",
+        description: "Locate the external.css stylesheet resource in the main frame.",
+        test(resolve, reject) {
+            InspectorTest.expectThat(styleSheetResource, "Should find the external.css stylesheet resource.");
+            InspectorTest.expectEqual(styleSheetResource.type, WI.Resource.Type.StyleSheet, "Resource type should be StyleSheet.");
+            resolve();
+        }
+    });
+
+    suite.addTestCase({
+        name: "PrimeCache",
+        description: "Looking up the resource populates the frame+URL cache.",
+        async test() {
+            let styleSheet = await lookup();
+            InspectorTest.expectThat(styleSheet, "Lookup should resolve to a stylesheet.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SecondLookupHitsCache",
+        description: "A repeat lookup is served from the cache without re-fetching.",
+        async test() {
+            let before = fetchCount;
+            await lookup();
+            InspectorTest.expectEqual(fetchCount, before, "Repeat lookup should be served from cache (no re-fetch).");
+        }
+    });
+
+    suite.addTestCase({
+        name: "TypeChangeInvalidatesCache",
+        description: "Resource.Event.TypeDidChange must evict the frame+URL cache entry so the next lookup re-fetches. Regression guard for the delete targeting the wrong map (166259@main).",
+        async test() {
+            let before = fetchCount;
+            styleSheetResource.dispatchEventToListeners(WI.Resource.Event.TypeDidChange, {oldType: WI.Resource.Type.XHR});
+            await lookup();
+            InspectorTest.expectEqual(fetchCount, before + 1, "Lookup after TypeDidChange should re-fetch (cache invalidated).");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Tests that CSSManager evicts its frame+URL stylesheet cache when a stylesheet resource changes, so stale stylesheets are not returned.</p>
+</body>
+</html>

--- a/Source/WebInspectorUI/UserInterface/Controllers/CSSManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/CSSManager.js
@@ -720,7 +720,7 @@ WI.CSSManager = class CSSManager extends WI.Object
     {
         // Clear known stylesheets for this URL and frame. This will cause the style sheets to
         // be updated next time _fetchInfoForAllStyleSheets is called.
-        this._styleSheetIdentifierMap.delete(this._frameURLMapKey(resource.parentFrame, resource.url));
+        this._styleSheetFrameURLMap.delete(this._frameURLMapKey(resource.parentFrame, resource.url));
     }
 
     _frameURLMapKey(frame, url)


### PR DESCRIPTION
#### fe24f90cc7e7901576f3561ff7b2dee255063cee
<pre>
Web Inspector: stylesheet resource cache is never invalidated when a resource is added or changes type
<a href="https://bugs.webkit.org/show_bug.cgi?id=319270">https://bugs.webkit.org/show_bug.cgi?id=319270</a>
<a href="https://rdar.apple.com/182113358">rdar://182113358</a>

Reviewed by Devin Rousso.

CSSManager keeps two maps: `_styleSheetIdentifierMap`, keyed by stylesheet id
(`target:styleSheetId`), and `_styleSheetFrameURLMap`, keyed by frame+URL
(`frame.id + &quot;:&quot; + url`). `_clearStyleSheetsForResource` is meant to evict the
frame+URL entry so the next `_lookupStyleSheet` misses and re-fetches via
`_fetchInfoForAllStyleSheets`, but it called `delete` on
`_styleSheetIdentifierMap` with a frame+URL key. That key can never exist in the
id-keyed map, so the delete was a permanent no-op and a stale stylesheet could be
returned after a stylesheet resource was added (`_resourceAdded`) or its type
changed to StyleSheet (`_resourceTypeDidChange`).

This was introduced in 166259@main when the plain-object maps were converted to
`Map`; the two `delete` lines in this method were retargeted to the wrong map
while every other reference correctly stayed on `_styleSheetFrameURLMap`.

Delete from `_styleSheetFrameURLMap` instead, matching the key that
`_frameURLMapKey` produces and the map that `_lookupStyleSheet` reads.

Test: inspector/css/clear-stylesheets-for-resource-invalidates-cache.html

* Source/WebInspectorUI/UserInterface/Controllers/CSSManager.js:
(WI.CSSManager.prototype._clearStyleSheetsForResource): Evict from the frame+URL
map so the next lookup re-fetches.

* LayoutTests/inspector/css/clear-stylesheets-for-resource-invalidates-cache.html: Added.
* LayoutTests/inspector/css/clear-stylesheets-for-resource-invalidates-cache-expected.txt: Added.
Primes the frame+URL cache, confirms a repeat lookup is served from the cache,
then confirms a lookup after Resource.Event.TypeDidChange re-fetches. The last
case fails without the fix.

Canonical link: <a href="https://commits.webkit.org/317084@main">https://commits.webkit.org/317084@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/54237f86efb8f17dd1579c2ce288c9562de0671e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174247 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48180 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41961 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183821 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132115 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ed7d7fae-9aa3-4855-a2c0-a91635674513) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49472 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47862 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135540 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4d342064-2caa-49a7-81eb-0be9bcdeb419) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177205 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38970 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156329 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116018 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c40ae393-b68d-424d-bb24-ccbb690546d8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37610 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35978 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32305 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148034 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35822 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186247 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39433 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40175 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144446 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47847 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155884 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144304 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38903 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48526 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32442 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114059 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39207 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120445 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47032 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10785 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46435 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46666 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46493 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->