### PR TITLE
Default WebGPU to enabled on VMs

### DIFF
--- a/Source/WebGPU/WebGPU/HardwareCapabilities.mm
+++ b/Source/WebGPU/WebGPU/HardwareCapabilities.mm
@@ -562,8 +562,13 @@ static bool isPhysicalHardware()
     static bool result = [] {
         uint32_t isVM = 0;
         size_t size = sizeof(isVM);
-        if (!sysctlbyname("kern.hv_vmm_present", &isVM, &size, NULL, 0))
-            return isVM ? static_cast<bool>([[NSUserDefaults standardUserDefaults] boolForKey:@"WebKitAllowWebGPUOnVMs"]) : true;
+        if (!sysctlbyname("kern.hv_vmm_present", &isVM, &size, NULL, 0)) {
+            if (isVM) {
+                id value = [[NSUserDefaults standardUserDefaults] objectForKey:@"WebKitAllowWebGPUOnVMs"];
+                return value ? static_cast<bool>([value boolValue]) : true;
+            }
+            return true;
+        }
         return true;
     }();
     return result;


### PR DESCRIPTION
#### 53351731e18b3aa983e69f2c607547da9515decd
<pre>
Default WebGPU to enabled on VMs
<a href="https://bugs.webkit.org/show_bug.cgi?id=319261">https://bugs.webkit.org/show_bug.cgi?id=319261</a>
<a href="https://rdar.apple.com/182108828">rdar://182108828</a>

Reviewed by Tadeu Zagallo.

Treat VMs are fully qualified as other devices for WebGPU.

* Source/WebGPU/WebGPU/HardwareCapabilities.mm:
(WebGPU::isPhysicalHardware):

Canonical link: <a href="https://commits.webkit.org/317144@main">https://commits.webkit.org/317144@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e824f9f5a32a68f015cf0321c906b9025ee4264

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174249 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48182 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41963 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183823 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132117 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/65717a7e-9c60-47bd-b20b-99e9361168a5) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49474 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47864 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135539 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95623 "3 flakes 6 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b058ea51-6426-48fb-9bfe-2f07a506f486) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177207 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38969 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156328 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116017 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/194bffcf-1859-4c6c-9034-485ab690b812) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37609 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35980 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32307 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148033 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35821 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186249 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39435 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40177 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144443 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47849 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144301 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38941 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48528 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32441 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114061 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39206 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120447 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47034 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10784 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46437 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46668 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46495 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->