### PR TITLE
Web Inspector: probe manager drops probes when a breakpoint has multiple probe actions added or removed at once

### DIFF
--- a/LayoutTests/inspector/debugger/probe-manager-remove-middle-action-expected.txt
+++ b/LayoutTests/inspector/debugger/probe-manager-remove-middle-action-expected.txt
@@ -1,0 +1,20 @@
+Testing that the probe manager removes a middle probe when its breakpoint action is removed.
+
+Probe set was added. New count: 1
+Probe with identifier 1 was added to probe set.
+Probe set's probe count: 1
+Breakpoint actions changed. New count: 1
+Probe with identifier 2 was added to probe set.
+Probe set's probe count: 2
+Breakpoint actions changed. New count: 2
+Probe with identifier 3 was added to probe set.
+Probe set's probe count: 3
+Breakpoint actions changed. New count: 3
+Breakpoint was added.
+PASS: Probe set should have three probes after adding three actions.
+Removing middle probe action.
+Probe with identifier 2 was removed from probe set.
+Probe set's probe count: 2
+Breakpoint actions changed. New count: 2
+PASS: Probe set should have two probes after removing the middle action.
+

--- a/LayoutTests/inspector/debugger/probe-manager-remove-middle-action.html
+++ b/LayoutTests/inspector/debugger/probe-manager-remove-middle-action.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script src="../../http/tests/inspector/debugger/debugger-test.js"></script>
+<script src="resources/script-for-breakpoint-actions.js"></script>
+<script>
+function test()
+{
+    WI.Frame.addEventListener(WI.Frame.Event.MainResourceDidChange, function() {
+        InspectorTest.startTracingBreakpoints();
+        InspectorTest.startTracingProbes();
+
+        WI.debuggerManager.addEventListener(WI.DebuggerManager.Event.ScriptAdded, function(event) {
+            var scriptObject = event.data.script;
+
+            if (!/script\-for\-breakpoint\-actions\.js$/.test(scriptObject.url))
+                return;
+
+            var location = scriptObject.createSourceCodeLocation(4, 0);
+            // Create a disabled breakpoint so it is never sent to the backend; this keeps
+            // the test deterministic (no async resolution event) while still exercising the
+            // frontend probe add/remove code path, which is driven by breakpoint action changes.
+            var breakpoint = new WI.JavaScriptBreakpoint(location, {disabled: true});
+
+            // Add three probe actions so a middle probe can be removed later.
+            var actions = [];
+            for (var i of [0, 1, 2]) {
+                var action = new WI.BreakpointAction(WI.BreakpointAction.Type.Probe, {data: "a"});
+                breakpoint.addAction(action);
+                actions.push(action);
+            }
+
+            WI.debuggerManager.addBreakpoint(breakpoint);
+
+            var probeSet = WI.debuggerManager.probeSets[0];
+            InspectorTest.expectEqual(probeSet.probes.length, 3, "Probe set should have three probes after adding three actions.");
+
+            // Remove the middle action; the loop that reaps missing probes must
+            // not stop at the first surviving probe.
+            InspectorTest.log("Removing middle probe action.");
+            breakpoint.removeAction(actions[1]);
+
+            InspectorTest.expectEqual(probeSet.probes.length, 2, "Probe set should have two probes after removing the middle action.");
+
+            InspectorTest.completeTest();
+        });
+    });
+
+    InspectorTest.reloadPage();
+}
+</script>
+</head>
+<body onload="runTest()">
+    <p>Testing that the probe manager removes a middle probe when its breakpoint action is removed.</p>
+</body>
+</html>

--- a/Source/WebInspectorUI/UserInterface/Controllers/DebuggerManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/DebuggerManager.js
@@ -935,7 +935,7 @@ WI.DebuggerManager = class DebuggerManager extends WI.Object
                 let newProbe = new WI.Probe(probeIdentifier, breakpoint, probeAction.data);
                 this._probesByIdentifier.set(probeIdentifier, newProbe);
                 probeSet.addProbe(newProbe);
-                break;
+                continue;
             }
 
             let probe = this._probesByIdentifier.get(probeIdentifier);
@@ -947,7 +947,7 @@ WI.DebuggerManager = class DebuggerManager extends WI.Object
         // Look for missing probes based on what we saw last.
         for (let probeIdentifier of knownProbeIdentifiers) {
             if (seenProbeIdentifiers.has(probeIdentifier))
-                break;
+                continue;
 
             // The probe has gone missing, remove it.
             let probeSet = this._probeSetForBreakpoint(breakpoint);


### PR DESCRIPTION
#### a39497ed4d9f8a3bfd65df6b07b50efe19eaac99
<pre>
Web Inspector: probe manager drops probes when a breakpoint has multiple probe actions added or removed at once
<a href="https://bugs.webkit.org/show_bug.cgi?id=319274">https://bugs.webkit.org/show_bug.cgi?id=319274</a>
<a href="https://rdar.apple.com/182115866">rdar://182115866</a>

Reviewed by Devin Rousso.

DebuggerManager.updateProbesForBreakpoint() has two loops that walk a
breakpoint&apos;s probe actions to reconcile them against the known probes.
Both used `break` where they should have used `continue`:

- The loop that creates newly-added probes bailed out entirely after
  creating the first new probe, so any additional new probes in the same
  pass were never created (and existing probes ordered after it never had
  their expressions refreshed).

- The loop that reaps probes no longer present stopped at the first probe
  that was still present, leaking any missing probe ordered after it in
  the known-identifier set (e.g. removing a middle or trailing probe left
  a stale WI.Probe in _probesByIdentifier and in the probe set).

These are normally masked because each single action mutation dispatches
its own ActionsDidChange event, so a pass usually sees only one changed
probe. The bug surfaces when a pass sees more than one change at once,
such as removing a non-first probe while others survive.

Changed both `break` statements to `continue`.

Test: inspector/debugger/probe-manager-remove-middle-action.html

* LayoutTests/inspector/debugger/probe-manager-remove-middle-action-expected.txt: Added.
* LayoutTests/inspector/debugger/probe-manager-remove-middle-action.html: Added.
* Source/WebInspectorUI/UserInterface/Controllers/DebuggerManager.js:
(WI.DebuggerManager.prototype.updateProbesForBreakpoint):

Canonical link: <a href="https://commits.webkit.org/317088@main">https://commits.webkit.org/317088@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2abf9644a4d0c11ec0c7e506a4e803a6fe04ba9d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174253 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48186 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41967 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183827 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132121 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49478 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47868 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135541 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177211 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38972 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156336 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116019 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0100f090-3c12-4880-a2a6-30b44f5be788) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37612 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35983 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32311 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148036 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35829 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186253 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39442 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40180 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144447 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47853 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155891 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144305 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38904 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48532 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32449 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114065 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39209 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120452 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47038 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10792 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46441 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46672 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46499 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->