### PR TITLE
[css-values-5 random-item()] Factor random-item() argument-grammar substitution into a helper following the attr()  pattern

### DIFF
--- a/Source/WebCore/style/StyleSubstitutionResolver.cpp
+++ b/Source/WebCore/style/StyleSubstitutionResolver.cpp
@@ -780,14 +780,11 @@ bool SubstitutionResolver::substituteInternalAutoBaseFunction(CSSParserTokenRang
     return true;
 }
 
-bool SubstitutionResolver::substituteRandomItemFunction(CSSParserTokenRange range, Vector<CSSParserToken>& tokens, const CSSParserContext& context)
+auto SubstitutionResolver::substituteRandomItemArgumentGrammar(CSSParserTokenRange range, const CSSParserContext& context) -> std::optional<RandomItemArgumentGrammarSubstitution>
 {
-    // https://drafts.csswg.org/css-values-5/#funcdef-random-item
-    //
-    // The argument grammar is validated at parse time:
-    //   <random-item-args> = random-item( <declaration-value>, [ <declaration-value>? ]# )
-    // Here the full grammar is applied: substitute the argument grammar first, then parse the
-    // first argument as <random-key> and select an item. This follows substituteAttrFunction.
+    // https://drafts.csswg.org/css-values-5/#argument-grammars
+    // <random-item-args> = random-item( <declaration-value>, [ <declaration-value>? ]# )
+    // Splits at the literal commas and substitutes the first argument (the <random-key>).
 
     range.consumeWhitespace();
 
@@ -798,10 +795,10 @@ bool SubstitutionResolver::substituteRandomItemFunction(CSSParserTokenRange rang
     auto randomKeyRange = randomKeyStart.rangeUntil(range);
 
     if (!CSSPropertyParserHelpers::consumeCommaIncludingWhitespace(range))
-        return false;
+        return { };
 
     // Collect the item ranges. Each item is a (possibly empty) <declaration-value>; a {}-wrapped
-    // block groups internal commas and is unwrapped when the selected item is substituted below.
+    // block groups internal commas and is unwrapped when the selected item is substituted.
     Vector<CSSParserTokenRange> items;
     do {
         auto itemStart = range;
@@ -811,17 +808,33 @@ bool SubstitutionResolver::substituteRandomItemFunction(CSSParserTokenRange rang
     } while (CSSPropertyParserHelpers::consumeCommaIncludingWhitespace(range));
 
     if (items.isEmpty())
-        return false;
+        return { };
 
     // <random-key> may itself contain arbitrary substitution functions (var(), attr(), ...);
-    // substitute them before parsing it as a <random-key>.
+    // substitute them before parsing it as a <random-key>. Items are substituted lazily, once
+    // the selected one is known.
     auto substitutedRandomKey = substituteTokenRange(randomKeyRange, context);
     if (!substitutedRandomKey)
+        return { };
+
+    return RandomItemArgumentGrammarSubstitution { WTF::move(*substitutedRandomKey), WTF::move(items) };
+}
+
+bool SubstitutionResolver::substituteRandomItemFunction(CSSParserTokenRange range, Vector<CSSParserToken>& tokens, const CSSParserContext& context)
+{
+    // https://drafts.csswg.org/css-values-5/#funcdef-random-item
+
+    // <random-item-args> = random-item( <declaration-value>, [ <declaration-value>? ]# )
+    auto randomItemArgs = substituteRandomItemArgumentGrammar(range, context);
+    if (!randomItemArgs)
         return false;
 
-    auto baseValue = randomItemBaseValue(WTF::move(*substitutedRandomKey));
+    // random-item() = random-item( <random-key> , [ <declaration-value>? ]# )
+    auto baseValue = randomItemBaseValue(WTF::move(randomItemArgs->randomKey));
     if (!baseValue)
         return false;
+
+    auto& items = randomItemArgs->items;
 
     // https://drafts.csswg.org/css-values-5/#random-item
     // "Let index be a random integer less than N (the number of items), given the base value R:

--- a/Source/WebCore/style/StyleSubstitutionResolver.h
+++ b/Source/WebCore/style/StyleSubstitutionResolver.h
@@ -80,6 +80,12 @@ private:
     };
     std::optional<AttrArgumentGrammarSubstitution> substituteAttrArgumentGrammar(CSSParserTokenRange, const CSSParserContext&);
 
+    struct RandomItemArgumentGrammarSubstitution {
+        Vector<CSSParserToken> randomKey;
+        Vector<CSSParserTokenRange> items;
+    };
+    std::optional<RandomItemArgumentGrammarSubstitution> substituteRandomItemArgumentGrammar(CSSParserTokenRange, const CSSParserContext&);
+
     struct IfBranch {
         // A null condition is the `else` keyword, which always matches.
         std::optional<Vector<CSSParserToken>> condition;


### PR DESCRIPTION
#### a26b16470591823b5c79246d9264e3a89aa9fca9
<pre>
[css-values-5 random-item()] Factor random-item() argument-grammar substitution into a helper following the attr()  pattern
<a href="https://bugs.webkit.org/show_bug.cgi?id=319276">https://bugs.webkit.org/show_bug.cgi?id=319276</a>
<a href="https://rdar.apple.com/182117859">rdar://182117859</a>

Reviewed by Tim Nguyen.

Follow-up to bug 317702 (random-item() computed-value resolution), addressing
Antti&apos;s review feedback on PR #68097:

<a href="https://github.com/WebKit/WebKit/pull/68097#discussion_r3551786137">https://github.com/WebKit/WebKit/pull/68097#discussion_r3551786137</a>

This patch extracts substituteRandomItemArgumentGrammar(), mirroring
substituteAttrArgumentGrammar():

- It splits &lt;random-item-args&gt; = random-item( &lt;declaration-value&gt;,
    [ &lt;declaration-value&gt;? ]# ) at the literal commas, substitutes the first
    argument (the &lt;random-key&gt;), and returns the substituted key plus the raw
    item ranges.
- substituteRandomItemFunction() then resolves the base value and
    selects/substitutes the chosen item as a distinct second step. As with
    attr()&apos;s fallback, the items are substituted lazily.

* Source/WebCore/style/StyleSubstitutionResolver.cpp:
(WebCore::Style::SubstitutionResolver::substituteRandomItemArgumentGrammar):
(WebCore::Style::SubstitutionResolver::substituteRandomItemFunction):
* Source/WebCore/style/StyleSubstitutionResolver.h:

Canonical link: <a href="https://commits.webkit.org/317104@main">https://commits.webkit.org/317104@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d49a8039ffb44b9ef6fa7c007d20bbe73fe61ea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174264 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48197 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41978 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183838 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132132 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/681edd3c-3a1d-4802-b6bd-f1f1971ab451) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176129 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49489 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47879 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135551 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/62d956e3-5f7e-4b07-aae3-6d7fa7f808b4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177222 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38985 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156341 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116029 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/097c5923-6bac-45c5-bdbe-a3f5cf8bc0b7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37625 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35994 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32322 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148049 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35834 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186264 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39455 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40191 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144459 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47864 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144316 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38918 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48543 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32454 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114076 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39218 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120465 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47049 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10797 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46452 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46683 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46510 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->