### PR TITLE
Web Inspector: parseMIMEType doesn't strip quotes from a quoted charset

### DIFF
--- a/LayoutTests/inspector/unit-tests/mimetype-utilities-expected.txt
+++ b/LayoutTests/inspector/unit-tests/mimetype-utilities-expected.txt
@@ -67,6 +67,26 @@ PASS: type should be: "mime/generic"
 PASS: boundary should be: "foo"
 PASS: encoding should be: "bar"
 
+Test "mime/generic ; charset = \"bar\""
+PASS: type should be: "mime/generic"
+PASS: boundary should be: null
+PASS: encoding should be: "bar"
+
+Test "mime/generic ; charset=\"bar\" ; boundary=\"foo\""
+PASS: type should be: "mime/generic"
+PASS: boundary should be: "\"foo\""
+PASS: encoding should be: "bar"
+
+Test "mime/generic ; charset=ut\"f-8"
+PASS: type should be: "mime/generic"
+PASS: boundary should be: null
+PASS: encoding should be: "utf-8"
+
+Test "mime/generic ; charset=\"ut\"f-8\""
+PASS: type should be: "mime/generic"
+PASS: boundary should be: null
+PASS: encoding should be: "utf-8"
+
 -- Running test case: fileExtensionForFilename
 PASS: File extension for null filename should be null.
 PASS: File extension for filename without a period should be null.

--- a/LayoutTests/inspector/unit-tests/mimetype-utilities.html
+++ b/LayoutTests/inspector/unit-tests/mimetype-utilities.html
@@ -109,6 +109,31 @@ function test()
                 encoding: "bar",
             });
 
+            test('mime/generic ; charset = "bar"', {
+                type: "mime/generic",
+                boundary: null,
+                encoding: "bar",
+            });
+
+            test('mime/generic ; charset="bar" ; boundary="foo"', {
+                type: "mime/generic",
+                boundary: '"foo"',
+                encoding: "bar",
+            });
+
+            // All quote characters are stripped, including interior ones from malformed values.
+            test('mime/generic ; charset=ut"f-8', {
+                type: "mime/generic",
+                boundary: null,
+                encoding: "utf-8",
+            });
+
+            test('mime/generic ; charset="ut"f-8"', {
+                type: "mime/generic",
+                boundary: null,
+                encoding: "utf-8",
+            });
+
             return true;
         }
     });

--- a/Source/WebInspectorUI/UserInterface/Base/Utilities.js
+++ b/Source/WebInspectorUI/UserInterface/Base/Utilities.js
@@ -1484,7 +1484,7 @@ function parseMIMEType(fullMimeType)
         if (subparts[0].toLowerCase() === "boundary")
             boundary = subparts[1];
         else if (subparts[0].toLowerCase() === "charset")
-            encoding = subparts[1].replace("^\"|\"$", ""); // Trim quotes.
+            encoding = subparts[1].replaceAll("\"", ""); // Trim quotes.
     }
 
     return {type, boundary: boundary || null, encoding: encoding || null};


### PR DESCRIPTION
#### 2bc447c7562b89bf6a26a52fdc9a3c9f44efde8b
<pre>
Web Inspector: parseMIMEType doesn&apos;t strip quotes from a quoted charset
<a href="https://bugs.webkit.org/show_bug.cgi?id=319279">https://bugs.webkit.org/show_bug.cgi?id=319279</a>
<a href="https://rdar.apple.com/182119496">rdar://182119496</a>

Reviewed by Devin Rousso.

parseMIMEType passed a plain string to String.prototype.replace when
trying to trim the surrounding quotes from a charset value. A string
first argument is matched literally, not as a regular expression, so the
call searched for the literal sequence `^&quot;|&quot;$` — which never appears in
a real value — and the quotes were never removed. As a result a header
like `text/html; charset=&quot;utf-8&quot;` yielded an encoding of `&quot;utf-8&quot;`
(quotes included), which then showed up quoted in the resource details
and headers views.

Use replaceAll to strip the quote characters from the charset value.

* Source/WebInspectorUI/UserInterface/Base/Utilities.js:
(parseMIMEType):

* LayoutTests/inspector/unit-tests/mimetype-utilities.html:
* LayoutTests/inspector/unit-tests/mimetype-utilities-expected.txt:
Add coverage for quoted charset (and a quoted boundary, which is left
untrimmed as before).

Canonical link: <a href="https://commits.webkit.org/317120@main">https://commits.webkit.org/317120@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/890ad60ee19ea7fd999e74c6385c891bf0f8bad7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174370 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48303 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42084 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183946 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/132238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/489f46e1-e5da-47bc-851f-7210b0d0c2b9) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49595 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47985 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/135636 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/132238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9b70ea04-daad-495e-bb6e-c17f59710f28) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177328 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39074 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/156428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116114 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ac4b75a7-a412-4a90-9bd7-fa56d154eac4) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/37715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32428 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/148138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35920 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186372 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/39581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144553 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47970 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155982 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144411 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38928 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48649 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32540 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114191 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39308 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/120591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47155 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10884 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46558 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46789 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46616 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->