### PR TITLE
[JSC][Temporal] Fix non-ISO Calendar bugs in CalendarICUBridge

### DIFF
--- a/JSTests/stress/temporal-calendar-icu-bridge-non-iso.js
+++ b/JSTests/stress/temporal-calendar-icu-bridge-non-iso.js
@@ -1,0 +1,58 @@
+//@ requireOptions("--useTemporal=1")
+
+function shouldBe(actual, expected, label) {
+    if (actual !== expected)
+        throw new Error(`${label}: expected ${expected}, got ${actual}`);
+}
+
+// Buddhist: `year` is BE (Gregorian + 543). BE 2567 = Gregorian 2024.
+{
+    const pd = Temporal.PlainDate.from({year:2567, month:1, day:1, calendar:"buddhist"});
+    shouldBe(pd.toString(), "2024-01-01[u-ca=buddhist]", "buddhist year:2567 -> ISO 2024");
+    shouldBe(pd.year, 2567, "buddhist .year = BE year");
+    shouldBe(pd.eraYear, 2567, "buddhist .eraYear = BE year");
+    shouldBe(pd.withCalendar("iso8601").year, 2024, "buddhist -> iso8601 year");
+    shouldBe(pd.era, "be", "buddhist .era");
+}
+{
+    const bud = Temporal.PlainDate.from("2024-01-01").withCalendar("buddhist");
+    shouldBe(bud.year, 2567, "ISO 2024 -> buddhist year");
+}
+{
+    const pd = Temporal.PlainDate.from({era:"be", eraYear:2567, month:1, day:1, calendar:"buddhist"});
+    shouldBe(pd.year, 2567, "buddhist era:be eraYear:2567 -> year");
+    shouldBe(pd.toString(), "2024-01-01[u-ca=buddhist]", "buddhist era -> ISO");
+}
+
+// Coptic `am` era: AM 1740 M01 D01 = ISO 2023-09-12.
+{
+    const pd = Temporal.PlainDate.from({era:"am", eraYear:1740, month:1, day:1, calendar:"coptic"});
+    shouldBe(pd.year, 1740, "coptic am eraYear:1740 -> year");
+    shouldBe(pd.toString(), "2023-09-12[u-ca=coptic]", "coptic am 1740 -> ISO 2023-09-12");
+    shouldBe(pd.era, "am", "coptic .era");
+}
+{
+    const pd = Temporal.PlainDate.from({year:1740, month:1, day:1, calendar:"coptic"});
+    shouldBe(pd.toString(), "2023-09-12[u-ca=coptic]", "coptic year:1740 -> ISO 2023-09-12");
+}
+
+// Ethiopic `am` era: AM 2016 M01 D01 = ISO 2023-09-12.
+{
+    const pd = Temporal.PlainDate.from({era:"am", eraYear:2016, month:1, day:1, calendar:"ethiopic"});
+    shouldBe(pd.toString(), "2023-09-12[u-ca=ethiopic]", "ethiopic am 2016 -> ISO 2023-09-12");
+    shouldBe(pd.year, 2016, "ethiopic .year");
+}
+
+// Japanese pre-1582: proleptic Gregorian. 1500 is Julian-leap but not Gregorian-leap.
+{
+    const pd = Temporal.PlainDate.from({era:"ce", eraYear:1500, month:6, day:15, calendar:"japanese"});
+    shouldBe(pd.daysInYear, 365, "japanese ce 1500 daysInYear (Gregorian)");
+    shouldBe(pd.inLeapYear, false, "japanese ce 1500 inLeapYear (Gregorian)");
+    const feb = Temporal.PlainDate.from({era:"ce", eraYear:1500, month:2, day:1, calendar:"japanese"});
+    shouldBe(feb.daysInMonth, 28, "japanese ce 1500 Feb has 28 days");
+}
+{
+    const pd = Temporal.PlainDate.from({era:"ce", eraYear:1600, month:2, day:29, calendar:"japanese"});
+    shouldBe(pd.inLeapYear, true, "japanese ce 1600 inLeapYear");
+    shouldBe(pd.daysInYear, 366, "japanese ce 1600 daysInYear");
+}

--- a/Source/JavaScriptCore/API/tests/TemporalCoreTest.cpp
+++ b/Source/JavaScriptCore/API/tests/TemporalCoreTest.cpp
@@ -2768,6 +2768,25 @@ static void testCalendarDateFromFields()
     // --- Invalid era ---
     auto rBadEra = calendarDateFromFields(id("gregory"_s), 0, 1, 1, StringView("invalid"_s), 2024, std::nullopt, TemporalOverflow::Reject);
     TCHECK_TRUE(!rBadEra.has_value(), "gregory: invalid era -> error");
+
+    // Buddhist: user's `year` is BE (= Gregorian + 543).
+    auto rBud = calendarDateFromFields(id("buddhist"_s), 2567, 1, 1, std::nullopt, std::nullopt, std::nullopt, TemporalOverflow::Reject);
+    TCHECK_TRUE(rBud.has_value() && rBud->year() == 2024, "buddhist: BE 2567 -> ISO 2024");
+    auto rBudEra = calendarDateFromFields(id("buddhist"_s), std::nullopt, 1, 1, StringView("be"_s), 2567, std::nullopt, TemporalOverflow::Reject);
+    TCHECK_TRUE(rBudEra.has_value() && rBudEra->year() == 2024, "buddhist: era be, eraYear=2567 -> ISO 2024");
+    // Reference-year path: BE 2515 = Gregorian 1972 leap; Feb 29 must succeed.
+    auto rBudRef = calendarDateFromFields(id("buddhist"_s), 2515, 2, 29, std::nullopt, std::nullopt, std::nullopt, TemporalOverflow::Reject);
+    TCHECK_TRUE(rBudRef.has_value() && rBudRef->year() == 1972 && rBudRef->day() == 29u, "buddhist: BE 2515 Feb 29 -> ISO 1972-02-29");
+
+    // Coptic am era: era 1 (AM), not era 0. AM 1740 M01 D01 = ISO 2023-09-12.
+    auto rCop = calendarDateFromFields(id("coptic"_s), std::nullopt, 1, 1, StringView("am"_s), 1740, std::nullopt, TemporalOverflow::Reject);
+    TCHECK_TRUE(rCop.has_value() && rCop->year() == 2023 && rCop->month() == 9u && rCop->day() == 12u, "coptic: am 1740 M01 D01 -> ISO 2023-09-12");
+    auto rCopY = calendarDateFromFields(id("coptic"_s), 1740, 1, 1, std::nullopt, std::nullopt, std::nullopt, TemporalOverflow::Reject);
+    TCHECK_TRUE(rCopY.has_value() && rCopY->year() == 2023, "coptic: year=1740 -> ISO 2023 (era-free)");
+
+    // Ethiopic am era: same fix as Coptic. AM 2016 M01 D01 = ISO 2023-09-12.
+    auto rEth = calendarDateFromFields(id("ethiopic"_s), std::nullopt, 1, 1, StringView("am"_s), 2016, std::nullopt, TemporalOverflow::Reject);
+    TCHECK_TRUE(rEth.has_value() && rEth->year() == 2023, "ethiopic: am 2016 -> ISO 2023");
 }
 
 static void testCalendarICUNonISO()
@@ -2854,6 +2873,21 @@ static void testCalendarICUNonISO()
     TCHECK_TRUE(rHL.has_value(), "hebrew: 5782 leap check ok");
     // Hebrew 5782 is a leap year (has Adar II)
     TCHECK_TRUE(*rHL, "hebrew: 5782 is leap");
+
+    // Buddhist: calendarYear returns BE year (Gregorian + 543).
+    auto rBudY = calendarYear(calendarIDFromString("buddhist"_s), { 2024, 1, 1 });
+    TCHECK_TRUE(rBudY.has_value() && *rBudY == 2567, "buddhist: ISO 2024 -> BE 2567");
+
+    // Japanese pre-1582: proleptic Gregorian (not Julian). ISO 1500 is Julian-leap but not Gregorian-leap.
+    auto rJpFeb = calendarDaysInMonth(calendarIDFromString("japanese"_s), { 1500, 2, 15 });
+    TCHECK_TRUE(rJpFeb.has_value() && *rJpFeb == 28, "japanese: 1500 Feb = 28 days");
+    auto rJpDIY = calendarDaysInYear(calendarIDFromString("japanese"_s), { 1500, 6, 15 });
+    TCHECK_TRUE(rJpDIY.has_value() && *rJpDIY == 365, "japanese: 1500 daysInYear = 365");
+    auto rJpLeap = calendarInLeapYear(calendarIDFromString("japanese"_s), { 1500, 6, 15 });
+    TCHECK_TRUE(rJpLeap.has_value() && !*rJpLeap, "japanese: 1500 not leap");
+    // 1600 IS a Gregorian leap (400-year rule).
+    auto rJp1600 = calendarInLeapYear(calendarIDFromString("japanese"_s), { 1600, 6, 15 });
+    TCHECK_TRUE(rJp1600.has_value() && *rJp1600, "japanese: 1600 is leap");
 }
 
 // ---------------------------------------------------------------------------
@@ -3775,7 +3809,7 @@ static void runStressTests()
     testCalendarInLeapYearISO(); // ISO leap year
     testCalendarISO8601Fields(); // ISO field accessors
     testCalendarICUNonISO(); // Non-ISO calendars (hebrew, chinese, japanese, persian)
-    testCalendarDateFromFields(); // calendarDateFromFields: era, monthCode, overflow, ROC, Japanese
+    testCalendarDateFromFields(); // calendarDateFromFields: era, monthCode, overflow, ROC, Japanese, Buddhist, Coptic, Ethiopic
     testCalendarFieldsFunctions(); // yearMonthFromFields, monthDayFromFields, differenceYearMonth, plainYearMonthAdd, etc.
 
     // parseISODateTime

--- a/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
@@ -95,6 +95,17 @@ public:
 };
 WTF_MAKE_TZONE_ALLOCATED_IMPL(CalendarCacheEntry);
 
+// Japanese/ROC/Buddhist derive from Gregorian and reject ucal_setGregorianChange
+// (U_UNSUPPORTED_ERROR), so year-length / month-length / leap-year accessors
+// route through gregory to get proleptic Gregorian. Era-facing paths keep the
+// derived calendar so era labels remain correct.
+static CalendarID gregorianArithmeticCalendarFor(CalendarID calendarId)
+{
+    if (calendarId == japaneseCalendarID() || calendarId == rocCalendarID() || calendarId == buddhistCalendarID())
+        return gregoryCalendarID();
+    return calendarId;
+}
+
 struct CalendarLRUCachePolicy {
     static bool isKeyNull(const CalendarID&) { return false; }
     static RefPtr<CalendarCacheEntry> createValueForNullKey() { return nullptr; }
@@ -399,7 +410,7 @@ static std::optional<int32_t> mapTemporalEraToICUEra(CalendarID calendarId, Stri
         return std::nullopt;
     }
     if (calendarId == copticCalendarID() || calendarId == ethiopicCalendarID())
-        return era == "am"_s ? std::optional<int32_t>(0) : std::nullopt;
+        return era == "am"_s ? std::optional<int32_t>(1) : std::nullopt;
     if (calendarId == ethioaaCalendarID())
         return era == "aa"_s ? std::optional<int32_t>(0) : std::nullopt;
     if (calendarId == hebrewCalendarID())
@@ -513,6 +524,13 @@ TemporalResult<int32_t> calendarYear(CalendarID calendarId, const ISO8601::Plain
             if (U_FAILURE(status)) [[unlikely]]
                 return makeUnexpected(rangeError(icuReadCalendarFailed));
             return !era ? -(eraYear - 1) : eraYear;
+        }
+        // Buddhist: UCAL_EXTENDED_YEAR is the Gregorian year; UCAL_YEAR is the BE year.
+        if (calendarId == buddhistCalendarID()) {
+            int32_t eraYear = ucal_get(cal, UCAL_YEAR, &status);
+            if (U_FAILURE(status)) [[unlikely]]
+                return makeUnexpected(rangeError(icuReadCalendarFailed));
+            return eraYear;
         }
         auto result = ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
         if (U_FAILURE(status)) [[unlikely]]
@@ -685,7 +703,7 @@ TemporalResult<std::optional<int32_t>> calendarEraYear(CalendarID calendarId, co
 TemporalResult<int32_t> calendarDaysInMonth(CalendarID calendarId, const ISO8601::PlainDate& isoDate)
 {
     // 1. Return the number of days in the month containing isoDate in calendarId.
-    return withCalendar(calendarId, [&](UCalendar* cal) -> TemporalResult<int32_t> {
+    return withCalendar(gregorianArithmeticCalendarFor(calendarId), [&](UCalendar* cal) -> TemporalResult<int32_t> {
         if (!cal) [[unlikely]]
             return makeUnexpected(rangeError(icuOpenCalendarFailed));
         if (!setCalendarToISODate(cal, isoDate)) [[unlikely]]
@@ -707,7 +725,7 @@ TemporalResult<int32_t> calendarDaysInMonth(CalendarID calendarId, const ISO8601
 TemporalResult<int32_t> calendarDaysInYear(CalendarID calendarId, const ISO8601::PlainDate& isoDate)
 {
     // 1. Return the number of days in the year containing isoDate in calendarId.
-    return withCalendar(calendarId, [&](UCalendar* cal) -> TemporalResult<int32_t> {
+    return withCalendar(gregorianArithmeticCalendarFor(calendarId), [&](UCalendar* cal) -> TemporalResult<int32_t> {
         if (!cal) [[unlikely]]
             return makeUnexpected(rangeError(icuOpenCalendarFailed));
         if (!setCalendarToISODate(cal, isoDate)) [[unlikely]]
@@ -788,7 +806,7 @@ TemporalResult<bool> calendarInLeapYear(CalendarID calendarId, const ISO8601::Pl
             return makeUnexpected(months.error());
         return *months > 12;
     }
-    return withCalendar(calendarId, [&](UCalendar* cal) -> TemporalResult<bool> {
+    return withCalendar(gregorianArithmeticCalendarFor(calendarId), [&](UCalendar* cal) -> TemporalResult<bool> {
         if (!cal) [[unlikely]]
             return makeUnexpected(rangeError(icuOpenCalendarFailed));
         if (!setCalendarToISODate(cal, isoDate)) [[unlikely]]
@@ -1569,9 +1587,8 @@ int32_t ecmaReferenceYear(CalendarID calendarId, uint8_t monthNumber, bool isLea
     }
 
     if (calendarId == buddhistCalendarID()) {
-        // Buddhist: ICU4C UCAL_EXTENDED_YEAR for Buddhist = ISO/Gregorian year (not Buddhist era year).
-        // So ISO year 1972 is the reference — same as gregory/japanese.
-        return 1972;
+        // BE 2515 = Gregorian 1972 (leap); Feb has 29 days.
+        return 2515;
     }
 
     if (calendarId == rocCalendarID()) {
@@ -1660,6 +1677,10 @@ TemporalResult<ISO8601::PlainDate> calendarDateFromFields(CalendarID calendarId,
                 ucal_set(cal, UCAL_ERA, 1); // roc
                 ucal_set(cal, UCAL_YEAR, y);
             }
+        } else if (calendarId == buddhistCalendarID()) {
+            // Buddhist: `year` is the BE year (= Gregorian + 543). UCAL_YEAR is BE; UCAL_EXTENDED_YEAR is Gregorian.
+            ucal_set(cal, UCAL_ERA, 0); // be
+            ucal_set(cal, UCAL_YEAR, year.value_or(0));
         } else
             ucal_set(cal, UCAL_EXTENDED_YEAR, year.value_or(0));
 


### PR DESCRIPTION
#### 2fb282a825385d9f53f09b6adc07b18f19203276
<pre>
[JSC][Temporal] Fix non-ISO Calendar bugs in CalendarICUBridge
<a href="https://bugs.webkit.org/show_bug.cgi?id=319278">https://bugs.webkit.org/show_bug.cgi?id=319278</a>
<a href="https://rdar.apple.com/182118211">rdar://182118211</a>

Reviewed by Yusuke Suzuki.

Four bugs found by cross-checking against temporal_rs and icu4x:

1. Coptic / Ethiopic `am` era was mapped to ICU era 0 (before-AM); the
correct value is 1 (AM). Dates constructed via era:&quot;am&quot; ended up ~5500
years off.

2. Japanese / ROC / Buddhist year/month/leap-year accessors used ICU&apos;s
Julian arithmetic for pre-1582 dates (ICU4C rejects
ucal_setGregorianChange on these derived calendars). Spec requires
proleptic Gregorian; route those accessors through the base Gregorian
calendar via gregorianArithmeticCalendarFor().

3. Buddhist year: ICU&apos;s UCAL_EXTENDED_YEAR is the Gregorian year, not the
BE year (BE = Gregorian + 543). Read/write paths now use UCAL_YEAR
(which ICU exposes as BE for Buddhist).

4. Buddhist ecmaReferenceYear: was 1972 (Gregorian-year convention), but
post-fix (3) the Buddhist write path expects BE, so 1972 was interpreted
as BE and resolved to Gregorian 1429 (non-leap), regressing
intl402/.../constrain-to-leap-day.js. Use 2515 BE (= Gregorian 1972,
leap), matching the calendar-native-year convention already used for
ROC (61) and Indian.

Tests: JSTests/stress/temporal-calendar-icu-bridge-non-iso.js
       Source/JavaScriptCore/API/tests/TemporalCoreTest.cpp

Canonical link: <a href="https://commits.webkit.org/317087@main">https://commits.webkit.org/317087@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/55883e834276ba270c65e2b2b94e7a09ce2a9739

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174265 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48198 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41979 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183839 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132133 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0865644e-a034-49db-9691-fd6c5b1b0f6d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49490 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47880 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135553 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177223 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38984 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156343 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116031 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/34c6a667-242c-4891-b65c-0cf2af23c343) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37624 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/35995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32323 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/4853 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148048 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35836 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186265 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/35527 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39456 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40192 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144461 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47865 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144318 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48544 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32456 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114077 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26494 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39228 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120466 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/211300 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47050 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10800 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55065 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46453 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46684 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46511 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->