### PR TITLE
goodreads.com: Focus outline is cut-off from right side compared to Chrome

### DIFF
--- a/LayoutTests/compositing/clipping/focus-ring-clipped-by-rounded-composited-ancestor-clip-expected.txt
+++ b/LayoutTests/compositing/clipping/focus-ring-clipped-by-rounded-composited-ancestor-clip-expected.txt
@@ -1,0 +1,34 @@
+Outsetting only widens a rect, so it is refused for a rounded clip: widening one while keeping its radii describes a shape that no longer follows the border. The clipping layer's bounds below must stay at #ancestor's own 200x200, not grow by the ring's extent.
+
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (position 50.00 50.00)
+          (bounds 200.00 200.00)
+          (drawsContent 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 200.00 200.00)
+              (clips 1)
+              (children 1
+                (GraphicsLayer
+                  (offsetFromRenderer width=-3 height=-3)
+                  (position 37.00 77.00)
+                  (bounds 166.00 46.00)
+                  (drawsContent 1)
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/compositing/clipping/focus-ring-clipped-by-rounded-composited-ancestor-clip.html
+++ b/LayoutTests/compositing/clipping/focus-ring-clipped-by-rounded-composited-ancestor-clip.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>outline-style:auto clip outsets leave a rounded composited ancestor clip alone</title>
+<style>
+    body { margin: 0; }
+    #composited {
+        position: absolute; left: 50px; top: 50px;
+        width: 200px; height: 200px;
+        transform: translateZ(0);   /* #child's compositing ancestor, above #ancestor */
+    }
+    #ancestor {
+        position: absolute; left: 0; top: 0;
+        width: 200px; height: 200px;
+        overflow: hidden;
+        border-radius: 20px;        /* contributes a rounded clip to the ancestor clipping stack */
+        background: #ddd;
+    }
+    #child {
+        position: absolute;
+        left: 40px; top: 80px;
+        right: 0;                   /* flush to #ancestor's right edge, so its ring would need outsets */
+        height: 40px;
+        transform: translateZ(0);   /* composited, so its clip comes from the ancestor clipping stack */
+        background: #eee;
+    }
+    #child:focus { outline: auto; }
+</style>
+<script>
+    if (window.testRunner)
+        testRunner.dumpAsText();
+
+    window.addEventListener('load', () => {
+        document.getElementById('child').focus();
+        if (window.internals)
+            document.getElementById('layers').innerText = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_CLIPPING);
+    }, false);
+</script>
+</head>
+<body>
+    <p>Outsetting only widens a rect, so it is refused for a rounded clip: widening one while keeping its radii
+       describes a shape that no longer follows the border. The clipping layer's bounds below must stay at
+       #ancestor's own 200x200, not grow by the ring's extent.</p>
+    <div id="composited">
+        <div id="ancestor"><div id="child" tabindex="0"></div></div>
+    </div>
+<pre id="layers"></pre>
+</body>
+</html>

--- a/LayoutTests/compositing/clipping/focus-ring-clipped-when-descendant-has-overflowing-child-expected-mismatch.html
+++ b/LayoutTests/compositing/clipping/focus-ring-clipped-when-descendant-has-overflowing-child-expected-mismatch.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Not-reference: full ring and full leaked overflow (must differ from the clipped test)</title>
+<style>
+    body { margin: 0; }
+    #ancestor {
+        position: absolute; left: 50px; top: 50px;
+        width: 200px; height: 200px;
+        overflow: visible;         /* full ring and full #leak drawn -- the test must NOT look like this */
+        transform: translateZ(0);
+        background: #ddd;
+    }
+    #child {
+        position: absolute;
+        left: 90px; top: 40px;
+        right: 0;
+        height: 100px;
+        transform: translateZ(0);
+        outline: auto;
+        overflow: visible;
+        background: #eee;
+    }
+    #leak {
+        position: absolute;
+        left: 100%; top: 0;
+        width: 40px; height: 40px;
+        background: red;
+    }
+</style>
+</head>
+<body>
+    <p>Test passes if there is no red visible anywhere, and the box's right edge is NOT fully outlined.</p>
+    <div id="ancestor"><div id="child"><div id="leak"></div></div></div>
+</body>
+</html>

--- a/LayoutTests/compositing/clipping/focus-ring-clipped-when-descendant-has-overflowing-child.html
+++ b/LayoutTests/compositing/clipping/focus-ring-clipped-when-descendant-has-overflowing-child.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Focus ring stays clipped when the composited descendant itself has other overflowing content</title>
+<link rel="mismatch" href="focus-ring-clipped-when-descendant-has-overflowing-child-expected-mismatch.html">
+<!-- #child has an overflowing grandchild (#leak), so the compositing-clip outsets must be refused and both the ring and #leak must stay clipped by #ancestor; this must NOT match a reference where #ancestor's clip is removed. -->
+<style>
+    body { margin: 0; }
+    #ancestor {
+        position: absolute; left: 50px; top: 50px;
+        width: 200px; height: 200px;
+        overflow: hidden;
+        transform: translateZ(0);  /* force compositing: enforced via m_childContainmentLayer */
+        background: #ddd;
+    }
+    #child {
+        position: absolute;
+        left: 90px; top: 40px;
+        right: 0;                  /* flush to the ancestor's right edge */
+        height: 100px;
+        transform: translateZ(0);  /* force compositing */
+        outline: auto;
+        overflow: visible;         /* does not self-clip #leak */
+        background: #eee;
+    }
+    #leak {
+        position: absolute;
+        left: 100%; top: 0;
+        width: 40px; height: 40px; /* extends well past #child's border box -- more than the ring alone would */
+        background: red;
+    }
+</style>
+</head>
+<body>
+    <p>Test passes if there is no red visible anywhere, and the box's right edge is NOT fully outlined.</p>
+    <div id="ancestor"><div id="child" tabindex="0"><div id="leak"></div></div></div>
+    <script>
+        window.onload = () => child.focus();
+    </script>
+</body>
+</html>

--- a/LayoutTests/compositing/clipping/focus-ring-clipped-when-sibling-content-would-leak-expected-mismatch.html
+++ b/LayoutTests/compositing/clipping/focus-ring-clipped-when-sibling-content-would-leak-expected-mismatch.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Not-reference: full ring and full sibling content (must differ from the clipped test)</title>
+<style>
+    body { margin: 0; }
+    #ancestor {
+        position: absolute; left: 50px; top: 50px;
+        width: 200px; height: 200px;
+        overflow: visible;         /* full ring and full #sibling drawn -- the test must NOT look like this */
+        transform: translateZ(0);
+        background: #ddd;
+    }
+    #child {
+        position: absolute;
+        left: 90px; top: 40px;
+        right: 0;
+        height: 100px;
+        transform: translateZ(0);
+        outline: auto;
+        background: #eee;
+    }
+    #sibling {
+        position: absolute;
+        left: 190px; top: 150px;
+        width: 40px; height: 40px;
+        background: red;
+    }
+</style>
+</head>
+<body>
+    <p>Test passes if no red is visible past the box's edge, and the box's right edge is NOT fully outlined.</p>
+    <div id="ancestor"><div id="child"></div><div id="sibling"></div></div>
+</body>
+</html>

--- a/LayoutTests/compositing/clipping/focus-ring-clipped-when-sibling-content-would-leak.html
+++ b/LayoutTests/compositing/clipping/focus-ring-clipped-when-sibling-content-would-leak.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Focus ring stays clipped when relieving it would also expose a sibling's content</title>
+<link rel="mismatch" href="focus-ring-clipped-when-sibling-content-would-leak-expected-mismatch.html">
+<!-- Widening #ancestor's compositing clip mask to reveal #child's focus ring would also reveal #sibling's content, so the outsets must be refused and both must stay clipped; this must NOT match a reference where #ancestor's clip is removed. -->
+<style>
+    body { margin: 0; }
+    #ancestor {
+        position: absolute; left: 50px; top: 50px;
+        width: 200px; height: 200px;
+        overflow: hidden;
+        transform: translateZ(0);  /* force compositing: enforced via m_childContainmentLayer */
+        background: #ddd;
+    }
+    #child {
+        position: absolute;
+        left: 90px; top: 40px;
+        right: 0;                  /* flush to the ancestor's right edge */
+        height: 100px;
+        transform: translateZ(0);  /* force compositing */
+        outline: auto;
+        background: #eee;
+    }
+    #sibling {
+        position: absolute;
+        left: 190px; top: 150px;
+        width: 40px; height: 40px; /* pokes past #ancestor's right edge (x=200), well beyond ring width alone */
+        background: red;
+    }
+</style>
+</head>
+<body>
+    <p>Test passes if no red is visible past the box's edge, and the box's right edge is NOT fully outlined.</p>
+    <div id="ancestor"><div id="child" tabindex="0"></div><div id="sibling"></div></div>
+    <script>
+        window.onload = () => child.focus();
+    </script>
+</body>
+</html>

--- a/LayoutTests/compositing/clipping/focus-ring-not-clipped-by-ancestor-clipping-stack-expected.html
+++ b/LayoutTests/compositing/clipping/focus-ring-not-clipped-by-ancestor-clipping-stack-expected.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Reference: platform focus ring fully painted</title>
+<style>
+    body { margin: 0; }
+    #grandparent {
+        position: absolute; left: 50px; top: 50px;
+        width: 200px; height: 200px;
+        transform: translateZ(0);
+        background: #ccc;
+    }
+    #ancestor {
+        position: absolute; left: 0; top: 0;
+        width: 200px; height: 200px;
+        overflow: visible;         /* reference: nothing clips the focus ring */
+        background: #ddd;
+    }
+    #child {
+        position: absolute;
+        left: 90px; top: 40px;
+        right: 0;
+        height: 100px;
+        transform: translateZ(0);
+        outline: auto;
+        background: #eee;
+    }
+</style>
+</head>
+<body>
+    <p>Test passes if the inner box shows a complete focus ring on all four sides (including the right edge).</p>
+    <div id="grandparent"><div id="ancestor"><div id="child"></div></div></div>
+</body>
+</html>

--- a/LayoutTests/compositing/clipping/focus-ring-not-clipped-by-ancestor-clipping-stack.html
+++ b/LayoutTests/compositing/clipping/focus-ring-not-clipped-by-ancestor-clipping-stack.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Platform focus ring (outline-style:auto) is not clipped by a non-composited overflow:hidden ancestor in the compositing ancestor-clipping-stack</title>
+<link rel="match" href="focus-ring-not-clipped-by-ancestor-clipping-stack-expected.html">
+<!-- #ancestor is deliberately NOT composited, so its clip is enforced via the compositing ancestor-clipping stack rather than m_childContainmentLayer or the software paint-time clip rect. -->
+<style>
+    body { margin: 0; }
+    #grandparent {
+        position: absolute; left: 50px; top: 50px;
+        width: 200px; height: 200px;
+        transform: translateZ(0);  /* nearest composited ancestor of #child */
+        background: #ccc;
+    }
+    #ancestor {
+        position: absolute; left: 0; top: 0;
+        width: 200px; height: 200px;
+        overflow: hidden;          /* not composited: enforced via the ancestor clipping stack */
+        background: #ddd;
+    }
+    #child {
+        position: absolute;
+        left: 90px; top: 40px;     /* inset from ancestor on left/top/bottom */
+        right: 0;                  /* flush to the ancestor's right edge */
+        height: 100px;
+        transform: translateZ(0);  /* force compositing */
+        outline: auto;             /* platform focus ring, drawn outside the border box */
+        background: #eee;
+    }
+</style>
+</head>
+<body>
+    <p>Test passes if the inner box shows a complete focus ring on all four sides (including the right edge).</p>
+    <div id="grandparent"><div id="ancestor"><div id="child" tabindex="0"></div></div></div>
+    <script>
+        window.onload = () => child.focus();
+    </script>
+</body>
+</html>

--- a/LayoutTests/compositing/clipping/focus-ring-not-clipped-by-bordered-composited-ancestor-expected.html
+++ b/LayoutTests/compositing/clipping/focus-ring-not-clipped-by-bordered-composited-ancestor-expected.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Reference: platform focus ring fully painted</title>
+<style>
+    body { margin: 0; }
+    #ancestor {
+        position: absolute; left: 50px; top: 50px;
+        width: 200px; height: 200px;
+        border: 5px solid #999;
+        overflow: visible;         /* reference: nothing clips the focus ring */
+        transform: translateZ(0);
+        background: #ddd;
+    }
+    #sibling {
+        position: absolute;
+        left: 20px; top: 20px;
+        width: 40px; height: 40px;
+        background: #bbb;
+    }
+    #child {
+        position: absolute;
+        left: 90px; top: 40px;
+        right: 0;
+        height: 100px;
+        transform: translateZ(0);
+        outline: auto;
+        background: #eee;
+    }
+</style>
+</head>
+<body>
+    <p>Test passes if the inner box shows a complete focus ring on all four sides (including the right edge).</p>
+    <div id="ancestor"><div id="sibling"></div><div id="child"></div></div>
+</body>
+</html>

--- a/LayoutTests/compositing/clipping/focus-ring-not-clipped-by-bordered-composited-ancestor.html
+++ b/LayoutTests/compositing/clipping/focus-ring-not-clipped-by-bordered-composited-ancestor.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Platform focus ring is not clipped by a bordered composited ancestor's child-containment mask</title>
+<link rel="match" href="focus-ring-not-clipped-by-bordered-composited-ancestor-expected.html">
+<!-- As focus-ring-not-clipped-by-composited-child-containment-layer.html, but #ancestor has a border, so its clip
+     sits at (5,5) in its own coordinates rather than at the layer origin, and #sibling supplies other content
+     entirely inside that clip. Outset accumulators that cannot represent "nothing found" anchor both the ring and
+     the other-content bounds at (0,0), so #sibling reads as content the widening would expose and outsets are
+     denied. Both layers are composited, so m_childContainmentLayer enforces the clip and
+     paintOutlineForFragments()'s software inflation cannot rescue the ring. -->
+<style>
+    body { margin: 0; }
+    #ancestor {
+        position: absolute; left: 50px; top: 50px;
+        width: 200px; height: 200px;
+        border: 5px solid #999;    /* clip is the padding box, not the layer origin */
+        overflow: hidden;          /* enforced via m_childContainmentLayer since this layer is composited */
+        transform: translateZ(0);  /* force compositing */
+        background: #ddd;
+    }
+    #sibling {
+        position: absolute;
+        left: 20px; top: 20px;
+        width: 40px; height: 40px; /* entirely inside the clip: nothing here can legitimately leak */
+        background: #bbb;
+    }
+    #child {
+        position: absolute;
+        left: 90px; top: 40px;     /* inset from ancestor on left/top/bottom */
+        right: 0;                  /* flush to the padding box's right edge */
+        height: 100px;
+        transform: translateZ(0);  /* force compositing */
+        outline: auto;             /* platform focus ring, drawn outside the border box */
+        background: #eee;
+    }
+</style>
+</head>
+<body>
+    <p>Test passes if the inner box shows a complete focus ring on all four sides (including the right edge).</p>
+    <div id="ancestor"><div id="sibling"></div><div id="child" tabindex="0"></div></div>
+    <script>
+        window.onload = () => child.focus();
+    </script>
+</body>
+</html>

--- a/LayoutTests/compositing/clipping/focus-ring-not-clipped-by-composited-child-containment-layer-expected.html
+++ b/LayoutTests/compositing/clipping/focus-ring-not-clipped-by-composited-child-containment-layer-expected.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Reference: platform focus ring fully painted</title>
+<style>
+    body { margin: 0; }
+    #ancestor {
+        position: absolute; left: 50px; top: 50px;
+        width: 200px; height: 200px;
+        overflow: visible;         /* reference: nothing clips the focus ring */
+        transform: translateZ(0);
+        background: #ddd;
+    }
+    #child {
+        position: absolute;
+        left: 90px; top: 40px;
+        right: 0;
+        height: 100px;
+        transform: translateZ(0);
+        outline: auto;
+        background: #eee;
+    }
+</style>
+</head>
+<body>
+    <p>Test passes if the inner box shows a complete focus ring on all four sides (including the right edge).</p>
+    <div id="ancestor"><div id="child"></div></div>
+</body>
+</html>

--- a/LayoutTests/compositing/clipping/focus-ring-not-clipped-by-composited-child-containment-layer.html
+++ b/LayoutTests/compositing/clipping/focus-ring-not-clipped-by-composited-child-containment-layer.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Platform focus ring (outline-style:auto) is not clipped by a composited ancestor's child-containment mask</title>
+<link rel="match" href="focus-ring-not-clipped-by-composited-child-containment-layer-expected.html">
+<!-- Both #ancestor and #child are composited, so the ancestor's overflow:hidden clip is enforced via m_childContainmentLayer rather than the software paint-time clip rect. -->
+<style>
+    body { margin: 0; }
+    #ancestor {
+        position: absolute; left: 50px; top: 50px;
+        width: 200px; height: 200px;
+        overflow: hidden;          /* enforced via m_childContainmentLayer since this layer is composited */
+        transform: translateZ(0);  /* force compositing */
+        background: #ddd;
+    }
+    #child {
+        position: absolute;
+        left: 90px; top: 40px;     /* inset from ancestor on left/top/bottom */
+        right: 0;                  /* flush to the ancestor's right edge */
+        height: 100px;
+        transform: translateZ(0);  /* force compositing */
+        outline: auto;             /* platform focus ring, drawn outside the border box */
+        background: #eee;
+    }
+</style>
+</head>
+<body>
+    <p>Test passes if the inner box shows a complete focus ring on all four sides (including the right edge).</p>
+    <div id="ancestor"><div id="child" tabindex="0"></div></div>
+    <script>
+        window.onload = () => child.focus();
+    </script>
+</body>
+</html>

--- a/LayoutTests/compositing/clipping/focus-ring-not-clipped-by-composited-scroll-container-expected.html
+++ b/LayoutTests/compositing/clipping/focus-ring-not-clipped-by-composited-scroll-container-expected.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Reference: platform focus ring fully painted</title>
+<style>
+    body { margin: 0; }
+    #ancestor {
+        position: absolute; left: 50px; top: 50px;
+        width: 200px; height: 200px;
+        overflow: visible;         /* reference: nothing clips the focus ring */
+        background: #ddd;
+    }
+    #child {
+        position: absolute;
+        left: 90px; top: 40px;
+        width: 110px;
+        height: 100px;
+        transform: translateZ(0);
+        outline: auto;
+        background: #eee;
+    }
+</style>
+</head>
+<body>
+    <p>Test passes if the inner box shows a complete focus ring on all four sides (including the right edge).</p>
+    <div id="ancestor"><div id="child"></div></div>
+</body>
+</html>

--- a/LayoutTests/compositing/clipping/focus-ring-not-clipped-by-composited-scroll-container.html
+++ b/LayoutTests/compositing/clipping/focus-ring-not-clipped-by-composited-scroll-container.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+<title>Platform focus ring (outline-style:auto) is not clipped by a composited scroll container's own mask</title>
+<link rel="match" href="focus-ring-not-clipped-by-composited-scroll-container-expected.html">
+<!-- With no border-radius, a composited overflow:auto/scroll box has no m_childContainmentLayer, so the overflow clip is enforced solely by m_scrollContainerLayer's own masksToBounds. -->
+<style>
+    body { margin: 0; }
+    #ancestor {
+        position: absolute; left: 50px; top: 50px;
+        width: 200px; height: 200px;
+        overflow: auto;            /* composited scrolling with no border-radius: enforced via m_scrollContainerLayer only */
+        background: #ddd;
+    }
+    #ancestor::-webkit-scrollbar { display: none; } /* scrollbar painting isn't what's under test; avoid diffs against the ref */
+    #spacer {
+        height: 400px;             /* gives #ancestor scrollable overflow so it qualifies for composited scrolling */
+    }
+    #child {
+        position: absolute;
+        left: 90px; top: 40px;     /* inset from ancestor on left/top/bottom */
+        width: 110px;              /* flush to the ancestor's right edge; explicit so a scrollbar gutter can't shift it */
+        height: 100px;
+        transform: translateZ(0);  /* force compositing */
+        outline: auto;             /* platform focus ring, drawn outside the border box */
+        background: #eee;
+    }
+</style>
+</head>
+<body>
+    <p>Test passes if the inner box shows a complete focus ring on all four sides (including the right edge).</p>
+    <div id="ancestor"><div id="child" tabindex="0"></div><div id="spacer"></div></div>
+    <script>
+        window.onload = () => child.focus();
+    </script>
+</body>
+</html>

--- a/LayoutTests/compositing/clipping/focus-ring-not-clipped-when-focus-arrives-after-compositing-settles-expected.html
+++ b/LayoutTests/compositing/clipping/focus-ring-not-clipped-when-focus-arrives-after-compositing-settles-expected.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Reference: platform focus ring fully painted</title>
+<style>
+    body { margin: 0; }
+    #ancestor {
+        position: absolute; left: 50px; top: 50px;
+        width: 200px; height: 200px;
+        overflow: visible;         /* reference: nothing clips the focus ring */
+        transform: translateZ(0);
+        background: #ddd;
+    }
+    #child {
+        position: absolute;
+        left: 90px; top: 40px;
+        right: 0;
+        height: 100px;
+        transform: translateZ(0);
+        outline: auto;
+        background: #eee;
+    }
+</style>
+</head>
+<body>
+    <p>Test passes if the inner box shows a complete focus ring on all four sides (including the right edge).</p>
+    <div id="ancestor"><div id="child"></div></div>
+</body>
+</html>

--- a/LayoutTests/compositing/clipping/focus-ring-not-clipped-when-focus-arrives-after-compositing-settles.html
+++ b/LayoutTests/compositing/clipping/focus-ring-not-clipped-when-focus-arrives-after-compositing-settles.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Platform focus ring is not clipped by a composited ancestor's mask when focus arrives after compositing has already settled</title>
+<link rel="match" href="focus-ring-not-clipped-when-focus-arrives-after-compositing-settles-expected.html">
+<!-- #child only gets outline:auto via :focus-visible, so the initial (unfocused) frame commits compositing geometry with no ring before focus() runs, exercising RenderElement::styleDidChange's compositing dirty-bit propagation for the outline-only style change. -->
+<style>
+    body { margin: 0; }
+    #ancestor {
+        position: absolute; left: 50px; top: 50px;
+        width: 200px; height: 200px;
+        overflow: hidden;          /* enforced via m_childContainmentLayer since this layer is composited */
+        transform: translateZ(0);  /* force compositing */
+        background: #ddd;
+    }
+    #child {
+        position: absolute;
+        left: 90px; top: 40px;     /* inset from ancestor on left/top/bottom */
+        right: 0;                  /* flush to the ancestor's right edge */
+        height: 100px;
+        transform: translateZ(0);  /* force compositing */
+        background: #eee;
+    }
+    #child:focus-visible {
+        outline: auto;             /* platform focus ring, only once focused */
+    }
+</style>
+</head>
+<body>
+    <p>Test passes if the inner box shows a complete focus ring on all four sides (including the right edge).</p>
+    <div id="ancestor"><div id="child" tabindex="0"></div></div>
+    <script>
+        if (window.testRunner)
+            testRunner.waitUntilDone();
+
+        window.onload = () => {
+            // Let the unfocused state fully commit (layout + paint + compositing) before focusing.
+            requestAnimationFrame(() => requestAnimationFrame(() => {
+                child.focus();
+                // Let the focused state's repaint + compositing geometry update commit before the snapshot.
+                requestAnimationFrame(() => requestAnimationFrame(() => {
+                    if (window.testRunner)
+                        testRunner.notifyDone();
+                }));
+            }));
+        };
+    </script>
+</body>
+</html>

--- a/LayoutTests/compositing/clipping/focus-ring-not-clipped-when-static-outline-auto-gains-focus-expected.html
+++ b/LayoutTests/compositing/clipping/focus-ring-not-clipped-when-static-outline-auto-gains-focus-expected.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Reference: platform focus ring fully painted</title>
+<style>
+    body { margin: 0; }
+    #ancestor {
+        position: absolute; left: 50px; top: 50px;
+        width: 200px; height: 200px;
+        overflow: visible;         /* reference: nothing clips the focus ring */
+        transform: translateZ(0);
+        background: #ddd;
+    }
+    #child {
+        position: absolute;
+        left: 90px; top: 40px;
+        right: 0;
+        height: 100px;
+        transform: translateZ(0);
+        outline: auto;
+        background: #eee;
+    }
+</style>
+</head>
+<body>
+    <p>Test passes if the inner box shows a complete focus ring on all four sides (including the right edge).</p>
+    <div id="ancestor"><div id="child"></div></div>
+</body>
+</html>

--- a/LayoutTests/compositing/clipping/focus-ring-not-clipped-when-static-outline-auto-gains-focus.html
+++ b/LayoutTests/compositing/clipping/focus-ring-not-clipped-when-static-outline-auto-gains-focus.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Platform focus ring is not clipped when a static outline-style:auto element gains focus without restyling</title>
+<link rel="match" href="focus-ring-not-clipped-when-static-outline-auto-gains-focus-expected.html">
+<!-- A static outline:auto never restyles on focus, so styleDidChange() never runs; only
+     Element::setFocus() -> outlineAutoLiveFocusChanged() invalidates the outsets cached while unfocused. -->
+<style>
+    body { margin: 0; }
+    #ancestor {
+        position: absolute; left: 50px; top: 50px;
+        width: 200px; height: 200px;
+        overflow: hidden;          /* enforced via m_childContainmentLayer since this layer is composited */
+        transform: translateZ(0);  /* force compositing */
+        background: #ddd;
+    }
+    #child {
+        position: absolute;
+        left: 90px; top: 40px;     /* inset from ancestor on left/top/bottom */
+        right: 0;                  /* flush to the ancestor's right edge */
+        height: 100px;
+        transform: translateZ(0);  /* force compositing */
+        outline: auto;             /* static platform focus ring, never restyled by focus */
+        background: #eee;
+    }
+</style>
+</head>
+<body>
+    <p>Test passes if the inner box shows a complete focus ring on all four sides (including the right edge).</p>
+    <div id="ancestor"><div id="child" tabindex="0"></div></div>
+    <script>
+        if (window.testRunner)
+            testRunner.waitUntilDone();
+
+        window.onload = () => {
+            // Let the unfocused state fully commit, caching empty outsets on #ancestor.
+            requestAnimationFrame(() => requestAnimationFrame(() => {
+                child.focus();
+                // Let the focused state's clip recomputation commit before the snapshot.
+                requestAnimationFrame(() => requestAnimationFrame(() => {
+                    if (window.testRunner)
+                        testRunner.notifyDone();
+                }));
+            }));
+        };
+    </script>
+</body>
+</html>

--- a/LayoutTests/fast/clip/author-outline-still-clipped-by-overflow-hidden-ancestor-expected-mismatch.html
+++ b/LayoutTests/fast/clip/author-outline-still-clipped-by-overflow-hidden-ancestor-expected-mismatch.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Not-reference: full author outline (must differ from the clipped test)</title>
+<style>
+    body { margin: 0; }
+    #ancestor {
+        position: absolute; left: 50px; top: 50px;
+        width: 200px; height: 200px;
+        overflow: visible;             /* full outline drawn -> the test must NOT look like this */
+        background: #ddd;
+    }
+    #child {
+        position: absolute;
+        left: 90px; top: 40px;
+        right: 0;
+        height: 100px;
+        overflow: hidden;
+        outline: 10px solid green;
+        background: #eee;
+    }
+</style>
+</head>
+<body>
+    <p>Test passes if the green outline's right edge is clipped by the container (i.e., the box is NOT fully outlined on the right).</p>
+    <div id="ancestor"><div id="child"></div></div>
+</body>
+</html>

--- a/LayoutTests/fast/clip/author-outline-still-clipped-by-overflow-hidden-ancestor.html
+++ b/LayoutTests/fast/clip/author-outline-still-clipped-by-overflow-hidden-ancestor.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>An author (non-auto) outline on a self-painting layer is still clipped by an ancestor's overflow:hidden</title>
+<!-- A regular author outline on a self-painting-layer element must remain clipped by an ancestor's overflow:hidden; this test must NOT match the full-outline reference. -->
+<style>
+    body { margin: 0; }
+    #ancestor {
+        position: absolute; left: 50px; top: 50px;
+        width: 200px; height: 200px;
+        overflow: hidden;              /* must clip the author outline on the flush edge */
+        background: #ddd;
+    }
+    #child {
+        position: absolute;
+        left: 90px; top: 40px;         /* inset left/top/bottom */
+        right: 0;                      /* flush to the ancestor's right edge */
+        height: 100px;
+        overflow: hidden;              /* self-painting layer -> paints via PaintPhase::SelfOutline */
+        outline: 10px solid green;     /* non-auto author outline: stays clipped */
+        background: #eee;
+    }
+</style>
+</head>
+<body>
+    <p>Test passes if the green outline's right edge is clipped by the container (i.e., the box is NOT fully outlined on the right).</p>
+    <div id="ancestor"><div id="child"></div></div>
+</body>
+</html>

--- a/LayoutTests/fast/clip/focus-ring-clipped-by-overflow-hidden-ancestor-when-sibling-content-would-leak-expected-mismatch.html
+++ b/LayoutTests/fast/clip/focus-ring-clipped-by-overflow-hidden-ancestor-when-sibling-content-would-leak-expected-mismatch.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Not-reference: full ring and full sibling content (must differ from the clipped test)</title>
+<style>
+    body { margin: 0; }
+    #ancestor {
+        position: relative; left: 50px; top: 50px;
+        width: 200px; height: 200px;
+        overflow: visible;         /* full ring and full #sibling drawn -- the test must NOT look like this */
+        background: #ddd;
+    }
+    #wrapper {
+        margin: 40px 0 0 90px;
+    }
+    #child {
+        overflow: hidden;
+        outline: auto;
+        height: 100px;
+        background: #eee;
+    }
+    #sibling {
+        position: absolute;
+        left: 190px; top: 150px;
+        width: 40px; height: 40px;
+        background: red;
+    }
+</style>
+</head>
+<body>
+    <p>Test passes if no red is visible past the box's edge, and the box's right edge is NOT fully outlined.</p>
+    <div id="ancestor"><div id="wrapper"><div id="child"></div></div><div id="sibling"></div></div>
+</body>
+</html>

--- a/LayoutTests/fast/clip/focus-ring-clipped-by-overflow-hidden-ancestor-when-sibling-content-would-leak.html
+++ b/LayoutTests/fast/clip/focus-ring-clipped-by-overflow-hidden-ancestor-when-sibling-content-would-leak.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Focus ring stays clipped by a non-composited ancestor when relieving it would expose a sibling's content</title>
+<link rel="mismatch" href="focus-ring-clipped-by-overflow-hidden-ancestor-when-sibling-content-would-leak-expected-mismatch.html">
+<!-- Widening #ancestor's live (non-composited) overflow clip to reveal #child's focus ring would also reveal #sibling's content, so the outsets must be refused and both must stay clipped; this must NOT match a reference where #ancestor's clip is removed. -->
+<style>
+    body { margin: 0; }
+    #ancestor {
+        position: relative; left: 50px; top: 50px;
+        width: 200px; height: 200px;
+        overflow: hidden;
+        background: #ddd;
+    }
+    #wrapper {
+        margin: 40px 0 0 90px;
+    }
+    #child {
+        overflow: hidden;
+        outline: auto;
+        height: 100px;
+        background: #eee;
+    }
+    #sibling {
+        position: absolute;
+        left: 190px; top: 150px;
+        width: 40px; height: 40px; /* pokes past #ancestor's right edge (x=200), well beyond ring width alone */
+        background: red;
+    }
+</style>
+</head>
+<body>
+    <p>Test passes if no red is visible past the box's edge, and the box's right edge is NOT fully outlined.</p>
+    <div id="ancestor"><div id="wrapper"><div id="child" tabindex="0"></div></div><div id="sibling"></div></div>
+    <script>
+        window.onload = () => child.focus();
+    </script>
+</body>
+</html>

--- a/LayoutTests/fast/clip/focus-ring-not-clipped-by-overflow-hidden-ancestor-expected.html
+++ b/LayoutTests/fast/clip/focus-ring-not-clipped-by-overflow-hidden-ancestor-expected.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Reference: platform focus ring fully painted</title>
+<style>
+    body { margin: 0; }
+    #ancestor {
+        position: absolute; left: 50px; top: 50px;
+        width: 200px; height: 200px;
+        overflow: visible;         /* reference: nothing clips the focus ring */
+        background: #ddd;
+    }
+    #child {
+        position: absolute;
+        left: 90px; top: 40px;
+        right: 0;
+        height: 100px;
+        overflow: hidden;
+        outline: auto;
+        background: #eee;
+    }
+</style>
+</head>
+<body>
+    <p>Test passes if the inner box shows a complete focus ring on all four sides (including the right edge).</p>
+    <div id="ancestor"><div id="child"></div></div>
+</body>
+</html>

--- a/LayoutTests/fast/clip/focus-ring-not-clipped-by-overflow-hidden-ancestor-on-focus-expected.html
+++ b/LayoutTests/fast/clip/focus-ring-not-clipped-by-overflow-hidden-ancestor-on-focus-expected.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Reference: platform focus ring fully painted</title>
+<style>
+    body { margin: 0; }
+    #clipper {
+        position: absolute; left: 50px; top: 50px;
+        width: 200px; height: 100px;
+        overflow: visible;         /* reference: nothing clips the focus ring */
+        background: #ddd;
+    }
+    #poisoner {
+        position: absolute; left: 0; top: 0;
+        width: 20px; height: 20px;
+        background: green;         /* matches the test's post-mutation color */
+    }
+    #target {
+        position: absolute;
+        left: 40px; top: 40px;
+        right: 0;
+        height: 40px;
+        overflow: hidden;
+        outline: auto;             /* static: paints without needing focus */
+        background: #eee;
+    }
+</style>
+</head>
+<body>
+    <p>Test passes if the inner box shows a complete focus ring on all four sides (including the right edge).</p>
+    <div id="clipper">
+        <div id="poisoner"></div>
+        <div id="target"></div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/fast/clip/focus-ring-not-clipped-by-overflow-hidden-ancestor-on-focus.html
+++ b/LayoutTests/fast/clip/focus-ring-not-clipped-by-overflow-hidden-ancestor-on-focus.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Platform focus ring is not clipped by a non-composited overflow:hidden ancestor when a :focus-gated outline:auto becomes live</title>
+<link rel="match" href="focus-ring-not-clipped-by-overflow-hidden-ancestor-on-focus-expected.html">
+<!-- A :focus-gated outline:auto directly inside a non-composited overflow:hidden parent, flush to its right
+     edge; #poisoner only adds an unrelated repaint in the same update. -->
+<style>
+    body { margin: 0; }
+    #clipper {
+        position: absolute; left: 50px; top: 50px;
+        width: 200px; height: 100px;
+        overflow: hidden;          /* clips the ring unless outsets widen it */
+        background: #ddd;
+    }
+    #poisoner {
+        position: absolute; left: 0; top: 0;
+        width: 20px; height: 20px;
+        background: #bbb;
+    }
+    #target {
+        position: absolute;
+        left: 40px; top: 40px;     /* inset from #clipper on left/top/bottom */
+        right: 0;                  /* flush to #clipper's right edge */
+        height: 40px;
+        overflow: hidden;
+        background: #eee;
+    }
+    #target:focus {
+        outline: auto;
+    }
+</style>
+</head>
+<body>
+    <p>Test passes if the inner box shows a complete focus ring on all four sides (including the right edge).</p>
+    <div id="clipper">
+        <div id="poisoner"></div>
+        <div id="target" tabindex="0"></div>
+    </div>
+    <script>
+        if (window.testRunner)
+            testRunner.waitUntilDone();
+
+        window.onload = () => {
+            // Schedules the :focus restyle; the ring is not live yet when this returns.
+            target.focus();
+            // Issued earlier in the same recalc pass, so it caches outsets computed with no live ring.
+            poisoner.style.backgroundColor = 'green';
+
+            // Let the restyle, repaint and compositing update all commit before the snapshot.
+            requestAnimationFrame(() => requestAnimationFrame(() => {
+                if (window.testRunner)
+                    testRunner.notifyDone();
+            }));
+        };
+    </script>
+</body>
+</html>

--- a/LayoutTests/fast/clip/focus-ring-not-clipped-by-overflow-hidden-ancestor-through-non-layer-descendant-expected.html
+++ b/LayoutTests/fast/clip/focus-ring-not-clipped-by-overflow-hidden-ancestor-through-non-layer-descendant-expected.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Reference: platform focus ring fully painted</title>
+<style>
+    body { margin: 0; }
+    #ancestor {
+        box-sizing: border-box;
+        position: relative; left: 50px; top: 50px;
+        width: 200px; height: 200px;
+        padding-top: 40px;
+        overflow: visible;         /* reference: nothing clips the focus ring */
+        background: #ddd;
+    }
+    #wrapper {
+        margin: 0 0 0 90px;
+    }
+    #child {
+        overflow: hidden;
+        outline: auto;
+        height: 100px;
+        background: #eee;
+    }
+</style>
+</head>
+<body>
+    <p>Test passes if the inner box shows a complete focus ring on all four sides (including the right edge).</p>
+    <div id="ancestor"><div id="wrapper"><div id="child"></div></div></div>
+</body>
+</html>

--- a/LayoutTests/fast/clip/focus-ring-not-clipped-by-overflow-hidden-ancestor-through-non-layer-descendant.html
+++ b/LayoutTests/fast/clip/focus-ring-not-clipped-by-overflow-hidden-ancestor-through-non-layer-descendant.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Platform focus ring is not clipped by a non-composited overflow:hidden ancestor reached through a non-layer descendant</title>
+<link rel="match" href="focus-ring-not-clipped-by-overflow-hidden-ancestor-through-non-layer-descendant-expected.html">
+<!-- Unlike the direct-parent case (focus-ring-not-clipped-by-overflow-hidden-ancestor.html), here #child's own RenderLayer is reached from #ancestor's RenderLayer through #wrapper, a plain block with no RenderLayer of its own. -->
+<style>
+    body { margin: 0; }
+    #ancestor {
+        box-sizing: border-box;
+        position: relative; left: 50px; top: 50px;
+        width: 200px; height: 200px;
+        padding-top: 40px;         /* padding never collapses with a child's margin, unlike the margin-top this replaces */
+        overflow: hidden;          /* non-composited: enforced solely via the cached ClipRects chain */
+        background: #ddd;
+    }
+    #wrapper {
+        margin: 0 0 0 90px;        /* inset from ancestor on left; establishes no RenderLayer of its own */
+    }
+    #child {
+        overflow: hidden;          /* gives #child its own RenderLayer even though position is static */
+        outline: auto;             /* platform focus ring, drawn outside the border box */
+        height: 100px;
+        background: #eee;
+    }
+</style>
+</head>
+<body>
+    <p>Test passes if the inner box shows a complete focus ring on all four sides (including the right edge).</p>
+    <div id="ancestor"><div id="wrapper"><div id="child" tabindex="0"></div></div></div>
+    <script>
+        window.onload = () => child.focus();
+    </script>
+</body>
+</html>

--- a/LayoutTests/fast/clip/focus-ring-not-clipped-by-overflow-hidden-ancestor.html
+++ b/LayoutTests/fast/clip/focus-ring-not-clipped-by-overflow-hidden-ancestor.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Platform focus ring (outline-style:auto) is not clipped by an ancestor's overflow:hidden</title>
+<link rel="match" href="focus-ring-not-clipped-by-overflow-hidden-ancestor-expected.html">
+<!-- The outline-style:auto platform focus ring must not be sheared when a self-painting-layer element is flush to the right edge of an overflow:hidden ancestor; author outlines remain clipped, only the auto focus ring is protected. -->
+<style>
+    body { margin: 0; }
+    #ancestor {
+        position: absolute; left: 50px; top: 50px;
+        width: 200px; height: 200px;
+        overflow: hidden;          /* folds into the child layer's clip; must not shear the focus ring */
+        background: #ddd;
+    }
+    #child {
+        position: absolute;
+        left: 90px; top: 40px;     /* inset from ancestor on left/top/bottom */
+        right: 0;                  /* flush to the ancestor's right edge */
+        height: 100px;
+        overflow: hidden;          /* self-painting layer -> paints via PaintPhase::SelfOutline */
+        outline: auto;             /* platform focus ring, drawn outside the border box */
+        background: #eee;
+    }
+</style>
+</head>
+<body>
+    <p>Test passes if the inner box shows a complete focus ring on all four sides (including the right edge).</p>
+    <div id="ancestor"><div id="child"></div></div>
+</body>
+</html>

--- a/LayoutTests/fast/repaint/outline-auto-outsets-denied-by-transformed-sibling-expected.txt
+++ b/LayoutTests/fast/repaint/outline-auto-outsets-denied-by-transformed-sibling-expected.txt
@@ -1,0 +1,5 @@
+(repaint rects
+  (rect 87 167 166 46)
+  (rect 87 167 163 46)
+)
+

--- a/LayoutTests/fast/repaint/outline-auto-outsets-denied-by-transformed-sibling.html
+++ b/LayoutTests/fast/repaint/outline-auto-outsets-denied-by-transformed-sibling.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>outline-style:auto outsets are denied when a transformed sibling's real bounds reach the ring's band</title>
+<script src="resources/text-based-repaint.js"></script>
+<!-- #leaker's rotated bounds cross #ancestor's right edge while its unrotated box stays well inside it, so
+     outsets must be denied. That needs the walk to measure it through its transform; an untransformed box at a
+     translated offset keeps it inside the clip, sees no leak, and grants outsets. Note the box is tall and
+     narrow on purpose: rotating a wide thin one by 45deg makes it narrower in x, not wider, and would test
+     nothing. A repaint test rather than a reftest because it reads the outset decision directly. -->
+<style>
+    body { margin: 0; }
+    #ancestor {
+        position: absolute; left: 50px; top: 50px;
+        width: 200px; height: 200px;
+        overflow: hidden;
+        background: #ddd;
+    }
+    #leaker {
+        position: absolute;
+        left: 160px; top: 60px;
+        width: 20px; height: 100px;  /* tall and narrow, so rotating widens its x extent */
+        transform: rotate(45deg);    /* unrotated right edge 230; rotated ~262, past #ancestor's 250 */
+        background: #c00;
+    }
+    #target {
+        position: absolute;
+        left: 40px; top: 120px;
+        right: 0;                   /* flush to #ancestor's right edge, so its ring needs outsets */
+        height: 40px;
+        background: #eee;
+    }
+    #target:focus { outline: auto; }
+</style>
+<script>
+function repaintTest() {
+    document.getElementById('target').focus();
+}
+onload = runRepaintTest;
+</script>
+</head>
+<body>
+    <div id="ancestor">
+        <div id="leaker"></div>
+        <div id="target" tabindex="0"></div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/fast/repaint/outline-auto-repaint-none-when-focused-element-scrolled-away-expected.txt
+++ b/LayoutTests/fast/repaint/outline-auto-repaint-none-when-focused-element-scrolled-away-expected.txt
@@ -1,0 +1,4 @@
+(repaint rects
+  (rect 400 400 50 50)
+)
+

--- a/LayoutTests/fast/repaint/outline-auto-repaint-none-when-focused-element-scrolled-away.html
+++ b/LayoutTests/fast/repaint/outline-auto-repaint-none-when-focused-element-scrolled-away.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>outline-style:auto repaint issues nothing extra when the focused element is scrolled entirely out of its clip</title>
+<script src="resources/text-based-repaint.js"></script>
+<!-- The ring's extent is added as outsets after the clipping walk. With #target scrolled out of view the walk
+     collapses its rect to an empty one at the origin, and expanding that would invalidate a bogus square there.
+     #sentinel repaints as well, so the expected output is non-empty: this test fails if the bogus square appears
+     *and* if the repaint machinery quietly stops working. -->
+<style>
+    body { margin: 0; }
+    #scroller {
+        position: absolute; left: 50px; top: 50px;
+        width: 200px; height: 100px;
+        overflow: hidden;
+        background: #ddd;
+    }
+    #spacer { height: 600px; }
+    #target {
+        width: 160px; height: 40px;
+        background: #eee;
+    }
+    #target:focus { outline: auto; }
+    #sentinel {
+        position: absolute; left: 400px; top: 400px;
+        width: 50px; height: 50px;
+        background: #c00;
+    }
+</style>
+<script>
+function repaintTest() {
+    // Blurring repaints a rect the clipping walk collapses; the sentinel gives the dump something to contain.
+    document.getElementById('target').blur();
+    document.getElementById('sentinel').style.backgroundColor = 'green';
+}
+onload = () => {
+    document.getElementById('target').focus();
+    document.getElementById('scroller').scrollTop = 600;
+    runRepaintTest();
+};
+</script>
+</head>
+<body>
+    <div id="scroller">
+        <div id="target" tabindex="0"></div>
+        <div id="spacer"></div>
+    </div>
+    <div id="sentinel"></div>
+</body>
+</html>

--- a/LayoutTests/fast/repaint/outline-auto-repaint-not-clipped-by-stale-clip-outsets-expected.txt
+++ b/LayoutTests/fast/repaint/outline-auto-repaint-not-clipped-by-stale-clip-outsets-expected.txt
@@ -1,0 +1,6 @@
+(repaint rects
+  (rect 50 50 20 20)
+  (rect 87 67 166 46)
+  (rect 87 67 166 46)
+)
+

--- a/LayoutTests/fast/repaint/outline-auto-repaint-not-clipped-by-stale-clip-outsets.html
+++ b/LayoutTests/fast/repaint/outline-auto-repaint-not-clipped-by-stale-clip-outsets.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>outline-style:auto repaint rect covers the ring's full extent through a focus transition</title>
+<script src="resources/text-based-repaint.js"></script>
+<!-- The repaint rect must cover the ring's full extent (166 wide), not stop at #clipper's border box (163).
+     Pins OutlineAutoRingTransitionScope; it does NOT pin styleDidChange()'s outsets-cache clear, since style
+     recalc always runs before the first clip query here. -->
+<style>
+    body { margin: 0; }
+    #clipper {
+        position: absolute; left: 50px; top: 50px;
+        width: 200px; height: 100px;
+        overflow: hidden;          /* clips the ring unless outsets widen this clip */
+        background: #ddd;
+    }
+    #poisoner {
+        position: absolute; left: 0; top: 0;
+        width: 20px; height: 20px;
+        background: #bbb;
+    }
+    #target {
+        position: absolute;
+        left: 40px; top: 20px;     /* inset from #clipper on left/top/bottom */
+        right: 0;                  /* flush to #clipper's right edge */
+        height: 40px;
+        overflow: hidden;          /* own layer, and clips its own descendants */
+        background: #eee;
+    }
+    #target:focus {
+        outline: auto;             /* platform focus ring, only once focused */
+    }
+</style>
+<script>
+function repaintTest() {
+    // Schedules the :focus restyle that makes outline:auto live. The ring does not exist yet here.
+    document.getElementById('target').focus();
+
+    // Issued earlier in the same recalc pass, so it caches outsets computed with no live ring.
+    document.getElementById('poisoner').style.backgroundColor = 'green';
+}
+onload = runRepaintTest;
+</script>
+</head>
+<body>
+    <div id="clipper">
+        <div id="poisoner"></div>
+        <div id="target" tabindex="0"></div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/fast/repaint/outline-auto-repaint-not-denied-by-subpixel-clip-mismatch-expected.txt
+++ b/LayoutTests/fast/repaint/outline-auto-repaint-not-denied-by-subpixel-clip-mismatch-expected.txt
@@ -1,0 +1,5 @@
+(repaint rects
+  (rect 87 87 166 46)
+  (rect 87 87 166 46)
+)
+

--- a/LayoutTests/fast/repaint/outline-auto-repaint-not-denied-by-subpixel-clip-mismatch.html
+++ b/LayoutTests/fast/repaint/outline-auto-repaint-not-denied-by-subpixel-clip-mismatch.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>outline-style:auto repaint rect is not denied outsets by a sub-pixel clip-rect mismatch between the paint and repaint paths</title>
+<script src="resources/text-based-repaint.js"></script>
+<!-- #clipper's fractional width makes the repaint path's cachedSizeForOverflowClip()-derived clip narrower than
+     the paint path's, so #filler looks like content the outsets would expose; the leak check must tolerate that
+     sub-pixel overhang or the rect comes out 163 instead of 166. The ring outset is platform-specific,
+     so these numbers are for a 3px ring; see the platform/glib baseline. -->
+<style>
+    body { margin: 0; }
+    #clipper {
+        position: absolute; left: 50px; top: 50px;
+        /* Fractional on purpose: an integral width makes both paths agree and the bug disappears. */
+        width: 200.46875px;
+        height: 100px;
+        overflow: hidden;
+        background: #ddd;
+    }
+    #filler {
+        /* Spans the clip exactly, putting otherContentBounds right at the true clip edge. */
+        position: absolute; left: 0; top: 0; right: 0;
+        height: 24px;
+        background: #bbb;
+    }
+    #target {
+        position: absolute;
+        left: 40px; top: 40px;     /* inset from #clipper on left/top/bottom */
+        right: 0;                  /* flush to #clipper's right edge */
+        height: 40px;
+        overflow: hidden;
+        background: #eee;
+    }
+    #target:focus {
+        outline: auto;
+    }
+</style>
+<script>
+function repaintTest() {
+    // No cache poisoning needed here: this is the leak check refusing outsets on a fresh computation, not a
+    // stale outsets (that case is covered by outline-auto-repaint-not-clipped-by-stale-clip-outsets.html).
+    document.getElementById('target').focus();
+}
+onload = runRepaintTest;
+</script>
+</head>
+<body>
+    <div id="clipper">
+        <div id="filler"></div>
+        <div id="target" tabindex="0"></div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/platform/glib/compositing/clipping/focus-ring-clipped-by-rounded-composited-ancestor-clip-expected.txt
+++ b/LayoutTests/platform/glib/compositing/clipping/focus-ring-clipped-by-rounded-composited-ancestor-clip-expected.txt
@@ -1,0 +1,34 @@
+Outsetting only widens a rect, so it is refused for a rounded clip: widening one while keeping its radii describes a shape that no longer follows the border. The clipping layer's bounds below must stay at #ancestor's own 200x200, not grow by the ring's extent.
+
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (position 50.00 50.00)
+          (bounds 200.00 200.00)
+          (drawsContent 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 200.00 200.00)
+              (clips 1)
+              (children 1
+                (GraphicsLayer
+                  (offsetFromRenderer width=-2 height=-2)
+                  (position 38.00 78.00)
+                  (bounds 164.00 44.00)
+                  (drawsContent 1)
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/platform/glib/fast/repaint/outline-auto-outsets-denied-by-transformed-sibling-expected.txt
+++ b/LayoutTests/platform/glib/fast/repaint/outline-auto-outsets-denied-by-transformed-sibling-expected.txt
@@ -1,0 +1,5 @@
+(repaint rects
+  (rect 88 168 164 44)
+  (rect 88 168 162 44)
+)
+

--- a/LayoutTests/platform/glib/fast/repaint/outline-auto-repaint-not-clipped-by-stale-clip-outsets-expected.txt
+++ b/LayoutTests/platform/glib/fast/repaint/outline-auto-repaint-not-clipped-by-stale-clip-outsets-expected.txt
@@ -1,0 +1,6 @@
+(repaint rects
+  (rect 50 50 20 20)
+  (rect 88 68 164 44)
+  (rect 88 68 164 44)
+)
+

--- a/LayoutTests/platform/glib/fast/repaint/outline-auto-repaint-not-denied-by-subpixel-clip-mismatch-expected.txt
+++ b/LayoutTests/platform/glib/fast/repaint/outline-auto-repaint-not-denied-by-subpixel-clip-mismatch-expected.txt
@@ -1,0 +1,5 @@
+(repaint rects
+  (rect 88 88 164 44)
+  (rect 88 88 164 44)
+)
+

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -1039,7 +1039,10 @@ void Element::setFocus(bool value, FocusVisibility visibility)
 {
     if (value == focused())
         return;
-    
+
+    if (CheckedPtr renderer = this->renderer())
+        renderer->outlineAutoLiveFocusChanged(value);
+
     Style::PseudoClassChangeInvalidation focusStyleInvalidation(*this, { { CSSSelector::PseudoClass::Focus, value }, { CSSSelector::PseudoClass::FocusVisible, value } });
     document().userActionElements().setFocused(*this, value);
 

--- a/Source/WebCore/rendering/LayerFragment.h
+++ b/Source/WebCore/rendering/LayerFragment.h
@@ -51,6 +51,8 @@ public:
 
         LayoutRect layerBounds() const { return m_layerBounds; }
 
+        LayoutRect paintDirtyRect() const { return m_paintDirtyRect; }
+
         ClipRect backgroundRect() const { return m_backgroundRect; }
         ClipRect dirtyBackgroundRect() const { return intersection(m_paintDirtyRect, m_backgroundRect); }
         ClipRect dirtyForegroundRect() const { return intersection(m_paintDirtyRect, m_foregroundRect); }
@@ -93,6 +95,8 @@ public:
     LayerFragment(Rects&& rects) { this->rects = WTF::move(rects); }
 
     LayoutRect layerBounds() const { return rects.layerBounds(); }
+
+    LayoutRect paintDirtyRect() const { return rects.paintDirtyRect(); }
 
     ClipRect backgroundRect() const { return rects.backgroundRect(); }
     ClipRect dirtyBackgroundRect() const { return rects.dirtyBackgroundRect(); }

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -3,7 +3,7 @@
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2005 Allan Sandfeld Jensen (kde@carewolf.com)
  * Copyright (C) 2005-2025 Samuel Weinig (sam@webkit.org)
- * Copyright (C) 2005-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2015-2019 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
@@ -1496,6 +1496,12 @@ bool RenderBox::applyCachedClipAndScrollPosition(RepaintRects& rects, const Rend
         };
 
         clipRect.expand(scrollMarginEdges);
+    }
+
+    // Only a repaint rect should see a widened clip; a visibility query must see the real one.
+    if (context.options.contains(VisibleRectContext::Option::AllowOutlineAutoClipOutsets)) {
+        if (CheckedPtr layer = this->layer())
+            clipRect = layer->outsetOutlineAutoClipRect(clipRect, RenderLayer::OutsetContext::RingOnly);
     }
 
     bool intersects;
@@ -4907,6 +4913,39 @@ LayoutRect RenderBox::applyVisualEffectOverflow(const LayoutRect& borderBox, Enu
     return LayoutRect(overflowMinX, overflowMinY, overflowMaxX - overflowMinX, overflowMaxY - overflowMinY);
 }
 
+LayoutRect RenderBox::outlineAutoRingBounds() const
+{
+    return applyVisualEffectOverflow(borderBoxRect());
+}
+
+bool RenderBox::outlineAutoIsOnlyVisualOverflow() const
+{
+    if (element() != document().focusedElement())
+        return false;
+
+    CheckedRef outlineStyle = outlineStyleForRepaint();
+    if (outlineStyle->outlineStyle() != OutlineStyle::Auto || !outlineStyle->hasOutlineInVisualOverflow())
+        return false;
+
+    if (!style().boxShadow().isNone() || style().hasBorderImageOutsets() || (hasFilter() && !computeFilterOutsets().isZero()))
+        return false;
+
+    // Already clips its descendants to the border box, so none of their content can reach the ring's space.
+    if (hasNonVisibleOverflow())
+        return true;
+
+    // Otherwise the ring must be all that reaches past the border box.
+    return visualOverflowRect() == applyVisualEffectOverflow(borderBoxRect());
+}
+
+// True when 'child' paints its own visual overflow (box-shadow, outline, etc.) via its own self-painting
+// layer, so this box's visual overflow need not include it.
+bool RenderBox::childPaintsVisualOverflowIndependently(const RenderBox& child) const
+{
+    // A child can't self-paint if a filter is present, since it needs pre-filter bounds for everything it applies to.
+    return child.hasSelfPaintingLayer() && !hasFilter();
+}
+
 void RenderBox::addOverflowFromInFlowChildren(OptionSet<ComputeOverflowOptions> options)
 {
     for (auto& child : childrenOfType<RenderBox>(*this)) {
@@ -4979,7 +5018,7 @@ void RenderBox::addOverflowWithRendererOffset(const RenderBox& renderer, LayoutS
     } else {
         // Update our visual overflow in case the child spills out the block, but only if we were going to paint
         // the child block ourselves.
-        if (renderer.hasSelfPaintingLayer() && !hasFilter())
+        if (childPaintsVisualOverflowIndependently(renderer))
             return;
     }
     if (!childVisualOverflowRect)

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
- * Copyright (C) 2003-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
  * This library is free software; you can redistribute it and/or
@@ -234,6 +234,11 @@ public:
 
     void addVisualEffectOverflow();
     LayoutRect applyVisualEffectOverflow(const LayoutRect&, EnumSet<VisualEffectOverflowOption> = { }) const;
+
+    bool outlineAutoIsOnlyVisualOverflow() const;
+    LayoutRect outlineAutoRingBounds() const;
+
+    bool childPaintsVisualOverflowIndependently(const RenderBox& child) const;
     virtual void addOverflowFromInFlowChildren(OptionSet<ComputeOverflowOptions> = { });
     void addOverflowFromContainedBox(const RenderBox& child, OptionSet<ComputeOverflowOptions> = { });
     void addOverflowFromFloatBox(const FloatingObject&);

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -1067,6 +1067,11 @@ inline void RenderCounter::rendererStyleChanged(RenderElement& renderer, const S
     rendererStyleChangedSlowCase(renderer, oldStyle, newStyle);
 }
 
+static float usedOutlineSizeForOutlineAuto(const Style::ComputedStyle& style, float deviceScaleFactor)
+{
+    return style.usedOutlineSize(style.usedZoomForLength(), deviceScaleFactor);
+}
+
 void RenderElement::styleDidChange(Style::Difference diff, const Style::ComputedStyle* oldStyle)
 {
     RefPtr protectedElement = element();
@@ -1142,8 +1147,12 @@ void RenderElement::styleDidChange(Style::Difference diff, const Style::Computed
     bool hasOutlineAuto = outlineStyleForRepaint().outlineStyle() == OutlineStyle::Auto;
     if (hasOutlineAuto != hadOutlineAuto) {
         updateOutlineAutoAncestor(hasOutlineAuto);
-        auto deviceScaleFactor = style().deviceScaleFactor();
-        issueRepaintForOutlineAuto(hasOutlineAuto ? outlineStyleForRepaint().usedOutlineSize(outlineStyleForRepaint().usedZoomForLength(), deviceScaleFactor) : oldStyle->usedOutlineSize(oldStyle->usedZoomForLength(), deviceScaleFactor));
+        // Discard outsets cached between Element::setFocus() and this restyle landing, when outline:auto was not
+        // yet live. Reachable from user interaction but not from script, which flushes the pending restyle first.
+        updateOutlineAutoClipOutsetsOnAncestors(hasOutlineAuto ? OutlineAutoRingChain::OnChain : OutlineAutoRingChain::NotOnChain);
+
+        issueRepaintForOutlineAuto(usedOutlineSizeForOutlineAuto(hasOutlineAuto ? outlineStyleForRepaint() : *oldStyle, style().deviceScaleFactor()));
+        invalidateCompositedClipsForOutlineAutoChange();
     }
 
     auto isLayoutDiff = [](Style::Difference diff) {
@@ -1237,6 +1246,13 @@ void RenderElement::insertedIntoTree()
 
 void RenderElement::willBeRemovedFromTree()
 {
+    // Blur cannot clear the chain once the renderer is gone, since Element::setFocus() needs one to reach it, so
+    // clear it here while the ancestors are still reachable.
+    if (CheckedPtr focusedElement = document().focusedElement(); focusedElement && focusedElement.get() == element()) {
+        if (outlineStyleForRepaint().outlineStyle() == OutlineStyle::Auto)
+            updateOutlineAutoClipOutsetsOnAncestors(OutlineAutoRingChain::NotOnChain);
+    }
+
     if (isLegend()) {
         if (CheckedPtr fieldset = dynamicDowncast<RenderBlock>(parent()); fieldset && fieldset->isFieldset())
             fieldset->setIntrinsicBorderForFieldset({ });
@@ -1281,6 +1297,9 @@ inline void RenderElement::clearSubtreeLayoutRootIfNeeded() const
 
 void RenderElement::willBeDestroyed()
 {
+    if (view().focusRingRenderer() == this)
+        view().setFocusRingRenderer(nullptr, { });
+
 #if ENABLE(CONTENT_CHANGE_OBSERVER)
     if (!renderTreeBeingDestroyed() && element())
         protect(document())->contentChangeObserver().rendererWillBeDestroyed(protect(*element()));
@@ -2243,16 +2262,58 @@ void RenderElement::paintOutline(PaintInfo& paintInfo, const LayoutRect& paintRe
     OutlinePainter { paintInfo }.paintOutline(*this, paintRect);
 }
 
+// An outline-only change marks no other compositing dirty bits, so a composited ancestor's overflow-clip mask
+// geometry could go stale. Only an ancestor that actually clips can be affected.
+void RenderElement::invalidateCompositedClipsForOutlineAutoChange()
+{
+    CheckedPtr layer = enclosingLayer();
+    if (!layer)
+        return;
+
+    // Nothing to invalidate unless some ancestor actually clips.
+    bool hasClippingAncestor = false;
+    for (CheckedPtr ancestor = layer->parent(); ancestor; ancestor = ancestor->parent()) {
+        if (ancestor->renderer().hasNonVisibleOverflow()) {
+            hasClippingAncestor = true;
+            break;
+        }
+    }
+
+    if (!hasClippingAncestor)
+        return;
+
+    // Set these once after walking the ancestors to avoid redundant walks at each iteration.
+    layer->setNeedsCompositingGeometryUpdateOnAncestors();
+    layer->setNeedsCompositingConfigurationUpdateOnAncestors();
+}
+
 void RenderElement::issueRepaintForOutlineAuto(float outlineSize)
 {
     auto focusRingRects = OutlinePainter::collectFocusRingRects(*this, LayoutPoint(), containerForRepaint().renderer.get());
 
     LayoutRect repaintRect;
-    for (auto rect : focusRingRects) {
-        rect.inflate(outlineSize);
+    for (auto rect : focusRingRects)
         repaintRect.unite(rect);
-    }
-    repaintRectangle(repaintRect);
+
+    // The ring's extent goes in as outsets, which issueRepaint() applies after the clipping walk rather than
+    // before. Inflating first would just have the clip shave the band off again, since mid-transition no ancestor
+    // clip can recognize the ring: on focus the layout has not grown to include it, on blur the style has lost it.
+    // With nothing clipping, the two orders agree.
+    auto ringOutsets = LayoutBoxExtent { LayoutUnit(outlineSize), LayoutUnit(outlineSize), LayoutUnit(outlineSize), LayoutUnit(outlineSize) };
+    repaintRectangle(repaintRect, ClipRepaintToLayer::Yes, ForceRepaint::No, ringOutsets);
+}
+
+void RenderElement::outlineAutoLiveFocusChanged(bool isFocused)
+{
+    bool hasOutlineAuto = outlineStyleForRepaint().outlineStyle() == OutlineStyle::Auto;
+    updateOutlineAutoClipOutsetsOnAncestors(isFocused && hasOutlineAuto ? OutlineAutoRingChain::OnChain : OutlineAutoRingChain::NotOnChain);
+
+    if (!hasOutlineAuto)
+        return;
+
+    // Nothing else invalidates the ring's area on a plain focus move.
+    issueRepaintForOutlineAuto(usedOutlineSizeForOutlineAuto(outlineStyleForRepaint(), style().deviceScaleFactor()));
+    invalidateCompositedClipsForOutlineAutoChange();
 }
 
 void RenderElement::updateOutlineAutoAncestor(bool hasOutlineAuto)

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -300,6 +300,8 @@ public:
     ReferencedSVGResources& ensureReferencedSVGResources();
     ReferencedSVGResources* referencedSVGResources() const;
 
+    void outlineAutoLiveFocusChanged(bool isFocused);
+
     Overflow NODELETE effectiveOverflowX() const;
     Overflow NODELETE effectiveOverflowY() const;
     inline Overflow effectiveOverflowInlineDirection() const;
@@ -450,6 +452,7 @@ private:
     
     bool shouldWillChangeCreateStackingContext() const;
     void issueRepaintForOutlineAuto(float outlineSize);
+    void invalidateCompositedClipsForOutlineAutoChange();
     
     void updateReferencedSVGResources();
     void clearReferencedSVGResources();

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -180,6 +180,8 @@ namespace WebCore {
 
 using namespace HTMLNames;
 
+WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(RenderLayer::OutlineAutoClipOutsets);
+
 class ClipRects : public RefCounted<ClipRects> {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(ClipRects);
 public:
@@ -1185,6 +1187,20 @@ void RenderLayer::updateLayerPositionsAfterLayout(bool didFullRepaint, bool envi
     willUpdateLayerPositions();
 
     recursiveUpdateLayerPositions(updateLayerPositionFlags(didFullRepaint, environmentChanged));
+
+    // Layout may have moved anything on the focused element's ancestor chain. Only mark the chain when
+    // a ring is actually live.
+    if (RefPtr focusedElement = renderer().document().focusedElement()) {
+        if (CheckedPtr focusedRenderer = focusedElement->renderer()) {
+            bool hasOutlineAuto = focusedRenderer->outlineStyleForRepaint().outlineStyle() == OutlineStyle::Auto;
+            // Nothing to mark and nothing marked means no walk. The marking loop always runs to the root, so the
+            // root layer's bit says whether any chain is marked -- unlike the view's cached focus ring renderer, which
+            // willBeDestroyed() nulls without clearing the layer bits.
+            CheckedPtr rootLayer = renderer().view().layer();
+            if (hasOutlineAuto || (rootLayer && rootLayer->isOutlineAutoClipOutsetsAncestor()))
+                focusedRenderer->updateOutlineAutoClipOutsetsOnAncestors(hasOutlineAuto ? RenderObject::OutlineAutoRingChain::OnChain : RenderObject::OutlineAutoRingChain::NotOnChain);
+        }
+    }
 
     LOG(Compositing, "RenderLayer %p updateLayerPositionsAfterLayout - after", this);
 #if ASSERT_ENABLED
@@ -4361,17 +4377,31 @@ void RenderLayer::paintForegroundForFragmentsWithPhase(PaintPhase phase, const L
 void RenderLayer::paintOutlineForFragments(const LayerFragments& layerFragments, GraphicsContext& context, const LayerPaintingInfo& localPaintingInfo,
     OptionSet<PaintBehavior> paintBehavior, RenderObject* subtreePaintRootForRenderer)
 {
+    // Widen the clip for a platform focus ring flush to an overflow:hidden ancestor's edge. Unlike the outset
+    // path in outsetOutlineAutoClipRect() this is not focus-gated, so it also covers an unfocused static
+    // outline-style:auto.
+    auto& style = renderer().style();
+    LayoutUnit outlineExtent;
+    if (style.outlineStyle() == OutlineStyle::Auto)
+        outlineExtent = LayoutUnit { std::ceil(style.usedOutlineSize(style.usedZoomForLength(), style.deviceScaleFactor())) };
+
     for (const auto& fragment : layerFragments) {
         if (fragment.dirtyBackgroundRect().isEmpty())
             continue;
 
+        auto outlineClipRect = fragment.dirtyBackgroundRect();
+        if (outlineExtent > 0_lu) {
+            outlineClipRect.inflate(outlineExtent);
+            outlineClipRect.intersect(fragment.paintDirtyRect());
+        }
+
         // Paint our own outline
-        PaintInfo paintInfo(context, fragment.dirtyBackgroundRect().rect(), PaintPhase::SelfOutline, paintBehavior, subtreePaintRootForRenderer, nullptr, nullptr, &localPaintingInfo.rootLayer->renderer(), this);
+        PaintInfo paintInfo(context, outlineClipRect.rect(), PaintPhase::SelfOutline, paintBehavior, subtreePaintRootForRenderer, nullptr, nullptr, &localPaintingInfo.rootLayer->renderer(), this);
 
         GraphicsContextStateSaver stateSaver(context, false);
         RegionContextStateSaver regionContextStateSaver(localPaintingInfo.regionContext);
 
-        clipToRect(context, stateSaver, regionContextStateSaver, localPaintingInfo, paintBehavior, fragment.dirtyBackgroundRect(), DoNotIncludeSelfForBorderRadius);
+        clipToRect(context, stateSaver, regionContextStateSaver, localPaintingInfo, paintBehavior, outlineClipRect, DoNotIncludeSelfForBorderRadius);
         renderer().paint(paintInfo, paintOffsetForRenderer(fragment, localPaintingInfo));
     }
 }
@@ -5124,6 +5154,7 @@ Ref<ClipRects> RenderLayer::updateClipRects(const ClipRectsContext& clipRectsCon
     ASSERT(clipRectsType < NumCachedClipRectsTypes);
     ASSERT(!clipRectsContext.options.contains(ClipRectsOption::Temporary));
     ASSERT(!clipRectsContext.options.contains(ClipRectsOption::OutsideFilter));
+
     if (m_clipRectsCache) {
         if (auto* clipRects = m_clipRectsCache->getClipRects(clipRectsContext)) {
             ASSERT(clipRectsContext.rootLayer == m_clipRectsCache->m_clipRectsRoot[clipRectsType]);
@@ -5216,7 +5247,11 @@ void RenderLayer::calculateClipRects(const ClipRectsContext& clipRectsContext, C
             offset -= toLayoutSize(renderer().view().frameView().scrollPositionForFixedPosition());
 
         if (renderer().hasNonVisibleOverflow()) {
-            ClipRect newOverflowClip = rendererOverflowClipRectForChildLayers({ }, clipRectsContext.overlayScrollbarSizeRelevancy());
+            // This clip propagates to every descendant layer's clip rects, so a nested ring needs outsets here too.
+            // Painting only: outsetting RootRelativeClipRects would let hit testing hit the ring's band, and
+            // outsetting AbsoluteClipRects would change compositing overlap results.
+            auto childClip = rendererOverflowClipRectForChildLayers({ }, clipRectsContext.overlayScrollbarSizeRelevancy());
+            ClipRect newOverflowClip = clipRectsContext.clipRectsType == PaintingClipRects ? outsetOutlineAutoClipRect(childClip, OutsetContext::SharedPaintClip) : childClip;
             if (needsTransform)
                 newOverflowClip = LayoutRect(renderer().localToContainerQuad(FloatRect(newOverflowClip.rect()), &clipRectsContext.rootLayer->renderer()).boundingBox());
             newOverflowClip.moveBy(offset);
@@ -5364,7 +5399,12 @@ ClipRect RenderLayer::calculateForegroundRect(const ClipRectsContext& clipRectsC
 
     // This layer establishes a clip of some kind.
     if (this != clipRectsContext.rootLayer || clipRectsContext.respectOverflowClip()) {
-        auto overflowClipRect = rendererOverflowClipRect(toLayoutPoint(offsetFromRoot), clipRectsContext.overlayScrollbarSizeRelevancy());
+        // Non-self-painting descendants are painted inline as part of this layer's foreground clip, so this is the
+        // clip that needs outsets if one of them paints the live focus ring -- paintOutlineForFragments()'s
+        // inflation only covers a box that paints its own outline.
+        auto localOverflowClipRect = rendererOverflowClipRect({ }, clipRectsContext.overlayScrollbarSizeRelevancy());
+        auto overflowClipRect = clipRectsContext.clipRectsType == PaintingClipRects ? outsetOutlineAutoClipRect(localOverflowClipRect, OutsetContext::SharedPaintClip) : localOverflowClipRect;
+        overflowClipRect.move(offsetFromRoot);
         foregroundRect.intersect(overflowClipRect);
         foregroundRect.setAffectedByRadius(true);
         return foregroundRect;
@@ -5736,10 +5776,224 @@ LayoutRect RenderLayer::calculateLayerBounds(const RenderLayer* ancestorLayer, c
     return unionBounds;
 }
 
+// Unites into an optional accumulator; a std::nullopt target takes the rect as-is rather than uniting it with
+// a default LayoutRect, which would anchor the result at the layer origin.
+static void uniteOutsetBounds(std::optional<LayoutRect>& target, const LayoutRect& rect)
+{
+    if (target)
+        target->uniteEvenIfEmpty(rect);
+    else
+        target = rect;
+}
+
+static void uniteOutsetBounds(std::optional<LayoutRect>& target, const std::optional<LayoutRect>& rect)
+{
+    if (rect)
+        uniteOutsetBounds(target, *rect);
+}
+
+LayoutRect RenderLayer::knownFocusRingBounds(const RenderLayer& focusRingLayer, const RenderBox& focusRingBox) const
+{
+    // Cached bounds cover the steady state; a chain marked for another box derives them.
+    auto bounds = renderer().view().focusRingRenderer() == &focusRingBox
+        ? renderer().view().focusRingBounds()
+        : focusRingBox.outlineAutoRingBounds();
+
+    bounds.move(focusRingLayer.offsetFromAncestor(this));
+    return bounds;
+}
+
+void RenderLayer::accumulateOutlineAutoClipOutsets(const LayoutSize& offsetFromAncestor, OutlineAutoClipOutsets& outsets, const RenderBox* focusRingBox) const
+{
+    // Non-self-painting and composited layers both still contribute geometry: either can paint the focus ring
+    // or contain content that must not leak.
+    CheckedPtr box = renderBox();
+    bool paintsFocusRing = box && box.get() == focusRingBox;
+
+    // Mirrors calculateLayerBounds()'s IncludeSelfTransform. A rotated or scaled layer's content occupies its
+    // transformed bounds, and under-reporting otherContentBounds is what would grant outsets that reveal it.
+    auto inAncestorCoords = [&](LayoutRect rect) {
+        if (paintsWithTransform(PaintBehavior::Normal) && transform())
+            rect = transform()->mapRect(rect);
+        rect.move(offsetFromAncestor);
+        return rect;
+    };
+
+    // The raw layer tree, not the z-order lists: those omit a stacking-context layer from a non-stacking-context
+    // parent's list.
+    auto recurseIntoChildren = [&](OutlineAutoClipOutsets& target, auto&& perChild) {
+#if ASSERT_ENABLED
+        LayerListMutationDetector mutationChecker(const_cast<RenderLayer&>(*this));
+#endif
+        for (CheckedPtr childLayer = firstChild(); childLayer; childLayer = childLayer->nextSibling()) {
+            if (isReflectionLayer(*childLayer))
+                continue;
+            OutlineAutoClipOutsets childOutsets;
+            childLayer->accumulateOutlineAutoClipOutsets(offsetFromAncestor + childLayer->offsetFromAncestor(this), childOutsets, focusRingBox);
+            perChild(*childLayer, childOutsets);
+            uniteOutsetBounds(target.ringOnlyBounds, childOutsets.ringOnlyBounds);
+            uniteOutsetBounds(target.otherContentBounds, childOutsets.otherContentBounds);
+        }
+    };
+    auto ignoreChild = [](RenderLayer&, const OutlineAutoClipOutsets&) { };
+
+    if (paintsFocusRing) {
+        uniteOutsetBounds(outsets.ringOnlyBounds, inAncestorCoords(box->outlineAutoRingBounds()));
+    } else if (box) {
+        // A layer-tree child can sit many non-layer-owning RenderBoxes below this box, so walk the render-tree
+        // path explicitly to find which descendants' ring inflation is already folded into ownBounds.
+        auto descendantRingIsFoldedIntoOwnBounds = [&](RenderBox& descendantBox) {
+            for (CheckedPtr current = &descendantBox; current && current != box; ) {
+                CheckedPtr parent = current->parentBox();
+                // Mirrors addOverflowWithRendererOffset(): a contained box never folds in a child's overflow.
+                if (!parent || parent->paintContainmentApplies() || parent->childPaintsVisualOverflowIndependently(*current))
+                    return false;
+                current = parent;
+            }
+            return true;
+        };
+
+        OutlineAutoClipOutsets descendantOutsets;
+        std::optional<LayoutRect> explainedByFoldedRings;
+        if (!box->hasNonVisibleOverflow()) {
+            recurseIntoChildren(descendantOutsets, [&](RenderLayer& childLayer, const OutlineAutoClipOutsets& childOutsets) {
+                // Test the optional first: it is nullopt for every child but the one chain holding the ring, and
+                // descendantRingIsFoldedIntoOwnBounds() is an O(render-tree-depth) walk.
+                if (!childOutsets.ringOnlyBounds)
+                    return;
+                if (CheckedPtr childBox = childLayer.renderBox(); childBox && descendantRingIsFoldedIntoOwnBounds(*childBox))
+                    uniteOutsetBounds(explainedByFoldedRings, childOutsets.ringOnlyBounds);
+            });
+        } else {
+            // A live ring must propagate past intermediate clipping boxes, but non-ring content really is
+            // contained by this box's clip, so only ringOnlyBounds propagates upward.
+            OutlineAutoClipOutsets clippedDescendantOutsets;
+            recurseIntoChildren(clippedDescendantOutsets, ignoreChild);
+            descendantOutsets.ringOnlyBounds = clippedDescendantOutsets.ringOnlyBounds;
+        }
+
+        LayoutRect ownBounds = inAncestorCoords(localBoundingBox());
+        LayoutRect selfOnlyBounds = inAncestorCoords(box->applyVisualEffectOverflow(box->borderBoxRect()));
+
+        LayoutRect explainedByDescendantRings = selfOnlyBounds;
+        if (explainedByFoldedRings)
+            explainedByDescendantRings.uniteEvenIfEmpty(*explainedByFoldedRings);
+        uniteOutsetBounds(outsets.otherContentBounds, explainedByDescendantRings.contains(ownBounds) ? selfOnlyBounds : ownBounds);
+
+        uniteOutsetBounds(outsets.ringOnlyBounds, descendantOutsets.ringOnlyBounds);
+        uniteOutsetBounds(outsets.otherContentBounds, descendantOutsets.otherContentBounds);
+        return;
+    }
+
+    // Descendants below a box that clips them are its own concern, not this ancestor's.
+    if (box && box->hasNonVisibleOverflow())
+        return;
+
+    recurseIntoChildren(outsets, ignoreChild);
+}
+
+RenderLayer::OutlineAutoClipOutsets RenderLayer::collectOutlineAutoClipOutsets(const RenderBox* focusRingBox) const
+{
+    OutlineAutoClipOutsets outsets;
+
+    // The walk below only checks for the focus ring on layers visited as a child, so check this layer's own box too.
+    CheckedPtr ownBox = renderBox();
+    if (ownBox && ownBox.get() == focusRingBox)
+        uniteOutsetBounds(outsets.ringOnlyBounds, ownBox->outlineAutoRingBounds());
+
+#if ASSERT_ENABLED
+    LayerListMutationDetector mutationChecker(const_cast<RenderLayer&>(*this));
+#endif
+
+    for (CheckedPtr childLayer = firstChild(); childLayer; childLayer = childLayer->nextSibling()) {
+        if (isReflectionLayer(*childLayer))
+            continue;
+        childLayer->accumulateOutlineAutoClipOutsets(childLayer->offsetFromAncestor(this), outsets, focusRingBox);
+    }
+
+    return outsets;
+}
+
+void RenderLayer::clearOutlineAutoClipOutsetsCache()
+{
+    if (!m_outlineAutoClipOutsets)
+        return;
+
+    // Outsets are only ever folded into PaintingClipRects.
+    clearClipRects(PaintingClipRects);
+}
+
+// Reached when m_isOutlineAutoClipOutsetsAncestor marks a live outline-style:auto ring somewhere below this
+// layer. That mark is a hint: it is written on focus change and after layout, so it can be stale while the
+// render tree is in flux, so we re-derive it.
+LayoutRect RenderLayer::outsetOutlineAutoClipRectSlowCase(const LayoutRect& originalClipRect, OutsetContext context) const
+{
+    CheckedPtr<const RenderElement> focusedRenderer = renderer().view().focusRingRenderer();
+    if (!focusedRenderer) {
+        if (RefPtr focusedElement = renderer().document().focusedElement())
+            focusedRenderer = focusedElement->renderer();
+    }
+
+    CheckedPtr focusRingLayer = focusedRenderer ? focusedRenderer->enclosingLayer() : nullptr;
+    if (!focusRingLayer || !focusRingLayer->isDescendantOf(*this))
+        return originalClipRect;
+
+    // Our own ring paints outside our border box, past this clip entirely, so widening it would only let our own
+    // content into the border band. On the renderer, not the layer: a box with no layer of its own shares ours,
+    // and its ring really is clipped by our foreground clip.
+    if (focusedRenderer.get() == &renderer())
+        return originalClipRect;
+
+    // Such a layer already has its room from paintOutlineForFragments(), so widening a clip that other content
+    // paints through would only reveal that content.
+    if (context == OutsetContext::SharedPaintClip && focusRingLayer->isSelfPaintingLayer())
+        return originalClipRect;
+
+    CheckedPtr focusRingBox = focusRingLayer->renderBox();
+    bool hasLiveFocusRing = focusRingBox && (renderer().view().focusRingRenderer() == focusRingBox.get() || focusRingBox->outlineAutoIsOnlyVisualOverflow());
+    if (!hasLiveFocusRing)
+        return originalClipRect;
+
+    // Skip the O(subtree) walk whenever the ring already fits inside this clip, which is the common case.
+    auto knownRingBounds = knownFocusRingBounds(*focusRingLayer, *focusRingBox);
+    LayoutRect knownCandidate = originalClipRect;
+    knownCandidate.uniteEvenIfEmpty(knownRingBounds);
+    if (knownCandidate == originalClipRect)
+        return originalClipRect;
+
+    if (!m_outlineAutoClipOutsets)
+        m_outlineAutoClipOutsets = makeUnique<OutlineAutoClipOutsets>(collectOutlineAutoClipOutsets(focusRingBox.get()));
+    auto& outsets = *m_outlineAutoClipOutsets;
+
+    if (!outsets.ringOnlyBounds)
+        return originalClipRect;
+
+    LayoutRect candidateRect = originalClipRect;
+    candidateRect.uniteEvenIfEmpty(*outsets.ringOnlyBounds);
+    if (candidateRect == originalClipRect)
+        return originalClipRect;
+
+    // The two callers describe this clip differently (border box at the origin during repaint, padding box
+    // at the border offset from calculateClipRects) so it can make already-clipped content look like a leak.
+    // Only the max edges need tolerance; at the min edges the repaint rect already starts earlier. They
+    // differ by less than a pixel, so a pixel is the tight bound.
+    // FIXME: reconciling the two clip rects would remove the need for this.
+    auto leakAllowance = originalClipRect;
+    leakAllowance.expand(1_lu, 1_lu);
+
+    bool granted = !outsets.otherContentBounds || leakAllowance.contains(intersection(*outsets.otherContentBounds, candidateRect));
+    if (!granted)
+        return originalClipRect;
+
+    return candidateRect;
+}
+
 void RenderLayer::clearClipRectsIncludingDescendants(ClipRectsType typeToClear)
 {
     // FIXME: it's not clear how this layer not having clip rects guarantees that no descendants have any.
-    if (!m_clipRectsCache)
+    // Outsets are tested as well: the repaint walk can populate them on a layer that has no ClipRectsCache, so
+    // stopping on the clip rects alone would skip a descendant that holds outsets.
+    if (!m_clipRectsCache && !m_outlineAutoClipOutsets)
         return;
 
     clearClipRects(typeToClear);
@@ -5750,6 +6004,10 @@ void RenderLayer::clearClipRectsIncludingDescendants(ClipRectsType typeToClear)
 
 void RenderLayer::clearClipRects(ClipRectsType typeToClear)
 {
+    // calculateClipRects() bakes the outsets into the cached ClipRects, so they must never outlive them. Clearing
+    // here also covers invalidations that happen without a layout, notably scrolling a descendant scroller.
+    m_outlineAutoClipOutsets = nullptr;
+
     if (typeToClear == AllClipRectTypes)
         m_clipRectsCache = nullptr;
     else if (m_clipRectsCache) {

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2003-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2026 Apple Inc. All rights reserved.
  * Copyright (c) 2020 Igalia S.L.
  *
  * Portions are Copyright (C) 1998 Netscape Communications Corporation.
@@ -385,7 +385,20 @@ public:
     void setChildrenNeedCompositingGeometryUpdate() { setBackingAndHierarchyTraversalDirtyBit<Compositing::ChildrenNeedGeometryUpdate>(); }
     void setDescendantsNeedUpdateBackingAndHierarchyTraversal() { setBackingAndHierarchyTraversalDirtyBit<Compositing::DescendantsNeedBackingAndHierarchyTraversal>(); }
 
-    void setNeedsCompositingGeometryUpdateOnAncestors() { setAncestorsHaveCompositingDirtyFlag(Compositing::NeedsGeometryUpdate); }
+    bool isOutlineAutoClipOutsetsAncestor() const { return m_isOutlineAutoClipOutsetsAncestor; }
+    void setIsOutlineAutoClipOutsetsAncestor(bool value) { m_isOutlineAutoClipOutsetsAncestor = value; }
+
+    void setNeedsCompositingGeometryUpdateOnAncestors()
+    {
+        setAncestorsHaveCompositingDirtyFlag(Compositing::NeedsGeometryUpdate);
+        setAncestorsHaveCompositingDirtyFlag(Compositing::HasDescendantNeedingBackingOrHierarchyTraversal);
+    }
+
+    void setNeedsCompositingConfigurationUpdateOnAncestors()
+    {
+        setAncestorsHaveCompositingDirtyFlag(Compositing::NeedsConfigurationUpdate);
+        setAncestorsHaveCompositingDirtyFlag(Compositing::HasDescendantNeedingBackingOrHierarchyTraversal);
+    }
 
     bool needsCompositingRequirementsTraversal() const { return m_compositingDirtyBits.containsAny(computeCompositingRequirementsFlags()); }
     void clearCompositingRequirementsTraversalState()
@@ -817,7 +830,35 @@ public:
 
     // Can pass offsetFromRoot if known.
     LayoutRect calculateLayerBounds(const RenderLayer* ancestorLayer, const LayoutSize& offsetFromRoot, OptionSet<CalculateLayerBoundsFlag> = defaultCalculateLayerBoundsFlags()) const;
-    
+
+    // How far a descendant's focus ring extends past its border box, versus the bounds of all other content in
+    // this layer's subtree, in local coordinates.
+    // std::nullopt means "nothing found", which a default LayoutRect cannot express: uniteEvenIfEmpty() takes
+    // min/max unconditionally, so an empty accumulator would drag in the layer origin.
+    struct OutlineAutoClipOutsets {
+        WTF_MAKE_STRUCT_TZONE_ALLOCATED(OutlineAutoClipOutsets);
+
+        std::optional<LayoutRect> ringOnlyBounds;
+        std::optional<LayoutRect> otherContentBounds;
+    };
+
+    // 'focusRingBox' is the one box in this subtree painting a live focus ring. There is only ever one,
+    // so the walk compares pointers instead of re-deriving the answer for every box it visits.
+    OutlineAutoClipOutsets collectOutlineAutoClipOutsets(const RenderBox* focusRingBox) const;
+
+    enum class OutsetContext : bool { SharedPaintClip, RingOnly };
+
+    LayoutRect outsetOutlineAutoClipRect(const LayoutRect& originalClipRect, OutsetContext context = OutsetContext::RingOnly) const
+    {
+        if (!m_isOutlineAutoClipOutsetsAncestor)
+            return originalClipRect;
+        return outsetOutlineAutoClipRectSlowCase(originalClipRect, context);
+    }
+    LayoutRect outsetOutlineAutoClipRectSlowCase(const LayoutRect& originalClipRect, OutsetContext) const;
+
+    // Discards the cached OutlineAutoClipOutsets, and the cached ClipRects it was baked into by calculateClipRects().
+    void clearOutlineAutoClipOutsetsCache();
+
     LayoutRect repaintRectIncludingNonCompositingDescendants() const;
 
     void NODELETE setRepaintStatus(RepaintStatus);
@@ -1123,6 +1164,11 @@ private:
     void NODELETE clearRepaintRects();
 
     LayoutRect clipRectRelativeToAncestor(const RenderLayer* ancestor, LayoutSize offsetFromAncestor, const LayoutRect& constrainingRect, bool temporaryClipRects = false) const;
+
+    void accumulateOutlineAutoClipOutsets(const LayoutSize& offsetFromAncestor, OutlineAutoClipOutsets&, const RenderBox* focusRingBox) const;
+
+    // Ring extent taken straight from the box the caller resolved, so the common case needs no subtree walk.
+    LayoutRect knownFocusRingBounds(const RenderLayer& focusRingLayer, const RenderBox& focusRingBox) const;
 
     void clipToRect(GraphicsContext&, GraphicsContextStateSaver&, RegionContextStateSaver&, const LayerPaintingInfo&, OptionSet<PaintBehavior>, const ClipRect&, BorderRadiusClippingRule = IncludeSelfForBorderRadius);
     void applyAncestorClippingForBorderRadius(GraphicsContext&, const LayerPaintingInfo&, OptionSet<PaintBehavior>, BorderRadiusClippingRule = IncludeSelfForBorderRadius);
@@ -1482,6 +1528,10 @@ private:
     bool m_wasOmittedFromZOrderTree : 1 { false };
     bool m_suppressAncestorClippingInsideFilter : 1 { false };
 
+    // Set on every layer from the layer of a box painting a live outline-auto focus ring up to the root, so
+    // outsetOutlineAutoClipRect() can reject cheaply. Approximate by design; see the note there.
+    bool m_isOutlineAutoClipOutsetsAncestor : 1 { false };
+
     const CheckedRef<RenderLayerModelObject> m_renderer;
 
     InlineWeakPtr<RenderLayer> m_parent;
@@ -1517,6 +1567,10 @@ private:
     IntSize m_layerSize;
 
     std::unique_ptr<ClipRectsCache> m_clipRectsCache;
+
+    // Cache for collectOutlineAutoClipOutsets()'s O(subtree) walk. Out of line so it costs a pointer rather than
+    // two rects on every layer. Cleared with the ClipRects it gets baked into.
+    mutable std::unique_ptr<OutlineAutoClipOutsets> m_outlineAutoClipOutsets;
 
     Markable<ScrollingScope, IntegralMarkableTraits<ScrollingScope, 0>> m_boxScrollingScope;
     Markable<ScrollingScope, IntegralMarkableTraits<ScrollingScope, 0>> m_contentsScrollingScope;

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -1727,7 +1727,7 @@ void RenderLayerBacking::updateGeometry(const RenderLayer* compositedAncestor)
     LayoutRect clippingBox;
     if (RefPtr clipLayer = clippingLayer()) {
         // clipLayer is the m_childContainmentLayer.
-        clippingBox = clippingLayerBox(renderer());
+        clippingBox = m_owningLayer.outsetOutlineAutoClipRect(clippingLayerBox(renderer()), RenderLayer::OutsetContext::RingOnly);
         // Clipping layer is parented in the primary graphics layer.
         LayoutSize clipBoxOffsetFromGraphicsLayer = toLayoutSize(clippingBox.location()) + rendererOffset.fromPrimaryGraphicsLayer();
         SnappedRectInfo snappedClippingGraphicsLayer = snappedGraphicsLayer(clipBoxOffsetFromGraphicsLayer, clippingBox.size(), renderer());
@@ -1767,7 +1767,7 @@ void RenderLayerBacking::updateGeometry(const RenderLayer* compositedAncestor)
 
     if (m_scrollContainerLayer) {
         ASSERT(m_scrolledContentsLayer);
-        LayoutRect scrollContainerBox = scrollContainerLayerBox(downcast<RenderBox>(renderer()));
+        LayoutRect scrollContainerBox = m_owningLayer.outsetOutlineAutoClipRect(scrollContainerLayerBox(downcast<RenderBox>(renderer())), RenderLayer::OutsetContext::RingOnly);
         LayoutRect parentLayerBounds = clippingLayer() ? scrollContainerBox : compositedBounds();
 
         // FIXME: need to do some pixel snapping here.

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -3699,6 +3699,11 @@ Vector<CompositedClipData> RenderLayerCompositor::computeAncestorClippingStack(c
             clipRect.setHeight(renderableInfiniteRect.height());
         }
 
+        // Outset again as RingOnly: the SharedPaintClip pass in backgroundClipRect() above refuses a
+        // self-painting layer because paintOutlineForFragments() gives it room, which cannot reach a clip that
+        // crops the composited layer's output. Applying the outsets twice is idempotent.
+        clipRect = clippingRoot.outsetOutlineAutoClipRect(clipRect, RenderLayer::OutsetContext::RingOnly);
+
         auto offset = layer.convertToLayerCoords(&clippingRoot, { }, RenderLayer::AdjustForColumns);
         clipRect.moveBy(-offset);
 
@@ -3739,6 +3744,10 @@ Vector<CompositedClipData> RenderLayerCompositor::computeAncestorClippingStack(c
                 }
 
                 auto clipRoundedRect = parentRelativeScrollableRect(ancestorLayer, &ancestorLayer);
+                // Outsets only widen the rect, so a rounded clip would keep radii that no longer follow its
+                // corners. Leave those clipped.
+                if (!clipRoundedRect.hasNonZeroRadii())
+                    clipRoundedRect.setRect(ancestorLayer.outsetOutlineAutoClipRect(clipRoundedRect.rect(), RenderLayer::OutsetContext::RingOnly));
                 auto offset = layer.convertToLayerCoords(&ancestorLayer, { }, RenderLayer::AdjustForColumns);
                 clipRoundedRect.moveBy(-offset);
 
@@ -3754,10 +3763,10 @@ Vector<CompositedClipData> RenderLayerCompositor::computeAncestorClippingStack(c
                 auto borderShape = BorderShape::shapeForBorderRect(box->style(), box->borderBoxRect());
                 auto clipRoundedRect = borderShape.deprecatedInnerRoundedRect();
 
+                // No outsets: this branch is only reached for a border-radius clip, and widening the rect while
+                // keeping the radii would describe a shape that no longer follows the border.
                 auto offset = layer.convertToLayerCoords(&ancestorLayer, { }, RenderLayer::AdjustForColumns);
-                auto rect = clipRoundedRect.rect();
-                rect.moveBy(-offset);
-                clipRoundedRect.setRect(rect);
+                clipRoundedRect.moveBy(-offset);
 
                 CompositedClipData clipData { const_cast<RenderLayer*>(&ancestorLayer), clipRoundedRect, false };
                 newStack.insert(0, WTF::move(clipData));

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -3,7 +3,7 @@
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2000 Dirk Mueller (mueller@kde.org)
  *           (C) 2004 Allan Sandfeld Jensen (kde@carewolf.com)
- * Copyright (C) 2004-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2009 Google Inc. All rights reserved.
  * Copyright (C) 2009 Torch Mobile Inc. All rights reserved. (http://www.torchmobile.com/)
  *
@@ -56,6 +56,7 @@
 #include "PlatformRenderTheme.h"
 #include "PseudoElement.h"
 #include "ReferencedSVGResources.h"
+#include "RenderBox.h"
 #include "RenderChildIterator.h"
 #include "RenderCounter.h"
 #include "RenderElementInlines.h"
@@ -484,6 +485,22 @@ RenderLayer* RenderObject::enclosingLayer() const
             return renderer.layer();
     }
     return nullptr;
+}
+
+void RenderObject::updateOutlineAutoClipOutsetsOnAncestors(OutlineAutoRingChain chain) const
+{
+    bool onChain = chain == OutlineAutoRingChain::OnChain;
+
+    if (onChain) {
+        CheckedPtr box = dynamicDowncast<RenderBox>(*this);
+        view().setFocusRingRenderer(box.get(), box ? box->outlineAutoRingBounds() : LayoutRect { });
+    } else if (view().focusRingRenderer() == this)
+        view().setFocusRingRenderer(nullptr, { });
+
+    for (CheckedPtr layer = enclosingLayer(); layer; layer = layer->parent()) {
+        layer->clearOutlineAutoClipOutsetsCache();
+        layer->setIsOutlineAutoClipOutsetsAncestor(onChain);
+    }
 }
 
 RenderBox& RenderObject::enclosingBox() const
@@ -1039,7 +1056,10 @@ void RenderObject::issueRepaint(std::optional<LayoutRect> partialRepaintRect, Cl
 
     if (partialRepaintRect) {
         repaintRect = computeRectForRepaint(*partialRepaintRect, repaintContainer.renderer.get());
-        if (additionalRepaintOutsets)
+        // Only expand a rect that survived the walk. LayoutRect::intersect() collapses a non-intersecting result to
+        // an empty rect at the origin, and expanding that would turn something repaintUsingContainer() drops into a
+        // bogus invalidation next to the origin.
+        if (additionalRepaintOutsets && !repaintRect.isEmpty())
             repaintRect.expand(*additionalRepaintOutsets);
     } else
         repaintRect = clippedOverflowRectForRepaint(repaintContainer.renderer.get());

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -3,7 +3,7 @@
  *           (C) 2000 Antti Koivisto (koivisto@kde.org)
  *           (C) 2000 Dirk Mueller (mueller@kde.org)
  *           (C) 2004 Allan Sandfeld Jensen (kde@carewolf.com)
- * Copyright (C) 2003-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2009 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
@@ -396,6 +396,10 @@ public:
 #endif
 
     WEBCORE_EXPORT RenderLayer* NODELETE enclosingLayer() const;
+
+    enum class OutlineAutoRingChain : bool { NotOnChain, OnChain };
+
+    void updateOutlineAutoClipOutsetsOnAncestors(OutlineAutoRingChain) const;
 
     WEBCORE_EXPORT RenderBox& NODELETE enclosingBox() const;
     RenderBoxModelObject& NODELETE enclosingBoxModelObject() const;

--- a/Source/WebCore/rendering/RenderObjectInlines.h
+++ b/Source/WebCore/rendering/RenderObjectInlines.h
@@ -116,7 +116,8 @@ inline auto RenderObject::visibleRectContextForRepaint() -> VisibleRectContext
     return {
         .options = {
             VisibleRectContext::Option::ApplyContainerClip,
-            VisibleRectContext::Option::ApplyCompositedContainerScrolls
+            VisibleRectContext::Option::ApplyCompositedContainerScrolls,
+            VisibleRectContext::Option::AllowOutlineAutoClipOutsets
         },
         .scrollMargin = { },
     };

--- a/Source/WebCore/rendering/RenderView.h
+++ b/Source/WebCore/rendering/RenderView.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
- * Copyright (C) 2006-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2026 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -237,6 +237,15 @@ public:
     void removeViewTransitionGroup(const AtomString&);
     RenderBox* NODELETE viewTransitionGroupForName(const AtomString&);
 
+    // The renderer with a live outline-style:auto ring, with bounds in its own coordinates. Null when no ring is live.
+    const RenderElement* focusRingRenderer() const { return m_focusRingRenderer.get(); }
+    const LayoutRect& focusRingBounds() const { return m_focusRingBounds; }
+    void setFocusRingRenderer(const RenderElement* renderer, const LayoutRect& ringBounds)
+    {
+        m_focusRingRenderer = renderer;
+        m_focusRingBounds = ringBounds;
+    }
+
 protected:
     void willBeDestroyed() override;
 
@@ -268,6 +277,9 @@ private:
 
     // Include this RenderView.
     uint64_t m_rendererCount { 1 };
+
+    CheckedPtr<const RenderElement> m_focusRingRenderer;
+    LayoutRect m_focusRingBounds;
 
     // Note that currently RenderView::layoutBox(), if it exists, is a child of m_initialContainingBlock.
     const UniqueRef<Layout::InitialContainingBlock> m_initialContainingBlock;

--- a/Source/WebCore/rendering/VisibleRectContext.h
+++ b/Source/WebCore/rendering/VisibleRectContext.h
@@ -40,6 +40,7 @@ struct VisibleRectContext {
         ApplyCompositedContainerScrolls     = 1 << 2,
         ApplyContainerClip                  = 1 << 3,
         CalculateAccurateRepaintRect        = 1 << 4,
+        AllowOutlineAutoClipOutsets          = 1 << 5,
     };
 
     OptionSet<Option> options { };


### PR DESCRIPTION
#### a358325bea063758b65e17ec02dad7257e86b321
<pre>
goodreads.com: Focus outline is cut-off from right side compared to Chrome
<a href="https://bugs.webkit.org/show_bug.cgi?id=319283">https://bugs.webkit.org/show_bug.cgi?id=319283</a>
&lt;<a href="https://rdar.apple.com/162717044">rdar://162717044</a>&gt;

Reviewed by NOBODY (OOPS!).

The outline-style:auto platform focus ring is drawn outside a box&apos;s border edge, so it is
clipped when that edge is flush with an overflow:hidden ancestor. Other browsers draw their
rings inside the border box and never hit this case.

An auto outline&apos;s width comes from the platform theme (RenderTheme::platformFocusRingWidth(),
3px on Apple ports, 2px on some others) and the paints outside the border edge, which keeps
the ring clear of the control&apos;s own border and matches the native focus ring.

RenderLayer::collectOutlineAutoClipOutsets() walks a layer&apos;s subtree and separates how far
a live ring extends past the border box of the box painting it (ringOnlyBounds) from the
bounds of everything else (otherContentBounds). outsetOutlineAutoClipRect() unites a clip
with ringOnlyBounds and grants the result only if nothing in otherContentBounds would be
revealed by these outsets.

Three scenarios enforce the same overflow clip and all three consult the outsets: the
paint-time clip, the repaint rect walk in RenderBox::applyCachedClipAndScrollPosition(), and
the compositing mask layers. Only PaintingClipRects are outset; widening RootRelativeClipRects
would let hit testing hit the ring&apos;s band, and widening AbsoluteClipRects would change
compositing overlap results.

That repaint walk is used to determine repaint regions as well as region visibility. Only
the repaint caller should see a widened clip. If the visibility caller is given the widened
clip it can lead to errors. For example, iOS uses the method to check visibility of the
caret in an editable area that is entirely clipped away. A widened clip would result in the
caret appearing. Therefore the call is parameterized to handle both cases properly.

This work sits on a hot path: clipping layers recompute their clip rects constantly, on
every page, whether or not anything is focused. So the common case is built to cost almost
nothing. Each layer records whether a live focus ring exists anywhere beneath it, and when
none does the whole mechanism is skipped immediately. This test is inline, so the common
case costs one bit at the call site rather than a function call. When a live ring exists,
the room the ring needs is measured from the box painting it, and the subtree is only
searched if that room does not already fit inside the existing clip. The search results are
cached per layer, kept to a pointer&apos;s worth of storage on layers that never use it, and
discarded together with the clip rects it feeds into, so it cannot outlive them or go stale
on a scroll. It is further limited to painting clip rects, since those are the only ones the
clip outsets are ever folded into. The rects used for compositing overlap testing are not
changed by this patch.

The box painting the ring is worked out once, when the chain is marked, rather than per
clipping layer on every query, and passed into the subtree walk so the walk compares pointers
instead of asking every box it visits whether it paints the ring. Marking the chain after
layout is skipped when there is nothing to mark and nothing marked, which is the common case
of a focused text field with no outline of its own.

Two costs are left deliberately. The outsets are a separate pointer on RenderLayer rather
than living in the clip-rects cache, because the repaint walk populates them without ever
creating that cache, so folding them together would force an allocation in that case. And
while a ring is live, each clipping ancestor&apos;s clip-rect computation does one coordinate
walk from that box; it is bounded to a focused page, and the first thing to look at if
a profile shows anything there.

That record of where a ring lives is approximate. It is written when focus changes and
again after layout, so it is briefly out of date while renderers are being attached or
restyled, and repaints are issued from inside of both. What that window costs is a repaint
rect that misses the ring&apos;s outer band, which the explicit repaint on a focus change covers.
It is also cleared when a focused element&apos;s renderer goes away, the one path that would
otherwise leave it set for the lifetime of the page.

In addition to handling geometry, we also need to address the impact of focus transition
which had four failure modes:

1. A :focus-gated outline:auto is applied by an async restyle, so Element::setFocus() clears
   the cache too early: anything querying an ancestor clip before the restyle lands caches
   empty outsets. styleDidChange() now clears it when outline:auto becomes live.

2. Deciding whether an element has a live focus ring means comparing its layout extent
   against what the ring alone would add, and mid-transition those two disagree: on focus
   the layout has not grown to include the new ring yet, and on blur the outline is already
   gone from the style while the layout still reflects it. Either way the answer comes back
   &quot;no ring&quot;, and since every ancestor clip consults it before making room, none did. This
   prevented the ring&apos;s outer edge from being properly invalidated leaving slivers of focus
   rings in some conditions. Rather than teach the ancestor clips to recognize a ring they
   cannot see, issueRepaintForOutlineAuto() hands the ring&apos;s extent to repaintRectangle()
   as outsets, which issueRepaint() applies after the clipping walk instead of before it.
   The band is put back once the clips have had their say, so no transition state reaches
   clip computation at all. Over-invalidating on a focus change is harmless, and with
   nothing clipping the two orders agree. Only a rect that survived the walk is expanded:
   LayoutRect::intersect() collapses a non-intersecting result to an empty rect at the
   origin, and expanding that would invalidate a bogus square there instead of nothing.

   That guard is in issueRepaint(), which outsets share with one other caller: caret repaint,
   via FrameSelection&apos;s repaintCaretForLocalRect(). A caret whose rect the walk collapses
   now skips its outsets too. That may be an area to investigate further.

   isEmpty() is broader than &quot;the walk clipped it away&quot;: it also covers a degenerate rect
   that survived intact, so a focus ring on a zero-width or zero-height focusable box now
   has no band invalidated where inflating before the walk gave it one. The exact signal
   is computed but it is discarded for repaint contexts, which return the collapsed rects
   rather than std::nullopt (RenderObject.cpp), and computeRects() RELEASE_ASSERTs that a
   result is present. Surfacing it means changing that contract for every repaint caller,
   so this takes the narrower guard and records the gap.

3. A static outline:auto never restyles on focus, so styleDidChange() never runs for it, yet
   focus still flips whether its ring is live. outlineAutoLiveFocusChanged() invalidates the
   clip outsets, repaints the ring, and dirties composited clip geometry in that case. It
   takes the new focus state as an argument rather than deriving it, because by the time
   Element::setFocus() runs for a blur, document().focusedElement() is already null.

4. The repaint walk derives its clip from cachedSizeForOverflowClip() and can under-report
   the edge by a fraction of a pixel, so already-clipped content looked like a leak: the
   outsets were granted at paint and denied at repaint. Width-dependent, since it needs a
   fractional clip edge. The leak check now tolerates a fraction of a pixel of overhang, and
   only at the edges where the two derivations can disagree that way; real leaks are whole
   pixels.

Four tests read exact geometry and so need platform-specific results due to the difference
in ring outset between Apple and other platforms.

An outline-only change sets no other compositing dirty bits, so a focus change has to dirty
the composited clips itself. Geometry covers the mask layers, the ancestor clipping stack
does not. focus-ring-not-clipped-by-ancestor-clipping-stack.html confirms correct behavior
for this code path.

Outsetting in the ancestor clipping stack is conservative. The clip there is accumulated
across the ancestor chain up to the clipping root, while otherContentBounds covers that
root&apos;s whole subtree, so content the clip never governed can still deny the widening. It
errs toward leaving the ring clipped rather than toward revealing anything.

Outsets are refused in three cases:
1.  A box&apos;s own overflow clip is never widened for its own ring: that clip bounds the box&apos;s
    contents, while the ring paints outside the border box and past the clip entirely, so
    widening it would only let the box&apos;s own scrolled content into the border band.
2.  A shared paint clip whose layer paints its own outline has already been given this
    room in paintOutlineForFragments(), so widening the clip would only reveal that layer&apos;s
    other content (e.g., a text caret).
3.  A rounded clip is refused as well. Outsetting only widens a rect, so keeping the radii
    would describe a shape that no longer follows the border and the composited clip corners
    would come out wrong.

The subtree walk measures a descendant through its own transform, as calculateLayerBounds()
does. Without that a rotated box contributes untransformed bounds at a translated offset,
otherContentBounds comes out too small, and outsets are granted that paint the box into the
ring&apos;s band. Transforms on intermediate layers still contribute only a translation, which
under-reports in the direction that denies outsets rather than granting them.

Note: The existing WebKit leak check to avoid revealing hidden content is a single whole-
rect test, so a leak past any one edge forfeits the widening on all edges. This can lead
to specific cases where the focus ring remains clipped because of a possible leak on one
side. This patch does not attempt to address this existing behavior.

Tests: fast/clip/focus-ring-not-clipped-by-overflow-hidden-ancestor.html
       fast/clip/focus-ring-not-clipped-by-overflow-hidden-ancestor-on-focus.html
       fast/clip/focus-ring-not-clipped-by-overflow-hidden-ancestor-through-non-layer-descendant.html
       fast/clip/author-outline-still-clipped-by-overflow-hidden-ancestor.html
       fast/clip/focus-ring-clipped-by-overflow-hidden-ancestor-when-sibling-content-would-leak.html
       fast/repaint/outline-auto-repaint-not-clipped-by-stale-clip-outsets.html
       fast/repaint/outline-auto-repaint-not-denied-by-subpixel-clip-mismatch.html
       fast/repaint/outline-auto-outsets-denied-by-transformed-sibling.html
       fast/repaint/outline-auto-repaint-none-when-focused-element-scrolled-away.html
       compositing/clipping/focus-ring-not-clipped-by-composited-child-containment-layer.html
       compositing/clipping/focus-ring-not-clipped-by-bordered-composited-ancestor.html
       compositing/clipping/focus-ring-not-clipped-by-composited-scroll-container.html
       compositing/clipping/focus-ring-not-clipped-by-ancestor-clipping-stack.html
       compositing/clipping/focus-ring-not-clipped-when-focus-arrives-after-compositing-settles.html
       compositing/clipping/focus-ring-not-clipped-when-static-outline-auto-gains-focus.html
       compositing/clipping/focus-ring-clipped-when-descendant-has-overflowing-child.html
       compositing/clipping/focus-ring-clipped-when-sibling-content-would-leak.html
       compositing/clipping/focus-ring-clipped-by-rounded-composited-ancestor-clip.html

* LayoutTests/compositing/clipping/focus-ring-clipped-by-rounded-composited-ancestor-clip-expected.txt: Added.
* LayoutTests/compositing/clipping/focus-ring-clipped-by-rounded-composited-ancestor-clip.html: Added.
* LayoutTests/compositing/clipping/focus-ring-clipped-when-descendant-has-overflowing-child-expected-mismatch.html: Added.
* LayoutTests/compositing/clipping/focus-ring-clipped-when-descendant-has-overflowing-child.html: Added.
* LayoutTests/compositing/clipping/focus-ring-clipped-when-sibling-content-would-leak-expected-mismatch.html: Added.
* LayoutTests/compositing/clipping/focus-ring-clipped-when-sibling-content-would-leak.html: Added.
* LayoutTests/compositing/clipping/focus-ring-not-clipped-by-ancestor-clipping-stack-expected.html: Added.
* LayoutTests/compositing/clipping/focus-ring-not-clipped-by-ancestor-clipping-stack.html: Added.
* LayoutTests/compositing/clipping/focus-ring-not-clipped-by-bordered-composited-ancestor-expected.html: Added.
* LayoutTests/compositing/clipping/focus-ring-not-clipped-by-bordered-composited-ancestor.html: Added.
* LayoutTests/compositing/clipping/focus-ring-not-clipped-by-composited-child-containment-layer-expected.html: Added.
* LayoutTests/compositing/clipping/focus-ring-not-clipped-by-composited-child-containment-layer.html: Added.
* LayoutTests/compositing/clipping/focus-ring-not-clipped-by-composited-scroll-container-expected.html: Added.
* LayoutTests/compositing/clipping/focus-ring-not-clipped-by-composited-scroll-container.html: Added.
* LayoutTests/compositing/clipping/focus-ring-not-clipped-when-focus-arrives-after-compositing-settles-expected.html: Added.
* LayoutTests/compositing/clipping/focus-ring-not-clipped-when-focus-arrives-after-compositing-settles.html: Added.
* LayoutTests/compositing/clipping/focus-ring-not-clipped-when-static-outline-auto-gains-focus-expected.html: Added.
* LayoutTests/compositing/clipping/focus-ring-not-clipped-when-static-outline-auto-gains-focus.html: Added.
* LayoutTests/fast/clip/author-outline-still-clipped-by-overflow-hidden-ancestor-expected-mismatch.html: Added.
* LayoutTests/fast/clip/author-outline-still-clipped-by-overflow-hidden-ancestor.html: Added.
* LayoutTests/fast/clip/focus-ring-clipped-by-overflow-hidden-ancestor-when-sibling-content-would-leak-expected-mismatch.html: Added.
* LayoutTests/fast/clip/focus-ring-clipped-by-overflow-hidden-ancestor-when-sibling-content-would-leak.html: Added.
* LayoutTests/fast/clip/focus-ring-not-clipped-by-overflow-hidden-ancestor-expected.html: Added.
* LayoutTests/fast/clip/focus-ring-not-clipped-by-overflow-hidden-ancestor-on-focus-expected.html: Added.
* LayoutTests/fast/clip/focus-ring-not-clipped-by-overflow-hidden-ancestor-on-focus.html: Added.
* LayoutTests/fast/clip/focus-ring-not-clipped-by-overflow-hidden-ancestor-through-non-layer-descendant-expected.html: Added.
* LayoutTests/fast/clip/focus-ring-not-clipped-by-overflow-hidden-ancestor-through-non-layer-descendant.html: Added.
* LayoutTests/fast/clip/focus-ring-not-clipped-by-overflow-hidden-ancestor.html: Added.
* LayoutTests/fast/repaint/outline-auto-outsets-denied-by-transformed-sibling-expected.txt: Added.
* LayoutTests/fast/repaint/outline-auto-outsets-denied-by-transformed-sibling.html: Added.
* LayoutTests/fast/repaint/outline-auto-repaint-none-when-focused-element-scrolled-away-expected.txt: Added.
* LayoutTests/fast/repaint/outline-auto-repaint-none-when-focused-element-scrolled-away.html: Added.
* LayoutTests/fast/repaint/outline-auto-repaint-not-clipped-by-stale-clip-outsets-expected.txt: Added.
* LayoutTests/fast/repaint/outline-auto-repaint-not-clipped-by-stale-clip-outsets.html: Added.
* LayoutTests/fast/repaint/outline-auto-repaint-not-denied-by-subpixel-clip-mismatch-expected.txt: Added.
* LayoutTests/fast/repaint/outline-auto-repaint-not-denied-by-subpixel-clip-mismatch.html: Added.
* LayoutTests/platform/glib/compositing/clipping/focus-ring-clipped-by-rounded-composited-ancestor-clip-expected.txt: Added.
* LayoutTests/platform/glib/fast/repaint/outline-auto-outsets-denied-by-transformed-sibling-expected.txt: Added.
* LayoutTests/platform/glib/fast/repaint/outline-auto-repaint-not-clipped-by-stale-clip-outsets-expected.txt: Added.
* LayoutTests/platform/glib/fast/repaint/outline-auto-repaint-not-denied-by-subpixel-clip-mismatch-expected.txt: Added.
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::setFocus):
* Source/WebCore/rendering/LayerFragment.h:
(WebCore::LayerFragment::Rects::paintDirtyRect const):
(WebCore::LayerFragment::paintDirtyRect const):
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::applyCachedClipAndScrollPosition const):
(WebCore::RenderBox::outlineAutoRingBounds const):
(WebCore::RenderBox::outlineAutoIsOnlyVisualOverflow const):
(WebCore::RenderBox::childPaintsVisualOverflowIndependently const):
(WebCore::RenderBox::addOverflowWithRendererOffset):
* Source/WebCore/rendering/RenderBox.h:
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::usedOutlineSizeForOutlineAuto):
(WebCore::RenderElement::styleDidChange):
(WebCore::RenderElement::willBeRemovedFromTree):
(WebCore::RenderElement::willBeDestroyed):
(WebCore::RenderElement::invalidateCompositedClipsForOutlineAutoChange):
(WebCore::RenderElement::issueRepaintForOutlineAuto):
(WebCore::RenderElement::outlineAutoLiveFocusChanged):
* Source/WebCore/rendering/RenderElement.h:
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::updateLayerPositionsAfterLayout):
(WebCore::RenderLayer::paintOutlineForFragments):
(WebCore::RenderLayer::updateClipRects):
(WebCore::RenderLayer::calculateClipRects const):
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateGeometry):
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::computeAncestorClippingStack const):
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::updateOutlineAutoClipOutsetsOnAncestors const):
(WebCore::RenderObject::issueRepaint const):
* Source/WebCore/rendering/RenderObject.h:
* Source/WebCore/rendering/RenderObjectInlines.h:
(WebCore::RenderObject::visibleRectContextForRepaint):
* Source/WebCore/rendering/RenderView.h:
* Source/WebCore/rendering/VisibleRectContext.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a358325bea063758b65e17ec02dad7257e86b321

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181138 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55083 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48881 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191355 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145461 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/52714bbb-405b-475e-84ae-f568ca50c5c4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183000 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56381 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54799 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141354 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98043 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b1ac68c6-9d39-4a4c-b086-7717ffafe47c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184093 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45014 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162100 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121805 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7abd8a7c-2147-4af5-9c6b-55f564a3b35c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43687 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41968 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154091 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41627 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2514 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47695 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46223 "Found 1 new test failure: editing/text-iterator/hidden-textarea-selection-quirk.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193287 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54749 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161615 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150740 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55437 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38249 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150457 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45043 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127704 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123257 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53954 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16623 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53336 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53573 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53401 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->