### PR TITLE
[GFC][Integration] Resolved track listing should be properly reflected

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-definition/grid-template-columns-rows-resolved-values-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-definition/grid-template-columns-rows-resolved-values-002-expected.txt
@@ -1,0 +1,6 @@
+
+PASS Resolved grid-template-columns is the used track sizes
+PASS Resolved grid-template-rows is the used track sizes
+PASS Resolved grid-template-columns is the used track sizes with fixed-length gaps
+PASS Resolved grid-template-rows is the used track sizes with fixed-length gaps
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-definition/grid-template-columns-rows-resolved-values-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-definition/grid-template-columns-rows-resolved-values-002.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Grid Layout Test: 'grid-template-columns' and 'grid-template-rows' resolved values are the used track sizes</title>
+<link rel="help" href="https://drafts.csswg.org/css-grid-2/#resolved-track-list">
+<meta name="assert" content="The resolved value of grid-template-columns and grid-template-rows for a grid container is the used value, with each track serialized as a length in pixels, including for grids with explicitly placed items and fixed-length gaps.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  .grid {
+    display: grid;
+    grid-template-columns: 100px 200px 300px;
+    grid-template-rows: 40px 60px;
+  }
+  .withGaps {
+    gap: 10px 20px;
+  }
+  .a { grid-row: 1 / 2; grid-column: 1 / 2; }
+  .b { grid-row: 2 / 3; grid-column: 1 / 2; }
+</style>
+<div id="log"></div>
+
+<div class="grid" id="grid"><div class="a"></div><div class="b"></div></div>
+<div class="grid withGaps" id="gridWithGaps"><div class="a"></div><div class="b"></div></div>
+
+<script>
+test(() => {
+  assert_equals(getComputedStyle(document.getElementById("grid")).gridTemplateColumns, "100px 200px 300px");
+}, "Resolved grid-template-columns is the used track sizes");
+
+test(() => {
+  assert_equals(getComputedStyle(document.getElementById("grid")).gridTemplateRows, "40px 60px");
+}, "Resolved grid-template-rows is the used track sizes");
+
+test(() => {
+  assert_equals(getComputedStyle(document.getElementById("gridWithGaps")).gridTemplateColumns, "100px 200px 300px");
+}, "Resolved grid-template-columns is the used track sizes with fixed-length gaps");
+
+test(() => {
+  assert_equals(getComputedStyle(document.getElementById("gridWithGaps")).gridTemplateRows, "40px 60px");
+}, "Resolved grid-template-rows is the used track sizes with fixed-length gaps");
+</script>

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.cpp
@@ -217,6 +217,9 @@ void GridLayout::layout()
     CheckedRef renderGrid = gridBoxRenderer();
     renderGrid->updateLogicalHeight();
     updateOverflow(renderGrid);
+
+    // https://drafts.csswg.org/css-grid-2/#resolved-track-list
+    renderGrid->setResolvedTrackSizes(WTF::move(usedTrackSizes.columnSizes), WTF::move(usedTrackSizes.rowSizes));
 }
 
 void GridLayout::updateOverflow(RenderGrid& renderGrid)

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -466,14 +466,15 @@ void RenderGrid::layoutGrid(RelayoutChildren relayoutChildren)
 
         resetLogicalHeightBeforeLayoutIfNeeded();
 
+        // We are committed to a full grid layout; invalidate the resolved track list now so that a
+        // stale read asserts if this layout (either the grid formatting context path below or the
+        // legacy path) fails to repopulate it.
+        m_resolvedTrackList.invalidate();
+
         if (layoutUsingGridFormattingContext()) {
             endAndCommitUpdateScrollInfoAfterLayoutTransaction();
             return;
         }
-
-        // We are committed to a full grid layout; invalidate the resolved track list now so that a
-        // stale read asserts if we fail to repopulate it below (see updateResolvedTrackListsAfterLayout).
-        m_resolvedTrackList.invalidate();
 
         // Fieldsets need to find their legend and position it inside the border of the object.
         // The legend then gets skipped during normal layout. The same is true for ruby text.
@@ -1532,9 +1533,7 @@ Vector<LayoutUnit> RenderGrid::computeResolvedTrackList(Style::GridTrackSizingDi
 
 const Vector<LayoutUnit>& RenderGrid::trackSizesForComputedStyle(Style::GridTrackSizingDirection direction) const
 {
-    // FIXME: The grid formatting context path does not yet populate the resolved track list, so
-    // only assert validity for the legacy layout path.
-    ASSERT(m_hasGridFormattingContextLayout.value_or(false) || m_resolvedTrackList.isValid);
+    ASSERT(m_resolvedTrackList.isValid);
     return m_resolvedTrackList.sizes(direction);
 }
 
@@ -1542,6 +1541,14 @@ void RenderGrid::updateResolvedTrackListsAfterLayout()
 {
     m_resolvedTrackList.sizes(Style::GridTrackSizingDirection::Columns) = computeResolvedTrackList(Style::GridTrackSizingDirection::Columns);
     m_resolvedTrackList.sizes(Style::GridTrackSizingDirection::Rows) = computeResolvedTrackList(Style::GridTrackSizingDirection::Rows);
+    m_resolvedTrackList.isValid = true;
+}
+
+void RenderGrid::setResolvedTrackSizes(Vector<LayoutUnit>&& columnSizes, Vector<LayoutUnit>&& rowSizes)
+{
+    ASSERT(!m_resolvedTrackList.isValid);
+    m_resolvedTrackList.columnSizes = WTF::move(columnSizes);
+    m_resolvedTrackList.rowSizes = WTF::move(rowSizes);
     m_resolvedTrackList.isValid = true;
 }
 

--- a/Source/WebCore/rendering/RenderGrid.h
+++ b/Source/WebCore/rendering/RenderGrid.h
@@ -283,6 +283,7 @@ private:
     // We compute this once at the end of layout instead of on demand for each getComputedStyle query.
     Vector<LayoutUnit> computeResolvedTrackList(Style::GridTrackSizingDirection) const;
     void updateResolvedTrackListsAfterLayout();
+    void setResolvedTrackSizes(Vector<LayoutUnit>&& columnSizes, Vector<LayoutUnit>&& rowSizes);
 
     ContentAlignmentData& offsetBetweenTracks(Style::GridTrackSizingDirection direction) LIFETIME_BOUND { return direction == Style::GridTrackSizingDirection::Columns ? m_offsetBetweenColumns : m_offsetBetweenRows; }
     const ContentAlignmentData& offsetBetweenTracks(Style::GridTrackSizingDirection direction) const LIFETIME_BOUND { return direction == Style::GridTrackSizingDirection::Columns ? m_offsetBetweenColumns : m_offsetBetweenRows; }


### PR DESCRIPTION
#### 0906e08508debe46c7e89f44a688675085c43eff
<pre>
[GFC][Integration] Resolved track listing should be properly reflected
<a href="https://bugs.webkit.org/show_bug.cgi?id=319281">https://bugs.webkit.org/show_bug.cgi?id=319281</a>
<a href="https://rdar.apple.com/182120327">rdar://182120327</a>

Reviewed by Alan Baradlay.

In 317067@main we had RenderGrid store its resolved track listing as a
specific output of layout instead of trying to reverse engineer it from
the positions vector, gap sizes, etc.

In this patch we adopt the new behavior and make sure that any content
that runs through GFC can still report its resolved track listing
correctly in the same way. This is done by just having the integration
logic set the value in the same way legacy grid layout does on the end
of layout.

* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::layoutGrid):
Now that GFC also writes to the same structure we can have legacy grid
layout invalidate it even earlier.

Canonical link: <a href="https://commits.webkit.org/317165@main">https://commits.webkit.org/317165@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/60e69a2cca96cf3d14067fd2485ab5b0616ce996

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174280 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48213 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41994 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183854 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132148 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1f602217-ce94-4611-b6c1-5faca9dc843e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176145 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49505 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47895 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135564 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95649 "3 flakes 3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0b008cd5-3a8f-4599-80ad-842eefb7c915) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177238 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38999 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156358 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116042 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a80b0f78-360d-4ebb-afe2-bbe01b331d8f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37640 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36008 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32338 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148063 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35851 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186280 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39475 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40205 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144475 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47880 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155913 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144332 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38959 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48559 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32471 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114095 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39238 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120485 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47065 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10815 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46468 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46699 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46526 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->