### PR TITLE
[web-animations-2] Auto-aligning the start time should apply a pending playback rate

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/play-animation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/play-animation-expected.txt
@@ -12,7 +12,7 @@ PASS The ready promise should be replaced if the animation is not already pendin
 PASS A pending ready promise should be resolved and not replaced when the animation enters the running state
 PASS Resuming an animation from paused realigns with scroll position.
 PASS If a pause operation is interrupted, the ready promise is reused
-FAIL A pending playback rate is used when determining timeline range alignment assert_approx_equals: values do not match for "undefined" expected 100 +/- 0.125 but got -100
+PASS A pending playback rate is used when determining timeline range alignment
 PASS Playing a canceled animation sets the start time
 PASS Playing a canceled animation backwards sets the start time
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/play-animation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/play-animation.html
@@ -225,9 +225,6 @@ promise_test(async t => {
   // Set pending playback rate to the opposite direction
   animation.updatePlaybackRate(-1);
   assert_true(animation.pending);
-  // Note: Updating the playback rate calls play without rewind. For a
-  // scroll-timeline, this will immediately apply the playback rate.
-  // TODO: Determine if we should defer applying the new playback rate.
   assert_equals(animation.playbackRate, 1);
 
   // When we play, we should align to the target end, NOT to zero (which

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/reverse-animation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/reverse-animation-expected.txt
@@ -1,12 +1,12 @@
 
 PASS Setting current time while reverse-pending preserves currentTime
 PASS Reversing an animation inverts the playback rate
-FAIL Reversing an animation resets a sticky start time. assert_approx_equals: values do not match for "undefined" expected 100 +/- 0.125 but got -100
+PASS Reversing an animation resets a sticky start time.
 PASS Reversing an animation does not cause it to leave the pending state
 PASS Reversing an animation does not cause it to resolve the ready promise
 PASS Reversing an animation with a negative playback rate should cause the animation to play in a forward direction
 PASS Reversing when when playbackRate == 0 should preserve the playback rate
-FAIL Reversing an idle animation aligns startTime with the rangeEnd boundary assert_approx_equals: values do not match for "animation.startTime should be at its effect end" expected 100 +/- 0.125 but got -100
+PASS Reversing an idle animation aligns startTime with the rangeEnd boundary
 PASS Reversing an animation without an active timeline throws an InvalidStateError
 PASS Reversing an animation plays a pausing animation
 PASS Reversing should use the negative pending playback rate

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -1546,7 +1546,10 @@ void WebAnimation::autoAlignStartTime()
     // 7. Set start time to start offset if effective playback rate ≥ 0, and end offset otherwise.
     auto previousStartTime = std::exchange(m_startTime, effectivePlaybackRate() >= 0 ? startOffset : endOffset);
 
-    // 8. Clear hold time.
+    // 8. Apply any pending playback rate on animation.
+    applyPendingPlaybackRate();
+
+    // 9. Clear hold time.
     m_holdTime = std::nullopt;
 
     if (previousStartTime != m_startTime)


### PR DESCRIPTION
#### b2af1be4d3fb31204052898779df0c0ee827f9d4
<pre>
[web-animations-2] Auto-aligning the start time should apply a pending playback rate
<a href="https://bugs.webkit.org/show_bug.cgi?id=319289">https://bugs.webkit.org/show_bug.cgi?id=319289</a>
<a href="https://rdar.apple.com/182129525">rdar://182129525</a>

Reviewed by Tim Nguyen.

Implement the spec change made for <a href="https://github.com/w3c/csswg-drafts/issues/14173.">https://github.com/w3c/csswg-drafts/issues/14173.</a>

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/play-animation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/play-animation.html:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/reverse-animation-expected.txt:
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::autoAlignStartTime):

Canonical link: <a href="https://commits.webkit.org/317127@main">https://commits.webkit.org/317127@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/709cd64c13a00b25722b30d69fdf6ad3abbb7f29

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174288 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48221 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42002 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183862 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132156 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176153 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49513 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47903 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135573 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/997f66fa-3cca-47a7-9915-2378baea19f7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177246 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39013 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156364 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116051 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/28d8f803-66cf-4320-b7ec-81119713bb6c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37654 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36015 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32346 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148077 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35857 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186288 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39485 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40212 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144481 "Found 1 new test failure: compositing/color-matching/image-color-matching.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47888 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155919 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144338 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48567 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32477 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114103 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26506 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39241 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120493 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47073 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10821 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46476 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46707 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46534 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->