### PR TITLE
Can't swipe between videos on pr0gramm.com while a video is playing

### DIFF
--- a/LayoutTests/media/modern-media-controls/ios-inline-media-controls/touch/ios-inline-media-controls-timeline-scrub-stops-propagation-expected.txt
+++ b/LayoutTests/media/modern-media-controls/ios-inline-media-controls/touch/ios-inline-media-controls-timeline-scrub-stops-propagation-expected.txt
@@ -1,11 +1,12 @@
-Test that scrubbing the timeline does not propagate touch events to parent elements.
+Test that touch events on the timeline scrubber do not propagate to parent elements, while touch events on the bare video surface do.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS containerReceivedTouchStart is false
-PASS containerReceivedTouchMove is false
-PASS containerReceivedTouchEnd is false
+A touch on the timeline scrubber should not propagate to the video element:
+PASS containerReceivedTouch is false
+A touch on the bare media controls surface should propagate to the video element:
+PASS containerReceivedTouch is true
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/media/modern-media-controls/ios-inline-media-controls/touch/ios-inline-media-controls-timeline-scrub-stops-propagation.html
+++ b/LayoutTests/media/modern-media-controls/ios-inline-media-controls/touch/ios-inline-media-controls-timeline-scrub-stops-propagation.html
@@ -2,58 +2,67 @@
 <html>
 <head>
     <script src="../../../../resources/js-test-pre.js"></script>
-    <script src="../../resources/media-controls-utils.js"></script>
-    <script src="../../../../resources/ui-helper.js"></script>
     <script src="../../../video-test.js"></script>
 </head>
 <body>
-    <video id="video" src="../../../content/test.mp4" controls style="width: 400px;"></video>
+    <video id="video" src="../../../content/test.mp4" controls muted playsinline style="width: 400px;"></video>
     <script>
         window.jsTestIsAsync = true;
-        
-        description("Test that scrubbing the timeline does not propagate touch events to parent elements.");
-        
-        // Make video globally accessible for testExpectedEventuallySilent
+
+        description("Test that touch events on the timeline scrubber do not propagate to parent elements, while touch events on the bare video surface do.");
+
         window.video = document.getElementById('video');
         var video = window.video;
-        let containerReceivedTouchStart = false;
-        let containerReceivedTouchMove = false;
-        let containerReceivedTouchEnd = false;
-        
-        video.addEventListener('touchstart', () => { containerReceivedTouchStart = true; }, {once: true});
-        video.addEventListener('touchmove', () => { containerReceivedTouchMove = true; }, {once: true});
-        video.addEventListener('touchend', () => { containerReceivedTouchEnd = true; }, {once: true});
-        
+        let containerReceivedTouch = false;
+
+        function resetTouchFlag()
+        {
+            containerReceivedTouch = false;
+            video.addEventListener('touchstart', () => { containerReceivedTouch = true; }, { once: true });
+        }
+
+        function dispatchTouchStart(target)
+        {
+            target.dispatchEvent(new Event('touchstart', { bubbles: true, composed: true }));
+        }
+
         video.addEventListener('loadedmetadata', async () => {
             await testExpectedEventuallySilent("window.internals.shadowRoot(window.video)", null, "!=", 500);
-            
+
             const shadowRoot = window.internals.shadowRoot(video);
             if (!shadowRoot) {
                 testFailed("Could not get shadow root");
                 finishJSTest();
                 return;
             }
-            
+
             const controlsElement = shadowRoot.querySelector('.media-controls');
             if (!controlsElement) {
                 testFailed("Could not find media controls element");
                 finishJSTest();
                 return;
             }
-            
-            const rect = controlsElement.getBoundingClientRect();
-            const start = UIHelper.midPointOfRect(rect);
-            
-            await UIHelper.sendEventStream(new UIHelper.EventStreamBuilder()
-                .begin(start.x, start.y)
-                .move(start.x + 50, start.y, 0.5)
-                .end()
-                .takeResult());
-            
-            shouldBeFalse("containerReceivedTouchStart");
-            shouldBeFalse("containerReceivedTouchMove");
-            shouldBeFalse("containerReceivedTouchEnd");
-            
+
+            await video.play();
+            await testExpectedEventuallySilent("window.internals.shadowRoot(window.video).querySelector('.time-control .scrubber')", null, "!=", 500);
+
+            const scrubber = shadowRoot.querySelector('.time-control .scrubber');
+            if (!scrubber) {
+                testFailed("Could not find timeline scrubber");
+                finishJSTest();
+                return;
+            }
+
+            debug("A touch on the timeline scrubber should not propagate to the video element:");
+            resetTouchFlag();
+            dispatchTouchStart(scrubber);
+            shouldBeFalse("containerReceivedTouch");
+
+            debug("A touch on the bare media controls surface should propagate to the video element:");
+            resetTouchFlag();
+            dispatchTouchStart(controlsElement);
+            shouldBeTrue("containerReceivedTouch");
+
             video.remove();
             finishJSTest();
         });

--- a/Source/WebCore/Modules/modern-media-controls/media/media-controller.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/media-controller.js
@@ -454,7 +454,8 @@ class MediaController
         let touchEvents = ["touchstart", "touchmove", "touchend"];
         for (let touchEvent of touchEvents) {
             this.controls.element.addEventListener(touchEvent, (event) => {
-                event.stopPropagation();
+                if (event.target !== this.controls.element)
+                    event.stopPropagation();
             });
         }
     }


### PR DESCRIPTION
#### 6de5dd7b71a8e2e554a795b25f01ff411d5a6a8b
<pre>
Can&apos;t swipe between videos on pr0gramm.com while a video is playing
<a href="https://bugs.webkit.org/show_bug.cgi?id=319291">https://bugs.webkit.org/show_bug.cgi?id=319291</a>
<a href="https://rdar.apple.com/181186791">rdar://181186791</a>

Reviewed by Jer Noble.

The media controls stop propagation of touchstart/touchmove/touchend so that scrubbing the timeline
isn&apos;t misinterpreted as a page gesture. Those listeners were attached to the full-surface
.media-controls element, which swallowed all touch events over the entire video area — including
swipes over the bare video body. This broke sites like pr0gramm.com that install their own
touch/swipe handlers on an ancestor of the &lt;video&gt; to navigate between posts.

Only stop propagation when the touch actually lands on an interactive control (a descendant of the
controls element) rather than on the bare video surface. A touch on the video body targets
.media-controls itself (its faded children have pointer-events: none), so it now propagates to
the page; a touch that scrubs the timeline or hits a button targets a descendant and is still
swallowed.

* LayoutTests/media/modern-media-controls/ios-inline-media-controls/touch/ios-inline-media-controls-timeline-scrub-stops-propagation-expected.txt:
* LayoutTests/media/modern-media-controls/ios-inline-media-controls/touch/ios-inline-media-controls-timeline-scrub-stops-propagation.html:
* Source/WebCore/Modules/modern-media-controls/media/media-controller.js:
(MediaController.prototype._stopPropagationOnTouchEvents):

Canonical link: <a href="https://commits.webkit.org/317201@main">https://commits.webkit.org/317201@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7bc43f2affcc03ff1ea587ab5b793a84c5d4583f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174569 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48502 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42283 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184146 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132437 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b30e2eb3-bfeb-47a6-85bc-1a2083ba9f96) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176434 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49794 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48185 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135820 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95848 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6599adeb-3e74-4216-8d44-2917bdc884ce) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177527 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39252 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156614 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116298 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37893 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32627 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148316 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36106 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186573 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/39838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40465 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144740 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48169 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156169 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144600 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38980 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48848 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39487 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/120837 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47355 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11072 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46757 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46988 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46815 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->