### PR TITLE
[macOS] Scroll stretch behavior should more closely match NSScrollView

### DIFF
--- a/Source/WebCore/PAL/pal/spi/mac/NSScrollViewSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSScrollViewSPI.h
@@ -43,6 +43,10 @@ WTF_EXTERN_C_BEGIN
 CGFloat _NSElasticDeltaForReboundDelta(CGFloat delta);
 CGFloat _NSElasticDeltaForTimeDelta(CGFloat initialPosition, CGFloat initialVelocity, CGFloat elapsedTime);
 CGFloat _NSReboundDeltaForElasticDelta(CGFloat delta);
+#if HAVE(APPKIT_GESTURES_SUPPORT)
+CGFloat _NSHyperbolicElasticDeltaForReboundDelta(CGFloat delta, CGFloat c, CGFloat d);
+CGFloat _NSHyperbolicReboundDeltaForElasticDelta(CGFloat delta, CGFloat c, CGFloat d);
+#endif
 
 WTF_EXTERN_C_END
 

--- a/Source/WebCore/page/scrolling/ScrollingTree.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTree.cpp
@@ -1165,6 +1165,12 @@ String ScrollingTree::scrollingTreeAsText(OptionSet<ScrollingStateTreeAsTextBeha
     return ts.release();
 }
 
+float ScrollingTree::rubberbandHyperbolicCoefficientForTesting()
+{
+    RefPtr rootNode = m_rootNode;
+    return rootNode ? rootNode->rubberbandHyperbolicCoefficientForTesting() : 0;
+}
+
 bool ScrollingTree::hasFixedOrSticky() const
 {
     return !m_fixedOrStickyNodes.isEmptyIgnoringNullReferences();

--- a/Source/WebCore/page/scrolling/ScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingTree.h
@@ -223,6 +223,8 @@ public:
 
     WEBCORE_EXPORT String scrollingTreeAsText(OptionSet<ScrollingStateTreeAsTextBehavior> = { });
 
+    WEBCORE_EXPORT float rubberbandHyperbolicCoefficientForTesting();
+
     bool isMonitoringWheelEvents() const { return m_isMonitoringWheelEvents; }
     void setIsMonitoringWheelEvents(bool b) { m_isMonitoringWheelEvents = b; }
     bool inCommitTreeState() const { return m_inCommitTreeState; }

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp
@@ -529,6 +529,11 @@ void ScrollingTreeScrollingNode::wasScrolledByDelegatedScrolling(const FloatPoin
     scrollingTree()->scrollingTreeNodeDidScroll(*this, scrollingLayerPositionAction);
 }
 
+float ScrollingTreeScrollingNode::rubberbandHyperbolicCoefficientForTesting() const
+{
+    return m_delegate ? m_delegate->rubberbandHyperbolicCoefficientForTesting() : 0;
+}
+
 void ScrollingTreeScrollingNode::dumpProperties(TextStream& ts, OptionSet<ScrollingStateTreeAsTextBehavior> behavior) const
 {
     ScrollingTreeNode::dumpProperties(ts, behavior);

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h
@@ -216,6 +216,8 @@ protected:
 
     void handleScrollPositionRequest(const RequestedScrollData&);
 
+    float rubberbandHyperbolicCoefficientForTesting() const;
+
     void dumpProperties(WTF::TextStream&, OptionSet<ScrollingStateTreeAsTextBehavior>) const override;
 
     std::unique_ptr<ScrollingTreeScrollingNodeDelegate> m_delegate;

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h
@@ -65,6 +65,8 @@ public:
     virtual FloatPoint adjustedScrollPosition(const FloatPoint& scrollPosition) const { return scrollPosition; }
     virtual String scrollbarStateForOrientation(ScrollbarOrientation) const { return ""_s; }
 
+    virtual float rubberbandHyperbolicCoefficientForTesting() const { return 0; }
+
 #if HAVE(RUBBER_BANDING)
     virtual std::optional<RubberbandingState> captureRubberbandingState() const { return std::nullopt; }
 #endif

--- a/Source/WebCore/page/scrolling/ThreadedScrollingTreeScrollingNodeDelegate.h
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingTreeScrollingNodeDelegate.h
@@ -46,6 +46,10 @@ class ThreadedScrollingTreeScrollingNodeDelegate : public ScrollingTreeScrolling
 public:
     void updateSnapScrollState();
 
+#if HAVE(APPKIT_GESTURES_SUPPORT)
+    float rubberbandHyperbolicCoefficientForTesting() const final { return m_scrollController.rubberbandHyperbolicCoefficientForTesting(); }
+#endif
+
 protected:
     explicit ThreadedScrollingTreeScrollingNodeDelegate(ScrollingTreeScrollingNode&);
     virtual ~ThreadedScrollingTreeScrollingNodeDelegate();

--- a/Source/WebCore/platform/PlatformWheelEvent.h
+++ b/Source/WebCore/platform/PlatformWheelEvent.h
@@ -27,6 +27,7 @@
 
 #include <WebCore/FloatPoint.h>
 #include <WebCore/IntPoint.h>
+#include <WebCore/MouseEventTypes.h>
 #include <WebCore/PlatformEvent.h>
 #include <wtf/Platform.h>
 #include <wtf/WindowsExtras.h>
@@ -146,6 +147,9 @@ public:
     bool hasPreciseScrollingDeltas() const { return m_hasPreciseScrollingDeltas; }
     void setHasPreciseScrollingDeltas(bool hasPreciseScrollingDeltas) { m_hasPreciseScrollingDeltas = hasPreciseScrollingDeltas; }
 
+    MouseEventInputSource inputSource() const { return m_inputSource; }
+    void setInputSource(MouseEventInputSource inputSource) { m_inputSource = inputSource; }
+
 #if PLATFORM(COCOA)
     unsigned scrollCount() const { return m_scrollCount; }
     FloatSize unacceleratedScrollingDelta() const { return { m_unacceleratedScrollingDeltaX, m_unacceleratedScrollingDeltaY }; }
@@ -188,6 +192,7 @@ protected:
     PlatformWheelEventGranularity m_granularity { PlatformWheelEventGranularity::ScrollByPixelWheelEvent };
     bool m_directionInvertedFromDevice { false };
     bool m_hasPreciseScrollingDeltas { false };
+    MouseEventInputSource m_inputSource { MouseEventInputSource::UserDriven };
 
     IntPoint m_position;
     IntPoint m_globalPosition;

--- a/Source/WebCore/platform/ScrollingEffectsController.h
+++ b/Source/WebCore/platform/ScrollingEffectsController.h
@@ -212,7 +212,14 @@ public:
     std::optional<RubberbandingState> captureRubberbandingState() const;
     bool restoreRubberbandingState(const RubberbandingState&);
     bool NODELETE shouldAttemptRubberbandingRestoration(const RubberbandingState&);
+#if HAVE(APPKIT_GESTURES_SUPPORT)
+    FloatSize NODELETE computeDampedStretchDelta(FloatSize delta, bool horizontalDeltaOpposesStretch, bool verticalDeltaOpposesStretch);
+    float NODELETE deltaAdjustedForRefreshController(float generalDampedHeight, float verticalDelta, float verticalStretch, bool verticalDeltaOpposesStretch);
+
+    float rubberbandHyperbolicCoefficientForTesting() const { return m_rubberbandHyperbolicCoefficient; }
+#else
     FloatSize NODELETE deltaAdjustedForRefreshController(const FloatSize& adjustedDelta, bool);
+#endif
 #endif
 
 private:
@@ -310,7 +317,10 @@ private:
     FloatSize m_cumulativeGestureDelta;
     MonotonicTime m_lastGestureEventTime;
 
-#if HAVE(NSREFRESHCONTROLLER)
+#if HAVE(APPKIT_GESTURES_SUPPORT)
+    float m_rubberbandHyperbolicCoefficient { 0 };
+    bool m_gestureBeganAtTop { false };
+#elif HAVE(NSREFRESHCONTROLLER)
     bool m_skipAdditionalDeltaAdjustments { false };
 #endif
 

--- a/Source/WebCore/platform/mac/ScrollingEffectsController.mm
+++ b/Source/WebCore/platform/mac/ScrollingEffectsController.mm
@@ -38,6 +38,10 @@
 #import <wtf/SystemTracing.h>
 #import <wtf/text/TextStream.h>
 
+#if USE(APPLE_INTERNAL_SDK)
+#import <WebKitAdditions/ScrollingEffectsControllerAdditions.mm>
+#endif
+
 #if PLATFORM(MAC)
 
 namespace WebCore {
@@ -46,6 +50,7 @@ static const Seconds scrollVelocityZeroingTimeout = 100_ms;
 static const float rubberbandDirectionLockStretchRatio = 1;
 static const float rubberbandMinimumRequiredDeltaBeforeStretch = 10;
 
+#if !HAVE(APPKIT_GESTURES_SUPPORT)
 static float elasticDeltaForReboundDelta(float delta)
 {
     return _NSElasticDeltaForReboundDelta(delta);
@@ -55,6 +60,7 @@ static float reboundDeltaForElasticDelta(float delta)
 {
     return _NSReboundDeltaForElasticDelta(delta);
 }
+#endif
 
 static float scrollWheelMultiplier()
 {
@@ -141,6 +147,15 @@ static std::optional<BoxSide> NODELETE affectedSideOnDominantAxis(FloatSize delt
     return ScrollableArea::targetSideForScrollDelta(delta, dominantAxis);
 }
 
+#if HAVE(APPKIT_GESTURES_SUPPORT)
+static FloatSize hyperbolicReboundDeltaForElasticDelta(IntSize stretchAmount, float rubberbandHyperbolicCoefficient, FloatSize viewportSize)
+{
+    const auto width = _NSHyperbolicReboundDeltaForElasticDelta(stretchAmount.width(), rubberbandHyperbolicCoefficient, viewportSize.width());
+    const auto height = _NSHyperbolicReboundDeltaForElasticDelta(stretchAmount.height(), rubberbandHyperbolicCoefficient, viewportSize.height());
+    return { static_cast<float>(width), static_cast<float>(height) };
+}
+#endif
+
 bool ScrollingEffectsController::handleWheelEvent(const PlatformWheelEvent& wheelEvent)
 {
     if (processWheelEventForScrollSnap(wheelEvent))
@@ -174,8 +189,15 @@ bool ScrollingEffectsController::handleWheelEvent(const PlatformWheelEvent& whee
         m_lastGestureEventTime = { };
 
         IntSize stretchAmount = m_client.stretchAmount();
+#if HAVE(APPKIT_GESTURES_SUPPORT)
+        const auto viewportSize = m_client.scrollExtents().viewportSize;
+        m_gestureBeganAtTop = m_client.edgePinnedState().top();
+        m_rubberbandHyperbolicCoefficient = rubberBandHyperbolicCoefficient(wheelEvent);
+        m_stretchScrollForce = hyperbolicReboundDeltaForElasticDelta(stretchAmount, m_rubberbandHyperbolicCoefficient, viewportSize);
+#else
         m_stretchScrollForce.setWidth(reboundDeltaForElasticDelta(stretchAmount.width()));
         m_stretchScrollForce.setHeight(reboundDeltaForElasticDelta(stretchAmount.height()));
+#endif
         m_unappliedOverscrollDelta = { };
 
         stopRubberBandAnimation();
@@ -346,6 +368,48 @@ bool ScrollingEffectsController::modifyScrollDeltaForStretching(const PlatformWh
     return false;
 }
 
+#if HAVE(APPKIT_GESTURES_SUPPORT)
+float ScrollingEffectsController::deltaAdjustedForRefreshController(float generalDampedHeight, float verticalDelta, float verticalStretch, bool verticalDeltaOpposesStretch)
+{
+    // This logic mirrors AppKit. We layer the refresh-control reveal on top of the general vertical curve.
+    if (!m_client.hasRefreshController() || verticalDeltaOpposesStretch || !verticalDelta)
+        return generalDampedHeight;
+
+    if (!m_gestureBeganAtTop || m_momentumScrollInProgress)
+        return generalDampedHeight;
+
+    if (verticalStretch > 0 || verticalDelta >= 0)
+        return generalDampedHeight;
+
+    // Vertical stretch at the top is negative. Take the absolute value and work in positive magnitudes.
+    const auto currentStretchMagnitude = std::abs(verticalStretch);
+    verticalDelta = std::abs(verticalDelta);
+
+    const auto activationHeight = m_client.refreshControllerSnappingThreshold();
+    const auto viewportHeight = m_client.scrollExtents().viewportSize.height();
+
+    // Split delta between the linear zone (below the control's activation height) and the hyperbolic zone (above).
+    auto newStretchMagnitude = 0.f;
+    if (currentStretchMagnitude + verticalDelta > activationHeight) {
+        const auto stretchAlreadyInHyperbolic = std::max(0.0f, currentStretchMagnitude - activationHeight);
+        const auto deltaConsumedInLinear = std::max(0.0f, activationHeight - currentStretchMagnitude);
+        const auto deltaForHyperbolic = verticalDelta - deltaConsumedInLinear;
+        const auto currentHyperbolicReboundDelta = _NSHyperbolicReboundDeltaForElasticDelta(stretchAlreadyInHyperbolic, m_rubberbandHyperbolicCoefficient, viewportHeight);
+        const auto combinedHyperbolicReboundDelta = currentHyperbolicReboundDelta + deltaForHyperbolic;
+
+        // The new magnitude will be layered on top of the general scroll curve. Floor it like the non-refresh-control
+        // path so that the positions remain pixel-aligned.
+        newStretchMagnitude = activationHeight + std::ceilf(_NSHyperbolicElasticDeltaForReboundDelta(combinedHyperbolicReboundDelta, m_rubberbandHyperbolicCoefficient, viewportHeight));
+    } else
+        newStretchMagnitude = currentStretchMagnitude + verticalDelta;
+
+    const auto signedNewStretch = -newStretchMagnitude;
+    // Keep the force as if this stretch had come from the general hyperbolic curve so that any
+    // later general-path event that takes place is handled correctly.
+    m_stretchScrollForce.setHeight(_NSHyperbolicReboundDeltaForElasticDelta(signedNewStretch, m_rubberbandHyperbolicCoefficient, viewportHeight));
+    return signedNewStretch - verticalStretch;
+}
+#else
 FloatSize ScrollingEffectsController::deltaAdjustedForRefreshController(const FloatSize& delta, bool verticalDeltaOpposesStretch)
 {
 #if HAVE(NSREFRESHCONTROLLER)
@@ -390,6 +454,48 @@ FloatSize ScrollingEffectsController::deltaAdjustedForRefreshController(const Fl
     return delta;
 #endif
 }
+#endif
+
+#if HAVE(APPKIT_GESTURES_SUPPORT)
+
+FloatSize ScrollingEffectsController::computeDampedStretchDelta(FloatSize delta, bool horizontalDeltaOpposesStretch, bool verticalDeltaOpposesStretch)
+{
+    // This logic mirrors AppKit.
+    const auto stretchAmount = m_client.stretchAmount();
+    auto hyperbolicDampedDeltaForAxis = [&](ScrollEventAxis axis) -> std::pair<float, float> {
+        // Returns (dampedDelta, newForce). When the axis opposes the current stretch we don't
+        // accumulate into force (the caller already zeroed it), and the delta passes straight through.
+
+        auto lengthForAxis = [](FloatSize size, ScrollEventAxis axis) {
+            return (axis == ScrollEventAxis::Horizontal) ? size.width() : size.height();
+        };
+        const auto viewportSize = m_client.scrollExtents().viewportSize;
+        const auto viewportLength = lengthForAxis(viewportSize, axis);
+        const auto deltaForAxis = lengthForAxis(delta, axis);
+        const auto currentForce = lengthForAxis(m_stretchScrollForce, axis);
+        const auto currentStretch = lengthForAxis(stretchAmount, axis);
+        const auto opposesStretch = axis == ScrollEventAxis::Horizontal ? horizontalDeltaOpposesStretch : verticalDeltaOpposesStretch;
+
+        if (opposesStretch)
+            return { deltaForAxis, currentForce };
+        if (!deltaForAxis)
+            return { 0, currentForce };
+
+        const auto newForce = currentForce + deltaForAxis;
+        const auto newStretch = ceilf(_NSHyperbolicElasticDeltaForReboundDelta(newForce, m_rubberbandHyperbolicCoefficient, viewportLength));
+        return { newStretch - currentStretch, newForce };
+    };
+
+    const auto [dampedWidth, newForceWidth] = hyperbolicDampedDeltaForAxis(ScrollEventAxis::Horizontal);
+    auto [dampedHeight, newForceHeight] = hyperbolicDampedDeltaForAxis(ScrollEventAxis::Vertical);
+    m_stretchScrollForce = { newForceWidth, newForceHeight };
+
+    dampedHeight = deltaAdjustedForRefreshController(dampedHeight, delta.height(), stretchAmount.height(), verticalDeltaOpposesStretch);
+
+    return { dampedWidth, dampedHeight };
+}
+
+#endif
 
 bool ScrollingEffectsController::shouldAttemptRubberbandingRestoration(const RubberbandingState& state)
 {
@@ -453,6 +559,9 @@ bool ScrollingEffectsController::applyScrollDeltaWithStretching(const PlatformWh
     if (delta.isZero())
         return canStartAnimation;
 
+#if HAVE(APPKIT_GESTURES_SUPPORT)
+    auto dampedDelta = computeDampedStretchDelta(delta, horizontalDeltaOpposesStretch, verticalDeltaOpposesStretch);
+#else
     auto stretchAmount = m_client.stretchAmount();
 
     FloatSize adjustedDelta = deltaAdjustedForRefreshController(delta, verticalDeltaOpposesStretch);
@@ -480,10 +589,11 @@ bool ScrollingEffectsController::applyScrollDeltaWithStretching(const PlatformWh
         const auto dampedHeight = ceilf(elasticDeltaForReboundDelta(m_stretchScrollForce.height()));
         dampedDelta.setHeight(dampedHeight - stretchAmount.height());
     }
+#endif
 
     clampDeltaForAllowedAxes(wheelEvent, dampedDelta);
 
-    LOG_WITH_STREAM(ScrollAnimations, stream << "ScrollingEffectsController::applyScrollDeltaWithStretching() - stretchScrollForce " << m_stretchScrollForce << " move delta " << delta << " adjustedDelta " << adjustedDelta << " dampedDelta " << dampedDelta);
+    LOG_WITH_STREAM(ScrollAnimations, stream << "ScrollingEffectsController::applyScrollDeltaWithStretching() - stretchScrollForce " << m_stretchScrollForce << " move delta " << delta << " dampedDelta " << dampedDelta);
 
     m_client.immediateScrollBy(dampedDelta, ScrollClamping::Unclamped);
 

--- a/Source/WebKit/Shared/WebEventConversion.cpp
+++ b/Source/WebKit/Shared/WebEventConversion.cpp
@@ -378,6 +378,7 @@ public:
         m_scrollCount = webEvent.scrollCount();
         m_unacceleratedScrollingDeltaX = webEvent.unacceleratedScrollingDelta().width();
         m_unacceleratedScrollingDeltaY = webEvent.unacceleratedScrollingDelta().height();
+        m_inputSource = platform(webEvent.inputSource());
 #endif
     }
 };

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
@@ -116,6 +116,7 @@ typedef NSVisualEffectView _WKPlatformVisualEffectView;
 
 @property (nonatomic, setter=_setScrollingUpdatesDisabledForTesting:) BOOL _scrollingUpdatesDisabledForTesting;
 @property (nonatomic, readonly) NSString *_scrollingTreeAsText;
+@property (nonatomic, readonly) double _rubberbandHyperbolicCoefficientForTesting;
 
 @property (nonatomic, readonly) pid_t _networkProcessIdentifier;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -359,6 +359,14 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
     return coordinator->scrollingTreeAsText().createNSString().autorelease();
 }
 
+- (double)_rubberbandHyperbolicCoefficientForTesting
+{
+    if (CheckedPtr coordinator = _page->scrollingCoordinatorProxy())
+        return coordinator->rubberbandHyperbolicCoefficientForTesting();
+
+    return 0;
+}
+
 - (pid_t)_networkProcessIdentifier
 {
     RefPtr networkProcess = _page->websiteDataStore().networkProcessIfExists();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
@@ -372,6 +372,11 @@ String RemoteScrollingCoordinatorProxy::scrollingTreeAsText() const
     return m_scrollingTree->scrollingTreeAsText();
 }
 
+float RemoteScrollingCoordinatorProxy::rubberbandHyperbolicCoefficientForTesting() const
+{
+    return m_scrollingTree->rubberbandHyperbolicCoefficientForTesting();
+}
+
 bool RemoteScrollingCoordinatorProxy::hasScrollableMainFrame() const
 {
     // FIXME: Locking

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -167,6 +167,7 @@ public:
 #endif
 
     String scrollingTreeAsText() const;
+    float rubberbandHyperbolicCoefficientForTesting() const;
 
     void resetStateAfterProcessExited();
 

--- a/Tools/TestWebKitAPI/Helpers/cocoa/WebPage+Extras.swift
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/WebPage+Extras.swift
@@ -74,6 +74,14 @@ extension WebPage {
         try await backingWebView._getRenderTreeAsString()
     }
 
+    /// The hyperbolic elastic coefficient the main-frame scrolling node latched for its most recent
+    /// gesture, which depends on the scroll source.
+    ///
+    /// - Returns: The latched rubberband hyperbolic coefficient.
+    public func rubberbandHyperbolicCoefficient() -> Double {
+        backingWebView._rubberbandHyperbolicCoefficientForTesting
+    }
+
     /// Inserts text into the web page.
     ///
     /// - Parameter text: The text to insert.
@@ -172,6 +180,26 @@ extension WebPage {
         backingWebView.rightMouseUp(with: mouseEvent(.rightMouseUp, at: location, clickCount: 1, pressure: 0))
     }
 
+    /// Synthesizes a user-driven trackpad-driven scroll gesture and delivers it to the web view.
+    ///
+    /// - Parameters:
+    ///   - location: The location in window coordinates to scroll at.
+    ///   - delta: The scroll delta in pixels (positive `y` scrolls the content up).
+    public func scrollWheel(at location: NSPoint, delta: CGSize) {
+        let beganPhaseDelta = CGSize(
+            width: Int(delta.width.rounded(.awayFromZero)).signum(),
+            height: Int(delta.height.rounded(.awayFromZero)).signum()
+        )
+
+        let changedPhaseDelta = CGSize(
+            width: delta.width - beganPhaseDelta.width,
+            height: delta.height - beganPhaseDelta.height
+        )
+        backingWebView.scrollWheel(with: scrollWheelEvent(at: location, delta: beganPhaseDelta, phase: .began, momentumPhase: .none))
+        backingWebView.scrollWheel(with: scrollWheelEvent(at: location, delta: changedPhaseDelta, phase: .changed, momentumPhase: .none))
+        backingWebView.scrollWheel(with: scrollWheelEvent(at: location, delta: .zero, phase: .ended, momentumPhase: .none))
+    }
+
     /// Suspends until WebKit has processed all pending mouse events delivered to this page.
     public func waitForPendingMouseEvents() async {
         await withCheckedContinuation { continuation in
@@ -214,6 +242,44 @@ extension WebPage {
             )
         else {
             preconditionFailure("Could not create NSEvent.")
+        }
+
+        return event
+    }
+
+    private func scrollWheelEvent(
+        at location: NSPoint,
+        delta: CGSize,
+        phase: CGScrollPhase,
+        momentumPhase: CGMomentumScrollPhase
+    ) -> NSEvent {
+        guard let window = unsafe backingWebView.window else {
+            preconditionFailure("Could not create scroll NSEvent because there is no NSWindow.")
+        }
+
+        guard
+            let cgEvent = CGEvent(
+                scrollWheelEvent2Source: nil,
+                units: .pixel,
+                wheelCount: 2,
+                wheel1: Int32(delta.height),
+                wheel2: Int32(delta.width),
+                wheel3: 0
+            )
+        else {
+            preconditionFailure("Could not create CGEvent for scroll.")
+        }
+
+        cgEvent.setIntegerValueField(.scrollWheelEventScrollPhase, value: Int64(phase.rawValue))
+        cgEvent.setIntegerValueField(.scrollWheelEventMomentumPhase, value: Int64(momentumPhase.rawValue))
+
+        // CGEvent locations are in flipped, global screen coordinates.
+        let locationInScreen = window.convertPoint(toScreen: location)
+        let primaryScreenHeight = NSScreen.screens.first?.frame.height ?? 0
+        cgEvent.location = CGPoint(x: locationInScreen.x, y: primaryScreenHeight - locationInScreen.y)
+
+        guard let event = NSEvent(cgEvent: cgEvent) else {
+            preconditionFailure("Could not create scroll NSEvent.")
         }
 
         return event

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift
@@ -671,6 +671,62 @@ extension AppKitGesturesTests.Basic {
     }
 
     @Test
+    func scrollInputSourceUpdatesrubberbandHyperbolicCoefficient() async throws {
+        let html = """
+            <body style="margin: 0; width: 100%; height: 20000px;
+                         background: repeating-linear-gradient(to bottom, blue 0 50px, white 50px 100px);">
+            </body>
+            """
+        try await page.load(html: html).wait()
+        await page.waitForNextPresentationUpdate()
+
+        // No gesture has run yet.
+        #expect(page.rubberbandHyperbolicCoefficient() == 0)
+        try await page.callJavaScript { "window.scrollTo(0, 0);" }
+        #expect(page.rubberbandHyperbolicCoefficient() == 0)
+
+        await page.waitForNextPresentationUpdate()
+
+        let automationLocation = screenBounds(ofPointInWindowCoordinates: window.frame.center)
+        let trackpadLocation = window.frame.center
+
+        func expectCoefficient(_ expected: CGFloat, _ message: Comment) {
+            let actual = page.rubberbandHyperbolicCoefficient()
+            #expect(abs(actual - Double(expected)) < 0.0001, message)
+        }
+
+        // 1. Trackpad scroll.
+        page.scrollWheel(at: trackpadLocation, delta: CGSize(width: 0, height: 600))
+        await page.waitForNextPresentationUpdate()
+        // End the scroll by programatically scrolling back to 0,0.
+        try await page.callJavaScript { "window.scrollTo(0, 0);" }
+
+        expectCoefficient(trackpadRubberbandHyperbolicCoefficient, "after initial trackpad scroll")
+
+        // 2. Automation scroll.
+        await recap.play { composer in
+            composer._wk_scroll(
+                withStart: automationLocation,
+                end: CGPoint(x: automationLocation.x, y: automationLocation.y + 200),
+                duration: .seconds(0.5)
+            )
+        }
+        await page.waitForNextPresentationUpdate()
+        // End the scroll by programatically scrolling back to 0,0.
+        try await page.callJavaScript { "window.scrollTo(0, 0);" }
+
+        expectCoefficient(automationHyperbolicCoefficient, "after automated scroll")
+
+        // 3. Trackpad scroll again.
+        page.scrollWheel(at: trackpadLocation, delta: CGSize(width: 0, height: 600))
+        await page.waitForNextPresentationUpdate()
+        // End the scroll by programatically scrolling back to 0,0.
+        try await page.callJavaScript { "window.scrollTo(0, 0);" }
+
+        expectCoefficient(trackpadRubberbandHyperbolicCoefficient, "after returning to trackpad scroll")
+    }
+
+    @Test
     func interruptingDeceleratingScrollDoesNotFollowLink() async throws {
         let html = """
             <a id="link" href="about:blank"


### PR DESCRIPTION
#### ce76e2b79384d3b751287f8c8da007d3c7fd9fc4
<pre>
[macOS] Scroll stretch behavior should more closely match NSScrollView
<a href="https://bugs.webkit.org/show_bug.cgi?id=318641">https://bugs.webkit.org/show_bug.cgi?id=318641</a>
<a href="https://rdar.apple.com/174548304">rdar://174548304</a>

Reviewed by Abrar Rahman Protyasha and Richard Robinson.

Update WebKit&apos;s scroll stretch behavior to more closely resemble NSScrollView.
In the normal scroll-stretch path, there should be no observable change for
user-driven scrolling. In scroll-stretch path when a refresh control is present,
the scroll deltas are no longer dampened whatsoever until the stretch surpasses
the full activation height of the refresh control.

For automation-driven scrolling, the hyperbolic coefficient used during rubberband
animations is altered in order to align with AppKit.

Test: Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift

* Source/WebCore/PAL/pal/spi/mac/NSScrollViewSPI.h:
* Source/WebCore/page/scrolling/ScrollingTree.cpp:
(WebCore::ScrollingTree::rubberbandHyperbolicCoefficientForTesting):
* Source/WebCore/page/scrolling/ScrollingTree.h:
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp:
(WebCore::ScrollingTreeScrollingNode::rubberbandHyperbolicCoefficientForTesting const):
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h:
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h:
(WebCore::ScrollingTreeScrollingNodeDelegate::rubberbandHyperbolicCoefficientForTesting const):
* Source/WebCore/page/scrolling/ThreadedScrollingTreeScrollingNodeDelegate.h:
* Source/WebCore/platform/PlatformWheelEvent.h:
(WebCore::PlatformWheelEvent::inputSource const):
(WebCore::PlatformWheelEvent::setInputSource):
* Source/WebCore/platform/ScrollingEffectsController.h:
(WebCore::ScrollingEffectsController::rubberbandHyperbolicCoefficientForTesting const):
* Source/WebCore/platform/mac/ScrollingEffectsController.mm:
(WebCore::hyperbolicReboundDeltaForElasticDelta):
(WebCore::ScrollingEffectsController::handleWheelEvent):
(WebCore::ScrollingEffectsController::deltaAdjustedForRefreshController):
(WebCore::ScrollingEffectsController::computeDampedStretchDelta):
(WebCore::ScrollingEffectsController::applyScrollDeltaWithStretching):
* Source/WebKit/Shared/WebEventConversion.cpp:
(WebKit::WebKit2PlatformWheelEvent::WebKit2PlatformWheelEvent):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(-[WKWebView _rubberbandHyperbolicCoefficientForTesting]):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp:
(WebKit::RemoteScrollingCoordinatorProxy::rubberbandHyperbolicCoefficientForTesting const):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
* Tools/TestWebKitAPI/Helpers/cocoa/WebPage+Extras.swift:
(rubberbandHyperbolicCoefficient):
(scrollWheel(at:delta:)):
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift:
(AppKitGesturesTests.scrollInputSourceUpdatesrubberbandHyperbolicCoefficient):

Canonical link: <a href="https://commits.webkit.org/317207@main">https://commits.webkit.org/317207@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a05b4e312644d363dee4618d0304107a6ed6868a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174346 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48279 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42060 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183922 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132214 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/74d11dda-35fd-4a28-97b7-e35fdd7003d7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176211 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49571 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47961 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135621 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95689 "3 flakes 3 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7ce0f1ff-5d0c-4d12-be0e-6da08071f915) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177304 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39053 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156414 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116099 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37694 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36063 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32404 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148117 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35906 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186348 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39553 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40260 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144533 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47946 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144391 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38986 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48625 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32526 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114167 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39292 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120563 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47131 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10870 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46534 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46765 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46592 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->