### PR TITLE
[WASM] BBQ JIT omits mask before shr operation

### DIFF
--- a/JSTests/wasm/stress/bbq-const-fold-shift-mask.js
+++ b/JSTests/wasm/stress/bbq-const-fold-shift-mask.js
@@ -1,0 +1,24 @@
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+// https://bugs.webkit.org/show_bug.cgi?id=270257
+// BBQ const-fold of shifts must mask the count (i32 & 31, i64 & 63).
+
+let wat = `
+(module
+  (func (export "i32_shr_u") (result i32)
+    i32.const 2147483647
+    i32.const 536870909
+    i32.shr_u)
+  (func (export "i64_shr_u") (result i64)
+    i64.const 0x7fffffffffffffff
+    i64.const 0x1ffffffd
+    i64.shr_u)
+)
+`;
+
+let instance = await instantiate(wat);
+// 536870909 & 31 == 29; 0x7fffffff >>> 29 == 3
+assert.eq(instance.exports.i32_shr_u(), 3);
+// 0x1ffffffd & 63 == 61; 0x7fffffffffffffff >>> 61 == 3
+assert.eq(instance.exports.i64_shr_u(), 3n);

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -2506,7 +2506,7 @@ void BBQJIT::moveShiftAmountIfNecessary(Location& rhsLocation)
     PREPARE_FOR_SHIFT;
     EMIT_BINARY(
         "I32Shl", TypeKind::I32,
-        BLOCK(Value::fromI32(lhs.asI32() << rhs.asI32())),
+        BLOCK(Value::fromI32(lhs.asI32() << (rhs.asI32() & 31))),
         BLOCK(
             moveShiftAmountIfNecessary(rhsLocation);
             m_jit.lshift32(lhsLocation.asGPR(), rhsLocation.asGPR(), resultLocation.asGPR());
@@ -2528,7 +2528,7 @@ void BBQJIT::moveShiftAmountIfNecessary(Location& rhsLocation)
     PREPARE_FOR_SHIFT;
     EMIT_BINARY(
         "I32ShrS", TypeKind::I32,
-        BLOCK(Value::fromI32(lhs.asI32() >> rhs.asI32())),
+        BLOCK(Value::fromI32(lhs.asI32() >> (rhs.asI32() & 31))),
         BLOCK(
             moveShiftAmountIfNecessary(rhsLocation);
             m_jit.rshift32(lhsLocation.asGPR(), rhsLocation.asGPR(), resultLocation.asGPR());
@@ -2550,7 +2550,7 @@ void BBQJIT::moveShiftAmountIfNecessary(Location& rhsLocation)
     PREPARE_FOR_SHIFT;
     EMIT_BINARY(
         "I32ShrU", TypeKind::I32,
-        BLOCK(Value::fromI32(static_cast<uint32_t>(lhs.asI32()) >> static_cast<uint32_t>(rhs.asI32()))),
+        BLOCK(Value::fromI32(static_cast<int32_t>(static_cast<uint32_t>(lhs.asI32()) >> (rhs.asI32() & 31)))),
         BLOCK(
             moveShiftAmountIfNecessary(rhsLocation);
             m_jit.urshift32(lhsLocation.asGPR(), rhsLocation.asGPR(), resultLocation.asGPR());

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
@@ -2725,7 +2725,7 @@ void BBQJIT::emitThrowOnNullReferenceBeforeAccess(Location ref, ptrdiff_t offset
     PREPARE_FOR_SHIFT;
     EMIT_BINARY(
         "I64Shl", TypeKind::I64,
-        BLOCK(Value::fromI64(lhs.asI64() << rhs.asI64())),
+        BLOCK(Value::fromI64(lhs.asI64() << (rhs.asI64() & 63))),
         BLOCK(
             moveShiftAmountIfNecessary(rhsLocation);
             m_jit.lshift64(lhsLocation.asGPR(), rhsLocation.asGPR(), resultLocation.asGPR());
@@ -2747,7 +2747,7 @@ void BBQJIT::emitThrowOnNullReferenceBeforeAccess(Location ref, ptrdiff_t offset
     PREPARE_FOR_SHIFT;
     EMIT_BINARY(
         "I64ShrS", TypeKind::I64,
-        BLOCK(Value::fromI64(lhs.asI64() >> rhs.asI64())),
+        BLOCK(Value::fromI64(lhs.asI64() >> (rhs.asI64() & 63))),
         BLOCK(
             moveShiftAmountIfNecessary(rhsLocation);
             m_jit.rshift64(lhsLocation.asGPR(), rhsLocation.asGPR(), resultLocation.asGPR());
@@ -2769,7 +2769,7 @@ void BBQJIT::emitThrowOnNullReferenceBeforeAccess(Location ref, ptrdiff_t offset
     PREPARE_FOR_SHIFT;
     EMIT_BINARY(
         "I64ShrU", TypeKind::I64,
-        BLOCK(Value::fromI64(static_cast<uint64_t>(lhs.asI64()) >> static_cast<uint64_t>(rhs.asI64()))),
+        BLOCK(Value::fromI64(static_cast<int64_t>(static_cast<uint64_t>(lhs.asI64()) >> (rhs.asI64() & 63)))),
         BLOCK(
             moveShiftAmountIfNecessary(rhsLocation);
             m_jit.urshift64(lhsLocation.asGPR(), rhsLocation.asGPR(), resultLocation.asGPR());


### PR DESCRIPTION
#### f854abcc8468cc480403e228da57b42ccbbee009
<pre>
[WASM] BBQ JIT omits mask before shr operation
<a href="https://bugs.webkit.org/show_bug.cgi?id=270257">https://bugs.webkit.org/show_bug.cgi?id=270257</a>

Reviewed by Yusuke Suzuki.

When both operands of a shift are constants, BBQ folded with a raw C++
shift. Shift counts outside [0, 31] / [0, 63] are C++ undefined behavior,
so BBQ could disagree with OMG/IPInt (e.g. 0x7fffffff &gt;&gt; 536870909
produced 0 in BBQ vs 3 elsewhere). WebAssembly defines shift amounts
modulo the bit width; B3 already masks when folding.

Mask constant shift counts in BBQ folding: i32 &amp; 31, i64 &amp; 63.

* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(BBQJIT::addI32Shl):
(BBQJIT::addI32ShrS):
(BBQJIT::addI32ShrU):
* Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp:
(BBQJIT::addI64Shl):
(BBQJIT::addI64ShrS):
(BBQJIT::addI64ShrU):
* JSTests/wasm/stress/bbq-const-fold-shift-mask.js: Added. Covers the bug
PoC (i32) and an i64 analog.

Canonical link: <a href="https://commits.webkit.org/317190@main">https://commits.webkit.org/317190@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07bcea4045401e72af3f2addfbcae510657bd11b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174434 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48367 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42148 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184011 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132302 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49659 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48049 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135695 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95747 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177392 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39133 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156490 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116173 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37774 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36143 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32492 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/4999 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148197 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35982 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186437 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/35696 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39659 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40340 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144611 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48034 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144468 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48713 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32602 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114272 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26531 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39369 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120775 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/211487 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47220 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10946 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55167 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46622 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46853 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46680 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->