### PR TITLE
Random page crashes due to invalid IPC message WebResourceLoader_WillSendRequestReply

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -1476,12 +1476,16 @@ void NetworkResourceLoader::continueWillSendRedirectedRequest(ResourceRequest&& 
         if (!protectedThis)
             return completionHandler({ });
 
+        Ref connection = protectedThis->m_connection;
+        if (!connection->connection().isValid())
+            return completionHandler({ });
+
+        if (newRequest.isNull())
+            return completionHandler({ });
+
         if (newRequest.firstPartyForCookies() != firstPartyForCookiesFromRedirectRequest) {
-            Ref connection = protectedThis->m_connection;
-            auto allowCookieAccess = connection->networkProcess().allowsFirstPartyForCookies(
-                connection->webProcessIdentifier(), newRequest.firstPartyForCookies());
-            MESSAGE_CHECK_COMPLETION_BASE(allowCookieAccess == NetworkProcess::AllowCookieAccess::Allow,
-                connection->connection(), completionHandler({ }));
+            auto allowCookieAccess = connection->networkProcess().allowsFirstPartyForCookies(connection->webProcessIdentifier(), newRequest.firstPartyForCookies());
+            MESSAGE_CHECK_COMPLETION_BASE(allowCookieAccess == NetworkProcess::AllowCookieAccess::Allow, connection->connection(), completionHandler({ }));
         }
 
         protectedThis->continueWillSendRequest(WTF::move(newRequest), isAllowedToAskUserForCredentials, WTF::move(completionHandler));


### PR DESCRIPTION
#### 524399615e2486b95285b548abfbacf255f4e776
<pre>
Random page crashes due to invalid IPC message WebResourceLoader_WillSendRequestReply
<a href="https://bugs.webkit.org/show_bug.cgi?id=318878">https://bugs.webkit.org/show_bug.cgi?id=318878</a>
<a href="https://rdar.apple.com/181753576">rdar://181753576</a>

Reviewed by Charlie Wolfe.

Merge back:

    WebResourceLoader::WillSendRequest reply may lead to cross-origin cookie access
    <a href="https://bugs.webkit.org/show_bug.cgi?id=313866">https://bugs.webkit.org/show_bug.cgi?id=313866</a>
    <a href="https://rdar.apple.com/180785211">rdar://180785211</a>

    Reviewed by Charlie Wolfe.

    Consider this sequence of events:
    1. A compromised web process schedules a load with its own origin used for
       firstPartyForCookies.
    2. NetworkConnectionToWebProcess::scheduleResourceLoad() is called and the
       message check passes.
    3. The request goes through and the server responds with 302 (redirect).
    4. NetworkResourceLoader::continueWillSendRedirectedRequest() calls
       WebResourceLoader::WillSendRequest() which gives the web process the chance
       to alter the request that will be sent to perform the redirect.
    5. The compromised web process alters the request so that firstPartyForCookies
       is now a different origin.
    6. NetworkResourceLoader::continueWillSendRequest() receives this altered
       request and passes it off to CFNetwork.
    7. The result of this request is that the compromised web process receives
       the cookies of this different origin.

    There are multiple callsites of continueWillSendRequest(), but only one place
    which allows the web process to alter the request before it&apos;s given to
    continueWillSendRequest(). So we fix this by adding a message check right
    before that callsite that will double check that the origin contained in this
    potentially modified request from the web process is in this web process&apos;s
    allowed list. If not, the web process will be killed so that it doesn&apos;t recieve
    the cross-origin cookies.

    We also only do this message check if the web process actually changes the
    origin. This is because there are cases where the origin is not yet in the
    allowlist but not because the web process modified it (like in:
    imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-url.https.html?origin=cross-site-redirect
    where there is a cross-site redirect as part of a prefetch, so the cross-site
    origin is supplied by the server but hasn&apos;t made it into the allow list since
    the navigation to it is not complete).

    When we a previously attempted to add this message check, we found that it
    resulted in users hitting the message check in the wild. Based on the fault logs,
    we speculate that the issue could be:

    1. A network load is scheduled with the keep alive option.
    2. NetworkResourceLoader::continueWillSendRedirectedRequest() sends the IPC
       WebResourceLoader::WillSendRequest().
    3. Before the web process can respond, it exits. So the web process does not
       call the completion handler.
    4. The IPC connection between the network and web process is torn down by
       Connection::dispatchDidCloseAndInvalidate().
    5. This function first calls NetworkProcessConnectionToWebProcess::didClose()
       which keeps the NetworkResourceLoader alive because of the keepalive option
       and removes the web process from m_allowedFirstPartiesForCookies.
    6. Then it calls Connection::invalidate() which calls cancelAsyncReplyHandlers()
       which calls the completionHandler with a default constructed ResourceRequest.
    7. In the completionHandler, the NetworkResourceLoader is alive and the default
       constructed request&apos;s firstPartyForCookies is empty (which doesn&apos;t match the
       likely non-empty stored firstPartyForCookiesFromRedirectRequest), so we
       proceed to the check. Since the web process is no longer in
       m_allowedFirstPartiesForCookies, allowsFirstPartyForCookies returns Disallow
       and the message check is hit.

    So if the completionHandler is called because of the web process exiting (and
    thus the connection being torn down), we early return before doing the check.

    We also early return in the case where WebResourceLoader::willSendRequest()
    responds with a default constucted ResourceRequest if there is no coreLoader.

    * Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
    (WebKit::NetworkResourceLoader::continueWillSendRedirectedRequest):

    Identifier: 305413.1058@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/317582@main">https://commits.webkit.org/317582@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/87b56cdd5078dfac29f4b5b8e40380f019a177ed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175638 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49571 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43354 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185230 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a272b359-7229-44b5-a18a-83b67f1072a7) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50863 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49253 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136766 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1b579d43-132e-4878-9f51-31a304e6c569) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178594 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40205 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157544 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117244 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7abf2f6b-ecc4-4a93-8a15-c8cf36f79761) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38847 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37222 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149266 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37036 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33700 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41262 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41428 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187650 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49238 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145745 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39228 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49918 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33660 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145583 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40392 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122113 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115939 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48425 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12013 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47827 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48059 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47884 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->