### PR TITLE
[GFC] Add a columns-only fast path for intrinsic width computation

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
@@ -319,7 +319,13 @@ GridFormattingContext::IntrinsicWidths GridFormattingContext::computeIntrinsicWi
         // Clone items per scenario since the placement and sizing algorithm consumes them.
         auto unplacedGridItemsForScenario = unplacedGridItems;
 
-        return GridLayout { *this }.layout(unplacedGridItemsForScenario, layoutState).usedTrackSizes.columnSizes;
+        // When no grid item's inline contribution depends on its own block size, the column sizes are
+        // final after step 1 of the grid sizing algorithm, so ask GridLayout for that step alone.
+        auto scope = m_intrinsicWidthSizingPath == IntrinsicWidthSizingPath::ColumnsOnly
+            ? GridLayoutScope::ColumnSizingOnly
+            : GridLayoutScope::Full;
+
+        return GridLayout { *this }.layout(unplacedGridItemsForScenario, layoutState, scope).usedTrackSizes.columnSizes;
     };
 
     TrackSizes minContentColumnSizes = columnSizesForConstraint(AxisConstraint::minContent());

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
@@ -204,7 +204,7 @@ static GridAreaSizes computeGridAreaSizes(const PlacedGridItems& gridItems, cons
 }
 
 // https://drafts.csswg.org/css-grid-1/#layout-algorithm
-GridLayoutResult GridLayout::layout(UnplacedGridItems& unplacedGridItems, const GridLayoutState& gridLayoutState)
+GridLayoutResult GridLayout::layout(UnplacedGridItems& unplacedGridItems, const GridLayoutState& gridLayoutState, GridLayoutScope scope)
 {
     auto& gridDefinition = gridLayoutState.gridDefinition;
     auto& gridTemplateColumnsTrackSizes = gridDefinition.gridTemplateColumns.sizes;
@@ -217,6 +217,16 @@ GridLayoutResult GridLayout::layout(UnplacedGridItems& unplacedGridItems, const 
 
     auto columnTrackSizingFunctionsList = trackSizingFunctions(columnsCount, gridTemplateColumnsTrackSizes, gridDefinition.gridAutoColumns);
     auto rowTrackSizingFunctionsList = trackSizingFunctions(rowsCount, gridTemplateRowsTrackSizes, gridDefinition.gridAutoRows);
+
+    // https://drafts.csswg.org/css-grid-1/#algo-grid-sizing
+    // Fast path: the caller only needs the column sizes resolved by step 1 of the grid sizing
+    // algorithm (e.g. intrinsic width computation where no grid item's inline contribution depends
+    // on its block size). Steps 2-4 cannot change the column sizes, so size the columns alone and
+    // skip row sizing, grid-item layout, and alignment.
+    if (scope == GridLayoutScope::ColumnSizingOnly) {
+        TrackSizes columnSizes = sizeColumnTracks(placedGridItems, columnTrackSizingFunctionsList, rowTrackSizingFunctionsList, gridLayoutState);
+        return { { columnSizes, { } }, { } };
+    }
 
     // 2. FIXME: Find the size of the grid container.
 

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
@@ -58,11 +58,16 @@ struct GridLayoutResult {
     GridItemRects gridItemRects;
 };
 
+enum class GridLayoutScope : bool {
+    Full, // Run the whole grid sizing algorithm, lay out the grid items, and align them.
+    ColumnSizingOnly // Run only the first step of the grid sizing algorithm (size the columns); skip row sizing, grid-item layout, and alignment.
+};
+
 class GridLayout {
 public:
     GridLayout(const GridFormattingContext&);
 
-    GridLayoutResult layout(UnplacedGridItems&, const GridLayoutState&);
+    GridLayoutResult layout(UnplacedGridItems&, const GridLayoutState&, GridLayoutScope = GridLayoutScope::Full);
 
 private:
 


### PR DESCRIPTION
#### ac8f2d360bbdd3aff75e5df8666ea6a4280d4576
<pre>
[GFC] Add a columns-only fast path for intrinsic width computation
<a href="https://bugs.webkit.org/show_bug.cgi?id=319294">https://bugs.webkit.org/show_bug.cgi?id=319294</a>
&lt;<a href="https://rdar.apple.com/182131247">rdar://182131247</a>&gt;

Reviewed by Sammy Gill.

GridFormattingContext::computeIntrinsicWidths() only needs the grid&apos;s
column track sizes, but it obtained them by running the full grid layout
(GridLayout::layout) once per intrinsic scenario. That full path also
sizes the rows, lays out every grid item, and computes margins,
alignment, and item rects — all of which are discarded when only the
column sizes are read.

Not all of the work needs to be done for every grid layout. A grid with items
that do not depend on their block size when computing inline contributions
does not require all of layout, and we can instead finish with just the first step
of the grid sizing algorithm.

Spec:

<a href="https://www.w3.org/TR/css-grid-2/#algo-grid-sizing">https://www.w3.org/TR/css-grid-2/#algo-grid-sizing</a>

See also:

<a href="https://commits.webkit.org/317063@main">https://commits.webkit.org/317063@main</a>

* Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp:
(WebCore::Layout::GridFormattingContext::computeIntrinsicWidths):
* Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp:
(WebCore::Layout::GridLayout::layout):
* Source/WebCore/layout/formattingContexts/grid/GridLayout.h:

Canonical link: <a href="https://commits.webkit.org/317187@main">https://commits.webkit.org/317187@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/74ffafbd1218427133a140349b3ac3f471090e79

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174416 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48349 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42130 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183993 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132284 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/44bb287d-5d50-43a0-99f4-03adfac255c0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176281 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49641 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48031 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135680 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95736 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b5cd3c87-5896-40a0-bda8-912169e50779) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177374 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39115 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156474 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116158 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b280282f-15f3-4f5e-976b-70c1912eb9d7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37756 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36125 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32474 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148179 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35966 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186419 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39637 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40322 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144593 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48016 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144451 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48695 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32586 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114251 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26528 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39352 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120648 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47202 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10930 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46604 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46835 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46662 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->