### PR TITLE
Clean up JS Temporal getNamedTimeZoneEpochNanoseconds

### DIFF
--- a/JSTests/microbenchmarks/temporal-zoned-date-time-from-named-time-zone.js
+++ b/JSTests/microbenchmarks/temporal-zoned-date-time-from-named-time-zone.js
@@ -1,0 +1,34 @@
+//@ requireOptions("--useTemporal=1")
+
+// Perf/regression benchmark for getNamedTimeZoneEpochNanoseconds
+// (TimeZoneICUBridge.cpp), the local-wall-clock -> epoch resolver for named IANA
+// zones that was rewritten to use ucal_getTimeZoneOffsetFromLocal.
+//
+// The base ZonedDateTimes are built once, outside the timed loop, so the loop
+// body is dominated by the inverse resolution rather than by property-bag
+// parsing and allocation. ZonedDateTime.with re-resolves the modified local
+// wall-clock time to an epoch (interpretISODateTimeOffset ->
+// getPossibleEpochNanosecondsFor -> getNamedTimeZoneEpochNanoseconds) on every
+// call. A named zone forces the ICU path; UTC/offset zones bypass it via the
+// isUTCOffset() fast path. The `minute` is varied per iteration so every call is
+// a distinct local time and no input-keyed result caching can turn this into a
+// no-op guard.
+const timeZone = "America/Vancouver";
+const cases = [
+    { year: 2024, month: 7,  day: 15, hour: 12, minute: 30, timeZone }, // normal (DST)
+    { year: 2024, month: 1,  day: 15, hour: 12, minute: 30, timeZone }, // normal (standard)
+    { year: 2024, month: 11, day: 3,  hour: 1,  minute: 30, timeZone }, // fall-back fold
+    { year: 2024, month: 3,  day: 10, hour: 3,  minute: 30, timeZone }, // day of spring-forward
+];
+const zdts = cases.map(c => Temporal.ZonedDateTime.from(c, { disambiguation: "compatible" }));
+
+let acc = 0n;
+for (var i = 0; i < 1e4; ++i) {
+    for (var j = 0; j < zdts.length; ++j) {
+        const zdt = zdts[j].with({ minute: i % 60 }); // re-resolves local->epoch each call
+        acc += zdt.epochNanoseconds;                  // read result so it can't be DCE'd
+    }
+}
+
+if (acc === 0n)
+    throw "Bad result: " + acc;

--- a/Source/JavaScriptCore/runtime/temporal/core/TimeZoneICUBridge.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/TimeZoneICUBridge.cpp
@@ -217,29 +217,13 @@ TemporalResult<ISO8601::PlainDateTime> getISODateTimeFor(const TimeZone& timeZon
     return exactTimeToLocalDateAndTime(epochNs, *offsetResult);
 }
 
-// tryPreLMTFallback — workaround for ICU4C snapping pre-first-transition dates to the wrong year.
-// icu4x: transition_offset_at (utils/zoneinfo64/src/lib.rs) correctly uses type_offsets[0] for pre-transition dates.
-// NOTE: ICU4C ucal_setDateTime snaps to the first recorded year (e.g. 1884 for America/Vancouver); this detects that gap and queries the correct LMT offset.
-static std::optional<double> tryPreLMTFallback(UCalendar* calendar, double localMs, double icuEpochMs)
-{
-    const double oneDayMs = 86'400'000.0; // nsPerDay / nsPerMillisecond
-    if (std::abs(icuEpochMs - localMs) <= oneDayMs)
-        return std::nullopt;
-
-    auto lmtOffsetMs = getOffsetMsAtEpoch(calendar, localMs);
-    if (!lmtOffsetMs)
-        return std::nullopt;
-
-    double fallbackEpochMs = localMs - static_cast<double>(*lmtOffsetMs);
-    auto fallbackOffset = getOffsetMsAtEpoch(calendar, fallbackEpochMs);
-    if (!fallbackOffset || (fallbackEpochMs + static_cast<double>(*fallbackOffset) != localMs))
-        return std::nullopt;
-
-    return fallbackEpochMs;
-}
-
 // getNamedTimeZoneEpochNanoseconds — ICU4C implementation of the implementation-defined AO
 // https://tc39.es/proposal-temporal/#sec-getnamedtimezoneepochnanoseconds
+// NOTE: Uses ucal_getTimeZoneOffsetFromLocal (ICU 69+), which resolves a local wall-clock time
+// to its UTC offset(s) directly, with explicit control over the gap (nonExistingTimeOpt) and
+// fold (duplicatedTimeOpt) cases. Querying the FORMER (pre-transition) and LATTER (post-transition)
+// interpretations yields the two bracket offsets, from which normal/gap/fold follow arithmetically.
+// This replaces the previous ucal_setDateTime + transition-probing + pre-LMT-fallback approach.
 static TemporalResult<PossibleEpochNanoseconds> getNamedTimeZoneEpochNanoseconds(const TimeZone& timeZone, const ISO8601::PlainDate& date, const ISO8601::PlainTime& time)
 {
     // NOTE: Sub-ms fields are added back after ms-level computation; offset changes occur at ≥second granularity.
@@ -257,143 +241,49 @@ static TemporalResult<PossibleEpochNanoseconds> getNamedTimeZoneEpochNanoseconds
             return ISO8601::ExactTime(base.epochNanoseconds() + subMs);
         };
 
-        // Set ICU calendar to local date+time. ICU months are 0-indexed.
-        // Explicitly set UCAL_MILLISECOND to avoid retaining a stale field (ucal_setDateTime does not set ms).
+        // Store the naive local epoch as the calendar's time value. ucal_getTimeZoneOffsetFromLocal
+        // reinterprets that stored value as wall-clock (local) time. IMPORTANT: do NOT use
+        // ucal_setDateTime here — it would apply ICU's own disambiguation and store a resolved UTC
+        // instant, which is not what getTimeZoneOffsetFromLocal expects to read.
         UErrorCode status = U_ZERO_ERROR;
-        ucal_setDateTime(cal,
-            date.year(), static_cast<int32_t>(date.month()) - 1, date.day(),
-            time.hour(), time.minute(), time.second(),
-            &status);
+        ucal_setMillis(cal, localMs, &status);
         if (U_FAILURE(status)) [[unlikely]]
             return makeUnexpected(rangeError(icuSetCalendarFailed));
-        ucal_set(cal, UCAL_MILLISECOND, time.millisecond());
 
-        // ICU resolves the local time to one epoch (its "default" interpretation).
-        double icuEpochMs = ucal_getMillis(cal, &status);
-        if (U_FAILURE(status)) [[unlikely]]
-            return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
+        // Query both interpretations of the local time. Away from any transition they are equal.
+        //   FORMER = offset in effect before a nearby transition, LATTER = offset after it.
+        auto offsetMsFor = [&](UTimeZoneLocalOption opt) -> std::optional<int64_t> {
+            UErrorCode s = U_ZERO_ERROR;
+            int32_t rawOffset = 0;
+            int32_t dstOffset = 0;
+            ucal_getTimeZoneOffsetFromLocal(cal, opt, opt, &rawOffset, &dstOffset, &s);
+            if (U_FAILURE(s)) [[unlikely]]
+                return std::nullopt;
+            return static_cast<int64_t>(rawOffset) + static_cast<int64_t>(dstOffset);
+        };
 
-        auto icuOffsetMs = getOffsetMsAtEpoch(cal, icuEpochMs);
-        if (!icuOffsetMs)
+        auto before = offsetMsFor(UCAL_TZ_LOCAL_FORMER);
+        auto after = offsetMsFor(UCAL_TZ_LOCAL_LATTER);
+        if (!before || !after) [[unlikely]]
             return makeUnexpected(rangeError(icuTimeZoneOffsetFailed));
 
-        // If icuEpoch + offset ≠ localMs the local time is in a DST gap (spring-forward).
-        bool icuValid = (icuEpochMs + static_cast<double>(*icuOffsetMs) == localMs);
-        if (!icuValid) {
-            if (auto fallbackMs = tryPreLMTFallback(cal, localMs, icuEpochMs))
-                return PossibleEpochNanoseconds { makeExactTime(*fallbackMs) };
+        constexpr int64_t nsPerMs = static_cast<int64_t>(ISO8601::ExactTime::nsPerMillisecond);
 
-            // Gap: store bracket offsets in GapOffsets so disambiguate needs no extra ICU calls.
-            // afterNs = post-transition offset (= the ICU-resolved offset at the gap).
-            int64_t afterNs = static_cast<int64_t>(*icuOffsetMs) * static_cast<int64_t>(ISO8601::ExactTime::nsPerMillisecond);
-            // beforeNs = pre-transition offset (find via previous transition or 1-day probe fallback).
-            int64_t beforeNs = afterNs;
-            {
-                ucal_setMillis(cal, icuEpochMs, &status);
-                if (U_FAILURE(status)) [[unlikely]]
-                    return makeUnexpected(rangeError(icuTimeZoneOffsetFailed));
+        // Normal: a single offset is in force → exactly one instant.
+        if (*before == *after)
+            return PossibleEpochNanoseconds { makeExactTime(localMs - static_cast<double>(*before)) };
 
-                UDate transitionMs = 0;
-                // icuEpochMs can be the exact transition instant. UCAL_TZ_TRANSITION_PREVIOUS_INCLUSIVE is including icuEpochMs's instant itself.
-                // We use it instead of UCAL_TZ_TRANSITION_PREVIOUS as it is not including icuEpochMs itself.
-                auto result = ucal_getTimeZoneTransitionDate(cal, UCAL_TZ_TRANSITION_PREVIOUS_INCLUSIVE, &transitionMs, &status);
-                if (U_FAILURE(status)) [[unlikely]]
-                    return makeUnexpected(rangeError(icuTimeZoneOffsetFailed));
+        // Offset jumped up (spring-forward) → the local time is skipped (gap): no instant maps here.
+        // Hand the bracket offsets to the disambiguator, preserving the prior GapOffsets contract
+        // (disambiguate: earlier = naiveNs − afterNs; later/compatible = naiveNs − beforeNs).
+        if (*after > *before)
+            return PossibleEpochNanoseconds { GapOffsets { *before * nsPerMs, *after * nsPerMs } };
 
-                if (result) {
-                    auto preOffset = getOffsetMsAtEpoch(cal, transitionMs - 1.0);
-                    if (preOffset)
-                        beforeNs = static_cast<int64_t>(*preOffset) * static_cast<int64_t>(ISO8601::ExactTime::nsPerMillisecond);
-                }
-                if (beforeNs == afterNs) {
-                    constexpr int64_t nsPerDay = 86'400'000'000'000LL;
-                    Int128 naiveNs = static_cast<Int128>(localMs) * ISO8601::ExactTime::nsPerMillisecond + subMs;
-                    // Inline getOffsetNanosecondsFor — avoids recursive withTimeZone call which would deadlock.
-                    double probeEpochMs = static_cast<double>(static_cast<int64_t>((naiveNs - Int128(nsPerDay)) / static_cast<int64_t>(ISO8601::ExactTime::nsPerMillisecond)));
-                    auto probeOffset = getOffsetMsAtEpoch(cal, probeEpochMs);
-                    if (probeOffset)
-                        beforeNs = static_cast<int64_t>(*probeOffset) * static_cast<int64_t>(ISO8601::ExactTime::nsPerMillisecond);
-                }
-            }
-            return PossibleEpochNanoseconds { GapOffsets { beforeNs, afterNs } };
-        }
-
-        auto primaryCandidate = makeExactTime(icuEpochMs);
-
-        // Check for a second candidate (DST fold) via nearest transition boundary.
-        // 25 hours covers all known IANA single-step transitions including 24-hour date-line crossings.
-        const double maxFoldWindowMs = 90'000'000.0; // 25 hours in ms
-        std::optional<ISO8601::ExactTime> secondCandidate;
-
-        auto tryFoldFromTransition = [&](UTimeZoneTransitionType transType) -> bool {
-            UErrorCode status = U_ZERO_ERROR;
-            ucal_setMillis(cal, icuEpochMs, &status);
-            if (U_FAILURE(status)) [[unlikely]]
-                return false;
-            UDate transitionMs = 0;
-            auto result = ucal_getTimeZoneTransitionDate(cal, transType, &transitionMs, &status);
-            if (U_FAILURE(status)) [[unlikely]]
-                return false;
-            if (!result)
-                return false;
-            if (std::abs(transitionMs - icuEpochMs) > maxFoldWindowMs)
-                return false;
-            double otherSideMs = (transType == UCAL_TZ_TRANSITION_PREVIOUS)
-                ? transitionMs - 1.0
-                : transitionMs + 1.0;
-            auto otherOffset = getOffsetMsAtEpoch(cal, otherSideMs);
-            if (!otherOffset || *otherOffset == *icuOffsetMs)
-                return false;
-            double probe = localMs - static_cast<double>(*otherOffset);
-            if (probe == icuEpochMs)
-                return false;
-            auto verifyOffset = getOffsetMsAtEpoch(cal, probe);
-            if (!verifyOffset || *verifyOffset != *otherOffset)
-                return false;
-            secondCandidate = makeExactTime(probe);
-            return true;
-        };
-
-        if (!tryFoldFromTransition(UCAL_TZ_TRANSITION_PREVIOUS))
-            tryFoldFromTransition(UCAL_TZ_TRANSITION_NEXT);
-
-        // ICU quirk: retry from 1ms later to catch transition-boundary fold case.
-        if (!secondCandidate) {
-            auto tryFoldFromOffset = [&](double probeEpochMs) -> bool {
-                UErrorCode status = U_ZERO_ERROR;
-                ucal_setMillis(cal, probeEpochMs, &status);
-                if (U_FAILURE(status)) [[unlikely]]
-                    return false;
-                UDate transitionMs = 0;
-                auto result = ucal_getTimeZoneTransitionDate(cal, UCAL_TZ_TRANSITION_PREVIOUS, &transitionMs, &status);
-                if (U_FAILURE(status)) [[unlikely]]
-                    return false;
-                if (!result)
-                    return false;
-                if (std::abs(transitionMs - icuEpochMs) > maxFoldWindowMs)
-                    return false;
-            auto otherOffset = getOffsetMsAtEpoch(cal, transitionMs - 1.0);
-            if (!otherOffset || *otherOffset == *icuOffsetMs)
-                return false;
-            double probe = localMs - static_cast<double>(*otherOffset);
-            if (probe == icuEpochMs)
-                return false;
-            auto verifyOffset = getOffsetMsAtEpoch(cal, probe);
-            if (!verifyOffset || *verifyOffset != *otherOffset)
-                return false;
-            secondCandidate = makeExactTime(probe);
-            return true;
-        };
-        tryFoldFromOffset(icuEpochMs + 1.0);
-    }
-
-        if (!secondCandidate)
-            return PossibleEpochNanoseconds { primaryCandidate };
-
-        ISO8601::ExactTime earlier = primaryCandidate;
-        ISO8601::ExactTime later = *secondCandidate;
-        if (earlier.epochNanoseconds() > later.epochNanoseconds())
-            std::swap(earlier, later);
+        // Offset jumped down (fall-back) → the local time occurs twice (fold).
+        // earlier uses the larger (pre-transition) offset; later uses the smaller (post-transition).
+        ISO8601::ExactTime earlier = makeExactTime(localMs - static_cast<double>(*before));
+        ISO8601::ExactTime later = makeExactTime(localMs - static_cast<double>(*after));
+        ASSERT(earlier.epochNanoseconds() <= later.epochNanoseconds());
         return PossibleEpochNanoseconds { std::array<ISO8601::ExactTime, 2> { earlier, later } };
     }); // withTimeZone
 }


### PR DESCRIPTION
#### df073f7df0ffd5ca628c52d47943c54cad3d5cd9
<pre>
Clean up JS Temporal getNamedTimeZoneEpochNanoseconds
<a href="https://bugs.webkit.org/show_bug.cgi?id=319296">https://bugs.webkit.org/show_bug.cgi?id=319296</a>
<a href="https://rdar.apple.com/182132863">rdar://182132863</a>

Reviewed by Yijia Huang and Yusuke Suzuki.

getNamedTimeZoneEpochNanoseconds makes a number of ICU calls which could
be reduced by invoking ICU function ucal_getTimeZoneOffsetFromLocal to
deal with time zone offsets. New JSTests/ microbenchmark appears
performance neutral.

                                                     ToT                     Patched

temporal-zoned-date-time-from-named-time-zone  19.3681+-0.0994           19.3105+-0.0791
&lt;geometric&gt;                                    19.3681+-0.0994           19.3105+-0.0791          might be 1.0030x faster

* JSTests/microbenchmarks/temporal-zoned-date-time-from-named-time-zone.js: Added.
* Source/JavaScriptCore/runtime/temporal/core/TimeZoneICUBridge.cpp:

Canonical link: <a href="https://commits.webkit.org/317723@main">https://commits.webkit.org/317723@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca9362c0fcdd346c9df032987e623eee16e09fe0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175943 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49876 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43660 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185536 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ebe68ba2-d52a-4a63-b28e-a495c5d70dce) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51168 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49558 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137012 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ca9c6123-4ce1-4fca-88aa-c8e6ab4ceb37) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178899 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40484 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157791 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117491 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/71f6cb56-4178-4896-aba0-b35d5dd2801f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39126 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37501 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/6300 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149545 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37283 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34006 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/37207 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41576 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41707 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187958 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49543 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146017 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39327 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50223 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33908 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145855 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40640 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122419 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116296 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48730 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12264 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48132 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48364 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48189 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->