### PR TITLE
[css-values-5 random-item()] Share <random-key> parsing between random() and random-item()

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-computed-expected.txt
@@ -27,4 +27,7 @@ PASS random-item() selection is stable across style recalculation
 PASS Independent auto random-item() instances each resolve to a valid item
 PASS A shared dashed-ident key selects the same item across properties
 PASS random() and random-item() using auto in one declaration both resolve
+PASS A bare element-scoped key selects the same item across random-item() instances
+PASS random() and random-item() share the base value for a bare element-scoped key
+PASS Property color value 'random-item(--, rgb(1, 0, 0), rgb(0, 1, 0))'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-computed.html
@@ -130,5 +130,32 @@ test(() => {
     assert_in_array(getComputedStyle(target).getPropertyValue('--i').trim(), ['1px', '2px', '3px']);
 }, 'random() and random-item() using auto in one declaration both resolve');
 
+// A bare element-scoped key (no <dashed-ident>) is a null-named key, not a per-instance auto key, so
+// two element-scoped random-item()s with the same list select the same item. This matches random()'s
+// element-scoped keying (both parse <random-key> through the same consumer).
+test(() => {
+    const target = document.getElementById('target');
+    const items = '5px, 15px, 25px, 35px, 45px';
+    target.style.cssText = `--length: random-item(element-scoped, ${items}); --length2: random-item(element-scoped, ${items});`;
+    const a = getComputedStyle(target).getPropertyValue('--length').trim();
+    const b = getComputedStyle(target).getPropertyValue('--length2').trim();
+    assert_equals(b, a, 'element-scoped selects the same item for the same list');
+}, 'A bare element-scoped key selects the same item across random-item() instances');
+
+// random() and random-item() share a base value for the same bare element-scoped key. With
+// width == R * 500px and items 0..400 by 100, random-item() selects index floor(R * 5), whose value
+// is floor(width / 100) * 100. Equality proves both functions resolve the same element-scoped key.
+test(() => {
+    const target = document.getElementById('target');
+    target.style.cssText = 'width: random(element-scoped, 0px, 500px); margin-left: random-item(element-scoped, 0px, 100px, 200px, 300px, 400px);';
+    const w = parseFloat(getComputedStyle(target).width);
+    const m = parseFloat(getComputedStyle(target).marginLeft);
+    assert_equals(m, Math.min(400, Math.floor(w / 100) * 100), 'random() and random-item() share the element-scoped base value');
+}, 'random() and random-item() share the base value for a bare element-scoped key');
+
+// A <dashed-ident> as short as "--" is a valid key (parity with random()); the value resolves rather
+// than becoming guaranteed-invalid.
+test_computed_value('color', 'random-item(--, rgb(1, 0, 0), rgb(0, 1, 0))', ['rgb(1, 0, 0)', 'rgb(0, 1, 0)']);
+
 </script>
 

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -974,6 +974,7 @@ css/CSSPropertyInitialValues.cpp
 css/CSSPropertyRule.cpp
 css/CSSPropertySourceData.cpp
 css/CSSQuotesValue.cpp
+css/CSSRandomKeyParser.cpp
 css/CSSRatioValue.cpp
 css/CSSRayValue.cpp
 css/CSSRegisteredCounterStyle.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -20344,6 +20344,8 @@
 		BCB9C3382FC37CA800BA905E /* CSSQuotes.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CSSQuotes.cpp; sourceTree = "<group>"; };
 		BCB9C3392FC37DBE00BA905E /* CSSQuotesValue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CSSQuotesValue.h; sourceTree = "<group>"; };
 		BCB9C33A2FC37DBE00BA905E /* CSSQuotesValue.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CSSQuotesValue.cpp; sourceTree = "<group>"; };
+		3F793C53E2BC4B55A7DD92A6 /* CSSRandomKeyParser.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CSSRandomKeyParser.cpp; sourceTree = "<group>"; };
+		E726A03F07434F85BA54EB90 /* CSSRandomKeyParser.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CSSRandomKeyParser.h; sourceTree = "<group>"; };
 		BCBB8AB513F1AFB000734DF0 /* PODInterval.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PODInterval.h; sourceTree = "<group>"; };
 		BCBB8AB613F1AFB000734DF0 /* PODIntervalTree.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PODIntervalTree.h; sourceTree = "<group>"; };
 		BCBB8AB713F1AFB000734DF0 /* PODRedBlackTree.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PODRedBlackTree.h; sourceTree = "<group>"; };
@@ -41885,6 +41887,8 @@
 				491342962B425C0100FEEF18 /* CSSPseudoSelectors.json */,
 				BCB9C33A2FC37DBE00BA905E /* CSSQuotesValue.cpp */,
 				BCB9C3392FC37DBE00BA905E /* CSSQuotesValue.h */,
+				3F793C53E2BC4B55A7DD92A6 /* CSSRandomKeyParser.cpp */,
+				E726A03F07434F85BA54EB90 /* CSSRandomKeyParser.h */,
 				CAE9F90D146441F000C245B0 /* CSSRatioValue.cpp */,
 				CAE9F90E146441F000C245B0 /* CSSRatioValue.h */,
 				66007A0127444CE200946C9B /* CSSRayValue.cpp */,

--- a/Source/WebCore/css/CSSRandomKeyParser.cpp
+++ b/Source/WebCore/css/CSSRandomKeyParser.cpp
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CSSRandomKeyParser.h"
+
+#include "CSSParserTokenRange.h"
+#include "CSSParserTokenRangeGuard.h"
+#include "CSSPropertyParserConsumer+Ident.h"
+#include "CSSPropertyParserConsumer+MetaConsumer.h"
+#include "CSSPropertyParserConsumer+NumberDefinitions.h"
+#include "CSSPropertyParserState.h"
+#include "CSSValueKeywords.h"
+#include <wtf/StdLibExtras.h>
+
+namespace WebCore {
+namespace CSSPropertyParserHelpers {
+
+std::optional<CSSCalc::Random::Sharing> consumeUnresolvedRandomKey(CSSParserTokenRange& tokens, CSS::PropertyParserState& state, NOESCAPE const Function<CSSCalc::RandomSharingOptions::Auto()>& makeAuto)
+{
+    // <random-key> = auto | <random-cache-key> | fixed <number [0,1]>
+    // <random-cache-key> = <dashed-ident> || element-scoped || [ property-scoped | property-index-scoped | <random-ua-ident> ]
+
+    if (tokens.peek().id() == CSSValueFixed) {
+        CSSParserTokenRangeGuard guard { tokens };
+
+        tokens.consumeIncludingWhitespace();
+
+        // Use a non-property parsing state for the fixed number value to disconnect it from the current parse.
+        // FIXME: Add a mechanism to pass along the depth count when doing this so that we can limit stack usage.
+        // FIXME: This should probably maintain the `cssRandomFunctionCount` state from the current state to allow for random() functions nested in the <number> or should document why this is not necessary.
+        auto numberParsingState = CSS::PropertyParserState {
+            .context = state.context,
+            .pool = state.pool,
+            .absoluteLengthUnitsOnly = state.absoluteLengthUnitsOnly
+        };
+
+        auto number = MetaConsumer<CSS::Number<CSS::ClosedUnitRange>>::consume(tokens, numberParsingState);
+        if (!number)
+            return { };
+
+        guard.commit();
+
+        return CSSCalc::Random::Sharing { CSSCalc::Random::SharingFixed { .value = WTF::move(*number) } };
+    }
+
+    std::optional<Variant<CSSCalc::RandomSharingOptions::Auto, CSS::CustomIdent>> identifier;
+    std::optional<CSS::Keyword::ElementScoped> elementScoped;
+
+    CSSParserTokenRangeGuard guard { tokens };
+
+    auto consumeIdentifier = [&] -> bool {
+        if (identifier)
+            return false;
+        if (tokens.peek().id() == CSSValueAuto) {
+            tokens.consumeIncludingWhitespace();
+            identifier = makeAuto();
+            return true;
+        }
+        if (auto dashedIdent = consumeUnresolvedDashedIdent(tokens, state)) {
+            identifier = WTF::move(*dashedIdent);
+            return true;
+        }
+        return false;
+    };
+    auto consumeElementScoped = [&] -> bool {
+        if (elementScoped)
+            return false;
+        if (tokens.peek().id() == CSSValueElementScoped) {
+            tokens.consumeIncludingWhitespace();
+            elementScoped = CSS::Keyword::ElementScoped { };
+            return true;
+        }
+        return false;
+    };
+
+    for (unsigned i = 0; i < 2; ++i) {
+        if (consumeIdentifier() || consumeElementScoped())
+            continue;
+        break;
+    }
+
+    if (!identifier && !elementScoped)
+        return { };
+
+    guard.commit();
+
+    return CSSCalc::Random::Sharing { CSSCalc::Random::SharingOptions {
+        .identifier = identifier.value_or(CSS::CustomIdent { nullAtom() }),
+        .elementScoped = elementScoped
+    } };
+}
+
+CSSCalc::RandomSharingOptions::Auto autoRandomSharingKey(const CSS::PropertyParserState& state)
+{
+    return {
+        .property = state.currentProperty,
+        .index = state.cssRandomFunctionCount
+    };
+}
+
+} // namespace CSSPropertyParserHelpers
+} // namespace WebCore

--- a/Source/WebCore/css/CSSRandomKeyParser.h
+++ b/Source/WebCore/css/CSSRandomKeyParser.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSCalcTree.h"
+#include <optional>
+#include <wtf/Compiler.h>
+#include <wtf/Function.h>
+
+namespace WebCore {
+
+class CSSParserTokenRange;
+
+namespace CSS {
+struct PropertyParserState;
+}
+
+namespace CSSPropertyParserHelpers {
+
+// <random-key> = auto | <random-cache-key> | fixed <number [0,1]>
+// <random-cache-key> = <dashed-ident> || element-scoped || [ property-scoped | property-index-scoped | <random-ua-ident> ]
+// https://drafts.csswg.org/css-values-5/#random-caching
+//
+// property-scoped / property-index-scoped / <random-ua-ident> are not yet supported by this consumer; only the
+// subset needed by random() and random-item() ([ [ auto | <dashed-ident> ] || element-scoped ] | fixed <number [0,1]>)
+// is parsed. `makeAuto` is called (at most once) to produce the caching key used for `auto`, letting callers pick
+// their own auto-index scheme (e.g. parse-time vs. substitution-time counters).
+std::optional<CSSCalc::Random::Sharing> consumeUnresolvedRandomKey(CSSParserTokenRange&, CSS::PropertyParserState&, NOESCAPE const Function<CSSCalc::RandomSharingOptions::Auto()>& makeAuto);
+
+CSSCalc::RandomSharingOptions::Auto autoRandomSharingKey(const CSS::PropertyParserState&);
+
+} // namespace CSSPropertyParserHelpers
+} // namespace WebCore

--- a/Source/WebCore/css/calc/CSSCalcTree+Evaluation.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Evaluation.cpp
@@ -235,6 +235,28 @@ std::optional<double> evaluate(const IndirectNode<Tan>& root, const EvaluationOp
     return evaluateTrig(root, options);
 }
 
+std::optional<double> resolveRandomBaseValue(const Random::Sharing& sharing, Style::BuilderState& builderState)
+{
+    return WTF::switchOn(sharing,
+        [&](const Random::SharingOptions& sharingOptions) -> std::optional<double> {
+            if (sharingOptions.elementScoped.has_value() && !builderState.element())
+                return { };
+
+            return WTF::switchOn(sharingOptions.identifier,
+                [&](const Random::SharingOptions::Auto& autoValue) {
+                    return builderState.lookupCSSRandomBaseValue(autoValue, sharingOptions.elementScoped);
+                },
+                [&](const CSS::CustomIdent& customIdent) {
+                    return builderState.lookupCSSRandomBaseValue(Style::toStyle(customIdent, builderState), sharingOptions.elementScoped);
+                }
+            );
+        },
+        [&](const Random::SharingFixed& sharingFixed) -> std::optional<double> {
+            return Style::toStyle(sharingFixed.value, builderState).value;
+        }
+    );
+}
+
 std::optional<double> evaluate(const IndirectNode<Random>& root, const EvaluationOptions& options)
 {
     if (!options.conversionData || !options.conversionData->styleBuilderState())
@@ -254,30 +276,7 @@ std::optional<double> evaluate(const IndirectNode<Random>& root, const Evaluatio
 
     CheckedPtr builderState = options.conversionData->styleBuilderState();
 
-    auto randomBaseValue = WTF::switchOn(root->sharing,
-        [&](const Random::SharingOptions& sharingOptions) -> std::optional<double> {
-            if (sharingOptions.elementScoped.has_value() && !builderState->element())
-                return { };
-
-            return WTF::switchOn(sharingOptions.identifier,
-                [&](const Random::SharingOptions::Auto& autoValue) {
-                    return builderState->lookupCSSRandomBaseValue(
-                        autoValue,
-                        sharingOptions.elementScoped
-                    );
-                },
-                [&](const CSS::CustomIdent& customIdent) {
-                    return builderState->lookupCSSRandomBaseValue(
-                        Style::toStyle(customIdent, *builderState),
-                        sharingOptions.elementScoped
-                    );
-                }
-            );
-        },
-        [&](const Random::SharingFixed& sharingFixed) -> std::optional<double> {
-            return Style::toStyle(sharingFixed.value, *builderState).value;
-        }
-    );
+    auto randomBaseValue = resolveRandomBaseValue(root->sharing, *builderState);
     if (!randomBaseValue)
         return { };
 

--- a/Source/WebCore/css/calc/CSSCalcTree+Evaluation.h
+++ b/Source/WebCore/css/calc/CSSCalcTree+Evaluation.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include "CSSCalcTree.h"
 #include "CSSPrimitiveNumericRange.h"
 #include "CSSToLengthConversionData.h"
 #include <optional>
@@ -32,6 +33,10 @@ namespace WebCore {
 
 namespace CSS {
 enum class Category : uint8_t;
+}
+
+namespace Style {
+class BuilderState;
 }
 
 class CSSCalcSymbolTable;
@@ -57,6 +62,10 @@ struct EvaluationOptions {
 
 std::optional<double> evaluateDouble(const Tree&, const EvaluationOptions&);
 std::optional<double> evaluateWithoutFallback(const Anchor&, const EvaluationOptions&);
+
+// Resolves a random() <random-value-sharing> to its base value in [0, 1] against the builder state.
+// Shared by random()'s evaluation and random-item()'s substitution-time resolution.
+std::optional<double> resolveRandomBaseValue(const Random::Sharing&, Style::BuilderState&);
 
 } // namespace CSSCalc
 } // namespace WebCore

--- a/Source/WebCore/css/calc/CSSCalcTree+Parser.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Parser.cpp
@@ -43,6 +43,7 @@
 #include "CSSPropertyParserConsumer+Primitives.h"
 #include "CSSPropertyParserState.h"
 #include "CSSPropertyParsing.h"
+#include "CSSRandomKeyParser.h"
 #include "CSSSerializationContext.h"
 #include "CSSUnits.h"
 #include "Logging.h"
@@ -655,110 +656,6 @@ static std::optional<TypedChild> consumeRound(CSSParserTokenRange& tokens, int d
     return std::nullopt;
 }
 
-static std::optional<Random::SharingFixed> consumeOptionalRandomSharingFixed(CSSParserTokenRange& tokens, ParserState& state)
-{
-    // <random-value-sharing-fixed> = fixed <number [0,1]>
-
-    ASSERT(tokens.peek().id() == CSSValueFixed);
-
-    CSSParserTokenRangeGuard guard { tokens };
-
-    tokens.consumeIncludingWhitespace();
-
-    // Use a non-property parsing state for the fixed number value to disconnect it from the current parse.
-    // FIXME: Add a mechanism to pass along the depth count when doing this so that we can limit stack usage.
-    // FIXME: This should probably maintain the `cssRandomFunctionCount` state from the current state to allow for random() functions nested in the <number> or should document why this is not necessary.
-    auto numberParsingState = CSS::PropertyParserState {
-        .context = state.propertyParserState.context,
-        .pool = state.propertyParserState.pool,
-        .absoluteLengthUnitsOnly = state.propertyParserState.absoluteLengthUnitsOnly
-    };
-
-    auto number = CSSPropertyParserHelpers::MetaConsumer<CSS::Number<CSS::ClosedUnitRange>>::consume(tokens, numberParsingState);
-    if (!number)
-        return { };
-
-    guard.commit();
-
-    return Random::SharingFixed {
-        .value = WTF::move(*number)
-    };
-}
-
-static Random::SharingOptions::Auto NODELETE makeRandomSharingAuto(ParserState& state)
-{
-    return {
-        .property = state.propertyParserState.currentProperty,
-        .index = state.propertyParserState.cssRandomFunctionCount
-    };
-}
-
-static std::optional<Random::SharingOptions> consumeOptionalRandomSharingOptions(CSSParserTokenRange& tokens, ParserState& state)
-{
-    // <random-value-sharing> = [ auto | <dashed-ident> ] || element-scoped | fixed <number [0,1]>
-
-    std::optional<Variant<Random::SharingOptions::Auto, CSS::CustomIdent>> identifier;
-    std::optional<CSS::Keyword::ElementScoped> elementScoped;
-
-    CSSParserTokenRangeGuard guard { tokens };
-
-    auto consumeIdentifier = [&] -> bool {
-        if (identifier)
-            return false;
-        if (tokens.peek().id() == CSSValueAuto) {
-            tokens.consumeIncludingWhitespace();
-            identifier = makeRandomSharingAuto(state);
-            return true;
-        }
-        if (auto dashedIdent = CSSPropertyParserHelpers::consumeUnresolvedDashedIdent(tokens, state.propertyParserState)) {
-            identifier = WTF::move(*dashedIdent);
-            return true;
-        }
-        return false;
-    };
-    auto consumeElementScoped = [&] -> bool {
-        if (elementScoped)
-            return false;
-        if (tokens.peek().id() == CSSValueElementScoped) {
-            tokens.consumeIncludingWhitespace();
-            elementScoped = CSS::Keyword::ElementScoped { };
-            return true;
-        }
-        return false;
-    };
-
-    for (unsigned i = 0; i < 2; ++i) {
-        if (consumeIdentifier() || consumeElementScoped())
-            continue;
-        break;
-    }
-
-    if (!identifier && !elementScoped)
-        return { };
-
-    guard.commit();
-
-    return Random::SharingOptions {
-        .identifier = identifier.value_or(CSS::CustomIdent { nullAtom() }),
-        .elementScoped = elementScoped
-    };
-}
-
-static std::optional<Random::Sharing> consumeOptionalRandomSharing(CSSParserTokenRange& tokens, ParserState& state)
-{
-    // <random-value-sharing> = [ auto | <dashed-ident> ] || element-scoped | fixed <number [0,1]>
-
-    if (tokens.peek().id() == CSSValueFixed) {
-        if (auto fixed = consumeOptionalRandomSharingFixed(tokens, state))
-            return Random::Sharing { WTF::move(*fixed) };
-        return { };
-    } else {
-        if (auto options = consumeOptionalRandomSharingOptions(tokens, state))
-            return Random::Sharing { WTF::move(*options) };
-        return { };
-    }
-}
-
 static std::optional<TypedChild> consumeRandom(CSSParserTokenRange& tokens, int depth, ParserState& state)
 {
     // <random()> = random( <random-value-sharing>? , <calc-sum>, <calc-sum>, <calc-sum>? )
@@ -778,7 +675,7 @@ static std::optional<TypedChild> consumeRandom(CSSParserTokenRange& tokens, int 
     using Op = Random;
 
     std::optional<Random::Sharing> sharing;
-    if (auto optionalSharing = consumeOptionalRandomSharing(tokens, state)) {
+    if (auto optionalSharing = CSSPropertyParserHelpers::consumeUnresolvedRandomKey(tokens, state.propertyParserState, [&] { return CSSPropertyParserHelpers::autoRandomSharingKey(state.propertyParserState); })) {
         if (!CSSPropertyParserHelpers::consumeCommaIncludingWhitespace(tokens)) {
             LOG_WITH_STREAM(Calc, stream << "Failed '" << nameLiteralForSerialization(Op::id) << "' function - missing comma after <random-value-sharing>");
             return { };
@@ -787,7 +684,7 @@ static std::optional<TypedChild> consumeRandom(CSSParserTokenRange& tokens, int 
         sharing = WTF::move(optionalSharing);
     } else {
         sharing = Random::SharingOptions {
-            .identifier = makeRandomSharingAuto(state),
+            .identifier = CSSPropertyParserHelpers::autoRandomSharingKey(state.propertyParserState),
             .elementScoped = CSS::Keyword::ElementScoped { },
         };
     }

--- a/Source/WebCore/style/StyleSubstitutionResolver.cpp
+++ b/Source/WebCore/style/StyleSubstitutionResolver.cpp
@@ -26,17 +26,16 @@
 #include "config.h"
 #include "StyleSubstitutionResolver.h"
 
-#include "CSSCalcRandomCachingKey.h"
+#include "CSSCalcTree+Evaluation.h"
 #include "CSSCustomPropertySyntax.h"
 #include "CSSCustomPropertyValue.h"
 #include "CSSPrimitiveValue.h"
 #include "CSSPropertyNames.h"
 #include "CSSPropertyParser.h"
 #include "CSSPropertyParserConsumer+Ident.h"
-#include "CSSPropertyParserConsumer+MetaConsumer.h"
-#include "CSSPropertyParserConsumer+NumberDefinitions.h"
 #include "CSSPropertyParserConsumer+Primitives.h"
 #include "CSSPropertyParserState.h"
+#include "CSSRandomKeyParser.h"
 #include "CSSRegisteredCustomProperty.h"
 #include "CSSSelectorParser.h"
 #include "CSSSerializationContext.h"
@@ -859,57 +858,13 @@ bool SubstitutionResolver::substituteRandomItemFunction(CSSParserTokenRange rang
 std::optional<double> SubstitutionResolver::randomItemBaseValue(Vector<CSSParserToken> randomKey)
 {
     // <random-key> = auto | <random-cache-key> | fixed <number [0,1]>
-    // The subset supported here matches random()'s current support:
-    //   [ [ auto | <dashed-ident> ] || element-scoped ] | fixed <number [0,1]>
+    // Parsed with the shared consumer so random-item()'s <random-key> stays in sync with random()'s.
+    // The supported subset matches random(): [ [ auto | <dashed-ident> ] || element-scoped ] | fixed <number [0,1]>;
     // property-scoped / property-index-scoped / <random-ua-ident> are a follow-up, in sync with random().
     CSSParserTokenRange randomKeyRange { randomKey };
     randomKeyRange.consumeWhitespace();
-    if (randomKeyRange.atEnd())
-        return { };
 
-    if (randomKeyRange.peek().id() == CSSValueFixed) {
-        randomKeyRange.consumeIncludingWhitespace();
-        // fixed <number [0,1]>, reusing random()'s number consumer so calc()/var()-derived numbers
-        // are accepted identically.
-        auto numberParsingState = CSS::PropertyParserState { .context = m_substitutionValue->context() };
-        auto number = CSSPropertyParserHelpers::MetaConsumer<CSS::Number<CSS::ClosedUnitRange>>::consume(randomKeyRange, numberParsingState);
-        if (!number || !randomKeyRange.atEnd())
-            return { };
-        return Style::toStyle(*number, m_styleBuilder.state()).value;
-    }
-
-    std::optional<CSS::Keyword::ElementScoped> elementScoped;
-    std::optional<AtomString> dashedIdent;
-    bool isAuto = false;
-
-    while (!randomKeyRange.atEnd()) {
-        auto& token = randomKeyRange.peek();
-        if (!elementScoped && token.id() == CSSValueElementScoped) {
-            elementScoped = CSS::Keyword::ElementScoped { };
-            randomKeyRange.consumeIncludingWhitespace();
-            continue;
-        }
-        if (!isAuto && !dashedIdent && token.id() == CSSValueAuto) {
-            isAuto = true;
-            randomKeyRange.consumeIncludingWhitespace();
-            continue;
-        }
-        if (!isAuto && !dashedIdent && token.type() == IdentToken && isCustomPropertyName(token.value())) {
-            dashedIdent = token.value().toAtomString();
-            randomKeyRange.consumeIncludingWhitespace();
-            continue;
-        }
-        break;
-    }
-
-    if (!randomKeyRange.atEnd())
-        return { };
-
-    if (elementScoped && !m_styleBuilder.state().element())
-        return { };
-
-    if (dashedIdent)
-        return m_styleBuilder.state().lookupCSSRandomBaseValue(CSSCalc::RandomCachingKey { Style::CustomIdent { *dashedIdent } }, elementScoped);
+    auto parserState = CSS::PropertyParserState { .context = m_substitutionValue->context() };
 
     // "auto" (or an omitted identifier alongside element-scoped) keys on the current property,
     // disambiguated by a per-resolver index so independent auto instances in one declaration select
@@ -919,12 +874,17 @@ std::optional<double> SubstitutionResolver::randomItemBaseValue(Vector<CSSParser
     // parse-time cssRandomFunctionCount. An auto random-item() and an auto random() in the same
     // property value can therefore land on the same RandomCachingKey and share a base value, and the
     // index follows the selected branch rather than parse position. Unifying this with random()'s
-    // counter is the job of the shared <random-key> helper follow-up.
-    auto autoKey = CSSCalc::RandomSharingOptions::Auto {
-        .property = m_styleBuilder.state().cssPropertyID(),
-        .index = m_randomItemAutoIndex++
-    };
-    return m_styleBuilder.state().lookupCSSRandomBaseValue(CSSCalc::RandomCachingKey { autoKey }, elementScoped);
+    // counter is a follow-up.
+    auto sharing = CSSPropertyParserHelpers::consumeUnresolvedRandomKey(randomKeyRange, parserState, [&] {
+        return CSSCalc::RandomSharingOptions::Auto {
+            .property = m_styleBuilder.state().cssPropertyID(),
+            .index = m_randomItemAutoIndex++
+        };
+    });
+    if (!sharing || !randomKeyRange.atEnd())
+        return { };
+
+    return CSSCalc::resolveRandomBaseValue(*sharing, m_styleBuilder.state());
 }
 
 auto SubstitutionResolver::substituteIfArgumentGrammar(CSSParserTokenRange range, const CSSParserContext& context) -> std::optional<Vector<IfBranch>>


### PR DESCRIPTION
#### 306d64a3ebf767b8467315d6b7eefa7383445c36
<pre>
[css-values-5 random-item()] Share &lt;random-key&gt; parsing between random() and random-item()
<a href="https://bugs.webkit.org/show_bug.cgi?id=319297">https://bugs.webkit.org/show_bug.cgi?id=319297</a>
<a href="https://rdar.apple.com/182133406">rdar://182133406</a>

Reviewed by Elika Etemad.

random() and random-item() each had their own copy of the &lt;random-key&gt; parsing
(the auto / &lt;dashed-ident&gt; / element-scoped / fixed &lt;number&gt; sharing key). Per
review discussion on PR #68097, factor that logic into a single shared consumer
so the two stay in sync.

Add CSSPropertyParserHelpers::consumeUnresolvedRandomKey(), which parses
&lt;random-key&gt; and returns a CSSCalc::Random::Sharing. A makeAuto callback supplies
the RandomSharingOptions::Auto key, so each caller keeps its own auto-index source.
random() drops its private consumeOptionalRandomSharingFixed /
consumeOptionalRandomSharingOptions and calls the shared consumer (no behavior
change). random-item()&apos;s randomItemBaseValue() drops its hand-rolled parsing, calls
the shared consumer, and resolves the parsed Sharing to a base value mirroring
random()&apos;s evaluation.

Since random-item() now parses &lt;random-key&gt; identically to random(), two
previously-divergent random-item() behaviors change to match random() and the
spec: a bare `element-scoped` key is now a null-named &lt;random-cache-key&gt; shared
across instances (rather than a per-instance auto key, so it no longer consumes a
per-declaration auto index), and a &lt;dashed-ident&gt; as short as `--` is now accepted.

* LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-computed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-computed.html:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSRandomKeyParser.cpp: Added.
(WebCore::CSSPropertyParserHelpers::consumeUnresolvedRandomKey):
* Source/WebCore/css/CSSRandomKeyParser.h: Added.
* Source/WebCore/css/calc/CSSCalcTree+Parser.cpp:
(WebCore::CSSCalc::consumeOptionalRandomSharing):
(WebCore::CSSCalc::consumeOptionalRandomSharingFixed): Deleted.
(WebCore::CSSCalc::consumeOptionalRandomSharingOptions): Deleted.
* Source/WebCore/style/StyleSubstitutionResolver.cpp:
(WebCore::Style::SubstitutionResolver::randomItemBaseValue):

Canonical link: <a href="https://commits.webkit.org/317259@main">https://commits.webkit.org/317259@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fabe84775278dbc732b103f8eb2e7d40bd949d3e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174794 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48727 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42508 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184374 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/132702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9228f4bc-8f0a-42d4-8b04-2e1195a2a468) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176659 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50019 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48410 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/136017 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/132702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c17ffbb9-5bf9-4d37-aa13-31b164a2ce50) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177752 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39455 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/156811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116495 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a07ab336-f551-4924-8518-035e9feddf56) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38096 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36476 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32852 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148519 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36303 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186799 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/40168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/144948 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48394 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156367 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144807 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39012 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49074 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39678 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/121140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47580 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11273 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46982 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47213 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47040 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->