### PR TITLE
[ANGLE] Fix WebGL out/inout shaders failing to compile on newer Metal

### DIFF
--- a/Source/ThirdParty/ANGLE/src/compiler/translator/msl/ProgramPrelude.cpp
+++ b/Source/ThirdParty/ANGLE/src/compiler/translator/msl/ProgramPrelude.cpp
@@ -1017,7 +1017,7 @@ struct ANGLE_VectorElemRef
     ANGLE_VectorElemRef(thread metal::vec<T, N> &vec, int index)
         : mVec(vec), mRef(vec[index]), mIndex(index)
     {}
-    operator thread T &() { return mRef; }
+    operator thread T &() thread { return mRef; }
 };
 template <typename T, int N>
 ANGLE_ALWAYS_INLINE ANGLE_VectorElemRef<T, N> ANGLE_elem_ref(thread metal::vec<T, N> &vec, int index)
@@ -1052,7 +1052,7 @@ struct ANGLE_SwizzleRef
             mRef[i] = mVec[j];
         }
     }
-    operator thread metal::vec<T, SN> &() { return mRef; }
+    operator thread metal::vec<T, SN> &() thread { return mRef; }
 };
 template <typename T, int N>
 ANGLE_ALWAYS_INLINE ANGLE_VectorElemRef<T, N> ANGLE_swizzle_ref(thread metal::vec<T, N> &vec, int i0)
@@ -1090,7 +1090,7 @@ struct ANGLE_Out
     ANGLE_Out(thread T &dest)
         : mTemp(dest), mDest(dest)
     {}
-    operator thread T &() { return mTemp; }
+    operator thread T &() thread { return mTemp; }
 };
 template <typename T>
 ANGLE_ALWAYS_INLINE ANGLE_Out<T> ANGLE_out(thread T &dest)
@@ -1109,7 +1109,7 @@ struct ANGLE_InOut
     ANGLE_InOut(thread T &dest)
         : mTemp(dest), mDest(dest)
     {}
-    operator thread T &() { return mTemp; }
+    operator thread T &() thread { return mTemp; }
 };
 template <typename T>
 ANGLE_ALWAYS_INLINE ANGLE_InOut<T> ANGLE_inout(thread T &dest)


### PR DESCRIPTION
#### 4d4a69df0d2109f7d125e634a24c5d58bcab930e
<pre>
[ANGLE] Fix WebGL out/inout shaders failing to compile on newer Metal
<a href="https://bugs.webkit.org/show_bug.cgi?id=319298">https://bugs.webkit.org/show_bug.cgi?id=319298</a>
<a href="https://rdar.apple.com/181719662">rdar://181719662</a>

Reviewed by Mike Wyrzykowski.

ANGLE translates GLSL out and inout function parameters into Metal using small
helper structs whose conversion operator returns a reference into the struct.
Older Metal compilers placed that reference in the thread address space by
default, but a recent Metal compiler change defaults unlabeled references to the
generic address space instead. The returned reference no longer matches the
declared thread reference, so the shader fails to compile and WebGL pages that
pass out/inout parameters render nothing, producing many console errors.

Fix by adding a trailing thread qualifier to the conversion operator of each
helper struct (ANGLE_Out, ANGLE_InOut, ANGLE_VectorElemRef, and
ANGLE_SwizzleRef), which keeps both the object and the reference it returns in
the thread address space and restores the previous behavior.

* Source/ThirdParty/ANGLE/src/compiler/translator/msl/ProgramPrelude.cpp:

Canonical link: <a href="https://commits.webkit.org/317176@main">https://commits.webkit.org/317176@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b664edb07651017465f80b732b98705b8e3685c3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174307 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48240 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42021 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183881 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132175 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b8c46659-f213-44c8-a55f-f48ce2c071a6) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49532 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47922 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135587 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95666 "1 flakes 5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/236d1471-8d00-43e7-b8fd-13b4ec157769) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177265 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39030 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156377 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116065 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/904340c3-625d-43f0-b700-78c5ef8057b1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37671 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36030 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32365 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148094 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35870 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186307 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40227 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144497 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47907 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144357 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38966 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48586 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32490 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114125 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39258 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47092 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10834 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46495 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46726 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46553 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->