### PR TITLE
WebAssembly streaming instantiation uses the result promise as the import object when imports are omitted

### DIFF
--- a/JSTests/wasm/stress/streaming-instantiate-omitted-imports.js
+++ b/JSTests/wasm/stress/streaming-instantiate-omitted-imports.js
@@ -1,0 +1,74 @@
+// https://bugs.webkit.org/show_bug.cgi?id=316985
+// Streaming instantiate must not treat the result promise as the import object
+// when the import argument is omitted.
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("bad value: " + actual + " (expected " + expected + ")");
+}
+
+// (module
+//   (type (func (result i32)))
+//   (import "p" "f" (func (type 0)))
+//   (func (type 0) (call 0))
+//   (export "run" (func 1))
+// )
+const bytes = new Uint8Array([
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+    0x01, 0x05, 0x01, 0x60, 0x00, 0x01, 0x7f,
+    0x02, 0x07, 0x01, 0x01, 0x70, 0x01, 0x66, 0x00, 0x00,
+    0x03, 0x02, 0x01, 0x00,
+    0x07, 0x07, 0x01, 0x03, 0x72, 0x75, 0x6e, 0x00, 0x01,
+    0x0a, 0x06, 0x01, 0x04, 0x00, 0x10, 0x00, 0x0b,
+]);
+
+async function shouldReject(promise) {
+    let rejected = false;
+    try {
+        await promise;
+    } catch (e) {
+        rejected = true;
+    }
+    shouldBe(rejected, true);
+}
+
+async function main() {
+    // Pollute Promise.prototype so a wrong importObject (== result promise)
+    // would resolve imports via the prototype chain.
+    let getterReceiver;
+    Object.defineProperty(Promise.prototype, "p", {
+        configurable: true,
+        get() {
+            getterReceiver = this;
+            return { f() { return 1337; } };
+        },
+    });
+
+    try {
+        await shouldReject(WebAssembly.instantiate(bytes));
+
+        getterReceiver = undefined;
+        const streamingPromise = $vm.createWasmStreamingCompilerForInstantiate(function (compiler) {
+            compiler.addBytes(bytes);
+        });
+        await shouldReject(streamingPromise);
+        // Getter must not have been invoked on the result promise.
+        shouldBe(getterReceiver, undefined);
+
+        // With a real import object, streaming instantiate still works.
+        const { instance } = await $vm.createWasmStreamingCompilerForInstantiate(function (compiler) {
+            compiler.addBytes(bytes);
+        }, {
+            p: { f() { return 42; } },
+        });
+        shouldBe(instance.exports.run(), 42);
+    } finally {
+        delete Promise.prototype.p;
+    }
+}
+
+main().catch(function (error) {
+    print(String(error));
+    print(String(error.stack));
+    $vm.abort();
+});

--- a/Source/JavaScriptCore/wasm/WasmStreamingCompiler.cpp
+++ b/Source/JavaScriptCore/wasm/WasmStreamingCompiler.cpp
@@ -188,8 +188,11 @@ void StreamingCompiler::didComplete()
         RefPtr<SourceProvider> provider = m_source.provider();
         m_vm.deferredWorkTimer->scheduleWorkSoonIfActive(m_ticket, [result = WTF::move(result), provider = WTF::move(provider), compileOptions = WTF::move(m_compileOptions)](DeferredWorkTimer::Ticket& ticket) mutable {
             JSPromise* promise = uncheckedDowncast<JSPromise>(ticket.target());
-            JSGlobalObject* globalObject = uncheckedDowncast<JSGlobalObject>(ticket.dependencies()[0]);
-            JSObject* importObject = uncheckedDowncast<JSObject>(ticket.dependencies()[1]);
+            auto& dependencies = ticket.dependencies();
+            JSGlobalObject* globalObject = uncheckedDowncast<JSGlobalObject>(dependencies[0]);
+            JSObject* importObject = nullptr;
+            if (dependencies.size() > 2)
+                importObject = uncheckedDowncast<JSObject>(dependencies[1]);
             VM& vm = globalObject->vm();
             auto scope = DECLARE_THROW_SCOPE(vm);
 


### PR DESCRIPTION
#### 7f065ab4abdb982cbf80de24d8a7fde95d8306de
<pre>
WebAssembly streaming instantiation uses the result promise as the import object when imports are omitted
<a href="https://bugs.webkit.org/show_bug.cgi?id=316985">https://bugs.webkit.org/show_bug.cgi?id=316985</a>

Reviewed by Yusuke Suzuki.

StreamingCompiler records [globalObject, importObject?] as deferred-work
dependencies; DeferredWorkTimer then appends the result promise. FullCompile
completion always treated dependencies()[1] as the import object, so when
imports were omitted that slot was the result promise. Script could then
satisfy import modules via Promise.prototype.

Only read an import object when dependencies include one (size &gt; 2);
otherwise pass nullptr into instantiateForStreaming.

* Source/JavaScriptCore/wasm/WasmStreamingCompiler.cpp:
(StreamingCompiler::didComplete):
* JSTests/wasm/stress/streaming-instantiate-omitted-imports.js: Added.
Regression for the bug PoC plus a positive path with real imports.

Canonical link: <a href="https://commits.webkit.org/317268@main">https://commits.webkit.org/317268@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e53c8f1db97b020f1e4f57c97cc78551a8c12aa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174762 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48695 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42476 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184342 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132670 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49987 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48378 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135988 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177720 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39427 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156780 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116466 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38068 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32820 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5289 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148491 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36272 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186767 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/36024 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/40118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40643 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144916 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48362 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144775 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49042 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26564 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39650 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/121093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/211853 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47548 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11242 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55256 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46950 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47181 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47008 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->