### PR TITLE
Fix WebTransport reading with byob streams

### DIFF
--- a/Source/WebCore/Modules/streams/ReadableStream.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStream.cpp
@@ -160,11 +160,6 @@ ExceptionOr<Ref<ReadableStream>> ReadableStream::createFromByteUnderlyingSource(
     return { WTF::move(readableStream) };
 }
 
-ExceptionOr<Ref<InternalReadableStream>> ReadableStream::createInternalReadableStream(JSDOMGlobalObject& globalObject, Ref<ReadableStreamSource>&& source)
-{
-    return InternalReadableStream::createFromUnderlyingSource(globalObject, toJSNewlyCreated(&globalObject, &globalObject, WTF::move(source)), JSC::jsUndefined(), { });
-}
-
 ExceptionOr<Ref<ReadableStream>> ReadableStream::create(JSDOMGlobalObject& globalObject, Ref<ReadableStreamSource>&& source, std::optional<double> highWaterMark)
 {
     return createFromJSValues(globalObject, toJSNewlyCreated(&globalObject, &globalObject, WTF::move(source)), JSC::jsUndefined(), highWaterMark);

--- a/Source/WebCore/Modules/streams/ReadableStream.h
+++ b/Source/WebCore/Modules/streams/ReadableStream.h
@@ -187,12 +187,11 @@ public:
 
 protected:
     static ExceptionOr<Ref<ReadableStream>> createFromJSValues(JSC::JSGlobalObject&, JSC::JSValue, JSC::JSValue, std::optional<double>);
-    static ExceptionOr<Ref<InternalReadableStream>> createInternalReadableStream(JSDOMGlobalObject&, Ref<ReadableStreamSource>&&);
     explicit ReadableStream(ScriptExecutionContext*, RefPtr<InternalReadableStream>&& = { }, RefPtr<DependencyToVisit>&& = { }, IsSourceReachableFromOpaqueRoot = IsSourceReachableFromOpaqueRoot::No);
+    void setupReadableByteStreamController(JSDOMGlobalObject&, ReadableByteStreamController::PullAlgorithm&&, ReadableByteStreamController::CancelAlgorithm&&, double, StartSynchronously);
 
 private:
     ExceptionOr<void> setupReadableByteStreamControllerFromUnderlyingSource(JSDOMGlobalObject&, JSC::JSValue, UnderlyingSource&&, double);
-    void setupReadableByteStreamController(JSDOMGlobalObject&, ReadableByteStreamController::PullAlgorithm&&, ReadableByteStreamController::CancelAlgorithm&&, double, StartSynchronously);
 
     bool NODELETE isPulling() const;
     void teedBranchIsDestroyed(ReadableStream&);

--- a/Source/WebCore/Modules/webtransport/WebTransport.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransport.cpp
@@ -55,6 +55,7 @@
 #include "WebTransportError.h"
 #include "WebTransportOptions.h"
 #include "WebTransportReceiveStream.h"
+#include "WebTransportReceiveStreamByteSource.h"
 #include "WebTransportReceiveStreamSource.h"
 #include "WebTransportReliabilityMode.h"
 #include "WebTransportSendGroup.h"
@@ -234,7 +235,7 @@ void WebTransport::receiveIncomingUnidirectionalStream(WebTransportStreamIdentif
         return;
 
     auto& jsDOMGlobalObject = *downcast<JSDOMGlobalObject>(globalObject);
-    Ref incomingStream = WebTransportReceiveStreamSource::createIncomingDataSource(*this, identifier);
+    Ref incomingStream = WebTransportReceiveStreamByteSource::create(*this, identifier);
     auto stream = [&] {
         Locker<JSC::JSLock> locker(jsDOMGlobalObject.vm().apiLock());
         return WebTransportReceiveStream::create(identifier, *session, jsDOMGlobalObject, incomingStream.copyRef());
@@ -252,7 +253,7 @@ void WebTransport::receiveIncomingUnidirectionalStream(WebTransportStreamIdentif
         protect(m_session)->destroyStream(identifier, std::nullopt);
 }
 
-static ExceptionOr<Ref<WebTransportBidirectionalStream>> createBidirectionalStream(WebTransport& transport, WebTransportSession& session, JSDOMGlobalObject& globalObject, Ref<WebTransportSendStreamSink>&& sink, Ref<WebTransportReceiveStreamSource>&& source)
+static ExceptionOr<Ref<WebTransportBidirectionalStream>> createBidirectionalStream(WebTransport& transport, WebTransportSession& session, JSDOMGlobalObject& globalObject, Ref<WebTransportSendStreamSink>&& sink, Ref<WebTransportReceiveStreamByteSource>&& source)
 {
     auto identifier = sink->identifier();
     auto sendStream = [&] {
@@ -284,7 +285,7 @@ void WebTransport::receiveBidirectionalStream(WebTransportStreamIdentifier ident
 
     Ref sink = WebTransportSendStreamSink::create(*this, identifier);
     auto& jsDOMGlobalObject = *downcast<JSDOMGlobalObject>(globalObject);
-    Ref incomingStream = WebTransportReceiveStreamSource::createIncomingDataSource(*this, identifier);
+    Ref incomingStream = WebTransportReceiveStreamByteSource::create(*this, identifier);
     auto stream = WebCore::createBidirectionalStream(*this, *session, jsDOMGlobalObject, sink.copyRef(), incomingStream.copyRef());
     if (stream.hasException())
         return;
@@ -569,7 +570,7 @@ void WebTransport::createBidirectionalStream(ScriptExecutionContext& context, We
 
         Ref sink = WebTransportSendStreamSink::create(protectedThis.get(), *identifier);
         auto& jsDOMGlobalObject = *downcast<JSDOMGlobalObject>(globalObject);
-        Ref incomingStream = WebTransportReceiveStreamSource::createIncomingDataSource(protectedThis.get(), *identifier);
+        Ref incomingStream = WebTransportReceiveStreamByteSource::create(protectedThis.get(), *identifier);
         auto stream = WebCore::createBidirectionalStream(protectedThis, *session, jsDOMGlobalObject, sink.copyRef(), incomingStream.copyRef());
         if (stream.hasException())
             return promise->reject(stream.releaseException());

--- a/Source/WebCore/Modules/webtransport/WebTransport.h
+++ b/Source/WebCore/Modules/webtransport/WebTransport.h
@@ -55,6 +55,7 @@ class WebTransportBidirectionalStreamSource;
 class WebTransportDatagramDuplexStream;
 class WebTransportDatagramsWritable;
 class WebTransportError;
+class WebTransportReceiveStreamByteSource;
 class WebTransportReceiveStreamSource;
 class WebTransportSendGroup;
 class WebTransportSendStream;
@@ -155,7 +156,7 @@ private:
     const Ref<DatagramSource> m_datagramSource;
     const Ref<WebTransportReceiveStreamSource> m_receiveStreamSource;
     const Ref<WebTransportBidirectionalStreamSource> m_bidirectionalStreamSource;
-    HashMap<WebTransportStreamIdentifier, Ref<WebTransportReceiveStreamSource>> m_readStreamSources;
+    HashMap<WebTransportStreamIdentifier, Ref<WebTransportReceiveStreamByteSource>> m_readStreamSources;
     HashMap<WebTransportStreamIdentifier, Ref<WebTransportSendStreamSink>> m_sendStreamSinks;
     WeakHashSet<WebTransportDatagramsWritable> m_datagramsWritables;
 };

--- a/Source/WebCore/Modules/webtransport/WebTransportReceiveStream.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransportReceiveStream.cpp
@@ -29,27 +29,40 @@
 #include "JSDOMConvertDictionary.h"
 #include "JSDOMPromiseDeferred.h"
 #include "JSWebTransportReceiveStreamStats.h"
+#include "ReadableByteStreamController.h"
 #include "ScriptExecutionContextInlines.h"
 #include "TaskSource.h"
+#include "WebTransportReceiveStreamByteSource.h"
+#include "WebTransportReceiveStreamSource.h"
 #include "WebTransportReceiveStreamStats.h"
 #include "WebTransportSession.h"
+#include <JavaScriptCore/JSPromise.h>
 #include <wtf/CompletionHandler.h>
 
 namespace WebCore {
 
-ExceptionOr<Ref<WebTransportReceiveStream>> WebTransportReceiveStream::create(WebTransportStreamIdentifier identifier, WebTransportSession& session, JSDOMGlobalObject& globalObject, Ref<ReadableStreamSource>&& source)
+ExceptionOr<Ref<WebTransportReceiveStream>> WebTransportReceiveStream::create(WebTransportStreamIdentifier identifier, WebTransportSession& session, JSDOMGlobalObject& globalObject, Ref<WebTransportReceiveStreamByteSource>&& source)
 {
-    auto result = createInternalReadableStream(globalObject, WTF::move(source));
-    if (result.hasException())
-        return result.releaseException();
-
-    Ref stream = adoptRef(*new WebTransportReceiveStream(protect(globalObject.scriptExecutionContext()).get(), identifier, session, result.releaseReturnValue()));
+    Ref stream = adoptRef(*new WebTransportReceiveStream(protect(globalObject.scriptExecutionContext()).get(), identifier, session));
     stream->suspendIfNeeded();
+
+    ReadableByteStreamController::PullAlgorithm pullAlgorithm = [source](auto& globalObject, auto&) {
+        return source->pull(globalObject);
+    };
+
+    ReadableByteStreamController::CancelAlgorithm cancelAlgorithm = [source](auto& globalObject, auto&, auto&& reason) {
+        auto [promise, deferred] = createPromiseAndWrapper(globalObject);
+        source->cancel(reason ? *reason : JSC::jsUndefined(), WTF::move(deferred));
+        return promise;
+    };
+
+    stream->setupReadableByteStreamController(globalObject, WTF::move(pullAlgorithm), WTF::move(cancelAlgorithm), 0, ReadableStream::StartSynchronously::No);
+
     return stream;
 }
 
-WebTransportReceiveStream::WebTransportReceiveStream(ScriptExecutionContext* context, WebTransportStreamIdentifier identifier, WebTransportSession& session, Ref<InternalReadableStream>&& stream)
-    : ReadableStream(context, WTF::move(stream))
+WebTransportReceiveStream::WebTransportReceiveStream(ScriptExecutionContext* context, WebTransportStreamIdentifier identifier, WebTransportSession& session)
+    : ReadableStream(context, { }, { }, ReadableStream::IsSourceReachableFromOpaqueRoot::Yes)
     , m_identifier(identifier)
     , m_session(session) { }
 

--- a/Source/WebCore/Modules/webtransport/WebTransportReceiveStreamByteSource.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransportReceiveStreamByteSource.cpp
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebTransportReceiveStreamByteSource.h"
+
+#include "JSDOMException.h"
+#include "JSDOMGlobalObject.h"
+#include "JSDOMPromiseDeferred.h"
+#include "JSWebTransportError.h"
+#include "JSWebTransportReceiveStream.h"
+#include "ReadableByteStreamController.h"
+#include "ReadableStream.h"
+#include "WebTransport.h"
+#include "WebTransportError.h"
+#include "WebTransportSession.h"
+#include <JavaScriptCore/ArrayBuffer.h>
+#include <JavaScriptCore/HeapCellInlines.h>
+#include <JavaScriptCore/JSCellInlines.h>
+#include <wtf/Scope.h>
+#include <wtf/StdLibExtras.h>
+
+namespace WebCore {
+
+Ref<DOMPromise> WebTransportReceiveStreamByteSource::pull(JSDOMGlobalObject& globalObject)
+{
+    // FIXME: This should implement https://w3c.github.io/webtransport/#webtransportreceivestream-pull-bytes
+    // See DatagramByteSource::pull.
+    auto* promise = JSC::JSPromise::resolvedPromise(&globalObject, JSC::jsUndefined());
+    return DOMPromise::create(globalObject, *promise);
+}
+
+WebTransportReceiveStreamByteSource::WebTransportReceiveStreamByteSource(WebTransport& transport, WebTransportStreamIdentifier identifier)
+    : m_transport(transport)
+    , m_identifier(identifier)
+{
+}
+
+void WebTransportReceiveStreamByteSource::receiveBytes(std::span<const uint8_t> bytes, bool withFin, std::optional<Exception>&& exception)
+{
+    if (m_isCancelled || m_isClosed)
+        return;
+
+    RefPtr stream = m_stream.get();
+    if (!stream)
+        return;
+    auto* globalObject = stream->globalObject();
+    if (!globalObject)
+        return;
+    RefPtr controller = stream->controller();
+    if (!controller)
+        return;
+
+    if (exception) {
+        controller->error(*globalObject, *exception);
+        if (RefPtr transport = m_transport.get())
+            transport->receiveStreamClosed(m_identifier);
+        return;
+    }
+
+    if (bytes.size()) {
+        if (RefPtr arrayBuffer = ArrayBuffer::tryCreateUninitialized(bytes.size(), 1)) {
+            memcpySpan(arrayBuffer->mutableSpan(), bytes);
+            controller->enqueue(*globalObject, *arrayBuffer);
+        }
+        // FIXME: Error the stream if allocation fails.
+    }
+
+    if (withFin) {
+        m_isClosed = true;
+        controller->closeAndRespondToPendingPullIntos(*globalObject);
+        if (RefPtr transport = m_transport.get())
+            transport->receiveStreamClosed(m_identifier);
+    }
+}
+
+void WebTransportReceiveStreamByteSource::receiveError(JSDOMGlobalObject& globalObject, JSC::JSValue error)
+{
+    if (m_isClosed || m_isCancelled)
+        return;
+    m_isCancelled = true;
+
+    Locker<JSC::JSLock> locker(globalObject.vm().apiLock());
+    if (RefPtr stream = m_stream.get()) {
+        if (RefPtr controller = stream->controller())
+            controller->error(globalObject, error);
+    }
+
+    if (RefPtr transport = m_transport.get())
+        transport->receiveStreamClosed(m_identifier);
+}
+
+void WebTransportReceiveStreamByteSource::cancel(JSC::JSValue reason, Ref<DeferredPromise>&& promise)
+{
+    auto scope = makeScopeExit([&] {
+        promise->resolve();
+    });
+
+    if (m_isCancelled)
+        return;
+    m_isCancelled = true;
+
+    RefPtr transport = m_transport.get();
+    if (!transport)
+        return;
+    transport->receiveStreamClosed(m_identifier);
+
+    RefPtr session = transport->session();
+    if (!session)
+        return;
+
+    std::optional<uint64_t> errorCode;
+    if (auto* jsWebTransportError = dynamicDowncast<JSWebTransportError>(reason)) {
+        auto& webTransportError = jsWebTransportError->wrapped();
+        if (auto webTransportErrorCode = webTransportError.streamErrorCode())
+            errorCode = static_cast<uint64_t>(*webTransportErrorCode);
+    }
+    session->cancelReceiveStream(m_identifier, errorCode);
+}
+
+}

--- a/Source/WebCore/Modules/webtransport/WebTransportReceiveStreamByteSource.h
+++ b/Source/WebCore/Modules/webtransport/WebTransportReceiveStreamByteSource.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,36 +25,47 @@
 
 #pragma once
 
-#include "ReadableStream.h"
+#include "ReadableStreamSource.h"
 
 namespace WebCore {
 
+class DOMPromise;
 class DeferredPromise;
-class WebTransportReceiveStreamByteSource;
-class WebTransportSession;
+class Exception;
+class ReadableStream;
+class WebTransport;
+class WebTransportReceiveStream;
 
-struct WebTransportReceiveStreamStats;
 struct WebTransportStreamIdentifierType;
 
 using WebTransportStreamIdentifier = ObjectIdentifier<WebTransportStreamIdentifierType>;
 
-class WebTransportReceiveStream final : public ReadableStream {
+class WebTransportReceiveStreamByteSource final : public RefCounted<WebTransportReceiveStreamByteSource> {
 public:
-    static ExceptionOr<Ref<WebTransportReceiveStream>> create(WebTransportStreamIdentifier, WebTransportSession&, JSDOMGlobalObject&, Ref<WebTransportReceiveStreamByteSource>&&);
-    ~WebTransportReceiveStream() final;
+    static Ref<WebTransportReceiveStreamByteSource> create(WebTransport& transport, WebTransportStreamIdentifier identifier) { return adoptRef(*new WebTransportReceiveStreamByteSource(transport, identifier)); }
 
-    void getStats(ScriptExecutionContext&, Ref<DeferredPromise>&&);
+    Ref<DOMPromise> pull(JSDOMGlobalObject&);
+    void receiveBytes(std::span<const uint8_t>, bool, std::optional<Exception>&&);
+    void receiveError(JSDOMGlobalObject&, JSC::JSValue error);
+    void cancel(JSC::JSValue reason, Ref<DeferredPromise>&&);
+
+    void setStream(ReadableStream& stream)
+    {
+        ASSERT(!m_stream);
+        m_stream = stream;
+    }
+    ReadableStream* stream() const { return m_stream.get(); }
+
 private:
-    WebTransportReceiveStream(ScriptExecutionContext*, WebTransportStreamIdentifier, WebTransportSession&);
+    WebTransportReceiveStreamByteSource(WebTransport&, WebTransportStreamIdentifier);
 
-    virtual Type type() const { return Type::WebTransport; }
+    bool m_isCancelled { false };
+    bool m_isClosed { false };
 
+    ThreadSafeWeakPtr<WebTransport> m_transport;
+    WeakPtr<ReadableStream> m_stream;
     const WebTransportStreamIdentifier m_identifier;
-    const ThreadSafeWeakPtr<WebTransportSession> m_session;
 };
 
 }
 
-SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::WebTransportReceiveStream)
-static bool isType(const WebCore::ReadableStream& stream) { return stream.type() == WebCore::ReadableStream::Type::WebTransport; }
-SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/Modules/webtransport/WebTransportReceiveStreamSource.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransportReceiveStreamSource.cpp
@@ -28,28 +28,25 @@
 
 #include "JSDOMException.h"
 #include "JSDOMGlobalObject.h"
+#include "JSDOMPromiseDeferred.h"
 #include "JSWebTransportError.h"
 #include "JSWebTransportReceiveStream.h"
+#include "ReadableByteStreamController.h"
+#include "ReadableStream.h"
 #include "WebTransport.h"
 #include "WebTransportError.h"
 #include "WebTransportSession.h"
+#include <JavaScriptCore/ArrayBuffer.h>
 #include <JavaScriptCore/HeapCellInlines.h>
 #include <JavaScriptCore/JSCellInlines.h>
 #include <wtf/Scope.h>
+#include <wtf/StdLibExtras.h>
 
 namespace WebCore {
 
-WebTransportReceiveStreamSource::WebTransportReceiveStreamSource() = default;
-
-WebTransportReceiveStreamSource::WebTransportReceiveStreamSource(WebTransport& transport, WebTransportStreamIdentifier identifier)
-    : m_transport(transport)
-    , m_identifier(identifier)
-{
-}
-
 bool WebTransportReceiveStreamSource::receiveIncomingStream(JSC::JSGlobalObject& globalObject, Ref<WebTransportReceiveStream>& stream)
 {
-    if (m_isCancelled || m_identifier)
+    if (m_isCancelled)
         return false;
     auto& jsDOMGlobalObject = downcast<JSDOMGlobalObject>(globalObject);
     Locker<JSC::JSLock> locker(jsDOMGlobalObject.vm().apiLock());
@@ -61,73 +58,10 @@ bool WebTransportReceiveStreamSource::receiveIncomingStream(JSC::JSGlobalObject&
     return true;
 }
 
-void WebTransportReceiveStreamSource::receiveBytes(std::span<const uint8_t> bytes, bool withFin, std::optional<WebCore::Exception>&& exception)
+void WebTransportReceiveStreamSource::doCancel(JSC::JSValue)
 {
-    if (m_isCancelled || m_isClosed || !m_identifier)
-        return;
-    if (exception) {
-        controller().error(*exception);
-        clean();
-        if (RefPtr transport = m_transport.get())
-            transport->receiveStreamClosed(*m_identifier);
-        return;
-    }
-    if (bytes.size()) {
-        auto arrayBuffer = ArrayBuffer::tryCreateUninitialized(bytes.size(), 1);
-        if (arrayBuffer)
-            memcpySpan(arrayBuffer->mutableSpan(), bytes);
-        if (!controller().enqueue(WTF::move(arrayBuffer)))
-            doCancel({ });
-    }
-    if (withFin) {
-        m_isClosed = true;
-        controller().close();
-        clean();
-        if (RefPtr transport = m_transport.get())
-            transport->receiveStreamClosed(*m_identifier);
-    }
-}
-
-void WebTransportReceiveStreamSource::receiveError(JSDOMGlobalObject& globalObject, JSC::JSValue error)
-{
-    if (m_isClosed || m_isCancelled || !m_identifier)
-        return;
     m_isCancelled = true;
-
-    Locker<JSC::JSLock> locker(globalObject.vm().apiLock());
-    controller().error(globalObject, error);
-    clean();
-
-    if (RefPtr transport = m_transport.get())
-        transport->receiveStreamClosed(*m_identifier);
+    cancelFinished();
 }
 
-void WebTransportReceiveStreamSource::doCancel(JSC::JSValue value)
-{
-    auto scope = makeScopeExit([&] {
-        cancelFinished();
-    });
-
-    if (m_isCancelled)
-        return;
-    m_isCancelled = true;
-    if (!m_identifier)
-        return;
-    RefPtr transport = m_transport.get();
-    if (!transport)
-        return;
-    transport->receiveStreamClosed(*m_identifier);
-
-    RefPtr session = transport->session();
-    if (!session)
-        return;
-
-    std::optional<uint64_t> errorCode;
-    if (auto* jsWebTransportError = dynamicDowncast<JSWebTransportError>(value)) {
-        auto& webTransportError = jsWebTransportError->wrapped();
-        if (auto webTransportErrorCode = webTransportError.streamErrorCode())
-            errorCode = static_cast<uint64_t>(*webTransportErrorCode);
-    }
-    session->cancelReceiveStream(*m_identifier, errorCode);
-}
 }

--- a/Source/WebCore/Modules/webtransport/WebTransportReceiveStreamSource.h
+++ b/Source/WebCore/Modules/webtransport/WebTransportReceiveStreamSource.h
@@ -29,6 +29,7 @@
 
 namespace WebCore {
 
+class DeferredPromise;
 class Exception;
 class ReadableStream;
 class WebTransport;
@@ -41,16 +42,10 @@ using WebTransportStreamIdentifier = ObjectIdentifier<WebTransportStreamIdentifi
 class WebTransportReceiveStreamSource : public RefCountedReadableStreamSource {
 public:
     static Ref<WebTransportReceiveStreamSource> createIncomingStreamsSource() { return adoptRef(*new WebTransportReceiveStreamSource()); }
-    static Ref<WebTransportReceiveStreamSource> createIncomingDataSource(WebTransport& transport, WebTransportStreamIdentifier identifier) { return adoptRef(*new WebTransportReceiveStreamSource(transport, identifier)); }
     bool receiveIncomingStream(JSC::JSGlobalObject&, Ref<WebTransportReceiveStream>&);
-    void receiveBytes(std::span<const uint8_t>, bool, std::optional<WebCore::Exception>&&);
-    void receiveError(JSDOMGlobalObject&, JSC::JSValue error);
-    void setStream(ReadableStream& stream) { m_stream = stream; }
-    RefPtr<ReadableStream> stream() const { return m_stream; };
 
 private:
-    WebTransportReceiveStreamSource();
-    WebTransportReceiveStreamSource(WebTransport&, WebTransportStreamIdentifier);
+    WebTransportReceiveStreamSource() = default;
     void setActive() final { }
     void setInactive() final { }
     void doStart() final { }
@@ -58,11 +53,6 @@ private:
     void doCancel(JSC::JSValue) final;
 
     bool m_isCancelled { false };
-    bool m_isClosed { false };
-
-    ThreadSafeWeakPtr<WebTransport> m_transport;
-    WeakPtr<ReadableStream> m_stream;
-    const std::optional<WebTransportStreamIdentifier> m_identifier;
 };
 
 }

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -532,6 +532,7 @@ Modules/webtransport/WebTransportDatagramDuplexStream.cpp
 Modules/webtransport/WebTransportDatagramsWritable.cpp
 Modules/webtransport/WebTransportError.cpp
 Modules/webtransport/WebTransportReceiveStream.cpp
+Modules/webtransport/WebTransportReceiveStreamByteSource.cpp
 Modules/webtransport/WebTransportReceiveStreamSource.cpp
 Modules/webtransport/WebTransportSendGroup.cpp
 Modules/webtransport/WebTransportSendStream.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -23513,6 +23513,8 @@
 		F916C48C0DB510F80076CD83 /* JSXMLHttpRequestProgressEvent.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = JSXMLHttpRequestProgressEvent.h; sourceTree = "<group>"; };
 		F9F0ED770DB50CA200D16DB9 /* XMLHttpRequestProgressEvent.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = XMLHttpRequestProgressEvent.h; sourceTree = "<group>"; };
 		F9F0ED780DB50CA200D16DB9 /* XMLHttpRequestProgressEvent.idl */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = text; path = XMLHttpRequestProgressEvent.idl; sourceTree = "<group>"; };
+		FA0394113009AAF9007EE051 /* WebTransportReceiveStreamByteSource.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebTransportReceiveStreamByteSource.h; sourceTree = "<group>"; };
+		FA0394123009AAF9007EE051 /* WebTransportReceiveStreamByteSource.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebTransportReceiveStreamByteSource.cpp; sourceTree = "<group>"; };
 		FA0B46CB2E8C5E330073E9B3 /* WebTransportConnectionStats.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebTransportConnectionStats.h; sourceTree = "<group>"; };
 		FA0B46CC2E8C5E330073E9B3 /* WebTransportConnectionStats.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebTransportConnectionStats.idl; sourceTree = "<group>"; };
 		FA0B46D02E8C920F0073E9B3 /* WebTransportSendStreamSink.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebTransportSendStreamSink.h; sourceTree = "<group>"; };
@@ -38231,8 +38233,8 @@
 				BCCE029B2E789AD90028EA38 /* StyleSingleAnimationRangeName.h */,
 				BC73202B2E73487A00A6584F /* StyleSingleAnimationTimeline.cpp */,
 				BC73201B2E7343D900A6584F /* StyleSingleAnimationTimeline.h */,
-				715FD2F6300838CD00E41A1C /* StyleSingleAnimationTrigger.h */,
 				715FD2F7300838CD00E41A1C /* StyleSingleAnimationTrigger.cpp */,
+				715FD2F6300838CD00E41A1C /* StyleSingleAnimationTrigger.h */,
 			);
 			path = animations;
 			sourceTree = "<group>";
@@ -43348,6 +43350,8 @@
 				FAC3C3EC2A9966FF001E2EB8 /* WebTransportReceiveStream.cpp */,
 				FAC3C3FF2A996705001E2EB8 /* WebTransportReceiveStream.h */,
 				FAC3C3D62A9960DC001E2EB8 /* WebTransportReceiveStream.idl */,
+				FA0394123009AAF9007EE051 /* WebTransportReceiveStreamByteSource.cpp */,
+				FA0394113009AAF9007EE051 /* WebTransportReceiveStreamByteSource.h */,
 				FAC849952A9FD86000D407EF /* WebTransportReceiveStreamSource.cpp */,
 				FAC849942A9FD86000D407EF /* WebTransportReceiveStreamSource.h */,
 				FAC3C3E82A9966FD001E2EB8 /* WebTransportReceiveStreamStats.h */,
@@ -47265,7 +47269,6 @@
 				E451C6322394031A00993190 /* MarginTypes.h in Headers */,
 				CE1866451F72E5B400A0CAB6 /* MarkedText.h in Headers */,
 				93309DF8099E64920056E581 /* markup.h in Headers */,
-				715FD2F8300838D500E41A1C /* StyleSingleAnimationTrigger.h in Headers */,
 				9728C3141268E4390041E89B /* MarkupAccumulator.h in Headers */,
 				3A18A2ED2AFEAA7C00DB976C /* MarkupExclusionRule.h in Headers */,
 				00C60E3F13D76D7E0092A275 /* MarkupTokenizerInlines.h in Headers */,
@@ -49122,6 +49125,7 @@
 				BC73201F2E7343E800A6584F /* StyleSingleAnimationRange.h in Headers */,
 				BCCE029C2E789AD90028EA38 /* StyleSingleAnimationRangeName.h in Headers */,
 				BC73201D2E7343E800A6584F /* StyleSingleAnimationTimeline.h in Headers */,
+				715FD2F8300838D500E41A1C /* StyleSingleAnimationTrigger.h in Headers */,
 				BCCE02912E766AA30028EA38 /* StyleSingleTransitionDelay.h in Headers */,
 				BCCE02922E766AAA0028EA38 /* StyleSingleTransitionDuration.h in Headers */,
 				BC7320022E732F3F00A6584F /* StyleSingleTransitionProperty.h in Headers */,

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebTransport.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebTransport.mm
@@ -147,6 +147,56 @@ TEST(WebTransport, ClientBidirectional)
     EXPECT_TRUE(challenged);
 }
 
+TEST(WebTransport, ClientBidirectionalBYOB)
+{
+    if (!WebTransportServer::isAvailable())
+        return;
+
+    WebTransportServer echoServer([](ConnectionGroup group) -> ConnectionTask {
+        auto connection = co_await group.receiveIncomingConnection();
+        auto request = co_await connection.awaitableReceiveBytes();
+        request.append('d');
+        request.append('e');
+        request.append('f');
+        co_await connection.awaitableSend(WTF::move(request));
+    });
+
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
+    enableWebTransport(configuration.get());
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
+    [webView setNavigationDelegate:delegate.get()];
+    __block bool challenged { false };
+    __block uint16_t port = echoServer.port();
+    delegate.get().didReceiveAuthenticationChallenge = ^(WKWebView *, NSURLAuthenticationChallenge *challenge, void (^completionHandler)(NSURLSessionAuthChallengeDisposition, NSURLCredential *)) {
+        validateChallenge(challenge, port);
+        challenged = true;
+        completionHandler(NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust]);
+    };
+
+    NSString *html = [NSString stringWithFormat:@""
+        "<script>async function test() {"
+        "  try {"
+        "    let t = new WebTransport('https://127.0.0.1:%d/');"
+        "    await t.ready;"
+        "    let s = await t.createBidirectionalStream();"
+        "    let w = s.writable.getWriter();"
+        "    await w.write(new TextEncoder().encode('abc'));"
+        "    let r = s.readable.getReader({ mode: 'byob' });"
+        "    const { value, done } = await r.read(new Uint8Array(6));"
+        "    await w.close();"
+        "    r.releaseLock();"
+        "    t.close();"
+        "    alert('successfully read ' + new TextDecoder().decode(value) + ' done: ' + done);"
+        "  } catch (e) { alert('caught ' + e); }"
+        "}; test();"
+        "</script>",
+        port];
+    [webView loadHTMLString:html baseURL:[NSURL URLWithString:@"https://webkit.org/"]];
+    EXPECT_WK_STREQ([webView _test_waitForAlert], "successfully read abcdef done: false");
+    EXPECT_TRUE(challenged);
+}
+
 TEST(WebTransport, Datagram)
 {
     if (!WebTransportServer::isAvailable())


### PR DESCRIPTION
#### e67a8c3c5b57de098125f98fa7c2238bf173dc98
<pre>
Fix WebTransport reading with byob streams
<a href="https://bugs.webkit.org/show_bug.cgi?id=319299">https://bugs.webkit.org/show_bug.cgi?id=319299</a>

Reviewed by Youenn Fablet.

wpt/webtransport/streams-echo.https.any.html fails after 316945@main
is reapplied because this line of JS is throwing a TypeError:

const reader = bidi_stream.readable.getReader({mode: &apos;byob&apos;});

It is throwing in ReadableStream::getReader with the string &quot;Invalid mode is specified&quot;.
I keep WebTransportReceiveStream to be the source of stream streams (WebTransport&apos;s
incomingBidirectionalStreams and incomingUnidirectionalStreams)

WebTransportReceiveStreamByteSource is introduced.  It actually receives the bytes
from the network and gives them to JS as array buffers, and it supports byob buffers.

AI definitely helped me out with this one.

* Source/WebCore/Modules/streams/ReadableStream.cpp:
(WebCore::ReadableStream::createInternalReadableStream): Deleted.
* Source/WebCore/Modules/streams/ReadableStream.h:
* Source/WebCore/Modules/webtransport/WebTransport.cpp:
(WebCore::WebTransport::receiveIncomingUnidirectionalStream):
(WebCore::createBidirectionalStream):
(WebCore::WebTransport::receiveBidirectionalStream):
(WebCore::WebTransport::createBidirectionalStream):
* Source/WebCore/Modules/webtransport/WebTransport.h:
* Source/WebCore/Modules/webtransport/WebTransportReceiveStream.cpp:
(WebCore::WebTransportReceiveStream::create):
(WebCore::WebTransportReceiveStream::WebTransportReceiveStream):
* Source/WebCore/Modules/webtransport/WebTransportReceiveStream.h:
* Source/WebCore/Modules/webtransport/WebTransportReceiveStreamByteSource.cpp: Copied from Source/WebCore/Modules/webtransport/WebTransportReceiveStreamSource.cpp.
(WebCore::WebTransportReceiveStreamByteSource::pull):
(WebCore::WebTransportReceiveStreamByteSource::WebTransportReceiveStreamByteSource):
(WebCore::WebTransportReceiveStreamByteSource::receiveBytes):
(WebCore::WebTransportReceiveStreamByteSource::receiveError):
(WebCore::WebTransportReceiveStreamByteSource::cancel):
* Source/WebCore/Modules/webtransport/WebTransportReceiveStreamByteSource.h: Copied from Source/WebCore/Modules/webtransport/WebTransportReceiveStreamSource.h.
* Source/WebCore/Modules/webtransport/WebTransportReceiveStreamSource.cpp:
(WebCore::WebTransportReceiveStreamSource::receiveIncomingStream):
(WebCore::WebTransportReceiveStreamSource::doCancel):
(WebCore::WebTransportReceiveStreamSource::WebTransportReceiveStreamSource): Deleted.
(WebCore::WebTransportReceiveStreamSource::receiveBytes): Deleted.
(WebCore::WebTransportReceiveStreamSource::receiveError): Deleted.
* Source/WebCore/Modules/webtransport/WebTransportReceiveStreamSource.h:
(WebCore::WebTransportReceiveStreamSource::createIncomingStreamsSource):
(WebCore::WebTransportReceiveStreamSource::createIncomingDataSource): Deleted.
(WebCore::WebTransportReceiveStreamSource::setStream): Deleted.
(WebCore::WebTransportReceiveStreamSource::stream const): Deleted.
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebTransport.mm:
(TestWebKitAPI::TEST(WebTransport, ClientBidirectionalBYOB)):

Canonical link: <a href="https://commits.webkit.org/317416@main">https://commits.webkit.org/317416@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91da55c47947b3dab2b6508e9491551a11e48bec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175261 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49193 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42974 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184846 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/133624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177125 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50485 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48876 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136430 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/133624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cfdb8543-20a6-4038-ba57-6e5d40d3b62e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178218 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39847 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/157193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116909 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/093b6ad1-a3a2-425c-8200-79c137cc14d1) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/38488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33319 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/148911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36686 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187267 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/40880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/145393 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48860 "Built successfully") | | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145235 "Found 2 new API test failures: WebKitGTK/TestEditor:/webkit/WebKitWebEditor/selection-changed, TestWTF:WTF_ParkingLot.UnparkOneFiftyThenFiftyAllFast (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49540 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115419 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26641 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40061 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/121733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48046 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11659 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47449 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47679 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47506 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->