### PR TITLE
Web Inspector: `inspectorOverride` should apply to `SettingsValues`

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3488,6 +3488,7 @@ FullScreenEnabled:
   humanReadableDescription: "Fullscreen API"
   condition: ENABLE(FULLSCREEN_API)
   hidden: EXPERIMENTAL_FULLSCREEN_API_HIDDEN
+  inspectorOverride: true
   defaultValue:
     WebKitLegacy:
       default: false
@@ -6335,6 +6336,7 @@ NotificationsEnabled:
   humanReadableName: "Notifications"
   humanReadableDescription: "Enable the Notifications API"
   condition: ENABLE(NOTIFICATIONS)
+  inspectorOverride: true
   defaultValue:
     WebKitLegacy:
       "PLATFORM(IOS_FAMILY)": false
@@ -6786,6 +6788,7 @@ PointerLockEnabled:
   condition: ENABLE(POINTER_LOCK)
   humanReadableName: "Pointer Lock API"
   humanReadableDescription: "Enable the Pointer Lock API"
+  inspectorOverride: true
   defaultValue:
     WebKitLegacy:
       "PLATFORM(IOS_FAMILY)": false
@@ -6987,6 +6990,7 @@ PushAPIEnabled:
   category: dom
   humanReadableName: "Push API"
   humanReadableDescription: "Enable Push API"
+  inspectorOverride: true
   defaultValue:
     WebCore:
       default: false

--- a/Source/WebCore/Scripts/GenerateSettings.rb
+++ b/Source/WebCore/Scripts/GenerateSettings.rb
@@ -150,11 +150,7 @@ class Setting
   end
 
   def hasComplexSetter?
-    @onChange != nil
-  end
-
-  def hasComplexGetter?
-    hasInspectorOverride?
+    @onChange != nil || hasInspectorOverride?
   end
 
   def setterFunctionName
@@ -194,8 +190,6 @@ class Conditional
   attr_accessor :boolSettingsNeedingImplementation
   attr_accessor :nonBoolSettings
   attr_accessor :nonBoolSettingsNeedingImplementation
-  attr_accessor :settingsWithComplexGetters
-  attr_accessor :settingsWithComplexGettersNeedingImplementation
   attr_accessor :settingsWithComplexSetters
   attr_accessor :settingsWithComplexSettersNeedingImplementation
 
@@ -210,9 +204,6 @@ class Conditional
   
     @nonBoolSettings = @settings.reject { |setting| setting.type == "bool" }
     @nonBoolSettingsNeedingImplementation = @nonBoolSettings.reject { |setting| setting.customImplementation }
-
-    @settingsWithComplexGetters = @settings.select { |setting| setting.hasComplexGetter? }
-    @settingsWithComplexGettersNeedingImplementation = @settingsWithComplexGetters.reject { |setting| setting.customImplementation }
 
     @settingsWithComplexSetters = @settings.select { |setting| setting.hasComplexSetter? }
     @settingsWithComplexSettersNeedingImplementation = @settingsWithComplexSetters.reject { |setting| setting.customImplementation }

--- a/Source/WebCore/Scripts/SettingsTemplates/Settings.cpp.erb
+++ b/Source/WebCore/Scripts/SettingsTemplates/Settings.cpp.erb
@@ -115,7 +115,7 @@ SettingsValues SettingsValues::isolatedCopy() const
 {
     return {
 <%- for @setting in @allSettingsSet.inspectorOverrideSettings do -%>
-        crossThreadCopy(<%= @setting.name %>InspectorOverride),
+        crossThreadCopy(<%= @setting.name %>BeforeInspectorOverride),
 <%- end -%>
         crossThreadCopy(fontGenericFamilies),
 <%- for @condition in @allSettingsSet.conditions do -%>
@@ -191,30 +191,25 @@ void Settings::disableFeaturesForLockdownMode()
 }
 
 <%- for @condition in @allSettingsSet.conditions do -%>
-<%- if @condition.settingsWithComplexGettersNeedingImplementation.length != 0 or @condition.settingsWithComplexSettersNeedingImplementation.length != 0 -%>
+<%- if @condition.settingsWithComplexSettersNeedingImplementation.length != 0 -%>
 <%- if @condition.condition -%>
 #if <%= @condition.condition %>
 <%- end -%>
-<%- for @setting in @condition.settingsWithComplexGettersNeedingImplementation do -%>
-<%= @setting.parameterType %> Settings::<%= @setting.getterFunctionName %>() const
-{
-<%- if @setting.hasInspectorOverride? -%>
-    if (m_values.<%= @setting.name %>InspectorOverride) [[unlikely]] {
-        ASSERT(InspectorInstrumentation::hasFrontends());
-        return m_values.<%= @setting.name %>InspectorOverride.value();
-    }
-<%- end -%>
-    return m_values.<%= @setting.name %>;
-}
-<%- end -%>
-
 <%- for @setting in @condition.settingsWithComplexSettersNeedingImplementation -%>
 void Settings::<%= @setting.setterFunctionName %>(<%= @setting.parameterType %> <%= @setting.name %>)
 {
+<%- if @setting.hasInspectorOverride? -%>
+    if (m_values.<%= @setting.name %>BeforeInspectorOverride) [[unlikely]] {
+        m_values.<%= @setting.name %>BeforeInspectorOverride = <%= @setting.name %>;
+        return;
+    }
+<%- end -%>
     if (m_values.<%= @setting.name %> == <%= @setting.name %>)
         return;
     m_values.<%= @setting.name %> = <%= @setting.name %>;
+<%- if @setting.onChange -%>
     <%= @setting.onChange %>();
+<%- end -%>
 }
 <%- end -%>
 <%- if @condition.condition -%>
@@ -224,23 +219,31 @@ void Settings::<%= @setting.setterFunctionName %>(<%= @setting.parameterType %> 
 <%- end -%>
 
 <%- for @setting in @allSettingsSet.inspectorOverrideSettings do -%>
-<%- if @setting.hasComplexSetter? -%>
 void Settings::<%= @setting.setterFunctionName %>InspectorOverride(std::optional<<%= @setting.parameterType %>> <%= @setting.name %>InspectorOverride)
 {
-    if (m_values.<%= @setting.name %>InspectorOverride == <%= @setting.name %>InspectorOverride)
-        return;
-    m_values.<%= @setting.name %>InspectorOverride = <%= @setting.name %>InspectorOverride;
 <%- if @setting.condition -%>
 #if <%= @setting.condition %>
 <%- end -%>
-    <%= @setting.onChange %>();
-<%- if @setting.condition -%>
-<%- if @condition.condition -%>
-#endif
+    auto previousValue = m_values.<%= @setting.name %>;
+    if (<%= @setting.name %>InspectorOverride) {
+        ASSERT(InspectorInstrumentation::hasFrontends());
+        if (!m_values.<%= @setting.name %>BeforeInspectorOverride)
+            m_values.<%= @setting.name %>BeforeInspectorOverride = previousValue;
+        m_values.<%= @setting.name %> = <%= @setting.name %>InspectorOverride.value();
+    } else if (m_values.<%= @setting.name %>BeforeInspectorOverride) {
+        m_values.<%= @setting.name %> = m_values.<%= @setting.name %>BeforeInspectorOverride.value();
+        m_values.<%= @setting.name %>BeforeInspectorOverride = std::nullopt;
+    }
+<%- if @setting.onChange -%>
+    if (m_values.<%= @setting.name %> != previousValue)
+        <%= @setting.onChange %>();
 <%- end -%>
+<%- if @setting.condition -%>
+#else
+    UNUSED_PARAM(<%= @setting.name %>InspectorOverride);
+#endif
 <%- end -%>
 }
 
-<%- end -%>
 <%- end -%>
 }

--- a/Source/WebCore/Scripts/SettingsTemplates/Settings.h.erb
+++ b/Source/WebCore/Scripts/SettingsTemplates/Settings.h.erb
@@ -39,7 +39,7 @@ struct SettingsValues {
     SettingsValues isolatedCopy() const;
 
 <%- for @setting in @allSettingsSet.inspectorOverrideSettings do -%>
-    std::optional<<%= @setting.type %>> <%= @setting.name %>InspectorOverride;
+    std::optional<<%= @setting.type %>> <%= @setting.name %>BeforeInspectorOverride;
 <%- end -%>
 
     FontGenericFamilies fontGenericFamilies;
@@ -90,11 +90,7 @@ public:
 #if <%= @condition.condition %>
 <%- end -%>
 <%- for @setting in @condition.settingsNeedingImplementation do -%>
-    <%- if @setting.hasComplexGetter? -%>
-    WEBCORE_EXPORT <%= @setting.parameterType %> <%= @setting.getterFunctionName %>() const;
-    <%- else -%>
     <%= @setting.parameterType %> <%= @setting.getterFunctionName %>() const { return m_values.<%= @setting.name %>; }
-    <%- end -%>
     <%- if @setting.hasComplexSetter? -%>
     WEBCORE_EXPORT void <%= @setting.setterFunctionName %>(<%= @setting.parameterType %>);
     <%- else -%>
@@ -107,11 +103,7 @@ public:
 <%- end -%>
 
 <%- for @setting in @allSettingsSet.inspectorOverrideSettings do -%>
-    <%- if @setting.hasComplexSetter? -%>
     WEBCORE_EXPORT void <%= @setting.setterFunctionName %>InspectorOverride(std::optional<<%= @setting.parameterType %>>);
-    <%- else -%>
-    void <%= @setting.setterFunctionName %>InspectorOverride(std::optional<<%= @setting.parameterType %>> <%= @setting.name %>InspectorOverride) { m_values.<%= @setting.name %>InspectorOverride = <%= @setting.name %>InspectorOverride; }
-    <%- end -%>
 <%- end -%>
     FontGenericFamilies& fontGenericFamilies() final { return m_values.fontGenericFamilies; }
     const FontGenericFamilies& fontGenericFamilies() const final { return m_values.fontGenericFamilies; }

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
@@ -161,6 +161,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorPageAgent::disable()
     auto& inspectedPageSettings = m_inspectedPage->settings();
     inspectedPageSettings.setAuthorAndUserStylesEnabledInspectorOverride(std::nullopt);
     inspectedPageSettings.setFixedBackgroundsPaintRelativeToDocumentInspectorOverride(std::nullopt);
+    inspectedPageSettings.setFullScreenEnabledInspectorOverride(std::nullopt);
     inspectedPageSettings.setICECandidateFilteringEnabledInspectorOverride(std::nullopt);
     inspectedPageSettings.setImagesEnabledInspectorOverride(std::nullopt);
     inspectedPageSettings.setInputTypeMonthEnabledInspectorOverride(std::nullopt);
@@ -168,21 +169,13 @@ Inspector::Protocol::ErrorStringOr<void> InspectorPageAgent::disable()
     inspectedPageSettings.setMediaCaptureRequiresSecureConnectionInspectorOverride(std::nullopt);
     inspectedPageSettings.setMockCaptureDevicesEnabledInspectorOverride(std::nullopt);
     inspectedPageSettings.setNeedsSiteSpecificQuirksInspectorOverride(std::nullopt);
+    inspectedPageSettings.setNotificationsEnabledInspectorOverride(std::nullopt);
+    inspectedPageSettings.setPointerLockEnabledInspectorOverride(std::nullopt);
+    inspectedPageSettings.setPushAPIEnabledInspectorOverride(std::nullopt);
     inspectedPageSettings.setScriptEnabledInspectorOverride(std::nullopt);
     inspectedPageSettings.setShowDebugBordersInspectorOverride(std::nullopt);
     inspectedPageSettings.setShowRepaintCounterInspectorOverride(std::nullopt);
     inspectedPageSettings.setWebSecurityEnabledInspectorOverride(std::nullopt);
-
-#if ENABLE(FULLSCREEN_API)
-    overrideSettingByModifyingValue(m_fullScreenEnabledBeforeOverride, std::nullopt, &Settings::fullScreenEnabled, &Settings::setFullScreenEnabled);
-#endif
-#if ENABLE(NOTIFICATIONS)
-    overrideSettingByModifyingValue(m_notificationsEnabledBeforeOverride, std::nullopt, &Settings::notificationsEnabled, &Settings::setNotificationsEnabled);
-#endif
-#if ENABLE(POINTER_LOCK)
-    overrideSettingByModifyingValue(m_pointerLockEnabledBeforeOverride, std::nullopt, &Settings::pointerLockEnabled, &Settings::setPointerLockEnabled);
-#endif
-    overrideSettingByModifyingValue(m_pushAPIEnabledBeforeOverride, std::nullopt, &Settings::pushAPIEnabled, &Settings::setPushAPIEnabled);
 
     inspectedPageSettings.setForcedPrefersReducedMotionAccessibilityValue(ForcedAccessibilityValue::System);
     inspectedPageSettings.setForcedPrefersContrastAccessibilityValue(ForcedAccessibilityValue::System);
@@ -223,19 +216,6 @@ Inspector::Protocol::ErrorStringOr<void> InspectorPageAgent::overrideUserAgent(c
     return { };
 }
 
-void InspectorPageAgent::overrideSettingByModifyingValue(std::optional<bool>& savedValue, std::optional<bool> value, bool (Settings::*getter)() const, void (Settings::*setter)(bool))
-{
-    Ref inspectedPageSettings = m_inspectedPage->settings();
-    if (value) {
-        if (!savedValue)
-            savedValue = (inspectedPageSettings.get().*getter)();
-        (inspectedPageSettings.get().*setter)(*value);
-    } else if (savedValue) {
-        (inspectedPageSettings.get().*setter)(*savedValue);
-        savedValue = std::nullopt;
-    }
-}
-
 Inspector::Protocol::ErrorStringOr<void> InspectorPageAgent::overrideSetting(Inspector::Protocol::Page::Setting setting, std::optional<bool>&& value)
 {
     auto& inspectedPageSettings = m_inspectedPage->settings();
@@ -254,9 +234,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorPageAgent::overrideSetting(Ins
         return { };
 
     case Inspector::Protocol::Page::Setting::FullScreenEnabled:
-#if ENABLE(FULLSCREEN_API)
-        overrideSettingByModifyingValue(m_fullScreenEnabledBeforeOverride, value, &Settings::fullScreenEnabled, &Settings::setFullScreenEnabled);
-#endif
+        inspectedPageSettings.setFullScreenEnabledInspectorOverride(value);
         return { };
 
     case Inspector::Protocol::Page::Setting::ICECandidateFilteringEnabled:
@@ -294,19 +272,15 @@ Inspector::Protocol::ErrorStringOr<void> InspectorPageAgent::overrideSetting(Ins
         return { };
 
     case Inspector::Protocol::Page::Setting::NotificationsEnabled:
-#if ENABLE(NOTIFICATIONS)
-        overrideSettingByModifyingValue(m_notificationsEnabledBeforeOverride, value, &Settings::notificationsEnabled, &Settings::setNotificationsEnabled);
-#endif
+        inspectedPageSettings.setNotificationsEnabledInspectorOverride(value);
         return { };
 
     case Inspector::Protocol::Page::Setting::PointerLockEnabled:
-#if ENABLE(POINTER_LOCK)
-        overrideSettingByModifyingValue(m_pointerLockEnabledBeforeOverride, value, &Settings::pointerLockEnabled, &Settings::setPointerLockEnabled);
-#endif
+        inspectedPageSettings.setPointerLockEnabledInspectorOverride(value);
         return { };
 
     case Inspector::Protocol::Page::Setting::PushAPIEnabled:
-        overrideSettingByModifyingValue(m_pushAPIEnabledBeforeOverride, value, &Settings::pushAPIEnabled, &Settings::setPushAPIEnabled);
+        inspectedPageSettings.setPushAPIEnabledInspectorOverride(value);
         return { };
 
     case Inspector::Protocol::Page::Setting::ScriptEnabled:

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.h
@@ -59,7 +59,6 @@ class LocalFrame;
 class Page;
 class RemoteFrame;
 class RenderObject;
-class Settings;
 class FragmentedSharedBuffer;
 
 class InspectorPageAgent final : public InspectorAgentBase, public Inspector::PageBackendDispatcherHandler, public CanMakeCheckedPtr<InspectorPageAgent> {
@@ -136,8 +135,6 @@ private:
     void overridePrefersContrast(std::optional<Inspector::Protocol::Page::UserPreferenceValue>&&);
     void overridePrefersColorScheme(std::optional<Inspector::Protocol::Page::UserPreferenceValue>&&);
 
-    void overrideSettingByModifyingValue(std::optional<bool>& savedValue, std::optional<bool> value, bool (Settings::*getter)() const, void (Settings::*setter)(bool));
-
     Ref<Inspector::Protocol::Page::Frame> buildObjectForFrame(LocalFrame*);
     Ref<Inspector::Protocol::Page::FrameResourceTree> buildObjectForFrameTree(Frame*);
 
@@ -153,11 +150,6 @@ private:
     String m_bootstrapScript;
     bool m_isFirstLayoutAfterOnLoad { false };
     bool m_showPaintRects { false };
-
-    std::optional<bool> m_fullScreenEnabledBeforeOverride;
-    std::optional<bool> m_notificationsEnabledBeforeOverride;
-    std::optional<bool> m_pointerLockEnabledBeforeOverride;
-    std::optional<bool> m_pushAPIEnabledBeforeOverride;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 860d7d88a9b5c4e1294ee415a4c2b4cbeb89974b
<pre>
Web Inspector: `inspectorOverride` should apply to `SettingsValues`
<a href="https://bugs.webkit.org/show_bug.cgi?id=319302">https://bugs.webkit.org/show_bug.cgi?id=319302</a>

Reviewed by Yusuke Suzuki.

IDL bindings consumes settings via the raw `SettingsValues` instead of the corresponding getter on `Settings`.

As a result, `inspectorOverride` has no effect on it since that intercepts the getter on `Settings` instead of modifying `SettingsValues`.

It&apos;s probably far more common to read a `Settings` value than write it, so move this logic to the setter instead.

As a result, the `inspectorOverride` is now used to store the old value and any non-`inspectorOverride` set value since then.

This allows for the `inspectorOverride` setter to modify the underlying `SettingsValues`.

When the `inspectorOverride` is removed, the stored value is used to (re)set the `SettingsValues`.

This has the added benefit of removing an extra function call when getting `Settings` that have an `inspectorOverride`.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Scripts/GenerateSettings.rb:
* Source/WebCore/Scripts/SettingsTemplates/Settings.h.erb:
* Source/WebCore/Scripts/SettingsTemplates/Settings.cpp.erb:

* Source/WebCore/inspector/agents/InspectorPageAgent.cpp:
(WebCore::InspectorPageAgent::disable):
(WebCore::InspectorPageAgent::overrideSetting):
(WebCore::InspectorPageAgent::overrideSettingByModifyingValue): Deleted.
* Source/WebCore/inspector/agents/InspectorPageAgent.h:

Canonical link: <a href="https://commits.webkit.org/317841@main">https://commits.webkit.org/317841@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b246474da8f886503a9519343c67ae62463e6410

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174320 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48253 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42034 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183896 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132188 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176185 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49545 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47935 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135599 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95675 "3 flakes 4 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177278 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39035 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156395 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116077 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37676 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36044 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32378 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/4904 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148099 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35887 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186322 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/35582 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39523 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40241 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144509 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47920 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144367 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39409 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48599 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32507 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114140 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39273 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120531 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/211355 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47105 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10851 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55078 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46508 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46739 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46566 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->