### PR TITLE
Add log messaging relay to the Model Process

### DIFF
--- a/Source/WebKit/ModelProcess/ModelProcess.cpp
+++ b/Source/WebKit/ModelProcess/ModelProcess.cpp
@@ -214,6 +214,11 @@ void ModelProcess::initializeModelProcess(ModelProcessCreationParameters&& param
 
     applyProcessCreationParameters(WTF::move(parameters.auxiliaryProcessParameters));
     RELEASE_LOG(Process, "%p - ModelProcess::initializeModelProcess:", this);
+
+#if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
+    initializeLogForwarding(parameters.isDebugLoggingEnabled);
+#endif
+
     WTF::Thread::setCurrentThreadIsUserInitiated();
     WebCore::initializeCommonAtomStrings();
 

--- a/Source/WebKit/ModelProcess/ModelProcess.h
+++ b/Source/WebKit/ModelProcess/ModelProcess.h
@@ -106,6 +106,9 @@ private:
 
     // Message Handlers
     void initializeModelProcess(ModelProcessCreationParameters&&, CompletionHandler<void()>&&);
+#if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT) && ENABLE(STREAMING_IPC_IN_LOG_FORWARDING)
+    void sendCreateLogStreamToParent(IPC::Connection&, IPC::StreamServerConnectionHandle&&, LogStreamIdentifier, CompletionHandler<void(IPC::Semaphore&&, IPC::Semaphore&&)>&&) override;
+#endif
     void createModelConnectionToWebProcess(WebCore::ProcessIdentifier, PAL::SessionID, IPC::Connection::Handle&&, ModelProcessConnectionParameters&&, const std::optional<String>& attributionTaskID, CompletionHandler<void()>&&);
     void sharedPreferencesForWebProcessDidChange(WebCore::ProcessIdentifier, SharedPreferencesForWebProcess&&, CompletionHandler<void()>&&);
     void addSession(PAL::SessionID);

--- a/Source/WebKit/ModelProcess/ModelProcessCreationParameters.h
+++ b/Source/WebKit/ModelProcess/ModelProcessCreationParameters.h
@@ -39,6 +39,9 @@ struct ModelProcessCreationParameters {
     bool restrictiveRenderingMode { false };
     std::optional<int> debugEntityMemoryLimit;
     std::optional<int> debugImmersiveEntityMemoryLimit;
+#if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
+    bool isDebugLoggingEnabled { false };
+#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/ModelProcess/ModelProcessCreationParameters.serialization.in
+++ b/Source/WebKit/ModelProcess/ModelProcessCreationParameters.serialization.in
@@ -31,6 +31,9 @@ headers: "ModelProcessCreationParameters.h" "AuxiliaryProcessCreationParameters.
     bool restrictiveRenderingMode;
     std::optional<int> debugEntityMemoryLimit;
     std::optional<int> debugImmersiveEntityMemoryLimit;
+#if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
+    bool isDebugLoggingEnabled;
+#endif
 };
 
 #endif

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessCocoa.mm
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessCocoa.mm
@@ -31,6 +31,12 @@
 #import "ModelConnectionToWebProcess.h"
 #import <wtf/RetainPtr.h>
 
+#if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT) && ENABLE(STREAMING_IPC_IN_LOG_FORWARDING)
+#import "LogStreamIdentifier.h"
+#import "ModelProcessProxyMessages.h"
+#import "StreamServerConnection.h"
+#endif
+
 namespace WebKit {
 using namespace WebCore;
 
@@ -39,6 +45,13 @@ void ModelProcess::dispatchSimulatedNotificationsForPreferenceChange(const Strin
 {
 }
 #endif // ENABLE(CFPREFS_DIRECT_MODE)
+
+#if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT) && ENABLE(STREAMING_IPC_IN_LOG_FORWARDING)
+void ModelProcess::sendCreateLogStreamToParent(IPC::Connection& parentConnection, IPC::StreamServerConnectionHandle&& handle, LogStreamIdentifier identifier, CompletionHandler<void(IPC::Semaphore&&, IPC::Semaphore&&)>&& completionHandler)
+{
+    parentConnection.sendWithAsyncReply(Messages::ModelProcessProxy::CreateLogStream(WTF::move(handle), identifier), WTF::move(completionHandler));
+}
+#endif
 
 } // namespace WebKit
 

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Model.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Model.sb.in
@@ -40,4 +40,3 @@
             SYS_getsockopt
             SYS_setsockopt)))
 (deny syscall-unix (with no-report))
-(allow mach-lookup (log-services))

--- a/Source/WebKit/Shared/AuxiliaryProcess.h
+++ b/Source/WebKit/Shared/AuxiliaryProcess.h
@@ -41,6 +41,10 @@
 #include <wtf/text/StringHash.h>
 #include <wtf/text/WTFString.h>
 
+#if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
+#include "LogStreamIdentifier.h"
+#endif
+
 #if PLATFORM(COCOA)
 #include <wtf/RetainPtr.h>
 #include <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
@@ -50,6 +54,10 @@ OBJC_CLASS NSDictionary;
 
 namespace IPC {
 class SharedBufferReference;
+#if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
+class Semaphore;
+struct StreamServerConnectionHandle;
+#endif
 }
 
 namespace WebKit {
@@ -128,6 +136,15 @@ protected:
     virtual void initializeProcessName(const AuxiliaryProcessInitializationParameters&);
     virtual void initializeSandbox(const AuxiliaryProcessInitializationParameters&, SandboxInitializationParameters&);
     virtual void initializeConnection(IPC::Connection*);
+
+#if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
+    void initializeLogForwarding(bool isDebugLoggingEnabled);
+#if ENABLE(STREAMING_IPC_IN_LOG_FORWARDING)
+    virtual void sendCreateLogStreamToParent(IPC::Connection&, IPC::StreamServerConnectionHandle&&, LogStreamIdentifier, CompletionHandler<void(IPC::Semaphore&&, IPC::Semaphore&&)>&&) { ASSERT_NOT_REACHED(); }
+#else
+    virtual void sendCreateLogStreamToParent(IPC::Connection&, LogStreamIdentifier, CompletionHandler<void()>&&) { ASSERT_NOT_REACHED(); }
+#endif
+#endif
 
     virtual bool shouldTerminate() = 0;
     virtual void terminate();

--- a/Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm
@@ -26,7 +26,6 @@
 #import "config.h"
 #import "AuxiliaryProcess.h"
 
-#import "LibAccessibilitySoftLink.h"
 #import "Logging.h"
 #import "OSStateSPI.h"
 #import "SharedBufferReference.h"
@@ -71,9 +70,144 @@
 #import <wtf/darwin/XPCObjectPtr.h>
 #endif
 
+#if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
+#import "LaunchLogHook.h"
+#import "LogClient.h"
+#import "LogStream.h"
+#import "StreamClientConnection.h"
+#import <WebCore/PublicSuffixStore.h>
+#import <wtf/BlockPtr.h>
+#import <wtf/OSObjectPtr.h>
+#import <wtf/SystemFree.h>
+#import <wtf/SystemTracing.h>
+#import <wtf/Threading.h>
+#import <wtf/spi/cocoa/OSLogSPI.h>
+#endif
+
+#import "LibAccessibilitySoftLink.h"
 #import <pal/cf/AudioToolboxSoftLink.h>
 
 namespace WebKit {
+
+#if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
+static bool shouldIgnoreLogMessage(std::span<const char> logChannel)
+{
+    return equalSpans(logChannel, "com.apple.xpc\0"_span) || equalSpans(logChannel, "com.apple.CoreAnalytics\0"_span);
+}
+
+#if PLATFORM(IOS_FAMILY)
+static void prewarmLogs()
+{
+    // This call will create container manager log objects.
+    // FIXME: this can be removed if we move all calls to topPrivatelyControlledDomain out of these processes.
+    // This would be desirable, since these processes are blocking access to the container manager daemon.
+    WebCore::PublicSuffixStore::singleton().topPrivatelyControlledDomain("apple.com"_s);
+
+    static std::array<std::pair<ASCIILiteral, ASCIILiteral>, 5> logs { {
+        { "com.apple.CFBundle"_s, "strings"_s },
+        { "com.apple.network"_s, ""_s },
+        { "com.apple.CFNetwork"_s, "ATS"_s },
+        { "com.apple.coremedia"_s, ""_s },
+        { "com.apple.SafariShared"_s, "Translation"_s },
+    } };
+
+    for (auto& log : logs) {
+        OSObjectPtr logHandle = adoptOSObject(os_log_create(log.first, log.second));
+        bool enabled = os_log_type_enabled(logHandle.get(), OS_LOG_TYPE_ERROR);
+        UNUSED_PARAM(enabled);
+    }
+}
+#endif // PLATFORM(IOS_FAMILY)
+
+static void registerLogClient(bool isDebugLoggingEnabled, std::unique_ptr<LogClient>&& newLogClient)
+{
+#if PLATFORM(IOS_FAMILY)
+    prewarmLogs();
+#endif
+
+    RELEASE_ASSERT(!WebCore::logClient());
+    WebCore::logClient() = WTF::move(newLogClient);
+
+    // OS_LOG_TYPE_DEFAULT implies default, fault, and error.
+    // OS_LOG_TYPE_DEBUG implies debug, info, default, fault, and error.
+    const auto minimumType = isDebugLoggingEnabled ? OS_LOG_TYPE_DEBUG : OS_LOG_TYPE_DEFAULT;
+
+    LaunchLogHook::singleton().disable();
+
+    static os_log_hook_t prevHook = nullptr;
+
+    prevHook = os_log_set_hook(minimumType, makeBlockPtr([isDebugLoggingEnabled](os_log_type_t type, os_log_message_t msg) {
+        if (prevHook)
+            prevHook(type, msg);
+
+        if (msg->buffer_sz > 1024)
+            return;
+
+        // Don't send debug/info messages unless debug logging is enabled. Even though OS_LOG_TYPE_DEFAULT would be the minimum,
+        // the hook will be called for other subsystems with debug and info types.
+        if (!isDebugLoggingEnabled && type & (OS_LOG_TYPE_DEBUG | OS_LOG_TYPE_INFO))
+            return;
+
+        if (Thread::currentThreadIsRealtime())
+            return;
+
+        auto logChannel = unsafeSpan(msg->subsystem);
+        if (logChannel.size() >= logSubsystemMaxSize)
+            return;
+        if (shouldIgnoreLogMessage(logChannel))
+            return;
+        auto logCategory = unsafeSpan(msg->category);
+        if (logCategory.size() >= logCategoryMaxSize)
+            return;
+
+        if (type == OS_LOG_TYPE_FAULT)
+            type = OS_LOG_TYPE_ERROR;
+
+        if (auto messageString = adoptSystemMalloc(os_log_copy_message_string(msg))) {
+            auto logString = spanConstCast<char>(unsafeSpan(messageString.get()));
+            if (logString.size() >= logStringMaxSize)
+                logString = logString.first(logStringMaxSize - 1);
+            WebCore::logClient()->log(byteCast<uint8_t>(logChannel), byteCast<uint8_t>(logCategory), byteCast<uint8_t>(logString), type);
+        }
+    }).get());
+
+    WTFSignpostIndirectLoggingEnabled = true;
+}
+
+void AuxiliaryProcess::initializeLogForwarding(bool isDebugLoggingEnabled)
+{
+    if (os_trace_get_mode() != OS_TRACE_MODE_OFF)
+        return;
+
+    RefPtr parentConnection = parentProcessConnection();
+    if (!parentConnection)
+        return;
+
+    RELEASE_LOG(Process, "%p - AuxiliaryProcess::initializeLogForwarding: Debug logging enabled: %d", this, isDebugLoggingEnabled);
+
+#if ENABLE(STREAMING_IPC_IN_LOG_FORWARDING)
+    static constexpr auto connectionBufferSizeLog2 = 17;
+    auto connectionPair = IPC::StreamClientConnection::create(connectionBufferSizeLog2, 1_s);
+    if (!connectionPair)
+        CRASH();
+    auto [connection, handle] = WTF::move(*connectionPair);
+    protect(connection)->open(protect(*this), RunLoop::currentSingleton());
+    auto newLogClient = makeUnique<LogClient>(Ref { connection });
+    auto identifier = newLogClient->identifier();
+    sendCreateLogStreamToParent(*parentConnection, WTF::move(handle), identifier, [newLogClient = WTF::move(newLogClient), connection = WTF::move(connection), isDebugLoggingEnabled] (IPC::Semaphore&& wakeUpSemaphore, IPC::Semaphore&& clientWaitSemaphore) mutable {
+        connection->setSemaphores(WTF::move(wakeUpSemaphore), WTF::move(clientWaitSemaphore));
+        registerLogClient(isDebugLoggingEnabled, WTF::move(newLogClient));
+    });
+#else
+    auto newLogClient = makeUnique<LogClient>(*parentConnection);
+    auto identifier = newLogClient->identifier();
+    sendCreateLogStreamToParent(*parentConnection, identifier, [newLogClient = WTF::move(newLogClient), isDebugLoggingEnabled] () mutable {
+        registerLogClient(isDebugLoggingEnabled, WTF::move(newLogClient));
+    });
+#endif
+}
+#endif // ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
+
 
 #if PLATFORM(MAC) || PLATFORM(MACCATALYST)
 static void initializeTimerCoalescingPolicy()

--- a/Source/WebKit/Shared/LogStream.h
+++ b/Source/WebKit/Shared/LogStream.h
@@ -31,6 +31,8 @@
 #include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
+#include <wtf/spi/cocoa/OSLogSPI.h>
+#include <wtf/text/ASCIILiteral.h>
 
 #if ENABLE(STREAMING_IPC_IN_LOG_FORWARDING)
 #include "StreamMessageReceiver.h"
@@ -46,7 +48,9 @@ constexpr size_t logCategoryMaxSize = 32;
 constexpr size_t logSubsystemMaxSize = 32;
 constexpr size_t logStringMaxSize = 256;
 
-class WebProcessProxy;
+void logWithProcessNamePrefix(os_log_t, os_log_type_t, ASCIILiteral processName, int pid, const char* message);
+
+class AuxiliaryProcessProxy;
 // Type which receives log messages from another process and invokes the platform logging.
 // The messages are found from generated LogStream.messages.in in build directory,
 // DerivedSources/WebKit/LogStream.messages.in.
@@ -63,9 +67,9 @@ class LogStream final :
 #endif
 public:
 #if ENABLE(STREAMING_IPC_IN_LOG_FORWARDING)
-    static RefPtr<LogStream> create(WebProcessProxy&, IPC::StreamServerConnectionHandle&&, LogStreamIdentifier, CompletionHandler<void(IPC::Semaphore& streamWakeUpSemaphore, IPC::Semaphore& streamClientWaitSemaphore)>&&);
+    static RefPtr<LogStream> create(AuxiliaryProcessProxy&, ASCIILiteral processName, IPC::StreamServerConnectionHandle&&, LogStreamIdentifier, CompletionHandler<void(IPC::Semaphore& streamWakeUpSemaphore, IPC::Semaphore& streamClientWaitSemaphore)>&&);
 #else
-    static Ref<LogStream> create(WebProcessProxy&, Ref<IPC::Connection>&&, LogStreamIdentifier);
+    static Ref<LogStream> create(AuxiliaryProcessProxy&, ASCIILiteral processName, Ref<IPC::Connection>&&, LogStreamIdentifier);
 #endif
     ~LogStream();
 
@@ -86,7 +90,7 @@ private:
 #else
     using ConnectionType = IPC::Connection;
 #endif
-    LogStream(WebProcessProxy&, Ref<ConnectionType>&&, LogStreamIdentifier);
+    LogStream(AuxiliaryProcessProxy&, ASCIILiteral processName, Ref<ConnectionType>&&, LogStreamIdentifier);
 
 #if ENABLE(STREAMING_IPC_IN_LOG_FORWARDING)
     // IPC::StreamServerConnection::Client overrides.
@@ -105,12 +109,13 @@ private:
 
 #if ENABLE(STREAMING_IPC_IN_LOG_FORWARDING)
     const Ref<IPC::StreamServerConnection> m_connection;
-    WeakPtr<WebProcessProxy> m_process;
+    WeakPtr<AuxiliaryProcessProxy> m_process;
 #else
     ThreadSafeWeakPtr<IPC::Connection> m_connection;
 #endif
     const LogStreamIdentifier m_identifier;
     const ProcessID m_pid;
+    const ASCIILiteral m_processName;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/LogStream.mm
+++ b/Source/WebKit/Shared/LogStream.mm
@@ -26,11 +26,11 @@
 
 #if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
 
+#import "AuxiliaryProcessProxy.h"
 #import "LogStreamMessages.h"
 #import "Logging.h"
 #import "StreamConnectionWorkQueue.h"
 #import "StreamServerConnection.h"
-#import "WebProcessProxy.h"
 #import <wtf/NeverDestroyed.h>
 #import <wtf/OSObjectPtr.h>
 #import <wtf/TZoneMallocInlines.h>
@@ -47,6 +47,18 @@ static std::atomic<unsigned> globalLogCountForTesting { 0 };
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(LogStream);
 
+void logWithProcessNamePrefix(os_log_t log, os_log_type_t type, ASCIILiteral processName, int pid, const char* message)
+{
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+    if (processName == "WebContent"_s)
+        os_log_with_type(log, type, "WebContent[%d] %{public}s", pid, message); // NOLINT
+    else if (processName == "Model"_s)
+        os_log_with_type(log, type, "Model[%d] %{public}s", pid, message); // NOLINT
+    else
+        os_log_with_type(log, type, "%{public}s[%d] %{public}s", processName.characters(), pid, message); // NOLINT
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+}
+
 #if ENABLE(STREAMING_IPC_IN_LOG_FORWARDING)
 // All LogStreams share a single work queue: the StreamServerConnection for each LogStream is opened on
 // (and thus bound to) this queue, so all of its connection work -- including invalidate() -- must run
@@ -58,13 +70,14 @@ static IPC::StreamConnectionWorkQueue& logWorkQueue()
 }
 #endif
 
-LogStream::LogStream(WebProcessProxy& process, Ref<ConnectionType>&& connection, LogStreamIdentifier identifier)
+LogStream::LogStream(AuxiliaryProcessProxy& process, ASCIILiteral processName, Ref<ConnectionType>&& connection, LogStreamIdentifier identifier)
     : m_connection(WTF::move(connection))
 #if ENABLE(STREAMING_IPC_IN_LOG_FORWARDING)
     , m_process(process)
 #endif
     , m_identifier(identifier)
     , m_pid(process.processID())
+    , m_processName(processName)
 {
 }
 
@@ -134,13 +147,13 @@ void LogStream::logOnBehalfOfWebContent(std::span<const uint8_t> subsystemSpan, 
     // Use '%{public}s' in the format string for the preprocessed string from the WebContent process.
     // This should not reveal any redacted information in the string, since it has already been composed in the WebContent process.
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    SUPPRESS_UNCOUNTED_LOCAL os_log_with_type(osLog.get(), static_cast<os_log_type_t>(logType), "WebContent[%d] %{public}s", m_pid, string.data());
+    SUPPRESS_UNCOUNTED_LOCAL logWithProcessNamePrefix(osLog.get(), static_cast<os_log_type_t>(logType), m_processName, m_pid, string.data());
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 #if ENABLE(STREAMING_IPC_IN_LOG_FORWARDING)
 
-RefPtr<LogStream> LogStream::create(WebProcessProxy& process, IPC::StreamServerConnectionHandle&& serverConnection, LogStreamIdentifier identifier, CompletionHandler<void(IPC::Semaphore& streamWakeUpSemaphore, IPC::Semaphore& streamClientWaitSemaphore)>&& completionHandler)
+RefPtr<LogStream> LogStream::create(AuxiliaryProcessProxy& process, ASCIILiteral processName, IPC::StreamServerConnectionHandle&& serverConnection, LogStreamIdentifier identifier, CompletionHandler<void(IPC::Semaphore& streamWakeUpSemaphore, IPC::Semaphore& streamClientWaitSemaphore)>&& completionHandler)
 {
     RefPtr connection = IPC::StreamServerConnection::tryCreate(WTF::move(serverConnection), { });
     if (!connection) {
@@ -151,7 +164,7 @@ RefPtr<LogStream> LogStream::create(WebProcessProxy& process, IPC::StreamServerC
     }
     Ref logQueue = logWorkQueue();
 
-    Ref instance = adoptRef(*new LogStream(process, connection.releaseNonNull(), identifier));
+    Ref instance = adoptRef(*new LogStream(process, processName, connection.releaseNonNull(), identifier));
     instance->m_connection->open(instance.get(), logQueue.get());
     instance->m_connection->startReceivingMessages(instance, Messages::LogStream::messageReceiverName(), identifier.toUInt64());
     completionHandler(logQueue->wakeUpSemaphore(), instance->m_connection->clientWaitSemaphore());
@@ -160,7 +173,7 @@ RefPtr<LogStream> LogStream::create(WebProcessProxy& process, IPC::StreamServerC
 
 void LogStream::didReceiveInvalidMessage(IPC::StreamServerConnection&, IPC::MessageName messageName, const Vector<uint32_t>&)
 {
-    RELEASE_LOG_FAULT_WITH_PAYLOAD(IPC, "Received an invalid message %s from WebContent process %d, requesting for it to be terminated.", description(messageName), m_pid);
+    RELEASE_LOG_FAULT_WITH_PAYLOAD(IPC, "Received an invalid message %s from %s process %d, requesting for it to be terminated.", description(messageName), m_processName, m_pid);
     callOnMainRunLoop([weakProcess = m_process] {
         if (RefPtr process = weakProcess.get())
             process->terminate();
@@ -169,9 +182,9 @@ void LogStream::didReceiveInvalidMessage(IPC::StreamServerConnection&, IPC::Mess
 
 #else
 
-Ref<LogStream> LogStream::create(WebProcessProxy& process, Ref<IPC::Connection>&& connection, LogStreamIdentifier identifier)
+Ref<LogStream> LogStream::create(AuxiliaryProcessProxy& process, ASCIILiteral processName, Ref<IPC::Connection>&& connection, LogStreamIdentifier identifier)
 {
-    return adoptRef(*new LogStream(process, WTF::move(connection), identifier));
+    return adoptRef(*new LogStream(process, processName, WTF::move(connection), identifier));
 }
 
 #endif

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
@@ -45,6 +45,14 @@
 #include <wtf/UniqueRef.h>
 #include <wtf/WeakPtrFactory.h>
 
+#if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
+#include "LogStream.h"
+#include "LogStreamIdentifier.h"
+#include "ScopedActiveMessageReceiveQueue.h"
+#include "XPCEventHandler.h"
+#include <wtf/OSObjectPtr.h>
+#endif
+
 namespace WebCore {
 class SharedBuffer;
 }
@@ -271,6 +279,30 @@ protected:
     void logInvalidMessage(IPC::Connection&, IPC::MessageName);
     virtual ASCIILiteral processName() const = 0;
 
+#if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
+    // Re-emits os_log messages forwarded by a child process during its launch window, before the
+    // streaming LogStream is established. Shared by every process type that forwards logs.
+    class LogXPCEventHandler final : public XPCEventHandler {
+    public:
+        explicit LogXPCEventHandler(const AuxiliaryProcessProxy&);
+
+        bool handleXPCEvent(xpc_object_t) final;
+
+    private:
+        WeakPtr<AuxiliaryProcessProxy> m_process;
+        bool m_logEndpointEnabled { true };
+    };
+
+#if ENABLE(STREAMING_IPC_IN_LOG_FORWARDING)
+    void createLogStream(IPC::StreamServerConnectionHandle&&, LogStreamIdentifier, CompletionHandler<void(IPC::Semaphore& streamWakeUpSemaphore, IPC::Semaphore& streamClientWaitSemaphore)>&&);
+#else
+    void createLogStream(LogStreamIdentifier, CompletionHandler<void()>&&);
+#endif
+    void stopLogStream();
+
+    virtual void didReceiveLogsDuringLaunchForTesting() { }
+#endif
+
     virtual void getLaunchOptions(ProcessLauncher::LaunchOptions&);
     virtual void platformGetLaunchOptions(ProcessLauncher::LaunchOptions&) { }
 
@@ -325,6 +357,10 @@ private:
     Vector<PendingMessage> m_pendingMessages;
     RefPtr<ProcessLauncher> m_processLauncher;
     RefPtr<IPC::Connection> m_connection;
+
+#if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
+    IPC::ScopedActiveMessageReceiveQueue<LogStream> m_logStream;
+#endif
     IPC::MessageReceiverMap m_messageReceiverMap;
     bool m_alwaysRunsAtBackgroundPriority { false };
     bool m_didBeginResponsivenessChecks { false };

--- a/Source/WebKit/UIProcess/Cocoa/AuxiliaryProcessProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/AuxiliaryProcessProxyCocoa.mm
@@ -39,6 +39,17 @@
 #import <wtf/Scope.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
+#if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
+#import "LaunchLogMessages.h"
+#import "LogStreamMessages.h"
+#import "Logging.h"
+#import "XPCEndpoint.h"
+#import <wtf/OSObjectPtr.h>
+#import <wtf/darwin/XPCExtras.h>
+#import <wtf/darwin/XPCObjectPtr.h>
+#import <wtf/spi/cocoa/OSLogSPI.h>
+#endif
+
 #import <pal/cf/AudioToolboxSoftLink.h>
 
 namespace WebKit {
@@ -190,5 +201,71 @@ void AuxiliaryProcessProxy::notifyPreferencesChanged(const String& domain, const
     send(Messages::AuxiliaryProcess::PreferenceDidUpdate(domain, key, encodedValue), 0);
 }
 #endif
+
+#if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
+AuxiliaryProcessProxy::LogXPCEventHandler::LogXPCEventHandler(const AuxiliaryProcessProxy& process)
+    : m_process(process)
+{
+}
+
+bool AuxiliaryProcessProxy::LogXPCEventHandler::handleXPCEvent(xpc_object_t event)
+{
+    auto messageName = xpcDictionaryGetString(event, XPCEndpoint::xpcMessageNameKey);
+    if (messageName == logMessageName) {
+        RefPtr process = m_process.get();
+        if (!process)
+            return true;
+
+        MESSAGE_CHECK_WITH_RETURN_VALUE_BASE(m_logEndpointEnabled, process->connection(), false);
+
+        auto subsystem = xpcDictionaryGetString(event, subsystemKey);
+        auto category = xpcDictionaryGetString(event, categoryKey);
+        auto messageString = xpcDictionaryGetString(event, messageStringKey);
+        auto logType = xpc_dictionary_get_uint64(event, logTypeKey);
+        auto pid = xpc_connection_get_pid(protect(xpc_dictionary_get_remote_connection(event)));
+
+        OSObjectPtr<os_log_t> osLog;
+        if (!subsystem.isEmpty() && !category.isEmpty())
+            osLog = adoptOSObject(os_log_create(subsystem.utf8().data(), category.utf8().data()));
+
+        process->didReceiveLogsDuringLaunchForTesting();
+        logWithProcessNamePrefix(osLog ? osLog.get() : OS_LOG_DEFAULT, static_cast<os_log_type_t>(logType), process->processName(), static_cast<int>(pid), messageString.utf8().data());
+    } else if (messageName == disableLogMessageName) {
+        RefPtr process = m_process.get();
+        if (!process)
+            return true;
+        m_logEndpointEnabled = false;
+        RELEASE_LOG(Process, "Log endpoint is disabled");
+    }
+    return false;
+}
+
+#if ENABLE(STREAMING_IPC_IN_LOG_FORWARDING)
+void AuxiliaryProcessProxy::createLogStream(IPC::StreamServerConnectionHandle&& serverConnection, LogStreamIdentifier identifier, CompletionHandler<void(IPC::Semaphore& streamWakeUpSemaphore, IPC::Semaphore& streamClientWaitSemaphore)>&& completionHandler)
+{
+    MESSAGE_CHECK_BASE(!m_logStream.get(), connection());
+    m_logStream = LogStream::create(*this, processName(), WTF::move(serverConnection), identifier, WTF::move(completionHandler));
+}
+#else
+void AuxiliaryProcessProxy::createLogStream(LogStreamIdentifier identifier, CompletionHandler<void()>&& completionHandler)
+{
+    MESSAGE_CHECK_BASE(!m_logStream.get(), connection());
+    Ref logStream = LogStream::create(*this, processName(), protect(connection()), identifier);
+    addMessageReceiver(Messages::LogStream::messageReceiverName(), logStream->identifier(), logStream);
+    m_logStream = WTF::move(logStream);
+    completionHandler();
+}
+#endif
+
+void AuxiliaryProcessProxy::stopLogStream()
+{
+    if (!m_logStream.get())
+        return;
+#if !ENABLE(STREAMING_IPC_IN_LOG_FORWARDING)
+    removeMessageReceiver(Messages::LogStream::messageReceiverName(), m_logStream->identifier());
+#endif
+    m_logStream.reset();
+}
+#endif // ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm
@@ -287,25 +287,6 @@ bool WebProcessProxy::shouldDisableJITCage() const
 }
 #endif
 
-#if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
-#if ENABLE(STREAMING_IPC_IN_LOG_FORWARDING)
-void WebProcessProxy::createLogStream(IPC::StreamServerConnectionHandle&& serverConnection, LogStreamIdentifier identifier, CompletionHandler<void(IPC::Semaphore& streamWakeUpSemaphore, IPC::Semaphore& streamClientWaitSemaphore)>&& completionHandler)
-{
-    MESSAGE_CHECK(!m_logStream.get());
-    m_logStream = LogStream::create(*this, WTF::move(serverConnection), identifier, WTF::move(completionHandler));
-}
-#else
-void WebProcessProxy::createLogStream(LogStreamIdentifier identifier, CompletionHandler<void()>&& completionHandler)
-{
-    MESSAGE_CHECK(!m_logStream.get());
-    Ref logStream = LogStream::create(*this, protect(connection()), identifier);
-    addMessageReceiver(Messages::LogStream::messageReceiverName(), logStream->identifier(), logStream);
-    m_logStream = WTF::move(logStream);
-    completionHandler();
-}
-#endif
-#endif // ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
-
 #if ENABLE(REMOTE_INSPECTOR)
 void WebProcessProxy::createServiceWorkerDebuggable(WebCore::ServiceWorkerIdentifier identifier, URL&& url, WebCore::ServiceWorkerIsInspectable isInspectable, CompletionHandler<void(bool shouldWaitForAutoInspection)>&& completionHandler)
 {
@@ -374,23 +355,7 @@ void WebProcessProxy::platformDestroy()
     [[WKStylusDeviceObserver sharedInstance] stop];
 #endif
 #endif // PLATFORM(IOS_FAMILY)
-
-#if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
-    stopLogStream();
-#endif
 }
-
-#if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
-void WebProcessProxy::stopLogStream()
-{
-    if (!m_logStream.get())
-        return;
-#if !ENABLE(STREAMING_IPC_IN_LOG_FORWARDING)
-    removeMessageReceiver(Messages::LogStream::messageReceiverName(), m_logStream->identifier());
-#endif
-    m_logStream.reset();
-}
-#endif
 
 void WebProcessProxy::platformResumeProcess()
 {
@@ -409,46 +374,12 @@ void WebProcessProxy::platformSuspendProcess()
 #if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
 RefPtr<XPCEventHandler> WebProcessProxy::xpcEventHandler() const
 {
-    return adoptRef(new WebProcessProxy::WebProcessXPCEventHandler(*this));
+    return adoptRef(new LogXPCEventHandler(*this));
 }
 
-bool WebProcessProxy::WebProcessXPCEventHandler::handleXPCEvent(xpc_object_t event)
+void WebProcessProxy::didReceiveLogsDuringLaunchForTesting()
 {
-    auto messageName = xpcDictionaryGetString(event, XPCEndpoint::xpcMessageNameKey);
-    if (messageName == logMessageName) {
-        RefPtr webProcess = m_webProcess.get();
-        if (!webProcess)
-            return true;
-
-        MESSAGE_CHECK_WITH_RETURN_VALUE_BASE(m_logEndpointEnabled, webProcess->connection(), false);
-
-        auto subsystem = xpcDictionaryGetString(event, subsystemKey);
-        auto category = xpcDictionaryGetString(event, categoryKey);
-        auto messageString = xpcDictionaryGetString(event, messageStringKey);
-        auto logType = xpc_dictionary_get_uint64(event, logTypeKey);
-        auto pid = xpc_connection_get_pid(protect(xpc_dictionary_get_remote_connection(event)));
-
-        OSObjectPtr<os_log_t> osLog;
-        if (!subsystem.isEmpty() && !category.isEmpty())
-            osLog = adoptOSObject(os_log_create(subsystem.utf8().data(), category.utf8().data()));
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-        os_log_with_type(osLog ? osLog.get() : OS_LOG_DEFAULT, static_cast<os_log_type_t>(logType), "WebContent[%d] %{public}s", static_cast<int>(pid), messageString.utf8().data());
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
-        webProcess->m_didReceiveLogsDuringLaunchForTesting = true;
-    } else if (messageName == disableLogMessageName) {
-        RefPtr webProcess = m_webProcess.get();
-        if (!webProcess)
-            return true;
-        m_logEndpointEnabled = false;
-        RELEASE_LOG(Process, "Log endpoint is disabled");
-    }
-    return false;
-}
-
-WebProcessProxy::WebProcessXPCEventHandler::WebProcessXPCEventHandler(const WebProcessProxy& webProcess)
-    : m_webProcess(webProcess)
-{
+    m_didReceiveLogsDuringLaunchForTesting = true;
 }
 #endif // ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
 

--- a/Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
+++ b/Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
@@ -423,7 +423,18 @@ void ProcessLauncher::tryFinishLaunchingProcess(ASCIILiteral name, Function<void
     xpc_dictionary_set_string(bootstrapMessage.get(), "ui-process-name", [processName UTF8String]);
     xpc_dictionary_set_string(bootstrapMessage.get(), "service-name", name);
 
-    if (m_launchOptions.processType == ProcessLauncher::ProcessType::Web) {
+    bool shouldForwardLogsToUIProcess = false;
+    switch (m_launchOptions.processType) {
+    case ProcessLauncher::ProcessType::Web:
+#if ENABLE(MODEL_PROCESS)
+    case ProcessLauncher::ProcessType::Model:
+#endif
+        shouldForwardLogsToUIProcess = true;
+        break;
+    default:
+        break;
+    }
+    if (shouldForwardLogsToUIProcess) {
 #if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
         bool disableLogging = true;
 #else

--- a/Source/WebKit/UIProcess/Model/ModelProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Model/ModelProcessProxy.cpp
@@ -176,6 +176,12 @@ void ModelProcessProxy::modelProcessExited(ProcessTerminationReason reason)
 {
     Ref protectedThis { *this };
 
+#if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
+    // Tear down the log stream promptly on process exit rather than waiting for this proxy to be
+    // destroyed, mirroring WebProcessProxy::shutDown(). See rdar://182244946.
+    stopLogStream();
+#endif
+
     switch (reason) {
     case ProcessTerminationReason::ExceededMemoryLimit:
     case ProcessTerminationReason::ExceededCPULimit:

--- a/Source/WebKit/UIProcess/Model/ModelProcessProxy.h
+++ b/Source/WebKit/UIProcess/Model/ModelProcessProxy.h
@@ -42,6 +42,12 @@
 #include "LayerHostingContext.h"
 #endif
 
+#if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
+#include "LogStream.h"
+#include "LogStreamIdentifier.h"
+#include "ScopedActiveMessageReceiveQueue.h"
+#endif
+
 #if PLATFORM(VISION) && ENABLE(GPU_PROCESS)
 namespace IPC {
 class SharedFileHandle;
@@ -101,6 +107,9 @@ private:
 
     // ProcessLauncher::Client
     void didFinishLaunching(ProcessLauncher*, IPC::Connection::Identifier&&) override;
+#if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
+    RefPtr<XPCEventHandler> xpcEventHandler() const final;
+#endif
 
     // IPC::Connection::Client
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
@@ -133,6 +142,7 @@ private:
 #if PLATFORM(VISION) && ENABLE(GPU_PROCESS)
     bool m_didInitializeSharedSimulationConnection { false };
 #endif
+
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Model/ModelProcessProxy.messages.in
+++ b/Source/WebKit/UIProcess/Model/ModelProcessProxy.messages.in
@@ -40,6 +40,10 @@ messages -> ModelProcessProxy {
 #if PLATFORM(VISION) && ENABLE(GPU_PROCESS) && HAVE(CORE_RE)
     RequestSharedSimulationConnection(WebCore::ProcessIdentifier webProcessIdentifier) -> (std::optional<IPC::SharedFileHandle> sharedSimulationConnection)
 #endif
+
+#if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT) && ENABLE(STREAMING_IPC_IN_LOG_FORWARDING)
+    CreateLogStream(IPC::StreamServerConnectionHandle connectionHandle, WebKit::LogStreamIdentifier identifier) -> (IPC::Semaphore streamWakeUpSemaphore, IPC::Semaphore streamClientWaitSemaphore)
+#endif
 }
 
 #endif // ENABLE(MODEL_PROCESS)

--- a/Source/WebKit/UIProcess/Model/cocoa/ModelProcessProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Model/cocoa/ModelProcessProxyCocoa.mm
@@ -30,6 +30,11 @@
 
 #include "ModelProcessCreationParameters.h"
 
+#if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
+#include "Logging.h"
+#include <wtf/spi/cocoa/OSLogSPI.h>
+#endif
+
 #if PLATFORM(VISION) && ENABLE(GPU_PROCESS) && HAVE(CORE_RE)
 
 #include "GPUProcessProxy.h"
@@ -62,6 +67,10 @@ void ModelProcessProxy::updateModelProcessCreationParameters(ModelProcessCreatio
     value = [NSUserDefaults.standardUserDefaults objectForKey:immersiveMemoryLimitFlag];
     if ([value isKindOfClass:NSNumber.class])
         parameters.debugImmersiveEntityMemoryLimit = [value integerValue];
+
+#if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
+    parameters.isDebugLoggingEnabled = os_log_debug_enabled(OS_LOG_DEFAULT);
+#endif
 }
 
 #if PLATFORM(VISION) && ENABLE(GPU_PROCESS) && ENABLE(MODEL_PROCESS) && HAVE(CORE_RE)
@@ -96,8 +105,14 @@ void ModelProcessProxy::requestSharedSimulationConnection(WebCore::ProcessIdenti
 #undef MESSAGE_CHECK
 #endif
 
+#if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
+RefPtr<XPCEventHandler> ModelProcessProxy::xpcEventHandler() const
+{
+    return adoptRef(new LogXPCEventHandler(*this));
+}
+#endif // ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
+
 }
 
 
 #endif // ENABLE(MODEL_PROCESS)
-

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -676,6 +676,7 @@ private:
     bool shouldDisableJITCage() const final;
 #if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
     RefPtr<XPCEventHandler> xpcEventHandler() const final;
+    void didReceiveLogsDuringLaunchForTesting() final;
 #endif
 
     void validateFreezerStatus();
@@ -774,15 +775,6 @@ private:
     void updateRuntimeStatistics();
     void enableMediaPlaybackIfNecessary();
     void sharedPreferencesDidChange();
-
-#if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
-#if ENABLE(STREAMING_IPC_IN_LOG_FORWARDING)
-    void createLogStream(IPC::StreamServerConnectionHandle&&, LogStreamIdentifier, CompletionHandler<void(IPC::Semaphore& streamWakeUpSemaphore, IPC::Semaphore& streamClientWaitSemaphore)>&&);
-#else
-    void createLogStream(LogStreamIdentifier, CompletionHandler<void()>&&);
-#endif
-    void stopLogStream();
-#endif
 
 #if ENABLE(REMOTE_INSPECTOR) && PLATFORM(COCOA)
     void createServiceWorkerDebuggable(WebCore::ServiceWorkerIdentifier, URL&&, WebCore::ServiceWorkerIsInspectable, CompletionHandler<void(bool shouldWaitForAutoInspection)>&&);
@@ -965,10 +957,6 @@ private:
 
     bool m_hasRegisteredServiceWorkerClients { true };
 
-#if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
-    IPC::ScopedActiveMessageReceiveQueue<LogStream> m_logStream;
-#endif
-
 #if ENABLE(CONTENT_EXTENSIONS)
     bool m_resourceMonitorRuleListRequestedBySomePage { false };
     RefPtr<WebCompiledContentRuleList> m_resourceMonitorRuleList;
@@ -985,18 +973,6 @@ private:
     HashMap<String, SandboxExtension::Handle> m_fileSandboxExtensions;
 
 #if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
-    class WebProcessXPCEventHandler final : public XPCEventHandler {
-    public:
-        explicit WebProcessXPCEventHandler(const WebProcessProxy&);
-
-        bool handleXPCEvent(xpc_object_t) final;
-
-    private:
-        WeakPtr<WebProcessProxy> m_webProcess;
-
-        bool m_logEndpointEnabled { true };
-    };
-
     bool m_didReceiveLogsDuringLaunchForTesting { false };
 #endif // ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
 } SWIFT_SHARED_REFERENCE(refWebProcessProxy, derefWebProcessProxy);

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -767,7 +767,11 @@ private:
     void accessibilityRelayProcessSuspended(bool);
 
 #if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
-    void initializeLogForwarding(const WebProcessCreationParameters&);
+#if ENABLE(STREAMING_IPC_IN_LOG_FORWARDING)
+    void sendCreateLogStreamToParent(IPC::Connection&, IPC::StreamServerConnectionHandle&&, LogStreamIdentifier, CompletionHandler<void(IPC::Semaphore&&, IPC::Semaphore&&)>&&) override;
+#else
+    void sendCreateLogStreamToParent(IPC::Connection&, LogStreamIdentifier, CompletionHandler<void()>&&) override;
+#endif
 #endif
 
     bool NODELETE isProcessBeingCachedForPerformance();

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -127,7 +127,6 @@
 #import <wtf/ProcessPrivilege.h>
 #import <wtf/RuntimeApplicationChecks.h>
 #import <wtf/SoftLinking.h>
-#import <wtf/SystemFree.h>
 #import <wtf/cf/NotificationCenterCF.h>
 #import <wtf/cocoa/Entitlements.h>
 #import <wtf/cocoa/NSURLExtras.h>
@@ -135,7 +134,6 @@
 #import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/cocoa/VectorCocoa.h>
 #import <wtf/darwin/DispatchExtras.h>
-#import <wtf/spi/cocoa/OSLogSPI.h>
 #import <wtf/spi/darwin/SandboxSPI.h>
 #import <wtf/text/MakeString.h>
 
@@ -184,12 +182,6 @@
 #if HAVE(MEDIA_ACCESSIBILITY_FRAMEWORK)
 #import "WebCaptionPreferencesDelegate.h"
 #import <WebCore/CaptionUserPreferencesMediaAF.h>
-#endif
-
-#if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
-#import "LaunchLogHook.h"
-#import "LogStream.h"
-#import "LogStreamMessages.h"
 #endif
 
 #if ENABLE(DATA_DETECTION) && PLATFORM(IOS_FAMILY)
@@ -398,7 +390,7 @@ void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& para
 #endif
 
 #if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
-    initializeLogForwarding(parameters);
+    initializeLogForwarding(parameters.isDebugLoggingEnabled);
 #endif
 
 #if ENABLE(NOTIFY_BLOCKING)
@@ -862,121 +854,17 @@ RetainPtr<NSDictionary> WebProcess::additionalStateForDiagnosticReport() const
 #endif // USE(OS_STATE)
 
 #if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
-#if PLATFORM(IOS_FAMILY)
-static void prewarmLogs()
-{
-    // This call will create container manager log objects.
-    // FIXME: this can be removed if we move all calls to topPrivatelyControlledDomain out of the WebContent process.
-    // This would be desirable, since the WebContent process is blocking access to the container manager daemon.
-    PublicSuffixStore::singleton().topPrivatelyControlledDomain("apple.com"_s);
-
-    static std::array<std::pair<ASCIILiteral, ASCIILiteral>, 5> logs { {
-        { "com.apple.CFBundle"_s, "strings"_s },
-        { "com.apple.network"_s, ""_s },
-        { "com.apple.CFNetwork"_s, "ATS"_s },
-        { "com.apple.coremedia"_s, ""_s },
-        { "com.apple.SafariShared"_s, "Translation"_s },
-    } };
-
-    for (auto& log : logs) {
-        auto logHandle = adoptOSObject(os_log_create(log.first, log.second));
-        bool enabled = os_log_type_enabled(logHandle.get(), OS_LOG_TYPE_ERROR);
-        UNUSED_PARAM(enabled);
-    }
-}
-#endif // PLATFORM(IOS_FAMILY)
-
-static bool shouldIgnoreLogMessage(std::span<const char> logChannel)
-{
-    return equalSpans(logChannel, "com.apple.xpc\0"_span) || equalSpans(logChannel, "com.apple.CoreAnalytics\0"_span);
-}
-
-static void registerLogClient(bool isDebugLoggingEnabled, std::unique_ptr<LogClient>&& newLogClient)
-{
-#if PLATFORM(IOS_FAMILY)
-    prewarmLogs();
-#endif
-
-    RELEASE_ASSERT(!logClient());
-    logClient() = WTF::move(newLogClient);
-
-    // OS_LOG_TYPE_DEFAULT implies default, fault, and error.
-    // OS_LOG_TYPE_DEBUG implies debug, info, default, fault, and error.
-    const auto minimumType = isDebugLoggingEnabled ? OS_LOG_TYPE_DEBUG : OS_LOG_TYPE_DEFAULT;
-
-    LaunchLogHook::singleton().disable();
-
-    static os_log_hook_t prevHook = nullptr;
-
-    prevHook = os_log_set_hook(minimumType, makeBlockPtr([isDebugLoggingEnabled](os_log_type_t type, os_log_message_t msg) {
-        if (prevHook)
-            prevHook(type, msg);
-
-        if (msg->buffer_sz > 1024)
-            return;
-
-        // Don't send debug/info messages unless debug logging is enabled. Even though OS_LOG_TYPE_DEFAULT would be the minimum,
-        // the hook will be called for other subsystems with debug and info types.
-        if (!isDebugLoggingEnabled && type & (OS_LOG_TYPE_DEBUG | OS_LOG_TYPE_INFO))
-            return;
-
-        if (Thread::currentThreadIsRealtime())
-            return;
-
-        auto logChannel = unsafeSpan(msg->subsystem);
-        if (logChannel.size() >= logSubsystemMaxSize)
-            return;
-        if (shouldIgnoreLogMessage(logChannel))
-            return;
-        auto logCategory = unsafeSpan(msg->category);
-        if (logCategory.size() >= logCategoryMaxSize)
-            return;
-
-        if (type == OS_LOG_TYPE_FAULT)
-            type = OS_LOG_TYPE_ERROR;
-
-        if (auto messageString = adoptSystemMalloc(os_log_copy_message_string(msg))) {
-            auto logString = spanConstCast<char>(unsafeSpan(messageString.get()));
-            if (logString.size() >= logStringMaxSize)
-                logString = logString.first(logStringMaxSize - 1);
-            logClient()->log(byteCast<uint8_t>(logChannel), byteCast<uint8_t>(logCategory), byteCast<uint8_t>(logString), type);
-        }
-    }).get());
-
-    WTFSignpostIndirectLoggingEnabled = true;
-}
-
-void WebProcess::initializeLogForwarding(const WebProcessCreationParameters& parameters)
-{
-    if (os_trace_get_mode() != OS_TRACE_MODE_OFF)
-        return;
-
-    RefPtr parentConnection = parentProcessConnection();
-    if (!parentConnection)
-        return;
-
-    WEBPROCESS_RELEASE_LOG(Process, "initializeLogForwarding: Debug logging enabled: %d", parameters.isDebugLoggingEnabled);
-
 #if ENABLE(STREAMING_IPC_IN_LOG_FORWARDING)
-    static constexpr auto connectionBufferSizeLog2 = 17;
-    auto connectionPair = IPC::StreamClientConnection::create(connectionBufferSizeLog2, 1_s);
-    if (!connectionPair)
-        CRASH();
-    auto [connection, handle] = WTF::move(*connectionPair);
-    protect(connection)->open(protect(*this), RunLoop::currentSingleton());
-    std::unique_ptr newLogClient = makeUnique<LogClient>(Ref { connection });
-    parentConnection->sendWithAsyncReply(Messages::WebProcessProxy::CreateLogStream(WTF::move(handle), newLogClient->identifier()), [newLogClient = WTF::move(newLogClient), connection = WTF::move(connection), isDebugLoggingEnabled = parameters.isDebugLoggingEnabled] (IPC::Semaphore&& wakeUpSemaphore, IPC::Semaphore&& clientWaitSemaphore) mutable {
-        connection->setSemaphores(WTF::move(wakeUpSemaphore), WTF::move(clientWaitSemaphore));
-        registerLogClient(isDebugLoggingEnabled, WTF::move(newLogClient));
-    });
-#else
-    std::unique_ptr newLogClient = makeUnique<LogClient>(*parentConnection);
-    parentConnection->sendWithAsyncReply(Messages::WebProcessProxy::CreateLogStream(newLogClient->identifier()), [newLogClient = WTF::move(newLogClient), isDebugLoggingEnabled = parameters.isDebugLoggingEnabled] mutable {
-        registerLogClient(isDebugLoggingEnabled, WTF::move(newLogClient));
-    });
-#endif
-
+void WebProcess::sendCreateLogStreamToParent(IPC::Connection& parentConnection, IPC::StreamServerConnectionHandle&& handle, LogStreamIdentifier identifier, CompletionHandler<void(IPC::Semaphore&&, IPC::Semaphore&&)>&& completionHandler)
+{
+    parentConnection.sendWithAsyncReply(Messages::WebProcessProxy::CreateLogStream(WTF::move(handle), identifier), WTF::move(completionHandler));
 }
+#else
+void WebProcess::sendCreateLogStreamToParent(IPC::Connection& parentConnection, LogStreamIdentifier identifier, CompletionHandler<void()>&& completionHandler)
+{
+    parentConnection.sendWithAsyncReply(Messages::WebProcessProxy::CreateLogStream(identifier), WTF::move(completionHandler));
+}
+#endif
 
 #endif
 


### PR DESCRIPTION
#### 64e4e8a7d098e5535b6f07ce2f0efec70fa6395a
<pre>
Add log messaging relay to the Model Process
<a href="https://bugs.webkit.org/show_bug.cgi?id=319852">https://bugs.webkit.org/show_bug.cgi?id=319852</a>
<a href="https://rdar.apple.com/182429803">rdar://182429803</a>

Reviewed by Per Arne Vollan.

Under ENABLE(LOGD_BLOCKING_IN_WEBCONTENT), child processes are denied logd and
relay os_log to the UI process. Model #includes the WebContent sandbox profile,
so it inherited the block but had no relay, silently dropping all os_log from
com.apple.WebKit.Model; a direct log-service grant in Model&apos;s profile was added
as a temporary stopgap.

Give Model the relay by sharing it: the child-side setup (initializeLogForwarding
and registerLogClient — the os_log hook, log prewarming, and signpost forwarding)
moves to AuxiliaryProcess and the UI-side re-emit (LogStream, createLogStream,
launch-window XPC handler) to AuxiliaryProcessProxy, leaving only the process name
and the CreateLogStream message per process.

With the relay in place, remove the stopgap log service permission from Model&apos;s
sandbox profile.

* Source/WebKit/ModelProcess/ModelProcess.cpp:
(WebKit::ModelProcess::initializeModelProcess):
* Source/WebKit/ModelProcess/ModelProcess.h:
* Source/WebKit/ModelProcess/ModelProcessCreationParameters.h:
* Source/WebKit/ModelProcess/ModelProcessCreationParameters.serialization.in:
* Source/WebKit/ModelProcess/cocoa/ModelProcessCocoa.mm:
(WebKit::ModelProcess::sendCreateLogStreamToParent):
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Model.sb.in:
* Source/WebKit/Shared/AuxiliaryProcess.h:
(WebKit::AuxiliaryProcess::sendCreateLogStreamToParent):
* Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm:
(WebKit::shouldIgnoreLogMessage):
(WebKit::prewarmLogs):
(WebKit::registerLogClient):
(WebKit::AuxiliaryProcess::initializeLogForwarding):
* Source/WebKit/Shared/LogStream.h:
* Source/WebKit/Shared/LogStream.mm:
(WebKit::LogStream::LogStream):
(WebKit::LogStream::logOnBehalfOfWebContent):
(WebKit::LogStream::create):
(WebKit::LogStream::didReceiveInvalidMessage):
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.h:
(WebKit::AuxiliaryProcessProxy::didReceiveLogsDuringLaunchForTesting):
* Source/WebKit/UIProcess/Cocoa/AuxiliaryProcessProxyCocoa.mm:
(WebKit::AuxiliaryProcessProxy::LogXPCEventHandler::LogXPCEventHandler):
(WebKit::AuxiliaryProcessProxy::LogXPCEventHandler::handleXPCEvent):
(WebKit::AuxiliaryProcessProxy::createLogStream):
(WebKit::AuxiliaryProcessProxy::stopLogStream):
* Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm:
(WebKit::WebProcessProxy::platformDestroy):
(WebKit::WebProcessProxy::xpcEventHandler const):
(WebKit::WebProcessProxy::didReceiveLogsDuringLaunchForTesting):
(WebKit::WebProcessProxy::createLogStream):
(WebKit::WebProcessProxy::stopLogStream): Deleted.
(WebKit::WebProcessProxy::WebProcessXPCEventHandler::handleXPCEvent): Deleted.
(WebKit::WebProcessProxy::WebProcessXPCEventHandler::WebProcessXPCEventHandler): Deleted.
* Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm:
(WebKit::ProcessLauncher::tryFinishLaunchingProcess):
* Source/WebKit/UIProcess/Model/ModelProcessProxy.cpp:
(WebKit::ModelProcessProxy::modelProcessExited):
* Source/WebKit/UIProcess/Model/ModelProcessProxy.h:
* Source/WebKit/UIProcess/Model/ModelProcessProxy.messages.in:
* Source/WebKit/UIProcess/Model/cocoa/ModelProcessProxyCocoa.mm:
(WebKit::ModelProcessProxy::updateModelProcessCreationParameters):
(WebKit::ModelProcessProxy::xpcEventHandler const):
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/WebProcess/WebProcess.h:
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::accessibilityFocusedUIElement):

Canonical link: <a href="https://commits.webkit.org/318004@main">https://commits.webkit.org/318004@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa848cafa384dbe872a6b912a110522295b0f7f3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176988 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50925 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44720 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186591 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52218 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50611 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137902 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179944 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41416 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158690 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118371 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40072 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38436 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150482 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38190 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35059 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42678 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42654 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189014 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50592 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146982 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39511 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51275 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/34814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146778 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41532 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123488 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117776 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49780 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13170 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49179 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49416 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49240 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->