### PR TITLE
CanvasRenderingContext2DBase: always unwind state stack on destruction

### DIFF
--- a/LayoutTests/fast/canvas/canvas-open-two-layers-then-gc-crash-expected.txt
+++ b/LayoutTests/fast/canvas/canvas-open-two-layers-then-gc-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/canvas/canvas-open-two-layers-then-gc-crash.html
+++ b/LayoutTests/fast/canvas/canvas-open-two-layers-then-gc-crash.html
@@ -1,0 +1,23 @@
+<!-- webkit-test-runner [ GraphicsContextFiltersEnabled=false ]-->
+<!DOCTYPE html>
+
+<title>Shouldn't crash when two canvas layers are opened, then the CanvasRenderingContext2D is garbage collected</title>
+<script src="../../resources/gc.js"></script>
+
+<p>This test passes if it does not crash.</p>
+<canvas width="300" height="300" id="canvas"></canvas>
+
+<script>
+  if (window.testRunner)
+    testRunner.dumpAsText();
+
+  let context = canvas.getContext("2d");
+
+  context.beginLayer();
+  context.beginLayer();
+
+  // GC the context and <canvas>.
+  context = null;
+  canvas.remove();
+  gc();
+</script>

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -266,15 +266,17 @@ CanvasRenderingContext2DBase::CanvasRenderingContext2DBase(CanvasBase& canvas, C
 
 CanvasRenderingContext2DBase::~CanvasRenderingContext2DBase()
 {
-#if ASSERT_ENABLED
     m_unrealizedSaveCount = 0;
     size_t restoreCount = m_stateStack.size() - 1;
     for (size_t i = 0; i < restoreCount; ++i)
         restore();
-    m_stateStack.first() = State();
+
+    // Should only have one state now.
+    ASSERT(m_stateStack.size() == 1);
+
+    // The buffer created in buffer() is save(), so restore() here to match.
     if (RefPtr buffer = m_buffer)
         buffer->context().restore();
-#endif
 }
 
 bool CanvasRenderingContext2DBase::isAccelerated() const

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
@@ -510,7 +510,14 @@ private:
 
     static constexpr unsigned MaxSaveCount = 1024 * 16;
     mutable RefPtr<ImageBuffer> m_buffer;
-    Vector<State, 1> m_stateStack; // References go m_stateStack -> targetSwitcher -> m_buffer, so destroy state stack first.
+
+    // When layers are opened, m_stateStack contains target switchers where the top
+    // targetSwitcher on the stack draws to the targetSwitcher under it, ... until
+    // it eventually draws to m_buffer. So m_stateStack has to be freed in the stack
+    // order (top in stack/last in vector first, bottom in stack/first in vector last),
+    // then m_buffer can be freed after.
+    Vector<State, 1> m_stateStack;
+
     FloatRect m_dirtyRect;
     unsigned m_unrealizedSaveCount { 0 };
     bool m_usesCSSCompatibilityParseMode;


### PR DESCRIPTION
#### e4b357a32b53a80abbb20db9fe9aa389e182b6b7
<pre>
CanvasRenderingContext2DBase: always unwind state stack on destruction
<a href="https://rdar.apple.com/181410211">rdar://181410211</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=319288">https://bugs.webkit.org/show_bug.cgi?id=319288</a>

Reviewed by Simon Fraser.

CanvasRenderingContext2DBase::beginLayer works by putting a new targetSwitcher
on the state stack, so the new effective drawing context will be the drawing
context of the new targetSwitcher. Then when endLayer is called, targetSwitcher
goes away, and its destructor paints the layer content to the previous effective
drawing context, which could be the base buffer (m_buffer), or the previous
targetSwitcher on the stack.

This means the targetSwitcher on the top of the stack paints to the next one on
the stack, ... until the last one paints to m_buffer. Consequently, the state stack
has to be unwound from top to bottom of stack (last to first of vector) to
respect the dependency chain. The current destructor does this by repeatedly
calling restore(), but it&apos;s only enabled in Debug builds. In Release builds, the
default destructor is used, which frees the state stack in the WTF::Vector order
from first to last. The result is that freeing targetSwitcher might cause a
crash, as it paints to the previous targetSwitcher that&apos;s already freed.

Fix this by always unwinding the state stack properly on destruction, regardless
of Debug or Release builds.

Test: fast/canvas/canvas-open-two-layers-then-gc-crash.html

* LayoutTests/fast/canvas/canvas-open-two-layers-then-gc-crash-expected.txt: Added.
* LayoutTests/fast/canvas/canvas-open-two-layers-then-gc-crash.html: Added.
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::~CanvasRenderingContext2DBase):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h:

Canonical link: <a href="https://commits.webkit.org/317787@main">https://commits.webkit.org/317787@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71d73a1cc512439b3b5d0550356b981d5a84b39d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176160 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50095 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43885 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185756 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/58fe6eb2-d5eb-4433-9d1a-493f4cef721f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178023 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51387 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49779 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137208 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179116 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40683 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157980 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117683 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d1fbb22f-772f-4fcf-b09d-6f852bcd8cc2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39332 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37699 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149748 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37477 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34225 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41812 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41910 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188179 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49760 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/157525 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146230 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39373 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50443 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34095 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146054 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40833 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122648 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116622 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48948 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12449 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48350 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48584 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48408 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->