### PR TITLE
[JSC][Temporal] Fix non-ISO calendar dayOfYear

### DIFF
--- a/JSTests/stress/temporal-non-iso-dayofyear.js
+++ b/JSTests/stress/temporal-non-iso-dayofyear.js
@@ -1,0 +1,41 @@
+//@ requireOptions("--useTemporal=1")
+
+function shouldBe(actual, expected, message) {
+    if (actual !== expected)
+        throw new Error(`${message}: expected ${expected}, got ${actual}`);
+}
+
+function assertFirstTwoDays(create, name) {
+    const date = create();
+    shouldBe(date.dayOfYear, 1, `${name} first day`);
+    shouldBe(date.add({ days: 1 }).dayOfYear, 2, `${name} second day`);
+}
+
+assertFirstTwoDays(() => Temporal.PlainDate.from({ year: 5730, month: 1, day: 1, calendar: "hebrew" }), "Hebrew PlainDate");
+assertFirstTwoDays(() => Temporal.PlainDateTime.from({ year: 5730, month: 1, day: 1, calendar: "hebrew", hour: 12 }), "Hebrew PlainDateTime");
+assertFirstTwoDays(() => Temporal.ZonedDateTime.from({ year: 5730, month: 1, day: 1, calendar: "hebrew", hour: 12, timeZone: "UTC" }), "Hebrew ZonedDateTime");
+
+assertFirstTwoDays(() => Temporal.PlainDate.from({ year: 1969, month: 1, day: 1, calendar: "chinese" }), "Chinese PlainDate");
+assertFirstTwoDays(() => Temporal.PlainDate.from({ year: 1969, month: 1, day: 1, calendar: "dangi" }), "Dangi PlainDate");
+
+function assertCalendarDayOfYear(date, expected, name) {
+    shouldBe(date.dayOfYear, expected, `${name} day of year`);
+}
+
+assertCalendarDayOfYear(Temporal.PlainDate.from("1582-01-01").withCalendar("japanese"), 1, "Japanese PlainDate before 1873");
+assertCalendarDayOfYear(Temporal.PlainDateTime.from("1582-01-01T12:00").withCalendar("japanese"), 1, "Japanese PlainDateTime before 1873");
+assertCalendarDayOfYear(Temporal.ZonedDateTime.from("1582-01-01T12:00Z[UTC]").withCalendar("japanese"), 1, "Japanese ZonedDateTime before 1873");
+
+assertCalendarDayOfYear(Temporal.PlainDate.from("1872-12-31").withCalendar("japanese"), 366, "Japanese PlainDate fallback boundary");
+assertCalendarDayOfYear(Temporal.PlainDateTime.from("1872-12-31T12:00").withCalendar("japanese"), 366, "Japanese PlainDateTime fallback boundary");
+assertCalendarDayOfYear(Temporal.ZonedDateTime.from("1872-12-31T12:00Z[UTC]").withCalendar("japanese"), 366, "Japanese ZonedDateTime fallback boundary");
+assertCalendarDayOfYear(Temporal.PlainDate.from("1873-01-01").withCalendar("japanese"), 1, "Japanese PlainDate ICU boundary");
+assertCalendarDayOfYear(Temporal.PlainDateTime.from("1873-01-01T12:00").withCalendar("japanese"), 1, "Japanese PlainDateTime ICU boundary");
+assertCalendarDayOfYear(Temporal.ZonedDateTime.from("1873-01-01T12:00Z[UTC]").withCalendar("japanese"), 1, "Japanese ZonedDateTime ICU boundary");
+
+assertCalendarDayOfYear(Temporal.PlainDate.from("1582-01-01").withCalendar("roc"), 1, "ROC PlainDate before 1582");
+assertCalendarDayOfYear(Temporal.PlainDateTime.from("1582-01-01T12:00").withCalendar("roc"), 1, "ROC PlainDateTime before 1582");
+assertCalendarDayOfYear(Temporal.ZonedDateTime.from("1582-01-01T12:00Z[UTC]").withCalendar("roc"), 1, "ROC ZonedDateTime before 1582");
+assertCalendarDayOfYear(Temporal.PlainDate.from("1582-01-01").withCalendar("buddhist"), 1, "Buddhist PlainDate before 1582");
+assertCalendarDayOfYear(Temporal.PlainDateTime.from("1582-01-01T12:00").withCalendar("buddhist"), 1, "Buddhist PlainDateTime before 1582");
+assertCalendarDayOfYear(Temporal.ZonedDateTime.from("1582-01-01T12:00Z[UTC]").withCalendar("buddhist"), 1, "Buddhist ZonedDateTime before 1582");

--- a/Source/JavaScriptCore/runtime/TemporalPlainDatePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDatePrototype.cpp
@@ -711,6 +711,12 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainDatePrototypeGetterDayOfYear, (JSGlobalObj
     if (!plainDate) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDate.prototype.dayOfYear called on value that's not a PlainDate"_s);
 
+    if (!TemporalCore::calendarIsISO(plainDate->calendarID())) {
+        auto result = TemporalCore::calendarDayOfYear(plainDate->calendarID(), plainDate->plainDate());
+        if (!result) [[unlikely]]
+            return throwVMRangeError(globalObject, scope, result.error().message);
+        return JSValue::encode(jsNumber(*result));
+    }
     return JSValue::encode(jsNumber(plainDate->dayOfYear()));
 }
 

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateTimePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateTimePrototype.cpp
@@ -844,6 +844,12 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainDateTimePrototypeGetterDayOfYear, (JSGloba
     if (!plainDateTime) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.dayOfYear called on value that's not a PlainDateTime"_s);
 
+    if (!TemporalCore::calendarIsISO(plainDateTime->calendarID())) {
+        auto result = TemporalCore::calendarDayOfYear(plainDateTime->calendarID(), plainDateTime->plainDate());
+        if (!result) [[unlikely]]
+            return throwVMRangeError(globalObject, scope, result.error().message);
+        return JSValue::encode(jsNumber(*result));
+    }
     return JSValue::encode(jsNumber(plainDateTime->dayOfYear()));
 }
 

--- a/Source/JavaScriptCore/runtime/TemporalZonedDateTimePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalZonedDateTimePrototype.cpp
@@ -1443,8 +1443,12 @@ JSC_DEFINE_CUSTOM_GETTER(temporalZonedDateTimePrototypeGetterDayOfYear, (JSGloba
     auto [date, time] = zdt->getLocalDateTime(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
     // Step 4: Return 𝔽(CalendarISOToDate(calendar, isoDateTime.[[ISODate]]).[[DayOfYear]]).
-    // NOTE: for non-ISO calendars this should return the day within the calendar year, not the ISO year.
-    // JSC currently returns the ISO day-of-year for all calendars (pre-existing behavior, matches PlainDate).
+    if (!TemporalCore::calendarIsISO(zdt->calendarID())) {
+        auto result = TemporalCore::calendarDayOfYear(zdt->calendarID(), date);
+        if (!result) [[unlikely]]
+            return throwVMRangeError(globalObject, scope, result.error().message);
+        return JSValue::encode(jsNumber(*result));
+    }
     return JSValue::encode(jsNumber(ISO8601::dayOfYear(date)));
 }
 

--- a/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
@@ -207,6 +207,8 @@ static std::optional<ISO8601::PlainDate> isoDateFromCalendarChecked(UCalendar* c
 
 // Japanese era table — start years are historically fixed calendar facts.
 // icu4x: components/calendar/src/cal/japanese.rs Japanese::eras()
+static constexpr int32_t japaneseCalendarGregorianTransitionYear = 1873;
+
 struct JapaneseEra {
     int32_t startYear;
     ASCIILiteral name;
@@ -489,7 +491,7 @@ TemporalResult<CalendarFields> isoToCalendarFields(CalendarID calendarId, const 
         fields.era = mapICUEraToTemporalEra(calendarId, raw.ucalEra);
         fields.eraYear = raw.ucalYear;
         if (calendarId == japaneseCalendarID()) {
-            if (isoDate.year() < 1873) {
+            if (isoDate.year() < japaneseCalendarGregorianTransitionYear) {
                 fields.era = isoDate.year() > 0 ? "ce"_s : "bce"_s;
                 fields.eraYear = isoDate.year() > 0 ? isoDate.year() : (1 - isoDate.year());
             } else if (fields.era && *fields.era == "ce"_s)
@@ -549,7 +551,7 @@ TemporalResult<uint8_t> calendarMonth(CalendarID calendarId, const ISO8601::Plai
 {
     // 1. Return the ordinal month (1-based position in year, counting leap months) of isoDate in calendarId.
     // NOTE: Japanese pre-1873 "ce"/"bce" eras use ISO month directly to bypass ICU Julian conversion.
-    if (calendarId == japaneseCalendarID() && isoDate.year() < 1873)
+    if (calendarId == japaneseCalendarID() && isoDate.year() < japaneseCalendarGregorianTransitionYear)
         return isoDate.month();
     return withCalendar(calendarId, [&](UCalendar* cal) -> TemporalResult<uint8_t> {
         if (!cal) [[unlikely]]
@@ -573,7 +575,7 @@ TemporalResult<String> calendarMonthCode(CalendarID calendarId, const ISO8601::P
 {
     // 1. Return the month code string (e.g. "M01", "M05L") of isoDate in calendarId.
     // NOTE: Japanese pre-1873 "ce"/"bce" eras use ISO month code directly to bypass ICU Julian conversion.
-    if (calendarId == japaneseCalendarID() && isoDate.year() < 1873)
+    if (calendarId == japaneseCalendarID() && isoDate.year() < japaneseCalendarGregorianTransitionYear)
         return ISO8601::monthCode(isoDate.month());
     return withCalendar(calendarId, [&](UCalendar* cal) -> TemporalResult<String> {
         if (!cal) [[unlikely]]
@@ -597,7 +599,7 @@ TemporalResult<uint8_t> calendarDay(CalendarID calendarId, const ISO8601::PlainD
 {
     // 1. Return the day-of-month of isoDate in calendarId.
     // NOTE: Japanese pre-1873 "ce"/"bce" eras return ISO day directly to bypass ICU Julian conversion.
-    if (calendarId == japaneseCalendarID() && isoDate.year() < 1873)
+    if (calendarId == japaneseCalendarID() && isoDate.year() < japaneseCalendarGregorianTransitionYear)
         return isoDate.day();
     return withCalendar(calendarId, [&](UCalendar* cal) -> TemporalResult<uint8_t> {
         if (!cal) [[unlikely]]
@@ -609,6 +611,21 @@ TemporalResult<uint8_t> calendarDay(CalendarID calendarId, const ISO8601::PlainD
         if (U_FAILURE(status)) [[unlikely]]
             return makeUnexpected(rangeError(icuReadCalendarFailed));
         return static_cast<uint8_t>(day);
+    });
+}
+
+TemporalResult<uint16_t> calendarDayOfYear(CalendarID calendarId, const ISO8601::PlainDate& isoDate)
+{
+    return withCalendar(gregorianArithmeticCalendarFor(calendarId), [&](UCalendar* cal) -> TemporalResult<uint16_t> {
+        if (!cal) [[unlikely]]
+            return makeUnexpected(rangeError(icuOpenCalendarFailed));
+        if (!setCalendarToISODate(cal, isoDate)) [[unlikely]]
+            return makeUnexpected(rangeError(icuSetCalendarFailed));
+        UErrorCode status = U_ZERO_ERROR;
+        int32_t dayOfYear = ucal_get(cal, UCAL_DAY_OF_YEAR, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return makeUnexpected(rangeError(icuReadCalendarFailed));
+        return static_cast<uint16_t>(dayOfYear);
     });
 }
 
@@ -625,7 +642,7 @@ TemporalResult<std::optional<String>> calendarEra(CalendarID calendarId, const I
         return std::optional<String>(std::nullopt);
     // 2. Return the era string for isoDate in calendarId (e.g. "ce", "bce", "reiwa").
     // NOTE: Japanese dates before 1873 use "ce"/"bce" per spec, not ICU era names.
-    if (calendarId == japaneseCalendarID() && isoDate.year() < 1873)
+    if (calendarId == japaneseCalendarID() && isoDate.year() < japaneseCalendarGregorianTransitionYear)
         return std::optional<String>(isoDate.year() > 0 ? String("ce"_s) : String("bce"_s));
     // Read UCAL_ERA inside the lock, then map to era string outside (mapICUEraToTemporalEra
     // for Japanese calls japaneseEraStartYear which needs its own withCalendar call).
@@ -658,7 +675,7 @@ TemporalResult<std::optional<int32_t>> calendarEraYear(CalendarID calendarId, co
         return std::optional<int32_t>(std::nullopt);
     // 2. Return the era year (year within the current era) of isoDate in calendarId.
     // NOTE: Japanese "ce"/"bce" fallback: eraYear is the Gregorian year.
-    if (calendarId == japaneseCalendarID() && isoDate.year() < 1873)
+    if (calendarId == japaneseCalendarID() && isoDate.year() < japaneseCalendarGregorianTransitionYear)
         return std::optional<int32_t>(isoDate.year() > 0 ? isoDate.year() : (1 - isoDate.year()));
 
     struct RawEraYear {

--- a/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.h
+++ b/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.h
@@ -93,6 +93,8 @@ JS_EXPORT_PRIVATE TemporalResult<String> calendarMonthCode(CalendarID, const ISO
 
 JS_EXPORT_PRIVATE TemporalResult<uint8_t> calendarDay(CalendarID, const ISO8601::PlainDate& isoDate);
 
+JS_EXPORT_PRIVATE TemporalResult<uint16_t> calendarDayOfYear(CalendarID, const ISO8601::PlainDate& isoDate);
+
 JS_EXPORT_PRIVATE TemporalResult<std::optional<String>> calendarEra(CalendarID, const ISO8601::PlainDate& isoDate);
 
 JS_EXPORT_PRIVATE TemporalResult<std::optional<int32_t>> calendarEraYear(CalendarID, const ISO8601::PlainDate& isoDate);


### PR DESCRIPTION
#### cfda643c04c033a07680a3afe4574cadb8f64451
<pre>
[JSC][Temporal] Fix non-ISO calendar dayOfYear
<a href="https://bugs.webkit.org/show_bug.cgi?id=319305">https://bugs.webkit.org/show_bug.cgi?id=319305</a>

Reviewed by Yijia Huang.

Temporal dayOfYear currently returns the ISO ordinal day for every calendar.
Read UCAL_DAY_OF_YEAR through CalendarICUBridge for non-ISO calendars and use
the existing proleptic Gregorian arithmetic path where required. This fixes
PlainDate, PlainDateTime, and ZonedDateTime for non-ISO calendars.

Test: JSTests/stress/temporal-non-iso-dayofyear.js

* JSTests/stress/temporal-non-iso-dayofyear.js:
Added coverage for non-ISO calendar dayOfYear values and Gregorian arithmetic
boundaries.

* Source/JavaScriptCore/runtime/TemporalPlainDatePrototype.cpp:
(JSC::temporalPlainDatePrototypeGetterDayOfYear):
* Source/JavaScriptCore/runtime/TemporalPlainDateTimePrototype.cpp:
(JSC::temporalPlainDateTimePrototypeGetterDayOfYear):
* Source/JavaScriptCore/runtime/TemporalZonedDateTimePrototype.cpp:
(JSC::temporalZonedDateTimePrototypeGetterDayOfYear):
Use CalendarICUBridge for non-ISO calendar dayOfYear values.

* Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp:
(JSC::TemporalCore::japaneseCalendarGregorianTransitionYear):
(JSC::TemporalCore::calendarDayOfYear):
Add the day-of-year bridge and name the Japanese Gregorian transition year.

* Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.h:
(JSC::TemporalCore::calendarDayOfYear):
Declare the bridge.

Canonical link: <a href="https://commits.webkit.org/317240@main">https://commits.webkit.org/317240@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2f4b5c40819896160d71364d834c2c9c4d772b1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174335 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48268 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42049 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183911 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132203 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49560 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47950 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135612 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95684 "4 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177293 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39041 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156405 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116090 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37682 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36055 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32393 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/4914 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148105 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35897 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186337 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/35597 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39542 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40252 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144521 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47935 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144379 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39004 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48614 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32517 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114156 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39282 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120550 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/211370 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47120 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10861 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55082 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46523 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46754 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46581 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->