### PR TITLE
[WPE][WebKitTestRunner] Add EventSender.asyncTouch* methods

### DIFF
--- a/LayoutTests/fast/events/touch/multi-touch-inside-iframes.html
+++ b/LayoutTests/fast/events/touch/multi-touch-inside-iframes.html
@@ -105,7 +105,7 @@ function onTouch(event, receiver)
     touchEventCount++;
 }
 
-function runTest() {
+async function runTest() {
     document.getElementById("iframe1").contentWindow.document.title = "iframe1";
     document.getElementById("iframe2").contentWindow.document.title = "iframe2";
     if (window.eventSender) {
@@ -115,48 +115,48 @@ function runTest() {
         debug('First touch is on iframe1.');
         shouldBeEqualToString('document.elementFromPoint(101, 101).id', 'iframe1');
         eventSender.addTouchPoint(101, 101);
-        eventSender.touchStart();
+        await eventSender.asyncTouchStart();
         debug('');
 
         debug('Second touch is on iframe2, nothing should happen.');
         shouldBeEqualToString('document.elementFromPoint(251, 101).id', 'iframe2');
         eventSender.addTouchPoint(251, 101);
-        eventSender.touchStart();
+        await eventSender.asyncTouchStart();
         debug('');
 
         debug('Moves the first touch outside iframe1.');
         eventSender.updateTouchPoint(0, 201, 201);
-        eventSender.touchMove();
+        await eventSender.asyncTouchMove();
         debug('');
 
         debug('Release the first touch.');
         eventSender.releaseTouchPoint(0);
-        eventSender.touchEnd();
+        await eventSender.asyncTouchEnd();
         debug('');
 
         debug('Third touch is on iframe2, nothing should happen.');
         shouldBeEqualToString('document.elementFromPoint(261, 101).id', 'iframe2');
         eventSender.addTouchPoint(261, 101);
-        eventSender.touchStart();
+        await eventSender.asyncTouchStart();
         debug('');
 
         debug('Release all touches on iframe2, and touch iframe2 again.');
         eventSender.releaseTouchPoint(0);
         eventSender.releaseTouchPoint(1);
-        eventSender.touchEnd();
+        await eventSender.asyncTouchEnd();
         eventSender.addTouchPoint(251, 101);
-        eventSender.touchStart();
+        await eventSender.asyncTouchStart();
         debug('');
 
         debug('Touch iframe1, nothing shoud happen.');
         eventSender.addTouchPoint(101, 101);
-        eventSender.touchStart();
+        await eventSender.asyncTouchStart();
         debug('');
 
         debug('Release all touches.');
         eventSender.releaseTouchPoint(0);
         eventSender.releaseTouchPoint(1);
-        eventSender.touchEnd();
+        await eventSender.asyncTouchEnd();
     } else {
        debug('This test requires DRT.');
     }

--- a/LayoutTests/fast/events/touch/text-node-touch-target.html
+++ b/LayoutTests/fast/events/touch/text-node-touch-target.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../../resources/js-test.js"></script>
 <!--
   Touch tests that involve the ontouchstart, ontouchmove, ontouchend or ontouchcancel callbacks
   should be written in an asynchronous fashion so they can be run on mobile platforms like Android.
@@ -13,37 +13,35 @@
 <p id="description"></p>
 <div id="console"></div>
 <script>
-var targetDiv = document.createElement("div");
-targetDiv.id = "targetDiv";
-targetDiv.setAttribute('style', "position: absolute; top: 0; left: 0; background-color: blue; font-size: 24px;");
-targetDiv.innerText = 'This is some text';
-
-document.body.insertBefore(targetDiv, document.getElementById('console'));
-
-function touchStartHandler()
-{
-    shouldBeEqualToString('event.type', 'touchstart');
-    shouldBeEqualToString('event.touches[0].target.id', targetDiv.id);
-    shouldBeEqualToString('event.touches[0].target.nodeName', 'DIV');
-
-    successfullyParsed = true;
-    isSuccessfullyParsed();
-}
-
-targetDiv.addEventListener("touchstart", touchStartHandler, false);
-
 description("Tests that the event target for a touch on a text node is the parent element, not the text node.");
+jsTestIsAsync = true;
 
-if (window.eventSender) {
-    eventSender.clearTouchPoints();
-    eventSender.addTouchPoint(10, 10);
-    eventSender.touchStart();
-    eventSender.touchEnd();
-} else
-    debug('This test requires DRT.');
+onload = async () => {
+    var targetDiv = document.createElement("div");
+    targetDiv.id = "targetDiv";
+    targetDiv.setAttribute('style', "position: absolute; top: 0; left: 0; background-color: blue; font-size: 24px;");
+    targetDiv.innerText = 'This is some text';
 
+    document.body.insertBefore(targetDiv, document.getElementById('console'));
 
-var successfullyParsed = true;
+    function touchStartHandler()
+    {
+        shouldBeEqualToString('event.type', 'touchstart');
+        shouldBeEqualToString('event.touches[0].target.id', targetDiv.id);
+        shouldBeEqualToString('event.touches[0].target.nodeName', 'DIV');
+    }
+
+    targetDiv.addEventListener("touchstart", touchStartHandler, false);
+
+    if (window.eventSender) {
+        eventSender.clearTouchPoints();
+        eventSender.addTouchPoint(10, 10);
+        await eventSender.asyncTouchStart();
+        await eventSender.asyncTouchEnd();
+    } else
+        debug('This test requires DRT.');
+    finishJSTest();
+}
 </script>
 </body>
 </html>

--- a/LayoutTests/fast/events/touch/textarea-touch-target.html
+++ b/LayoutTests/fast/events/touch/textarea-touch-target.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../../resources/js-test.js"></script>
 <!--
   Touch tests that involve the ontouchstart, ontouchmove, ontouchend or ontouchcancel callbacks
   should be written in an asynchronous fashion so they can be run on mobile platforms like Android.
@@ -13,37 +13,38 @@
 <p id="description"></p>
 <div id="console"></div>
 <script>
-var target = document.createElement('textarea');
-target.id = "target";
-target.setAttribute('style', "position: absolute; top: 0; left: 0; font-size: 24px;");
+window.jsTestIsAsync = true;
 
-document.body.insertBefore(target, document.getElementById('console'));
+description("Tests that input elements can receive touch events.");
 
 function touchStartHandler()
 {
     shouldBeEqualToString('event.type', 'touchstart');
     shouldBeEqualToString('event.touches[0].target.id', target.id);
     shouldBeEqualToString('event.touches[0].target.nodeName', 'TEXTAREA');
-
-    successfullyParsed = true;
-    isSuccessfullyParsed();
 }
 
-target.addEventListener("touchstart", touchStartHandler, false);
+onload = async () => {
+    var target = document.createElement('textarea');
+    target.id = "target";
+    target.setAttribute('style', "position: absolute; top: 0; left: 0; font-size: 24px;");
 
-description("Tests that input elements can receive touch events.");
+    document.body.insertBefore(target, document.getElementById('console'));
 
-if (window.eventSender) {
-    eventSender.clearTouchPoints();
-    eventSender.addTouchPoint(10, 10);
-    eventSender.touchStart();
-    eventSender.touchEnd();
-} else
-    debug('This test requires DRT.');
+    target.addEventListener("touchstart", touchStartHandler, false);
 
-document.body.removeChild(target);
+    if (window.eventSender) {
+        eventSender.clearTouchPoints();
+        eventSender.addTouchPoint(10, 10);
+        await eventSender.asyncTouchStart();
+        eventSender.releaseTouchPoint(0);
+        await eventSender.asyncTouchEnd();
+    } else
+        debug('This test requires DRT.');
 
-var successfullyParsed = true;
+    document.body.removeChild(target);
+    finishJSTest();
+}
 </script>
 </body>
 </html>

--- a/LayoutTests/fast/events/touch/touch-coords-in-zoom-and-scroll.html
+++ b/LayoutTests/fast/events/touch/touch-coords-in-zoom-and-scroll.html
@@ -1,3 +1,4 @@
+<!DOCTYPE HTML>
 <script src="../../../resources/js-test.js"></script>
 <style>
     #pusher {
@@ -14,12 +15,12 @@
     window.jsTestIsAsync = true;
     var event;
 
-    function sendTouchStart(x, y)
+    async function sendTouchStart(x, y)
     {
         if (window.eventSender) {
             eventSender.clearTouchPoints();
             eventSender.addTouchPoint(x, y);
-            eventSender.touchStart();
+            await eventSender.asyncTouchStart();
         }
     }
 
@@ -54,11 +55,6 @@
         shouldBe("event.touches[0].pageY", "100");
     }
 
-    window.addEventListener("touchstart", base, false);
-    
-    sendTouchStart(100, 100);
-    window.removeEventListener("touchstart", base, false);
-
     var floatPrecision = 0.00001;
     
     // Just zoomed.
@@ -71,11 +67,6 @@
         shouldBeCloseTo("event.touches[0].pageX", 83.33333, floatPrecision);
         shouldBeCloseTo("event.touches[0].pageY", 83.33333, floatPrecision);
     }
-    window.addEventListener("touchstart", justZoomed, false);
-    zoomPageIn();
-    sendTouchStart(100, 100);
-    zoomPageOut();
-    window.removeEventListener("touchstart", justZoomed, false);
 
     // Just scrolled.
     function justScrolled(e)
@@ -87,11 +78,6 @@
         shouldBe("event.touches[0].pageX", "150");
         shouldBe("event.touches[0].pageY", "150");
     }
-    window.addEventListener("touchstart", justScrolled, false);
-    scrollPage(50, 50);
-    sendTouchStart(100, 100);
-    scrollPage(0, 0);
-    window.removeEventListener("touchstart", justScrolled, false);
 
     // Zoomed and scrolled.
     function zoomedAndScrolled(e)
@@ -103,22 +89,42 @@
         shouldBeCloseTo("event.touches[0].pageX", 133.33333, floatPrecision);
         shouldBeCloseTo("event.touches[0].pageY", 133.33333, floatPrecision);
     }
-    window.addEventListener("touchstart", zoomedAndScrolled, false);
-    zoomPageIn();
-    scrollPage(50, 50);
-    sendTouchStart(100, 100);
-    zoomPageOut();
-    scrollPage(0, 0);
-    window.removeEventListener("touchstart", zoomedAndScrolled, false);
 
-    if (window.eventSender) {
-        eventSender.touchEnd();
-        eventSender.clearTouchPoints();
-    }
-    
-    if (window.testRunner) {
-        var area = document.getElementById('testArea');
-        area.parentNode.removeChild(area);
-        finishJSTest();
+    onload = async () => {
+        window.addEventListener("touchstart", base, false);
+        
+        await sendTouchStart(100, 100);
+        window.removeEventListener("touchstart", base, false);
+
+        window.addEventListener("touchstart", justZoomed, false);
+        zoomPageIn();
+        await sendTouchStart(100, 100);
+        zoomPageOut();
+        window.removeEventListener("touchstart", justZoomed, false);
+
+        window.addEventListener("touchstart", justScrolled, false);
+        scrollPage(50, 50);
+        await sendTouchStart(100, 100);
+        scrollPage(0, 0);
+        window.removeEventListener("touchstart", justScrolled, false);
+
+        window.addEventListener("touchstart", zoomedAndScrolled, false);
+        zoomPageIn();
+        scrollPage(50, 50);
+        await sendTouchStart(100, 100);
+        zoomPageOut();
+        scrollPage(0, 0);
+        window.removeEventListener("touchstart", zoomedAndScrolled, false);
+
+        if (window.eventSender) {
+            await eventSender.asyncTouchEnd();
+            eventSender.clearTouchPoints();
+        }
+        
+        if (window.testRunner) {
+            var area = document.getElementById('testArea');
+            area.parentNode.removeChild(area);
+            finishJSTest();
+        }
     }
 </script>

--- a/LayoutTests/fast/events/touch/touch-slider-no-js-touch-listener.html
+++ b/LayoutTests/fast/events/touch/touch-slider-no-js-touch-listener.html
@@ -45,28 +45,29 @@ document.addEventListener('keydown', onKeyDown);
 description("Tests to ensure that touch events are delivered to an input element with type=range even when there are no touch event handlers in Javascript. This test is only expected to pass if ENABLE_TOUCH_SLIDER is defined.");
 window.jsTestIsAsync = true;
 
-
-if (window.eventSender) {
-    var x = slider.offsetLeft;
-    var y = slider.offsetTop + slider.clientHeight/2;
-    var w = slider.clientWidth;
-
-    checkPosition();
-
-    eventSender.clearTouchPoints();
-    eventSender.addTouchPoint(x + w/2, y);
-    eventSender.touchStart();
-
-    eventSender.updateTouchPoint(0, x, y);
-    eventSender.touchMove();
-
-    eventSender.releaseTouchPoint(0);
-    eventSender.touchEnd();
-
-    eventSender.keyDown(' ');
-
-} else {
-    debug('This test requires DRT.');
+onload = async () => {
+  if (window.eventSender) {
+      var x = slider.offsetLeft;
+      var y = slider.offsetTop + slider.clientHeight/2;
+      var w = slider.clientWidth;
+  
+      checkPosition();
+  
+      eventSender.clearTouchPoints();
+      eventSender.addTouchPoint(x + w/2, y);
+      await eventSender.asyncTouchStart();
+  
+      eventSender.updateTouchPoint(0, x, y);
+      await eventSender.asyncTouchMove();
+  
+      eventSender.releaseTouchPoint(0);
+      await eventSender.asyncTouchEnd();
+  
+      eventSender.keyDown(' ');
+  
+  } else {
+      debug('This test requires DRT.');
+  }
 }
 </script>
 </body>

--- a/LayoutTests/fast/events/touch/touch-slider.html
+++ b/LayoutTests/fast/events/touch/touch-slider.html
@@ -82,7 +82,7 @@ var checkPosition = (function() {
 
 })();
 
-function runTest(slider, rotated) {
+async function runTest(slider, rotated) {
 
     var w = slider.clientWidth;
     var h = slider.clientHeight;
@@ -96,19 +96,19 @@ function runTest(slider, rotated) {
 
     eventSender.clearTouchPoints();
     eventSender.addTouchPoint(x, y);
-    eventSender.touchStart();
+    await eventSender.asyncTouchStart();
 
     eventSender.updateTouchPoint(0, x - w/2, y + h/2);
-    eventSender.touchMove();
+    await eventSender.asyncTouchMove();
 
     eventSender.updateTouchPoint(0, x + w/2, y - h/2);
-    eventSender.touchMove();
+    await eventSender.asyncTouchMove();
 
     eventSender.updateTouchPoint(0, x, y);
-    eventSender.touchMove();
+    await eventSender.asyncTouchMove();
 
     eventSender.releaseTouchPoint(0);
-    eventSender.touchEnd();
+    await eventSender.asyncTouchEnd();
 }
 
 document.addEventListener("touchstart", onTouchStart, false);
@@ -119,15 +119,16 @@ document.addEventListener("keydown", onKeyDown, false);
 description("Tests that the touch events originating on an input element with type=range update the slider position. This test is only expected to pass if ENABLE_TOUCH_SLIDER is defined.");
 window.jsTestIsAsync = true;
 
-
-if (window.eventSender) {
-    runTest(slider1, false);
-    runTest(slider2, false);
-    runTest(slider3, true);
-
-    eventSender.keyDown(' ');
-} else {
-    debug('This test requires DRT.');
+onload = async () => {
+    if (window.eventSender) {
+        await runTest(slider1, false);
+        await runTest(slider2, false);
+        await runTest(slider3, true);
+    
+        eventSender.keyDown(' ');
+    } else {
+        debug('This test requires DRT.');
+    }
 }
 </script>
 </body>

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -3615,6 +3615,22 @@ void WKPageDoAfterProcessingAllPendingKeyEvents(WKPageRef page, void* context, W
 }
 #endif
 
+#if ENABLE(TOUCH_EVENTS) && !ENABLE(IOS_TOUCH_EVENTS)
+void WKPageDoAfterProcessingAllPendingWheelEvents(WKPageRef page, void* context, WKPageDoAfterProcessingAllPendingWheelEventsFunction completionHandler)
+{
+    protect(toImpl(page))->doAfterProcessingAllPendingWheelEvents([context, completionHandler] {
+        completionHandler(context);
+    });
+}
+
+void WKPageDoAfterProcessingAllPendingTouchEvents(WKPageRef page, void* context, WKPageDoAfterProcessingAllPendingTouchEventsFunction completionHandler)
+{
+    protect(toImpl(page))->doAfterProcessingAllPendingTouchEvents([context, completionHandler] {
+        completionHandler(context);
+    });
+}
+#endif
+
 void WKPageSetCursorDidChangeCallbackForTesting(WKPageRef page, WKPageCursorDidChangeCallbackForTesting callback, const void* clientInfo)
 {
     if (!callback) {

--- a/Source/WebKit/UIProcess/API/C/WKPagePrivate.h
+++ b/Source/WebKit/UIProcess/API/C/WKPagePrivate.h
@@ -244,6 +244,12 @@ WK_EXPORT void WKPageDoAfterProcessingAllPendingMouseEvents(WKPageRef page, void
 #if !defined(__APPLE__)
 typedef void (*WKPageDoAfterProcessingAllPendingKeyEventsFunction)(void* functionContext);
 WK_EXPORT void WKPageDoAfterProcessingAllPendingKeyEvents(WKPageRef page, void* context, WKPageDoAfterProcessingAllPendingKeyEventsFunction function);
+
+typedef void (*WKPageDoAfterProcessingAllPendingWheelEventsFunction)(void* functionContext);
+WK_EXPORT void WKPageDoAfterProcessingAllPendingWheelEvents(WKPageRef page, void* context, WKPageDoAfterProcessingAllPendingWheelEventsFunction function);
+
+typedef void (*WKPageDoAfterProcessingAllPendingTouchEventsFunction)(void* functionContext);
+WK_EXPORT void WKPageDoAfterProcessingAllPendingTouchEvents(WKPageRef page, void* context, WKPageDoAfterProcessingAllPendingTouchEventsFunction function);
 #endif
 
 typedef void (*WKPageCursorDidChangeCallbackForTesting)(WKStringRef cursorInfo, const void* clientInfo);

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -4689,6 +4689,55 @@ void WebPageProxy::flushPendingKeyEventCallbacks()
         callback();
 }
 
+#if ENABLE(TOUCH_EVENTS) && !ENABLE(IOS_TOUCH_EVENTS)
+void WebPageProxy::doAfterProcessingAllPendingWheelEvents(WTF::Function<void ()>&& action)
+{
+    if (!isProcessingWheelEvents()) {
+        action();
+        return;
+    }
+
+    internals().callbackHandlersAfterProcessingPendingWheelEvents.append(WTF::move(action));
+}
+
+void WebPageProxy::didFinishProcessingAllPendingWheelEvents()
+{
+    flushPendingWheelEventCallbacks();
+}
+
+void WebPageProxy::flushPendingWheelEventCallbacks()
+{
+    for (auto&& callback : std::exchange(internals().callbackHandlersAfterProcessingPendingWheelEvents, { }))
+        callback();
+}
+
+bool WebPageProxy::isProcessingTouchEvents() const
+{
+    return !internals().touchEventQueue.isEmpty();
+}
+
+void WebPageProxy::doAfterProcessingAllPendingTouchEvents(WTF::Function<void ()>&& action)
+{
+    if (!isProcessingTouchEvents()) {
+        action();
+        return;
+    }
+
+    internals().callbackHandlersAfterProcessingPendingTouchEvents.append(WTF::move(action));
+}
+
+void WebPageProxy::didFinishProcessingAllPendingTouchEvents()
+{
+    flushPendingTouchEventCallbacks();
+}
+
+void WebPageProxy::flushPendingTouchEventCallbacks()
+{
+    for (auto&& callback : std::exchange(internals().callbackHandlersAfterProcessingPendingTouchEvents, { }))
+        callback();
+}
+#endif
+
 #if PLATFORM(IOS_FAMILY)
 void WebPageProxy::handleWheelEventWithoutScrolling(const WebWheelEvent& event, CompletionHandler<void(bool)>&& completionHandler)
 {
@@ -4881,6 +4930,9 @@ void WebPageProxy::wheelEventHandlingCompleted(bool wasHandled)
 
     if (RefPtr automationSession = m_configuration->processPool().automationSession())
         automationSession->wheelEventsFlushedForPage(*this);
+#if ENABLE(TOUCH_EVENTS) && !ENABLE(IOS_TOUCH_EVENTS)
+    didFinishProcessingAllPendingWheelEvents();
+#endif
 }
 
 void WebPageProxy::cacheWheelEventScrollingAccelerationCurve(const NativeWebWheelEvent& nativeWheelEvent)
@@ -5330,6 +5382,11 @@ void WebPageProxy::touchEventHandlingCompleted(IPC::Connection* connection, std:
         bool isEventHandled = false;
         pageClient->doneWithTouchEvent(queuedEvents.deferredTouchEvents.at(i), isEventHandled);
     }
+
+#if ENABLE(TOUCH_EVENTS) && !ENABLE(IOS_TOUCH_EVENTS)
+    if (internals().touchEventQueue.isEmpty())
+        didFinishProcessingAllPendingTouchEvents();
+#endif
 }
 
 void WebPageProxy::handleTouchEvent(IPC::Connection* connection, const NativeWebTouchEvent& event)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1463,6 +1463,17 @@ public:
     void didFinishProcessingAllPendingKeyEvents();
     void flushPendingKeyEventCallbacks();
 
+#if ENABLE(TOUCH_EVENTS) && !ENABLE(IOS_TOUCH_EVENTS)
+    void doAfterProcessingAllPendingWheelEvents(Function<void()>&&);
+    void didFinishProcessingAllPendingWheelEvents();
+    void flushPendingWheelEventCallbacks();
+
+    bool isProcessingTouchEvents() const;
+    void doAfterProcessingAllPendingTouchEvents(Function<void()>&&);
+    void didFinishProcessingAllPendingTouchEvents();
+    void flushPendingTouchEventCallbacks();
+#endif
+
     bool NODELETE isProcessingWheelEvents() const;
     void handleNativeWheelEvent(const NativeWebWheelEvent&);
     void interruptSyntheticMomentumScrolling();

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -217,6 +217,10 @@ public:
     std::optional<WebCore::FontAttributes> cachedFontAttributesAtSelectionStart;
     Vector<Function<void()>> callbackHandlersAfterProcessingPendingMouseEvents;
     Vector<Function<void()>> callbackHandlersAfterProcessingPendingKeyEvents;
+#if ENABLE(TOUCH_EVENTS) && !ENABLE(IOS_TOUCH_EVENTS)
+    Vector<Function<void()>> callbackHandlersAfterProcessingPendingWheelEvents;
+    Vector<Function<void()>> callbackHandlersAfterProcessingPendingTouchEvents;
+#endif
     WebCore::FloatSize defaultUnobscuredSize;
     EditorState editorState;
     WebCore::IntSize fixedLayoutSize;

--- a/Tools/WebKitTestRunner/EventSenderProxy.h
+++ b/Tools/WebKitTestRunner/EventSenderProxy.h
@@ -108,10 +108,10 @@ public:
     void updateTouchPoint(int index, int x, int y);
     void setTouchModifier(WKEventModifiers, bool enable);
     void setTouchPointRadius(int radiusX, int radiusY);
-    void touchStart();
-    void touchMove();
-    void touchEnd();
-    void touchCancel();
+    void touchStart(CompletionHandler<void()>&& = nullptr);
+    void touchMove(CompletionHandler<void()>&& = nullptr);
+    void touchEnd(CompletionHandler<void()>&& = nullptr);
+    void touchCancel(CompletionHandler<void()>&& = nullptr);
     void clearTouchPoints();
     void releaseTouchPoint(int index);
     void cancelTouchPoint(int index);

--- a/Tools/WebKitTestRunner/InjectedBundle/ios/EventSenderProxyIOS.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/ios/EventSenderProxyIOS.mm
@@ -126,20 +126,28 @@ void EventSenderProxy::setTouchPointRadius(int radiusX, int radiusY)
 {
 }
 
-void EventSenderProxy::touchStart()
+void EventSenderProxy::touchStart(CompletionHandler<void()>&& completionHandler)
 {
+    if (completionHandler)
+        completionHandler();
 }
 
-void EventSenderProxy::touchMove()
+void EventSenderProxy::touchMove(CompletionHandler<void()>&& completionHandler)
 {
+    if (completionHandler)
+        completionHandler();
 }
 
-void EventSenderProxy::touchEnd()
+void EventSenderProxy::touchEnd(CompletionHandler<void()>&& completionHandler)
 {
+    if (completionHandler)
+        completionHandler();
 }
 
-void EventSenderProxy::touchCancel()
+void EventSenderProxy::touchCancel(CompletionHandler<void()>&& completionHandler)
 {
+    if (completionHandler)
+        completionHandler();
 }
 
 void EventSenderProxy::clearTouchPoints()

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -2232,6 +2232,18 @@ if (window.eventSender) {
     eventSender.asyncKeyDown = async (key, modifiers) => { // NOLINT
         await post(['AsyncKeyDown', key, modifiers]);
     };
+    eventSender.asyncTouchStart = async () => { // NOLINT
+        await post(['AsyncTouchStart']);
+    };
+    eventSender.asyncTouchMove = async () => { // NOLINT
+        await post(['AsyncTouchMove']);
+    };
+    eventSender.asyncTouchEnd = async () => { // NOLINT
+        await post(['AsyncTouchEnd']);
+    };
+    eventSender.asyncTouchCancel = async () => { // NOLINT
+        await post(['AsyncTouchCancel']);
+    };
 }
 )eventSenderJS";
 
@@ -3100,6 +3112,33 @@ void TestController::didReceiveScriptMessage(WKScriptMessageRef message, Complet
             [completionHandler = WTF::move(completionHandler)] mutable { completionHandler(nullptr); });
         return;
     }
+
+#if ENABLE(TOUCH_EVENTS) && !ENABLE(IOS_TOUCH_EVENTS)
+    if (WKStringIsEqualToUTF8CString(command, "AsyncTouchStart")) {
+        m_eventSenderProxy->touchStart([completionHandler = WTF::move(completionHandler)] mutable {
+            completionHandler(nullptr);
+        });
+        return;
+    }
+    if (WKStringIsEqualToUTF8CString(command, "AsyncTouchMove")) {
+        m_eventSenderProxy->touchMove([completionHandler = WTF::move(completionHandler)] mutable {
+            completionHandler(nullptr);
+        });
+        return;
+    }
+    if (WKStringIsEqualToUTF8CString(command, "AsyncTouchEnd")) {
+        m_eventSenderProxy->touchEnd([completionHandler = WTF::move(completionHandler)] mutable {
+            completionHandler(nullptr);
+        });
+        return;
+    }
+    if (WKStringIsEqualToUTF8CString(command, "AsyncTouchCancel")) {
+        m_eventSenderProxy->touchCancel([completionHandler = WTF::move(completionHandler)] mutable {
+            completionHandler(nullptr);
+        });
+        return;
+    }
+#endif
 
     ASSERT_NOT_REACHED();
 }
@@ -6073,6 +6112,35 @@ void TestController::doAfterProcessingAllPendingKeyEvents(CompletionHandler<void
         delete completionHandler;
     });
 }
+
+#if ENABLE(TOUCH_EVENTS) && !ENABLE(IOS_TOUCH_EVENTS)
+void TestController::doAfterProcessingAllPendingWheelEvents(CompletionHandler<void()>&& handler)
+{
+    auto* completionHandler = new CompletionHandler<void()>(WTF::move(handler));
+    WKPageDoAfterProcessingAllPendingWheelEvents(targetView()->page(), completionHandler, [](void* userData) {
+        auto* completionHandler = static_cast<CompletionHandler<void()>*>(userData);
+        (*completionHandler)();
+        delete completionHandler;
+    });
+}
+
+void TestController::doAfterProcessingAllPendingTouchEvents(CompletionHandler<void()>&& handler)
+{
+    auto* completionHandler = new CompletionHandler<void()>(WTF::move(handler));
+    WKPageDoAfterProcessingAllPendingTouchEvents(targetView()->page(), completionHandler, [](void* userData) {
+        auto* completionHandler = static_cast<CompletionHandler<void()>*>(userData);
+        (*completionHandler)();
+        delete completionHandler;
+    });
+}
+
+void TestController::doAfterProcessingAllPendingTouchAndWheelEvents(CompletionHandler<void()>&& handler)
+{
+    doAfterProcessingAllPendingTouchEvents([this, handler = WTF::move(handler)] mutable {
+        doAfterProcessingAllPendingWheelEvents(WTF::move(handler));
+    });
+}
+#endif
 #endif
 
 } // namespace WTR

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -511,6 +511,11 @@ public:
 #if !PLATFORM(COCOA)
     void doAfterProcessingAllPendingMouseEvents(CompletionHandler<void()>&&);
     void doAfterProcessingAllPendingKeyEvents(CompletionHandler<void()>&&);
+#if ENABLE(TOUCH_EVENTS) && !ENABLE(IOS_TOUCH_EVENTS)
+    void doAfterProcessingAllPendingWheelEvents(CompletionHandler<void()>&&);
+    void doAfterProcessingAllPendingTouchEvents(CompletionHandler<void()>&&);
+    void doAfterProcessingAllPendingTouchAndWheelEvents(CompletionHandler<void()>&&);
+#endif
 #endif
 
     static uint64_t responseHeaderCount(WKURLResponseRef);

--- a/Tools/WebKitTestRunner/gtk/EventSenderProxyGtk.cpp
+++ b/Tools/WebKitTestRunner/gtk/EventSenderProxyGtk.cpp
@@ -408,20 +408,28 @@ void EventSenderProxy::updateTouchPoint(int, int, int)
 {
 }
 
-void EventSenderProxy::touchStart()
+void EventSenderProxy::touchStart(CompletionHandler<void()>&& completionHandler)
 {
+    if (completionHandler)
+        completionHandler();
 }
 
-void EventSenderProxy::touchMove()
+void EventSenderProxy::touchMove(CompletionHandler<void()>&& completionHandler)
 {
+    if (completionHandler)
+        completionHandler();
 }
 
-void EventSenderProxy::touchEnd()
+void EventSenderProxy::touchEnd(CompletionHandler<void()>&& completionHandler)
 {
+    if (completionHandler)
+        completionHandler();
 }
 
-void EventSenderProxy::touchCancel()
+void EventSenderProxy::touchCancel(CompletionHandler<void()>&& completionHandler)
 {
+    if (completionHandler)
+        completionHandler();
 }
 
 void EventSenderProxy::clearTouchPoints()

--- a/Tools/WebKitTestRunner/libwpe/EventSenderProxyLibWPE.cpp
+++ b/Tools/WebKitTestRunner/libwpe/EventSenderProxyLibWPE.cpp
@@ -173,24 +173,32 @@ void EventSenderProxy::setTouchPointRadius(int, int)
     notImplemented();
 }
 
-void EventSenderProxy::touchStart()
+void EventSenderProxy::touchStart(CompletionHandler<void()>&& completionHandler)
 {
     m_client->touchStart(absoluteTimeForEventTime(m_time));
+    if (completionHandler)
+        m_testController->doAfterProcessingAllPendingTouchAndWheelEvents(WTF::move(completionHandler));
 }
 
-void EventSenderProxy::touchMove()
+void EventSenderProxy::touchMove(CompletionHandler<void()>&& completionHandler)
 {
     m_client->touchMove(absoluteTimeForEventTime(m_time));
+    if (completionHandler)
+        m_testController->doAfterProcessingAllPendingTouchAndWheelEvents(WTF::move(completionHandler));
 }
 
-void EventSenderProxy::touchEnd()
+void EventSenderProxy::touchEnd(CompletionHandler<void()>&& completionHandler)
 {
     m_client->touchEnd(absoluteTimeForEventTime(m_time));
+    if (completionHandler)
+        m_testController->doAfterProcessingAllPendingTouchAndWheelEvents(WTF::move(completionHandler));
 }
 
-void EventSenderProxy::touchCancel()
+void EventSenderProxy::touchCancel(CompletionHandler<void()>&& completionHandler)
 {
     m_client->touchCancel(absoluteTimeForEventTime(m_time));
+    if (completionHandler)
+        m_testController->doAfterProcessingAllPendingTouchAndWheelEvents(WTF::move(completionHandler));
 }
 
 void EventSenderProxy::clearTouchPoints()


### PR DESCRIPTION
#### 590cc045e1331238e245b8a909afcdbaf55f7169
<pre>
[WPE][WebKitTestRunner] Add EventSender.asyncTouch* methods
<a href="https://bugs.webkit.org/show_bug.cgi?id=319307">https://bugs.webkit.org/show_bug.cgi?id=319307</a>

Reviewed by Carlos Garcia Campos.

Added the following asynchronous touch event methods to EventSender.

- asyncTouchStart()
- asyncTouchMove()
- asyncTouchEnd()
- asyncTouchCancel()

See also 309000@main which added eventSender.asyncMouse* methods.

Rewrote some layout tests with them. They were blocking bug#318938.

* LayoutTests/fast/events/touch/multi-touch-inside-iframes.html:
* LayoutTests/fast/events/touch/text-node-touch-target.html:
* LayoutTests/fast/events/touch/textarea-touch-target.html:
* LayoutTests/fast/events/touch/touch-coords-in-zoom-and-scroll.html:
* LayoutTests/fast/events/touch/touch-slider-no-js-touch-listener.html:
* LayoutTests/fast/events/touch/touch-slider.html:
* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageDoAfterProcessingAllPendingWheelEvents):
(WKPageDoAfterProcessingAllPendingTouchEvents):
* Source/WebKit/UIProcess/API/C/WKPagePrivate.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::doAfterProcessingAllPendingWheelEvents):
(WebKit::WebPageProxy::didFinishProcessingAllPendingWheelEvents):
(WebKit::WebPageProxy::flushPendingWheelEventCallbacks):
(WebKit::WebPageProxy::isProcessingTouchEvents const):
(WebKit::WebPageProxy::doAfterProcessingAllPendingTouchEvents):
(WebKit::WebPageProxy::didFinishProcessingAllPendingTouchEvents):
(WebKit::WebPageProxy::flushPendingTouchEventCallbacks):
(WebKit::WebPageProxy::wheelEventHandlingCompleted):
(WebKit::WebPageProxy::touchEventHandlingCompleted):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxyInternals.h:
* Tools/WebKitTestRunner/EventSenderProxy.h:
* Tools/WebKitTestRunner/InjectedBundle/ios/EventSenderProxyIOS.mm:
(WTR::EventSenderProxy::touchStart):
(WTR::EventSenderProxy::touchMove):
(WTR::EventSenderProxy::touchEnd):
(WTR::EventSenderProxy::touchCancel):
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::if):
* Tools/WebKitTestRunner/TestController.h:
* Tools/WebKitTestRunner/gtk/EventSenderProxyGtk.cpp:
(WTR::EventSenderProxy::touchStart):
(WTR::EventSenderProxy::touchMove):
(WTR::EventSenderProxy::touchEnd):
(WTR::EventSenderProxy::touchCancel):
* Tools/WebKitTestRunner/libwpe/EventSenderProxyLibWPE.cpp:
(WTR::EventSenderProxy::touchStart):
(WTR::EventSenderProxy::touchMove):
(WTR::EventSenderProxy::touchEnd):
(WTR::EventSenderProxy::touchCancel):

Canonical link: <a href="https://commits.webkit.org/317140@main">https://commits.webkit.org/317140@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f74fafbbdcb3e538ea2fc9ef10145a5e847965a3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174342 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48275 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42056 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183918 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132210 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176207 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49567 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47957 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135617 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177300 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39049 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156409 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116095 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37690 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36060 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32400 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148113 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35901 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186344 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39549 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40257 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144528 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47942 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155963 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144386 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48621 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32521 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114163 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26513 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39287 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120557 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47127 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10865 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46530 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46761 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46588 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->