### PR TITLE
Web Inspector: _tokenTrackingControllerHighlightedMarkedExpression tests a leaked loop variable instead of the selected marker

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/SourceCodeTextEditor.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SourceCodeTextEditor.js
@@ -2155,8 +2155,8 @@ WI.SourceCodeTextEditor = class SourceCodeTextEditor extends WI.TextEditor
     _tokenTrackingControllerHighlightedMarkedExpression(candidate, markers)
     {
         // Look for the outermost editable marker.
-        var editableMarker;
-        for (var marker of markers) {
+        let editableMarker;
+        for (let marker of markers) {
             if (!marker.range || !Object.values(WI.TextMarker.Type).includes(marker.type))
                 continue;
 
@@ -2178,7 +2178,7 @@ WI.SourceCodeTextEditor = class SourceCodeTextEditor extends WI.TextEditor
 
         this._editingController = this.editingControllerForMarker(editableMarker);
 
-        if (marker.type === WI.TextMarker.Type.Color) {
+        if (editableMarker.type === WI.TextMarker.Type.Color) {
             var color = this._editingController.value;
             if (!color || !color.valid) {
                 editableMarker.clear();


### PR DESCRIPTION
#### c11d9781788dd0bf8fae0496ad66c65c1769afc5
<pre>
Web Inspector: _tokenTrackingControllerHighlightedMarkedExpression tests a leaked loop variable instead of the selected marker
<a href="https://bugs.webkit.org/show_bug.cgi?id=319321">https://bugs.webkit.org/show_bug.cgi?id=319321</a>
<a href="https://rdar.apple.com/182143986">rdar://182143986</a>

Reviewed by Devin Rousso.

_tokenTrackingControllerHighlightedMarkedExpression() iterates its markers
with `for (var marker of markers)` to find the outermost editableMarker. The
subsequent color-validity guard then tested `marker.type`, but because `var`
is function-scoped, `marker` leaks past the loop and holds the last element of
the array rather than the editableMarker actually selected. The branch it
guards is otherwise written entirely in terms of editableMarker -- it reads
this._editingController (built from editableMarker) and clears editableMarker
-- so the type check was inconsistent with the code it gates.

This is a latent correctness bug rather than a user-visible regression: it can
only change behavior when markersAtPosition() returns two overlapping markers
of different types where the outermost is not a color and the trailing one is,
and in the one case where that overlap occurs in practice (a color stop on a
continuation line of a multi-line gradient, whose single-line color-exclusion
heuristic misses it) the gradient&apos;s hover editor does not present regardless,
masking any observable difference. No reliable manual repro exists (I tried)
and the hover-driven path is not covered by the inspector test harness, so
no test is added.

Test the selected editableMarker&apos;s type, matching the editing controller and
the marker being cleared within the branch. Convert the `editableMarker` and
`marker` declarations from `var` to `let` so the loop variable is block-scoped
and can no longer leak past the loop, preventing this class of bug in the
future.

* Source/WebInspectorUI/UserInterface/Views/SourceCodeTextEditor.js:
(WI.SourceCodeTextEditor.prototype._tokenTrackingControllerHighlightedMarkedExpression):

Canonical link: <a href="https://commits.webkit.org/317124@main">https://commits.webkit.org/317124@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a563fdaae1612846aba5c4d7a5e963c185070a7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174378 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48311 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42092 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183954 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132246 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f4ad9688-4ae8-44ee-878d-13afa7d894ee) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49603 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47993 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135653 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ef744013-bf51-408f-a078-6d0cd57c95fc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177336 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39080 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/156440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116131 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e05f7695-5832-41d6-8ab9-cb1e38c1927d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37721 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32436 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/148144 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35932 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186380 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/39592 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144559 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47978 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144417 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38933 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48657 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114204 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39317 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120600 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47163 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10896 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46566 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46797 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46624 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->