### PR TITLE
[GFC] Stale grid item block sizes on subsequent layout

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/layout-algorithm/grid-item-stale-block-size-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/layout-algorithm/grid-item-stale-block-size-001-expected.txt
@@ -1,0 +1,4 @@
+XXX XXX
+
+PASS An intrinsic grid row uses the item's content block size, not a stale block size from a previous layout
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/layout-algorithm/grid-item-stale-block-size-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/layout-algorithm/grid-item-stale-block-size-001.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#algo-content">
+<meta name="assert" content="When a grid's inline size changes so that a grid item's content block size changes (here a min-content-width grid where 'XXX XXX' wraps onto two lines, then widened to max-content where it fits on one line), the item's intrinsic (auto) row must reflect the item's content block size at the new inline size rather than a stale block size from the previous layout.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+
+<style>
+#grid {
+  display: grid;
+  width: min-content;
+  grid: auto / auto;
+  font: 10px/1 Ahem;
+}
+</style>
+
+<div id="grid"><div style="grid-row: 1 / 2;">XXX XXX</div></div>
+
+<script>
+test(() => {
+  const grid = document.getElementById("grid");
+
+  // At min-content width, "XXX XXX" wraps onto two lines, so the row is 20px tall.
+  assert_equals(grid.offsetHeight, 20, "grid is two lines tall at min-content width");
+
+  // Widening to max-content lets "XXX XXX" fit on one line, so the row must shrink
+  // to that one-line content block size (10px), not stay at the previous 20px.
+  grid.style.width = "max-content";
+  assert_equals(grid.offsetHeight, 10, "grid is one line tall at max-content width");
+}, "An intrinsic grid row uses the item's content block size, not a stale block size from a previous layout");
+</script>

--- a/Source/WebCore/layout/integration/LayoutIntegrationFormattingContextLayout.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationFormattingContextLayout.cpp
@@ -72,6 +72,9 @@ void layoutWithFormattingContextForBox(const Layout::ElementBox& box, std::optio
     if (widthConstraint)
         renderer->clearOverridingBorderBoxLogicalWidth();
 
+    if (heightConstraint)
+        renderer->clearOverridingBorderBoxLogicalHeight();
+
     auto updater = BoxGeometryUpdater { layoutState, rootLayoutBox(box) };
     updater.updateBoxGeometryAfterIntegrationLayout(box, widthConstraint.value_or(renderer->containingBlock()->contentBoxLogicalWidth()));
 }


### PR DESCRIPTION
#### b744c179aab45dc545771adfc4a10c5f44611830
<pre>
[GFC] Stale grid item block sizes on subsequent layout
<a href="https://bugs.webkit.org/show_bug.cgi?id=319322">https://bugs.webkit.org/show_bug.cgi?id=319322</a>
<a href="https://rdar.apple.com/182144347">rdar://182144347</a>

Reviewed by Alan Baradlay.

When computing the block min/max content contributions for a grid item,
GFC will call into the respective integration function to to get this
value. What these two end up doing is calling into layoutWithFormattingContextForBox
in order to get that size. This function optionally takes in a width and
height constraint for the renderer that is sets as the overriding size
on it. Unfortunately, it does not clear the overriding height like it does
with the width so this can result in that size staying on the renderer
after the function returns. With respect to the described bug what ends
up happening is:

Layout frame 1:
- Compute the block min/max contributions
- Perform a final layout on the grid item which uses the same
  integration API *and does pass an overriding width/height*

** Some mutation occurs that causes us to do layout again **

Layout frame 2:
- Compute the block min/max contributions
Now we have the wrong values because the overriding sizes were not
cleared so we use those values again

So the fix is to clear the overriding block size because we do not want
these things living around longer than they need to.

Canonical link: <a href="https://commits.webkit.org/317166@main">https://commits.webkit.org/317166@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c56c9d27d47cdbc56521e71b187ff69989c45d6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174412 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48345 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42126 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183989 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132280 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dfb6b7c3-98ec-4007-a0f3-9893ea611d48) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176277 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49637 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48027 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135676 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177370 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39111 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156470 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116154 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3edeabde-afbc-4e6e-8274-a70a0bbcea1c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37752 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36120 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32470 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148175 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35962 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186415 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39632 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40317 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144608 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48012 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156024 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144448 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38958 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48691 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32582 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114245 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39347 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120642 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47198 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10926 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46600 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46831 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46658 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->