### PR TITLE
[iOS] Fix the build

### DIFF
--- a/LayoutTests/media/wireless-playback-media-player/route-name-fallback-expected.txt
+++ b/LayoutTests/media/wireless-playback-media-player/route-name-fallback-expected.txt
@@ -9,6 +9,6 @@ EVENT(playing)
 EXPECTED (route.routeName == '') OK
 RUN(internals.mockMediaDeviceRouteController.activateRoute(route))
 EVENT(connect)
-EXPECTED (placardTitleText() == 'AirPlay') OK
+EXPECTED (placardTitleText() === "AirPlay" == 'true') OK
 END OF TEST
 

--- a/LayoutTests/media/wireless-playback-media-player/route-name-fallback.html
+++ b/LayoutTests/media/wireless-playback-media-player/route-name-fallback.html
@@ -35,7 +35,6 @@
                 run(`internals.mockMediaDeviceRouteController.activateRoute(route)`);
                 await connectPromise;
 
-                // With no route name, the placard title falls back to the localized "AirPlay".
                 await testExpectedEventually('placardTitleText() === "AirPlay"', true);
                 endTest();
             }

--- a/LayoutTests/media/wireless-playback-media-player/route-name.html
+++ b/LayoutTests/media/wireless-playback-media-player/route-name.html
@@ -36,11 +36,7 @@
                 run(`internals.mockMediaDeviceRouteController.activateRoute(route)`);
                 await connectPromise;
 
-                // Wait for the AirPlay placard to appear, then verify it shows the route name
-                // from the first update (rather than briefly falling back to "AirPlay").
-                while (placardTitleText() === null)
-                    await new Promise(requestAnimationFrame);
-                testExpected('placardTitleText() === route.routeName', true);
+                await testExpectedEventually('placardTitleText() === route.routeName', true);
                 endTest();
             }
         </script>

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
@@ -383,18 +383,15 @@ String MediaControlsHost::externalDeviceDisplayName() const
 String MediaControlsHost::externalDeviceRouteName() const
 {
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
-    RefPtr player = m_mediaElement->player();
-    if (!player) {
-        LOG(Media, "MediaControlsHost::externalDeviceRouteName - returning \"\" because player is NULL");
-        return emptyString();
+    if (RefPtr player = m_mediaElement->player()) {
+        String name = player->wirelessPlaybackRouteName();
+        LOG(Media, "MediaControlsHost::externalDeviceRouteName - returning \"%s\"", name.utf8().data());
+        return name;
     }
 
-    String name = player->wirelessPlaybackRouteName();
-    LOG(Media, "MediaControlsHost::externalDeviceRouteName - returning \"%s\"", name.utf8().data());
-    return name;
-#else
-    return emptyString();
+    LOG(Media, "MediaControlsHost::externalDeviceRouteName - returning \"\" because player is NULL");
 #endif
+    return emptyString();
 }
 
 auto MediaControlsHost::externalDeviceType() const -> DeviceType

--- a/Source/WebCore/testing/MockMediaDeviceRoute.h
+++ b/Source/WebCore/testing/MockMediaDeviceRoute.h
@@ -57,6 +57,11 @@ public:
     String deviceName() const;
     void setDeviceName(const String&);
 
+    String protocolTypeIdentifier() const;
+    void setProtocolTypeIdentifier(const String&);
+
+    String routeName() const;
+
     bool ready() const;
     void setReady(bool);
 

--- a/Source/WebCore/testing/MockMediaDeviceRoute.idl
+++ b/Source/WebCore/testing/MockMediaDeviceRoute.idl
@@ -31,6 +31,8 @@
     undefined setURLCallback(MockMediaDeviceRouteURLCallback? callback);
 
     attribute DOMString deviceName;
+    attribute DOMString protocolTypeIdentifier;
+    readonly attribute DOMString routeName;
     attribute boolean ready;
     attribute boolean playing;
     attribute boolean hasPlaybackError;

--- a/Source/WebCore/testing/MockMediaDeviceRoute.mm
+++ b/Source/WebCore/testing/MockMediaDeviceRoute.mm
@@ -30,11 +30,15 @@
 
 #import "WebMockMediaDeviceRoute.h"
 #import <AVKit/AVKit.h>
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 #import <wtf/SoftLinking.h>
 #import <wtf/TZoneMallocInlines.h>
 
 SOFT_LINK_FRAMEWORK(AVKit)
 SOFT_LINK_CLASS(AVKit, AVPlaybackUserInterfaceMediaSelectionOption)
+
+SOFT_LINK_FRAMEWORK(UniformTypeIdentifiers)
+SOFT_LINK_CLASS(UniformTypeIdentifiers, UTType)
 
 namespace WebCore {
 
@@ -68,6 +72,21 @@ String MockMediaDeviceRoute::deviceName() const
 void MockMediaDeviceRoute::setDeviceName(const String& deviceName)
 {
     [m_platformRoute setRouteDisplayName:deviceName.createNSString().get()];
+}
+
+String MockMediaDeviceRoute::protocolTypeIdentifier() const
+{
+    return [[m_platformRoute protocolType] identifier];
+}
+
+void MockMediaDeviceRoute::setProtocolTypeIdentifier(const String& identifier)
+{
+    [m_platformRoute setProtocolType:[getUTTypeClassSingleton() typeWithIdentifier:identifier.createNSString().get()]];
+}
+
+String MockMediaDeviceRoute::routeName() const
+{
+    return [[m_platformRoute protocolType] localizedDescription];
 }
 
 bool MockMediaDeviceRoute::ready() const


### PR DESCRIPTION
#### 8bc7c5094a3b903366a05a3de3781809f7d21149
<pre>
[iOS] Fix the build
<a href="https://bugs.webkit.org/show_bug.cgi?id=319330">https://bugs.webkit.org/show_bug.cgi?id=319330</a>
<a href="https://rdar.apple.com/182145800">rdar://182145800</a>

Unreviewed build fix after 317107@main. Addressed review feedback that also happens to fix the build.

* LayoutTests/media/wireless-playback-media-player/route-name-fallback-expected.txt:
* LayoutTests/media/wireless-playback-media-player/route-name-fallback.html:
* LayoutTests/media/wireless-playback-media-player/route-name.html:
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp:
(WebCore::MediaControlsHost::externalDeviceRouteName const):
* Source/WebCore/testing/MockMediaDeviceRoute.h:
* Source/WebCore/testing/MockMediaDeviceRoute.idl:
* Source/WebCore/testing/MockMediaDeviceRoute.mm:
(WebCore::MockMediaDeviceRoute::protocolTypeIdentifier const):
(WebCore::MockMediaDeviceRoute::setProtocolTypeIdentifier):
(WebCore::MockMediaDeviceRoute::routeName const):

Canonical link: <a href="https://commits.webkit.org/317109@main">https://commits.webkit.org/317109@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8266fea1823e3d4e81a84135887dfbc59affc07

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174356 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/48289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/42070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/183932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/132224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176221 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/49581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/47971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/183932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/132224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177314 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/49581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/42070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/183932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/49581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/47971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/32414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/42070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/49581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/42070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/186358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/39566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/47971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/186358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/47956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/42070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/186358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/48635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/42070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26499 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/48635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/120574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/47141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/42070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/46544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/46775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/46602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->