### PR TITLE
[Scroll anchoring] Scroll jumping on apple.com/retail

### DIFF
--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1821,24 +1821,27 @@ bool Quirks::shouldDisableLazyIframeLoadingQuirk() const
     return m_quirksData.quirkIsEnabled(QuirksData::SiteSpecificQuirk::ShouldDisableLazyIframeLoadingQuirk);
 }
 
-// reddit.com with Sink It extension (rdar://176377447).
+// reddit.com with Sink It extension (rdar://176377447) and apple.com/retail (rdar://181007316).
 bool Quirks::shouldDisableScrollAnchoringQuirk() const
 {
-#if PLATFORM(IOS_FAMILY)
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
     if (!m_quirksData.quirkIsEnabled(QuirksData::SiteSpecificQuirk::ShouldDisableScrollAnchoringQuirk))
         return false;
 
-    RefPtr document = m_document.get();
-    if (!document)
-        return false;
+#if PLATFORM(IOS_FAMILY)
+    // reddit.com only disables scroll anchoring while the Sink It extension's element is present.
+    if (isDomain("reddit.com"_s)) {
+        RefPtr document = m_document.get();
+        if (!document)
+            return false;
 
-    static MainThreadNeverDestroyed<const AtomString> sinkItBackToTopID("sink-it-back-to-top"_s);
-    return !!document->getElementById(sinkItBackToTopID.get());
-#else
-    return false;
+        static MainThreadNeverDestroyed<const AtomString> sinkItBackToTopID("sink-it-back-to-top"_s);
+        return !!document->getElementById(sinkItBackToTopID.get());
+    }
 #endif
+
+    return true;
 }
 
 // Breaks express checkout on victoriassecret.com (rdar://104818312).
@@ -3825,8 +3828,13 @@ static void handlePinterestQuirks(QuirksData& quirksData, const URL& /* quirksUR
     quirksData.enableQuirk(QuirksData::SiteSpecificQuirk::ShouldAllowNotificationPermissionWithoutUserGesture);
 }
 
-static void handleAppleQuirks(QuirksData& quirksData, const URL& /* quirksURL */, const String& quirksDomainString, const URL&  /* documentURL */)
+static void handleAppleQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL&  /* documentURL */)
 {
+    // Quirk added for rdar://181007316, remove when rdar://182134549 is fixed.
+    if (quirksURL.path().contains("/retail"_s))
+        quirksData.enableQuirk(QuirksData::SiteSpecificQuirk::ShouldDisableScrollAnchoringQuirk);
+
+    // FIXME: Maybe EnsureCaptionVisibilityInFullscreenAndPictureInPicture should apply to apple.com.cn too?
     QUIRKS_EARLY_RETURN_IF_NOT_DOMAIN("apple.com"_s);
 
     // apple.com rdar://154434137

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -192,9 +192,7 @@ struct QuirksData {
         ShouldDisablePointerEventsQuirk,
 #endif
         ShouldDisablePushStateFilePathRestrictions,
-#if PLATFORM(IOS_FAMILY)
         ShouldDisableScrollAnchoringQuirk,
-#endif
 #if ENABLE(THREADED_ANIMATIONS)
         ShouldDisableThreadedAnimationsQuirk,
 #endif


### PR DESCRIPTION
#### 7dc5e35fab8ba1567abe5e5611b35accad2dc096
<pre>
[Scroll anchoring] Scroll jumping on apple.com/retail
<a href="https://bugs.webkit.org/show_bug.cgi?id=319308">https://bugs.webkit.org/show_bug.cgi?id=319308</a>
<a href="https://rdar.apple.com/181007316">rdar://181007316</a>

Reviewed by Abrar Rahman Protyasha.

Scroll anchoring on apple.com/retail causes jumpy scrolling near the top of the page.
The React-based content changes an element from `position: static` to `position: fixed`
which correctly suppresses anchoring, but in a subsequent update changes `padding`, which
triggers anchoring. This anchoring happens via WebKit&apos;s zero-delay layout timer, so escapes
the earlier suppression; other browsers see both as happening in the same suppression window,
although the behavior is poorly specified and browser behavior differs[1], as shown by a
new tentative WPT[2].

Because of differences between browsers, and real fix (removing the zero-delay layout
timer) being a very risky change, for now quirk scroll anchoring off for apple.com/retail
(and the equivalent sites like apple.com.cn/retail and apple.com/uk/retail).

[1] <a href="https://github.com/w3c/csswg-drafts/issues/14177">https://github.com/w3c/csswg-drafts/issues/14177</a>
[2] <a href="https://github.com/web-platform-tests/wpt/pull/61263">https://github.com/web-platform-tests/wpt/pull/61263</a>

* Source/WebCore/page/Quirks.cpp:
* Source/WebCore/page/QuirksData.h:

Canonical link: <a href="https://commits.webkit.org/317169@main">https://commits.webkit.org/317169@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ec830b044b55bd488e88792bddc06c2b4edd8be

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174492 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48425 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42206 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184069 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132360 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/76300b1b-56a4-4b13-97bb-20ff0b288785) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176357 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49717 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48108 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135754 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/27ef7d15-8d2e-4c9e-8121-9e7b1fc193d1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177450 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39190 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/156550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116232 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/10336db6-1f9c-4109-96c3-ff27b3ed679e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37831 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32550 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148254 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36042 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186495 "Hash 2ec830b0 for PR 69322 does not build (failure)") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/39749 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/186495 "Hash 2ec830b0 for PR 69322 does not build (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48092 "Built successfully") | | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/186495 "Hash 2ec830b0 for PR 69322 does not build (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38961 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48771 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114368 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39425 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120743 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47278 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11006 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46680 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46911 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46738 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->