### PR TITLE
Use C++17 `inline constexpr` variables instead of `extern const` in JavaScriptCore

### DIFF
--- a/Source/JavaScriptCore/b3/B3Common.cpp
+++ b/Source/JavaScriptCore/b3/B3Common.cpp
@@ -35,8 +35,6 @@
 
 namespace JSC { namespace B3 {
 
-const char* const tierName = "b3  ";
-
 bool shouldDumpIR(Procedure& procedure, B3CompilationMode mode)
 {
     if (procedure.shouldDumpIR())

--- a/Source/JavaScriptCore/b3/B3Common.h
+++ b/Source/JavaScriptCore/b3/B3Common.h
@@ -34,12 +34,13 @@
 #include <JavaScriptCore/JSExportMacros.h>
 #include <JavaScriptCore/Options.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/text/ASCIILiteral.h>
 
 namespace JSC { namespace B3 {
 
 class Procedure;
 
-extern const char* const tierName;
+inline constexpr ASCIILiteral tierName { "b3  "_s };
 
 enum B3CompilationMode {
     B3Mode,

--- a/Source/JavaScriptCore/b3/air/AirCode.cpp
+++ b/Source/JavaScriptCore/b3/air/AirCode.cpp
@@ -44,8 +44,6 @@
 
 namespace JSC { namespace B3 { namespace Air {
 
-const char* const tierName = "Air ";
-
 WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED_IMPL(CFG);
 WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED_IMPL(Code);
 WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED_IMPL(Dominators);

--- a/Source/JavaScriptCore/b3/air/AirCode.h
+++ b/Source/JavaScriptCore/b3/air/AirCode.h
@@ -45,6 +45,7 @@
 #include <wtf/SmallSet.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakRandom.h>
+#include <wtf/text/ASCIILiteral.h>
 
 namespace JSC {
 
@@ -74,7 +75,7 @@ typedef SharedTask<WasmBoundsCheckGeneratorFunction> WasmBoundsCheckGenerator;
 typedef void PrologueGeneratorFunction(CCallHelpers&, Code&);
 typedef SharedTask<PrologueGeneratorFunction> PrologueGenerator;
 
-extern const char* const tierName;
+inline constexpr ASCIILiteral tierName { "Air "_s };
 
 // This is an IR that is very close to the bare metal. It requires about 40x more bytes than the
 // generated machine code - for example if you're generating 1MB of machine code, you need about

--- a/Source/JavaScriptCore/dfg/DFGCommon.cpp
+++ b/Source/JavaScriptCore/dfg/DFGCommon.cpp
@@ -35,8 +35,6 @@
 
 namespace JSC { namespace DFG {
 
-const char* const tierName = "DFG ";
-
 FunctionAllowlist& ensureGlobalDFGAllowlist()
 {
     static LazyNeverDestroyed<FunctionAllowlist> dfgAllowlist;

--- a/Source/JavaScriptCore/dfg/DFGCommon.h
+++ b/Source/JavaScriptCore/dfg/DFGCommon.h
@@ -32,6 +32,7 @@
 
 #include <JavaScriptCore/Options.h>
 #include <limits.h>
+#include <wtf/text/ASCIILiteral.h>
 #include <wtf/text/StringImpl.h>
 
 namespace JSC {
@@ -46,7 +47,7 @@ struct Node;
 typedef uint32_t BlockIndex;
 static constexpr BlockIndex NoBlock = UINT_MAX;
 
-extern const char* const tierName;
+inline constexpr ASCIILiteral tierName { "DFG "_s };
 
 // Use RefChildren if the child ref counts haven't already been adjusted using
 // other means and either of the following is true:

--- a/Source/JavaScriptCore/ftl/FTLCompile.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCompile.cpp
@@ -51,8 +51,6 @@
 
 namespace JSC { namespace FTL {
 
-const char* const tierName = "FTL ";
-
 using namespace DFG;
 
 static void collectIRDumpDebugInfo(State& state, DFG::Graph& graph, CodeBlock* codeBlock)

--- a/Source/JavaScriptCore/ftl/FTLCompile.h
+++ b/Source/JavaScriptCore/ftl/FTLCompile.h
@@ -29,10 +29,11 @@
 
 #include "FTLState.h"
 #include "JITSafepoint.h"
+#include <wtf/text/ASCIILiteral.h>
 
 namespace JSC { namespace FTL {
 
-extern const char* const tierName;
+inline constexpr ASCIILiteral tierName { "FTL "_s };
 
 void compile(State&, Safepoint::Result&);
 

--- a/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
@@ -76,8 +76,6 @@ static JSC_DECLARE_HOST_FUNCTION(arrayProtoFuncCopyWithin);
 static JSC_DECLARE_HOST_FUNCTION(arrayProtoFuncToSpliced);
 static JSC_DECLARE_HOST_FUNCTION(arrayProtoFuncFlat);
 
-const ASCIILiteral unshiftArrayLengthExceeded { "unshift cannot produce an array of length larger than (2 ** 53) - 1"_s };
-
 // ------------------------------ ArrayPrototype ----------------------------
 
 const ClassInfo ArrayPrototype::s_info = { "Array"_s, &JSArray::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(ArrayPrototype) };

--- a/Source/JavaScriptCore/runtime/ArrayPrototype.h
+++ b/Source/JavaScriptCore/runtime/ArrayPrototype.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <JavaScriptCore/JSArray.h>
+#include <wtf/text/ASCIILiteral.h>
 
 namespace JSC {
 
@@ -52,6 +53,6 @@ JSC_DECLARE_HOST_FUNCTION(arrayProtoFuncValues);
 JSArray* tryConcatAppendArrayFastWithWatchpoints(JSGlobalObject*, VM&, JSArray* firstArray, JSArray* secondArray);
 JSArray* tryConcatOneArgFast(JSGlobalObject*, VM&, JSArray* firstArray, JSValue argument);
 
-extern const ASCIILiteral unshiftArrayLengthExceeded;
+inline constexpr ASCIILiteral unshiftArrayLengthExceeded { "unshift cannot produce an array of length larger than (2 ** 53) - 1"_s };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSCJSValue.cpp
+++ b/Source/JavaScriptCore/runtime/JSCJSValue.cpp
@@ -42,8 +42,6 @@ bool JSValue::isHeapBigIntSlow() const
     return isHeapBigInt();
 }
 
-constinit const char radixDigits[] = "0123456789abcdefghijklmnopqrstuvwxyz";
-
 double JSValue::toIntegerPreserveNaN(JSGlobalObject* globalObject) const
 {
     if (isInt32())

--- a/Source/JavaScriptCore/runtime/ParseInt.h
+++ b/Source/JavaScriptCore/runtime/ParseInt.h
@@ -271,7 +271,7 @@ static ALWAYS_INLINE typename std::invoke_result<CallbackWhenNoException, String
 }
 
 // Mapping from integers 0..35 to digit identifying this value, for radix 2..36.
-extern const char radixDigits[37]; // in JSCJSValue.cpp
+inline constexpr char radixDigits[37] = "0123456789abcdefghijklmnopqrstuvwxyz";
 
 } // namespace JSC
 

--- a/Source/JavaScriptCore/runtime/TemporalObject.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalObject.cpp
@@ -197,20 +197,6 @@ PropertyName temporalUnitSingularPropertyName(VM& vm, TemporalUnit unit)
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-// https://tc39.es/proposal-temporal/#table-temporal-temporaldurationlike-properties
-const TemporalUnit temporalUnitsInTableOrder[numberOfTemporalUnits] = {
-    TemporalUnit::Day,
-    TemporalUnit::Hour,
-    TemporalUnit::Microsecond,
-    TemporalUnit::Millisecond,
-    TemporalUnit::Minute,
-    TemporalUnit::Month,
-    TemporalUnit::Nanosecond,
-    TemporalUnit::Second,
-    TemporalUnit::Week,
-    TemporalUnit::Year,
-};
-
 std::optional<TemporalUnit> temporalUnitType(StringView unit)
 {
     StringView singular = singularUnit(unit);

--- a/Source/JavaScriptCore/runtime/temporal/core/TemporalEnums.h
+++ b/Source/JavaScriptCore/runtime/temporal/core/TemporalEnums.h
@@ -30,6 +30,7 @@
 
 #include <cstdint>
 #include <wtf/Int128.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/text/ASCIILiteral.h>
 #include <wtf/text/StringView.h>
 
@@ -107,7 +108,20 @@ static constexpr unsigned numberOfTemporalPlainYearMonthUnits = 0 JSC_TEMPORAL_P
 static constexpr unsigned numberOfTemporalPlainMonthDayUnits = 0 JSC_TEMPORAL_PLAIN_MONTH_DAY_UNITS(JSC_COUNT_TEMPORAL_UNITS);
 #undef JSC_COUNT_TEMPORAL_UNITS
 
-extern const TemporalUnit temporalUnitsInTableOrder[numberOfTemporalUnits];
+// https://tc39.es/proposal-temporal/#table-temporal-temporaldurationlike-properties
+inline constexpr auto temporalUnitsInTableOrder = WTF::toArray<TemporalUnit>({
+    TemporalUnit::Day,
+    TemporalUnit::Hour,
+    TemporalUnit::Microsecond,
+    TemporalUnit::Millisecond,
+    TemporalUnit::Minute,
+    TemporalUnit::Month,
+    TemporalUnit::Nanosecond,
+    TemporalUnit::Second,
+    TemporalUnit::Week,
+    TemporalUnit::Year,
+});
+static_assert(temporalUnitsInTableOrder.size() == numberOfTemporalUnits);
 
 // https://tc39.es/proposal-temporal/#table-temporal-units
 constexpr Int128 lengthInNanoseconds(TemporalUnit unit)


### PR DESCRIPTION
#### 2bd239bf12a80e3451870af6cd495d8c3715f4f9
<pre>
Use C++17 `inline constexpr` variables instead of `extern const` in JavaScriptCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=319329">https://bugs.webkit.org/show_bug.cgi?id=319329</a>
<a href="https://rdar.apple.com/182145798">rdar://182145798</a>

Reviewed by Keith Miller.

This lets the compiler see the constant values for better optimization.

* Source/JavaScriptCore/b3/B3Common.cpp:
* Source/JavaScriptCore/b3/B3Common.h:
* Source/JavaScriptCore/b3/air/AirCode.cpp:
* Source/JavaScriptCore/b3/air/AirCode.h:
* Source/JavaScriptCore/dfg/DFGCommon.cpp:
* Source/JavaScriptCore/dfg/DFGCommon.h:
* Source/JavaScriptCore/ftl/FTLCompile.cpp:
* Source/JavaScriptCore/ftl/FTLCompile.h:
* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
(): Deleted.
* Source/JavaScriptCore/runtime/ArrayPrototype.h:
* Source/JavaScriptCore/runtime/JSCJSValue.cpp:
* Source/JavaScriptCore/runtime/NumberPrototype.cpp:
(JSC::int52ToStringWithRadix):
(JSC::toStringWithRadixInternal):
* Source/JavaScriptCore/runtime/ParseInt.h:
* Source/JavaScriptCore/runtime/TemporalObject.cpp:
* Source/JavaScriptCore/runtime/temporal/core/TemporalEnums.h:
(JSC::WTF::toArray&lt;TemporalUnit&gt;):

Canonical link: <a href="https://commits.webkit.org/317148@main">https://commits.webkit.org/317148@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71bbdc6b57d03429ad4fc7762a7948ad2425cae6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174362 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48295 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42076 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183938 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132230 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49587 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47977 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135631 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177320 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39065 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156430 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116109 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37706 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36075 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32420 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/4939 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148129 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35922 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186364 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/35624 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39573 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40272 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144546 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47962 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144405 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38945 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48641 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32542 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114183 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39303 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120581 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/211397 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47147 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10886 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55084 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46550 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46781 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46608 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->