### PR TITLE
AX: REGRESSION(294788@main): Voice Control/inspector report the wrong tree-item level for a treeitem nested in a plain <ul>

### DIFF
--- a/LayoutTests/accessibility/treeitem-hierarchical-level-in-plain-list-expected.txt
+++ b/LayoutTests/accessibility/treeitem-hierarchical-level-in-plain-list-expected.txt
@@ -1,0 +1,9 @@
+This tests that a treeitem nested in a plain list (a ul with no role) does not gain a hierarchical level, while a treeitem nested in a role=group gains one.
+
+PASS: plainInner.hierarchicalLevel === plainOuter.hierarchicalLevel
+PASS: groupInner.hierarchicalLevel === groupOuter.hierarchicalLevel + 1
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/treeitem-hierarchical-level-in-plain-list.html
+++ b/LayoutTests/accessibility/treeitem-hierarchical-level-in-plain-list.html
@@ -1,0 +1,61 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<ul id="plainListTree" role="tree" tabindex="0">
+    <li id="plainOuterItem" role="treeitem">
+        <span>Level 1</span>
+        <ul>
+            <li id="plainInnerItem" role="treeitem">Level 2</li>
+        </ul>
+    </li>
+</ul>
+
+<ul id="groupTree" role="tree" tabindex="0">
+    <li id="groupOuterItem" role="treeitem">
+        <span>Level 1</span>
+        <ul role="group">
+            <li id="groupInnerItem" role="treeitem">Level 2</li>
+        </ul>
+    </li>
+</ul>
+
+<script>
+var output = "This tests that a treeitem nested in a plain list (a ul with no role) does not gain a hierarchical level, while a treeitem nested in a role=group gains one.\n\n";
+
+var plainOuter, plainInner, groupOuter, groupInner;
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    setTimeout(async function() {
+        // Wait for both trees to be built into the accessibility tree.
+        await waitFor(() => {
+            return accessibilityController.accessibleElementById("plainInnerItem")
+                && accessibilityController.accessibleElementById("groupInnerItem");
+        });
+
+        plainOuter = accessibilityController.accessibleElementById("plainOuterItem");
+        plainInner = accessibilityController.accessibleElementById("plainInnerItem");
+        groupOuter = accessibilityController.accessibleElementById("groupOuterItem");
+        groupInner = accessibilityController.accessibleElementById("groupInnerItem");
+
+        // A plain <ul> (no role) adds no level: the inner item is at the same level as the outer item.
+        output += await expectAsync("plainInner.hierarchicalLevel", "plainOuter.hierarchicalLevel");
+
+        // An authored role="group" adds exactly one level.
+        output += await expectAsync("groupInner.hierarchicalLevel", "groupOuter.hierarchicalLevel + 1");
+
+        debug(output);
+        document.getElementById("plainListTree").hidden = true;
+        document.getElementById("groupTree").hidden = true;
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -1670,10 +1670,12 @@ unsigned AXCoreObject::hierarchicalLevel() const
     // We measure tree hierarchy by the number of groups that the item is within.
     level = 1;
     for (RefPtr ancestor = parentObject(); ancestor; ancestor = ancestor->parentObject()) {
-        auto ancestorRole = ancestor->role();
-        if (ancestorRole == AccessibilityRole::Group)
+        // Only an explicitly-authored role="group" establishes a tree grouping level. A native list
+        // (e.g. a plain <ul>) that the list heuristic demoted to a generic Group role is not an
+        // authored grouping and must not add a level, nor should any other implicit Group.
+        if (ancestor->hasExplicitGroupRole())
             level++;
-        else if (ancestorRole == AccessibilityRole::Tree)
+        else if (ancestor->role() == AccessibilityRole::Tree)
             break;
     }
 

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -1082,6 +1082,8 @@ public:
     virtual String language() const = 0;
     String languageIncludingAncestors() const;
     virtual unsigned ariaLevel() const = 0;
+    // True only when the author explicitly set role="group" on this object.
+    virtual bool hasExplicitGroupRole() const = 0;
     // 1-based, to match the aria-level spec.
     unsigned hierarchicalLevel() const;
     virtual bool isInlineText() const = 0;

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -863,6 +863,9 @@ TextStream& operator<<(WTF::TextStream& stream, AXProperty property)
     case AXProperty::HeadingLevel:
         stream << "HeadingLevel";
         break;
+    case AXProperty::HasExplicitGroupRole:
+        stream << "HasExplicitGroupRole";
+        break;
     case AXProperty::IsARIAHidden:
         stream << "IsARIAHidden";
         break;

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -396,6 +396,7 @@ public:
     virtual void recomputeAriaRole() { }
     virtual AccessibilityRole ariaRoleAttribute() const { return AccessibilityRole::Unknown; }
     bool hasExplicitGenericRole() const { return ariaRoleAttribute() == AccessibilityRole::Generic; }
+    bool hasExplicitGroupRole() const final { return ariaRoleAttribute() == AccessibilityRole::Group; }
     bool hasImplicitGenericRole() const { return role() == AccessibilityRole::Generic && !hasExplicitGenericRole(); }
     bool ariaRoleHasPresentationalChildren() const;
     bool inheritsPresentationalRole() const override { return false; }

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -414,6 +414,7 @@ private:
 #endif
     std::optional<AccessibilityOrientation> explicitOrientation() const { return optionalAttributeValue<AccessibilityOrientation>(AXProperty::ExplicitOrientation); }
     unsigned ariaLevel() const final { return unsignedAttributeValue(AXProperty::ARIALevel); }
+    bool hasExplicitGroupRole() const final { return boolAttributeValue(AXProperty::HasExplicitGroupRole); }
     unsigned computedHeadingLevel() const final { return unsignedAttributeValue(AXProperty::HeadingLevel); }
     String language() const final { return stringAttributeValue(AXProperty::Language); }
     void setSelectedChildren(const AccessibilityChildrenVector&) final;

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -2232,6 +2232,7 @@ IsolatedObjectData createIsolatedObjectData(const Ref<AccessibilityObject>& axOb
         setProperty(AXProperty::IsAttachment, object.isAttachment());
         setProperty(AXProperty::IsBusy, object.isBusy());
         setProperty(AXProperty::IsExpanded, object.isExpanded());
+        setProperty(AXProperty::HasExplicitGroupRole, object.hasExplicitGroupRole());
 
         // FIXME: Caching isSecureField would require caching an additional property (on top of input type), so for now, let's still cache this.
         setProperty(AXProperty::IsSecureField, object.isSecureField());

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -188,6 +188,7 @@ enum class AXProperty : uint16_t {
 #endif
     TextColor,
     HasApplePDFAnnotationAttribute,
+    HasExplicitGroupRole,
     HasLinethrough,
     HasRemoteFrameChild,
     HeadingLevel,


### PR DESCRIPTION
#### da85a3bfd71bd13873ae8a43a09774ed89c23d62
<pre>
AX: REGRESSION(294788@main): Voice Control/inspector report the wrong tree-item level for a treeitem nested in a plain &lt;ul&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=319267">https://bugs.webkit.org/show_bug.cgi?id=319267</a>
<a href="https://rdar.apple.com/180455904">rdar://180455904</a>

Reviewed by Dominic Mazzoni.

294788@main (bc34242b2e93) moved hierarchicalLevel() to AXCoreObject and, in doing
so, changed the tree-level ancestor walk from the authored ARIA role
(ariaRoleAttribute()) to the computed role(). A plain &lt;ul&gt; whose only child is a
role=&quot;treeitem&quot; is demoted to a generic Group role by the list heuristic, so the
walk began counting it as a grouping level, reporting level 2 instead of 1.

Per the ARIA tree pattern, only an explicitly-authored role=&quot;group&quot; establishes a
grouping level. Introduce AXCoreObject::hasExplicitGroupRole() (cached on the
isolated tree) and count only those ancestors, matching the pre-294788 behavior
and other browsers.

* LayoutTests/accessibility/treeitem-hierarchical-level-in-plain-list-expected.txt: Added.
* LayoutTests/accessibility/treeitem-hierarchical-level-in-plain-list.html: Added.
* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::hierarchicalLevel const):
* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::createIsolatedObjectData):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:

Canonical link: <a href="https://commits.webkit.org/317178@main">https://commits.webkit.org/317178@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/02e2aa69908c04ee565d028f99b86646f0d8716e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174357 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48290 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42071 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183933 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132225 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2de9d10a-dd98-494f-a383-cf603ecad2d4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176222 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49582 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47972 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135628 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1e9ec456-69f0-45f6-90e5-3dff953da032) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177315 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39063 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156421 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116106 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/72bbff3b-551f-4743-8edf-66c433492237) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37704 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36072 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32415 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148127 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35913 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186359 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39567 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40269 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144542 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47957 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155975 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144401 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38967 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48636 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32533 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114178 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39301 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120575 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47142 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10877 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46545 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46776 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46603 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->