### PR TITLE
Rename WKJSSerializedNode to WKDOMNodeSnapshot

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -1470,8 +1470,8 @@ set(WebCore_NON_SVG_IDL_FILES
     page/WebKitBuffer.idl
     page/WebKitBufferNamespace.idl
     page/WebKitJSHandle.idl
+    page/WebKitNodeSnapshot.idl
     page/WebKitPoint.idl
-    page/WebKitSerializedNode.idl
     page/WindowPostMessageOptions.idl
     page/WorkerNavigator.idl
 

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -1994,7 +1994,7 @@ $(PROJECT_DIR)/page/WebKitBufferNamespace.idl
 $(PROJECT_DIR)/page/WebKitJSHandle.idl
 $(PROJECT_DIR)/page/WebKitNamespace.idl
 $(PROJECT_DIR)/page/WebKitPoint.idl
-$(PROJECT_DIR)/page/WebKitSerializedNode.idl
+$(PROJECT_DIR)/page/WebKitNodeSnapshot.idl
 $(PROJECT_DIR)/page/WindowEventHandlers.idl
 $(PROJECT_DIR)/page/WindowLocalStorage.idl
 $(PROJECT_DIR)/page/WindowOrWorkerGlobalScope+Crypto.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -3443,8 +3443,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebKitPlaybackTargetAvailabilityE
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebKitPlaybackTargetAvailabilityEvent.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebKitPoint.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebKitPoint.h
-$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebKitSerializedNode.cpp
-$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebKitSerializedNode.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebKitNodeSnapshot.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebKitNodeSnapshot.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebLock.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebLock.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebLockGrantedCallback.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -1641,7 +1641,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/page/WebKitJSHandle.idl \
     $(WebCore)/page/WebKitNamespace.idl \
     $(WebCore)/page/WebKitPoint.idl \
-    $(WebCore)/page/WebKitSerializedNode.idl \
+    $(WebCore)/page/WebKitNodeSnapshot.idl \
     $(WebCore)/page/WindowEventHandlers.idl \
     $(WebCore)/page/WindowLocalStorage.idl \
     $(WebCore)/page/WindowOrWorkerGlobalScope+Crypto.idl \

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2120,7 +2120,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     page/WebKitBuffer.h
     page/WebKitJSHandle.h
     page/WebKitNamespace.h
-    page/WebKitSerializedNode.h
+    page/WebKitNodeSnapshot.h
     page/WheelEventDeltaFilter.h
     page/WheelEventTestMonitor.h
     page/WindowFeatures.h
@@ -3728,7 +3728,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     ${WebCore_DERIVED_SOURCES_DIR}/JSStyleSheetList.h
     ${WebCore_DERIVED_SOURCES_DIR}/JSTreeWalker.h
     ${WebCore_DERIVED_SOURCES_DIR}/JSWebKitJSHandle.h
-    ${WebCore_DERIVED_SOURCES_DIR}/JSWebKitSerializedNode.h
+    ${WebCore_DERIVED_SOURCES_DIR}/JSWebKitNodeSnapshot.h
     ${WebCore_DERIVED_SOURCES_DIR}/JSXPathExpression.h
     ${WebCore_DERIVED_SOURCES_DIR}/JSXPathResult.h
     ${WebCore_DERIVED_SOURCES_DIR}/MathMLNames.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2316,7 +2316,7 @@ page/UserStyleSheet.cpp
 page/VisitedLinkStore.cpp
 page/VisualViewport.cpp
 page/WebKitJSHandle.cpp
-page/WebKitSerializedNode.cpp
+page/WebKitNodeSnapshot.cpp
 page/WebKitBuffer.cpp
 page/WebKitBufferNamespace.cpp
 page/WheelEventDeltaFilter.cpp
@@ -5275,7 +5275,7 @@ JSWebKitMediaKeys.cpp
 JSWebKitNamespace.cpp
 JSWebKitPlaybackTargetAvailabilityEvent.cpp
 JSWebKitPoint.cpp
-JSWebKitSerializedNode.cpp
+JSWebKitNodeSnapshot.cpp
 JSWebLock.cpp
 JSWebLockGrantedCallback.cpp
 JSWebLockManager.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -7353,8 +7353,8 @@
 		FADCF77E2DC5E3F000591E33 /* RemoteFrameGeometryTransformer.h in Headers */ = {isa = PBXBuildFile; fileRef = FADCF77C2DC5DB1700591E33 /* RemoteFrameGeometryTransformer.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FAEF5F6129D62710000AD8EC /* WindowPostMessageOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = FAEF5F5F29D6241C000AD8EC /* WindowPostMessageOptions.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FAFFC34B2E298AA000CCC89C /* SerializedNode.h in Headers */ = {isa = PBXBuildFile; fileRef = FAFFC34A2E298AA000CCC89C /* SerializedNode.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		FAFFC3522E2A0C2600CCC89C /* JSWebKitSerializedNode.h in Headers */ = {isa = PBXBuildFile; fileRef = FAFFC3512E2A0C2600CCC89C /* JSWebKitSerializedNode.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		FAFFC35D2E2AC24D00CCC89C /* WebKitSerializedNode.h in Headers */ = {isa = PBXBuildFile; fileRef = FAFFC34E2E29B1C200CCC89C /* WebKitSerializedNode.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FAFFC3522E2A0C2600CCC89C /* JSWebKitNodeSnapshot.h in Headers */ = {isa = PBXBuildFile; fileRef = FAFFC3512E2A0C2600CCC89C /* JSWebKitNodeSnapshot.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FAFFC35D2E2AC24D00CCC89C /* WebKitNodeSnapshot.h in Headers */ = {isa = PBXBuildFile; fileRef = FAFFC34E2E29B1C200CCC89C /* WebKitNodeSnapshot.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FB273E822086E6C700A54E87 /* SVGGeometryElement.h in Headers */ = {isa = PBXBuildFile; fileRef = FB273E7F2086E6A300A54E87 /* SVGGeometryElement.h */; };
 		FB273E852086E74D00A54E87 /* JSSVGGeometryElement.h in Headers */ = {isa = PBXBuildFile; fileRef = FB273E842086E73E00A54E87 /* JSSVGGeometryElement.h */; };
 		FB2C15C3165D649D0039C9F8 /* CachedSVGDocumentReference.h in Headers */ = {isa = PBXBuildFile; fileRef = FB2C15C2165D64900039C9F8 /* CachedSVGDocumentReference.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -23626,10 +23626,10 @@
 		FAEF5F6029D626D1000AD8EC /* WindowPostMessageOptions.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = WindowPostMessageOptions.idl; sourceTree = "<group>"; };
 		FAEF5F6229D62D15000AD8EC /* DOMWindow.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = DOMWindow.idl; sourceTree = "<group>"; };
 		FAFFC34A2E298AA000CCC89C /* SerializedNode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SerializedNode.h; sourceTree = "<group>"; };
-		FAFFC34E2E29B1C200CCC89C /* WebKitSerializedNode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebKitSerializedNode.h; sourceTree = "<group>"; };
-		FAFFC34F2E29B1C200CCC89C /* WebKitSerializedNode.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebKitSerializedNode.cpp; sourceTree = "<group>"; };
-		FAFFC3502E29B1C200CCC89C /* WebKitSerializedNode.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebKitSerializedNode.idl; sourceTree = "<group>"; };
-		FAFFC3512E2A0C2600CCC89C /* JSWebKitSerializedNode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSWebKitSerializedNode.h; sourceTree = "<group>"; };
+		FAFFC34E2E29B1C200CCC89C /* WebKitNodeSnapshot.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebKitNodeSnapshot.h; sourceTree = "<group>"; };
+		FAFFC34F2E29B1C200CCC89C /* WebKitNodeSnapshot.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebKitNodeSnapshot.cpp; sourceTree = "<group>"; };
+		FAFFC3502E29B1C200CCC89C /* WebKitNodeSnapshot.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebKitNodeSnapshot.idl; sourceTree = "<group>"; };
+		FAFFC3512E2A0C2600CCC89C /* JSWebKitNodeSnapshot.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSWebKitNodeSnapshot.h; sourceTree = "<group>"; };
 		FB273E7E2086E6A300A54E87 /* SVGGeometryElement.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SVGGeometryElement.cpp; sourceTree = "<group>"; };
 		FB273E7F2086E6A300A54E87 /* SVGGeometryElement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SVGGeometryElement.h; sourceTree = "<group>"; };
 		FB273E802086E6A300A54E87 /* SVGGeometryElement.idl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = SVGGeometryElement.idl; sourceTree = "<group>"; };
@@ -30690,7 +30690,7 @@
 				1CDDA4CC29E131F600DC5FB1 /* JSTextDetector.cpp */,
 				1CDDA4CE29E131F600DC5FB1 /* JSTextDetector.h */,
 				FA58F4472E1DE42E0098E1C8 /* JSWebKitJSHandle.h */,
-				FAFFC3512E2A0C2600CCC89C /* JSWebKitSerializedNode.h */,
+				FAFFC3512E2A0C2600CCC89C /* JSWebKitNodeSnapshot.h */,
 				446EE4E8255E0D9200454463 /* LocalizableAdditions.strings.out */,
 				FABE72FB1059C21100D999DD /* MathMLElementFactory.cpp */,
 				44A28AAB12DFB8AC00AE923B /* MathMLElementFactory.h */,
@@ -31439,11 +31439,11 @@
 				7C48A6CE191C9D6500026674 /* WebKitNamespace.cpp */,
 				7C48A6CF191C9D6500026674 /* WebKitNamespace.h */,
 				7C48A6D2191C9D8E00026674 /* WebKitNamespace.idl */,
+				FAFFC34F2E29B1C200CCC89C /* WebKitNodeSnapshot.cpp */,
+				FAFFC34E2E29B1C200CCC89C /* WebKitNodeSnapshot.h */,
+				FAFFC3502E29B1C200CCC89C /* WebKitNodeSnapshot.idl */,
 				494BD7930F55C8EE00747828 /* WebKitPoint.h */,
 				494BD7940F55C8EE00747828 /* WebKitPoint.idl */,
-				FAFFC34F2E29B1C200CCC89C /* WebKitSerializedNode.cpp */,
-				FAFFC34E2E29B1C200CCC89C /* WebKitSerializedNode.h */,
-				FAFFC3502E29B1C200CCC89C /* WebKitSerializedNode.idl */,
 				2E19516A1B6598D200DF6EEF /* WheelEventDeltaFilter.cpp */,
 				2EBBC3D71B65988300F5253D /* WheelEventDeltaFilter.h */,
 				7AE335EF1ACB09E200E401EF /* WheelEventTestMonitor.cpp */,
@@ -47007,9 +47007,9 @@
 				77EF62F412F9DB7400C77BD2 /* JSWebGLVertexArrayObjectOES.h in Headers */,
 				FA58F4482E1DE42E0098E1C8 /* JSWebKitJSHandle.h in Headers */,
 				7CC69941191EC5F500AF2270 /* JSWebKitNamespace.h in Headers */,
+				FAFFC3522E2A0C2600CCC89C /* JSWebKitNodeSnapshot.h in Headers */,
 				0FDA7C271883333200C954B5 /* JSWebKitPlaybackTargetAvailabilityEvent.h in Headers */,
 				494BD79E0F55C94C00747828 /* JSWebKitPoint.h in Headers */,
-				FAFFC3522E2A0C2600CCC89C /* JSWebKitSerializedNode.h in Headers */,
 				5DA5E0FD102B953800088CF9 /* JSWebSocket.h in Headers */,
 				65DF320609D1CC60000BE325 /* JSWheelEvent.h in Headers */,
 				E868034828603E8900799EE3 /* JSWindowEventHandlers+Gamepad.h in Headers */,
@@ -50049,10 +50049,10 @@
 				2D06214E1DA63A8E00A7FB26 /* WebKitMediaKeys.h in Headers */,
 				2D0621501DA63A9400A7FB26 /* WebKitMediaKeySession.h in Headers */,
 				7C48A6D1191C9D6500026674 /* WebKitNamespace.h in Headers */,
+				FAFFC35D2E2AC24D00CCC89C /* WebKitNodeSnapshot.h in Headers */,
 				7A22732120C9FAFE00DB1DEF /* WebKitNSImageExtras.h in Headers */,
 				A5DEBDA416FB908700836FE0 /* WebKitPlaybackTargetAvailabilityEvent.h in Headers */,
 				494BD7950F55C8EE00747828 /* WebKitPoint.h in Headers */,
-				FAFFC35D2E2AC24D00CCC89C /* WebKitSerializedNode.h in Headers */,
 				7AFD16D32C63F70200B51D1A /* WebLayer.h in Headers */,
 				4644F7FA272A1C250055599E /* WebLock.h in Headers */,
 				4644F7F8272A1C1F0055599E /* WebLockGrantedCallback.h in Headers */,

--- a/Source/WebCore/bindings/js/DOMWrapperWorld.h
+++ b/Source/WebCore/bindings/js/DOMWrapperWorld.h
@@ -82,8 +82,8 @@ public:
     bool allowsJSHandleCreation() const { return m_allowsJSHandleCreation; }
     void setAllowsJSHandleCreation() { m_allowsJSHandleCreation = true; }
 
-    void setAllowNodeSerialization() { m_allowNodeSerialization = true; }
-    bool allowNodeSerialization() const { return m_allowNodeSerialization; }
+    void setAllowNodeSnapshotCreation() { m_allowNodeSnapshotCreation = true; }
+    bool allowNodeSnapshotCreation() const { return m_allowNodeSnapshotCreation; }
 
     void setAllowElementUserInfo() { m_allowElementUserInfo = true; }
     bool allowElementUserInfo() const { return m_allowElementUserInfo; }
@@ -151,7 +151,7 @@ private:
     bool m_closedShadowRootIsExposedForExtensions : 1 { false };
     bool m_shouldDisableLegacyOverrideBuiltInsBehavior : 1 { false };
     bool m_allowsJSHandleCreation : 1 { false };
-    bool m_allowNodeSerialization : 1 { false };
+    bool m_allowNodeSnapshotCreation : 1 { false };
     bool m_allowPostLegacySynchronousMessage : 1 { false };
     bool m_isMediaControls : 1 { false };
 };

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -513,7 +513,7 @@ namespace WebCore {
     macro(WebKitMediaKeyNeededEvent) \
     macro(WebKitMediaKeySession) \
     macro(WebKitMediaKeys) \
-    macro(WebKitSerializedNode) \
+    macro(WebKitNodeSnapshot) \
     macro(WebKitJSHandle) \
     macro(WebSocket) \
     macro(WebTransport) \

--- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -2179,7 +2179,7 @@ sub IsPrivateHeader
     'JSStyleSheetList.h' => 1,
     'JSTreeWalker.h' => 1,
     'JSWebKitJSHandle.h' => 1,
-    'JSWebKitSerializedNode.h' => 1,
+    'JSWebKitNodeSnapshot.h' => 1,
     'JSXPathExpression.h' => 1,
     'JSXPathResult.h' => 1,
     );

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -851,7 +851,7 @@ VisualViewport& LocalDOMWindow::visualViewport()
 
 bool LocalDOMWindow::shouldHaveWebKitNamespaceForWorld(DOMWrapperWorld& world, JSC::JSGlobalObject* globalObject)
 {
-    if (world.allowNodeSerialization())
+    if (world.allowNodeSnapshotCreation())
         return true;
 
     if (downcast<JSDOMGlobalObject>(globalObject)->allowsJSHandleCreation())

--- a/Source/WebCore/page/WebKitNamespace.cpp
+++ b/Source/WebCore/page/WebKitNamespace.cpp
@@ -39,7 +39,7 @@
 #include "WebKitBuffer.h"
 #include "WebKitBufferNamespace.h"
 #include "WebKitJSHandle.h"
-#include "WebKitSerializedNode.h"
+#include "WebKitNodeSnapshot.h"
 #include <JavaScriptCore/JSCellInlines.h>
 #include <JavaScriptCore/JSGlobalObjectInlines.h>
 #include <wtf/SystemTracing.h>
@@ -102,11 +102,11 @@ Ref<WebKitJSHandle> WebKitNamespace::createJSHandle(JSC::Strong<JSC::JSObject> o
     return WebKitJSHandle::create(object.get());
 }
 
-ExceptionOr<Ref<WebKitSerializedNode>> WebKitNamespace::serializeNode(Node& node, SerializedNodeInit&& init)
+ExceptionOr<Ref<WebKitNodeSnapshot>> WebKitNamespace::createNodeSnapshot(Node& node, NodeSnapshotInit&& init)
 {
     if (node.isShadowRoot()) [[unlikely]]
         return Exception { ExceptionCode::NotSupportedError };
-    return WebKitSerializedNode::create(node, init.deep);
+    return WebKitNodeSnapshot::create(node, init.deep);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/WebKitNamespace.h
+++ b/Source/WebCore/page/WebKitNamespace.h
@@ -45,7 +45,7 @@ class UserMessageHandlersNamespace;
 class WebKitBuffer;
 class WebKitBufferNamespace;
 class WebKitJSHandle;
-class WebKitSerializedNode;
+class WebKitNodeSnapshot;
 
 class WebKitNamespace : public LocalDOMWindowProperty, public RefCounted<WebKitNamespace> {
 public:
@@ -61,10 +61,10 @@ public:
     JSC::JSValue evaluateScript(JSC::JSGlobalObject&, const String& source, const String& url);
     Ref<WebKitJSHandle> createJSHandle(JSC::Strong<JSC::JSObject>);
 
-    struct SerializedNodeInit {
+    struct NodeSnapshotInit {
         bool deep { false };
     };
-    ExceptionOr<Ref<WebKitSerializedNode>> serializeNode(Node&, SerializedNodeInit&&);
+    ExceptionOr<Ref<WebKitNodeSnapshot>> createNodeSnapshot(Node&, NodeSnapshotInit&&);
 
 private:
     explicit WebKitNamespace(LocalDOMWindow&, UserContentProvider&);

--- a/Source/WebCore/page/WebKitNamespace.idl
+++ b/Source/WebCore/page/WebKitNamespace.idl
@@ -34,9 +34,9 @@
     readonly attribute WebKitBufferNamespace buffers;
     [EnabledForWorld=isNonNormal, CallWith=CurrentGlobalObject] any evaluateScript(DOMString source, optional USVString? url = null);
     [EnabledForGlobalObject=allowsJSHandleCreation] WebKitJSHandle createJSHandle(object object);
-    [EnabledForWorld=allowNodeSerialization] WebKitSerializedNode serializeNode(Node node, optional WebKitSerializedNodeInit init = {});
+    [EnabledForWorld=allowNodeSnapshotCreation] WebKitNodeSnapshot createNodeSnapshot(Node node, optional WebKitNodeSnapshotInit init = {});
 };
 
-dictionary WebKitSerializedNodeInit {
+dictionary WebKitNodeSnapshotInit {
     boolean deep = false;
 };

--- a/Source/WebCore/page/WebKitNodeSnapshot.cpp
+++ b/Source/WebCore/page/WebKitNodeSnapshot.cpp
@@ -23,24 +23,16 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import "config.h"
-#import "WKJSSerializedNodeInternal.h"
+#include "config.h"
+#include "WebKitNodeSnapshot.h"
 
-#import <WebCore/WebCoreObjCExtras.h>
+#include "Node.h"
 
-@implementation WKJSSerializedNode
+namespace WebCore {
 
-- (void)dealloc
+WebKitNodeSnapshot::WebKitNodeSnapshot(const Node& node, bool deep)
+    : m_serializedNode(node.serializeNode(deep ? Node::CloningOperation::Everything : Node::CloningOperation::SelfOnly))
 {
-    if (WebCoreObjCScheduleDeallocateOnMainRunLoop(WKJSSerializedNode.class, self))
-        return;
-    SUPPRESS_UNRETAINED_ARG _node->API::SerializedNode::~SerializedNode();
-    [super dealloc];
 }
 
-- (API::Object&)_apiObject
-{
-    return *_node;
 }
-
-@end

--- a/Source/WebCore/page/WebKitNodeSnapshot.h
+++ b/Source/WebCore/page/WebKitNodeSnapshot.h
@@ -23,9 +23,24 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    EnabledForWorld=allowNodeSerialization,
-    Exposed=Window,
-    ExportMacro=WEBCORE_EXPORT
-] interface WebKitSerializedNode {
+#pragma once
+
+#include <WebCore/SerializedNode.h>
+
+namespace WebCore {
+
+class Node;
+
+class WebKitNodeSnapshot : public RefCounted<WebKitNodeSnapshot> {
+public:
+    static Ref<WebKitNodeSnapshot> create(const Node& node, bool deep) { return adoptRef(*new WebKitNodeSnapshot(node, deep)); }
+
+    const SerializedNode& serializedNode() const LIFETIME_BOUND { return m_serializedNode; }
+
+private:
+    WebKitNodeSnapshot(const Node&, bool);
+
+    const SerializedNode m_serializedNode;
 };
+
+} // namespace WebCore

--- a/Source/WebCore/page/WebKitNodeSnapshot.idl
+++ b/Source/WebCore/page/WebKitNodeSnapshot.idl
@@ -23,24 +23,9 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
-
-#include <WebCore/SerializedNode.h>
-
-namespace WebCore {
-
-class Node;
-
-class WebKitSerializedNode : public RefCounted<WebKitSerializedNode> {
-public:
-    static Ref<WebKitSerializedNode> create(const Node& node, bool deep) { return adoptRef(*new WebKitSerializedNode(node, deep)); }
-
-    const SerializedNode& serializedNode() const LIFETIME_BOUND { return m_serializedNode; }
-
-private:
-    WebKitSerializedNode(const Node&, bool);
-
-    const SerializedNode m_serializedNode;
+[
+    EnabledForWorld=allowNodeSnapshotCreation,
+    Exposed=Window,
+    ExportMacro=WEBCORE_EXPORT
+] interface WebKitNodeSnapshot {
 };
-
-} // namespace WebCore

--- a/Source/WebKit/Headers.cmake
+++ b/Source/WebKit/Headers.cmake
@@ -173,6 +173,7 @@ list(APPEND WebKit_PUBLIC_FRAMEWORK_HEADERS
     UIProcess/API/Cocoa/WKContentWorld.h
     UIProcess/API/Cocoa/WKContentWorldConfiguration.h
     UIProcess/API/Cocoa/WKContextMenuElementInfo.h
+    UIProcess/API/Cocoa/WKDOMNodeSnapshot.h
     UIProcess/API/Cocoa/WKDownload.h
     UIProcess/API/Cocoa/WKDownloadDelegate.h
     UIProcess/API/Cocoa/WKError.h
@@ -184,7 +185,6 @@ list(APPEND WebKit_PUBLIC_FRAMEWORK_HEADERS
     UIProcess/API/Cocoa/WKImmersiveEnvironment.h
     UIProcess/API/Cocoa/WKImmersiveEnvironmentDelegate.h
     UIProcess/API/Cocoa/WKJSHandle.h
-    UIProcess/API/Cocoa/WKJSSerializedNode.h
     UIProcess/API/Cocoa/WKNavigation.h
     UIProcess/API/Cocoa/WKNavigationAction.h
     UIProcess/API/Cocoa/WKNavigationDelegate.h

--- a/Source/WebKit/PlatformIOS.cmake
+++ b/Source/WebKit/PlatformIOS.cmake
@@ -994,11 +994,11 @@ list(APPEND WebKit_PRIVATE_FRAMEWORK_HEADERS ${_webkit_api_headers})
 unset(_webkit_api_headers)
 
 list(APPEND WebKit_PUBLIC_FRAMEWORK_HEADERS
+    UIProcess/API/Cocoa/WKDOMNodeSnapshot.h
     UIProcess/API/Cocoa/WKFormInfo.h
     UIProcess/API/Cocoa/WKImmersiveEnvironment.h
     UIProcess/API/Cocoa/WKImmersiveEnvironmentDelegate.h
     UIProcess/API/Cocoa/WKJSHandle.h
-    UIProcess/API/Cocoa/WKJSSerializedNode.h
     UIProcess/API/Cocoa/WKWebExtension.h
     UIProcess/API/Cocoa/WKWebExtensionAction.h
     UIProcess/API/Cocoa/WKWebExtensionCommand.h

--- a/Source/WebKit/Shared/API/Cocoa/WebKit.h
+++ b/Source/WebKit/Shared/API/Cocoa/WebKit.h
@@ -31,6 +31,7 @@
 #import <WebKit/WKContentWorld.h>
 #import <WebKit/WKContentWorldConfiguration.h>
 #import <WebKit/WKContextMenuElementInfo.h>
+#import <WebKit/WKDOMNodeSnapshot.h>
 #import <WebKit/WKDownload.h>
 #import <WebKit/WKDownloadDelegate.h>
 #import <WebKit/WKError.h>
@@ -43,7 +44,6 @@
 #import <WebKit/WKImmersiveEnvironment.h>
 #import <WebKit/WKImmersiveEnvironmentDelegate.h>
 #import <WebKit/WKJSHandle.h>
-#import <WebKit/WKJSSerializedNode.h>
 #import <WebKit/WKNavigation.h>
 #import <WebKit/WKNavigationAction.h>
 #import <WebKit/WKNavigationDelegate.h>

--- a/Source/WebKit/Shared/Cocoa/APIObject.mm
+++ b/Source/WebKit/Shared/Cocoa/APIObject.mm
@@ -33,12 +33,12 @@
 #import "WKContentWorldConfigurationInternal.h"
 #import "WKContentWorldInternal.h"
 #import "WKContextMenuElementInfoInternal.h"
+#import "WKDOMNodeSnapshotInternal.h"
 #import "WKDownloadInternal.h"
 #import "WKFormInfoInternal.h"
 #import "WKFrameInfoInternal.h"
 #import "WKHTTPCookieStoreInternal.h"
 #import "WKJSHandleInternal.h"
-#import "WKJSSerializedNodeInternal.h"
 #import "WKNSArray.h"
 #import "WKNSData.h"
 #import "WKNSDictionary.h"
@@ -534,7 +534,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         break;
 
     case Type::SerializedNode:
-        SUPPRESS_RETAINPTR_CTOR_ADOPT wrapper = [WKJSSerializedNode alloc];
+        SUPPRESS_RETAINPTR_CTOR_ADOPT wrapper = [WKDOMNodeSnapshot alloc];
         break;
 
     case Type::JSHandle:

--- a/Source/WebKit/Shared/ContentWorldData.serialization.in
+++ b/Source/WebKit/Shared/ContentWorldData.serialization.in
@@ -28,7 +28,7 @@ header: "ContentWorldData.h"
     AllowElementUserInfo,
     DisableLegacyBuiltinOverrides,
     AllowJSHandleCreation,
-    AllowNodeSerialization,
+    AllowNodeSnapshotCreation,
     Inspectable,
 };
 

--- a/Source/WebKit/Shared/ContentWorldShared.h
+++ b/Source/WebKit/Shared/ContentWorldShared.h
@@ -47,7 +47,7 @@ enum class ContentWorldOption : uint8_t {
     AllowElementUserInfo = 1 << 2,
     DisableLegacyBuiltinOverrides = 1 << 3,
     AllowJSHandleCreation = 1 << 4,
-    AllowNodeSerialization = 1 << 5,
+    AllowNodeSnapshotCreation = 1 << 5,
     Inspectable = 1 << 6,
 };
 

--- a/Source/WebKit/Shared/JavaScriptEvaluationResult.cpp
+++ b/Source/WebKit/Shared/JavaScriptEvaluationResult.cpp
@@ -43,7 +43,7 @@
 #include <WebCore/Document.h>
 #include <WebCore/ExceptionDetails.h>
 #include <WebCore/JSWebKitJSHandle.h>
-#include <WebCore/JSWebKitSerializedNode.h>
+#include <WebCore/JSWebKitNodeSnapshot.h>
 #include <WebCore/ScriptWrappableInlines.h>
 #include <WebCore/SerializedScriptValue.h>
 
@@ -393,7 +393,7 @@ auto JavaScriptEvaluationResult::JSExtractor::jsValueToExtractedValue(JSGlobalCo
         return makeUniqueRef<JSHandleInfo>(ref->identifier(), world->identifier(), frame->info(), ref->windowFrameIdentifier());
     }
 
-    if (auto* node = dynamicDowncast<JSWebKitSerializedNode>(jsObject)) {
+    if (auto* node = dynamicDowncast<JSWebKitNodeSnapshot>(jsObject)) {
         Ref serializedNode { node->wrapped() };
         return makeUniqueRef<SerializedNode>(serializedNode->serializedNode());
     }

--- a/Source/WebKit/Shared/JavaScriptEvaluationResult.mm
+++ b/Source/WebKit/Shared/JavaScriptEvaluationResult.mm
@@ -26,8 +26,8 @@
 #import "config.h"
 #import "JavaScriptEvaluationResult.h"
 
+#import "WKDOMNodeSnapshotInternal.h"
 #import "WKJSHandleInternal.h"
-#import "WKJSSerializedNodeInternal.h"
 #import "_WKJSHandle.h"
 
 namespace WebKit {
@@ -160,8 +160,8 @@ auto JavaScriptEvaluationResult::ObjCExtractor::toValue(id object) -> Value
         return { WTF::move(map) };
     }
 
-    if ([object isKindOfClass:WKJSSerializedNode.class])
-        return makeUniqueRef<WebCore::SerializedNode>(((WKJSSerializedNode *)object)->_node->coreSerializedNode());
+    if ([object isKindOfClass:WKDOMNodeSnapshot.class])
+        return makeUniqueRef<WebCore::SerializedNode>(((WKDOMNodeSnapshot *)object)->_node->coreSerializedNode());
 
     if ([object isKindOfClass:_WKJSHandle.class])
         return makeUniqueRef<JSHandleInfo>(((_WKJSHandle *)object)->_ref->info());

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -368,12 +368,12 @@ UIProcess/API/Cocoa/WKFrameInfo.mm @nonARC
 UIProcess/API/Cocoa/WKHTTPCookieStore.mm @nonARC
 UIProcess/API/Cocoa/WKImmersiveEnvironment.mm @nonARC
 UIProcess/API/Cocoa/WKJSHandle.mm @nonARC
-UIProcess/API/Cocoa/WKJSSerializedNode.mm @nonARC
 UIProcess/API/Cocoa/WKMenuItemIdentifiers.mm @nonARC
 UIProcess/API/Cocoa/WKNavigation.mm @nonARC
 UIProcess/API/Cocoa/WKNavigationAction.mm @nonARC
 UIProcess/API/Cocoa/WKNavigationData.mm @nonARC
 UIProcess/API/Cocoa/WKNavigationResponse.mm @nonARC
+UIProcess/API/Cocoa/WKDOMNodeSnapshot.mm @nonARC
 UIProcess/API/Cocoa/WKNSURLAuthenticationChallenge.mm @nonARC
 UIProcess/API/Cocoa/WKOpenPanelParameters.mm @nonARC
 UIProcess/API/Cocoa/WKPDFConfiguration.mm @nonARC

--- a/Source/WebKit/UIProcess/API/APIContentWorld.h
+++ b/Source/WebKit/UIProcess/API/APIContentWorld.h
@@ -68,8 +68,8 @@ public:
     bool allowJSHandleCreation() const { return m_options.contains(WebKit::ContentWorldOption::AllowJSHandleCreation); }
     void setAllowJSHandleCreation() { m_options.add(WebKit::ContentWorldOption::AllowJSHandleCreation); }
 
-    bool allowNodeSerialization() const { return m_options.contains(WebKit::ContentWorldOption::AllowNodeSerialization); }
-    void setAllowNodeSerialization() { m_options.add(WebKit::ContentWorldOption::AllowNodeSerialization); }
+    bool allowNodeSnapshotCreation() const { return m_options.contains(WebKit::ContentWorldOption::AllowNodeSnapshotCreation); }
+    void setAllowNodeSnapshotCreation() { m_options.add(WebKit::ContentWorldOption::AllowNodeSnapshotCreation); }
 
     void addAssociatedUserContentControllerProxy(WebKit::WebUserContentControllerProxy&);
 

--- a/Source/WebKit/UIProcess/API/APIContentWorldConfiguration.cpp
+++ b/Source/WebKit/UIProcess/API/APIContentWorldConfiguration.cpp
@@ -55,8 +55,8 @@ OptionSet<WebKit::ContentWorldOption> ContentWorldConfiguration::optionSet() con
         result.add(WebKit::ContentWorldOption::DisableLegacyBuiltinOverrides);
     if (allowJSHandleCreation())
         result.add(WebKit::ContentWorldOption::AllowJSHandleCreation);
-    if (allowNodeSerialization())
-        result.add(WebKit::ContentWorldOption::AllowNodeSerialization);
+    if (allowNodeSnapshotCreation())
+        result.add(WebKit::ContentWorldOption::AllowNodeSnapshotCreation);
     if (isInspectable())
         result.add(WebKit::ContentWorldOption::Inspectable);
 
@@ -130,14 +130,14 @@ void ContentWorldConfiguration::setAllowJSHandleCreation(bool allow)
     m_data.allowJSHandleCreation = allow;
 }
 
-bool ContentWorldConfiguration::allowNodeSerialization() const
+bool ContentWorldConfiguration::allowNodeSnapshotCreation() const
 {
-    return m_data.allowNodeSerialization;
+    return m_data.allowNodeSnapshotCreation;
 }
 
-void ContentWorldConfiguration::setAllowNodeSerialization(bool allow)
+void ContentWorldConfiguration::setAllowNodeSnapshotCreation(bool allow)
 {
-    m_data.allowNodeSerialization = allow;
+    m_data.allowNodeSnapshotCreation = allow;
 }
 
 bool ContentWorldConfiguration::isInspectable() const

--- a/Source/WebKit/UIProcess/API/APIContentWorldConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIContentWorldConfiguration.h
@@ -61,8 +61,8 @@ public:
     bool NODELETE allowJSHandleCreation() const;
     void NODELETE setAllowJSHandleCreation(bool);
 
-    bool NODELETE allowNodeSerialization() const;
-    void NODELETE setAllowNodeSerialization(bool);
+    bool NODELETE allowNodeSnapshotCreation() const;
+    void NODELETE setAllowNodeSnapshotCreation(bool);
 
     bool NODELETE isInspectable() const;
     void NODELETE setInspectable(bool);
@@ -79,7 +79,7 @@ private:
         bool allowElementUserInfo : 1 { false };
         bool disableLegacyBuiltinOverrides : 1 { false };
         bool allowJSHandleCreation : 1 { false };
-        bool allowNodeSerialization : 1 { false };
+        bool allowNodeSnapshotCreation : 1 { false };
         bool inspectable : 1 { true };
     };
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentWorldConfiguration.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentWorldConfiguration.h
@@ -53,12 +53,12 @@ WK_CLASS_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0))
 /*! @abstract A boolean value indicating whether the behavior that elements with a name attribute overrides builtin methods on document object should be enabled or not. */
 @property (nonatomic, getter=isLegacyBuiltinOverridesEnabled) BOOL legacyBuiltinOverridesEnabled NS_SWIFT_NAME(legacyBuiltinOverridesEnabled);
 
-/*! @abstract A boolean indicating whether or not `window.webkit.serializeNode` is available.
- @discussion JavaScript can call `window.webkit.serializeNode` with a return value to create a `WKJSSerializedNode`
+/*! @abstract A boolean indicating whether or not `window.webkit.createNodeSnapshot` is available.
+ @discussion JavaScript can call `window.webkit.createNodeSnapshot` with a return value to create a `WKDOMNodeSnapshot`
  object for the application to use in future JavaScript programs.
- Refer to the `WKJSSerializedNode` documentation for more information.
+ Refer to the `WKDOMNodeSnapshot` documentation for more information.
  */
-@property (nonatomic, getter=isNodeSerializationEnabled) BOOL nodeSerializationEnabled NS_SWIFT_NAME(nodeSerializationEnabled);
+@property (nonatomic, getter=isNodeSnapshotCreationEnabled) BOOL nodeSnapshotCreationEnabled NS_SWIFT_NAME(nodeSnapshotCreationEnabled);
 
 /*! @abstract A boolean indicating whether or not `window.webkit.createJSHandle` is available. */
 @property (nonatomic, getter=isJSHandleCreationEnabled, setter=setJSHandleCreationEnabled:) BOOL jsHandleCreationEnabled NS_SWIFT_NAME(jsHandleCreationEnabled);

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentWorldConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentWorldConfiguration.mm
@@ -77,7 +77,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
     [coder encodeBool:configuration->allowElementUserInfo() forKey:@"allowElementUserInfo"];
     [coder encodeBool:configuration->disableLegacyBuiltinOverrides() forKey:@"disableLegacyBuiltinOverrides"];
     [coder encodeBool:configuration->allowJSHandleCreation() forKey:@"allowJSHandleCreation"];
-    [coder encodeBool:configuration->allowNodeSerialization() forKey:@"allowNodeSerialization"];
+    [coder encodeBool:configuration->allowNodeSnapshotCreation() forKey:@"allowNodeSnapshotCreation"];
     [coder encodeBool:configuration->isInspectable() forKey:@"inspectable"];
 }
 
@@ -94,7 +94,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
     configuration->setAllowElementUserInfo([coder decodeBoolForKey:@"allowElementUserInfo"]);
     configuration->setDisableLegacyBuiltinOverrides([coder decodeBoolForKey:@"disableLegacyBuiltinOverrides"]);
     configuration->setAllowJSHandleCreation([coder decodeBoolForKey:@"allowJSHandleCreation"]);
-    configuration->setAllowNodeSerialization([coder decodeBoolForKey:@"allowNodeSerialization"]);
+    configuration->setAllowNodeSnapshotCreation([coder decodeBoolForKey:@"allowNodeSnapshotCreation"]);
     configuration->setInspectable([coder decodeBoolForKey:@"inspectable"]);
 
     return self;
@@ -167,14 +167,14 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
     _worldConfiguration->setInspectable(inspectable);
 }
 
-- (BOOL)isNodeSerializationEnabled
+- (BOOL)isNodeSnapshotCreationEnabled
 {
-    return _worldConfiguration->allowNodeSerialization();
+    return _worldConfiguration->allowNodeSnapshotCreation();
 }
 
-- (void)setNodeSerializationEnabled:(BOOL)allow
+- (void)setNodeSnapshotCreationEnabled:(BOOL)allow
 {
-    _worldConfiguration->setAllowNodeSerialization(allow);
+    _worldConfiguration->setAllowNodeSnapshotCreation(allow);
 }
 
 @end
@@ -251,14 +251,14 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
     _worldConfiguration->setAllowJSHandleCreation(allow);
 }
 
-- (BOOL)allowNodeSerialization
+- (BOOL)allowNodeSnapshotCreation
 {
-    return [self isNodeSerializationEnabled];
+    return [self isNodeSnapshotCreationEnabled];
 }
 
-- (void)setAllowNodeSerialization:(BOOL)allow
+- (void)setAllowNodeSnapshotCreation:(BOOL)allow
 {
-    [self setNodeSerializationEnabled:allow];
+    [self setNodeSnapshotCreationEnabled:allow];
 }
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKDOMNodeSnapshot.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKDOMNodeSnapshot.h
@@ -27,7 +27,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/*! A `WKJSSerializedNode` object contains the serialized representation of a DOM node
+/*! A `WKDOMNodeSnapshot` object contains a snapshot of a DOM node
  @discussion There are various ways that JavaScript executing inside web content results in some return value
  being passed up to the WebKit application.
  Examples include calls to `[WKWebView evaluateJavaScript:...]`, `[WKWebView callAsyncJavaScript:...]`, and the
@@ -36,19 +36,18 @@ NS_ASSUME_NONNULL_BEGIN
  When application JavaScript returns a JavaScript value, the default behavior is to try to convert it to a foundational type.
  e.g. a JavaScript Number becomes an NSNumber, or a JavaScript array becomes an NSArray, etc.
 
- When the return value is a DOM node, the default conversion is to "stringify" it and return that to the application as an NSString.
- If the JavaScript instead calls `window.webkit.serializeNode(...)` then WebKit will create a serialized representation of
+ If the JavaScript calls `window.webkit.createNodeSnapshot(...)` then WebKit will create a snapshot representation of
  that node as the return value.
 
  The node is an opaque object as far as the application is concerned, but it can be used as an argument to future JavaScript programs
  via `[WKWebView callAsyncJavaScript:...]`
 
- Unlike `WKJSHandle` - which keeps an actual JavaScript object alive in its originating context - a `WKJSSerializedNode` is not attached
+ Unlike `WKJSHandle` - which keeps an actual JavaScript object alive in its originating context - a `WKDOMNodeSnapshot` is not attached
  to a live JavaScript object, and it can be used as an argument to a JavaScript program running in any context.
  e.g. In a different frame, or after a navigation.
  */
 WK_CLASS_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0))
-@interface WKJSSerializedNode : NSObject
+@interface WKDOMNodeSnapshot : NSObject
 
 + (instancetype)new NS_UNAVAILABLE;
 - (instancetype)init NS_UNAVAILABLE;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKDOMNodeSnapshot.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKDOMNodeSnapshot.mm
@@ -23,16 +23,24 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "config.h"
-#include "WebKitSerializedNode.h"
+#import "config.h"
+#import "WKDOMNodeSnapshotInternal.h"
 
-#include "Node.h"
+#import <WebCore/WebCoreObjCExtras.h>
 
-namespace WebCore {
+@implementation WKDOMNodeSnapshot
 
-WebKitSerializedNode::WebKitSerializedNode(const Node& node, bool deep)
-    : m_serializedNode(node.serializeNode(deep ? Node::CloningOperation::Everything : Node::CloningOperation::SelfOnly))
+- (void)dealloc
 {
+    if (WebCoreObjCScheduleDeallocateOnMainRunLoop(WKDOMNodeSnapshot.class, self))
+        return;
+    SUPPRESS_UNRETAINED_ARG _node->API::SerializedNode::~SerializedNode();
+    [super dealloc];
 }
 
+- (API::Object&)_apiObject
+{
+    return *_node;
 }
+
+@end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKDOMNodeSnapshotInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKDOMNodeSnapshotInternal.h
@@ -24,19 +24,19 @@
  */
 
 #import "APISerializedNode.h"
-#import "WKJSSerializedNode.h"
+#import "WKDOMNodeSnapshot.h"
 #import "WKObject.h"
 #import <wtf/AlignedStorage.h>
 
 namespace WebKit {
 
 template<> struct WrapperTraits<API::SerializedNode> {
-    using WrapperClass = WKJSSerializedNode;
+    using WrapperClass = WKDOMNodeSnapshot;
 };
 
 }
 
-@interface WKJSSerializedNode () <WKObject> {
+@interface WKDOMNodeSnapshot () <WKObject> {
 @package
     AlignedStorage<API::SerializedNode> _node;
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -1532,7 +1532,7 @@ static WKMediaPlaybackState NODELETE toWKMediaPlaybackState(WebKit::MediaPlaybac
     auto removeTransientActivation = !_dontResetTransientActivationAfterRunJavaScript && WebKit::shouldEvaluateJavaScriptWithoutTransientActivation() ? WebCore::RemoveTransientActivation::Yes : WebCore::RemoveTransientActivation::No;
 
     std::optional<IPC::TransferString> scriptString;
-    if (world->_contentWorld->allowAutofill() || world->_contentWorld->allowNodeSerialization())
+    if (world->_contentWorld->allowAutofill() || world->_contentWorld->allowNodeSnapshotCreation())
         scriptString = IPC::TransferString::createCached(javaScriptString);
     else
         scriptString = IPC::TransferString::create(javaScriptString);

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKContentWorldConfiguration.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKContentWorldConfiguration.h
@@ -55,8 +55,8 @@ WK_CLASS_AVAILABLE(macos(15.4), ios(18.4), visionos(2.4))
 /*! @abstract A boolean indicating whether window.webkit.createJSHandle is available. */
 @property (nonatomic) BOOL allowJSHandleCreation WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4));
 
-/*! @abstract A boolean indicating whether window.webkit.serializeNode is available. */
-@property (nonatomic) BOOL allowNodeSerialization WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4));
+/*! @abstract A boolean indicating whether window.webkit.createNodeSnapshot is available. */
+@property (nonatomic) BOOL allowNodeSnapshotCreation WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4));
 
 @end
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1202,8 +1202,8 @@
 		5110AE0D133C16CB0072717A /* WKIconDatabase.h in Headers */ = {isa = PBXBuildFile; fileRef = 5110AE0B133C16CB0072717A /* WKIconDatabase.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		51130EC8294466AF00E076C5 /* _WKNotificationDataInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 51130EC5294466AE00E076C5 /* _WKNotificationDataInternal.h */; };
 		51130ECA294466AF00E076C5 /* _WKNotificationData.h in Headers */ = {isa = PBXBuildFile; fileRef = 51130EC7294466AF00E076C5 /* _WKNotificationData.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		5116CE712F3F983F00968E09 /* WKJSSerializedNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 5116CE6E2F3F983800968E09 /* WKJSSerializedNode.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5116CE722F3F983F00968E09 /* WKJSSerializedNodeInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 5116CE702F3F983800968E09 /* WKJSSerializedNodeInternal.h */; };
+		5116CE712F3F983F00968E09 /* WKDOMNodeSnapshot.h in Headers */ = {isa = PBXBuildFile; fileRef = 5116CE6E2F3F983800968E09 /* WKDOMNodeSnapshot.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5116CE722F3F983F00968E09 /* WKDOMNodeSnapshotInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 5116CE702F3F983800968E09 /* WKDOMNodeSnapshotInternal.h */; };
 		511F7D411EB1BCF500E47B83 /* WebsiteDataStoreParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = 511F7D401EB1BCEE00E47B83 /* WebsiteDataStoreParameters.h */; };
 		511FD1132C51AF4300BD8163 /* _WKMockUserNotificationCenter.mm in Sources */ = {isa = PBXBuildFile; fileRef = 511FD1102C51848900BD8163 /* _WKMockUserNotificationCenter.mm */; };
 		511FD1142C51AF4F00BD8163 /* _WKMockUserNotificationCenter.h in Headers */ = {isa = PBXBuildFile; fileRef = 511FD10F2C51848900BD8163 /* _WKMockUserNotificationCenter.h */; };
@@ -5988,9 +5988,9 @@
 		51130EC5294466AE00E076C5 /* _WKNotificationDataInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKNotificationDataInternal.h; sourceTree = "<group>"; };
 		51130EC6294466AF00E076C5 /* _WKNotificationData.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKNotificationData.mm; sourceTree = "<group>"; };
 		51130EC7294466AF00E076C5 /* _WKNotificationData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKNotificationData.h; sourceTree = "<group>"; };
-		5116CE6E2F3F983800968E09 /* WKJSSerializedNode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKJSSerializedNode.h; sourceTree = "<group>"; };
-		5116CE6F2F3F983800968E09 /* WKJSSerializedNode.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKJSSerializedNode.mm; sourceTree = "<group>"; };
-		5116CE702F3F983800968E09 /* WKJSSerializedNodeInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKJSSerializedNodeInternal.h; sourceTree = "<group>"; };
+		5116CE6E2F3F983800968E09 /* WKDOMNodeSnapshot.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKDOMNodeSnapshot.h; sourceTree = "<group>"; };
+		5116CE6F2F3F983800968E09 /* WKDOMNodeSnapshot.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKDOMNodeSnapshot.mm; sourceTree = "<group>"; };
+		5116CE702F3F983800968E09 /* WKDOMNodeSnapshotInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKDOMNodeSnapshotInternal.h; sourceTree = "<group>"; };
 		51195EA52F8E868000218439 /* WebBackForwardList.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebBackForwardList.messages.in; sourceTree = "<group>"; };
 		511F7D3F1EB1BCEE00E47B83 /* WebsiteDataStoreParameters.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = WebsiteDataStoreParameters.serialization.in; sourceTree = "<group>"; };
 		511F7D401EB1BCEE00E47B83 /* WebsiteDataStoreParameters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebsiteDataStoreParameters.h; sourceTree = "<group>"; };
@@ -13044,6 +13044,9 @@
 				075C07992D9211F700B3E900 /* WKContextMenuElementInfoAdapter.swift */,
 				5CE0C36B229F2D4B003695F0 /* WKContextMenuElementInfoInternal.h */,
 				5CE0C36A229F2D4A003695F0 /* WKContextMenuElementInfoPrivate.h */,
+				5116CE6E2F3F983800968E09 /* WKDOMNodeSnapshot.h */,
+				5116CE6F2F3F983800968E09 /* WKDOMNodeSnapshot.mm */,
+				5116CE702F3F983800968E09 /* WKDOMNodeSnapshotInternal.h */,
 				DF0C5F24252ECB8D00D921DB /* WKDownload.h */,
 				DF0C5F23252ECB8D00D921DB /* WKDownload.mm */,
 				DF0C5F26252ECB8E00D921DB /* WKDownloadDelegate.h */,
@@ -13078,9 +13081,6 @@
 				51DB22E72F3EB13300BDCDCE /* WKJSHandle.h */,
 				51DB22E82F3EB13300BDCDCE /* WKJSHandle.mm */,
 				51DB22E92F3EB13300BDCDCE /* WKJSHandleInternal.h */,
-				5116CE6E2F3F983800968E09 /* WKJSSerializedNode.h */,
-				5116CE6F2F3F983800968E09 /* WKJSSerializedNode.mm */,
-				5116CE702F3F983800968E09 /* WKJSSerializedNodeInternal.h */,
 				1AB40EE31BF677E300BA81BE /* WKMenuItemIdentifiers.mm */,
 				1AB40EE41BF677E300BA81BE /* WKMenuItemIdentifiersPrivate.h */,
 				1A5B1C4F1898606F004FCF9B /* WKNavigation.h */,
@@ -19391,6 +19391,8 @@
 				BC017D0B16260FF4007054F5 /* WKDOMInternals.h in Headers */,
 				BC017D0D16260FF4007054F5 /* WKDOMNode.h in Headers */,
 				BC5D24C216CD706D007D5461 /* WKDOMNodePrivate.h in Headers */,
+				5116CE712F3F983F00968E09 /* WKDOMNodeSnapshot.h in Headers */,
+				5116CE722F3F983F00968E09 /* WKDOMNodeSnapshotInternal.h in Headers */,
 				BC39C4361626366F008BC689 /* WKDOMRange.h in Headers */,
 				BC5D24C516CD7088007D5461 /* WKDOMRangePrivate.h in Headers */,
 				293EBEAB1627D9C9005F89F1 /* WKDOMText.h in Headers */,
@@ -19488,8 +19490,6 @@
 				51DB22F22F3EB16E00BDCDCE /* WKJSHandle.h in Headers */,
 				51DB22F12F3EB16E00BDCDCE /* WKJSHandleInternal.h in Headers */,
 				FA84D6692E579F38004BDAA4 /* WKJSHandleRef.h in Headers */,
-				5116CE712F3F983F00968E09 /* WKJSSerializedNode.h in Headers */,
-				5116CE722F3F983F00968E09 /* WKJSSerializedNodeInternal.h in Headers */,
 				2DD5E129210ADC7B00DB6012 /* WKKeyboardScrollingAnimator.h in Headers */,
 				51E8284E2B21395A009119F9 /* WKKeyedCoder.h in Headers */,
 				51A9E10B1315CD18009E7031 /* WKKeyValueStorageManager.h in Headers */,

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.cpp
@@ -135,9 +135,9 @@ void InjectedBundleScriptWorld::setAllowJSHandleCreation()
     m_world->setAllowsJSHandleCreation();
 }
 
-void InjectedBundleScriptWorld::setAllowNodeSerialization()
+void InjectedBundleScriptWorld::setAllowNodeSnapshotCreation()
 {
-    m_world->setAllowNodeSerialization();
+    m_world->setAllowNodeSnapshotCreation();
 }
 
 void InjectedBundleScriptWorld::setAllowPostingLegacySynchronousMessages()

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.h
@@ -64,7 +64,7 @@ public:
     void NODELETE exposeClosedShadowRootsForExtensions();
     void NODELETE disableOverrideBuiltinsBehavior();
     void NODELETE setAllowJSHandleCreation();
-    void NODELETE setAllowNodeSerialization();
+    void NODELETE setAllowNodeSnapshotCreation();
     void NODELETE setAllowPostingLegacySynchronousMessages();
 
     ContentWorldIdentifier identifier() const { return m_identifier; }

--- a/Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp
+++ b/Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp
@@ -172,8 +172,8 @@ void WebUserContentController::addContentWorldIfNecessary(const ContentWorldData
         scriptWorld->disableOverrideBuiltinsBehavior();
     if (world.options.contains(ContentWorldOption::AllowJSHandleCreation))
         scriptWorld->setAllowJSHandleCreation();
-    if (world.options.contains(ContentWorldOption::AllowNodeSerialization))
-        scriptWorld->setAllowNodeSerialization();
+    if (world.options.contains(ContentWorldOption::AllowNodeSnapshotCreation))
+        scriptWorld->setAllowNodeSnapshotCreation();
 
     Page::forEachPage([&] (auto& page) {
         Ref mainFrame = page.mainFrame();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -4950,7 +4950,7 @@ void WebPage::runJavaScriptInFrameInScriptWorld(RunJavaScriptParameters&& parame
 
 void WebPage::clearContentWorld(ContentWorldIdentifier worldIdentifier, CompletionHandler<void()>&& completionHandler)
 {
-    if (RefPtr world = m_userContentController->worldForIdentifier(worldIdentifier); world && world->coreWorld().allowNodeSerialization()) {
+    if (RefPtr world = m_userContentController->worldForIdentifier(worldIdentifier); world && world->coreWorld().allowNodeSnapshotCreation()) {
         WEBPAGE_RELEASE_LOG(Loading, "clearContentWorld: id=%" PUBLIC_LOG_STRING " name=%" PUBLIC_LOG_STRING, worldIdentifier.loggingString().ascii().data(), world->name().utf8().data());
         world->clearWrappers();
     }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SerializedNode.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SerializedNode.mm
@@ -29,7 +29,7 @@
 #import "Helpers/cocoa/TestNavigationDelegate.h"
 #import "Helpers/cocoa/TestWKWebView.h"
 #import <WebKit/WKContentWorldPrivate.h>
-#import <WebKit/WKJSSerializedNode.h>
+#import <WebKit/WKDOMNodeSnapshot.h>
 #import <WebKit/_WKContentWorldConfiguration.h>
 
 namespace TestWebKitAPI {
@@ -41,12 +41,12 @@ TEST(SerializedNode, Basic)
     [webView _test_waitForDidFinishNavigation];
 
     RetainPtr worldConfiguration = adoptNS([WKContentWorldConfiguration new]);
-    worldConfiguration.get().nodeSerializationEnabled = YES;
+    worldConfiguration.get().nodeSnapshotCreationEnabled = YES;
     RetainPtr world = [WKContentWorld worldWithConfiguration:worldConfiguration.get()];
 
     auto verifyNodeSerialization = [world, webView] (const char* constructor, const char* accessor, const char* expected, const char* className, const char* init = "deep:true") {
-        RetainPtr serializedNode = [webView objectByEvaluatingJavaScript:[NSString stringWithFormat:@"window.webkit.serializeNode(%s, { %s })", constructor, init] inFrame:nil inContentWorld:world.get()];
-        EXPECT_TRUE([serializedNode isKindOfClass:WKJSSerializedNode.class]);
+        RetainPtr serializedNode = [webView objectByEvaluatingJavaScript:[NSString stringWithFormat:@"window.webkit.createNodeSnapshot(%s, { %s })", constructor, init] inFrame:nil inContentWorld:world.get()];
+        EXPECT_TRUE([serializedNode isKindOfClass:WKDOMNodeSnapshot.class]);
         RetainPtr other = adoptNS([TestWKWebView new]);
 
         id instanceof = [other objectByCallingAsyncFunction:@"return Object.getPrototypeOf(n).toString()" withArguments:@{ @"n" : serializedNode.get() }];
@@ -94,7 +94,7 @@ TEST(SerializedNode, Basic)
     verifyNodeSerialization("document.getElementById('host')", "n.shadowRoot.mode + ' ' + n.shadowRoot.delegatesFocus + ' ' + n.shadowRoot.serializable + ' ' + n.shadowRoot.host.tagName + ' ' + n.shadowRoot.querySelector('c-d')", "open false false DIV null", "HTMLDivElement");
 
     __block bool done { false };
-    [webView evaluateJavaScript:@"window.webkit.serializeNode(document.getElementById('host').shadowRoot)" inFrame:nil inContentWorld:world.get() completionHandler:^(id, NSError *error) {
+    [webView evaluateJavaScript:@"window.webkit.createNodeSnapshot(document.getElementById('host').shadowRoot)" inFrame:nil inContentWorld:world.get() completionHandler:^(id, NSError *error) {
         EXPECT_WK_STREQ(error.domain, WKErrorDomain);
         EXPECT_EQ(error.code, WKErrorJavaScriptExceptionOccurred);
         done = true;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UserContentController.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UserContentController.mm
@@ -38,7 +38,7 @@
 #import <WebKit/WKContentWorld.h>
 #import <WebKit/WKContentWorldConfiguration.h>
 #import <WebKit/WKContentWorldPrivate.h>
-#import <WebKit/WKJSSerializedNode.h>
+#import <WebKit/WKDOMNodeSnapshot.h>
 #import <WebKit/WKProcessPoolPrivate.h>
 #import <WebKit/WKScriptMessage.h>
 #import <WebKit/WKScriptMessageHandlerWithReply.h>
@@ -2024,9 +2024,9 @@ TEST(WKUserContentController, EvaluateLargeJavaScriptStringInAutoFillWorld)
 - (void)userContentController:(WKUserContentController *)userContentController didReceiveScriptMessage:(WKScriptMessage *)message replyHandler:(void (^)(id, NSString *errorMessage))replyHandler
 {
     WKWebView *webView = message.webView;
-    [webView evaluateJavaScript:@"window.webkit.serializeNode(document.createElement('div'))" inFrame:nil inContentWorld:self.world completionHandler:^(id result, NSError *error) {
+    [webView evaluateJavaScript:@"window.webkit.createNodeSnapshot(document.createElement('div'))" inFrame:nil inContentWorld:self.world completionHandler:^(id result, NSError *error) {
         EXPECT_NULL(error);
-        EXPECT_TRUE([result isKindOfClass:WKJSSerializedNode.class]);
+        EXPECT_TRUE([result isKindOfClass:WKDOMNodeSnapshot.class]);
         replyHandler(result, nil);
     }];
 }
@@ -2036,7 +2036,7 @@ TEST(WKUserContentController, EvaluateLargeJavaScriptStringInAutoFillWorld)
 TEST(WKUserContentController, MessageHandlerReplyWithSerializedNode)
 {
     RetainPtr worldConfiguration = adoptNS([WKContentWorldConfiguration new]);
-    worldConfiguration.get().nodeSerializationEnabled = YES;
+    worldConfiguration.get().nodeSnapshotCreationEnabled = YES;
     RetainPtr world = [WKContentWorld worldWithConfiguration:worldConfiguration.get()];
 
     RetainPtr handler = adoptNS([SerializedNodeReplyHandler new]);
@@ -2071,7 +2071,7 @@ TEST(WKUserContentController, MessageHandlerInjectsWebKitNamespace)
     // The other WebKitNamespace attributes shouldn't be accessible.
     EXPECT_FALSE([[webView objectByEvaluatingJavaScript:@"window.webkit.evaluateScript"] boolValue]);
     EXPECT_FALSE([[webView objectByEvaluatingJavaScript:@"window.webkit.createJSHandle"] boolValue]);
-    EXPECT_FALSE([[webView objectByEvaluatingJavaScript:@"window.webkit.serializeNode"] boolValue]);
+    EXPECT_FALSE([[webView objectByEvaluatingJavaScript:@"window.webkit.createNodeSnapshot"] boolValue]);
 }
 
 TEST(WKUserContentController, PostMessageDuringPageClose)

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/UserContentControllerTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/UserContentControllerTests.swift
@@ -56,24 +56,24 @@ struct UserContentControllerTests {
 
         let evaluateScript: Void? = try await page.callJavaScript(returning: Void?.self) {
             """
-            return window.webkit.evaluateScript;
+            return !!window.webkit.evaluateScript;
             """
         }
-        #expect(evaluateScript == nil)
+        #expect(evaluateScript == false)
 
         let createJSHandle: Void? = try await page.callJavaScript(returning: Void?.self) {
             """
-            return window.webkit.createJSHandle;
+            return !!window.webkit.createJSHandle;
             """
         }
-        #expect(createJSHandle == nil)
+        #expect(createJSHandle == false)
 
-        let serializeNode: Void? = try await page.callJavaScript(returning: Void?.self) {
+        let nodeSnapshotCreator: Void? = try await page.callJavaScript(returning: Void?.self) {
             """
-            return window.webkit.serializeNode;
+            return !!window.webkit.createNodeSnapshot;
             """
         }
-        #expect(serializeNode == nil)
+        #expect(cloneNode == false)
     }
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageTests.swift
@@ -151,7 +151,7 @@ struct WebPageTests {
     @Test
     func clearContentWorld() async throws {
         let worldConfiguration = WKContentWorld.Configuration()
-        worldConfiguration.nodeSerializationEnabled = true
+        worldConfiguration.nodeSnapshotCreationEnabled = true
         let world = WKContentWorld(configuration: worldConfiguration)
 
         let page = WebPage()


### PR DESCRIPTION
#### b804b0e920ae5fd253517bb97f9a70bff06803c0
<pre>
Rename WKJSSerializedNode to WKDOMNodeSnapshot
<a href="https://bugs.webkit.org/show_bug.cgi?id=319331">https://bugs.webkit.org/show_bug.cgi?id=319331</a>

Reviewed by Richard Robinson.

This responds to API review feedback.  &quot;Serialized&quot; is an odd implementation detail,
and this object does not conform to NSCoding.  &quot;Snapshot&quot; is more clear,
and not limited to the same script execution context.  I therefore also rename the
world configuration and JavaScript entry points.

Tests: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SerializedNode.mm
       Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UserContentController.mm

* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/DOMWrapperWorld.h:
(WebCore::DOMWrapperWorld::setAllowNodeSnapshotCreation):
(WebCore::DOMWrapperWorld::allowNodeSnapshotCreation const):
(WebCore::DOMWrapperWorld::setAllowNodeSerialization): Deleted.
(WebCore::DOMWrapperWorld::allowNodeSerialization const): Deleted.
* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:
* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
(IsPrivateHeader):
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::shouldHaveWebKitNamespaceForWorld):
* Source/WebCore/page/WebKitNamespace.cpp:
(WebCore::WebKitNamespace::createNodeSnapshot):
(WebCore::WebKitNamespace::serializeNode): Deleted.
* Source/WebCore/page/WebKitNamespace.h:
* Source/WebCore/page/WebKitNamespace.idl:
* Source/WebCore/page/WebKitNodeSnapshot.cpp: Renamed from Source/WebCore/page/WebKitSerializedNode.cpp.
(WebCore::WebKitNodeSnapshot::WebKitNodeSnapshot):
* Source/WebCore/page/WebKitNodeSnapshot.h: Renamed from Source/WebCore/page/WebKitSerializedNode.h.
(WebCore::WebKitNodeSnapshot::create):
* Source/WebCore/page/WebKitNodeSnapshot.idl: Renamed from Source/WebCore/page/WebKitSerializedNode.idl.
* Source/WebKit/Headers.cmake:
* Source/WebKit/PlatformIOS.cmake:
* Source/WebKit/Shared/API/Cocoa/WebKit.h:
* Source/WebKit/Shared/Cocoa/APIObject.mm:
(API::Object::newObject):
* Source/WebKit/Shared/ContentWorldData.serialization.in:
* Source/WebKit/Shared/ContentWorldShared.h:
* Source/WebKit/Shared/JavaScriptEvaluationResult.cpp:
(WebKit::JavaScriptEvaluationResult::JSExtractor::jsValueToExtractedValue):
* Source/WebKit/Shared/JavaScriptEvaluationResult.mm:
(WebKit::JavaScriptEvaluationResult::ObjCExtractor::toValue):
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/API/APIContentWorld.h:
* Source/WebKit/UIProcess/API/APIContentWorldConfiguration.cpp:
(API::ContentWorldConfiguration::optionSet const):
(API::ContentWorldConfiguration::allowNodeSnapshotCreation const):
(API::ContentWorldConfiguration::setAllowNodeSnapshotCreation):
(API::ContentWorldConfiguration::allowNodeSerialization const): Deleted.
(API::ContentWorldConfiguration::setAllowNodeSerialization): Deleted.
* Source/WebKit/UIProcess/API/APIContentWorldConfiguration.h:
* Source/WebKit/UIProcess/API/Cocoa/WKContentWorldConfiguration.h:
* Source/WebKit/UIProcess/API/Cocoa/WKContentWorldConfiguration.mm:
(-[WKContentWorldConfiguration encodeWithCoder:]):
(-[WKContentWorldConfiguration initWithCoder:]):
(-[WKContentWorldConfiguration isNodeSnapshotCreationEnabled]):
(-[WKContentWorldConfiguration setNodeSnapshotCreationEnabled:]):
(-[_WKContentWorldConfiguration allowNodeSnapshotCreation]):
(-[_WKContentWorldConfiguration setAllowNodeSnapshotCreation:]):
(-[WKContentWorldConfiguration isNodeSerializationEnabled]): Deleted.
(-[WKContentWorldConfiguration setNodeSerializationEnabled:]): Deleted.
(-[_WKContentWorldConfiguration allowNodeSerialization]): Deleted.
(-[_WKContentWorldConfiguration setAllowNodeSerialization:]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKDOMNodeSnapshot.h: Renamed from Source/WebKit/UIProcess/API/Cocoa/WKJSSerializedNode.h.
* Source/WebKit/UIProcess/API/Cocoa/WKDOMNodeSnapshot.mm: Renamed from Source/WebKit/UIProcess/API/Cocoa/WKJSSerializedNode.mm.
(-[WKDOMNodeSnapshot dealloc]):
* Source/WebKit/UIProcess/API/Cocoa/WKDOMNodeSnapshotInternal.h: Renamed from Source/WebKit/UIProcess/API/Cocoa/WKJSSerializedNodeInternal.h.
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _evaluateJavaScript:asAsyncFunction:withSourceURL:withArguments:forceUserGesture:inFrame:inWorld:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKContentWorldConfiguration.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.cpp:
(WebKit::InjectedBundleScriptWorld::setAllowNodeSnapshotCreation):
(WebKit::InjectedBundleScriptWorld::setAllowNodeSerialization): Deleted.
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.h:
* Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp:
(WebKit::WebUserContentController::addContentWorldIfNecessary):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::clearContentWorld):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SerializedNode.mm:
(TestWebKitAPI::TEST(SerializedNode, Basic)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UserContentController.mm:
(-[SerializedNodeReplyHandler userContentController:didReceiveScriptMessage:replyHandler:]):
(TEST(WKUserContentController, MessageHandlerReplyWithSerializedNode)):
(TEST(WKUserContentController, MessageHandlerInjectsWebKitNamespace)):
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/UserContentControllerTests.swift:
(UserContentControllerTests.jsBufferInjectsWebKitNamespace):
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageTests.swift:
(WebPageTests.clearContentWorld):

Canonical link: <a href="https://commits.webkit.org/317213@main">https://commits.webkit.org/317213@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db209739d11bcab2d6c9a4fcf60c76c1668e76ab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174565 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48498 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42279 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184142 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132433 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/406274c7-97a7-4a7d-933b-fc4529fc5382) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176430 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49790 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48181 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135817 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ba353382-a1a3-4088-b3a2-af594e3f7bc2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177523 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39247 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156612 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116295 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/aa6f4c27-ba9b-4e4e-a9a9-33d17507f43f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37888 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36264 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32623 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148311 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36104 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186569 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39828 "Found 121 new failures in b3/B3Value.h, b3/testb3_7.cpp, WebProcess/Network/WebResourceLoader.cpp, UIProcess/WebProcessPool.cpp, Shared/Cocoa/WKNSArray.mm, Shared/SessionState.cpp, NetworkProcess/NetworkResourceLoadParameters.cpp, WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm, WebProcess/WebPage/WebPage.cpp, WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm ...") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40461 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144735 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48165 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144595 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48844 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32724 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26538 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39485 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120833 "Found 121 new failures in b3/testb3_7.cpp, b3/B3Value.h, WebProcess/Network/WebResourceLoader.cpp, UIProcess/WebProcessPool.cpp, Shared/Cocoa/WKNSArray.mm, Shared/SessionState.cpp, NetworkProcess/NetworkResourceLoadParameters.cpp, WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm, WebProcess/WebPage/WebPage.cpp, WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm ...") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47351 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11069 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46753 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46984 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46811 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->