### PR TITLE
[JSC] Move TypedArray.of from builtin JS to C++

### DIFF
--- a/Source/JavaScriptCore/builtins/TypedArrayConstructor.js
+++ b/Source/JavaScriptCore/builtins/TypedArrayConstructor.js
@@ -24,24 +24,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-function of(/* items... */)
-{
-    "use strict";
-    var len = @argumentCount();
-
-    if (!@isConstructor(this))
-        @throwTypeError("TypedArray.of requires |this| to be a constructor");
-
-    var result = new this(len);
-    if (@typedArrayLength(result) < len)
-        @throwTypeError("TypedArray.of constructed typed array of insufficient length");
-
-    for (var i = 0; i < len; i++)
-        result[i] = arguments[i];
-
-    return result;
-}
-
 function from(items /* [ , mapfn [ , thisArg ] ] */)
 {
     "use strict";

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -1151,6 +1151,7 @@ public:
     template<TypedArrayType type> Structure* resizableOrGrowableSharedTypedArrayStructureWithTypedArrayType() const { return typedArrayStructure(type, /* isResizableOrGrowableShared */ true); }
 
     inline JSObject* typedArrayConstructor(TypedArrayType) const;
+    inline JSObject* typedArrayConstructorConcurrently(TypedArrayType) const;
     inline JSObject* typedArrayPrototype(TypedArrayType) const;
 
     inline JSCell* linkTimeConstant(LinkTimeConstant) const;

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h
@@ -674,6 +674,11 @@ inline JSObject* JSGlobalObject::typedArrayConstructor(TypedArrayType type) cons
     return lazyTypedArrayStructure(type).constructor(this);
 }
 
+inline JSObject* JSGlobalObject::typedArrayConstructorConcurrently(TypedArrayType type) const
+{
+    return lazyTypedArrayStructure(type).constructorConcurrently();
+}
+
 inline JSObject* JSGlobalObject::typedArrayPrototype(TypedArrayType type) const
 {
     return lazyTypedArrayStructure(type).prototype(this);

--- a/Source/JavaScriptCore/runtime/JSTypedArrayViewConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/JSTypedArrayViewConstructor.cpp
@@ -29,11 +29,14 @@
 #include "GetterSetter.h"
 #include "JSCBuiltins.h"
 #include "JSCInlines.h"
+#include "JSGenericTypedArrayViewInlines.h"
 #include "JSTypedArrayViewPrototype.h"
+#include "JSTypedArrays.h"
 
 namespace JSC {
 
 static JSC_DECLARE_HOST_FUNCTION(constructTypedArrayView);
+static JSC_DECLARE_HOST_FUNCTION(typedArrayConstructorOf);
 
 JSTypedArrayViewConstructor::JSTypedArrayViewConstructor(VM& vm, Structure* structure)
     : Base(vm, structure, constructTypedArrayView, constructTypedArrayView)
@@ -48,7 +51,7 @@ void JSTypedArrayViewConstructor::finishCreation(VM& vm, JSGlobalObject* globalO
     putDirectWithoutTransition(vm, vm.propertyNames->prototype, prototype, PropertyAttribute::DontEnum | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
     putDirectNonIndexAccessorWithoutTransition(vm, vm.propertyNames->speciesSymbol, globalObject->typedArraySpeciesGetterSetter(), PropertyAttribute::Accessor | PropertyAttribute::ReadOnly | PropertyAttribute::DontEnum);
 
-    JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->of, typedArrayConstructorOfCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
+    JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->of, typedArrayConstructorOf, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public);
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->from, typedArrayConstructorFromCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
     globalObject->installTypedArrayConstructorSpeciesWatchpoint(this);
 }
@@ -64,6 +67,78 @@ JSC_DEFINE_HOST_FUNCTION(constructTypedArrayView, (JSGlobalObject* globalObject,
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     return throwVMTypeError(globalObject, scope, "%TypedArray% should not be called directly"_s);
+}
+
+template<typename ViewClass>
+static ALWAYS_INLINE void typedArrayOfSetElements(JSGlobalObject* globalObject, ViewClass* result, CallFrame* callFrame)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    unsigned length = callFrame->argumentCount();
+    for (unsigned index = 0; index < length; ++index) {
+        result->setIndex(globalObject, index, callFrame->uncheckedArgument(index));
+        RETURN_IF_EXCEPTION(scope, void());
+    }
+}
+
+template<typename ViewClass>
+static ALWAYS_INLINE ViewClass* typedArrayOfFast(JSGlobalObject* globalObject, CallFrame* callFrame)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    unsigned length = callFrame->argumentCount();
+
+    Structure* structure = globalObject->typedArrayStructure(ViewClass::TypedArrayStorageType, /* isResizableOrGrowableShared */ false);
+    ViewClass* result = ViewClass::createUninitialized(globalObject, structure, length);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    scope.release();
+    typedArrayOfSetElements<ViewClass>(globalObject, result, callFrame);
+    return result;
+}
+
+// https://tc39.es/ecma262/#sec-%typedarray%.of
+JSC_DEFINE_HOST_FUNCTION(typedArrayConstructorOf, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    size_t length = callFrame->argumentCount();
+    JSValue thisValue = callFrame->thisValue();
+
+    if (!thisValue.isConstructor()) [[unlikely]]
+        return throwVMTypeError(globalObject, scope, "TypedArray.of requires |this| to be a constructor"_s);
+
+#define JSC_TYPED_ARRAY_OF_FAST(name) \
+    if (thisValue == globalObject->typedArrayConstructorConcurrently(Type##name)) \
+        RELEASE_AND_RETURN(scope, JSValue::encode(typedArrayOfFast<JS##name##Array>(globalObject, callFrame)));
+    FOR_EACH_TYPED_ARRAY_TYPE_EXCLUDING_DATA_VIEW(JSC_TYPED_ARRAY_OF_FAST)
+#undef JSC_TYPED_ARRAY_OF_FAST
+
+    MarkedArgumentBuffer args;
+    args.append(jsNumber(length));
+    ASSERT(!args.hasOverflowed());
+    JSObject* constructed = construct(globalObject, thisValue, args, "TypedArray.of requires |this| to be a constructor"_s);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    JSArrayBufferView* view = validateTypedArray(globalObject, constructed);
+    RETURN_IF_EXCEPTION(scope, { });
+    if (view->length() < length) [[unlikely]]
+        return throwVMTypeError(globalObject, scope, "TypedArray.of constructed typed array of insufficient length"_s);
+
+    switch (view->type()) {
+#define JSC_TYPED_ARRAY_OF_SET(name) \
+    case name##ArrayType: { \
+        scope.release(); \
+        typedArrayOfSetElements(globalObject, uncheckedDowncast<JS##name##Array>(view), callFrame); \
+        return JSValue::encode(view); \
+    }
+    FOR_EACH_TYPED_ARRAY_TYPE_EXCLUDING_DATA_VIEW(JSC_TYPED_ARRAY_OF_SET)
+#undef JSC_TYPED_ARRAY_OF_SET
+    default:
+        RELEASE_ASSERT_NOT_REACHED();
+        return { };
+    }
 }
 
 } // namespace JSC


### PR DESCRIPTION
#### d4e7e6dacaa86556d56b6ae87a39479d9c126e0e
<pre>
[JSC] Move TypedArray.of from builtin JS to C++
<a href="https://bugs.webkit.org/show_bug.cgi?id=319332">https://bugs.webkit.org/show_bug.cgi?id=319332</a>
<a href="https://rdar.apple.com/182148177">rdar://182148177</a>

Reviewed by Sosuke Suzuki.

This patch moves TypedArray.of from builtin JS to C++.
This is trivially convertible as it is not involving callbacks etc.
We have a fast path for normal TypedArray constructors and we store
arguments quickly by using type-specialized path.

* Source/JavaScriptCore/builtins/TypedArrayConstructor.js:
(of): Deleted.
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
* Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h:
(JSC::JSGlobalObject::typedArrayConstructorConcurrently const):
* Source/JavaScriptCore/runtime/JSTypedArrayViewConstructor.cpp:
(JSC::JSTypedArrayViewConstructor::finishCreation):
(JSC::typedArrayOfSetElements):
(JSC::typedArrayOfFast):
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/317162@main">https://commits.webkit.org/317162@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d4245d8ef4dcc87397070b4274d2cc0c421350d2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174409 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48342 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42123 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183986 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132277 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7be67427-d2cb-47b9-be70-a1fdf755dbd9) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49634 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48024 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135684 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/28cdc7cf-a01a-4384-a312-5d9e2cad421e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177367 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39109 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156472 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116162 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e04f0367-5602-47c3-8b63-4867ee3c19c1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37750 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36118 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32467 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/4981 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148173 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35964 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186412 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/35671 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39628 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40315 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144588 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48009 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144446 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48688 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32584 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114242 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26520 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39350 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120639 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/211444 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47195 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10928 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55097 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46597 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46828 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46655 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->