### PR TITLE
Web Inspector: RemoteObject.getCollectionEntries crashes on protocol error instead of reporting it

### DIFF
--- a/LayoutTests/inspector/model/remote-object-get-collection-entries-error-expected.txt
+++ b/LayoutTests/inspector/model/remote-object-get-collection-entries-error-expected.txt
@@ -1,0 +1,13 @@
+Tests that WI.RemoteObject.prototype.getCollectionEntries handles a protocol error gracefully.
+
+
+== Running test suite: WI.RemoteObject.prototype.getCollectionEntries.Error
+-- Running test case: WI.RemoteObject.prototype.getCollectionEntries.Success
+PASS: Should get an array of entries.
+PASS: Should get 2 entries.
+PASS: Each entry should be a WI.CollectionEntry.
+PASS: Each entry should be a WI.CollectionEntry.
+
+-- Running test case: WI.RemoteObject.prototype.getCollectionEntries.StaleObject
+PASS: Should invoke the callback with null on a protocol error, not throw.
+

--- a/LayoutTests/inspector/model/remote-object-get-collection-entries-error.html
+++ b/LayoutTests/inspector/model/remote-object-get-collection-entries-error.html
@@ -1,0 +1,58 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+var map = new Map([["a", 1], ["b", 2]]);
+
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("WI.RemoteObject.prototype.getCollectionEntries.Error");
+
+    suite.addTestCase({
+        name: "WI.RemoteObject.prototype.getCollectionEntries.Success",
+        description: "getCollectionEntries should resolve to an array of WI.CollectionEntry for a live collection.",
+        test(resolve, reject) {
+            WI.runtimeManager.evaluateInInspectedWindow("window.map", {objectGroup: "test", doNotPauseOnExceptionsAndMuteConsole: true}, (remoteObject, wasThrown) => {
+                InspectorTest.assert(remoteObject instanceof WI.RemoteObject, "Should get a WI.RemoteObject.");
+                InspectorTest.assert(!wasThrown, "Should not throw.");
+
+                remoteObject.getCollectionEntries((entries) => {
+                    InspectorTest.expectThat(Array.isArray(entries), "Should get an array of entries.");
+                    InspectorTest.expectEqual(entries.length, 2, "Should get 2 entries.");
+                    for (let entry of entries)
+                        InspectorTest.expectThat(entry instanceof WI.CollectionEntry, "Each entry should be a WI.CollectionEntry.");
+                    resolve();
+                });
+            });
+        },
+    });
+
+    suite.addTestCase({
+        name: "WI.RemoteObject.prototype.getCollectionEntries.StaleObject",
+        description: "getCollectionEntries should invoke the callback with null (not throw) when the backend returns an error for a released object.",
+        test(resolve, reject) {
+            WI.runtimeManager.evaluateInInspectedWindow("new Map([[1, 2]])", {objectGroup: "test", doNotPauseOnExceptionsAndMuteConsole: true}, async (remoteObject, wasThrown) => {
+                InspectorTest.assert(remoteObject instanceof WI.RemoteObject, "Should get a WI.RemoteObject.");
+                InspectorTest.assert(!wasThrown, "Should not throw.");
+
+                // Release the object so its objectId becomes stale. A subsequent
+                // getCollectionEntries will produce a protocol error on the backend.
+                await remoteObject.target.RuntimeAgent.releaseObject(remoteObject._objectId);
+
+                remoteObject.getCollectionEntries((entries) => {
+                    InspectorTest.expectNull(entries, "Should invoke the callback with null on a protocol error, not throw.");
+                    resolve();
+                });
+            });
+        },
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Tests that WI.RemoteObject.prototype.getCollectionEntries handles a protocol error gracefully.</p>
+</body>
+</html>

--- a/Source/WebInspectorUI/UserInterface/Protocol/RemoteObject.js
+++ b/Source/WebInspectorUI/UserInterface/Protocol/RemoteObject.js
@@ -395,6 +395,11 @@ WI.RemoteObject = class RemoteObject
 
         // COMPATIBILITY (iOS 13): `startIndex` and `numberToFetch` were renamed to `fetchStart` and `fetchCount` (but kept in the same position).
         this._target.RuntimeAgent.getCollectionEntries(this._objectId, objectGroup, fetchStart, fetchCount, (error, entries) => {
+            if (error) {
+                callback(null);
+                return;
+            }
+
             callback(entries.map((x) => WI.CollectionEntry.fromPayload(x, this._target)));
         });
     }

--- a/Source/WebInspectorUI/UserInterface/Views/FormattedValue.js
+++ b/Source/WebInspectorUI/UserInterface/Views/FormattedValue.js
@@ -141,6 +141,8 @@ WI.FormattedValue.createElementForNodePreview = function(preview, {remoteObjectA
             }
 
             remoteObjectAccessor((remoteObject) => {
+                if (!remoteObject)
+                    return;
                 remoteObject.pushNodeToFrontend((nodeId) => {
                     domNode = WI.domManager.nodeForId(nodeId);
                     if (domNode)

--- a/Source/WebInspectorUI/UserInterface/Views/ObjectPreviewView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ObjectPreviewView.js
@@ -198,6 +198,10 @@ WI.ObjectPreviewView = class ObjectPreviewView extends WI.Object
             let options = {
                 remoteObjectAccessor: (callback) => {
                     this._object.getCollectionEntries((entries) => {
+                        if (!entries?.length) {
+                            callback(null);
+                            return;
+                        }
                         let remoteObject = isKey ? entries[0].key : entries[0].value;
                         WI.consoleManager.releaseRemoteObjectWithConsoleClear(remoteObject);
                         callback(remoteObject);


### PR DESCRIPTION
#### ee7a441e1017219ba935cc967cf7dc0734d93526
<pre>
Web Inspector: RemoteObject.getCollectionEntries crashes on protocol error instead of reporting it
<a href="https://bugs.webkit.org/show_bug.cgi?id=319333">https://bugs.webkit.org/show_bug.cgi?id=319333</a>
<a href="https://rdar.apple.com/182148993">rdar://182148993</a>

Reviewed by Devin Rousso.

WI.RemoteObject.prototype.getCollectionEntries ignored the `error`
argument in its RuntimeAgent.getCollectionEntries reply handler and
unconditionally called `entries.map(...)`. When the backend returns an
error (e.g. the collection&apos;s object was released or the target
navigated, so its objectId is stale), `entries` is undefined and the
handler throws &quot;TypeError: undefined is not an object&quot;, which is
swallowed by the backend dispatcher and leaves the callback never
invoked.

That crash also masks the intended error path: both ObjectTreeView and
ObjectTreePropertyTreeElement wrap the callback with an `if (!list)`
check that shows &quot;Could not fetch properties. Object may no longer
exist.&quot;, but the exception fires before that handler ever runs.

Guard on `error` and pass null to the callback, matching the existing
_getPropertyDescriptorsResolver pattern and the callers&apos; `!list` error
handling. Null (rather than an empty array) is required so the tree
views surface the error instead of silently rendering &quot;No Entries&quot;.

Since the callback can now receive null, also harden the collection
entry node-preview path, which previously assumed a non-null array:
ObjectPreviewView&apos;s remoteObjectAccessor dereferenced `entries[0]`
unconditionally, and FormattedValue&apos;s node-highlight consumer called
pushNodeToFrontend() on the resulting remote object. Both now bail out
on a null result instead of throwing.

Without fix, we timeout on the attached test case.

Test: inspector/model/remote-object-get-collection-entries-error.html

* LayoutTests/inspector/model/remote-object-get-collection-entries-error-expected.txt: Added.
* LayoutTests/inspector/model/remote-object-get-collection-entries-error.html: Added.
* Source/WebInspectorUI/UserInterface/Protocol/RemoteObject.js:
(WI.RemoteObject.prototype.getCollectionEntries):
* Source/WebInspectorUI/UserInterface/Views/ObjectPreviewView.js:
(WI.ObjectPreviewView.prototype._appendCollectionEntryNodePreview):
* Source/WebInspectorUI/UserInterface/Views/FormattedValue.js:
(WI.FormattedValue.createElementForNodePreview):

Canonical link: <a href="https://commits.webkit.org/317191@main">https://commits.webkit.org/317191@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14cbd06201ab69a39d87022ef353fb2855f7fb73

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174574 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48507 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/42288 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184151 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/132442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c0701122-8ce3-4a06-ac33-7e50c62552af) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49799 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48190 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/135825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/132442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b43b0146-10b4-431f-83ff-b0f29fbf1d3d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177532 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/39255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/156617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116303 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c7bf4991-fbae-4c84-8ffa-5c56a901648d) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/37896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32632 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/148319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/36109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186578 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/39844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/144745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48174 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/156172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144605 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38971 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48853 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39488 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/120844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47360 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/11075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46762 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46993 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46820 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->