### PR TITLE
[libpas] Test zero_mode merge-on-coalesce in LargeFreeHeapTests

### DIFF
--- a/Source/bmalloc/libpas/src/test/LargeFreeHeapTests.cpp
+++ b/Source/bmalloc/libpas/src/test/LargeFreeHeapTests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2019 Apple Inc. All rights reserved.
+ * Copyright (c) 2018-2019, 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,12 +35,19 @@
 #include "pas_page_malloc.h"
 #include "pas_page_sharing_pool.h"
 #include "pas_simple_large_free_heap.h"
+#include "pas_zero_mode.h"
 #include <set>
 #include <vector>
 
 using namespace std;
 
 namespace {
+
+std::ostream& operator<<(std::ostream& out, pas_zero_mode mode)
+{
+    out << pas_zero_mode_get_string(mode);
+    return out;
+}
 
 pas_alignment alignSimple(size_t size)
 {
@@ -74,7 +81,8 @@ struct Action {
     static Action allocate(
         size_t size, pas_alignment alignment, uintptr_t expectedResult,
         function<pas_aligned_allocation_result(size_t size, pas_alignment alignment)> allocator = trappingAllocator,
-        function<void(void* base, size_t size)> deallocator = trappingDeallocator)
+        function<void(void* base, size_t size)> deallocator = trappingDeallocator,
+        pas_zero_mode expectedResultZeroMode = pas_zero_mode_may_have_non_zero)
     {
         Action result;
         result.kind = Allocate;
@@ -83,13 +91,15 @@ struct Action {
         result.allocator = allocator;
         result.deallocator = deallocator;
         result.result = expectedResult;
+        result.expectedResultZeroMode = expectedResultZeroMode;
         return result;
     }
-    
+
     static Action deallocate(
         uintptr_t base, size_t size,
         function<pas_aligned_allocation_result(size_t size, pas_alignment alignment)> allocator = trappingAllocator,
-        function<void(void* base, size_t size)> deallocator = trappingDeallocator)
+        function<void(void* base, size_t size)> deallocator = trappingDeallocator,
+        pas_zero_mode zeroMode = pas_zero_mode_may_have_non_zero)
     {
         Action result;
         result.kind = Deallocate;
@@ -97,9 +107,10 @@ struct Action {
         result.size = size;
         result.allocator = allocator;
         result.deallocator = deallocator;
+        result.deallocZeroMode = zeroMode;
         return result;
     }
-    
+
     Kind kind { Allocate };
     uintptr_t base { 0 };
     size_t size { 0 };
@@ -107,32 +118,40 @@ struct Action {
     function<pas_aligned_allocation_result(size_t size, pas_alignment alignment)> allocator;
     function<void(void* base, size_t size)> deallocator;
     uintptr_t result { 0 };
+    pas_zero_mode deallocZeroMode { pas_zero_mode_may_have_non_zero };
+    pas_zero_mode expectedResultZeroMode { pas_zero_mode_may_have_non_zero };
 };
 
 struct Free {
     Free() = default;
-    
-    Free(uintptr_t begin, uintptr_t end)
+
+    Free(uintptr_t begin, uintptr_t end,
+         pas_zero_mode zeroMode = pas_zero_mode_may_have_non_zero)
         : begin(begin)
         , end(end)
+        , zeroMode(zeroMode)
     {
     }
-    
+
     bool operator==(const Free& other) const
     {
         return begin == other.begin
-            && end == other.end;
+            && end == other.end
+            && zeroMode == other.zeroMode;
     }
-    
+
     bool operator<(const Free& other) const
     {
         if (begin != other.begin)
             return begin < other.begin;
-        return end < other.end;
+        if (end != other.end)
+            return end < other.end;
+        return zeroMode < other.zeroMode;
     }
-    
+
     uintptr_t begin;
     uintptr_t end;
+    pas_zero_mode zeroMode { pas_zero_mode_may_have_non_zero };
 };
 
 struct Allocation {
@@ -140,22 +159,25 @@ struct Allocation {
     
     Allocation(size_t expectedSize, pas_alignment expectedAlignment,
                uintptr_t leftPadding, uintptr_t resultBase,
-               uintptr_t rightPadding, uintptr_t end)
+               uintptr_t rightPadding, uintptr_t end,
+               pas_zero_mode zeroMode = pas_zero_mode_may_have_non_zero)
         : expectedSize(expectedSize)
         , expectedAlignment(expectedAlignment)
         , leftPadding(leftPadding)
         , resultBase(resultBase)
         , rightPadding(rightPadding)
         , end(end)
+        , zeroMode(zeroMode)
     {
     }
-    
+
     size_t expectedSize { 0 };
     pas_alignment expectedAlignment { 0 };
     uintptr_t leftPadding { 0 };
     uintptr_t resultBase { 0 };
     uintptr_t rightPadding { 0 };
     uintptr_t end { 0 };
+    pas_zero_mode zeroMode { pas_zero_mode_may_have_non_zero };
 };
 
 function<pas_aligned_allocation_result(size_t size, pas_alignment alignment)>
@@ -177,8 +199,8 @@ allocateFinite(vector<Allocation> allocations)
         result.result_size = allocation.rightPadding - allocation.resultBase;
         result.right_padding = (void*)allocation.rightPadding;
         result.right_padding_size = allocation.end - allocation.rightPadding;
-        result.zero_mode = pas_zero_mode_may_have_non_zero;
-        
+        result.zero_mode = allocation.zeroMode;
+
         return result;
     };
 }
@@ -189,11 +211,12 @@ allocateOnce(size_t expectedSize,
              uintptr_t leftPadding,
              uintptr_t resultBase,
              uintptr_t rightPadding,
-             uintptr_t end)
+             uintptr_t end,
+             pas_zero_mode zeroMode = pas_zero_mode_may_have_non_zero)
 {
     return allocateFinite({ Allocation(expectedSize, expectedAlignment,
                                        leftPadding, resultBase,
-                                       rightPadding, end) });
+                                       rightPadding, end, zeroMode) });
 }
 
 function<void(void* base, size_t size)> deallocateFinite(vector<Free> frees)
@@ -210,7 +233,8 @@ function<void(void* base, size_t size)> deallocateFinite(vector<Free> frees)
 ostream& operator<<(ostream& out, const Free& free)
 {
     out << "{begin = " << free.begin << ", end = " << free.end
-        << ", size = " << (free.end - free.begin) << "}";
+        << ", size = " << (free.end - free.begin)
+        << ", zero_mode = " << free.zeroMode << "}";
     return out;
 }
 
@@ -287,14 +311,17 @@ void testLargeFreeHeapImpl(HeapType* heap,
             cout << "    Allocating size = " << action.size
                  << ", alignment = " << pas_string_stream_get_string(&stream) << endl;
             pas_string_stream_destruct(&stream);
-            CHECK_EQUAL(allocateFunc(heap, action.size, action.alignment, &config).begin,
-                        action.result);
+            pas_allocation_result allocationResult =
+                allocateFunc(heap, action.size, action.alignment, &config);
+            CHECK_EQUAL(allocationResult.begin, action.result);
+            CHECK_EQUAL(allocationResult.zero_mode, action.expectedResultZeroMode);
             break;
         }
         case Action::Deallocate:
-            cout << "    Freeing base = " << action.base << endl;
+            cout << "    Freeing base = " << action.base
+                 << ", zero_mode = " << action.deallocZeroMode << endl;
             deallocateFunc(heap, action.base, action.base + action.size,
-                           pas_zero_mode_may_have_non_zero,
+                           action.deallocZeroMode,
                            &config);
             break;
         }
@@ -308,7 +335,7 @@ void testLargeFreeHeapImpl(HeapType* heap,
         heap,
         iterateFunc,
         [&] (pas_large_free largeFree) {
-            Free free(largeFree.begin, largeFree.end);
+            Free free(largeFree.begin, largeFree.end, largeFree.zero_mode);
             if (freesFound.count(free)) {
                 cout << "    FAIL: Found duplicate entry " << free << endl;
                 ok = false;
@@ -460,6 +487,27 @@ void testGiveBackGuardOnAllocationFailure(bool talksToLargeSharingPool)
     // give_back must be skipped too -- otherwise the balance drifts upward by
     // aligned_size on every failed allocation.
     CHECK_EQUAL(pas_physical_page_sharing_pool_balance, static_cast<intptr_t>(0));
+}
+
+void testMergeZeroModeOnCoalesce(pas_zero_mode leftMode, pas_zero_mode rightMode,
+                                 pas_zero_mode expectedMode,
+                                 bool deallocateRightFirst, bool useFastHeap)
+{
+    // Free two adjacent regions [1000, 1100) and [1100, 1200) carrying the given zero_modes. The
+    // heap must coalesce them into a single [1000, 1200) free region whose zero_mode is
+    // pas_zero_mode_merge(leftMode, rightMode) -- is_all_zero only if BOTH sides are is_all_zero
+    // (see pas_large_free_create_merged). We deallocate in both orders to exercise coalescing with
+    // the new region arriving on either side of the existing one.
+    Action lower = Action::deallocate(1000, 100, trappingAllocator, trappingDeallocator, leftMode);
+    Action upper = Action::deallocate(1100, 100, trappingAllocator, trappingDeallocator, rightMode);
+    vector<Action> actions = deallocateRightFirst
+        ? vector<Action> { upper, lower }
+        : vector<Action> { lower, upper };
+    set<Free> frees = { Free(1000, 1200, expectedMode) };
+    if (useFastHeap)
+        testFastLargeFreeHeap(actions, frees, 1);
+    else
+        testSimpleLargeFreeHeap(actions, frees, 1);
 }
 
 } // anonymous namespace
@@ -1262,5 +1310,21 @@ void addLargeFreeHeapTests()
 
     ADD_TEST(testGiveBackGuardOnAllocationFailure(true));
     ADD_TEST(testGiveBackGuardOnAllocationFailure(false));
+
+    // zero_mode merge/coalesce truth table. Coalescing two adjacent frees must merge their
+    // zero_modes conservatively: is_all_zero only when BOTH are is_all_zero, else may_have_non_zero.
+    // All four (left, right) combinations, both deallocation orders, on the simple and fast heaps.
+    for (bool useFastHeap : { false, true }) {
+        for (bool rightFirst : { false, true }) {
+            ADD_TEST(testMergeZeroModeOnCoalesce(pas_zero_mode_is_all_zero, pas_zero_mode_is_all_zero,
+                                                 pas_zero_mode_is_all_zero, rightFirst, useFastHeap));
+            ADD_TEST(testMergeZeroModeOnCoalesce(pas_zero_mode_is_all_zero, pas_zero_mode_may_have_non_zero,
+                                                 pas_zero_mode_may_have_non_zero, rightFirst, useFastHeap));
+            ADD_TEST(testMergeZeroModeOnCoalesce(pas_zero_mode_may_have_non_zero, pas_zero_mode_is_all_zero,
+                                                 pas_zero_mode_may_have_non_zero, rightFirst, useFastHeap));
+            ADD_TEST(testMergeZeroModeOnCoalesce(pas_zero_mode_may_have_non_zero, pas_zero_mode_may_have_non_zero,
+                                                 pas_zero_mode_may_have_non_zero, rightFirst, useFastHeap));
+        }
+    }
 }
 


### PR DESCRIPTION
#### 2f1aa98aafd5165aa14ab05c9e4f789968825e90
<pre>
[libpas] Test zero_mode merge-on-coalesce in LargeFreeHeapTests
<a href="https://bugs.webkit.org/show_bug.cgi?id=319334">https://bugs.webkit.org/show_bug.cgi?id=319334</a>
<a href="https://rdar.apple.com/182150627">rdar://182150627</a>

Reviewed by Yusuke Suzuki.

LargeFreeHeapTests never checked pas_zero_mode: the mock allocator and
deallocate path hardcoded may_have_non_zero and the free-range comparison
ignored it, leaving the conservative merge done when free ranges coalesce
untested. A regression there would let zeroedMalloc return non-zeroed
memory.

Thread zero_mode through the harness (Allocation, Action::deallocate, the
now-asserted allocation result, and Free), all defaulting to
may_have_non_zero so existing tests are unchanged, and add
testMergeZeroModeOnCoalesce: free two adjacent ranges and assert the
coalesced mode is pas_zero_mode_merge(left, right) across all four
combinations, both deallocation orders, and the simple and fast heaps.

Test: Source/bmalloc/libpas/src/test/LargeFreeHeapTests.cpp

* Source/bmalloc/libpas/src/test/LargeFreeHeapTests.cpp:
(std::operator&lt;&lt;):
(std::Action::allocate):
(std::Action::deallocate):
(std::Free::Free):
(std::Free::operator== const):
(std::Free::operator&lt; const):
(std::Allocation::Allocation):
(std::function&lt;pas_aligned_allocation_result):
(std::testLargeFreeHeapImpl):
(std::testMergeZeroModeOnCoalesce):
(addLargeFreeHeapTests):

Canonical link: <a href="https://commits.webkit.org/317116@main">https://commits.webkit.org/317116@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a497ed24bc5be064a0cf6748b3f836e9fd845368

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174371 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48304 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42085 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183947 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/132239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49596 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47986 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/135637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/132239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177329 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/39073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/156429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116115 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/37714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32429 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/4938 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/148137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35921 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186373 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/35633 "Built successfully and passed tests") | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/144554 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47971 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144412 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48650 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114193 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26503 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39311 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/211406 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47156 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10885 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55086 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46559 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46790 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46617 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->