### PR TITLE
[Web Inspector] Fix typos in inspector agents and frontend code

### DIFF
--- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -851,7 +851,7 @@ void InspectorInstrumentation::didCommitLoadImpl(InstrumentingAgents& instrument
             networkAgent->mainFrameNavigated(*loader);
 
         // The Web Inspector frontend relies on `networkAgent->mainFrameNavigated` being called first to establish the
-        // type of navigation that has occured.
+        // type of navigation that has occurred.
         if (auto* consoleAgent = instrumentingAgents.webConsoleAgent())
             consoleAgent->mainFrameNavigated();
 

--- a/Source/WebCore/inspector/InspectorOverlay.cpp
+++ b/Source/WebCore/inspector/InspectorOverlay.cpp
@@ -1043,7 +1043,7 @@ void InspectorOverlay::drawRulers(GraphicsContext& context, const InspectorOverl
 
         // Draw vertical ruler.
         {
-            GraphicsContextStateSaver veritcalRulerStateSaver(context);
+            GraphicsContextStateSaver verticalRulerStateSaver(context);
 
             context.translate(cornerX - scrollX, obscuredContentInsets.top() - scrollY + 0.5f);
 

--- a/Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp
@@ -374,7 +374,7 @@ void InspectorTimelineAgent::startProgrammaticCapture()
     } else
         m_programmaticCaptureRestoreBreakpointActiveValue = false;
 
-    toggleScriptProfilerInstrument(InstrumentState::Start); // Ensure JavaScript samping data.
+    toggleScriptProfilerInstrument(InstrumentState::Start); // Ensure JavaScript sampling data.
     toggleTimelineInstrument(InstrumentState::Start); // Ensure Console Profile event records.
     toggleInstruments(InstrumentState::Start); // Any other instruments the frontend wants us to record.
 }

--- a/Source/WebCore/inspector/agents/page/PageNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageNetworkAgent.cpp
@@ -134,7 +134,7 @@ ScriptExecutionContext* PageNetworkAgent::scriptExecutionContext(Inspector::Prot
 
     SUPPRESS_UNCOUNTED_LOCAL auto* document = frame->document();
     if (!document) {
-        errorString = "Missing frame of docuemnt for given frameId"_s;
+        errorString = "Missing frame of document for given frameId"_s;
         return nullptr;
     }
 

--- a/Source/WebInspectorUI/UserInterface/Base/Main.js
+++ b/Source/WebInspectorUI/UserInterface/Base/Main.js
@@ -1330,7 +1330,7 @@ WI.getMaximumSidebarWidth = function(sidebar)
         minimumWidth -= WI.navigationSidebar.width;
 
     if (tabContentView.detailsSidebarPanels && sidebar !== WI.detailsSidebar) {
-        // A sidebar within the detailsSidebar needs the minimum width of its sibilings.
+        // A sidebar within the detailsSidebar needs the minimum width of its siblings.
         for (let singleDetailsSidebar of WI.detailsSidebar.sidebars) {
             if (sidebar !== singleDetailsSidebar)
                 minimumWidth -= singleDetailsSidebar.width;

--- a/Source/WebInspectorUI/UserInterface/Base/Utilities.js
+++ b/Source/WebInspectorUI/UserInterface/Base/Utilities.js
@@ -949,9 +949,9 @@ Object.defineProperty(String, "tokenizeFormatString",
         }
 
         var index = 0;
-        for (var precentIndex = format.indexOf("%", index); precentIndex !== -1; precentIndex = format.indexOf("%", index)) {
-            addStringToken(format.substring(index, precentIndex));
-            index = precentIndex + 1;
+        for (var percentIndex = format.indexOf("%", index); percentIndex !== -1; percentIndex = format.indexOf("%", index)) {
+            addStringToken(format.substring(index, percentIndex));
+            index = percentIndex + 1;
 
             if (format[index] === "%") {
                 addStringToken("%");

--- a/Source/WebInspectorUI/UserInterface/Controllers/CSSManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/CSSManager.js
@@ -885,7 +885,7 @@ WI.CSSManager.Event = {
     StyleSheetRemoved: "css-manager-style-sheet-removed",
     ModifiedStylesChanged: "css-manager-modified-styles-changed",
     DefaultUserPreferencesDidChange: "css-manager-default-user-preferences-did-change",
-    OverriddenUserPreferencesDidChange: "css-manager-overriden-user-preferences-did-change",
+    OverriddenUserPreferencesDidChange: "css-manager-overridden-user-preferences-did-change",
 };
 
 WI.CSSManager.UserPreferenceDefaultValue = "System";

--- a/Source/WebInspectorUI/UserInterface/Controllers/DeviceSettingsManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/DeviceSettingsManager.js
@@ -30,9 +30,9 @@ WI.DeviceSettingsManager = class DeviceSettingsManager extends WI.Object
         super();
 
         this._deviceUserAgent = "";
-        this._overridenDeviceUserAgent = null;
-        this._overridenDeviceScreenSize = null;
-        this._overridenDeviceSettings = new Map;
+        this._overriddenDeviceUserAgent = null;
+        this._overriddenDeviceScreenSize = null;
+        this._overriddenDeviceSettings = new Map;
     }
 
     // Target
@@ -42,10 +42,10 @@ WI.DeviceSettingsManager = class DeviceSettingsManager extends WI.Object
         if (!target.hasDomain("Page"))
             return
 
-        if (this._overridenDeviceUserAgent)
-            target.PageAgent.overrideUserAgent(this._overridenDeviceUserAgent);
+        if (this._overriddenDeviceUserAgent)
+            target.PageAgent.overrideUserAgent(this._overriddenDeviceUserAgent);
 
-        for (let [setting, value] of this._overridenDeviceSettings)
+        for (let [setting, value] of this._overriddenDeviceSettings)
             target.PageAgent.overrideSetting(setting, value);
 
         const objectGroup = "user-agent";
@@ -68,13 +68,13 @@ WI.DeviceSettingsManager = class DeviceSettingsManager extends WI.Object
     // Public
 
     get deviceUserAgent() { return this._deviceUserAgent; }
-    get overridenDeviceUserAgent() { return this._overridenDeviceUserAgent; }
-    get overridenDeviceScreenSize() { return this._overridenDeviceScreenSize; }
-    get overridenDeviceSettings() { return this._overridenDeviceSettings; }
+    get overriddenDeviceUserAgent() { return this._overriddenDeviceUserAgent; }
+    get overriddenDeviceScreenSize() { return this._overriddenDeviceScreenSize; }
+    get overriddenDeviceSettings() { return this._overriddenDeviceSettings; }
 
     get hasOverridenDefaultSettings()
     {
-        return this._overridenDeviceUserAgent || this._overridenDeviceScreenSize || this._overridenDeviceSettings.size > 0;
+        return this._overriddenDeviceUserAgent || this._overriddenDeviceScreenSize || this._overriddenDeviceSettings.size > 0;
     }
 
     overrideDeviceSetting(setting, value, callback)
@@ -84,7 +84,7 @@ WI.DeviceSettingsManager = class DeviceSettingsManager extends WI.Object
             setting,
         };
 
-        let shouldOverride = !this._overridenDeviceSettings.has(setting);
+        let shouldOverride = !this._overriddenDeviceSettings.has(setting);
         if (shouldOverride)
             commandArguments.value = value;
 
@@ -96,9 +96,9 @@ WI.DeviceSettingsManager = class DeviceSettingsManager extends WI.Object
             }
 
             if (shouldOverride)
-                this._overridenDeviceSettings.set(setting, value);
+                this._overriddenDeviceSettings.set(setting, value);
             else
-                this._overridenDeviceSettings.delete(setting);
+                this._overriddenDeviceSettings.delete(setting);
 
             callback(shouldOverride);
             this.dispatchEventToListeners(WI.DeviceSettingsManager.Event.SettingChanged);
@@ -107,7 +107,7 @@ WI.DeviceSettingsManager = class DeviceSettingsManager extends WI.Object
 
     overrideUserAgent(value, force)
     {
-        if (value === this._overridenDeviceUserAgent)
+        if (value === this._overriddenDeviceUserAgent)
             return;
 
         let target = WI.assumingMainTarget();
@@ -123,7 +123,7 @@ WI.DeviceSettingsManager = class DeviceSettingsManager extends WI.Object
                 return;
             }
 
-            this._overridenDeviceUserAgent = shouldOverride ? value : null;
+            this._overriddenDeviceUserAgent = shouldOverride ? value : null;
 
             this.dispatchEventToListeners(WI.DeviceSettingsManager.Event.SettingChanged);
             target.PageAgent.reload();
@@ -132,7 +132,7 @@ WI.DeviceSettingsManager = class DeviceSettingsManager extends WI.Object
 
     overrideScreenSize(value, force)
     {
-        if (value === this._overridenDeviceScreenSize)
+        if (value === this._overriddenDeviceScreenSize)
             return;
 
         let target = WI.assumingMainTarget();
@@ -161,7 +161,7 @@ WI.DeviceSettingsManager = class DeviceSettingsManager extends WI.Object
                 return;
             }
 
-            this._overridenDeviceScreenSize = shouldOverride ? value : null;
+            this._overriddenDeviceScreenSize = shouldOverride ? value : null;
 
             this.dispatchEventToListeners(WI.DeviceSettingsManager.Event.SettingChanged);
             target.PageAgent.reload();

--- a/Source/WebInspectorUI/UserInterface/Models/CSSKeywordCompletions.js
+++ b/Source/WebInspectorUI/UserInterface/Models/CSSKeywordCompletions.js
@@ -101,16 +101,16 @@ WI.CSSKeywordCompletions.forPartialPropertyValue = function(text, propertyName, 
     }
 
     let functionName = null;
-    let preceedingFunctionDepth = 0;
+    let precedingFunctionDepth = 0;
     for (let i = indexOfTokenAtCaret; i >= 0; --i) {
         let value = tokens[i].value;
 
         // There may be one or more complete functions between the cursor and the current scope's functions name.
         if (value === ")")
-            ++preceedingFunctionDepth;
+            ++precedingFunctionDepth;
         else if (value === "(") {
-            if (preceedingFunctionDepth)
-                --preceedingFunctionDepth;
+            if (precedingFunctionDepth)
+                --precedingFunctionDepth;
             else {
                 functionName = tokens[i - 1]?.value;
                 break;

--- a/Source/WebInspectorUI/UserInterface/Protocol/RemoteObject.js
+++ b/Source/WebInspectorUI/UserInterface/Protocol/RemoteObject.js
@@ -421,7 +421,7 @@ WI.RemoteObject = class RemoteObject
         for (let propertyName of propertyNames) {
             // Check this here, otherwise things like '{}' would be valid Set keys.
             if (typeof propertyName !== "string" && typeof propertyName !== "number")
-                throw new Error(`Tried to get property using key is not a string or number: ${propertyName}`);
+                throw new Error(`Tried to get property using a key that is not a string or number: ${propertyName}`);
 
             if (seenPropertyNames.has(propertyName))
                 continue;
@@ -449,7 +449,7 @@ WI.RemoteObject = class RemoteObject
     {
         function inspectedPage_object_getProperty(property) {
             if (typeof property !== "string" && typeof property !== "number")
-                throw new Error(`Tried to get property using key is not a string or number: ${property}`);
+                throw new Error(`Tried to get property using a key that is not a string or number: ${property}`);
 
             return this[property];
         }

--- a/Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.js
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.js
@@ -672,7 +672,7 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
                     currentElement.parent.expand();
 
                 // Some subclasses may hide elements by default to avoid showing too many items initially, but to reveal
-                // an element we must load that element and previous sibilings as well.
+                // an element we must load that element and previous siblings as well.
                 currentElement.parent.showChildNode(currentElement);
 
                 currentElement = currentElement.parent;
@@ -1568,7 +1568,7 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
         var node = this.representedObject;
         var info = {titleDOM: document.createDocumentFragment(), hasChildren: this.hasChildren};
 
-        function trimedNodeValue()
+        function trimmedNodeValue()
         {
             // Trim empty lines from the beginning and extra space at the end since most style and script tags begin with a newline
             // and end with a newline and indentation for the end tag.
@@ -1674,10 +1674,10 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
             case Node.TEXT_NODE:
                 if (node.parentNode && node.parentNode.nodeName().toLowerCase() === "script") {
                     var newNode = info.titleDOM.createChild("span", "html-text-node large");
-                    newNode.appendChild(WI.syntaxHighlightStringAsDocumentFragment(trimedNodeValue(), "text/javascript"));
+                    newNode.appendChild(WI.syntaxHighlightStringAsDocumentFragment(trimmedNodeValue(), "text/javascript"));
                 } else if (node.parentNode && node.parentNode.nodeName().toLowerCase() === "style") {
                     var newNode = info.titleDOM.createChild("span", "html-text-node large");
-                    newNode.appendChild(WI.syntaxHighlightStringAsDocumentFragment(trimedNodeValue(), "text/css"));
+                    newNode.appendChild(WI.syntaxHighlightStringAsDocumentFragment(trimmedNodeValue(), "text/css"));
                 } else {
                     info.titleDOM.append("\"");
                     var textNodeElement = info.titleDOM.createChild("span", "html-text-node");

--- a/Source/WebInspectorUI/UserInterface/Views/NetworkTableContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/NetworkTableContentView.js
@@ -2614,7 +2614,7 @@ WI.NetworkTableContentView = class NetworkTableContentView extends WI.ContentVie
             delay = 100;
         else if (duration >= 60_000) // 60 seconds
             delay = 1_000;
-        else if (duration >= 3_600_000) // 1 minute
+        else if (duration >= 3_600_000) // 1 hour
             delay = 10_000;
 
         if (delay !== loadTimeStatistic.delay) {

--- a/Source/WebInspectorUI/UserInterface/Views/OverrideDeviceSettingsPopover.js
+++ b/Source/WebInspectorUI/UserInterface/Views/OverrideDeviceSettingsPopover.js
@@ -114,7 +114,7 @@ WI.OverrideDeviceSettingsPopover = class OverrideDeviceSettingsPopover extends W
 
                 let checkboxElement = labelElement.appendChild(document.createElement("input"));
                 checkboxElement.type = "checkbox";
-                checkboxElement.checked = WI.deviceSettingsManager.overridenDeviceSettings.has(setting);
+                checkboxElement.checked = WI.deviceSettingsManager.overriddenDeviceSettings.has(setting);
                 checkboxElement.addEventListener("change", (event) => {
                     WI.deviceSettingsManager.overrideDeviceSetting(setting, value, (enabled) => {
                         checkboxElement.checked = enabled;
@@ -181,7 +181,7 @@ WI.OverrideDeviceSettingsPopover = class OverrideDeviceSettingsPopover extends W
                 optionElement.value = value;
                 optionElement.textContent = name;
 
-                if (value === WI.deviceSettingsManager.overridenDeviceUserAgent)
+                if (value === WI.deviceSettingsManager.overriddenDeviceUserAgent)
                     selectedOptionElement = optionElement;
             }
 
@@ -197,7 +197,7 @@ WI.OverrideDeviceSettingsPopover = class OverrideDeviceSettingsPopover extends W
 
             userAgentValueInput = userAgentValue.appendChild(document.createElement("input"));
             userAgentValueInput.spellcheck = false;
-            userAgentValueInput.value = userAgentValueInput.placeholder = WI.deviceSettingsManager.overridenDeviceUserAgent || WI.deviceSettingsManager.deviceUserAgent;
+            userAgentValueInput.value = userAgentValueInput.placeholder = WI.deviceSettingsManager.overriddenDeviceUserAgent || WI.deviceSettingsManager.deviceUserAgent;
             userAgentValueInput.addEventListener("change", (inputEvent) => {
                WI.deviceSettingsManager.overrideUserAgent(userAgentValueInput.value, true);
             });
@@ -207,7 +207,7 @@ WI.OverrideDeviceSettingsPopover = class OverrideDeviceSettingsPopover extends W
 
         if (selectedOptionElement)
             userAgentValueSelect.value = selectedOptionElement.value;
-        else if (WI.deviceSettingsManager.overridenDeviceUserAgent) {
+        else if (WI.deviceSettingsManager.overriddenDeviceUserAgent) {
             userAgentValueSelect.value = WI.OverrideDeviceSettingsPopover.OtherValue;
             showUserAgentInput();
         }
@@ -265,7 +265,7 @@ WI.OverrideDeviceSettingsPopover = class OverrideDeviceSettingsPopover extends W
                 optionElement.value = value;
                 optionElement.textContent = name;
 
-                if (value === WI.deviceSettingsManager.overridenDeviceScreenSize)
+                if (value === WI.deviceSettingsManager.overriddenDeviceScreenSize)
                     selectedScreenSizeOptionElement = optionElement;
             }
 
@@ -281,7 +281,7 @@ WI.OverrideDeviceSettingsPopover = class OverrideDeviceSettingsPopover extends W
 
             screenSizeValueInput = screenSizeValue.appendChild(document.createElement("input"));
             screenSizeValueInput.spellcheck = false;
-            screenSizeValueInput.value = screenSizeValueInput.placeholder = WI.deviceSettingsManager.overridenDeviceScreenSize || (window.screen.width + "x" + window.screen.height);
+            screenSizeValueInput.value = screenSizeValueInput.placeholder = WI.deviceSettingsManager.overriddenDeviceScreenSize || (window.screen.width + "x" + window.screen.height);
             screenSizeValueInput.addEventListener("change", (inputEvent) => {
                 WI.deviceSettingsManager.overrideScreenSize(screenSizeValueInput.value, true);
             });
@@ -291,7 +291,7 @@ WI.OverrideDeviceSettingsPopover = class OverrideDeviceSettingsPopover extends W
 
         if (selectedScreenSizeOptionElement)
             screenSizeValueSelect.value = selectedScreenSizeOptionElement.value;
-        else if (WI.deviceSettingsManager.overridenDeviceScreenSize) {
+        else if (WI.deviceSettingsManager.overriddenDeviceScreenSize) {
             screenSizeValueSelect.value = WI.OverrideDeviceSettingsPopover.OtherValue;
             showScreenSizeInput();
         }

--- a/Source/WebInspectorUI/UserInterface/Views/TimelineOverview.js
+++ b/Source/WebInspectorUI/UserInterface/Views/TimelineOverview.js
@@ -464,7 +464,7 @@ WI.TimelineOverview = class TimelineOverview extends WI.View
         let currentTime = this._currentTime;
         if (this._viewMode === WI.TimelineOverview.ViewMode.RenderingFrames) {
             let renderingFramesTimeline = this._recording.timelines.get(WI.TimelineRecord.Type.RenderingFrame);
-            console.assert(renderingFramesTimeline, "Recoring missing rendering frames timeline");
+            console.assert(renderingFramesTimeline, "Recording missing rendering frames timeline");
 
             startTime = 0;
             endTime = renderingFramesTimeline.records.length;

--- a/Source/WebInspectorUI/UserInterface/Views/TreeOutline.js
+++ b/Source/WebInspectorUI/UserInterface/Views/TreeOutline.js
@@ -1088,7 +1088,7 @@ WI.TreeOutline.Event = {
     ElementRevealed: "element-revealed",
     ElementClicked: "element-clicked",
     ElementDisclosureDidChanged: "element-disclosure-did-change",
-    ElementVisibilityDidChange: "element-visbility-did-change",
+    ElementVisibilityDidChange: "element-visibility-did-change",
     SelectionDidChange: "selection-did-change",
 };
 

--- a/Source/WebInspectorUI/UserInterface/Workers/Formatter/FormatterWorker.js
+++ b/Source/WebInspectorUI/UserInterface/Workers/Formatter/FormatterWorker.js
@@ -56,7 +56,7 @@ FormatterWorker = class FormatterWorker
             if (includeSourceMapData) {
                 result.sourceMapData = formatter.sourceMapData;
                 // NOTE: With the JSFormatter, multi-line tokens, such as comments and strings,
-                // would not have had their newlines counted properly by the builder. Rather then
+                // would not have had their newlines counted properly by the builder. Rather than
                 // modify the formatter to check and account for newlines in every token just
                 // compute the list of line endings directly on the result.
                 result.sourceMapData.formattedLineEndings = result.formattedText.lineEndings();

--- a/Source/WebInspectorUI/UserInterface/Workers/Formatter/HTMLTreeBuilderFormatter.js
+++ b/Source/WebInspectorUI/UserInterface/Workers/Formatter/HTMLTreeBuilderFormatter.js
@@ -244,7 +244,7 @@ HTMLTreeBuilderFormatter = class HTMLTreeBuilderFormatter
         if (existingOpenTagIndex === -1)
             return false;
 
-        // Disallow impliticly closing beyond the container tag boundary.
+        // Disallow implicitly closing beyond the container tag boundary.
         if (containerScopeTagNames) {
             for (let i = existingOpenTagIndex + 1; i < this._stackOfOpenElements.length; ++i) {
                 let stackNode = this._stackOfOpenElements[i];

--- a/Source/WebInspectorUI/UserInterface/Workers/HeapSnapshot/HeapSnapshot.js
+++ b/Source/WebInspectorUI/UserInterface/Workers/HeapSnapshot/HeapSnapshot.js
@@ -818,7 +818,7 @@ HeapSnapshot = class HeapSnapshot
             currentPath.push({node: nodeIndex});
 
             // Loop in reverse order because edges were added in reverse order.
-            // It doesn't particularly matter other then consistency with previous code.
+            // It doesn't particularly matter other than consistency with previous code.
             let incomingEdgeIndexStart = this._nodeOrdinalToFirstIncomingEdge[nodeOrdinal];
             let incomingEdgeIndexEnd = this._nodeOrdinalToFirstIncomingEdge[nodeOrdinal + 1];
             for (let incomingEdgeIndex = incomingEdgeIndexEnd - 1; incomingEdgeIndex >= incomingEdgeIndexStart; --incomingEdgeIndex) {


### PR DESCRIPTION
#### 257eead8c5acc1cdf89699edcec9f8460f19e23a
<pre>
[Web Inspector] Fix typos in inspector agents and frontend code
<a href="https://bugs.webkit.org/show_bug.cgi?id=319337">https://bugs.webkit.org/show_bug.cgi?id=319337</a>
<a href="https://rdar.apple.com/182153852">rdar://182153852</a>

Reviewed by NOBODY (OOPS!).

Fix a batch of spelling typos and one incorrect comment across the
inspector backend agents and Web Inspector frontend. No behavior change.

* Source/WebCore/inspector/InspectorInstrumentation.cpp:
(WebCore::InspectorInstrumentation::...): &quot;has occured&quot; -&gt; &quot;has occurred&quot;.
* Source/WebCore/inspector/InspectorOverlay.cpp:
(WebCore::InspectorOverlay::...): veritcalRulerStateSaver -&gt; verticalRulerStateSaver.
* Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp:
(WebCore::InspectorTimelineAgent::...): &quot;samping&quot; -&gt; &quot;sampling&quot;.
* Source/WebCore/inspector/agents/page/PageNetworkAgent.cpp:
(WebCore::PageNetworkAgent::...): &quot;docuemnt&quot; -&gt; &quot;document&quot; in error string.
* Source/WebInspectorUI/UserInterface/Base/Main.js: &quot;sibilings&quot; -&gt; &quot;siblings&quot;.
* Source/WebInspectorUI/UserInterface/Base/Utilities.js: precentIndex -&gt; percentIndex.
* Source/WebInspectorUI/UserInterface/Controllers/CSSManager.js: Fix event
name string &quot;...overriden...&quot; -&gt; &quot;...overridden...&quot;.
* Source/WebInspectorUI/UserInterface/Controllers/DeviceSettingsManager.js:
Rename overridenDevice* -&gt; overriddenDevice* members and getters.
* Source/WebInspectorUI/UserInterface/Models/CSSKeywordCompletions.js:
preceedingFunctionDepth -&gt; precedingFunctionDepth.
* Source/WebInspectorUI/UserInterface/Protocol/RemoteObject.js: Clarify error
message &quot;using key is not a string&quot; -&gt; &quot;using a key that is not a string&quot;.
* Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.js: trimedNodeValue
-&gt; trimmedNodeValue; &quot;sibilings&quot; -&gt; &quot;siblings&quot;.
* Source/WebInspectorUI/UserInterface/Views/NetworkTableContentView.js: Fix
misleading comment; 3_600_000ms is 1 hour, not 1 minute.
* Source/WebInspectorUI/UserInterface/Views/OverrideDeviceSettingsPopover.js:
Update overriddenDevice* getter call sites.
* Source/WebInspectorUI/UserInterface/Views/TimelineOverview.js: &quot;Recoring&quot;
-&gt; &quot;Recording&quot;.
* Source/WebInspectorUI/UserInterface/Views/TreeOutline.js: Fix event name
string &quot;element-visbility-did-change&quot; -&gt; &quot;element-visibility-did-change&quot;.
* Source/WebInspectorUI/UserInterface/Workers/Formatter/FormatterWorker.js:
&quot;Rather then&quot; -&gt; &quot;Rather than&quot;.
* Source/WebInspectorUI/UserInterface/Workers/Formatter/HTMLTreeBuilderFormatter.js:
&quot;impliticly&quot; -&gt; &quot;implicitly&quot;.
* Source/WebInspectorUI/UserInterface/Workers/HeapSnapshot/HeapSnapshot.js:
&quot;other then&quot; -&gt; &quot;other than&quot;.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/257eead8c5acc1cdf89699edcec9f8460f19e23a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174376 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48309 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42090 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183952 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132244 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/54cf626a-c550-4311-b293-753a16bd4b55) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176241 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49601 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47991 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135641 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95706 "7 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c7111e5d-be9b-47a6-a7d7-3afcd20f9e06) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177334 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39078 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156439 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116119 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8e2aed89-d73e-45a1-a6e6-6ba551c3d303) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37719 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36089 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32434 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148142 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35931 "Found 1 new test failure: inspector/model/remote-object-api.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186378 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39590 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40286 "Found 1 new test failure: inspector/model/remote-object-api.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144557 "Found 1 new test failure: inspector/model/remote-object-api.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47976 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144415 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48655 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32551 "Found 1 new test failure: inspector/model/remote-object-api.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114202 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39315 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120598 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47161 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10895 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46564 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46795 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46622 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->