### PR TITLE
[libpas] Test zero_mode split preservation in LargeFreeHeapTests

### DIFF
--- a/Source/bmalloc/libpas/src/test/LargeFreeHeapTests.cpp
+++ b/Source/bmalloc/libpas/src/test/LargeFreeHeapTests.cpp
@@ -510,6 +510,41 @@ void testMergeZeroModeOnCoalesce(pas_zero_mode leftMode, pas_zero_mode rightMode
         testSimpleLargeFreeHeap(actions, frees, 1);
 }
 
+void testSplitPreservesZeroMode(pas_zero_mode mode, bool useFastHeap)
+{
+    // Seed a free region [1000, 2000) carrying `mode`, then allocate a 512-aligned sub-range from
+    // it. The split (pas_large_free_split) must copy `mode` to both leftover halves -- [1000, 1024)
+    // and [1124, 2000) -- and to the allocation result at 1024. Align 512 forces both a left and a
+    // right leftover.
+    vector<Action> actions = {
+        Action::deallocate(1000, 1000, trappingAllocator, trappingDeallocator, mode),
+        Action::allocate(100, alignSimple(512), 1024, trappingAllocator, trappingDeallocator, mode),
+    };
+    set<Free> frees = { Free(1000, 1024, mode), Free(1124, 2000, mode) };
+    if (useFastHeap)
+        testFastLargeFreeHeap(actions, frees, 1);
+    else
+        testSimpleLargeFreeHeap(actions, frees, 1);
+}
+
+void testSplitPreservesZeroModeFromSource(pas_zero_mode mode, bool useFastHeap)
+{
+    // Same split, but the region comes fresh from the memory source: allocating into an empty heap
+    // invokes the mock allocator, which returns a chunk [1000, 2000) carrying `mode` with the object
+    // at 1024. With no deallocator wired (paddings are kept, not given back), the left/right padding
+    // must enter the free list carrying `mode` and the allocation result must carry `mode`.
+    vector<Action> actions = {
+        Action::allocate(100, alignSimple(512), 1024,
+                         allocateOnce(100, alignSimple(512), 1000, 1024, 1124, 2000, mode),
+                         { }, mode),
+    };
+    set<Free> frees = { Free(1000, 1024, mode), Free(1124, 2000, mode) };
+    if (useFastHeap)
+        testFastLargeFreeHeap(actions, frees, 1);
+    else
+        testSimpleLargeFreeHeap(actions, frees, 1);
+}
+
 } // anonymous namespace
 
 void addLargeFreeHeapTests()
@@ -1325,6 +1360,17 @@ void addLargeFreeHeapTests()
             ADD_TEST(testMergeZeroModeOnCoalesce(pas_zero_mode_may_have_non_zero, pas_zero_mode_may_have_non_zero,
                                                  pas_zero_mode_may_have_non_zero, rightFirst, useFastHeap));
         }
+    }
+
+    // zero_mode split preservation. Allocating a sub-range from a free region must copy that
+    // region's zero_mode to both leftover halves and to the allocation result -- pas_large_free_split
+    // copies the parent mode to both halves. Covered both for a region seeded via deallocate and for
+    // a fresh chunk from the memory source, on the simple and fast heaps.
+    for (bool useFastHeap : { false, true }) {
+        ADD_TEST(testSplitPreservesZeroMode(pas_zero_mode_is_all_zero, useFastHeap));
+        ADD_TEST(testSplitPreservesZeroMode(pas_zero_mode_may_have_non_zero, useFastHeap));
+        ADD_TEST(testSplitPreservesZeroModeFromSource(pas_zero_mode_is_all_zero, useFastHeap));
+        ADD_TEST(testSplitPreservesZeroModeFromSource(pas_zero_mode_may_have_non_zero, useFastHeap));
     }
 }
 


### PR DESCRIPTION
#### d720aa247974bae1aab08eeb7951115b32da5c36
<pre>
[libpas] Test zero_mode split preservation in LargeFreeHeapTests
<a href="https://bugs.webkit.org/show_bug.cgi?id=319338">https://bugs.webkit.org/show_bug.cgi?id=319338</a>
<a href="https://rdar.apple.com/182153719">rdar://182153719</a>

Reviewed by Yusuke Suzuki.

Allocating a sub-range from a free region splits it (pas_large_free_split),
which must copy the region&apos;s zero_mode to both leftover halves and to the
allocation result. Add testSplitPreservesZeroMode (region seeded via
deallocate) and testSplitPreservesZeroModeFromSource (region returned fresh
by the memory source, also exercising the aligned-allocation zero_mode
path), each asserting both leftovers and the result keep the seed mode,
for is_all_zero and may_have_non_zero, on the simple and fast heaps.

Test: Source/bmalloc/libpas/src/test/LargeFreeHeapTests.cpp

* Source/bmalloc/libpas/src/test/LargeFreeHeapTests.cpp:
(std::testSplitPreservesZeroMode):
(std::testSplitPreservesZeroModeFromSource):
(addLargeFreeHeapTests):

Canonical link: <a href="https://commits.webkit.org/317151@main">https://commits.webkit.org/317151@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da7eef22dc1553d5a506526998c0ff227403dcd9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174377 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48310 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42091 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183953 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132245 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9fba91ae-d88d-4d81-890e-4f00d970a5f0) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49602 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47992 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135642 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4cb1747b-2405-4d1f-a99d-385d38927b81) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177335 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39079 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156438 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116120 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/accee92e-139b-409c-b477-632b7023739d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37720 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36087 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32435 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/4947 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148143 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35930 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186379 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/35639 "Built successfully and passed tests") | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40284 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144556 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47977 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144414 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48656 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32550 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114203 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26518 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39316 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/211412 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47162 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10894 "") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55088 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46565 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46796 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46623 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->