### PR TITLE
Web Inspector: protocol timing-data dumps not restored from settings on launch

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Protocol/InspectorBackend.js
+++ b/Source/WebInspectorUI/UserInterface/Protocol/InspectorBackend.js
@@ -310,7 +310,7 @@ InspectorBackendClass = class InspectorBackendClass
     _startOrStopAutomaticTracing()
     {
         this._defaultTracer.dumpMessagesToConsole = this.dumpInspectorProtocolMessages;
-        this._defaultTracer.dumpTimingDataToConsole = this.dumpTimingDataToConsole;
+        this._defaultTracer.dumpTimingDataToConsole = this.dumpInspectorTimeStats;
         this._defaultTracer.filterMultiplexingBackend = this.filterMultiplexingBackendInspectorProtocolMessages;
     }
 };


### PR DESCRIPTION
#### 4f271877177723e5a67724388733254b790fdfc5
<pre>
Web Inspector: protocol timing-data dumps not restored from settings on launch
<a href="https://bugs.webkit.org/show_bug.cgi?id=319340">https://bugs.webkit.org/show_bug.cgi?id=319340</a>
<a href="https://rdar.apple.com/182154230">rdar://182154230</a>

Reviewed by NOBODY (OOPS!).

_startOrStopAutomaticTracing() read `this.dumpTimingDataToConsole`, which
does not exist on InspectorBackendClass (the accessor is
`dumpInspectorTimeStats`), so it wrote `undefined` into the tracer&apos;s flag and
the persisted protocolAutoLogTimeStats setting was never applied on launch.
Read it through the correct getter, matching the sibling lines.

Not testable; since it is developer only console dump toggle and don&apos;t
have any harness to write test.

* Source/WebInspectorUI/UserInterface/Protocol/InspectorBackend.js:
(InspectorBackendClass.prototype._startOrStopAutomaticTracing):
(InspectorBackendClass):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f271877177723e5a67724388733254b790fdfc5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174379 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48312 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42093 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183955 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132247 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/059dd3f5-e6a5-43ed-b247-1445ca364b4b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49604 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47994 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135647 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95709 "5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fef43337-d791-4619-b536-b3aa2c7600c5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177337 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39081 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156442 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116125 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/07ada790-af9c-4a27-8938-f6962b469c5e) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37722 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-002.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36090 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32437 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148145 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35934 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186381 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39593 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40287 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144563 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47979 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144421 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/38932 "The change is no longer eligible for processing.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48658 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32554 "Found 1 new test failure: scrollingcoordinator/mac/latching/horizontal-overflow-back-swipe.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114205 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39324 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120601 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47164 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10898 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46567 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46798 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46625 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->