### PR TITLE
Resync `css-scroll-snap` from WPT Upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/input/paged.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/input/paged.html
@@ -18,8 +18,11 @@
 html, body {
   margin: 0;
 }
+/* Heights are rounded to whole pixels so snap points stay integral; a
+   fractional vh height can make a center snap land sub-pixel short of
+   maxScroll, which then trips the strict <= bounds check in visiblePages(). */
 .scroller {
-  height: 100vh;
+  height: round(100vh, 1px);
   overflow: auto;
   position: relative;
   scroll-snap-type: y mandatory;
@@ -27,19 +30,19 @@ html, body {
 }
 
 .gap {
-  height: 100vh;
+  height: round(100vh, 1px);
 }
 
 .page {
   counter-increment: --page;
-  height: 90vh;
+  height: round(90vh, 1px);
   scroll-snap-align: center;
   padding: 8px;
   position: relative;
   --page: counter(--page);
 }
 .short {
-  height: 25vh;
+  height: round(25vh, 1px);
 }
 .page > div::before {
   content: "Page " counter(--page);

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-snap-stop-002-nested.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-snap-stop-002-nested.html
@@ -31,7 +31,7 @@ div {
   <div id="space"></div>
   <div class="target" style="left:   0px;"></div>
   <div class="target" style="left: 400px; width: 900px;"></div>
-  <div class="target" style="left: 900px; scroll-snap-stop: always;"></div>
+  <div class="target" style="left: 900px; scroll-snap-stop: always;"></div
 </div>
 
 <script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-snap-stop-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-snap-stop-002.html
@@ -108,7 +108,7 @@ div {
   <div id="space"></div>
   <div class="target" style="left:   0px;"></div>
   <div class="target" style="left: 400px;"></div>
-  <div class="target" style="left: 700px; scroll-snap-stop: always;"></div>
+  <div class="target" style="left: 700px; scroll-snap-stop: always;"></div
 </div>
 
 <script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/nested-supercedes-common-to-both-axes.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/nested-supercedes-common-to-both-axes.html
@@ -54,7 +54,6 @@
       <div id="box1" class="snap box">Box 1
         <div id="box2" class="inner snap box">Box 2</div>
         <div id="box3" class="inner snap box">Box 3</div>
-        </div>
       </div>
     </div>
     <script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/prefer-common-to-both-axes-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/prefer-common-to-both-axes-expected.txt
@@ -1,5 +1,5 @@
 Box 1Box 2Box 3Box 4Box 5Box 6Box 7Box 8Box 9
 
-FAIL scroller prefers target aligned in both axes. assert_equals: scroller followed box1 in x axis after layout change expected 210 but got 110
+FAIL scroller prefers target aligned in both axes. assert_equals: scroller followed box1 in y axis after layout change expected 210 but got 110
 FAIL scroller follows selected snap target after layout shift, regardless of common snap area. assert_equals: scroller followed box8 in y axis after layout change expected 480 but got 380
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/re-snap-focused-target-after-scrollBy-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/re-snap-focused-target-after-scrollBy-expected.txt
@@ -1,0 +1,4 @@
+topfirstsecond
+
+PASS Scroller re-snaps to the focused target after scrollBy
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/re-snap-focused-target-after-scrollBy.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/re-snap-focused-target-after-scrollBy.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Scroll snap: re-snap to the focused target after scrollBy</title>
+<link rel="help" href="https://drafts.csswg.org/css-scroll-snap-1/#re-snap">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  #scroller {
+    overflow-y: scroll;
+    position: relative;
+    width: 400px;
+    height: 400px;
+    scroll-snap-type: y mandatory;
+    scrollbar-width: none;
+  }
+  #space {
+    height: 300vh;
+    scroll-snap-align: none;
+  }
+  .target {
+    position: absolute;
+    left: 0;
+    width: 100px;
+    height: 100px;
+    scroll-snap-align: start;
+  }
+  #top { top: 0; }
+  /* #first and #second coincide. */
+  #first, #second { top: 200px; }
+</style>
+</head>
+<body>
+  <div id="scroller">
+    <div id="space"></div>
+    <div id="top" class="target">top</div>
+    <div id="first" tabindex="0" class="target">first</div>
+    <div id="second" tabindex="0" class="target">second</div>
+  </div>
+  <script>
+    promise_test(async (t) => {
+      const scroller = document.getElementById("scroller");
+      const first = document.getElementById("first");
+      const second = document.getElementById("second");
+
+      // Wait for the initial mandatory snap to settle.
+      await new Promise(resolve =>
+          requestAnimationFrame(() => requestAnimationFrame(resolve)));
+      assert_equals(scroller.scrollTop, 0, "initially snapped to #top");
+      assert_equals(first.offsetTop, second.offsetTop,
+                    "#first and #second are coincident");
+
+      // Focus one of the two coincident targets without scrolling to it, so
+      // that the scrollBy below is what brings them into view.
+      first.focus({ preventScroll: true });
+      assert_equals(document.activeElement, first, "#first is focused");
+
+      // Scroll to the coincident targets with a scrollBy. The scroller should
+      // snap and select the focused target, #first.
+      const snapped_offset = first.offsetTop;
+      const scrollend = new Promise(resolve =>
+          scroller.addEventListener("scrollend", resolve, { once: true }));
+      scroller.scrollBy(0, snapped_offset);
+      await scrollend;
+      assert_equals(scroller.scrollTop, snapped_offset,
+                    "snapped to the coincident targets");
+
+      // Move the focused target slightly. If #first is the selected snap
+      // target, the scroller re-snaps to follow it; had #second been selected,
+      // the scroller would stay put.
+      first.style.top = `${snapped_offset + 50}px`;
+      assert_equals(scroller.scrollTop, first.offsetTop,
+                    "scroller re-snapped to follow the focused target #first");
+      assert_not_equals(scroller.scrollTop, snapped_offset,
+                        "scroller actually moved when the focused target moved");
+    }, "Scroller re-snaps to the focused target after scrollBy");
+  </script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/resources/common.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/resources/common.js
@@ -101,10 +101,10 @@ async function runScrollSnapSelectionVerificationTest(t, scroller,
     aligned_elements_y);
   t.step(() => {
     if (axis == "y" || axis == "both") {
-      verifySelectedSnapTarget(t, scroller, expected_target_y, axis);
+      verifySelectedSnapTarget(t, scroller, expected_target_y, "y");
     }
     if (axis == "x" || axis == "both") {
-      verifySelectedSnapTarget(t, scroller, expected_target_x, axis);
+      verifySelectedSnapTarget(t, scroller, expected_target_x, "x");
     }
   });
   // Restore initial scroll offsets.

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/w3c-import.log
@@ -28,5 +28,6 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/prefer-targeted-element-main-frame.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/prefer-targeted-element-positioned.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/prefer-targeted-element.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/re-snap-focused-target-after-scrollBy.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/re-snap-per-axis-target.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/stash.py

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/unreachable-snap-positions-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/unreachable-snap-positions-003-expected.txt
@@ -1,4 +1,3 @@
 
-
-FAIL Snaps to the positions defined by the element as much as possible assert_equals: expected 5 but got 0
+PASS Snaps to the positions defined by the element as much as possible
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/unreachable-snap-positions-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/unreachable-snap-positions-003.html
@@ -27,8 +27,8 @@
 <div id="scroller" class="content">
   <!-- There's intentionally no whitespace between these tags, so that they're
        laid out flush with each other with no space character between them. -->
-    <div class="item" style="width: 305px; background:teal"></div>
-    <div class="item" style="width: 100px; background:pink"></div>
+    <div class="item" style="width: 305px; background:teal"></div
+    ><div class="item" style="width: 100px; background:pink"></div>
 </div>
 
 <script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/unreachable-snap-positions-004-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/unreachable-snap-positions-004-expected.txt
@@ -1,4 +1,3 @@
 
-
-FAIL Snaps to the positions defined by the element as much as possible assert_equals: expected 10 but got 0
+PASS Snaps to the positions defined by the element as much as possible
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/unreachable-snap-positions-004.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/unreachable-snap-positions-004.html
@@ -29,8 +29,8 @@
 <div id="scroller" class="content">
   <!-- There's intentionally no whitespace between these tags, so that they're
        laid out flush with each other with no space character between them. -->
-    <div class="item" style="height: 610px; background:teal"></div>
-    <div class="item" style="height: 200px; background:pink"></div>
+    <div class="item" style="height: 610px; background:teal"></div
+    ><div class="item" style="height: 200px; background:pink"></div>
 </div>
 
 <script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/unrelated-gesture-scroll-during-snap.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/unrelated-gesture-scroll-during-snap.html
@@ -20,6 +20,7 @@
         display: inline-block;
         background-color: yellow;
         position: relative;
+        scrollbar-width: none;
       }
       .snapcontainer {
         scroll-snap-type: y mandatory;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/w3c-import.log
@@ -117,6 +117,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-to-visible-areas-margin-y-axis.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-to-visible-areas-x-axis.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-to-visible-areas-y-axis.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-to-zero-height-interior-area.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snapevent-constructor.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/unreachable-snap-positions-001.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/unreachable-snap-positions-002.html


### PR DESCRIPTION
#### 8c935ca7d697da2dff9db99fe3630112b638cd3e
<pre>
Resync `css-scroll-snap` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=319341">https://bugs.webkit.org/show_bug.cgi?id=319341</a>
<a href="https://rdar.apple.com/182154374">rdar://182154374</a>

Reviewed by Sammy Gill.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/96f79771e28940bebe2a260e23e4d8b55137b508">https://github.com/web-platform-tests/wpt/commit/96f79771e28940bebe2a260e23e4d8b55137b508</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/input/paged.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-snap-stop-002-nested.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-snap-stop-002.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/nested-supercedes-common-to-both-axes.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/prefer-common-to-both-axes-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/re-snap-focused-target-after-scrollBy-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/re-snap-focused-target-after-scrollBy.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/resources/common.js:
(async runScrollSnapSelectionVerificationTest):
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/unreachable-snap-positions-003-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/unreachable-snap-positions-003.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/unreachable-snap-positions-004-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/unreachable-snap-positions-004.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/unrelated-gesture-scroll-during-snap.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/317170@main">https://commits.webkit.org/317170@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80b4526ba90ab1e3b5fde2427a9e5284e93d7000

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174388 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48321 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42102 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183964 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132256 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/afd13b14-5051-4600-ad8d-0b690be94460) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49613 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48003 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135652 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177346 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39084 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156454 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116130 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/be5c6eb1-0713-41f5-b937-c0ef026237ad) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37725 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36098 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32446 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148148 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35946 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186391 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40295 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144568 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47988 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156008 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144426 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38960 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48667 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32566 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114214 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39323 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47173 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10910 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46576 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46807 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46634 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->