### PR TITLE
[GFC] remove borders from avoidance reasons

### DIFF
--- a/LayoutTests/fast/css-grid-layout/grid-2x2-items-with-borders-expected.html
+++ b/LayoutTests/fast/css-grid-layout/grid-2x2-items-with-borders-expected.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+/* Reference: reconstruct the 2x2 grid geometry without a grid formatting
+   context. Each item is an absolutely-positioned border-box block placed at
+   its grid area's origin/size, so the (real) borders and Ahem text land in the
+   exact pixels the grid is expected to produce. Using real borders keeps the
+   asymmetric corner joins identical to the tested output. */
+.container {
+    position: relative;
+    width: 784px;
+    height: 120px;
+}
+.item {
+    position: absolute;
+    box-sizing: border-box;
+    border-style: solid;
+    font: 20px/1 Ahem;
+}
+.topLeft {
+    left: 0;
+    top: 0;
+    width: 374px;
+    height: 44px;
+    border-width: 2px 4px 6px 8px;
+    border-color: green;
+}
+.topRight {
+    left: 374px;
+    top: 0;
+    width: 410px;
+    height: 44px;
+    border-width: 10px 12px 14px 16px;
+    border-color: yellow;
+}
+.bottomLeft {
+    left: 0;
+    top: 44px;
+    width: 374px;
+    height: 76px;
+    border-width: 18px 20px 22px 24px;
+    border-color: yellow;
+}
+.bottomRight {
+    left: 374px;
+    top: 44px;
+    width: 410px;
+    height: 76px;
+    border-width: 26px 28px 30px 32px;
+    border-color: green;
+}
+</style>
+</head>
+<body>
+<div class="container">
+    <div class="item topLeft">x</div>
+    <div class="item topRight">xx</div>
+    <div class="item bottomLeft">xxx</div>
+    <div class="item bottomRight">xxxx</div>
+</div>
+</body>
+</html>

--- a/LayoutTests/fast/css-grid-layout/grid-2x2-items-with-borders.html
+++ b/LayoutTests/fast/css-grid-layout/grid-2x2-items-with-borders.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.grid {
+    display: grid;
+    grid-template-columns: auto auto;
+    grid-template-rows: auto auto;
+    font: 20px/1 Ahem;
+}
+/* Four explicitly, single-span placed items (required for GFC coverage today),
+   each with a different, asymmetric border so every item and track exercises
+   the content-box -> border-box conversion independently. */
+.topLeft {
+    grid-row: 1 / 2;
+    grid-column: 1 / 2;
+    border-width: 2px 4px 6px 8px;
+    border-style: solid;
+    border-color: green;
+}
+.topRight {
+    grid-row: 1 / 2;
+    grid-column: 2 / 3;
+    border-width: 10px 12px 14px 16px;
+    border-style: solid;
+    border-color: yellow;
+}
+.bottomLeft {
+    grid-row: 2 / 3;
+    grid-column: 1 / 2;
+    border-width: 18px 20px 22px 24px;
+    border-style: solid;
+    border-color: yellow;
+}
+.bottomRight {
+    grid-row: 2 / 3;
+    grid-column: 2 / 3;
+    border-width: 26px 28px 30px 32px;
+    border-style: solid;
+    border-color: green;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+    <div class="topLeft">x</div>
+    <div class="topRight">xx</div>
+    <div class="bottomLeft">xxx</div>
+    <div class="bottomRight">xxxx</div>
+</div>
+</body>
+</html>

--- a/LayoutTests/fast/css-grid-layout/grid-item-with-border-track-sizing-expected.html
+++ b/LayoutTests/fast/css-grid-layout/grid-item-with-border-track-sizing-expected.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+/* Reference: the single bordered grid item occupies column 1 / row 1 of the
+   test's grid (a 734x64 area). The "filler" item there only exists to size the
+   second row/column tracks; it paints nothing, so it is omitted here.
+   Reconstruct the bordered box as a border-box block at the body's content
+   origin, matching the grid area's position and size. */
+.borderedItem {
+    box-sizing: border-box;
+    width: 734px;
+    height: 64px;
+    border-width: 13px 27px 31px 9px;
+    border-style: solid;
+    font: 20px/1 Ahem;
+}
+</style>
+</head>
+<body>
+<div class="borderedItem">xx</div>
+</body>
+</html>

--- a/LayoutTests/fast/css-grid-layout/grid-item-with-border-track-sizing.html
+++ b/LayoutTests/fast/css-grid-layout/grid-item-with-border-track-sizing.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.grid {
+    display: grid;
+    grid-template-columns: auto 50px;
+    grid-template-rows: auto 40px;
+}
+.borderedItem {
+    grid-row: 1 / 2;
+    grid-column: 1 / 2;
+    border-width: 13px 27px 31px 9px;
+    border-style: solid;
+    font: 20px/1 Ahem;
+}
+.filler {
+    grid-row: 2 / 3;
+    grid-column: 2 / 3;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+    <div class="borderedItem">xx</div>
+    <div class="filler"></div>
+</div>
+</body>
+</html>

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
@@ -71,7 +71,6 @@ enum class GridAvoidanceReason : uint8_t {
     GridHasUnsupportedMaxHeight,
     GridItemHasNonInitialMaxWidth,
     GridItemHasNonInitialMaxHeight,
-    GridItemHasBorder,
     GridItemHasPercentOrCalcPadding,
     GridItemHasMargin,
     GridItemHasBorderBoxSizing,
@@ -508,9 +507,6 @@ static EnumSet<GridAvoidanceReason> gridLayoutAvoidanceReason(const RenderGrid& 
         if (!gridItemStyle->maxHeight().isNone())
             ADD_REASON_AND_RETURN_IF_NEEDED(GridAvoidanceReason::GridItemHasNonInitialMaxHeight, reasons, reasonCollectionMode);
 
-        if (gridItemStyle->border().hasBorder())
-            ADD_REASON_AND_RETURN_IF_NEEDED(GridAvoidanceReason::GridItemHasBorder, reasons, reasonCollectionMode);
-
         // Fixed padding is threaded into item and track sizing as part of the border-box size and lays
         // out identically to legacy RenderGrid. Percentage and calc() padding resolve against the grid
         // item's grid area, which needs additional plumbing, so keep those items on the legacy path.
@@ -774,9 +770,6 @@ static void printReason(GridAvoidanceReason reason, TextStream& stream)
         break;
     case GridAvoidanceReason::GridItemHasNonInitialMaxHeight:
         stream << "grid item has non-initial max-height";
-        break;
-    case GridAvoidanceReason::GridItemHasBorder:
-        stream << "grid item has border";
         break;
     case GridAvoidanceReason::GridItemHasPercentOrCalcPadding:
         stream << "grid item has percent or calc padding";


### PR DESCRIPTION
#### e26ee87d8e4429ef495ae0f1eb2e66648e0c6c86
<pre>
[GFC] remove borders from avoidance reasons
<a href="https://bugs.webkit.org/show_bug.cgi?id=319346">https://bugs.webkit.org/show_bug.cgi?id=319346</a>
&lt;<a href="https://rdar.apple.com/182160152">rdar://182160152</a>&gt;

Reviewed by Sammy Gill.

GFC currently supports borders. Border tests were written to
pass our avoidance checks to properly verify that GFC was handling
borders as expected.

Usage of GFC can be verified with:

notifyutil -p com.apple.WebKit.showLegacyGridReasons

* LayoutTests/fast/css-grid-layout/grid-2x2-items-with-borders-expected.html: Added.
* LayoutTests/fast/css-grid-layout/grid-2x2-items-with-borders.html: Added.
* LayoutTests/fast/css-grid-layout/grid-item-with-border-track-sizing-expected.html: Added.
* LayoutTests/fast/css-grid-layout/grid-item-with-border-track-sizing.html: Added.
* Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp:
(WebCore::LayoutIntegration::gridLayoutAvoidanceReason):
(WebCore::LayoutIntegration::printReason):

Canonical link: <a href="https://commits.webkit.org/317653@main">https://commits.webkit.org/317653@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5db43f8d91e3ef1a0934e2f437c8d17de3a0324d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175766 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49699 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43483 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185359 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/adaef4ff-a052-4ea9-b789-b25f3f075e8c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177629 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50991 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49381 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136861 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2299bc90-9705-4506-ad3f-2f08479f0e02) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178722 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40319 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157633 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117340 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/537911a7-55bb-447f-bf49-4791d12f8614) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38961 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37342 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149380 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37125 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33828 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41393 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41548 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187780 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49366 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/157184 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145851 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50046 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33749 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145693 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26732 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40484 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122242 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116068 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48553 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12103 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47955 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48187 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48012 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->