### PR TITLE
[Web Inspector] Heap snapshot collection diff strides previous snapshot by wrong node field count

### DIFF
--- a/LayoutTests/inspector/heap/collection-diff-across-node-layouts-expected.txt
+++ b/LayoutTests/inspector/heap/collection-diff-across-node-layouts-expected.txt
@@ -1,0 +1,10 @@
+Test that a heap snapshot collection diff strides the previous snapshot's node list by the previous snapshot's own node field count.
+
+
+== Running test suite: HeapSnapshot.CollectionDiffAcrossNodeLayouts
+-- Running test case: HeapSnapshot.CollectionDiffAcrossNodeLayouts
+Collected node identifiers: [1]
+PASS: Should collect exactly one node identifier.
+PASS: Should collect node identifier 1 (the deleted node).
+PASS: Should not collect a garbage identifier read from a misaligned field.
+

--- a/LayoutTests/inspector/heap/collection-diff-across-node-layouts.html
+++ b/LayoutTests/inspector/heap/collection-diff-across-node-layouts.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("HeapSnapshot.CollectionDiffAcrossNodeLayouts");
+
+    suite.addTestCase({
+        name: "HeapSnapshot.CollectionDiffAcrossNodeLayouts",
+        description: "updateDeadNodesAndGatherCollectionData() must stride the previous snapshot's node list by that snapshot's own field count, not the current snapshot's.",
+        test(resolve, reject) {
+            let workerProxy = WI.HeapSnapshotWorkerProxy.singleton();
+            let targetId = WI.mainTarget.identifier;
+
+            // A "GCDebugging" snapshot has 7 fields per node:
+            //   [<id>, <size>, <className>, <flags>, <label>, <cellAddress>, <wrappedAddress>]
+            // Node ordinal 0 is the <root>. Node id 1 will be collected by the next snapshot;
+            // node id 2 survives. The size/cellAddress fields of node id 1 are given values (1
+            // and 77) that a buggy 4-field stride would misread as "deleted" node identifiers.
+            let gcDebuggingSnapshot = JSON.stringify({
+                version: 3,
+                type: "GCDebugging",
+                nodes: [
+                    0, 0, 0, 0, 0, 0, 0,   // <root>, id 0
+                    1, 1, 1, 0, 0, 77, 0,  // id 1 (will be collected)
+                    2, 8, 2, 0, 0, 0, 0,   // id 2 (survives)
+                ],
+                nodeClassNames: ["", "Foo", "Bar"],
+                edges: [
+                    0, 1, 0, 0,            // <root> -> id 1
+                    0, 2, 0, 0,            // <root> -> id 2
+                ],
+                edgeTypes: ["Internal", "Property", "Index", "Variable"],
+                edgeNames: [],
+                roots: [],
+                labels: [],
+            });
+
+            // An "Inspector" snapshot has 4 fields per node:
+            //   [<id>, <size>, <className>, <flags>]
+            // Node id 1 is gone (collected), id 2 survives, id 3 is new.
+            let inspectorSnapshot = JSON.stringify({
+                version: 3,
+                type: "Inspector",
+                nodes: [
+                    0, 0, 0, 0,            // <root>, id 0
+                    2, 8, 2, 0,            // id 2 (survives)
+                    3, 8, 2, 0,            // id 3 (new)
+                ],
+                nodeClassNames: ["", "Foo", "Bar"],
+                edges: [
+                    0, 2, 0, 0,            // <root> -> id 2
+                    0, 3, 0, 0,            // <root> -> id 3
+                ],
+                edgeTypes: ["Internal", "Property", "Index", "Variable"],
+                edgeNames: [],
+            });
+
+            let handled = false;
+            function handleCollection(event) {
+                if (handled)
+                    return;
+                handled = true;
+                workerProxy.removeEventListener(WI.HeapSnapshotWorkerProxy.Event.Collection, handleCollection);
+
+                let {collectedNodes} = event.data;
+                let collectedIdentifiers = Object.keys(collectedNodes).map(Number).sort((a, b) => a - b);
+                InspectorTest.log("Collected node identifiers: " + JSON.stringify(collectedIdentifiers));
+
+                InspectorTest.expectEqual(collectedIdentifiers.length, 1, "Should collect exactly one node identifier.");
+                InspectorTest.expectThat(collectedIdentifiers.includes(1), "Should collect node identifier 1 (the deleted node).");
+                InspectorTest.expectFalse(collectedIdentifiers.includes(77), "Should not collect a garbage identifier read from a misaligned field.");
+
+                resolve();
+            }
+            workerProxy.addEventListener(WI.HeapSnapshotWorkerProxy.Event.Collection, handleCollection);
+
+            // Create the previous (GCDebugging) snapshot, then the current (Inspector) snapshot.
+            // Creating the second snapshot triggers the collection diff, which fires a Collection
+            // event asynchronously from the worker.
+            workerProxy.createSnapshot(targetId, gcDebuggingSnapshot, () => {
+                workerProxy.createSnapshot(targetId, inspectorSnapshot, () => { });
+            });
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Test that a heap snapshot collection diff strides the previous snapshot's node list by the previous snapshot's own node field count.</p>
+</body>
+</html>

--- a/Source/WebInspectorUI/UserInterface/Workers/HeapSnapshot/HeapSnapshot.js
+++ b/Source/WebInspectorUI/UserInterface/Workers/HeapSnapshot/HeapSnapshot.js
@@ -401,8 +401,12 @@ HeapSnapshot = class HeapSnapshot
         }
 
         // Determine which node identifiers have since been deleted.
+        // Walk the previous snapshot using its own field count. This snapshot and the
+        // previous one may have been serialized with different layouts (e.g. an "Inspector"
+        // snapshot has 4 fields per node while a "GCDebugging" snapshot has 7), so striding
+        // by this._nodeFieldCount would read node identifiers from misaligned offsets.
         let collectedNodesList = [];
-        for (let nodeIndex = 0; nodeIndex < previousSnapshot._nodes.length; nodeIndex += this._nodeFieldCount) {
+        for (let nodeIndex = 0; nodeIndex < previousSnapshot._nodes.length; nodeIndex += previousSnapshot._nodeFieldCount) {
             let nodeIdentifier = previousSnapshot._nodes[nodeIndex + nodeIdOffset];
             let wasDeleted = !known.has(nodeIdentifier);
             if (wasDeleted)


### PR DESCRIPTION
#### bdd8ad2d8ad91441e12753da6dbb79c487de1b15
<pre>
[Web Inspector] Heap snapshot collection diff strides previous snapshot by wrong node field count
<a href="https://bugs.webkit.org/show_bug.cgi?id=319347">https://bugs.webkit.org/show_bug.cgi?id=319347</a>
<a href="https://rdar.apple.com/182161230">rdar://182161230</a>

Reviewed by Devin Rousso.

HeapSnapshot.updateDeadNodesAndGatherCollectionData() walked
previousSnapshot._nodes but strided by this._nodeFieldCount, the current
snapshot&apos;s field count. _nodeFieldCount is per-instance (4 for an
&quot;Inspector&quot; snapshot, 7 for a &quot;GCDebugging&quot; one), so when the two
snapshots had different layouts the loop read node identifiers from
misaligned offsets and produced a garbage collected-nodes set.

Stride the previous snapshot&apos;s node list by its own field count instead.

Test: inspector/heap/collection-diff-across-node-layouts.html

* LayoutTests/inspector/heap/collection-diff-across-node-layouts-expected.txt: Added.
* LayoutTests/inspector/heap/collection-diff-across-node-layouts.html: Added.
* Source/WebInspectorUI/UserInterface/Workers/HeapSnapshot/HeapSnapshot.js:
(HeapSnapshot.prototype.updateDeadNodesAndGatherCollectionData):

Canonical link: <a href="https://commits.webkit.org/317156@main">https://commits.webkit.org/317156@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/021e3f48c8e8717b7a32c89ab45a2c72c34b5d7d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174401 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48334 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42115 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183978 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132269 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4418f700-72fe-4861-8fa0-fcd245b56c34) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49626 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48016 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135666 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177359 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed webkitperl tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39101 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156460 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116144 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c909f443-f0b0-4580-89a3-ac32c26f483f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37742 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36110 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32459 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148165 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35952 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186404 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39617 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40307 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144578 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48001 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156014 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144436 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38954 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48680 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32572 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114230 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39336 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120626 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47186 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10916 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46589 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46820 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46647 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->