### PR TITLE
REGRESSION(316617@main): Use-after-free in IPC::Connection::SyncMessageState::~SyncMessageState()

### DIFF
--- a/Source/WebKit/Platform/IPC/Connection.cpp
+++ b/Source/WebKit/Platform/IPC/Connection.cpp
@@ -1084,6 +1084,10 @@ void Connection::processIncomingMessage(UniqueRef<Decoder> message)
     if (message->isAsyncReplyMessage()) {
         // Disallow async replies with invalid destinationIDs to be sent
         if (!AtomicObjectIdentifier<AsyncReplyIDType>::isValidIdentifier(message->destinationID())) {
+            // Drop our SyncMessageState reference while still holding m_incomingMessagesLock. Otherwise the
+            // ~SyncMessageState triggered by this last deref would run without the lock and could race with
+            // invalidate() dropping its own reference (both under m_incomingMessagesLock) on the dispatcher thread.
+            syncState = nullptr;
             incomingMessagesLocker.unlockEarly();
             waitForMessagesLocker.unlockEarly();
 #if ENABLE(IPC_TESTING_API)
@@ -1095,6 +1099,10 @@ void Connection::processIncomingMessage(UniqueRef<Decoder> message)
             return;
         }
         if (auto replyHandlerWithDispatcher = takeAsyncReplyHandlerWithDispatcherWithLockHeld(AtomicObjectIdentifier<AsyncReplyIDType>(message->destinationID()))) {
+            // Drop our SyncMessageState reference while still holding m_incomingMessagesLock, before unlocking to
+            // run the reply handler. Otherwise the ~SyncMessageState triggered by this last deref would run without
+            // the lock and could race with invalidate() dropping its own reference on the dispatcher thread.
+            syncState = nullptr;
             incomingMessagesLocker.unlockEarly();
             waitForMessagesLocker.unlockEarly();
 


### PR DESCRIPTION
#### 89d4e73db3539c113f7a055eb95652dd83795ec0
<pre>
REGRESSION(316617@main): Use-after-free in IPC::Connection::SyncMessageState::~SyncMessageState()
<a href="https://bugs.webkit.org/show_bug.cgi?id=319349">https://bugs.webkit.org/show_bug.cgi?id=319349</a>
<a href="https://rdar.apple.com/181691990">rdar://181691990</a>

Reviewed by Ben Nham.

316617@main added incomingMessagesLocker.unlockEarly() / waitForMessagesLocker.unlockEarly()
to the async-reply-with-dispatcher branch of Connection::processIncomingMessage() so the reply
handler would run without the locks held (matching the other branches and avoiding
re-entrancy). However, the `RefPtr syncState = m_syncState` local declared earlier in the
function is destroyed *before* those lockers at the return (reverse declaration order), so this
change moved the final SyncMessageState deref -- and the ~SyncMessageState() it can trigger --
out from under m_incomingMessagesLock on a hot path (every async reply, including GPUProcess
sendWithAsyncReply replies).

SyncMessageState is shared per-SerialFunctionDispatcher (SyncMessageState::getOrCreate()), so a
single instance is kept alive by the m_syncState of every Connection bound to that dispatcher
(e.g. the main UIProcess connection and the RemoteRenderingBackendProxy GPUProcess connection).
Connection::invalidate() drops its m_syncState reference under m_incomingMessagesLock on the
dispatcher thread. That lock is what serialized the &quot;read m_syncState, use it, drop it&quot; section
on the connection work queue against invalidate(). With the last deref now running unlocked, the
work-queue thread&apos;s ~SyncMessageState() can race invalidate()&apos;s teardown of the same shared
object, producing the heap-use-after-free reported by ASan during WebPage teardown
(~WebPage -&gt; ~RemoteRenderingBackendProxy -&gt; disconnectGPUProcess -&gt; Connection::invalidate).

Fix this by dropping our SyncMessageState reference (syncState = nullptr) while still holding
m_incomingMessagesLock, before unlockEarly(), in both async-reply branches. This preserves
316617@main&apos;s intent of running the reply handler unlocked while restoring the pre-regression
ordering. The completion handler does not need syncState.

* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::processIncomingMessage):

Canonical link: <a href="https://commits.webkit.org/317220@main">https://commits.webkit.org/317220@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c774bdcb050f4d573f206976b71877691880aab3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174404 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48337 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42118 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183981 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132272 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49629 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48019 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135670 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95724 "4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d3e0020b-cf26-45df-bdb7-08d785ead86c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177362 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39104 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156473 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116148 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/582cecbb-de59-4607-8a18-fcc708c8030d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37745 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36114 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32462 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148168 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35965 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186407 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39621 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40311 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144582 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48004 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144440 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38992 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48683 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32585 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114235 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39340 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120631 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47189 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10929 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46592 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46823 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46650 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->