### PR TITLE
[JSC] DFG should use the `ArrayIndexOf` / `ArrayIncludes` intrinsic for RegExp matches arrays

### DIFF
--- a/JSTests/microbenchmarks/regexp-matches-array-includes.js
+++ b/JSTests/microbenchmarks/regexp-matches-array-includes.js
@@ -1,0 +1,12 @@
+const regExp = /^\/(?:event\/([^/]+)(?:$()|\/comments$())|map\/([^/]+)\/events$()|static(?:|\/.*)$()|user\/lookup\/(?:email\/([^/]+)$()|username\/([^/]+)$()))/;
+const match = '/user/lookup/username/hey'.match(regExp);
+
+function test(array) {
+    return array.includes('hey');
+}
+noInline(test);
+
+for (let i = 0; i < 1e6; i++) {
+    if (!test(match))
+        throw new Error("bad");
+}

--- a/JSTests/microbenchmarks/regexp-matches-array-index-of.js
+++ b/JSTests/microbenchmarks/regexp-matches-array-index-of.js
@@ -1,0 +1,12 @@
+const regExp = /^\/(?:event\/([^/]+)(?:$()|\/comments$())|map\/([^/]+)\/events$()|static(?:|\/.*)$()|user\/lookup\/(?:email\/([^/]+)$()|username\/([^/]+)$()))/;
+const match = '/user/lookup/username/hey'.match(regExp);
+
+function test(array) {
+    return array.indexOf('', 1);
+}
+noInline(test);
+
+for (let i = 0; i < 1e6; i++) {
+    if (test(match) !== 10)
+        throw new Error("bad");
+}

--- a/JSTests/stress/regexp-matches-array-index-of-have-a-bad-time.js
+++ b/JSTests/stress/regexp-matches-array-index-of-have-a-bad-time.js
@@ -1,0 +1,27 @@
+//@ requireOptions("--useDollarVM=1")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected: ' + expected);
+}
+
+var regExp = /(x)?(y)(z)?/;
+
+function indexOfValue(array, value) {
+    return array.indexOf(value, 1);
+}
+noInline(indexOfValue);
+
+for (var i = 0; i < 1e5; ++i) {
+    var match = 'y'.match(regExp);
+    shouldBe(indexOfValue(match, 'y'), 2);
+    shouldBe(indexOfValue(match, undefined), 1);
+}
+
+$vm.haveABadTime();
+
+for (var i = 0; i < 1e5; ++i) {
+    var match = 'y'.match(regExp);
+    shouldBe(indexOfValue(match, 'y'), 2);
+    shouldBe(indexOfValue(match, undefined), 1);
+}

--- a/JSTests/stress/regexp-matches-array-index-of-mixed.js
+++ b/JSTests/stress/regexp-matches-array-index-of-mixed.js
@@ -1,0 +1,27 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected: ' + expected);
+}
+
+var regExp = /(x)?(y)(z)?/;
+
+function indexOfValue(array, value) {
+    return array.indexOf(value, 1);
+}
+noInline(indexOfValue);
+
+for (var i = 0; i < 1e5; ++i) {
+    var match = 'y'.match(regExp);
+    shouldBe(indexOfValue(match, 'y'), 2);
+    shouldBe(indexOfValue(match, undefined), 1);
+
+    var plain = ['y', undefined, 'y', undefined];
+    shouldBe(indexOfValue(plain, 'y'), 2);
+    shouldBe(indexOfValue(plain, undefined), 1);
+
+    var decorated = ['y', undefined, 'y', undefined];
+    decorated.index = 0;
+    decorated.input = 'y';
+    shouldBe(indexOfValue(decorated, 'y'), 2);
+    shouldBe(indexOfValue(decorated, undefined), 1);
+}

--- a/JSTests/stress/regexp-matches-array-index-of-mutated.js
+++ b/JSTests/stress/regexp-matches-array-index-of-mutated.js
@@ -1,0 +1,32 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected: ' + expected);
+}
+
+var regExp = /(x)?(y)(z)?/;
+
+function indexOfValue(array, value) {
+    return array.indexOf(value, 1);
+}
+noInline(indexOfValue);
+
+for (var i = 0; i < 1e5; ++i) {
+    var match = 'y'.match(regExp);
+    match[3] = 'replaced';
+    shouldBe(indexOfValue(match, 'replaced'), 3);
+    shouldBe(indexOfValue(match, undefined), 1);
+
+    var extended = 'y'.match(regExp);
+    extended.extra = 42;
+    shouldBe(indexOfValue(extended, 'y'), 2);
+
+    var grown = 'y'.match(regExp);
+    grown.length = 10;
+    shouldBe(indexOfValue(grown, 'y'), 2);
+    shouldBe(indexOfValue(grown, undefined), 1);
+
+    var holey = 'y'.match(regExp);
+    holey[8] = 'tail';
+    shouldBe(indexOfValue(holey, 'tail'), 8);
+    shouldBe(indexOfValue(holey, undefined), 1);
+}

--- a/JSTests/stress/regexp-matches-array-index-of-with-indices.js
+++ b/JSTests/stress/regexp-matches-array-index-of-with-indices.js
@@ -1,0 +1,25 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected: ' + expected);
+}
+
+var regExp = /a(b)?(c)?/d;
+
+function indexOfValue(array, value) {
+    return array.indexOf(value);
+}
+noInline(indexOfValue);
+
+function includesValue(array, value) {
+    return array.includes(value);
+}
+noInline(includesValue);
+
+for (var i = 0; i < 1e5; ++i) {
+    var match = 'ac'.match(regExp);
+    shouldBe(indexOfValue(match, 'c'), 2);
+    shouldBe(indexOfValue(match, undefined), 1);
+    shouldBe(indexOfValue(match, 'missing'), -1);
+    shouldBe(includesValue(match, 'c'), true);
+    shouldBe(includesValue(match, 'missing'), false);
+}

--- a/JSTests/stress/regexp-matches-array-index-of.js
+++ b/JSTests/stress/regexp-matches-array-index-of.js
@@ -1,0 +1,66 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected: ' + expected);
+}
+
+var regExp = /^\/(?:event\/([^/]+)(?:$()|\/comments$())|map\/([^/]+)\/events$()|static(?:|\/.*)$()|user\/lookup\/(?:email\/([^/]+)$()|username\/([^/]+)$()))/;
+
+function indexOfEmpty(array) {
+    return array.indexOf('', 1);
+}
+noInline(indexOfEmpty);
+
+function indexOfValue(array, value) {
+    return array.indexOf(value);
+}
+noInline(indexOfValue);
+
+function indexOfUndefined(array) {
+    return array.indexOf(undefined, 1);
+}
+noInline(indexOfUndefined);
+
+function indexOfNegativeFrom(array, value) {
+    return array.indexOf(value, -3);
+}
+noInline(indexOfNegativeFrom);
+
+function includesEmpty(array) {
+    return array.includes('');
+}
+noInline(includesEmpty);
+
+function includesValue(array, value) {
+    return array.includes(value);
+}
+noInline(includesValue);
+
+for (var i = 0; i < 1e5; ++i) {
+    var match = '/user/lookup/username/hey'.match(regExp);
+    shouldBe(indexOfEmpty(match), 10);
+    shouldBe(indexOfValue(match, 'hey'), 9);
+    shouldBe(indexOfValue(match, 'nonexistent'), -1);
+    shouldBe(indexOfUndefined(match), 1);
+    shouldBe(indexOfNegativeFrom(match, ''), 10);
+    shouldBe(includesEmpty(match), true);
+    shouldBe(includesValue(match, 'hey'), true);
+    shouldBe(includesValue(match, 'nonexistent'), false);
+
+    var match2 = regExp.exec('/event/42/comments');
+    shouldBe(indexOfEmpty(match2), 3);
+    shouldBe(indexOfValue(match2, '42'), 1);
+    shouldBe(includesValue(match2, '42'), true);
+}
+
+var namedRegExp = /(?<year>\d{4})-(?<month>\d{2})(?:-(?<day>\d{2}))?/;
+function indexOfOnNamed(array, value) {
+    return array.indexOf(value);
+}
+noInline(indexOfOnNamed);
+
+for (var i = 0; i < 1e5; ++i) {
+    var match = '2026-07'.match(namedRegExp);
+    shouldBe(indexOfOnNamed(match, '07'), 2);
+    shouldBe(indexOfOnNamed(match, undefined), 3);
+    shouldBe(indexOfOnNamed(match, '2026-07'), 0);
+}

--- a/Source/JavaScriptCore/bytecode/ArrayProfile.cpp
+++ b/Source/JavaScriptCore/bytecode/ArrayProfile.cpp
@@ -145,8 +145,11 @@ void ArrayProfile::computeUpdatedPrediction(CodeBlock* codeBlock, Structure* las
 
     JSGlobalObject* globalObject = codeBlock->globalObject();
     bool isResizableOrGrowableShared = false;
-    if (!globalObject->isOriginalArrayStructure(lastSeenStructure) && !globalObject->isOriginalTypedArrayStructure(lastSeenStructure, isResizableOrGrowableShared))
+    if (!globalObject->isOriginalArrayStructure(lastSeenStructure) && !globalObject->isOriginalTypedArrayStructure(lastSeenStructure, isResizableOrGrowableShared)) {
         m_arrayProfileFlags.add(ArrayProfileFlag::UsesNonOriginalArrayStructures);
+        if (lastSeenStructure == globalObject->regExpMatchesArrayStructure() || lastSeenStructure == globalObject->regExpMatchesArrayWithIndicesStructure())
+            m_arrayProfileFlags.add(ArrayProfileFlag::MayBeRegExpMatchesArray);
+    }
 
     if (isTypedArrayTypeIncludingDataView(lastSeenStructure->typeInfo().type())) {
         if (isResizableOrGrowableSharedTypedArrayIncludingDataView(lastSeenStructure->classInfoForCells()))

--- a/Source/JavaScriptCore/bytecode/ArrayProfile.h
+++ b/Source/JavaScriptCore/bytecode/ArrayProfile.h
@@ -209,6 +209,7 @@ enum class ArrayProfileFlag : uint32_t {
     UsesNonOriginalArrayStructures = 1 << 4,
     MayBeResizableOrGrowableSharedTypedArray = 1 << 5,
     DidPerformFirstRunPruning = 1 << 6,
+    MayBeRegExpMatchesArray = 1 << 7,
 };
 
 class ArrayProfile {
@@ -258,6 +259,8 @@ public:
     bool outOfBounds(const ConcurrentJSLocker&) const { return m_arrayProfileFlags.contains(ArrayProfileFlag::OutOfBounds); }
     
     bool usesOriginalArrayStructures(const ConcurrentJSLocker&) const { return !m_arrayProfileFlags.contains(ArrayProfileFlag::UsesNonOriginalArrayStructures); }
+
+    bool mayBeRegExpMatchesArray(const ConcurrentJSLocker&) const { return m_arrayProfileFlags.contains(ArrayProfileFlag::MayBeRegExpMatchesArray); }
 
     CString briefDescription(CodeBlock*);
     CString briefDescriptionWithoutUpdating();

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -1098,6 +1098,16 @@ private:
         return ArrayMode::fromObserved(locker, &profile, action, makeSafe);
     }
 
+    bool profiledArrayMayBeRegExpMatchesArray()
+    {
+        CodeBlock* codeBlock = m_inlineStackTop->m_profiledBlock;
+        ConcurrentJSLocker locker(codeBlock->m_lock);
+        ArrayProfile* profile = codeBlock->getArrayProfile(locker, codeBlock->bytecodeIndex(m_currentInstruction));
+        if (!profile)
+            return false;
+        return profile->mayBeRegExpMatchesArray(locker);
+    }
+
     Node* makeSafe(Node* node)
     {
         if (m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, Overflow))
@@ -2990,8 +3000,17 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
             if (!arrayMode.isJSArray())
                 return CallOptimizationResult::DidNothing;
 
-            if (!arrayMode.isJSArrayWithOriginalStructure())
-                return CallOptimizationResult::DidNothing;
+            if (!arrayMode.isJSArrayWithOriginalStructure()) {
+                if (arrayMode.type() != Array::Contiguous)
+                    return CallOptimizationResult::DidNothing;
+                if (!profiledArrayMayBeRegExpMatchesArray())
+                    return CallOptimizationResult::DidNothing;
+                JSGlobalObject* globalObject = m_graph.globalObjectFor(currentNodeOrigin().semantic);
+                if (!globalObject->havingABadTimeWatchpointSet().isStillValid())
+                    return CallOptimizationResult::DidNothing;
+                if (globalObject->regExpMatchesArrayStructure()->indexingType() != ArrayWithContiguous || globalObject->regExpMatchesArrayWithIndicesStructure()->indexingType() != ArrayWithContiguous)
+                    return CallOptimizationResult::DidNothing;
+            }
 
             // We do not want to convert arrays into one type just to perform indexOf.
             if (arrayMode.doesConversion())
@@ -3010,6 +3029,14 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
                     insertChecks();
 
                     Node* array = get(virtualRegisterForArgumentIncludingThis(0, registerOffset));
+                    if (!arrayMode.isJSArrayWithOriginalStructure()) {
+                        // The guards above ensure that we get here with a non-original structure only when speculating that the array is a RegExp matches array.
+                        m_graph.watchpoints().addLazily(globalObject->havingABadTimeWatchpointSet());
+                        StructureSet structureSet;
+                        structureSet.add(globalObject->regExpMatchesArrayStructure());
+                        structureSet.add(globalObject->regExpMatchesArrayWithIndicesStructure());
+                        addToGraph(CheckStructure, OpInfo(m_graph.addStructureSet(structureSet)), array);
+                    }
                     addVarArgChild(array);
                     addVarArgChild(get(virtualRegisterForArgumentIncludingThis(1, registerOffset))); // Search element.
                     if (argumentCountIncludingThis >= 3)


### PR DESCRIPTION
#### 1d97334bd2adc29eeb83cd1e268bdb22af458ad3
<pre>
[JSC] DFG should use the `ArrayIndexOf` / `ArrayIncludes` intrinsic for RegExp matches arrays
<a href="https://bugs.webkit.org/show_bug.cgi?id=319351">https://bugs.webkit.org/show_bug.cgi?id=319351</a>

Reviewed by Yusuke Suzuki.

RegExp matches arrays have non-original structures (they carry the index,
input, and groups property transitions), so the ArrayIndexOf/ArrayIncludes
intrinsic was rejected and every call went through the generic host function.
Since their prototype is still the original Array.prototype, we can use the
intrinsic by checking the structure against the matches array structures and
watching for having-a-bad-time, which replaces those structures with SlowPut
variants. The speculation is driven by a new ArrayProfile flag recorded when
profiling observes a matches array structure. Routers scanning the matches
array of a combined route regexp (e.g. Hono&apos;s RegExpRouter) hit this on every
request.

                                                    baseline                  patched

regexp-matches-array-index-of                 17.6912+-1.4997     ^     13.2829+-0.4919        ^ definitely 1.3319x faster
regexp-matches-array-includes                 22.3299+-1.0463     ^     16.6826+-0.3012        ^ definitely 1.3385x faster

Tests: JSTests/microbenchmarks/regexp-matches-array-includes.js
       JSTests/microbenchmarks/regexp-matches-array-index-of.js
       JSTests/stress/regexp-matches-array-index-of-have-a-bad-time.js
       JSTests/stress/regexp-matches-array-index-of-mixed.js
       JSTests/stress/regexp-matches-array-index-of-mutated.js
       JSTests/stress/regexp-matches-array-index-of-with-indices.js
       JSTests/stress/regexp-matches-array-index-of.js

* JSTests/microbenchmarks/regexp-matches-array-includes.js: Added.
(test):
* JSTests/microbenchmarks/regexp-matches-array-index-of.js: Added.
(test):
* JSTests/stress/regexp-matches-array-index-of-have-a-bad-time.js: Added.
(shouldBe):
(indexOfValue):
* JSTests/stress/regexp-matches-array-index-of-mixed.js: Added.
(shouldBe):
(indexOfValue):
* JSTests/stress/regexp-matches-array-index-of-mutated.js: Added.
(shouldBe):
(indexOfValue):
* JSTests/stress/regexp-matches-array-index-of-with-indices.js: Added.
(shouldBe):
(indexOfValue):
(includesValue):
* JSTests/stress/regexp-matches-array-index-of.js: Added.
(shouldBe):
(indexOfEmpty):
(indexOfValue):
(indexOfUndefined):
(indexOfNegativeFrom):
(includesEmpty):
(includesValue):
(indexOfOnNamed):
* Source/JavaScriptCore/bytecode/ArrayProfile.cpp:
(JSC::ArrayProfile::computeUpdatedPrediction):
* Source/JavaScriptCore/bytecode/ArrayProfile.h:
(JSC::ArrayProfile::mayBeRegExpMatchesArray const):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::profiledArrayMayBeRegExpMatchesArray):
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):

Canonical link: <a href="https://commits.webkit.org/317466@main">https://commits.webkit.org/317466@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c321310e3c96f93aa2e37f506556e0304cf54b1c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174406 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48339 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42120 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183983 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132274 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49631 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48021 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135673 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95727 "3 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177364 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39108 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156467 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116151 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37749 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36117 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32464 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/4976 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148172 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35959 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186409 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/35668 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39623 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40314 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144586 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48006 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144444 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39144 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48685 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32579 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114238 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39344 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120633 "Found 1060 new failures in b3/B3Value.h, b3/testb3_7.cpp, WebProcess/Network/WebResourceLoader.cpp, jit/OperationResult.h, UIProcess/WebProcessPool.cpp, testing/MockMediaSessionCoordinator.cpp, Shared/Cocoa/WKNSArray.mm, heap/WeakSet.h, API/tests/Regress141275.mm, wasm/WasmConstExprGenerator.cpp ...") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/211441 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47192 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10923 "") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55095 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46594 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46825 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46652 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->