### PR TITLE
[CMake] Fix build against recent internal SDKs

### DIFF
--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -868,6 +868,7 @@ if (ENABLE_BACK_FORWARD_LIST_SWIFT)
     requires cplusplus
     header \"${WebCore_PRIVATE_HEADERS_DIR}/DiagnosticLoggingKeys.h\"
     header \"${WebCore_PRIVATE_HEADERS_DIR}/DiagnosticLoggingClient.h\"
+    header \"${WebCore_PRIVATE_HEADERS_DIR}/TextGranularity.h\"
     export *
 }
 ")

--- a/Source/WebKit/Headers.cmake
+++ b/Source/WebKit/Headers.cmake
@@ -541,6 +541,7 @@ endif ()
 set(WebKit_PROJECT_HEADERS
     GPUProcess/graphics/Model/Float3.h
     GPUProcess/graphics/Model/Float4x4.h
+    GPUProcess/graphics/Model/ModelTypes.h
 
     Shared/mac/SecItemRequestData.h
 

--- a/Source/WebKit/PlatformMac.cmake
+++ b/Source/WebKit/PlatformMac.cmake
@@ -49,6 +49,11 @@ list(APPEND WebKit_SOURCES
     ${WEBKIT_DIR}/Platform/cocoa/WKMaterialHostingSupport.swift
     ${WEBKIT_DIR}/Shared/Model/WKStageModeOrbitSimulator.swift
     ${WEBKIT_DIR}/UIProcess/Cocoa/WKDeferringGestureRecognizer.swift
+    ${WEBKIT_DIR}/Platform/cocoa/FloatRectCG.swift
+    ${WEBKIT_DIR}/Platform/cocoa/IntRectCG.swift
+    ${WEBKIT_DIR}/UIProcess/API/Cocoa/Logger+Extras.swift
+    ${WEBKIT_DIR}/UIProcess/WebPageProxy.swift
+    ${WEBKIT_DIR}/UIProcess/mac/WKAppKitGestureController.swift
     ${WEBKIT_DIR}/UIProcess/mac/WKTextSelectionController.swift
     ${WEBKIT_DIR}/UIProcess/PDF/WKPDFHUDView.swift
 

--- a/Source/cmake/OptionsCocoa.cmake
+++ b/Source/cmake/OptionsCocoa.cmake
@@ -85,7 +85,7 @@ if (NOT USE_APPLE_INTERNAL_SDK)
     unset(_availability_overlay_yaml)
 endif ()
 
-if (EXISTS "/usr/local/include/WebKitAdditions" AND NOT EXISTS "/usr/local/include/AppleFeatures/AppleFeatures.h")
+if (NOT USE_APPLE_INTERNAL_SDK AND EXISTS "/usr/local/include/WebKitAdditions" AND NOT EXISTS "/usr/local/include/AppleFeatures/AppleFeatures.h")
     set(_apple_features_stub "${CMAKE_BINARY_DIR}/generated-stubs/AppleFeatures")
     file(MAKE_DIRECTORY "${_apple_features_stub}")
     file(CONFIGURE OUTPUT "${_apple_features_stub}/AppleFeatures.h" CONTENT


### PR DESCRIPTION
#### 4bcd765a466aeee9a3830da26916479348d26fb4
<pre>
[CMake] Fix build against recent internal SDKs
<a href="https://bugs.webkit.org/show_bug.cgi?id=319352">https://bugs.webkit.org/show_bug.cgi?id=319352</a>
<a href="https://rdar.apple.com/182164452">rdar://182164452</a>

Reviewed by Elliott Williams.

Four independent build breaks surface when building the Mac CMake port
against the internal macOS 27 SDK, where WebKitAdditions turns on feature
flags that the CMake build wasn&apos;t fully wired up for:

- OptionsCocoa.cmake: the empty AppleFeatures.h stub was placed on -isystem
  for internal-SDK builds too, shadowing the SDK&apos;s real header and tripping
  #warning-as-error in MediaExperience&apos;s MXFeatureFlags.h. Guard the stub with
  NOT USE_APPLE_INTERNAL_SDK, matching the sibling availability-overlay block.

- Headers.cmake: add GPUProcess/graphics/Model/ModelTypes.h to
  WebKit_PROJECT_HEADERS so &lt;WebKit/ModelTypes.h&gt; resolves via the header map,
  alongside its already-listed siblings Float3.h and Float4x4.h.

- CMakeLists.txt: expose TextGranularity.h through the WebCore_Private Swift
  module map so WKTextSelectionController.swift can name WebCore.TextGranularity.

- PlatformMac.cmake: add the companion Swift files of the AppKit-gestures unit
  (WebPageProxy.swift, Logger+Extras.swift, WKAppKitGestureController.swift,
  IntRectCG.swift, FloatRectCG.swift). WKTextSelectionController.swift was added
  without them, so the WebKit.swiftmodule emit-module failed on missing members.

* Source/WebKit/CMakeLists.txt:
* Source/WebKit/Headers.cmake:
* Source/WebKit/PlatformMac.cmake:
* Source/cmake/OptionsCocoa.cmake:

Canonical link: <a href="https://commits.webkit.org/317128@main">https://commits.webkit.org/317128@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c295bbcbb89fd076c3095dc2924e843f0146c974

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174410 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48343 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42124 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183987 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/132278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5f2c7a5d-012d-4a45-8425-ed32cce3b956) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49635 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48025 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/135674 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/132278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b9a4b7a7-1dc9-49c3-9d39-a3a708238735) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177368 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39110 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/156469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116152 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/13d7d8e5-0c00-4b1a-a4a2-b13ff8460685) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/37751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32468 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/4978 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/148174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35961 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186413 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/35672 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/39629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/144587 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48010 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144445 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38934 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48689 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114243 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39346 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/120640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/211445 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47196 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10925 "") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55098 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46598 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46829 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46656 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->