### PR TITLE
Web Inspector: Table._isRowVisible off-by-one and showColumn throws when the shown column is the only visible column

### DIFF
--- a/LayoutTests/inspector/table/table-column-and-row-boundaries-expected.txt
+++ b/LayoutTests/inspector/table/table-column-and-row-boundaries-expected.txt
@@ -1,0 +1,15 @@
+Tests Table row-visibility boundary checks and showing a column into an empty visible column set.
+
+
+== Running test suite: Table.ColumnAndRowBoundaries
+-- Running test case: Table.IsRowVisible.ExclusiveEnd
+PASS: Row just before the start should not be visible.
+PASS: First rendered row should be visible.
+PASS: Last rendered row should be visible.
+PASS: End index is exclusive, so row 20 should not be visible.
+
+-- Running test case: Table.ShowColumn.IntoEmptyVisibleSet
+PASS: No columns should be visible.
+PASS: The shown column should no longer be hidden.
+PASS: Only the shown column should be visible.
+

--- a/LayoutTests/inspector/table/table-column-and-row-boundaries.html
+++ b/LayoutTests/inspector/table/table-column-and-row-boundaries.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script src="resources/table-utilities.js"></script>
+<script>
+function test()
+{
+    InspectorTest.redirectRequestAnimationFrame();
+
+    let suite = InspectorTest.createSyncSuite("Table.ColumnAndRowBoundaries");
+
+    suite.addTestCase({
+        name: "Table.IsRowVisible.ExclusiveEnd",
+        description: "_isRowVisible should treat _visibleRowIndexEnd as an exclusive bound (the end index is not rendered).",
+        test() {
+            let table = InspectorTest.createTable(100);
+
+            // Simulate a strict visible window: rows [10, 20) are rendered, row 20 is not.
+            table._previousRevealedRowCount = 100;
+            table._visibleRowIndexStart = 10;
+            table._visibleRowIndexEnd = 20;
+
+            InspectorTest.expectFalse(table._isRowVisible(9), "Row just before the start should not be visible.");
+            InspectorTest.expectTrue(table._isRowVisible(10), "First rendered row should be visible.");
+            InspectorTest.expectTrue(table._isRowVisible(19), "Last rendered row should be visible.");
+            InspectorTest.expectFalse(table._isRowVisible(20), "End index is exclusive, so row 20 should not be visible.");
+
+            return true;
+        }
+    });
+
+    suite.addTestCase({
+        name: "Table.ShowColumn.IntoEmptyVisibleSet",
+        description: "showColumn should not throw when the shown column becomes the only visible column.",
+        test() {
+            let table = InspectorTest.createTable(10);
+
+            let indexColumn = table.columnWithIdentifier("index");
+            let nameColumn = table.columnWithIdentifier("name");
+
+            // Hide every column so the visible set is empty.
+            table.hideColumn(indexColumn);
+            table.hideColumn(nameColumn);
+            InspectorTest.expectShallowEqual(table.columns.filter((column) => !column.hidden).map((column) => column.identifier), [], "No columns should be visible.");
+
+            // Showing a column that is not first in column order previously dereferenced
+            // _visibleColumns[0] on an empty array and threw.
+            table.showColumn(nameColumn);
+
+            InspectorTest.expectFalse(nameColumn.hidden, "The shown column should no longer be hidden.");
+            InspectorTest.expectShallowEqual(table.columns.filter((column) => !column.hidden).map((column) => column.identifier), ["name"], "Only the shown column should be visible.");
+
+            return true;
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onLoad="runTest()">
+    <p>Tests Table row-visibility boundary checks and showing a column into an empty visible column set.</p>
+</body>
+</html>

--- a/Source/WebInspectorUI/UserInterface/Views/Table.js
+++ b/Source/WebInspectorUI/UserInterface/Views/Table.js
@@ -1303,7 +1303,7 @@ WI.Table = class Table extends WI.View
         if (!this._previousRevealedRowCount)
             return false;
 
-        return rowIndex >= this._visibleRowIndexStart && rowIndex <= this._visibleRowIndexEnd;
+        return rowIndex >= this._visibleRowIndexStart && rowIndex < this._visibleRowIndexEnd;
     }
 
     _indexToInsertColumn(column)
@@ -1313,7 +1313,7 @@ WI.Table = class Table extends WI.View
         for (let columnIdentifier of this._columnOrder) {
             if (columnIdentifier === column.identifier)
                 return currentVisibleColumnIndex;
-            if (columnIdentifier === this._visibleColumns[currentVisibleColumnIndex].identifier) {
+            if (currentVisibleColumnIndex < this._visibleColumns.length && columnIdentifier === this._visibleColumns[currentVisibleColumnIndex].identifier) {
                 currentVisibleColumnIndex++;
                 if (currentVisibleColumnIndex >= this._visibleColumns.length)
                     break;


### PR DESCRIPTION
#### 5e9140c0c7ed63b49ac8cbbee2ee8f392adf024c
<pre>
Web Inspector: Table._isRowVisible off-by-one and showColumn throws when the shown column is the only visible column
<a href="https://bugs.webkit.org/show_bug.cgi?id=319353">https://bugs.webkit.org/show_bug.cgi?id=319353</a>
<a href="https://rdar.apple.com/182164511">rdar://182164511</a>

Reviewed by Devin Rousso.

Two boundary bugs in Table:

- `_isRowVisible` compared against `_visibleRowIndexEnd` with `&lt;=`, but that
  index is an exclusive bound everywhere else (rows are created only for
  `i &lt; _visibleRowIndexEnd`), so it reported one non-rendered row as visible.
  `cellForRowAndColumn` would then pass the visibility gate and return a cache
  miss (or a stale row). Use `&lt;`.

- `_indexToInsertColumn` dereferenced `_visibleColumns[currentVisibleColumnIndex]`
  without a bounds check. `showColumn` calls it before inserting the column, so
  when the shown column is about to become the only visible one (empty
  `_visibleColumns`) and it isn&apos;t first in `_columnOrder`, the deref threw
  `undefined is not an object`. Guard the index against `_visibleColumns.length`.

* Source/WebInspectorUI/UserInterface/Views/Table.js:
(WI.Table.prototype._isRowVisible):
(WI.Table.prototype._indexToInsertColumn):
* LayoutTests/inspector/table/table-column-and-row-boundaries-expected.txt: Added.
* LayoutTests/inspector/table/table-column-and-row-boundaries.html: Added.

Canonical link: <a href="https://commits.webkit.org/317154@main">https://commits.webkit.org/317154@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/53982077cca7a95c543473a5dabd832dbf81b32c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174414 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48347 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42128 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183991 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132282 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49639 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48029 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135678 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/eea28fcd-85aa-4156-a806-9870b718f71c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177372 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39113 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156481 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116156 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37754 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32472 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148177 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35973 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186417 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39634 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40318 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144591 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48014 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156035 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144449 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38953 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48693 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32593 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114247 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39349 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120645 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47200 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10937 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46602 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46833 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46660 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->