### PR TITLE
fix opensource build on macOS 27 public beta with Xcode 27 beta

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView+RefreshControl.swift
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView+RefreshControl.swift
@@ -26,16 +26,15 @@
 #if HAVE_NSREFRESHCONTROLLER
 
 import Foundation
-@_spi(RefreshControl) public import AppKit
 #if canImport(WebKit_Internal)
 internal import WebKit_Internal
 #endif
 
-@_spi(_)
-extension WKWebView: AppKit.NSRefreshControlHosting {
+@objc(NSRefreshControlHosting)
+@implementation
+extension WKWebView {
     // Protocol conformance.
-    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
-    public func apply(verticalInset: CGFloat, animated: Bool, completion: (@Sendable @convention(block) () -> Void)?) {
+    func apply(withVerticalInset verticalInset: CGFloat, animated: Bool, completion: (@Sendable () -> Void)?) {
         defer {
             completion?()
         }
@@ -48,8 +47,7 @@ extension WKWebView: AppKit.NSRefreshControlHosting {
     }
 
     // Protocol conformance.
-    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
-    public func remove(verticalInset: CGFloat, animated: Bool, completion: (@Sendable @convention(block) () -> Void)?) {
+    func remove(withVerticalInset verticalInset: CGFloat, animated: Bool, completion: (@Sendable () -> Void)?) {
         defer {
             completion?()
         }
@@ -62,15 +60,13 @@ extension WKWebView: AppKit.NSRefreshControlHosting {
     }
 
     // Protocol conformance.
-    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     @objc(refreshControlVisibleHeight)
-    public var refreshControlVisibleHeight: CGFloat {
+    var refreshControlVisibleHeight: CGFloat {
         _refreshControlVisibleHeight
     }
 
     // Protocol conformance.
-    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
-    public var refreshControlHostBounds: NSRect {
+    var refreshControlHostBounds: NSRect {
         let insets = _obscuredContentInsets
         return NSRect(
             x: bounds.origin.x + insets.left,

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -31,6 +31,10 @@
 #import <WebKit/_WKTextExtraction.h>
 #import <pal/spi/cocoa/WritingToolsSPI.h>
 
+#if PLATFORM(MAC)
+#import "AppKitSPI.h"
+#endif
+
 #if !__has_feature(modules) || (defined(WK_SUPPORTS_SWIFT_OBJCXX_INTEROP) && WK_SUPPORTS_SWIFT_OBJCXX_INTEROP)
 
 #import "IdentifierTypes.h"
@@ -772,6 +776,20 @@ struct LiveResizeSnapshotState {
 - (BOOL)_scrollPocketInFullscreenEnabled;
 
 @end
+
+#if PLATFORM(MAC) && HAVE(NSREFRESHCONTROLLER)
+
+NS_SWIFT_UI_ACTOR
+@interface WKWebView (NSRefreshControlHosting) <NSRefreshControlHosting>
+
+- (void)applyWithVerticalInset:(CGFloat)verticalInset animated:(BOOL)animated completion:(NS_SWIFT_SENDABLE void (^ _Nullable)(void))completion;
+- (void)removeWithVerticalInset:(CGFloat)verticalInset animated:(BOOL)animated completion:(NS_SWIFT_SENDABLE void (^ _Nullable)(void))completion;
+@property (nonatomic, readonly) CGFloat refreshControlVisibleHeight;
+@property (nonatomic, readonly) NSRect refreshControlHostBounds;
+
+@end
+
+#endif // PLATFORM(MAC) && HAVE(NSREFRESHCONTROLLER)
 
 @interface WKWebView (WKTextExtraction)
 


### PR DESCRIPTION
#### 8eeeb9c6b962eb3405ceada57010fbde9e9ae9da
<pre>
fix opensource build on macOS 27 public beta with Xcode 27 beta
<a href="https://bugs.webkit.org/show_bug.cgi?id=319354">https://bugs.webkit.org/show_bug.cgi?id=319354</a>

Reviewed by NOBODY (OOPS!).

`NSRefreshControlHosting` is only exposed as AppKit SPI, so `AppKit.NSRefreshControlHosting` cannot be found when building with the public SDK.

We can&apos;t add a `AppKit_SPI.swiftinterface` (which makes the protocol available when building `WebKit`) as that would also have to be a required dependency of the `WebKit` Swift module, causing it to fail when importing `WebKit` because it cannot find that handwritten module.

Moving the implementation to `WebKitSwift` avoids that dependency, but requires a retroactive conformance, which is disallowed by style guide.

Instead, declare the conformance in Objective-C and implement it in Swift so it can remain in `WebKit` without adding an `AppKit_SPI` dependency.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView+RefreshControl.swift:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8eeeb9c6b962eb3405ceada57010fbde9e9ae9da

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175064 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48997 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42778 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184649 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132972 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50289 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48680 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136255 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96120 "2 flakes 5 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178022 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39694 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157045 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116733 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38335 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36720 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33122 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148758 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36537 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187070 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/40716 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40923 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145202 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48664 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145058 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49344 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33158 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115170 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39913 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121565 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47850 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11510 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47253 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47483 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47310 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->