### PR TITLE
Address BoxModelDetailsSectionRow review feedback

### DIFF
--- a/LayoutTests/inspector/view/box-model-details-section-row-large-values-expected.txt
+++ b/LayoutTests/inspector/view/box-model-details-section-row-large-values-expected.txt
@@ -7,3 +7,9 @@ PASS: The tooltip should preserve the exact computed value.
 -- Running test case: BoxModelDetailsSectionRow.RegularBorderRadius
 PASS: A regular fractional value should retain the existing rounding behavior.
 PASS: The tooltip should preserve the unrounded value.
+-- Running test case: BoxModelDetailsSectionRow.LargeFractionalBorderRadius
+PASS: A large fractional value should drop insignificant decimal precision.
+PASS: The tooltip should preserve the exact fractional value.
+-- Running test case: BoxModelDetailsSectionRow.MaximumLengthBorderRadius
+PASS: A value at the maximum length should remain unchanged.
+PASS: An unchanged value should not need a tooltip.

--- a/LayoutTests/inspector/view/box-model-details-section-row-large-values-expected.txt
+++ b/LayoutTests/inspector/view/box-model-details-section-row-large-values-expected.txt
@@ -1,0 +1,9 @@
+Testing compact display of large values in BoxModelDetailsSectionRow.
+
+== Running test suite: BoxModelDetailsSectionRow.LargeValues
+-- Running test case: BoxModelDetailsSectionRow.LargeBorderRadius
+PASS: A large value should use compact scientific notation.
+PASS: The tooltip should preserve the exact computed value.
+-- Running test case: BoxModelDetailsSectionRow.RegularBorderRadius
+PASS: A regular fractional value should retain the existing rounding behavior.
+PASS: The tooltip should preserve the unrounded value.

--- a/LayoutTests/inspector/view/box-model-details-section-row-large-values.html
+++ b/LayoutTests/inspector/view/box-model-details-section-row-large-values.html
@@ -1,0 +1,79 @@
+<!doctype html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+function test()
+{
+    const hugeBorderRadius = "340282001837565597733306976381245063168";
+
+    function createComputedStyle(borderRadius)
+    {
+        let values = new Map([
+            ["display", "block"],
+            ["position", "static"],
+            ["box-sizing", "content-box"],
+            ["width", "100px"],
+            ["height", "100px"],
+        ]);
+
+        for (let side of ["top", "right", "bottom", "left"]) {
+            values.set(`padding-${side}`, "0px");
+            values.set(`border-${side}-width`, "0px");
+            values.set(`margin-${side}`, "0px");
+        }
+
+        for (let corner of ["top-left", "top-right", "bottom-right", "bottom-left"])
+            values.set(`border-${corner}-radius`, corner === "top-left" ? `${borderRadius}px` : "0px");
+
+        return {
+            enabledProperties: [{}],
+            propertyForName(name) {
+                let value = values.get(name);
+                return value === undefined ? null : {value};
+            },
+        };
+    }
+
+    function createRow(borderRadius)
+    {
+        let row = new WI.BoxModelDetailsSectionRow;
+        row._nodeStyles = {computedStyle: createComputedStyle(borderRadius)};
+        row._updateMetrics();
+        return row;
+    }
+
+    let suite = InspectorTest.createSyncSuite("BoxModelDetailsSectionRow.LargeValues");
+
+    suite.addTestCase({
+        name: "BoxModelDetailsSectionRow.LargeBorderRadius",
+        test() {
+            let row = createRow(hugeBorderRadius);
+            let valueElement = row.element.querySelector(".box.border > .top-left");
+
+            InspectorTest.expectEqual(valueElement.textContent, "~3.4e+38", "A large value should use compact scientific notation.");
+            InspectorTest.expectEqual(valueElement.title, hugeBorderRadius, "The tooltip should preserve the exact computed value.");
+            return true;
+        },
+    });
+
+    suite.addTestCase({
+        name: "BoxModelDetailsSectionRow.RegularBorderRadius",
+        test() {
+            let row = createRow("12.3456");
+            let valueElement = row.element.querySelector(".box.border > .top-left");
+
+            InspectorTest.expectEqual(valueElement.textContent, "~12.35", "A regular fractional value should retain the existing rounding behavior.");
+            InspectorTest.expectEqual(valueElement.title, "12.3456", "The tooltip should preserve the unrounded value.");
+            return true;
+        },
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Testing compact display of large values in BoxModelDetailsSectionRow.</p>
+</body>
+</html>

--- a/LayoutTests/inspector/view/box-model-details-section-row-large-values.html
+++ b/LayoutTests/inspector/view/box-model-details-section-row-large-values.html
@@ -69,6 +69,50 @@ function test()
         },
     });
 
+    suite.addTestCase({
+        name: "BoxModelDetailsSectionRow.LargeFractionalBorderRadius",
+        test() {
+            let row = createRow("10000.42");
+            let valueElement = row.element.querySelector(".box.border > .top-left");
+
+            InspectorTest.expectEqual(
+                valueElement.textContent,
+                "~10000",
+                "A large fractional value should drop insignificant decimal precision."
+            );
+
+            InspectorTest.expectEqual(
+                valueElement.title,
+                "10000.42",
+                "The tooltip should preserve the exact fractional value."
+            );
+
+            return true;
+        },
+    });
+
+    suite.addTestCase({
+        name: "BoxModelDetailsSectionRow.MaximumLengthBorderRadius",
+        test() {
+            let row = createRow("12345678");
+            let valueElement = row.element.querySelector(".box.border > .top-left");
+
+            InspectorTest.expectEqual(
+                valueElement.textContent,
+                "12345678",
+                "A value at the maximum length should remain unchanged."
+            );
+
+            InspectorTest.expectEqual(
+                valueElement.title,
+                "",
+                "An unchanged value should not need a tooltip."
+            );
+
+            return true;
+        },
+    });
+
     suite.runTestCasesAndFinish();
 }
 </script>

--- a/Source/WebInspectorUI/UserInterface/Test.html
+++ b/Source/WebInspectorUI/UserInterface/Test.html
@@ -309,6 +309,8 @@
     <script src="Views/TableColumn.js"></script>
     <script src="Views/TreeElement.js"></script>
     <script src="Views/TreeOutline.js"></script>
+    <script src="Views/DetailsSectionRow.js"></script>
+    <script src="Views/BoxModelDetailsSectionRow.js"></script>
 
     <script src="Debug/DOMManager.js"></script>
 

--- a/Source/WebInspectorUI/UserInterface/Views/BoxModelDetailsSectionRow.css
+++ b/Source/WebInspectorUI/UserInterface/Views/BoxModelDetailsSectionRow.css
@@ -74,6 +74,20 @@
     margin-inline-start: 20px;
 }
 
+.details-section .row.box-model .box.border:is(.has-top-left-radius, .has-top-right-radius) {
+    padding-block-start: calc(3px + 1.5em);
+}
+
+.details-section .row.box-model .box.border:is(.has-top-left-radius, .has-top-right-radius) > .label {
+    inset-block-start: 3px;
+    inset-inline-start: 4px;
+    margin-inline-start: 0;
+}
+
+.details-section .row.box-model .box.border:is(.has-top-left-radius, .has-top-right-radius) > :is(.top-left, .top, .top-right) {
+    inset-block-start: calc(3px + 1.5em);
+}
+
 .details-section .row.box-model .box.border.has-top-left-radius,
 .details-section .row.box-model .box.border.has-top-left-radius .box {
     border-top-left-radius: var(--has-border-radius-border-radius);

--- a/Source/WebInspectorUI/UserInterface/Views/BoxModelDetailsSectionRow.js
+++ b/Source/WebInspectorUI/UserInterface/Views/BoxModelDetailsSectionRow.js
@@ -155,17 +155,31 @@ WI.BoxModelDetailsSectionRow = class BoxModelDetailsSectionRow extends WI.Detail
 
         function createValueElement(type, value, name, propertyName)
         {
-            // Check if the value is a float and whether it should be rounded.
-            let floatValue = parseFloat(value);
-            let shouldRoundValue = !isNaN(floatValue) && (floatValue % 1 !== 0);
+            const maximumValueLength = 10;
 
-            if (isNaN(floatValue))
-                value = figureDash;
+            let originalValue = String(value);
+            let floatValue = parseFloat(originalValue);
+            let displayValue = figureDash;
+
+            if (!isNaN(floatValue)) {
+                displayValue = originalValue;
+
+                // Round fractional values to two decimal places.
+                if (floatValue % 1 !== 0)
+                    displayValue = "~" + Math.round(floatValue * 100) / 100;
+
+                // Large computed values can contain dozens of digits and break the box model preview.
+                // Keep the exact value available through the tooltip and while editing.
+                if (displayValue.length > maximumValueLength) {
+                    let exponentialValue = floatValue.toExponential(1).replace(/\.0e/, "e");
+                    displayValue = "~" + exponentialValue;
+                }
+            }
 
             let element = document.createElement(type);
-            element.textContent = shouldRoundValue ? ("~" + Math.round(floatValue * 100) / 100) : value;
-            if (shouldRoundValue)
-                element.title = value;
+            element.textContent = displayValue;
+            if (displayValue !== originalValue && displayValue !== figureDash)
+                element.title = originalValue;
             element.addEventListener("dblclick", this._startEditing.bind(this, element, name, propertyName, style), false);
             return element;
         }

--- a/Source/WebInspectorUI/UserInterface/Views/BoxModelDetailsSectionRow.js
+++ b/Source/WebInspectorUI/UserInterface/Views/BoxModelDetailsSectionRow.js
@@ -155,35 +155,38 @@ WI.BoxModelDetailsSectionRow = class BoxModelDetailsSectionRow extends WI.Detail
 
         function createValueElement(type, value, name, propertyName)
         {
-            const maximumValueLength = 10;
+            const maximumValueLength = 8;
 
-            let originalValue = String(value);
-            let floatValue = parseFloat(originalValue);
+            let floatValue = parseFloat(value);
             let displayValue = figureDash;
 
             if (!isNaN(floatValue)) {
-                displayValue = originalValue;
+                displayValue = value;
 
-                // Round fractional values to two decimal places.
                 if (floatValue % 1 !== 0)
-                    displayValue = "~" + Math.round(floatValue * 100) / 100;
+                    displayValue = "~" + floatValue.maxDecimals(2);
 
-                // Large computed values can contain dozens of digits and break the box model preview.
-                // Keep the exact value available through the tooltip and while editing.
-                if (displayValue.length > maximumValueLength) {
-                    let exponentialValue = floatValue.toExponential(1).replace(/\.0e/, "e");
-                    displayValue = "~" + exponentialValue;
+                if (String(displayValue).length > maximumValueLength) {
+                    let integerValue = "~" + floatValue.maxDecimals(0);
+
+                    if (integerValue.length <= maximumValueLength)
+                        displayValue = integerValue;
+                    else {
+                        let exponentialValue = "~" + floatValue.toExponential(1);
+                        displayValue = exponentialValue.length < integerValue.length ? exponentialValue : integerValue;
+                    }
                 }
             }
 
             let element = document.createElement(type);
             element.textContent = displayValue;
-            if (displayValue !== originalValue && displayValue !== figureDash)
-                element.title = originalValue;
+
+            if (displayValue !== value && displayValue !== figureDash)
+                element.title = value;
+
             element.addEventListener("dblclick", this._startEditing.bind(this, element, name, propertyName, style), false);
             return element;
         }
-
         function createBoxPartElement(name, side)
         {
             let prefix = this._getComponentPrefix(name);


### PR DESCRIPTION
#### e189b5655c6b90ce22c2f18ac511d39c5e809bfe
<pre>
Address BoxModelDetailsSectionRow review feedback

<a href="https://bugs.webkit.org/show_bug.cgi?id=311421">https://bugs.webkit.org/show_bug.cgi?id=311421</a>
</pre>
----------------------------------------------------------------------
#### 214be66f6a02150b7652e23541f2ddcdd6acfccc
<pre>
Web Inspector: Prevent large box model values from overflowing

<a href="https://bugs.webkit.org/show_bug.cgi?id=311421">https://bugs.webkit.org/show_bug.cgi?id=311421</a>

Reviewed by NOBODY (OOPS!).

Large computed CSS values could overflow the box model visualization.
Display overly long numeric values using a compact representation while
preserving the original value for tooltips and editing.

* LayoutTests/inspector/view/box-model-details-section-row-large-values-expected.txt: Added.
* LayoutTests/inspector/view/box-model-details-section-row-large-values.html: Added.
* Source/WebInspectorUI/UserInterface/Views/BoxModelDetailsSectionRow.js:
(createValueElement):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e189b5655c6b90ce22c2f18ac511d39c5e809bfe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175504 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49436 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43217 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185090 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/137650 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50728 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49119 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136649 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96202 "3 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178461 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40067 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157407 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117127 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38709 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37095 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149131 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36900 "Found 1 new test failure: inspector/view/box-model-details-section-row-large-values.html (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33565 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41123 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41298 "Found 1 new test failure: inspector/view/box-model-details-section-row-large-values.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187515 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49103 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156963 "Exiting early after 10 failures. 10 tests run. 1 failures") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145618 "Found 1 new test failure: inspector/view/box-model-details-section-row-large-values.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49783 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33524 "Found 1 new test failure: inspector/view/box-model-details-section-row-large-values.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145455 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40273 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121976 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/115731 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48290 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11876 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47692 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47922 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47749 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->