### PR TITLE
[iOS] Video continues playing on wireless device after navigating to a new webpage

### DIFF
--- a/LayoutTests/media/wireless-playback-media-player/route-disconnects-when-player-destroyed-expected.txt
+++ b/LayoutTests/media/wireless-playback-media-player/route-disconnects-when-player-destroyed-expected.txt
@@ -1,0 +1,13 @@
+
+Test that a MediaDeviceRoute is disconnected when the media player using it is destroyed.
+
+RUN(internals.mockMediaDeviceRouteController.activateRoute(route))
+RUN(video.src = findMediaFile('video', '../content/test'))
+RUN(video.play())
+RUN(route.ready = true)
+EVENT(canplaythrough)
+EXPECTED (route.connected == 'true') OK
+RUN(video.src = '')
+EXPECTED (route.connected == 'false') OK
+END OF TEST
+

--- a/LayoutTests/media/wireless-playback-media-player/route-disconnects-when-player-destroyed.html
+++ b/LayoutTests/media/wireless-playback-media-player/route-disconnects-when-player-destroyed.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html><!-- webkit-test-runner [ WirelessPlaybackMediaPlayerEnabled=true ] -->
+<html>
+    <head>
+        <script src='../media-file.js'></script>
+        <script src='../video-test.js'></script>
+        <script>
+            var route;
+            var video;
+
+            async function start()
+            {
+                if (window.internals)
+                    internals.mockMediaDeviceRouteController.enabled = true;
+
+                route = internals.mockMediaDeviceRouteController.createMockMediaDeviceRoute();
+                run(`internals.mockMediaDeviceRouteController.activateRoute(route)`);
+
+                const urlPromise = new Promise((resolve) => {
+                    route.setURLCallback(async (url) => {
+                        resolve(url);
+                    });
+                });
+
+                video = document.getElementsByTagName('video')[0];
+                run(`video.src = findMediaFile('video', '../content/test')`);
+                run(`video.play()`);
+                await urlPromise;
+
+                const canplaythroughPromise = waitFor(video, 'canplaythrough');
+                run(`route.ready = true`);
+                await canplaythroughPromise;
+
+                await waitForConditionOrTimeout('route.connected', true);
+                testExpected(`route.connected`, true);
+
+                run(`video.src = ''`);
+                await waitForConditionOrTimeout('!route.connected', true);
+                testExpected(`route.connected`, false);
+
+                endTest();
+            }
+        </script>
+    </head>
+    <body onload='start()'>
+        <video controls></video>
+        <p>Test that a MediaDeviceRoute is disconnected when the media player using it is destroyed.</p>
+    </body>
+</html>

--- a/LayoutTests/media/wireless-playback-media-player/route-reconnects-after-reload-expected.txt
+++ b/LayoutTests/media/wireless-playback-media-player/route-reconnects-after-reload-expected.txt
@@ -1,0 +1,13 @@
+
+Test that a MediaDeviceRoute reconnects after the media element reloads.
+
+RUN(internals.mockMediaDeviceRouteController.activateRoute(route))
+RUN(video.src = findMediaFile('video', '../content/test'))
+RUN(video.play())
+RUN(route.ready = true)
+EVENT(canplaythrough)
+EXPECTED (route.connected == 'true') OK
+RUN(video.load())
+EXPECTED (route.connected == 'true') OK
+END OF TEST
+

--- a/LayoutTests/media/wireless-playback-media-player/route-reconnects-after-reload.html
+++ b/LayoutTests/media/wireless-playback-media-player/route-reconnects-after-reload.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html><!-- webkit-test-runner [ WirelessPlaybackMediaPlayerEnabled=true ] -->
+<html>
+    <head>
+        <script src='../media-file.js'></script>
+        <script src='../video-test.js'></script>
+        <script>
+            var route;
+            var video;
+
+            function nextURLCallback()
+            {
+                return new Promise((resolve) => {
+                    route.setURLCallback(async (url) => {
+                        resolve(url);
+                    });
+                });
+            }
+
+            async function start()
+            {
+                if (window.internals)
+                    internals.mockMediaDeviceRouteController.enabled = true;
+
+                route = internals.mockMediaDeviceRouteController.createMockMediaDeviceRoute();
+                run(`internals.mockMediaDeviceRouteController.activateRoute(route)`);
+
+                let urlPromise = nextURLCallback();
+
+                video = document.getElementsByTagName('video')[0];
+                run(`video.src = findMediaFile('video', '../content/test')`);
+                run(`video.play()`);
+                await urlPromise;
+
+                const canplaythroughPromise = waitFor(video, 'canplaythrough');
+                run(`route.ready = true`);
+                await canplaythroughPromise;
+
+                await waitForConditionOrTimeout('route.connected', true);
+                testExpected(`route.connected`, true);
+
+                // Reloading destroys the current media player (running its disconnect path) and
+                // creates a new one that loads the URL on the still-active route again. The route
+                // must reconnect, with no leaked observation from the destroyed player.
+                urlPromise = nextURLCallback();
+                run(`video.load()`);
+                await urlPromise;
+
+                await waitForConditionOrTimeout('route.connected', true);
+                testExpected(`route.connected`, true);
+
+                endTest();
+            }
+        </script>
+    </head>
+    <body onload='start()'>
+        <video controls></video>
+        <p>Test that a MediaDeviceRoute reconnects after the media element reloads.</p>
+    </body>
+</html>

--- a/Source/WebCore/platform/audio/ios/MediaDeviceRoute.h
+++ b/Source/WebCore/platform/audio/ios/MediaDeviceRoute.h
@@ -117,6 +117,7 @@ public:
     WebMediaDevicePlatformRoute *platformRoute() const;
 
     void loadURL(const URL&, CompletionHandler<void(const MediaDeviceRouteLoadURLResult&)>&&);
+    void disconnectFromSession();
 
     MediaTimeRange timeRange() const;
     bool ready() const;

--- a/Source/WebCore/platform/audio/ios/MediaDeviceRoute.mm
+++ b/Source/WebCore/platform/audio/ios/MediaDeviceRoute.mm
@@ -230,6 +230,20 @@ MediaDeviceRoute::MediaDeviceRoute(WebMediaDevicePlatformRoute *platformRoute)
 {
 }
 
+void MediaDeviceRoute::disconnectFromSession()
+{
+    [m_playbackControlObserver setPlaybackControl:nil];
+
+#if HAVE(AVROUTING_FRAMEWORK)
+    if (RetainPtr routeSession = std::exchange(m_routeSession, nil)) {
+        [routeSession stop];
+        [platformRoute() removeSession:routeSession.get()];
+    }
+#else
+    [platformRoute() stop];
+#endif
+}
+
 String MediaDeviceRoute::deviceName() const
 {
     return [m_platformRoute routeDisplayName];
@@ -253,9 +267,7 @@ void MediaDeviceRoute::setPlaybackPosition(MediaTime playbackPosition)
 
 MediaDeviceRoute::~MediaDeviceRoute()
 {
-#if HAVE(AVROUTING_FRAMEWORK)
-    [m_routeSession stop];
-#endif
+    disconnectFromSession();
 }
 
 FOR_EACH_KEY_PATH(DEFINE_GETTER)

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp
@@ -92,7 +92,10 @@ MediaPlayerPrivateWirelessPlayback::MediaPlayerPrivateWirelessPlayback(MediaPlay
 
 MediaPlayerPrivateWirelessPlayback::~MediaPlayerPrivateWirelessPlayback()
 {
+    ALWAYS_LOG(LOGIDENTIFIER);
     destroyTimebase();
+    if (RefPtr route = this->route())
+        route->disconnectFromSession();
 }
 
 static bool supportsURL(const URL& url)
@@ -115,6 +118,13 @@ void MediaPlayerPrivateWirelessPlayback::load(const URL& url, const LoadOptions&
 
     m_url = url;
     updateURLIfNeeded();
+}
+
+void MediaPlayerPrivateWirelessPlayback::cancelLoad()
+{
+    ALWAYS_LOG(LOGIDENTIFIER);
+    if (RefPtr route = this->route())
+        route->disconnectFromSession();
 }
 
 OptionSet<MediaPlaybackTargetType> MediaPlayerPrivateWirelessPlayback::playbackTargetTypes()

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.h
@@ -87,7 +87,7 @@ private:
 #if ENABLE(MEDIA_STREAM)
     void load(MediaStreamPrivate&) final { }
 #endif
-    void cancelLoad() final { }
+    void cancelLoad() final;
     void play() final;
     void pause() final;
     FloatSize naturalSize() const final { return { }; }

--- a/Source/WebCore/testing/MockMediaDeviceRoute.h
+++ b/Source/WebCore/testing/MockMediaDeviceRoute.h
@@ -62,6 +62,8 @@ public:
 
     String routeName() const;
 
+    bool connected() const;
+
     bool ready() const;
     void setReady(bool);
 

--- a/Source/WebCore/testing/MockMediaDeviceRoute.idl
+++ b/Source/WebCore/testing/MockMediaDeviceRoute.idl
@@ -33,6 +33,7 @@
     attribute DOMString deviceName;
     attribute DOMString protocolTypeIdentifier;
     readonly attribute DOMString routeName;
+    readonly attribute boolean connected;
     attribute boolean ready;
     attribute boolean playing;
     attribute boolean hasPlaybackError;

--- a/Source/WebCore/testing/MockMediaDeviceRoute.mm
+++ b/Source/WebCore/testing/MockMediaDeviceRoute.mm
@@ -89,6 +89,11 @@ String MockMediaDeviceRoute::routeName() const
     return [[m_platformRoute protocolType] localizedDescription];
 }
 
+bool MockMediaDeviceRoute::connected() const
+{
+    return [m_platformRoute isConnected];
+}
+
 bool MockMediaDeviceRoute::ready() const
 {
     return [m_platformRoute isReady];

--- a/Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.h
+++ b/Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.h
@@ -54,6 +54,7 @@ extern NSErrorDomain const WebMockMediaDeviceRouteErrorDomain;
 @property (nonatomic, strong, nullable) NSError *error;
 @property (nonatomic) CMTimeRange timeRange;
 @property (nonatomic, copy) NSArray<AVPlaybackUserInterfaceMediaSelectionOption *> *audioOptions;
+@property (nonatomic, readonly, getter=isConnected) BOOL connected;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.mm
+++ b/Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.mm
@@ -48,6 +48,7 @@ NSErrorDomain const WebMockMediaDeviceRouteErrorDomain = @"WebMockMediaDeviceRou
 @implementation WebMockMediaDeviceRoute {
     RefPtr<WebCore::MockMediaDeviceRouteURLCallback> _urlCallback;
     RefPtr<WebCore::DOMPromise> _urlPromise;
+    BOOL _connected;
 }
 
 @synthesize timeRange;
@@ -83,6 +84,11 @@ NSErrorDomain const WebMockMediaDeviceRouteErrorDomain = @"WebMockMediaDeviceRou
     self.playbackPosition = playbackPosition.get();
 }
 
+- (BOOL)isConnected
+{
+    return _connected;
+}
+
 - (WebCore::MockMediaDeviceRouteURLCallback* _Nullable)urlCallback
 {
     return _urlCallback.get();
@@ -110,6 +116,7 @@ NSErrorDomain const WebMockMediaDeviceRouteErrorDomain = @"WebMockMediaDeviceRou
 
         switch (std::exchange(strongSelf->_urlPromise, nullptr)->status()) {
         case WebCore::DOMPromise::Status::Fulfilled:
+            strongSelf->_connected = YES;
             return completionHandler(nil, strongSelf.get());
         case WebCore::DOMPromise::Status::Rejected:
             return completionHandler([NSError errorWithDomain:WebMockMediaDeviceRouteErrorDomain code:WebMockMediaDeviceRouteErrorCodeUnsupportedURL userInfo:nil], nil);
@@ -119,6 +126,11 @@ NSErrorDomain const WebMockMediaDeviceRouteErrorDomain = @"WebMockMediaDeviceRou
 
         RELEASE_ASSERT_NOT_REACHED();
     });
+}
+
+- (void)stop
+{
+    _connected = NO;
 }
 
 @end


### PR DESCRIPTION
#### 29e6190b2cd7afe4e1d13b6a6cbbff9f5d820416
<pre>
[iOS] Video continues playing on wireless device after navigating to a new webpage
<a href="https://bugs.webkit.org/show_bug.cgi?id=319358">https://bugs.webkit.org/show_bug.cgi?id=319358</a>
<a href="https://rdar.apple.com/182168097">rdar://182168097</a>

Reviewed by Jer Noble.

When a MediaDeviceRoute loads a video URL, that video will play on the wireless device represented
by the route until WebKit calls -stop on its underlying route session. MediaDeviceRoute called
-stop in its destructor, however, the route remains alive as long as it is selected in the system&apos;s
route picker. This selection is system-global and can outlive a navigation.

The route&apos;s underlying session&apos;s lifetime should match that of the
MediaPlayerPrivateWirelessPlayback that started the session. Made that so by introducing
MediaDeviceRoute::disconnectFromSession(), which clears the playback control observer&apos;s observed
object, calls -stop on the route session, and removes the route session from the route.
MediaPlayerPrivateWirelessPlayback calls disconnectSession() in cancelLoad and its destructor.

Tests: media/wireless-playback-media-player/route-disconnects-when-player-destroyed.html
       media/wireless-playback-media-player/route-reconnects-after-reload.html

* LayoutTests/media/wireless-playback-media-player/route-disconnects-when-player-destroyed-expected.txt: Added.
* LayoutTests/media/wireless-playback-media-player/route-disconnects-when-player-destroyed.html: Added.
* LayoutTests/media/wireless-playback-media-player/route-reconnects-after-reload-expected.txt: Added.
* LayoutTests/media/wireless-playback-media-player/route-reconnects-after-reload.html: Added.
* Source/WebCore/platform/audio/ios/MediaDeviceRoute.h:
* Source/WebCore/platform/audio/ios/MediaDeviceRoute.mm:
(WebCore::MediaDeviceRoute::disconnectFromSession):
(WebCore::MediaDeviceRoute::~MediaDeviceRoute):
* Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp:
(WebCore::MediaPlayerPrivateWirelessPlayback::~MediaPlayerPrivateWirelessPlayback):
(WebCore::MediaPlayerPrivateWirelessPlayback::cancelLoad):
* Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.h:
* Source/WebCore/testing/MockMediaDeviceRoute.h:
* Source/WebCore/testing/MockMediaDeviceRoute.idl:
* Source/WebCore/testing/MockMediaDeviceRoute.mm:
(WebCore::MockMediaDeviceRoute::connected const):
* Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.h:
* Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.mm:
(-[WebMockMediaDeviceRoute isConnected]):
(-[WebMockMediaDeviceRoute startWithURL:completionHandler:]):
(-[WebMockMediaDeviceRoute stop]):

Canonical link: <a href="https://commits.webkit.org/317186@main">https://commits.webkit.org/317186@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5abb4a2f42eb6c993a29dadd7b66ff1361174b25

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174423 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48356 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42137 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184000 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132291 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/552aa57e-7d4a-4804-b3b8-96d453682226) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176288 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49648 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48038 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135687 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fb8b0cb7-8bc8-4884-b45f-fb8694c7f894) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177381 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39122 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156482 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116165 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/248a37b7-93bf-40fb-8798-1d3525a537aa) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37763 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36131 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32481 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148186 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35974 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186426 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39645 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40328 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144599 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48023 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156036 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144457 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38970 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48702 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32594 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114259 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39358 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120656 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47209 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10938 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46611 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46842 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46669 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->