### PR TITLE
[Damage] Add rectsForPainting() and fix uniting two damages that share a grid

### DIFF
--- a/Source/WebCore/platform/graphics/Damage.h
+++ b/Source/WebCore/platform/graphics/Damage.h
@@ -307,6 +307,61 @@ public:
         return result;
     }
 
+    // Rects to paint. Unlike rects() they never overlap, and there are never more of them than the grid
+    // has cells, so a caller that draws each rect separately does a bounded amount of work. Overlapping
+    // rects are split at the cell borders and united per cell, which leaves at most one rect per cell.
+    // Rects that overlap nothing are left whole, because splitting them would only make more work for the
+    // callers that draw them.
+    Rects rectsForPainting() const
+    {
+        // A cell size of zero comes from a zero-sized rect, and the code below divides by it. It only
+        // happens with a rectangle threshold, where the cell size is derived from the rect.
+        if (size() <= 1 || m_mode != Mode::Rectangles || m_rects.cellSize.isEmpty())
+            return rects();
+
+        Rects paintRects;
+        paintRects.reserveInitialCapacity(size());
+        for (const auto& rect : *this) {
+            const auto paintRect = intersection(rect, m_rect);
+            if (!paintRect.isEmpty())
+                paintRects.append(paintRect);
+        }
+
+        // add() already unites into the grid once the rects reach the cell count, so the rects here never
+        // outnumber the cells and only the overlaps have to go. The scan is quadratic, but only in a count
+        // that bound keeps small.
+        if (!hasOverlappingRects(paintRects))
+            return paintRects;
+
+        const int columns = m_rects.gridCells.width();
+        const int rows = m_rects.gridCells.height();
+
+        // Visit every rect once and unite it into the cells it spans, rather than re-scanning every rect
+        // for every cell. A rect only ever spans a few cells, so this is linear in the rect count instead
+        // of rects times cells.
+        Rects cellBounds(columns * rows);
+        for (const auto& rect : paintRects) {
+            const int firstColumn = std::clamp((rect.x() - m_rect.x()) / m_rects.cellSize.width(), 0, columns - 1);
+            const int lastColumn = std::clamp((rect.maxX() - 1 - m_rect.x()) / m_rects.cellSize.width(), 0, columns - 1);
+            const int firstRow = std::clamp((rect.y() - m_rect.y()) / m_rects.cellSize.height(), 0, rows - 1);
+            const int lastRow = std::clamp((rect.maxY() - 1 - m_rect.y()) / m_rects.cellSize.height(), 0, rows - 1);
+
+            for (int row = firstRow; row <= lastRow; ++row) {
+                for (int column = firstColumn; column <= lastColumn; ++column) {
+                    const IntRect cellRect = { { m_rect.x() + column * m_rects.cellSize.width(), m_rect.y() + row * m_rects.cellSize.height() }, m_rects.cellSize };
+                    cellBounds[row * columns + column].unite(intersection(cellRect, rect));
+                }
+            }
+        }
+
+        cellBounds.removeAllMatching([](const IntRect& bounds) {
+            return bounds.isEmpty();
+        });
+
+        ASSERT(cellBounds.size() <= m_rects.gridCells.unclampedArea());
+        return cellBounds;
+    }
+
     void makeFull()
     {
         if (m_mode == Mode::Full)
@@ -438,8 +493,24 @@ public:
         if (m_mode == Mode::Rectangles) {
             // When both Damage are already united and have the same rect and grid, we can just iterate the rects and unite them.
             if (m_rects.shouldUnite && m_mode == other.m_mode && m_rect == other.m_rect && m_rects.gridCells == other.m_rects.gridCells && other.m_rects.shouldUnite && m_rects.rects.size() == other.m_rects.rects.size()) {
-                for (unsigned i = 0; i < m_rects.rects.size(); ++i)
+                m_minimumBoundingRectangle.unite(other.m_minimumBoundingRectangle);
+
+                // A single rect is the bounding rectangle itself, and carries no indices to mark.
+                if (m_rects.rects.size() == 1) {
+                    m_rects.rects[0] = m_minimumBoundingRectangle;
+                    return true;
+                }
+
+                for (unsigned i = 0; i < m_rects.rects.size(); ++i) {
+                    if (other.m_rects.rects[i].isEmpty())
+                        continue;
+
                     m_rects.rects[i].unite(other.m_rects.rects[i]);
+
+                    // The cell may be damaged in other but not here yet, and iteration goes through the
+                    // indices, so a cell whose bit is left unset would be dropped from rects().
+                    m_rects.indices.set(i);
+                }
                 return true;
             }
         }
@@ -457,6 +528,17 @@ public:
     }
 
 private:
+    static bool hasOverlappingRects(const Rects& rects)
+    {
+        for (size_t i = 0; i < rects.size(); ++i) {
+            for (size_t j = i + 1; j < rects.size(); ++j) {
+                if (rects[i].intersects(rects[j]))
+                    return true;
+            }
+        }
+        return false;
+    }
+
     IntSize gridSize(int maxRectangles) const
     {
         const float widthToHeightRatio = static_cast<float>(m_rect.width()) / m_rect.height();

--- a/Tools/TestWebKitAPI/Tests/WebCore/glib/Damage.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/glib/Damage.cpp
@@ -601,6 +601,98 @@ TEST(Damage, Unite)
     EXPECT_EQ(damage.rectsForTesting().size(), 1);
 }
 
+TEST(Damage, RectsForPainting)
+{
+    // The function should return the original rect when there is only a single one.
+    Damage damage(IntSize { 512, 512 });
+    EXPECT_TRUE(damage.add(IntRect { 250, 250, 12, 12 }));
+    ASSERT_EQ(damage.rectsForPainting().size(), 1);
+    EXPECT_EQ(damage.rectsForPainting()[0], IntRect(250, 250, 12, 12));
+
+    // The function should remove overlaps.
+    damage = Damage(IntSize { 512, 512 });
+    EXPECT_TRUE(damage.add(IntRect { 0, 0, 100, 100 }));
+    EXPECT_TRUE(damage.add(IntRect { 50, 50, 100, 100 }));
+    ASSERT_EQ(damage.rectsForPainting().size(), 1);
+    EXPECT_EQ(damage.rectsForPainting()[0], IntRect(0, 0, 150, 150));
+
+    // The function should remove empty rects.
+    damage = Damage(IntSize { 512, 512 });
+    EXPECT_TRUE(damage.add(IntRect { 0, 0, 10, 10 }));
+    EXPECT_TRUE(damage.add(IntRect { 10, 10, 10, 10 }));
+    EXPECT_TRUE(damage.add(IntRect { 20, 20, 10, 10 }));
+    EXPECT_TRUE(damage.add(IntRect { 30, 30, 10, 10 }));
+    EXPECT_TRUE(damage.add(IntRect { 40, 40, 10, 10 }));
+    EXPECT_EQ(damage.rects().size(), 1);
+    ASSERT_EQ(damage.rectsForPainting().size(), 1);
+    EXPECT_EQ(damage.rectsForPainting()[0], IntRect(0, 0, 50, 50));
+
+    // The function should clip the rects.
+    damage = Damage(IntSize { 512, 512 });
+    EXPECT_TRUE(damage.add(IntRect { -2, -2, 10, 10 }));
+    EXPECT_TRUE(damage.add(IntRect { 504, 504, 10, 10 }));
+    ASSERT_EQ(damage.rectsForPainting().size(), 2);
+    EXPECT_EQ(damage.rectsForPainting()[0], IntRect(0, 0, 8, 8));
+    EXPECT_EQ(damage.rectsForPainting()[1], IntRect(504, 504, 8, 8));
+
+    // The function should preserve the layout of cells when unification is enabled.
+    damage = Damage(IntSize { 512, 512 });
+    EXPECT_TRUE(damage.add(IntRect { 0, 0, 10, 10 }));
+    EXPECT_TRUE(damage.add(IntRect { 10, 10, 10, 10 }));
+    EXPECT_TRUE(damage.add(IntRect { 0, 256, 10, 10 }));
+    EXPECT_TRUE(damage.add(IntRect { 256, 0, 10, 10 }));
+    EXPECT_TRUE(damage.add(IntRect { 256, 256, 10, 10 }));
+    EXPECT_EQ(damage.rects().size(), 4);
+    EXPECT_EQ(damage.rects(), damage.rectsForPainting());
+
+    // The function should preserve the layout of cells when unification is enabled
+    // and the grid does not start at { 0, 0 }.
+    damage = Damage(IntRect { 256, 256, 512, 512 });
+    EXPECT_TRUE(damage.add(IntRect { 256, 256, 10, 10 }));
+    EXPECT_TRUE(damage.add(IntRect { 256 + 10, 256 + 10, 10, 10 }));
+    EXPECT_TRUE(damage.add(IntRect { 256, 256 + 256, 10, 10 }));
+    EXPECT_TRUE(damage.add(IntRect { 256 + 256, 256, 10, 10 }));
+    EXPECT_TRUE(damage.add(IntRect { 256 + 256, 256 + 256, 10, 10 }));
+    EXPECT_EQ(damage.rects().size(), 4);
+    EXPECT_EQ(damage.rects(), damage.rectsForPainting());
+
+    // The function should leave a rect spanning multiple cells whole when it overlaps nothing, because
+    // splitting is only there to remove overlaps.
+    damage = Damage(IntSize { 512, 512 });
+    EXPECT_TRUE(damage.add(IntRect { 250, 250, 12, 12 }));
+    EXPECT_TRUE(damage.add(IntRect { 100, 100, 10, 10 }));
+    ASSERT_EQ(damage.rectsForPainting().size(), 2);
+    EXPECT_EQ(damage.rectsForPainting()[0], IntRect(250, 250, 12, 12));
+    EXPECT_EQ(damage.rectsForPainting()[1], IntRect(100, 100, 10, 10));
+
+    // The function should split overlapping rects spanning multiple cells, one rect per cell.
+    damage = Damage(IntSize { 512, 512 });
+    EXPECT_TRUE(damage.add(IntRect { 250, 250, 12, 12 }));
+    EXPECT_TRUE(damage.add(IntRect { 255, 255, 12, 12 }));
+    ASSERT_EQ(damage.rectsForPainting().size(), 4);
+    EXPECT_EQ(damage.rectsForPainting()[0], IntRect(250, 250, 6, 6));
+    EXPECT_EQ(damage.rectsForPainting()[1], IntRect(256, 250, 11, 6));
+    EXPECT_EQ(damage.rectsForPainting()[2], IntRect(250, 256, 6, 11));
+    EXPECT_EQ(damage.rectsForPainting()[3], IntRect(256, 256, 11, 11));
+
+    // The function should never return more rects than the grid has cells, however many tiny rects are
+    // added, so that a caller drawing each rect separately does a bounded amount of work.
+    damage = Damage(IntSize { 512, 512 });
+    for (int i = 0; i < 100; ++i)
+        damage.add(IntRect { i * 5, i * 5, 1, 1 });
+    EXPECT_LE(damage.rectsForPainting().size(), 4u);
+
+    // The function should just return original rects when mode != Mode::Rectangles.
+    damage = Damage(IntRect { 1024, 512, 512, 512 }, Damage::Mode::BoundingBox);
+    EXPECT_TRUE(damage.add(IntRect { 1278, 678, 9, 341 }));
+    EXPECT_TRUE(damage.add(IntRect { 1285, 678, 5, 341 }));
+    EXPECT_FALSE(damage.add(IntRect { 1279, 678, 9, 341 }));
+    EXPECT_TRUE(damage.add(IntRect { 1286, 678, 5, 341 }));
+    EXPECT_EQ(damage.rects(), damage.rectsForPainting());
+    damage = Damage(IntRect { 1024, 512, 512, 512 }, Damage::Mode::Full);
+    EXPECT_EQ(damage.rects(), damage.rectsForPainting());
+}
+
 TEST(Damage, MaxRectangles)
 {
     Damage damage(IntSize { 512, 512 }, Damage::Mode::Rectangles, 2);


### PR DESCRIPTION
#### 9cc587ef6ae8f7e1ddc0d47cda5de2564d295728
<pre>
[Damage] Add rectsForPainting() and fix uniting two damages that share a grid
<a href="https://bugs.webkit.org/show_bug.cgi?id=319360">https://bugs.webkit.org/show_bug.cgi?id=319360</a>

Reviewed by Carlos Garcia Campos.

Add Damage::rectsForPainting(), which returns rects that never overlap, unlike
rects(), and that never outnumber the damage grid&apos;s cells. A caller that draws
each rect separately needs both: overlapping rects would composite translucent
content twice, and an unbounded rect count would turn one draw into arbitrarily
many. Overlapping rects are split at the cell borders and united per cell, which
leaves at most one rect per cell. Rects that overlap nothing are left whole,
because splitting them would only make more work for the caller that draws them.

Also fix add(const Damage&amp;). Its fast path for two damages that are already united
onto the same grid unites the per-cell rects, but leaves the indices that iteration
walks unset and the bounding rectangle stale, so a cell damaged in the other damage
but not yet here is stored and then never returned by rects(). It was unreachable
until now, because no two damages shared a grid.

The new API has no callers yet. Cover it with an API test.

* Source/WebCore/platform/graphics/Damage.h:
(WebCore::Damage::rectsForPainting const):
(WebCore::Damage::add):
(WebCore::Damage::hasOverlappingRects):
* Tools/TestWebKitAPI/Tests/WebCore/glib/Damage.cpp:
(TestWebKitAPI::TEST(Damage, RectsForPainting)):

Canonical link: <a href="https://commits.webkit.org/317137@main">https://commits.webkit.org/317137@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc56a48583a975df5587ebadc102a11362295967

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174455 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48388 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42169 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184032 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/132323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176320 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49680 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48070 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/135717 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/132323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177413 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39154 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/156512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116195 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/37795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32513 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/148218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36004 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186458 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/39687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/144632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48055 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144489 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48734 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114309 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26512 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39390 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/120698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47241 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10968 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46643 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46874 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46701 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->