### PR TITLE
Web Inspector: BoxShadow fails to parse valid lengths like "1.50px", "1e2px", and uppercase units

### DIFF
--- a/LayoutTests/inspector/model/boxShadow-expected.txt
+++ b/LayoutTests/inspector/model/boxShadow-expected.txt
@@ -60,12 +60,23 @@ PASS: default value should be "none"
 
 "1px 2rem 3in 4q rgb(11, 12, 13) inset" resolves to "1px 2rem 3in 4q rgb(11, 12, 13) inset"
 
+"1.50px 2rem" resolves to "1.5px 2rem"
+"1e2px 2rem" resolves to "100px 2rem"
+".5px 2rem" resolves to "0.5px 2rem"
+"1px 2.50rem 3in" resolves to "1px 2.5rem 3in"
+"1E2px 2rem 3in 4q" resolves to "100px 2rem 3in 4q"
+
+"1PX 2Rem 3IN 4Q" resolves to "1px 2rem 3in 4q"
+
 PASS: '1' should not be detected
 
 PASS: '1%' should not be detected
 PASS: '1px 2%' should not be detected
 PASS: '1px 2px 3%' should not be detected
 PASS: '1px 2px 3px 4%' should not be detected
+
+PASS: '1e400px 2rem' should not be detected
+PASS: '-1e400px 2rem' should not be detected
 
 PASS: '1px' should not be detected
 PASS: '1px 2rem 3in 4q 5pt' should not be detected

--- a/LayoutTests/inspector/model/boxShadow.html
+++ b/LayoutTests/inspector/model/boxShadow.html
@@ -88,6 +88,18 @@ function test()
             testGood("1px 2rem 3in 4q rgb(11, 12, 13) inset");
             InspectorTest.newline();
 
+            // number formats where String(parseFloat(x)) !== the source text
+            testGood("1.50px 2rem");
+            testGood("1e2px 2rem");
+            testGood(".5px 2rem");
+            testGood("1px 2.50rem 3in");
+            testGood("1E2px 2rem 3in 4q");
+            InspectorTest.newline();
+
+            // case-insensitive units
+            testGood("1PX 2Rem 3IN 4Q");
+            InspectorTest.newline();
+
             function testBad(string) {
                 let boxShadow = WI.BoxShadow.fromString(string);
                 InspectorTest.expectNull(boxShadow, `'${string}' should not be detected`);
@@ -102,6 +114,11 @@ function test()
             testBad("1px 2%");
             testBad("1px 2px 3%");
             testBad("1px 2px 3px 4%");
+            InspectorTest.newline();
+
+            // non-finite values (overflow to Infinity)
+            testBad("1e400px 2rem");
+            testBad("-1e400px 2rem");
             InspectorTest.newline();
 
             // missing or extra components

--- a/Source/WebInspectorUI/UserInterface/Models/BoxShadow.js
+++ b/Source/WebInspectorUI/UserInterface/Models/BoxShadow.js
@@ -132,10 +132,10 @@ WI.BoxShadow = class BoxShadow
     static parseNumberComponent(string)
     {
         let value = parseFloat(string);
-        if (isNaN(value))
+        if (!isFinite(value))
             return null;
 
-        let unit = string.replace(value, "");
+        let unit = string.replace(/^[-+]?(?:\d*\.?\d+(?:[eE][-+]?\d+)?|\d+\.)/, "").toLowerCase();
         if (!unit) {
             if (value)
                 return null;


### PR DESCRIPTION
#### 5958b2c58e6a3bc0fe998a100be1e03d8d7e75bb
<pre>
Web Inspector: BoxShadow fails to parse valid lengths like &quot;1.50px&quot;, &quot;1e2px&quot;, and uppercase units
<a href="https://bugs.webkit.org/show_bug.cgi?id=319362">https://bugs.webkit.org/show_bug.cgi?id=319362</a>
<a href="https://rdar.apple.com/182169640">rdar://182169640</a>

Reviewed by Devin Rousso.

WI.BoxShadow.parseNumberComponent() split a length component into value and
unit by calling `string.replace(value, &quot;&quot;)`, passing the parsed Number as the
search argument. String.prototype.replace coerces that Number to a string via
String(value) and removes only the first literal occurrence, so it only worked
when String(parseFloat(s)) reproduced the exact numeric prefix of the source
text. It did not for several valid CSS length forms:

- &quot;1.50px&quot;: String(1.5) is &quot;1.5&quot;, so &quot;1.5&quot; was stripped leaving &quot;0px&quot;, which
  is not a valid unit, so the whole box-shadow failed to parse.
- &quot;1e2px&quot;: String(100) is &quot;100&quot;, which is not a substring of &quot;1e2px&quot;, so the
  number was left in place leaving unit &quot;1e2px&quot;.
- &quot;.5px&quot;: String(0.5) is &quot;0.5&quot;, which is not a substring of &quot;.5px&quot;.

Strip the leading number positionally with a regular expression instead, so the
remaining text is always the unit regardless of how the number is spelled. The
exponent group requires a trailing digit, so units that begin with &quot;e&quot; (em, ex)
are preserved rather than mistaken for scientific notation.

While here, also fix two related issues at the same time:

- Non-finite values: a literal that overflows to Infinity (e.g. &quot;1e400px&quot;)
  passed the previous isNaN() guard and, with the regex now yielding a valid
  &quot;px&quot; unit, would serialize as &quot;Infinitypx&quot;. Guard with isFinite() so NaN,
  Infinity, and -Infinity are all rejected.

- Case-insensitive units: CSS units are case-insensitive, but the unit was
  matched against a lowercase Set, so &quot;1PX&quot; was rejected. Lowercase the unit
  before the membership check, which also canonicalizes serialization.

* LayoutTests/inspector/model/boxShadow-expected.txt:
* LayoutTests/inspector/model/boxShadow.html:
* Source/WebInspectorUI/UserInterface/Models/BoxShadow.js:
(WI.BoxShadow.parseNumberComponent):

Canonical link: <a href="https://commits.webkit.org/317161@main">https://commits.webkit.org/317161@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8975518982ee5694316caa9efcc8406d686afc4e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174428 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48361 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42142 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184005 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132296 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/47416c90-8e99-4801-933c-6756fb8d89f4) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49653 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48043 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135691 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95743 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b5bcdbfc-3847-44ff-900b-0e7645250ac0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177386 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39127 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156487 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116169 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a5c6a8bc-a996-4d97-9457-bc26a0159c9e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37768 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32486 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148191 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35979 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186431 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39652 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40334 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144605 "Found 1 new test failure: compositing/framesets/composited-frame-alignment.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48028 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156041 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144463 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38955 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48707 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32599 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114265 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39363 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/120740 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47214 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10943 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46616 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46847 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46674 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->