### PR TITLE
Web Inspector: protocol round-trip time is always NaN due to stale InspectorBackend.activeTracer references

### DIFF
--- a/LayoutTests/inspector/protocol/backend-round-trip-time-expected.txt
+++ b/LayoutTests/inspector/protocol/backend-round-trip-time-expected.txt
@@ -1,0 +1,14 @@
+Testing that the inspector backend reports a valid (non-NaN) round-trip time to an installed protocol tracer.
+
+
+== Running test suite: Protocol.BackendRoundTripTime
+-- Running test case: CustomTracer.GetterReflectsSetter
+PASS: customTracer should be null by default.
+PASS: customTracer should return the installed tracer.
+PASS: activeTracers should include the custom tracer.
+PASS: customTracer should be null after being cleared.
+
+-- Running test case: RoundTripTime.IsFiniteNumber
+PASS: A round-trip time should have been recorded for the command's response.
+PASS: Every recorded round-trip time should be a finite number (not NaN).
+

--- a/LayoutTests/inspector/protocol/backend-round-trip-time.html
+++ b/LayoutTests/inspector/protocol/backend-round-trip-time.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("Protocol.BackendRoundTripTime");
+
+    // A minimal tracer that records the round-trip time reported for each
+    // handled response, so the test can observe what Connection.js computes.
+    class RecordingProtocolTracer extends WI.ProtocolTracer {
+        constructor() {
+            super();
+            this.roundTripTimes = [];
+        }
+
+        logDidHandleResponse(connection, message, timings = null) {
+            if (timings)
+                this.roundTripTimes.push(timings.rtt);
+        }
+    }
+
+    suite.addTestCase({
+        name: "CustomTracer.GetterReflectsSetter",
+        description: "InspectorBackend.customTracer should read back the tracer installed via its setter.",
+        test(resolve, reject) {
+            InspectorTest.expectThat(InspectorBackend.customTracer === null, "customTracer should be null by default.");
+
+            let tracer = new RecordingProtocolTracer;
+            InspectorBackend.customTracer = tracer;
+            InspectorTest.expectEqual(InspectorBackend.customTracer, tracer, "customTracer should return the installed tracer.");
+            InspectorTest.expectThat(InspectorBackend.activeTracers.includes(tracer), "activeTracers should include the custom tracer.");
+
+            InspectorBackend.customTracer = null;
+            InspectorTest.expectThat(InspectorBackend.customTracer === null, "customTracer should be null after being cleared.");
+
+            resolve();
+        }
+    });
+
+    suite.addTestCase({
+        name: "RoundTripTime.IsFiniteNumber",
+        description: "The round-trip time reported to a tracer should be a finite number, not NaN.",
+        test(resolve, reject) {
+            let tracer = new RecordingProtocolTracer;
+            InspectorBackend.customTracer = tracer;
+
+            // Send a command *after* installing the tracer so its send-time
+            // timestamp is recorded and the round-trip time can be computed.
+            RuntimeAgent.evaluate.invoke({expression: "1 + 1"}, (error) => {
+                InspectorBackend.customTracer = null;
+
+                if (error) {
+                    InspectorTest.fail(`Unexpected protocol error: ${error}`);
+                    reject();
+                    return;
+                }
+
+                InspectorTest.expectThat(tracer.roundTripTimes.length > 0, "A round-trip time should have been recorded for the command's response.");
+
+                let allFinite = tracer.roundTripTimes.every((rtt) => Number.isFinite(Number(rtt)));
+                InspectorTest.expectThat(allFinite, "Every recorded round-trip time should be a finite number (not NaN).");
+
+                resolve();
+            });
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+    <p>Testing that the inspector backend reports a valid (non-NaN) round-trip time to an installed protocol tracer.</p>
+</body>
+</html>

--- a/Source/WebInspectorUI/UserInterface/Base/Main.js
+++ b/Source/WebInspectorUI/UserInterface/Base/Main.js
@@ -1930,16 +1930,16 @@ WI._contextMenuRequested = function(event)
         });
 
         let protocolSubMenu = proposedContextMenu.appendSubMenuItem(WI.unlocalizedString("Protocol Debugging"), null, false);
-        let isCapturingTraffic = InspectorBackend.activeTracer instanceof WI.CapturingProtocolTracer;
+        let isCapturingTraffic = InspectorBackend.customTracer instanceof WI.CapturingProtocolTracer;
 
         protocolSubMenu.appendCheckboxItem(WI.unlocalizedString("Capture Trace"), () => {
             if (isCapturingTraffic)
-                InspectorBackend.activeTracer = null;
+                InspectorBackend.customTracer = null;
             else
-                InspectorBackend.activeTracer = new WI.CapturingProtocolTracer;
+                InspectorBackend.customTracer = new WI.CapturingProtocolTracer;
         }, isCapturingTraffic);
 
-        let trace = InspectorBackend.activeTracer?.trace;
+        let trace = InspectorBackend.customTracer?.trace;
         if (trace && WI.FileUtilities.canSave(trace.saveMode)) {
             protocolSubMenu.appendSeparator();
 

--- a/Source/WebInspectorUI/UserInterface/Protocol/Connection.js
+++ b/Source/WebInspectorUI/UserInterface/Protocol/Connection.js
@@ -236,7 +236,7 @@ InspectorBackend.Connection = class InspectorBackendConnection
 
         let responseData = {command, request: messageObject, callback};
 
-        if (InspectorBackend.activeTracer)
+        if (InspectorBackend.activeTracers.length)
             responseData.sendRequestTimestamp = performance.now();
 
         this._pendingResponses.set(sequenceId, responseData);
@@ -257,7 +257,7 @@ InspectorBackend.Connection = class InspectorBackendConnection
 
         let responseData = {command, request: messageObject};
 
-        if (InspectorBackend.activeTracer)
+        if (InspectorBackend.activeTracers.length)
             responseData.sendRequestTimestamp = performance.now();
 
         let responsePromise = new Promise(function(resolve, reject) {

--- a/Source/WebInspectorUI/UserInterface/Protocol/InspectorBackend.js
+++ b/Source/WebInspectorUI/UserInterface/Protocol/InspectorBackend.js
@@ -137,6 +137,11 @@ InspectorBackendClass = class InspectorBackendClass
         }
     }
 
+    get customTracer()
+    {
+        return this._customTracer;
+    }
+
     get activeTracers()
     {
         return this._activeTracers;


### PR DESCRIPTION
#### 1a4d791147d359cac2bf9a6896563a4cbefcad1c
<pre>
Web Inspector: protocol round-trip time is always NaN due to stale InspectorBackend.activeTracer references
<a href="https://bugs.webkit.org/show_bug.cgi?id=319364">https://bugs.webkit.org/show_bug.cgi?id=319364</a>
<a href="https://rdar.apple.com/182170146">rdar://182170146</a>

Reviewed by NOBODY (OOPS!).

Since the tracer model was converted from a single tracer to an array of
active tracers (a `customTracer` setter plus an `activeTracers` getter),
several call sites were left referencing the singular `activeTracer`
accessor, which no longer exists and therefore evaluates to `undefined`:

- In Connection.js, `if (InspectorBackend.activeTracer)` was always
  falsy, so `responseData.sendRequestTimestamp` was never recorded. The
  round-trip time is computed as
  `(processingStartTimestamp - responseData.sendRequestTimestamp)`, which
  is `NaN` when the send timestamp is missing, so every tracer received a
  `NaN` rtt.

- In Main.js, the &quot;Capture Trace&quot; debug menu read and wrote the
  non-existent `activeTracer`, so the checkbox never reflected state, the
  toggle never installed/removed a capturing tracer, and &quot;Export Trace&quot;
  never appeared.

Fix the call sites to use the existing plural/`customTracer` accessors,
and add a `customTracer` getter so the value set via the setter can be
read back.

Test: inspector/protocol/backend-round-trip-time.html

* LayoutTests/inspector/protocol/backend-round-trip-time-expected.txt: Added.
* LayoutTests/inspector/protocol/backend-round-trip-time.html: Added.
* Source/WebInspectorUI/UserInterface/Base/Main.js:
* Source/WebInspectorUI/UserInterface/Protocol/Connection.js:
(InspectorBackend.Connection.prototype._sendCommandToBackendWithCallback):
(InspectorBackend.Connection.prototype._sendCommandToBackendExpectingPromise):
* Source/WebInspectorUI/UserInterface/Protocol/InspectorBackend.js:
(InspectorBackendClass.prototype.get customTracer):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a4d791147d359cac2bf9a6896563a4cbefcad1c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174430 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48363 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42144 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184007 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132298 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ba89d60b-b3e8-4bdd-9a59-54c9daa11127) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49655 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48045 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135692 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95744 "3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9a096c07-2781-468b-a026-0540fb5d24fb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177388 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39132 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156489 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116170 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3521174a-3c11-4497-abf3-633d5c333a9d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37773 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36140 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32488 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148196 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35981 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186433 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39654 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40337 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144607 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48030 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156043 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144465 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48709 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32601 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114267 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39365 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120664 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47216 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10945 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46618 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46849 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46676 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->