### PR TITLE
Web Inspector: HTML pretty-printer mis-nests <canvas> fallback content because "canvas" is wrongly treated as a void element

### DIFF
--- a/LayoutTests/inspector/formatting/formatting-html-expected.txt
+++ b/LayoutTests/inspector/formatting/formatting-html-expected.txt
@@ -8,6 +8,7 @@ PASS: auto-close-normal.html
 PASS: auto-close-special.html
 PASS: basic-1.html
 PASS: basic-2.html
+PASS: canvas.html
 PASS: comments.html
 PASS: eof-1.html
 PASS: eof-2.html

--- a/LayoutTests/inspector/formatting/formatting-html.html
+++ b/LayoutTests/inspector/formatting/formatting-html.html
@@ -14,6 +14,7 @@ function test()
         "resources/html-tests/auto-close-special.html",
         "resources/html-tests/basic-1.html",
         "resources/html-tests/basic-2.html",
+        "resources/html-tests/canvas.html",
         "resources/html-tests/comments.html",
         "resources/html-tests/eof-1.html",
         "resources/html-tests/eof-2.html",

--- a/LayoutTests/inspector/formatting/resources/html-tests/canvas-expected.html
+++ b/LayoutTests/inspector/formatting/resources/html-tests/canvas-expected.html
@@ -1,0 +1,9 @@
+<canvas id="c" width="300" height="150">
+    <p>Your browser does not support the canvas element.</p>
+</canvas>
+<div>
+    <canvas>
+        <a href="foo.html">Fallback link</a>
+    </canvas>
+</div>
+<canvas></canvas>

--- a/LayoutTests/inspector/formatting/resources/html-tests/canvas.html
+++ b/LayoutTests/inspector/formatting/resources/html-tests/canvas.html
@@ -1,0 +1,3 @@
+<canvas id="c" width="300" height="150"><p>Your browser does not support the canvas element.</p></canvas>
+<div><canvas><a href="foo.html">Fallback link</a></canvas></div>
+<canvas></canvas>

--- a/Source/WebInspectorUI/UserInterface/Workers/Formatter/HTMLTreeBuilderFormatter.js
+++ b/Source/WebInspectorUI/UserInterface/Workers/Formatter/HTMLTreeBuilderFormatter.js
@@ -333,7 +333,6 @@ HTMLTreeBuilderFormatter.TagNamesWithoutChildren = new Set([
     "base",
     "basefont",
     "br",
-    "canvas",
     "col",
     "command",
     "embed",


### PR DESCRIPTION
#### 2e738f0fc7c762980cc151c3263d46208924e6a4
<pre>
Web Inspector: HTML pretty-printer mis-nests &lt;canvas&gt; fallback content because &quot;canvas&quot; is wrongly treated as a void element
<a href="https://bugs.webkit.org/show_bug.cgi?id=319365">https://bugs.webkit.org/show_bug.cgi?id=319365</a>
<a href="https://rdar.apple.com/182171240">rdar://182171240</a>

Reviewed by Devin Rousso.

HTMLTreeBuilderFormatter.TagNamesWithoutChildren lists the HTML void
elements: tags that can never have children, so the tree builder does
not push them onto the stack of open elements. &quot;canvas&quot; was included in
this set since the formatter was first added, but &lt;canvas&gt; is not a void
element -- it has a transparent content model and legitimately contains
fallback content (e.g. &lt;p&gt; or &lt;a&gt; shown when canvas is unsupported).

Because &quot;canvas&quot; was in the set, _isEmptyNode() returned true for it, so
its fallback content was attached as siblings instead of children and
its closing tag went unmatched. Pretty-printing HTML that used canvas
fallback content therefore produced incorrectly-nested, non-indented
output.

Remove &quot;canvas&quot; from TagNamesWithoutChildren so it is treated as a
normal container element.

* LayoutTests/inspector/formatting/formatting-html-expected.txt:
* LayoutTests/inspector/formatting/formatting-html.html:
* LayoutTests/inspector/formatting/resources/html-tests/canvas-expected.html: Added.
* LayoutTests/inspector/formatting/resources/html-tests/canvas.html: Added.
* Source/WebInspectorUI/UserInterface/Workers/Formatter/HTMLTreeBuilderFormatter.js:

Canonical link: <a href="https://commits.webkit.org/317157@main">https://commits.webkit.org/317157@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/570f8ef1002b72a09b48b3bb828949de3f95c2a9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174436 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48369 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42150 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184013 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132304 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1b6cf43a-a838-4987-9b30-42828ee1b2e5) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49661 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48051 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135698 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/282da314-f852-4cac-b38c-db7f3af36437) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177394 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39137 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156497 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116176 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a614ca44-349d-4ac3-ae65-2b64fc74e694) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37778 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36145 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32494 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148201 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35989 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186439 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39661 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40342 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144613 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48036 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156051 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144470 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38952 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48715 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32609 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114276 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39371 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120686 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47222 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10953 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46624 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46855 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46682 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->