### PR TITLE
Web Inspector: HAR export reports a bogus port for remote addresses that have no port

### DIFF
--- a/LayoutTests/http/tests/inspector/network/har/har-remote-address-port-expected.txt
+++ b/LayoutTests/http/tests/inspector/network/har/har-remote-address-port-expected.txt
@@ -1,0 +1,20 @@
+Tests for WI.HARBuilder.port and WI.HARBuilder.ipAddress remote address parsing.
+
+
+== Running test suite: HAR.RemoteAddress
+-- Running test case: HAR.RemoteAddress.Port
+PASS: IPv4 address with a port returns the port.
+PASS: IPv4 address with a different port returns the port.
+PASS: Bracketed IPv6 address with a port returns the port.
+PASS: Bracketed IPv6 address with a port returns the port.
+PASS: IPv4 address with no port returns undefined.
+PASS: Hostname with no port returns undefined.
+PASS: Empty remote address returns undefined.
+PASS: Missing remote address returns undefined.
+
+-- Running test case: HAR.RemoteAddress.IPAddress
+PASS: Strips the port from an IPv4 address.
+PASS: IPv4 address with no port is unchanged.
+PASS: Empty remote address returns the empty string.
+PASS: Missing remote address returns the empty string.
+

--- a/LayoutTests/http/tests/inspector/network/har/har-remote-address-port.html
+++ b/LayoutTests/http/tests/inspector/network/har/har-remote-address-port.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../resources/inspector-test.js"></script>
+<script>
+function test()
+{
+    let suite = InspectorTest.createSyncSuite("HAR.RemoteAddress");
+
+    suite.addTestCase({
+        name: "HAR.RemoteAddress.Port",
+        description: "WI.HARBuilder.port should extract the trailing port, or undefined when there is none.",
+        test() {
+            InspectorTest.expectEqual(WI.HARBuilder.port("12.34.56.78:443"), 443, "IPv4 address with a port returns the port.");
+            InspectorTest.expectEqual(WI.HARBuilder.port("12.34.56.78:80"), 80, "IPv4 address with a different port returns the port.");
+            InspectorTest.expectEqual(WI.HARBuilder.port("[::1]:8080"), 8080, "Bracketed IPv6 address with a port returns the port.");
+            InspectorTest.expectEqual(WI.HARBuilder.port("[2001:db8::1]:443"), 443, "Bracketed IPv6 address with a port returns the port.");
+
+            // Regression test: lastIndexOf(":") returns -1 when there is no colon.
+            // A `!index` guard fails to catch -1 (which is truthy), so the whole
+            // string was parsed as a port (e.g. parseInt("12.34.56.78") === 12).
+            InspectorTest.expectEqual(WI.HARBuilder.port("12.34.56.78"), undefined, "IPv4 address with no port returns undefined.");
+            InspectorTest.expectEqual(WI.HARBuilder.port("localhost"), undefined, "Hostname with no port returns undefined.");
+
+            InspectorTest.expectEqual(WI.HARBuilder.port(""), undefined, "Empty remote address returns undefined.");
+            InspectorTest.expectEqual(WI.HARBuilder.port(undefined), undefined, "Missing remote address returns undefined.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "HAR.RemoteAddress.IPAddress",
+        description: "WI.HARBuilder.ipAddress should strip the trailing port.",
+        test() {
+            InspectorTest.expectEqual(WI.HARBuilder.ipAddress("12.34.56.78:443"), "12.34.56.78", "Strips the port from an IPv4 address.");
+            InspectorTest.expectEqual(WI.HARBuilder.ipAddress("12.34.56.78"), "12.34.56.78", "IPv4 address with no port is unchanged.");
+            InspectorTest.expectEqual(WI.HARBuilder.ipAddress(""), "", "Empty remote address returns the empty string.");
+            InspectorTest.expectEqual(WI.HARBuilder.ipAddress(undefined), "", "Missing remote address returns the empty string.");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Tests for WI.HARBuilder.port and WI.HARBuilder.ipAddress remote address parsing.</p>
+</body>
+</html>

--- a/Source/WebInspectorUI/UserInterface/Controllers/HARBuilder.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/HARBuilder.js
@@ -382,7 +382,7 @@ WI.HARBuilder = class HARBuilder
         // NOTE: Resource.remoteAddress always includes the port at the end.
         // So this always matches the last part.
         let index = remoteAddress.lastIndexOf(":");
-        if (!index)
+        if (index === -1)
             return undefined;
 
         let portString = remoteAddress.substring(index + 1);


### PR DESCRIPTION
#### a26f36bbc1ecbb91308959a32095b57bc33ed265
<pre>
Web Inspector: HAR export reports a bogus port for remote addresses that have no port
<a href="https://bugs.webkit.org/show_bug.cgi?id=319366">https://bugs.webkit.org/show_bug.cgi?id=319366</a>
<a href="https://rdar.apple.com/182171465">rdar://182171465</a>

Reviewed by Devin Rousso.

WI.HARBuilder.port() guarded its &quot;no port present&quot; case with `if (!index)`
after `remoteAddress.lastIndexOf(&quot;:&quot;)`. That guard only fires when the colon
is at index 0 (a leading-colon address); it never fires for the not-found
case, because lastIndexOf() returns -1, which is truthy. As a result, an
address with no trailing &quot;:port&quot; fell through to substring(-1 + 1) ==
substring(0) and parsed the entire string, e.g. parseInt(&quot;12.34.56.78&quot;)
yields 12, so the HAR entry recorded a nonsensical serverPort.

Fix the guard to test `index === -1` so an address without a port correctly
returns undefined.

Test: http/tests/inspector/network/har/har-remote-address-port.html

* Source/WebInspectorUI/UserInterface/Controllers/HARBuilder.js:
(WI.HARBuilder.port):
* LayoutTests/http/tests/inspector/network/har/har-remote-address-port.html: Added.
* LayoutTests/http/tests/inspector/network/har/har-remote-address-port-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/317155@main">https://commits.webkit.org/317155@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68cdf37bad9d48b7d83c8dff4d02d05c5c8fc256

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174437 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48370 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42151 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184014 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132305 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4b819c32-db41-4bbe-b7ae-6d46fdbc9caa) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49662 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48052 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135699 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5d0abc4c-0f45-403e-be2e-880f45568c07) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177395 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39134 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156495 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116177 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5101cba5-9e24-426e-ac0e-8a22ac44f8b2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37775 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32495 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148198 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35987 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186440 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39662 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40343 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144614 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48037 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156049 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144471 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38951 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48716 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32607 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114277 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39370 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120674 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47223 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10951 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46625 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46856 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46683 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->