### PR TITLE
Web Inspector: gradient editor drops explicit 0% color stops and mis-parses leading radial color stops

### DIFF
--- a/LayoutTests/inspector/model/gradient-expected.txt
+++ b/LayoutTests/inspector/model/gradient-expected.txt
@@ -44,6 +44,8 @@ PASS: 'linear-gradient(to top, red, blue)' is valid
 PASS: toString() output matches 'linear-gradient(to top, red, blue)'
 PASS: 'linear-gradient(30deg, red, blue)' is valid
 PASS: toString() output matches 'linear-gradient(30deg, red, blue)'
+PASS: 'linear-gradient(red 50%, lime 0%, blue)' is valid
+PASS: toString() output matches 'linear-gradient(red 50%, lime 0%, blue)'
 PASS: 'repeating-linear-gradient(red, blue)' is valid
 PASS: toString() output matches 'repeating-linear-gradient(red, blue)'
 PASS: 'radial-gradient(red, blue)' is valid
@@ -52,8 +54,16 @@ PASS: 'radial-gradient(30deg, red, blue)' is valid
 PASS: toString() output matches 'radial-gradient(30deg, red, blue)'
 PASS: 'radial-gradient(ellipse, red, blue)' is valid
 PASS: toString() output matches 'radial-gradient(ellipse, red, blue)'
+PASS: 'radial-gradient(red 50%, lime 0%, blue)' is valid
+PASS: toString() output matches 'radial-gradient(red 50%, lime 0%, blue)'
 PASS: 'repeating-radial-gradient(red, blue)' is valid
 PASS: toString() output matches 'repeating-radial-gradient(red, blue)'
+PASS: 'conic-gradient(red, blue)' is valid
+PASS: toString() output matches 'conic-gradient(red, blue)'
+PASS: 'conic-gradient(red 50%, lime 0%, blue)' is valid
+PASS: toString() output matches 'conic-gradient(red 50%, lime 0%, blue)'
+PASS: 'repeating-conic-gradient(red, blue)' is valid
+PASS: toString() output matches 'repeating-conic-gradient(red, blue)'
 
 -- Running test case: WI.LinearGradient.prototype.set angleUnits
 PASS: Gradient has angle value of '180'

--- a/LayoutTests/inspector/model/gradient.html
+++ b/LayoutTests/inspector/model/gradient.html
@@ -70,12 +70,18 @@ function test()
             test("linear-gradient(0deg, red, blue)", "linear-gradient(to top, red, blue)");
             test("linear-gradient(to top, red, blue)");
             test("linear-gradient(30deg, red, blue)");
+            test("linear-gradient(red 50%, lime 0%, blue)");
             test("repeating-linear-gradient(red, blue)");
 
             test("radial-gradient(red, blue)");
             test("radial-gradient(30deg, red, blue)");
             test("radial-gradient(ellipse, red, blue)");
+            test("radial-gradient(red 50%, lime 0%, blue)");
             test("repeating-radial-gradient(red, blue)");
+
+            test("conic-gradient(red, blue)");
+            test("conic-gradient(red 50%, lime 0%, blue)");
+            test("repeating-conic-gradient(red, blue)");
 
             resolve();
         }

--- a/Source/WebInspectorUI/UserInterface/Models/Gradient.js
+++ b/Source/WebInspectorUI/UserInterface/Models/Gradient.js
@@ -147,8 +147,7 @@ WI.Gradient = class Gradient
             if (!stop)
                 return null;
 
-            if (!stop.offset)
-                stop.offset = i / (count - 1);
+            stop.offset ??= i / (count - 1);
         }
 
         return stops;
@@ -375,7 +374,7 @@ WI.RadialGradient = class RadialGradient extends WI.Gradient
 
     static fromComponents(components)
     {
-        let sizing = !WI.Color.fromString(components[0].join(" ")) ? components.shift().join(" ") : "";
+        let sizing = !WI.Color.fromString(components[0][0]) ? components.shift().join(" ") : "";
 
         let stops = WI.Gradient.stopsWithComponents(components);
         if (!stops)


### PR DESCRIPTION
#### e901aed494625092d98eb37c79b140150032ca98
<pre>
Web Inspector: gradient editor drops explicit 0% color stops and mis-parses leading radial color stops
<a href="https://bugs.webkit.org/show_bug.cgi?id=319368">https://bugs.webkit.org/show_bug.cgi?id=319368</a>
<a href="https://rdar.apple.com/182172439">rdar://182172439</a>

Reviewed by NOBODY (OOPS!).

WI.Gradient parsing had two related defects that caused gradient strings
to round-trip incorrectly through the gradient editor:

1. stopsWithComponents() used `if (!stop.offset)` to detect a missing
 offset, which also matched a legitimate parsed offset of 0. Any
 explicit `0%` stop that was not first was silently discarded and
 recomputed as an evenly-spaced offset.

2. RadialGradient.fromComponents() detected the optional sizing prefix by
 testing `WI.Color.fromString(components[0].join(&quot; &quot;))`. When the first
 color stop carried an offset (e.g. `red 50%`), the joined string was
 not a valid color, so the first stop was wrongly consumed as sizing.

Only default the offset when it is missing (using `??=`), and detect
radial sizing from only the first token (sizing keywords such as
`circle`, `ellipse`, and `at` are never colors).

* LayoutTests/inspector/model/gradient-expected.txt:
* LayoutTests/inspector/model/gradient.html: Added linear, radial, and
conic round-trip cases covering an explicit 0% stop.
* Source/WebInspectorUI/UserInterface/Models/Gradient.js:
(WI.Gradient.stopsWithComponents):
(WI.RadialGradient.fromComponents):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e901aed494625092d98eb37c79b140150032ca98

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174575 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48508 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/42289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184152 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/132443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/65770b8e-a0df-4ffa-9847-f029db9ceb81) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49800 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48191 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/135829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/132443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9b142a6c-e6c2-45e0-a199-791948d103eb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177533 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/39258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/42289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116307 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/60d74f98-7d9e-43cb-bbff-903124e0c42f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/37899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32633 "Built successfully") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/42289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/148322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/42289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186579 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/39845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/144746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48175 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/42289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144606 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38973 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48854 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/42289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39491 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/120845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47361 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/42289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46763 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46994 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46821 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->