### PR TITLE
REGRESSION(312187@main) AudioParam ref-counting is not thread-safe, causing a crash when a node connected to it is destroyed on the audio thread

### DIFF
--- a/LayoutTests/webaudio/scriptprocessornode-connected-to-audioparam-crash-expected.txt
+++ b/LayoutTests/webaudio/scriptprocessornode-connected-to-audioparam-crash-expected.txt
@@ -1,0 +1,10 @@
+Tests that a ScriptProcessorNode connected to an AudioParam does not crash when the node gets destroyed on the audio rendering thread. This test passes if it does not crash.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Did not crash.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/webaudio/scriptprocessornode-connected-to-audioparam-crash.html
+++ b/LayoutTests/webaudio/scriptprocessornode-connected-to-audioparam-crash.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../resources/js-test.js"></script>
+<script>
+description("Tests that a ScriptProcessorNode connected to an AudioParam does not crash when the node gets destroyed on the audio rendering thread. This test passes if it does not crash.");
+
+jsTestIsAsync = true;
+
+function gc() {
+    if (window.GCController)
+        return GCController.collect();
+    for (let i = 0; i < 10000; i++)
+        new String("abc" + i);
+}
+
+// Build up the audio graph in a function scope so that all JavaScript
+// references become collectible once the function returns.
+function buildGraph() {
+    const context = new OfflineAudioContext({ numberOfChannels: 4, length: 7831, sampleRate: 66003 });
+    const scriptProcessor = context.createScriptProcessor();
+    const param = context.listener.upY;
+    param.linearRampToValueAtTime(0.6056944018169216, 0.44540190562655235);
+    scriptProcessor.connect(param);
+    scriptProcessor.connect(context.destination);
+    context.startRendering();
+    return context;
+}
+
+buildGraph();
+
+// Force the ScriptProcessorNode (and its JS wrapper) to be collected while
+// rendering is in progress on the audio thread, so that the node gets marked
+// for deletion on the audio thread and disconnects from the AudioParam there.
+gc();
+gc();
+
+setTimeout(() => {
+    gc();
+    setTimeout(() => {
+        testPassed("Did not crash.");
+        finishJSTest();
+    }, 100);
+}, 0);
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/webaudio/AudioParam.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioParam.cpp
@@ -378,7 +378,7 @@ void AudioParam::disconnect(AudioNodeOutput* output)
     if (!output)
         return;
 
-    INFO_LOG(LOGIDENTIFIER, output->node()->nodeType());
+    INFO_LOG_IF(!context()->isAudioThread(), LOGIDENTIFIER, output->node()->nodeType());
 
     if (removeOutput((*output)))
         output->removeParam(this);

--- a/Source/WebCore/Modules/webaudio/AudioParam.h
+++ b/Source/WebCore/Modules/webaudio/AudioParam.h
@@ -35,7 +35,7 @@
 #include <JavaScriptCore/Forward.h>
 #include <sys/types.h>
 #include <wtf/LoggerHelper.h>
-#include <wtf/RefCounted.h>
+#include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -46,7 +46,7 @@ enum class AutomationRateMode : bool { Fixed, Variable };
 
 class AudioParam final
     : public AudioSummingJunction
-    , public RefCounted<AudioParam>
+    , public ThreadSafeRefCounted<AudioParam, WTF::DestructionThread::Main>
 #if !RELEASE_LOG_DISABLED
     , private LoggerHelper
 #endif


### PR DESCRIPTION
#### e3b8f2b9b9b2f02d71510c5bf9045e51b687e0a9
<pre>
REGRESSION(312187@main) AudioParam ref-counting is not thread-safe, causing a crash when a node connected to it is destroyed on the audio thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=319369">https://bugs.webkit.org/show_bug.cgi?id=319369</a>
<a href="https://rdar.apple.com/182132498">rdar://182132498</a>

Reviewed by Jean-Yves Avenard.

Since 312187@main made AudioNode&apos;s ref-counting thread-safe, an AudioNode can be
deref&apos;d and marked for deletion on the audio rendering thread. When a node (e.g. a
ScriptProcessorNode) that is connected to an AudioParam gets deleted this way, the
teardown path AudioNode::deref() -&gt; markNodeForDeletionIfNecessary() -&gt;
AudioNodeOutput::disconnectAll() -&gt; disconnectAllParams() ref&apos;s and deref&apos;s the
connected AudioParam on the audio thread. AudioParam was still a plain
RefCounted&lt;AudioParam&gt;, so this tripped the ref/deref threading assertion
(applyRefDerefThreadingCheck) and crashed.

Make AudioParam&apos;s ref-counting thread-safe, matching AudioNodeInput which is
processed on the same audio-thread teardown path. AudioParam owns non-thread-safe
members (e.g. its String name), so it must never be destroyed off the main thread;
use ThreadSafeRefCounted&lt;AudioParam, DestructionThread::Main&gt; so that a final deref
on the audio thread defers destruction to the main thread.

Also avoid the INFO_LOG() call in AudioParam::disconnect() when running on the audio
thread, since building the log string allocates and heap allocations are forbidden
on the audio thread.

Test: webaudio/scriptprocessornode-connected-to-audioparam-crash.html

* LayoutTests/webaudio/scriptprocessornode-connected-to-audioparam-crash-expected.txt: Added.
* LayoutTests/webaudio/scriptprocessornode-connected-to-audioparam-crash.html: Added.
* Source/WebCore/Modules/webaudio/AudioParam.cpp:
(WebCore::AudioParam::disconnect):
* Source/WebCore/Modules/webaudio/AudioParam.h:

Canonical link: <a href="https://commits.webkit.org/317232@main">https://commits.webkit.org/317232@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d236165551129e43898fa398f8dba255c1b8ecd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174441 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48374 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42155 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184018 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132309 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/09812012-0752-47cb-aae9-8e1a49a26ca3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176306 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49666 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48056 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135703 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95754 "2 flakes 5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4ae7d413-535a-441d-8d04-3012877820ff) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177399 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39140 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156501 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116181 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/72cc1dee-26b3-4571-a0fd-810840e76594) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37781 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36150 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32499 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148204 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35993 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186444 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39668 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40347 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144618 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48041 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156055 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144475 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39000 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48720 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32613 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114284 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39376 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120679 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47227 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10957 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46629 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46860 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46687 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->