### PR TITLE
[YARR] JIT backtracking of greedy variable-width character classes in unicode mode is `O(count)` per step

### DIFF
--- a/JSTests/stress/regexp-unicode-greedy-charclass-backtrack-exhaustive.js
+++ b/JSTests/stress/regexp-unicode-greedy-charclass-backtrack-exhaustive.js
@@ -1,0 +1,90 @@
+// Exhaustively verifies backtracking of a greedy variable-width character class in
+// unicode mode against a reference implementation, over every string of up to 5
+// characters drawn from an alphabet covering all code unit width combinations:
+// BMP characters, a lone lead surrogate, a lone trail surrogate, and a surrogate pair.
+
+function shouldBe(actual, expected, msg) {
+    if (actual !== expected)
+        throw new Error(`FAIL: ${msg}: expected ${expected}, got ${actual}`);
+}
+
+// Reference for new RegExp("([^<excluded>]*)<literal>", "u").exec(subject):
+// leftmost start position (in code points), then greedy longest body first.
+function referenceExec(subject, excluded, literal) {
+    let cps = [...subject]; // code point segmentation, as in unicode mode
+    let unitOffsets = [];
+    let offset = 0;
+    for (let cp of cps) {
+        unitOffsets.push(offset);
+        offset += cp.length;
+    }
+    unitOffsets.push(offset);
+
+    let literalCps = [...literal];
+    for (let start = 0; start <= cps.length; start++) {
+        let max = 0;
+        while (start + max < cps.length && !excluded.includes(cps[start + max]))
+            max++;
+        for (let count = max; count >= 0; count--) {
+            let literalStart = start + count;
+            if (literalStart + literalCps.length > cps.length)
+                continue;
+            let matched = true;
+            for (let i = 0; i < literalCps.length; i++) {
+                if (cps[literalStart + i] !== literalCps[i]) {
+                    matched = false;
+                    break;
+                }
+            }
+            if (matched) {
+                let body = cps.slice(start, start + count).join("");
+                return { match: body + literal, body, index: unitOffsets[start] };
+            }
+        }
+    }
+    return null;
+}
+
+let lead = "\uD800";
+let trail = "\uDC00";
+let np = lead + trail; // U+10000, one code point, two code units
+
+const alphabet = ["a", "\"", "X", lead, trail, np];
+const maxLength = 5;
+
+const cases = [
+    { re: /([^"]*)X/u, excluded: ["\""], literal: "X" },
+    { re: new RegExp("([^\"]*)" + np, "u"), excluded: ["\""], literal: np },
+    { re: new RegExp("([^X]*)" + lead, "u"), excluded: ["X"], literal: lead },
+    { re: new RegExp("([^X]*)" + trail, "u"), excluded: ["X"], literal: trail },
+    { re: new RegExp("([^X" + np + "]*)a", "u"), excluded: ["X", np], literal: "a" },
+];
+
+function checkSubject(subject) {
+    for (let i = 0; i < cases.length; i++) {
+        let { re, excluded, literal } = cases[i];
+        let expected = referenceExec(subject, excluded, literal);
+
+        let actual = re.exec(subject);
+        if (expected === null) {
+            shouldBe(actual, null, `exec /${re.source}/u on ${JSON.stringify(subject)}`);
+            shouldBe(re.test(subject), false, `test /${re.source}/u on ${JSON.stringify(subject)}`);
+            continue;
+        }
+        shouldBe(actual === null, false, `exec /${re.source}/u on ${JSON.stringify(subject)}`);
+        shouldBe(actual[0], expected.match, `match /${re.source}/u on ${JSON.stringify(subject)}`);
+        shouldBe(actual[1], expected.body, `capture /${re.source}/u on ${JSON.stringify(subject)}`);
+        shouldBe(actual.index, expected.index, `index /${re.source}/u on ${JSON.stringify(subject)}`);
+        shouldBe(re.test(subject), true, `test /${re.source}/u on ${JSON.stringify(subject)}`);
+    }
+}
+
+function enumerate(prefix, length) {
+    checkSubject(prefix);
+    if (length === maxLength)
+        return;
+    for (let atom of alphabet)
+        enumerate(prefix + atom, length + 1);
+}
+
+enumerate("", 0);

--- a/JSTests/stress/regexp-unicode-greedy-charclass-backtrack-linear.js
+++ b/JSTests/stress/regexp-unicode-greedy-charclass-backtrack-linear.js
@@ -1,0 +1,64 @@
+function shouldBe(actual, expected, msg) {
+    if (actual !== expected)
+        throw new Error(`FAIL: ${msg}: expected ${expected}, got ${actual}`);
+}
+
+function shouldBeArray(actual, expected, msg) {
+    if (actual === null || expected === null) {
+        if (actual !== expected)
+            throw new Error(`FAIL: ${msg}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+        return;
+    }
+    if (actual.length !== expected.length)
+        throw new Error(`FAIL: ${msg}: length mismatch: expected ${expected.length}, got ${actual.length}`);
+    for (let i = 0; i < expected.length; i++) {
+        if (actual[i] !== expected[i])
+            throw new Error(`FAIL: ${msg}: index ${i}: expected ${JSON.stringify(expected[i])}, got ${JSON.stringify(actual[i])}`);
+    }
+}
+
+let np = "\u{10000}"; // non-BMP, 2 code units
+let lead = "\uD800";
+let trail = "\uDC00";
+
+for (let i = 0; i < testLoopCount; i++) {
+    // Backtrack steps back over a BMP character (1 code unit)
+    shouldBeArray(/([^"]*)X/u.exec("\u2014aaX"), ["\u2014aaX", "\u2014aa"], "greedy BMP backtrack");
+
+    // Backtrack steps back over a non-BMP character (2 code units)
+    shouldBeArray(/([^"]*)a/u.exec("b" + np + np + "a"), ["b" + np + np + "a", "b" + np + np], "greedy non-BMP backtrack");
+    shouldBeArray(new RegExp("([^\"]*)" + np, "u").exec("ab" + np), ["ab" + np, "ab"], "backtrack to non-BMP target");
+
+    // Backtrack steps back over lone surrogates (1 code unit each)
+    shouldBeArray(/([^"]*)a/u.exec("b" + trail + "a"), ["b" + trail + "a", "b" + trail], "greedy lone trail backtrack");
+    shouldBeArray(/([^"]*)a/u.exec("b" + lead + "a"), ["b" + lead + "a", "b" + lead], "greedy lone lead backtrack");
+    shouldBeArray(new RegExp("([^\"]*)" + trail + "$", "u").exec("a" + trail + trail), ["a" + trail + trail, "a" + trail], "backtrack to lone trail target");
+
+    // Mixed widths: backtrack repeatedly across pair/lone-surrogate/BMP boundaries
+    shouldBeArray(/([^"]*)a/u.exec(np + trail + np + lead + "a"), [np + trail + np + lead + "a", np + trail + np + lead], "greedy mixed-width backtrack");
+    shouldBeArray(new RegExp("([^X]*)" + lead + trail + "$", "u").exec("b" + np + np), ["b" + np + np, "b" + np], "backtrack over non-BMP to pair target");
+
+    // Non-greedy sanity
+    shouldBeArray(/([^"]*?)(a*)$/u.exec(np + "aaa"), [np + "aaa", np, "aaa"], "non-greedy sanity");
+
+    // Backtrack all the way back to the start of the term (match amount 0)
+    shouldBeArray(/b([^"]*)b/u.exec("b" + np + "ab"), ["b" + np + "ab", np + "a"], "backtrack from interior term start");
+    shouldBeArray(new RegExp("a([^X]*)" + np + "b", "u").exec("a" + np + "b"), ["a" + np + "b", ""], "backtrack to begin, next term rematches");
+
+    // Greedy with following term failing everywhere: no match
+    shouldBe(/[^"]*X/u.test(np + trail + lead + "aaa"), false, "no match after full backtrack");
+    shouldBe(new RegExp("[^\"]{0,4}X", "u").test(np + "aaa"), false, "bounded no match");
+
+    // lastIndex / global
+    let re = /[^X]*X/gu;
+    let s = np + "aX" + trail + "bX";
+    shouldBeArray(re.exec(s), [np + "aX"], "global first match");
+    shouldBe(re.lastIndex, 4, "global lastIndex after first");
+    shouldBeArray(re.exec(s), [trail + "bX"], "global second match");
+    shouldBe(re.lastIndex, 7, "global lastIndex after second");
+}
+
+// Before the fix, backtracking a greedy variable-width character class rewound to the
+// start of the term and rematched forward on every step, making this O(n^3) and taking
+// minutes. With the O(1) step-back it completes in milliseconds.
+shouldBe(/[^"]*X/u.test("\u2014" + "a".repeat(10000)), false, "complexity canary");

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -3473,36 +3473,27 @@ class YarrGenerator final : public YarrJITInfo {
         loadFromFrame(term->frameLocation + BackTrackInfoCharacterClass::matchAmountIndex(), countRegister);
         m_backtrackingState.append(m_jit.branchTest32(MacroAssembler::Zero, countRegister));
         m_jit.sub32(MacroAssembler::TrustedImm32(1), countRegister);
-        storeToFrame(countRegister, term->frameLocation + BackTrackInfoCharacterClass::matchAmountIndex());
 
         if (!m_decodeSurrogatePairs)
             m_jit.sub32(MacroAssembler::TrustedImm32(1), m_regs.index);
         else if (term->isFixedWidthCharacterClass())
             m_jit.sub32(MacroAssembler::TrustedImm32(term->characterClass->hasNonBMPCharacters() ? 2 : 1), m_regs.index);
         else {
-            // Rematch one less
+            // The last matched character occupied two code units iff the two code units
+            // preceding the current position form a surrogate pair.
             const MacroAssembler::RegisterID character = m_regs.regT0;
 
+            MacroAssembler::Jump backtrackToBegin = m_jit.branchTest32(MacroAssembler::Zero, countRegister);
+
+            m_jit.load32WithUnalignedHalfWords(negativeOffsetIndexedAddress(op.m_checkedOffset - term->inputPosition + 2, character), character);
+            m_jit.and32(surrogateTagMask, character);
+            m_jit.compare32(MacroAssembler::Equal, character, surrogatePairTags, character);
+            m_jit.add32(MacroAssembler::TrustedImm32(1), character);
+            m_jit.sub32(character, m_regs.index);
+            m_jit.jump(op.m_reentry);
+
+            backtrackToBegin.link(&m_jit);
             loadFromFrame(term->frameLocation + BackTrackInfoCharacterClass::beginIndex(), m_regs.index);
-
-            MacroAssembler::Label rematchLoop(&m_jit);
-            MacroAssembler::Jump doneRematching = m_jit.branchTest32(MacroAssembler::Zero, countRegister);
-
-            readCharacter(op.m_checkedOffset - term->inputPosition, character);
-
-            m_jit.sub32(MacroAssembler::TrustedImm32(1), countRegister);
-            m_jit.add32(MacroAssembler::TrustedImm32(1), m_regs.index);
-
-#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS)
-            MacroAssembler::Jump isBMPChar = m_jit.branch32(MacroAssembler::LessThan, character, MacroAssembler::TrustedImm32(0x10000));
-            m_jit.add32(MacroAssembler::TrustedImm32(1), m_regs.index);
-            isBMPChar.link(&m_jit);
-#endif
-
-            m_jit.jump(rematchLoop);
-            doneRematching.link(&m_jit);
-
-            loadFromFrame(term->frameLocation + BackTrackInfoCharacterClass::matchAmountIndex(), countRegister);
         }
         m_jit.jump(op.m_reentry);
     }


### PR DESCRIPTION
#### d886174dfa9e1a4608f81260947531009eb1c31e
<pre>
[YARR] JIT backtracking of greedy variable-width character classes in unicode mode is `O(count)` per step
<a href="https://bugs.webkit.org/show_bug.cgi?id=319370">https://bugs.webkit.org/show_bug.cgi?id=319370</a>

Reviewed by Yusuke Suzuki.

When backtracking a greedy character class that can match both BMP and
non-BMP characters under the unicode flag, backtrackCharacterClassGreedy
rewinds to the start of the term and rematches count - 1 characters
forward to recompute the index, because the width of the last matched
character is not fixed. This makes matching O(n^3) overall, while the
interpreter handles the same case in O(n^2):

    /[^&quot;]*X/u.test(&quot;\u2014&quot; + &quot;a&quot;.repeat(4000))  // JIT: ~9.5s, interpreter: 56ms

typescript-eslint&apos;s JSX detection regexp hits this path and makes
prettier hang for ~10 seconds on real-world input.

We can step back in O(1) instead: since all term positions in unicode
mode lie on code point boundaries, the last matched character occupied
two code units iff the two code units preceding the current position
form a surrogate pair. When the new match count is zero, we reload the
begin position from the frame instead. Also drop the storeToFrame of
the match count, which only existed so the rematch loop could reload it.

The example above now completes in 16ms (~600x), scaling as O(n^2).

Tests: JSTests/stress/regexp-unicode-greedy-charclass-backtrack-exhaustive.js
       JSTests/stress/regexp-unicode-greedy-charclass-backtrack-linear.js

* JSTests/stress/regexp-unicode-greedy-charclass-backtrack-exhaustive.js: Added.
(shouldBe):
(checkSubject):
(enumerate):
* JSTests/stress/regexp-unicode-greedy-charclass-backtrack-linear.js: Added.
(shouldBe):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:

Canonical link: <a href="https://commits.webkit.org/317381@main">https://commits.webkit.org/317381@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e283baf2828b27402682c263a288c51e3585f48e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175172 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49104 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42885 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184757 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/133079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177036 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50396 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48787 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136348 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/133079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178129 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/39781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/157131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116827 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/174493 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/38422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33230 "Built successfully") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/218/builds/5640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148845 "Build is in progress. Recent messages:") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36624 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187178 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/36433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/40791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145295 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/174572 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48771 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156687 "") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145151 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39099 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49451 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115287 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40002 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/121628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/212263 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47957 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11597 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55393 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47360 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47590 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47417 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->