### PR TITLE
No swatch to trigger the picker inside gradient functions unless using CSS variable stops

### DIFF
--- a/LayoutTests/inspector/css/inline-swatch-gradient-color-stops-expected.txt
+++ b/LayoutTests/inspector/css/inline-swatch-gradient-color-stops-expected.txt
@@ -1,0 +1,28 @@
+Testing that gradient functions show an inline color swatch before every <color> stop, matching the behavior of color-mix().
+
+
+== Running test suite: InlineSwatch.GradientColorStops
+-- Running test case: InlineSwatch.GradientColorStops.Linear
+PASS: "background-image" should have 2 color swatch(es), one before each <color>.
+PASS: "background-image" should have 1 gradient swatch(es).
+
+-- Running test case: InlineSwatch.GradientColorStops.CustomPropertyRadial
+PASS: "--radial" should have 2 color swatch(es), one before each <color>.
+PASS: "--radial" should have 1 gradient swatch(es).
+
+-- Running test case: InlineSwatch.GradientColorStops.CustomPropertyConic
+PASS: "--conic" should have 2 color swatch(es), one before each <color>.
+PASS: "--conic" should have 1 gradient swatch(es).
+
+-- Running test case: InlineSwatch.GradientColorStops.MaskRadialLengthStop
+PASS: "mask" should have 2 color swatch(es), one before each <color>.
+PASS: "mask" should have 1 gradient swatch(es).
+
+-- Running test case: InlineSwatch.GradientColorStops.BorderImageConicAngleStop
+PASS: "border-image" should have 2 color swatch(es), one before each <color>.
+PASS: "border-image" should have 1 gradient swatch(es).
+
+-- Running test case: InlineSwatch.GradientColorStops.ColorMix
+PASS: "background-color" should have 2 color swatch(es), one before each <color>.
+PASS: "background-color" should have 0 gradient swatch(es).
+

--- a/LayoutTests/inspector/css/inline-swatch-gradient-color-stops.html
+++ b/LayoutTests/inspector/css/inline-swatch-gradient-color-stops.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+function test() {
+    let nodeStyles = null;
+
+    let suite = InspectorTest.createAsyncSuite("InlineSwatch.GradientColorStops");
+
+    function propertyNamed(name) {
+        for (let rule of nodeStyles.matchedRules) {
+            if (rule.selectorText !== "div#x")
+                continue;
+
+            for (let property of rule.style.enabledProperties) {
+                if (property.name === name)
+                    return property;
+            }
+        }
+        return null;
+    }
+
+    function addTestCase(name, propertyName, expectedColorSwatches, expectedGradientSwatches) {
+        suite.addTestCase({
+            name,
+            test(resolve, reject) {
+                let property = propertyNamed(propertyName);
+                InspectorTest.assert(property, `Found property "${propertyName}".`);
+
+                // Render the property the same way the Styles sidebar does.
+                let spreadsheetProperty = new WI.SpreadsheetStyleProperty(null, property, {readOnly: true, hideDocumentation: true});
+
+                let colorSwatches = spreadsheetProperty.element.querySelectorAll(".inline-swatch.color").length;
+                let gradientSwatches = spreadsheetProperty.element.querySelectorAll(".inline-swatch.gradient").length;
+
+                InspectorTest.expectEqual(colorSwatches, expectedColorSwatches, `"${propertyName}" should have ${expectedColorSwatches} color swatch(es), one before each <color>.`);
+                InspectorTest.expectEqual(gradientSwatches, expectedGradientSwatches, `"${propertyName}" should have ${expectedGradientSwatches} gradient swatch(es).`);
+
+                resolve();
+            }
+        });
+    }
+
+    // A gradient should show a color swatch before every <color>, just like color-mix() does.
+
+    // `background-image` is a color-aware property.
+    addTestCase("InlineSwatch.GradientColorStops.Linear", "background-image", 2, 1);
+
+    // Custom properties are always processed, regardless of the property allowlist.
+    addTestCase("InlineSwatch.GradientColorStops.CustomPropertyRadial", "--radial", 2, 1);
+    addTestCase("InlineSwatch.GradientColorStops.CustomPropertyConic", "--conic", 2, 1);
+
+    // `mask` and `border-image` only accept an <image> (not a bare <color>), but a gradient
+    // value should still get a gradient swatch and a swatch for each color stop.
+    addTestCase("InlineSwatch.GradientColorStops.MaskRadialLengthStop", "mask", 2, 1);
+    addTestCase("InlineSwatch.GradientColorStops.BorderImageConicAngleStop", "border-image", 2, 1);
+
+    // For comparison, color-mix() already shows a swatch before each <color>.
+    addTestCase("InlineSwatch.GradientColorStops.ColorMix", "background-color", 2, 0);
+
+    WI.domManager.requestDocument((documentNode) => {
+        documentNode.querySelector("div#x", (contentNodeId) => {
+            if (contentNodeId) {
+                let domNode = WI.domManager.nodeForId(contentNodeId);
+                nodeStyles = WI.cssManager.stylesForNode(domNode);
+
+                if (nodeStyles.needsRefresh) {
+                    nodeStyles.singleFireEventListener(WI.DOMNodeStyles.Event.Refreshed, (event) => {
+                        suite.runTestCasesAndFinish();
+                    });
+                } else
+                    suite.runTestCasesAndFinish();
+            } else {
+                InspectorTest.fail("DOM node not found.");
+                InspectorTest.completeTest();
+            }
+        });
+    });
+}
+</script>
+</head>
+<body onload="runTest()">
+    <p>Testing that gradient functions show an inline color swatch before every &lt;color&gt; stop, matching the behavior of color-mix().</p>
+
+    <style>
+    div#x {
+        background-image: linear-gradient(hotpink, steelblue);
+        --radial: radial-gradient(hotpink 5em, steelblue);
+        --conic: conic-gradient(hotpink 75deg, steelblue);
+        mask: radial-gradient(hotpink 5em, steelblue);
+        border-image: conic-gradient(hotpink 75deg, steelblue) fill 0;
+        background-color: color-mix(in hsl, hotpink 35%, steelblue);
+    }
+    </style>
+    <div id="x"></div>
+</body>
+</html>

--- a/Source/WebInspectorUI/UserInterface/Models/CSSKeywordCompletions.js
+++ b/Source/WebInspectorUI/UserInterface/Models/CSSKeywordCompletions.js
@@ -184,6 +184,18 @@ WI.CSSKeywordCompletions.isColorAwareProperty = function(name)
     return false;
 };
 
+WI.CSSKeywordCompletions.isGradientAwareProperty = function(name)
+{
+    if (WI.CSSKeywordCompletions._gradientAwareProperties.has(name))
+        return true;
+
+    let isNotPrefixed = name.charAt(0) !== "-";
+    if (isNotPrefixed && WI.CSSKeywordCompletions._gradientAwareProperties.has("-webkit-" + name))
+        return true;
+
+    return false;
+};
+
 WI.CSSKeywordCompletions.isTimingFunctionAwareProperty = function(name)
 {
     if (WI.CSSKeywordCompletions._timingFunctionAwareProperties.has(name))
@@ -464,6 +476,19 @@ WI.CSSKeywordCompletions._colorAwareProperties = new Set([
 
     // iOS Properties
     "-webkit-tap-highlight-color",
+]);
+
+// Properties that accept an <image> (and therefore a CSS gradient) but not a bare <color>.
+// These are not color-aware (so they don't get color keyword completions), but a gradient
+// value inside them should still get a gradient swatch and per-color-stop swatches.
+WI.CSSKeywordCompletions._gradientAwareProperties = new Set([
+    "border-image", "border-image-source", "-webkit-border-image",
+    "content",
+    "cursor",
+    "list-style", "list-style-image",
+    "mask", "mask-image", "-webkit-mask", "-webkit-mask-image",
+    "mask-border", "mask-border-source", "-webkit-mask-box-image",
+    "shape-outside",
 ]);
 
 WI.CSSKeywordCompletions._timingFunctionAwareProperties = new Set([

--- a/Source/WebInspectorUI/UserInterface/Test.html
+++ b/Source/WebInspectorUI/UserInterface/Test.html
@@ -125,6 +125,7 @@
     <script src="Models/Script.js"></script>
     <script src="Models/LocalScript.js"></script>
 
+    <script src="Models/AlignmentData.js"></script>
     <script src="Models/Animation.js"></script>
     <script src="Models/AnimationCollection.js"></script>
     <script src="Models/BoxShadow.js"></script>
@@ -309,6 +310,8 @@
     <script src="Views/TableColumn.js"></script>
     <script src="Views/TreeElement.js"></script>
     <script src="Views/TreeOutline.js"></script>
+    <script src="Views/InlineSwatch.js"></script>
+    <script src="Views/SpreadsheetStyleProperty.js"></script>
 
     <script src="Debug/DOMManager.js"></script>
 

--- a/Source/WebInspectorUI/UserInterface/Views/SpreadsheetStyleProperty.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SpreadsheetStyleProperty.js
@@ -706,6 +706,10 @@ WI.SpreadsheetStyleProperty = class SpreadsheetStyleProperty extends WI.Object
         if (this._property.isVariable || WI.CSSKeywordCompletions.isColorAwareProperty(this._property.name)) {
             tokens = this._addGradientTokens(tokens);
             tokens = this._addColorTokens(tokens);
+        } else if (WI.CSSKeywordCompletions.isGradientAwareProperty(this._property.name)) {
+            // Image properties (e.g. `border-image`, `mask`) don't accept a bare <color>, but a
+            // gradient value should still get a gradient swatch and a swatch for each color stop.
+            tokens = this._addGradientTokens(tokens);
         }
 
         if (this._property.isVariable || WI.CSSKeywordCompletions.isTimingFunctionAwareProperty(this._property.name)) {
@@ -744,7 +748,14 @@ WI.SpreadsheetStyleProperty = class SpreadsheetStyleProperty extends WI.Object
                 let rawTokens = tokens.slice(gradientStartIndex, i + 1);
 
                 let text = this._resolveVariables(rawTokens.map((token) => token.value).join(""));
-                rawTokens = this._addVariableTokens(rawTokens);
+
+                // A gradient will always have a `(` after the function name. Recurse into
+                // the color stops so that each `<color>` gets its own swatch, matching the
+                // behavior of color functions like `color-mix()`.
+                let functionOpeningTokens = tokens.slice(gradientStartIndex, gradientStartIndex + 2);
+                let functionInnerTokens = this._addColorTokens(tokens.slice(gradientStartIndex + 2, i));
+                let functionClosingToken = tokens[i];
+                rawTokens = this._addVariableTokens([...functionOpeningTokens, ...functionInnerTokens, functionClosingToken]);
 
                 let gradient = WI.Gradient.fromString(text);
                 if (gradient)


### PR DESCRIPTION
#### 230e583a6d9fdfc0aad39151e9868c196cf9ef18
<pre>
No swatch to trigger the picker inside gradient functions unless using CSS variable stops
<a href="https://bugs.webkit.org/show_bug.cgi?id=267154">https://bugs.webkit.org/show_bug.cgi?id=267154</a>
<a href="https://rdar.apple.com/120643697">rdar://120643697</a>

Reviewed by NOBODY (OOPS!).

The Styles sidebar shows an inline color swatch before every &lt;color&gt; inside a
color-mix() value, but not inside a CSS gradient. Two separate problems caused
this:

1. `_addColorTokens` recurses into color functions (e.g. color-mix()) so that
  each inner &lt;color&gt; gets its own swatch, but `_addGradientTokens` treated the
  whole gradient as a single atomic swatch and never looked at the color stops.
  As a result, a gradient only produced the gradient-editor swatch, with no
  per-stop color swatches (except by accident when a var() made the gradient
  fail to parse and fall through to `_addColorTokens`).

Fix this by having `_addGradientTokens` run the gradient&apos;s interior tokens
through `_addColorTokens` before building the swatch contents, mirroring what
color functions already do. The gradient now gets both its gradient swatch
and a swatch for each color stop.

2. The gradient/color pipeline only runs for color-aware properties (those in
  the allowlist or ending in &quot;color&quot;). Image-only properties such as
  border-image and mask are neither, so they never got any swatch at all.

Add an `isGradientAwareProperty` check for properties that accept an &lt;image&gt;
(but not a bare &lt;color&gt;) and run `_addGradientTokens` for them, so gradients
in border-image, mask, list-style-image, etc. get gradient and color-stop
swatches without offering bogus &lt;color&gt; keyword completions.

* Source/WebInspectorUI/UserInterface/Models/CSSKeywordCompletions.js:
(WI.CSSKeywordCompletions.isGradientAwareProperty): Added.
(WI.CSSKeywordCompletions._gradientAwareProperties): Added.

* Source/WebInspectorUI/UserInterface/Views/SpreadsheetStyleProperty.js:
(WI.SpreadsheetStyleProperty.prototype._replaceSpecialTokens): Run gradient
processing for gradient-aware (image) properties in addition to color-aware ones.
(WI.SpreadsheetStyleProperty.prototype._addGradientTokens): Recurse the gradient
interior through `_addColorTokens` so each color stop gets a swatch.

* Source/WebInspectorUI/UserInterface/Test.html:
Load InlineSwatch.js, SpreadsheetStyleProperty.js, and AlignmentData.js so the
new test can render a property.

* LayoutTests/inspector/css/inline-swatch-gradient-color-stops.html: Added.
* LayoutTests/inspector/css/inline-swatch-gradient-color-stops-expected.txt: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/230e583a6d9fdfc0aad39151e9868c196cf9ef18

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174444 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48377 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42158 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184021 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132312 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49669 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48059 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135706 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95757 "1 flakes 3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ff2f40a4-f645-41b8-88b9-01451cf99e68) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177402 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39143 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156503 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116184 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37784 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36155 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32502 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148207 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35995 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186447 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39673 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40352 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144621 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48044 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156057 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144478 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48723 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32615 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114291 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39379 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120683 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47230 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10959 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46632 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46863 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46690 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->