### PR TITLE
[WASM] Allow linking immutable exnref global imports

### DIFF
--- a/JSTests/wasm/stress/exnref-global-get-segv.js
+++ b/JSTests/wasm/stress/exnref-global-get-segv.js
@@ -1,3 +1,9 @@
+// https://bugs.webkit.org/show_bug.cgi?id=293340
+// Importing an exported immutable (ref null exn) global must succeed.
+// Global::get() rejects exnref for the JS API; linking must copy the stored ref.
+
+import * as assert from "../assert.js";
+
 // (module
 //   (global (export "g") (ref null exn) (ref.null exn))
 // )
@@ -7,11 +13,18 @@ const instance1 = new WebAssembly.Instance(module1);
 
 // (module
 //   (import "M" "g" (global (ref null exn)))
+//   (func (export "is_null") (result i32)
+//     global.get 0
+//     ref.is_null)
 // )
-const wasm2 = new Uint8Array([0, 97, 115, 109, 1, 0, 0, 0, 2, 8, 1, 1, 77, 1, 103, 3, 105, 0]);
+const wasm2 = new Uint8Array([
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+    0x01, 0x05, 0x01, 0x60, 0x00, 0x01, 0x7f,
+    0x02, 0x08, 0x01, 0x01, 0x4d, 0x01, 0x67, 0x03, 0x69, 0x00,
+    0x03, 0x02, 0x01, 0x00,
+    0x07, 0x0b, 0x01, 0x07, 0x69, 0x73, 0x5f, 0x6e, 0x75, 0x6c, 0x6c, 0x00, 0x00,
+    0x0a, 0x07, 0x01, 0x05, 0x00, 0x23, 0x00, 0xd1, 0x0b,
+]);
 const module2 = new WebAssembly.Module(wasm2);
-try {
-    const instance2 = new WebAssembly.Instance(module2, { M: { g: instance1.exports.g } });
-} catch {
-    // no segv
-}
+const instance2 = new WebAssembly.Instance(module2, { M: { g: instance1.exports.g } });
+assert.eq(instance2.exports.is_null(), 1);

--- a/Source/JavaScriptCore/wasm/WasmGlobal.h
+++ b/Source/JavaScriptCore/wasm/WasmGlobal.h
@@ -73,6 +73,11 @@ public:
     Wasm::Type type() const { return m_type; }
     Wasm::Mutability mutability() const { return m_mutability; }
     JSValue get(JSGlobalObject*) const;
+    JSValue getReference() const
+    {
+        ASSERT(isRefType(m_type));
+        return m_value.m_externref.get();
+    }
     uint64_t getPrimitive() const { return m_value.m_primitive; }
     v128_t getVector() const { return m_value.m_vector; }
     void set(JSGlobalObject*, JSValue);

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
@@ -343,6 +343,8 @@ void WebAssemblyModuleRecord::initializeImports(JSGlobalObject* globalObject, JS
                             }
 
                             m_instance->setGlobal(import.kindIndex, value);
+                        } else if (Wasm::isExnref(declaredGlobalType)) {
+                            m_instance->setGlobal(import.kindIndex, globalValue->global()->getReference());
                         } else {
                             auto global = globalValue->global()->get(globalObject);
                             RETURN_IF_EXCEPTION(scope, void());


### PR DESCRIPTION
#### e1171d7da90fa90cbec9c2881007361fa6516660
<pre>
[WASM] Allow linking immutable exnref global imports
<a href="https://bugs.webkit.org/show_bug.cgi?id=293340">https://bugs.webkit.org/show_bug.cgi?id=293340</a>

Reviewed by Keith Miller.

Importing an immutable (ref null exn) global called Global::get(), which
rejects exnref for the JS API. Wasm-to-wasm linking only needs the stored
reference, not a JS-visible value.

Add Global::getReference() and use it when linking immutable exnref imports.
JS Global.value still rejects exnref.

* Source/JavaScriptCore/wasm/WasmGlobal.h:
(JSC::Wasm::Global::getReference): Added.
* Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp:
(JSC::WebAssemblyModuleRecord::initializeImports): Copy exnref via getReference().
* JSTests/wasm/stress/exnref-global-get-segv.js: Assert successful import and null value.

Canonical link: <a href="https://commits.webkit.org/317326@main">https://commits.webkit.org/317326@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4aa1467c0159036d0bf60903c7bc9c46bb790305

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174459 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48392 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42173 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184036 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132327 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49684 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48075 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135719 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95771 "5 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177417 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39157 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156519 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116197 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37798 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36169 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32517 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5028 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148221 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36011 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186462 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/35721 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39692 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40366 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144634 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48059 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144492 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39062 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48738 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32631 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114315 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39393 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120703 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/211512 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47245 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10975 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55174 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46647 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46878 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46705 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->