### PR TITLE
calculateBase64EncodedSize() truncates its input length to unsigned, undersizing the output buffer for inputs larger than 4 GB

### DIFF
--- a/Source/WTF/wtf/text/Base64.cpp
+++ b/Source/WTF/wtf/text/Base64.cpp
@@ -197,7 +197,7 @@ String base64EncodeToStringReturnNullIfOverflow(std::span<const std::byte> input
     return tryMakeString(base64Encoded(input, options));
 }
 
-unsigned calculateBase64EncodedSize(unsigned inputLength, OptionSet<Base64EncodeOption> options)
+unsigned calculateBase64EncodedSize(size_t inputLength, OptionSet<Base64EncodeOption> options)
 {
     if (inputLength > maximumBase64EncoderInputBufferSize)
         return 0;

--- a/Source/WTF/wtf/text/Base64.h
+++ b/Source/WTF/wtf/text/Base64.h
@@ -53,7 +53,7 @@ struct Base64Specification {
 // Rather than being perfectly precise, this is a bit conservative.
 static constexpr unsigned maximumBase64EncoderInputBufferSize = std::numeric_limits<unsigned>::max() / 77 * 76 / 4 * 3 - 2;
 
-WTF_EXPORT_PRIVATE unsigned calculateBase64EncodedSize(unsigned inputLength, OptionSet<Base64EncodeOption>);
+WTF_EXPORT_PRIVATE unsigned calculateBase64EncodedSize(size_t inputLength, OptionSet<Base64EncodeOption>);
 
 template<typename CharacterType> bool isBase64OrBase64URLCharacter(CharacterType);
 

--- a/Tools/TestWebKitAPI/Tests/WTF/Base64.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Base64.cpp
@@ -296,4 +296,20 @@ TEST(Base64, DecodeURLValidatePaddingIgnoreWhitespace)
     EXPECT_TRUE(Vector<uint8_t>({ 0, 1, 128, 254, 255 }) == base64Decode(" A A G A _ v 8 = "_s, options));
 }
 
+TEST(Base64, EncodedSizeRejectsInputAboveUnsignedRange)
+{
+    static constexpr OptionSet<Base64EncodeOption> options;
+
+    size_t hugeLengthTruncatingToSmallValue = static_cast<size_t>(std::numeric_limits<unsigned>::max()) + 100;
+    EXPECT_EQ(calculateBase64EncodedSize(hugeLengthTruncatingToSmallValue, options), 0U);
+
+    EXPECT_EQ(calculateBase64EncodedSize(static_cast<size_t>(WTF::maximumBase64EncoderInputBufferSize) + 1, options), 0U);
+
+    EXPECT_EQ(calculateBase64EncodedSize(0, options), 0U);
+    EXPECT_EQ(calculateBase64EncodedSize(1, options), 4U);
+    EXPECT_EQ(calculateBase64EncodedSize(3, options), 4U);
+    EXPECT_EQ(calculateBase64EncodedSize(6, options), 8U);
+    EXPECT_NE(calculateBase64EncodedSize(WTF::maximumBase64EncoderInputBufferSize, options), 0U);
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 39dc095e8f0e31f06cee8a5f7af31bdb041dc422
<pre>
calculateBase64EncodedSize() truncates its input length to unsigned, undersizing the output buffer for inputs larger than 4 GB
<a href="https://bugs.webkit.org/show_bug.cgi?id=319372">https://bugs.webkit.org/show_bug.cgi?id=319372</a>

Reviewed by Darin Adler.

calculateBase64EncodedSize() took an unsigned inputLength, but its callers
pass a size_t span size (base64EncodeInternal() at Base64.cpp:162 and the
StringTypeAdapter&lt;Base64Specification&gt; constructor at Base64.h:189). On
64-bit, an input span whose size() exceeds 2^32 was silently truncated to
32 bits at the call boundary. A size that is small once truncated (e.g.
2^32 + 100 -&gt; 100) but is actually far above maximumBase64EncoderInputBufferSize
slipped past the &quot;&gt; maximumBase64EncoderInputBufferSize&quot; guard and returned
a tiny non-zero encoded size. The full multi-gigabyte input span was then
handed to simdutf::binary_to_base64(), which writes ~size * 4 / 3 bytes into
the undersized destination buffer, overflowing it.

The decode path already guards this exact case (base64Decode() rejects
input.size() &gt; numeric_limits&lt;unsigned&gt;::max()); the encode path did not.
This is a latent defect rather than a practically reachable one: it requires
a single contiguous input buffer larger than 4 GB, and the String-based
entry points (e.g. btoa) are bounded by String::MaxLength (2^31 - 1).

Fix it by taking a size_t inputLength so the cap check runs on the full
length before any narrowing, matching the decode path. The result still fits
in unsigned because maximumBase64EncoderInputBufferSize is chosen so its
padded encoded size is below 2^32.

Test: Base64.EncodedSizeRejectsInputAboveUnsignedRange

* Source/WTF/wtf/text/Base64.cpp:
(WTF::calculateBase64EncodedSize):
* Source/WTF/wtf/text/Base64.h:
* Tools/TestWebKitAPI/Tests/WTF/Base64.cpp:
(TestWebKitAPI::TEST(Base64, EncodedSizeRejectsInputAboveUnsignedRange)):

Canonical link: <a href="https://commits.webkit.org/317218@main">https://commits.webkit.org/317218@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aab57fb5afd803cdd33b3d5726afd4ba6fdc304e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174450 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48383 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42164 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184027 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132318 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/100ad42d-3f26-4867-b590-10f297d3fbf0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176315 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49675 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48065 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135714 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/58eff1c1-537e-418f-8ec9-ddae2bdc57e4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177408 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39152 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156514 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116192 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6803df1f-b0b5-49d9-a8fa-f24f034dc8e3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37793 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36161 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32508 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5023 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148216 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36006 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186453 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/35712 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39681 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40358 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144630 "Found 1 new test failure: compositing/geometry/abs-position-inside-opacity.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48050 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144487 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38990 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48729 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32626 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114298 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39388 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120691 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/211503 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47236 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10970 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55172 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46638 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46869 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46696 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->