### PR TITLE
[LBSE] Cache the clip-path geometry instead of rebuilding it per clipped shape per frame

### DIFF
--- a/LayoutTests/svg/clip-path/clip-path-child-transform-change-expected.html
+++ b/LayoutTests/svg/clip-path/clip-path-child-transform-change-expected.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>A clip child's transform change must not be frozen by the clip geometry cache</title>
+<style>svg { display: block; }</style>
+</head>
+<body>
+<svg width="200" height="200" xmlns="http://www.w3.org/2000/svg">
+    <clipPath id="clip">
+        <rect x="0" y="0" width="50" height="50" transform="translate(100, 100)"/>
+    </clipPath>
+    <rect width="200" height="200" fill="green" clip-path="url(#clip)"/>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/clip-path/clip-path-child-transform-change.html
+++ b/LayoutTests/svg/clip-path/clip-path-child-transform-change.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+<meta charset="utf-8">
+<title>A clip child's transform change must not be frozen by the clip geometry cache</title>
+<!--
+    Regression test for the LBSE clip-path geometry cache. applyPathClipping() caches the clip
+    geometry, but the clip content's own transform can change via the SVG transform fast path
+    (which repaints the clipper's clients without relaying out the <clipPath>). If that transform
+    were cached along with the geometry it would freeze: the clip would stay at translate(0,0)
+    instead of following the change to translate(100,100). Both should render a green 50x50 square
+    at (100,100).
+-->
+<style>svg { display: block; }</style>
+<script>
+window.addEventListener('load', () => {
+    // First rAF: still before the initial paint. Second rAF: the initial paint (which populates the
+    // clip geometry cache with the translate(0,0) transform) has already happened, so mutating the
+    // transform now exercises the cache invalidation path.
+    requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+            document.getElementById("clipRect").setAttribute("transform", "translate(100, 100)");
+            requestAnimationFrame(() => {
+                requestAnimationFrame(() => document.documentElement.classList.remove("reftest-wait"));
+            });
+        });
+    });
+});
+</script>
+</head>
+<body>
+<svg width="200" height="200" xmlns="http://www.w3.org/2000/svg">
+    <clipPath id="clip">
+        <rect id="clipRect" x="0" y="0" width="50" height="50" transform="translate(0, 0)"/>
+    </clipPath>
+    <rect width="200" height="200" fill="green" clip-path="url(#clip)"/>
+</svg>
+</body>
+</html>

--- a/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
@@ -344,17 +344,25 @@ bool RenderSVGModelObject::applyCachedClipAndScrollPosition(RepaintRects& rects,
     return intersects;
 }
 
-Path RenderSVGModelObject::computeClipPath(AffineTransform& transform) const
+void RenderSVGModelObject::computeClipContentTransform(AffineTransform& transform) const
 {
     if (isTransformed())
         transform.multiply(computeRendererTransform());
 
+    RefPtr useElement = dynamicDowncast<SVGUseElement>(protect(element()));
+    if (!useElement)
+        return;
+
+    if (CheckedPtr clipChildRenderer = useElement->rendererClipChild()) {
+        CheckedRef layerModelObject = downcast<RenderLayerModelObject>(*clipChildRenderer);
+        if (layerModelObject->isTransformed())
+            transform.multiply(layerModelObject->computeRendererTransform());
+    }
+}
+
+Path RenderSVGModelObject::computeClipPathGeometry() const
+{
     if (RefPtr useElement = dynamicDowncast<SVGUseElement>(protect(element()))) {
-        if (CheckedPtr clipChildRenderer = useElement->rendererClipChild()) {
-            CheckedRef layerModelObject = downcast<RenderLayerModelObject>(*clipChildRenderer);
-            if (layerModelObject->isTransformed())
-                transform.multiply(layerModelObject->computeRendererTransform());
-        }
         if (RefPtr clipChild = useElement->clipChild())
             return pathFromGraphicsElement(*clipChild);
     }

--- a/Source/WebCore/rendering/svg/RenderSVGModelObject.h
+++ b/Source/WebCore/rendering/svg/RenderSVGModelObject.h
@@ -96,7 +96,8 @@ public:
     virtual LayoutRect overflowClipRect(const LayoutPoint& location, OverlayScrollbarSizeRelevancy = OverlayScrollbarSizeRelevancy::IgnoreOverlayScrollbarSize, PaintPhase = PaintPhase::BlockBackground) const;
     LayoutRect overflowClipRectForChildLayers(const LayoutPoint& location, OverlayScrollbarSizeRelevancy relevancy) { return overflowClipRect(location, relevancy); }
 
-    virtual Path computeClipPath(AffineTransform&) const;
+    Path computeClipPathGeometry() const;
+    void computeClipContentTransform(AffineTransform&) const;
     virtual void addFocusRingRects(Vector<LayoutRect>&, const LayoutPoint& additionalOffset, const RenderLayerModelObject* paintContainer) const;
 
     void invalidateCachedVisualOverflowRect() override { m_cachedVisualOverflowRect = std::nullopt; }

--- a/Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp
@@ -110,7 +110,12 @@ void RenderSVGResourceClipper::applyPathClipping(GraphicsContext& context, const
     if (layer()->isTransformed())
         clipPathTransform.multiply(layer()->transform()->toAffineTransform());
 
-    const auto& clipPath = clipRenderer.computeClipPath(clipPathTransform);
+    clipRenderer.computeClipContentTransform(clipPathTransform);
+    if (!m_cachedPathClip || m_cachedPathClipRenderer.get() != &clipRenderer) {
+        m_cachedPathClip = clipRenderer.computeClipPathGeometry();
+        m_cachedPathClipRenderer = clipRenderer;
+    }
+    const auto& clipPath = *m_cachedPathClip;
     auto windRule = clipRenderer.style().clipRule();
 
     if (auto* shape = dynamicDowncast<RenderSVGShape>(targetRenderer); shape && shape->shapeType() == RenderSVGShape::ShapeType::Rectangle) {
@@ -305,6 +310,12 @@ void RenderSVGResourceClipper::styleDidChange(Style::Difference diff, const Styl
     // Ensure that descendants with layers are rooted within our layer.
     if (hasLayer())
         layer()->setIsOpportunisticStackingContext(true);
+}
+
+void RenderSVGResourceClipper::clearCacheBeforeLayout()
+{
+    m_cachedPathClip = std::nullopt;
+    m_cachedPathClipRenderer = nullptr;
 }
 
 }

--- a/Source/WebCore/rendering/svg/RenderSVGResourceClipper.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceClipper.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include "Path.h"
 #include "RenderSVGResourceContainer.h"
 #include "SVGUnitTypes.h"
 
@@ -60,6 +61,11 @@ private:
     ASCIILiteral renderName() const final { return "RenderSVGResourceClipper"_s; }
 
     void styleDidChange(Style::Difference, const Style::ComputedStyle* oldStyle) final;
+
+    void clearCacheBeforeLayout() final;
+
+    mutable std::optional<Path> m_cachedPathClip;
+    mutable SingleThreadWeakPtr<RenderSVGModelObject> m_cachedPathClipRenderer;
 };
 
 }

--- a/Source/WebCore/rendering/svg/RenderSVGResourceContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceContainer.cpp
@@ -49,6 +49,7 @@ RenderSVGResourceContainer::~RenderSVGResourceContainer() = default;
 
 void RenderSVGResourceContainer::layout()
 {
+    clearCacheBeforeLayout();
     RenderSVGHiddenContainer::layout();
     repaintAllClients();
 }

--- a/Source/WebCore/rendering/svg/RenderSVGResourceContainer.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceContainer.h
@@ -41,6 +41,8 @@ public:
 protected:
     RenderSVGResourceContainer(Type, SVGElement&, Style::ComputedStyle&&);
 
+    virtual void clearCacheBeforeLayout() { }
+
 private:
     void layout() override;
     void willBeDestroyed() final;


### PR DESCRIPTION
#### 6574b387998abad57a67aa53491eef8ab2bc384c
<pre>
[LBSE] Cache the clip-path geometry instead of rebuilding it per clipped shape per frame
<a href="https://bugs.webkit.org/show_bug.cgi?id=319371">https://bugs.webkit.org/show_bug.cgi?id=319371</a>

Reviewed by Rob Buis.

RenderSVGResourceClipper::applyPathClipping() rebuilt the clip geometry for every clipped shape
on every frame: computeClipPath() -&gt; pathFromGraphicsElement() re-parses the clip child&apos;s
attributes into a new Path, and context.clipPath() then converts it to a CGPath via
Path::platformPath() -&gt; PathCG::create(). The geometry is constant for a given clip-path,
only the per-target transform differs and is applied separately via the CTM.

On MotionMark/Suits half the shapes carry a clip-path, so this rebuilt thousands of
identical clip paths per frame. Sampling at fixed, high complexity showed setupClipPathForRenderer
at ~12% of the WebProcess main thread (PathCG::create alone ~5%) - caching drops it to ~3% and
PathCG::create disappears.

Therefore cache the geometry as a Path on the clipper, flushed via a new clearCachesForLayout()
hook on RenderSVGResourceContainer, called from layout(). Only a relayout of the clip subtree
can change the clip geometry. Split computeClipPath() into computeClipPathGeometry() (cacheable) and
computeClipContentTransform(): the content transform is recomputed live every frame rather
than cached, because it can animate via the SVG/CSS transform fast path, which repaints the
clipper&apos;s clients without relaying out the &lt;clipPath&gt;.

Test: svg/clip-path/clip-path-child-transform-change.html

* LayoutTests/svg/clip-path/clip-path-child-transform-change-expected.html: Added.
* LayoutTests/svg/clip-path/clip-path-child-transform-change.html: Added.
* Source/WebCore/rendering/svg/RenderSVGModelObject.cpp:
(WebCore::RenderSVGModelObject::computeClipContentTransform const):
(WebCore::RenderSVGModelObject::computeClipPathGeometry const):
(WebCore::RenderSVGModelObject::computeClipPath const): Deleted.
* Source/WebCore/rendering/svg/RenderSVGModelObject.h:
* Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp:
(WebCore::RenderSVGResourceClipper::applyPathClipping):
(WebCore::RenderSVGResourceClipper::clearCacheBeforeLayout):
* Source/WebCore/rendering/svg/RenderSVGResourceClipper.h:
* Source/WebCore/rendering/svg/RenderSVGResourceContainer.cpp:
(WebCore::RenderSVGResourceContainer::layout):
* Source/WebCore/rendering/svg/RenderSVGResourceContainer.h:
(WebCore::RenderSVGResourceContainer::clearCacheBeforeLayout):

Canonical link: <a href="https://commits.webkit.org/317143@main">https://commits.webkit.org/317143@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7acc003ab351bf598caf5167f2ed799240b1c0ac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174451 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48384 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42165 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184028 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132319 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176316 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49676 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48066 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135712 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177409 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39150 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/156510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116190 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/37791 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32509 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148214 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36002 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186454 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39682 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144629 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48051 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156064 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144486 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48730 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114299 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26516 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39387 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/120692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47237 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10966 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46639 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46870 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46697 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->