### PR TITLE
Web Inspector: console.groupCollapsed messages sometimes render outside the collapsed group

### DIFF
--- a/LayoutTests/inspector/console/console-group-collapsed-render-batching-expected.txt
+++ b/LayoutTests/inspector/console/console-group-collapsed-render-batching-expected.txt
@@ -1,0 +1,10 @@
+Tests that messages inside a console.groupCollapsed() stay nested when the group's rendering spans multiple frames.
+
+
+== Running test suite: Console.GroupCollapsedRenderBatching
+-- Running test case: GroupSpanningRenderBatches
+PASS: All 150 children should be nested inside the collapsed group.
+
+-- Running test case: GroupContinuedAfterQueueDrains
+PASS: Child rendered in a later frame should nest in the still-open collapsed group.
+

--- a/LayoutTests/inspector/console/console-group-collapsed-render-batching.html
+++ b/LayoutTests/inspector/console/console-group-collapsed-render-batching.html
@@ -1,0 +1,150 @@
+<!doctype html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("Console.GroupCollapsedRenderBatching");
+
+    // The test front-end doesn't instantiate the full console UI, so provide minimal
+    // stand-ins for the container views the controller renders into. `ConsoleGroup`'s
+    // collapse behavior mirrors the production `WI.ConsoleGroup.prototype.render`.
+    WI.quickConsole = {needsLayout() {}};
+    WI.ConsoleCommandView = class ConsoleCommandView {};
+
+    WI.ConsoleSession = class ConsoleSession {
+        constructor() {
+            this.element = document.createElement("div");
+            this.element.className = "console-session";
+            this._messagesElement = this.element.appendChild(document.createElement("div"));
+            this._hasMessages = false;
+        }
+        append(element) { this._hasMessages = true; this._messagesElement.appendChild(element); }
+        addMessageView(messageView) { this.append(messageView.element); }
+        hasMessages() { return this._hasMessages; }
+    };
+
+    WI.ConsoleGroup = class ConsoleGroup {
+        constructor(parentGroup) { this._parentGroup = parentGroup; }
+        get parentGroup() { return this._parentGroup; }
+        render(messageView) {
+            let groupElement = document.createElement("div");
+            groupElement.className = "console-group";
+            groupElement.appendChild(messageView.element);
+            if (messageView.message.type === WI.ConsoleMessage.MessageType.StartGroupCollapsed)
+                groupElement.classList.add("collapsed");
+            this._messagesElement = groupElement.appendChild(document.createElement("div"));
+            this._messagesElement.className = "console-group-messages";
+            return groupElement;
+        }
+        append(element) { this._messagesElement.appendChild(element); }
+        addMessageView(messageView) { this.append(messageView.element); }
+    };
+
+    // Don't group failed source map errors; that path needs the full ConsoleManager.
+    WI.settings.experimentalGroupSourceMapErrors.value = false;
+
+    function makeMessageView(type) {
+        return {message: {type}, element: document.createElement("div"), render() {}};
+    }
+
+    function createController() {
+        let controller = Object.create(WI.JavaScriptLogViewController.prototype);
+        controller._element = document.createElement("div");
+        controller._scrollElement = document.createElement("div");
+        controller._sessions = [];
+        controller._currentSessionOrGroup = null;
+        controller._pendingMessagesForSessionOrGroup = new Map;
+        controller._openGroupForSessionOrGroup = new Map;
+        controller._scheduledRenderIdentifier = 0;
+        controller._cleared = true;
+        controller._previousMessageView = null;
+        controller._lastConsoleMessageViewForTarget = new WeakMap;
+        controller._lastCommitted = {text: "", special: false};
+        controller._repeatCountWasInterrupted = false;
+        controller._failedSourceMapsGroup = null;
+        controller.delegate = null;
+
+        // Avoid dependencies on layout, scrolling, and timestamp settings.
+        controller.scrollToBottom = function() {};
+        controller.isScrolledToBottom = function() { return false; };
+        controller._handleShowConsoleMessageTimestampsSettingChanged = function() {};
+
+        controller.startNewSession();
+        return controller;
+    }
+
+    // A message is properly nested inside a collapsed group when its element is a descendant
+    // of a `.console-group-messages` whose `.console-group` is `.collapsed`. If the group
+    // cursor is lost across render batches, the message is instead appended to the
+    // `.console-session` as a sibling of the group, and stays visible when the group collapses.
+    function isNestedInCollapsedGroup(messageView) {
+        let messagesElement = messageView.element.closest(".console-group-messages");
+        if (!messagesElement)
+            return false;
+        let groupElement = messagesElement.closest(".console-group");
+        return !!groupElement && groupElement.classList.contains("collapsed");
+    }
+
+    suite.addTestCase({
+        name: "GroupSpanningRenderBatches",
+        description: "A collapsed group with more children than fit in one render frame should keep every child nested.",
+        test(resolve, reject) {
+            let controller = createController();
+
+            controller._addToPendingMessages(makeMessageView(WI.ConsoleMessage.MessageType.StartGroupCollapsed));
+
+            // `maxMessagesPerFrame` is 100, so more than 99 children guarantees the group
+            // start and some of its children render in separate frames.
+            const childCount = 150;
+            let childViews = [];
+            for (let i = 0; i < childCount; ++i) {
+                let childView = makeMessageView(WI.ConsoleMessage.MessageType.Log);
+                childViews.push(childView);
+                controller._addToPendingMessages(childView);
+            }
+
+            controller._addToPendingMessages(makeMessageView(WI.ConsoleMessage.MessageType.EndGroup));
+
+            // Render synchronously; each call renders up to `maxMessagesPerFrame`.
+            do {
+                controller.renderPendingMessages();
+            } while (controller._pendingMessagesForSessionOrGroup.size);
+
+            let nestedCount = childViews.filter(isNestedInCollapsedGroup).length;
+            InspectorTest.expectEqual(nestedCount, childCount, `All ${childCount} children should be nested inside the collapsed group.`);
+
+            resolve();
+        }
+    });
+
+    suite.addTestCase({
+        name: "GroupContinuedAfterQueueDrains",
+        description: "A child logged after the pending queue drained on a group boundary should still nest in the open group.",
+        test(resolve, reject) {
+            let controller = createController();
+
+            // Frame 1: render only the group start; the pending queue drains here.
+            controller._addToPendingMessages(makeMessageView(WI.ConsoleMessage.MessageType.StartGroupCollapsed));
+            controller.renderPendingMessages();
+
+            // Frame 2: a child arrives afterwards and is rendered in a separate call.
+            let childView = makeMessageView(WI.ConsoleMessage.MessageType.Log);
+            controller._addToPendingMessages(childView);
+            controller.renderPendingMessages();
+
+            InspectorTest.expectThat(isNestedInCollapsedGroup(childView), "Child rendered in a later frame should nest in the still-open collapsed group.");
+
+            resolve();
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Tests that messages inside a <code>console.groupCollapsed()</code> stay nested when the group's rendering spans multiple frames.</p>
+</body>
+</html>

--- a/Source/WebInspectorUI/UserInterface/Controllers/JavaScriptLogViewController.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/JavaScriptLogViewController.js
@@ -66,6 +66,7 @@ WI.JavaScriptLogViewController = class JavaScriptLogViewController extends WI.Ob
         WI.settings.showConsoleMessageTimestamps.addEventListener(WI.Setting.Event.Changed, this._handleShowConsoleMessageTimestampsSettingChanged, this);
 
         this._pendingMessagesForSessionOrGroup = new Map;
+        this._openGroupForSessionOrGroup = new Map;
         this._scheduledRenderIdentifier = 0;
 
         this.startNewSession();
@@ -85,6 +86,7 @@ WI.JavaScriptLogViewController = class JavaScriptLogViewController extends WI.Ob
     {
         if (clearPreviousSessions) {
             this._pendingMessagesForSessionOrGroup.clear();
+            this._openGroupForSessionOrGroup.clear();
 
             if (this._sessions.length) {
                 for (let session of this._sessions)
@@ -104,6 +106,7 @@ WI.JavaScriptLogViewController = class JavaScriptLogViewController extends WI.Ob
         // Remove empty session.
         if (lastSession && !lastSession.hasMessages() && !this._pendingMessagesForSessionOrGroup.has(lastSession)) {
             this._sessions.pop();
+            this._openGroupForSessionOrGroup.delete(lastSession);
             lastSession.element.remove();
         }
 
@@ -354,7 +357,12 @@ WI.JavaScriptLogViewController = class JavaScriptLogViewController extends WI.Ob
         const maxMessagesPerFrame = 100;
         let renderedMessages = 0;
         for (let [session, messages] of this._pendingMessagesForSessionOrGroup) {
-            this._currentSessionOrGroup = session;
+            // Resume rendering in the group that was still open when this session's
+            // messages were last rendered. Otherwise a group whose messages span more
+            // than one frame (or whose remaining messages arrive after the queue drained
+            // on a group boundary) would have its later messages appended to the session
+            // instead of the group, so they would not be hidden when the group is collapsed.
+            this._currentSessionOrGroup = this._openGroupForSessionOrGroup.get(session) || session;
 
             let messagesToRender = messages.splice(0, maxMessagesPerFrame - renderedMessages);
             for (let message of messagesToRender) {
@@ -363,6 +371,14 @@ WI.JavaScriptLogViewController = class JavaScriptLogViewController extends WI.Ob
             }
 
             lastMessageView = messagesToRender.lastValue;
+
+            // Remember the currently open group (if any) so a later frame continues nesting
+            // into it. This must persist even when the pending queue drains on a group
+            // boundary, since more messages for the same open group may arrive later.
+            if (this._currentSessionOrGroup === session)
+                this._openGroupForSessionOrGroup.delete(session);
+            else
+                this._openGroupForSessionOrGroup.set(session, this._currentSessionOrGroup);
 
             if (!messages.length)
                 this._pendingMessagesForSessionOrGroup.delete(session);


### PR DESCRIPTION
#### e86171f6ef0b269ee0165771bcd69bb49da25cc7
<pre>
Web Inspector: console.groupCollapsed messages sometimes render outside the collapsed group
<a href="https://bugs.webkit.org/show_bug.cgi?id=319373">https://bugs.webkit.org/show_bug.cgi?id=319373</a>
<a href="https://rdar.apple.com/182177096">rdar://182177096</a>

Reviewed by NOBODY (OOPS!).

Console messages render in batches of up to 100 per animation frame, and group
nesting is rebuilt during rendering via the `_currentSessionOrGroup` cursor. That
cursor was reset to the session at the start of each `renderPendingMessages` call,
so it never carried across frames: a group whose members didn&apos;t all render in one
batch had its later members appended to the session instead of the group. Because
collapsing only hides messages inside the group, those escaped messages stayed
visible, and which ones escaped varied with batch timing.

Persist the open group per session in a new `_openGroupForSessionOrGroup` map,
resuming the cursor from it each batch so groups spanning frames stay nested.

* Source/WebInspectorUI/UserInterface/Controllers/JavaScriptLogViewController.js:
(WI.JavaScriptLogViewController):
(WI.JavaScriptLogViewController.prototype.startNewSession):
(WI.JavaScriptLogViewController.prototype.renderPendingMessages):
* LayoutTests/inspector/console/console-group-collapsed-render-batching-expected.txt: Added.
* LayoutTests/inspector/console/console-group-collapsed-render-batching.html: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e86171f6ef0b269ee0165771bcd69bb49da25cc7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174452 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48385 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42166 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184029 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132320 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/64838473-8a4d-41f7-ac8b-e5f9e7c281a8) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49677 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48067 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135713 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95767 "2 flakes 4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/76172c97-7448-419f-a96f-2124ea74096e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177410 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39149 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156509 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116191 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4deee249-a225-479f-ba57-9ef25d57875d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37790 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36159 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32510 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148213 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36001 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186455 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39683 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40356 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144627 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48052 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156063 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144490 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48731 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32621 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114304 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39385 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120693 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47238 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10965 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46640 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46871 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46698 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->