### PR TITLE
Web Inspector: autocompleting a vendor/-apple- prefixed value in Styles duplicates the prefix (e.g. -apple--apple-system)

### DIFF
--- a/LayoutTests/inspector/unit-tests/css-keyword-completions-expected.txt
+++ b/LayoutTests/inspector/unit-tests/css-keyword-completions-expected.txt
@@ -87,6 +87,14 @@ PASS: All expected completions were present.
 PASS: Expected result prefix to be "-webkit"
 PASS: All expected completions were present.
 
+-- Running test case: WI.CSSKeywordCompletions.forPartialPropertyValue.VendorPrefixedValueAfterSecondHyphen
+PASS: Expected result prefix to be "-webkit-f"
+PASS: All expected completions were present.
+
+-- Running test case: WI.CSSKeywordCompletions.forPartialPropertyValue.ApplePrefixedFontValue
+PASS: Expected result prefix to be "-apple-sys"
+PASS: All expected completions were present.
+
 -- Running test case: WI.CSSKeywordCompletions.forPartialPropertyValue.SubtractionCalc
 PASS: Expected result prefix to be ""
 PASS: All expected completions were present.

--- a/LayoutTests/inspector/unit-tests/css-keyword-completions.html
+++ b/LayoutTests/inspector/unit-tests/css-keyword-completions.html
@@ -272,6 +272,26 @@ function test()
         expectedCompletions: ["-webkit-flex"],
     });
 
+    // `-webkit-f|`
+    addTestForPartialPropertyValue({
+        name: "WI.CSSKeywordCompletions.forPartialPropertyValue.VendorPrefixedValueAfterSecondHyphen",
+        description: "Test that a value whose vendor prefix is complete (a `-vendor-` meta token) is entirely used as a prefix, so applying a completion does not duplicate the prefix (e.g. `-webkit--webkit-flex`).",
+        propertyName: "display",
+        text: "-webkit-f",
+        expectedPrefix: "-webkit-f",
+        expectedCompletions: ["-webkit-flex"],
+    });
+
+    // `-apple-sys|`
+    addTestForPartialPropertyValue({
+        name: "WI.CSSKeywordCompletions.forPartialPropertyValue.ApplePrefixedFontValue",
+        description: "Test that an `-apple-`-prefixed font value uses the whole identifier as the prefix, so applying a completion does not produce `-apple--apple-system`.",
+        propertyName: "font-family",
+        text: "-apple-sys",
+        expectedPrefix: "-apple-sys",
+        expectedCompletions: ["-apple-system"],
+    });
+
     // `calc(1 - |`
     addTestForPartialPropertyValue({
         name: "WI.CSSKeywordCompletions.forPartialPropertyValue.SubtractionCalc",

--- a/Source/WebInspectorUI/UserInterface/Models/CSSKeywordCompletions.js
+++ b/Source/WebInspectorUI/UserInterface/Models/CSSKeywordCompletions.js
@@ -95,8 +95,10 @@ WI.CSSKeywordCompletions.forPartialPropertyValue = function(text, propertyName, 
     if (currentTokenValue === ")" || tokenBeforeCaret?.value === ")")
         return {prefix: "", completions: []};
 
-    // The CodeMirror CSS-mode tokenizer splits a string like `-name` into two tokens: `-` and `name`.
-    if (currentTokenValue.length && tokenBeforeCaret?.value === "-") {
+    // The CodeMirror CSS-mode tokenizer splits a hyphen-prefixed identifier into two tokens: a leading `-`
+    // for a value like `-name`, or a `-vendor-` meta token followed by the remainder for a value like
+    // `-apple-system`. Rejoin the preceding hyphen-terminated token so the whole identifier is the prefix.
+    if (currentTokenValue.length && tokenBeforeCaret?.value.endsWith("-")) {
         currentTokenValue = tokenBeforeCaret.value + currentTokenValue;
     }
 


### PR DESCRIPTION
#### 4460daca377eee69fecc02563f3ed7023fc57ef2
<pre>
Web Inspector: autocompleting a vendor/-apple- prefixed value in Styles duplicates the prefix (e.g. -apple--apple-system)
<a href="https://bugs.webkit.org/show_bug.cgi?id=319374">https://bugs.webkit.org/show_bug.cgi?id=319374</a>
<a href="https://rdar.apple.com/182178871">rdar://182178871</a>

Reviewed by Devin Rousso.

Typing a hyphen-prefixed CSS value such as `-apple-system` or `-webkit-flex`
in the Elements &gt; Styles sidebar and then picking a completion produced a
duplicated prefix like `-apple--apple-system`, which is invalid and gets
dropped until the page is reloaded.

The CodeMirror CSS-mode tokenizer splits a hyphen-prefixed identifier in two
different ways: a value like `-name` becomes a bare `-` token followed by
`name`, while a value like `-apple-system` becomes a `-apple-` meta token
followed by `system`. `forPartialPropertyValue` only rejoined the preceding
token when it was exactly `-`, so once the second hyphen was typed the prefix
was computed as just the trailing segment (`system`). Applying the completion
then removed only that segment and inserted the full value on top of the
leftover `-apple-`, yielding `-apple--apple-system`.

Rejoin any hyphen-terminated preceding token (covering both the bare `-` and
the `-vendor-` meta token) so the whole identifier is used as the prefix.

* Source/WebInspectorUI/UserInterface/Models/CSSKeywordCompletions.js:
(WI.CSSKeywordCompletions.forPartialPropertyValue): Rejoin the preceding
token when it ends with `-`, not only when it is exactly `-`.

* LayoutTests/inspector/unit-tests/css-keyword-completions-expected.txt:
* LayoutTests/inspector/unit-tests/css-keyword-completions.html:
* Source/WebInspectorUI/UserInterface/Models/CSSKeywordCompletions.js:

Canonical link: <a href="https://commits.webkit.org/317167@main">https://commits.webkit.org/317167@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d041b34818d7bdbed536160d652e9a1e1795404a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174457 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48390 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42171 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184034 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132325 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49682 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48073 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135718 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5ae512c2-ce4a-4c53-94ae-bbbe3cb8571d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177415 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39156 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156517 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116196 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37797 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32515 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148220 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36009 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186460 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39689 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40363 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144633 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48057 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156071 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144491 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38962 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48736 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114313 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39391 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120700 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47243 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10973 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46645 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46876 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46703 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->