### PR TITLE
[Coordinated] Damage a layer when its state changes the composited result

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
@@ -367,6 +367,7 @@ void CoordinatedPlatformLayer::setMasksToBounds(bool masksToBounds)
 
     m_masksToBounds = masksToBounds;
     m_pendingChanges.add(Change::MasksToBounds);
+    damageWholeLayer();
     notifyCompositionRequired();
 }
 
@@ -411,6 +412,7 @@ void CoordinatedPlatformLayer::setBlendMode(BlendMode blendMode)
 
     m_blendMode = blendMode;
     m_pendingChanges.add(Change::BlendMode);
+    damageWholeLayer();
     notifyCompositionRequired();
 }
 
@@ -422,6 +424,7 @@ void CoordinatedPlatformLayer::setContentsVisible(bool contentsVisible)
 
     m_contentsVisible = contentsVisible;
     m_pendingChanges.add(Change::ContentsVisible);
+    damageWholeLayer();
     notifyCompositionRequired();
 }
 
@@ -440,6 +443,7 @@ void CoordinatedPlatformLayer::setContentsOpaque(bool contentsOpaque)
     m_contentsOpaque = contentsOpaque;
     m_pendingChanges.add(Change::ContentsOpaque);
     // FIXME: request a full repaint?
+    damageWholeLayer();
     notifyCompositionRequired();
 }
 
@@ -451,6 +455,7 @@ void CoordinatedPlatformLayer::setContentsRect(const FloatRect& contentsRect)
 
     m_contentsRect = contentsRect;
     m_pendingChanges.add(Change::ContentsRect);
+    damageWholeLayer();
     notifyCompositionRequired();
 }
 
@@ -462,6 +467,7 @@ void CoordinatedPlatformLayer::setContentsRectClipsDescendants(bool contentsRect
 
     m_contentsRectClipsDescendants = contentsRectClipsDescendants;
     m_pendingChanges.add(Change::ContentsRectClipsDescendants);
+    damageWholeLayer();
     notifyCompositionRequired();
 }
 
@@ -473,6 +479,7 @@ void CoordinatedPlatformLayer::setContentsClippingRect(const FloatRoundedRect& c
 
     m_contentsClippingRect = contentsClippingRect;
     m_pendingChanges.add(Change::ContentsClippingRect);
+    damageWholeLayer();
     notifyCompositionRequired();
 }
 
@@ -516,7 +523,7 @@ void CoordinatedPlatformLayer::setContentsBuffer(std::unique_ptr<CoordinatedPlat
     if (dirtyRegion)
         addDamage(WTF::move(*dirtyRegion));
     else
-        addDamage(Damage { m_size, Damage::Mode::Full });
+        damageWholeLayer();
 #else
     UNUSED_PARAM(dirtyRegion);
 #endif
@@ -565,6 +572,7 @@ void CoordinatedPlatformLayer::setContentsImage(NativeImage* image)
         m_imageBackingStore.current = nullptr;
     }
     m_pendingChanges.add(Change::ContentsImage);
+    damageWholeLayer();
     notifyCompositionRequired();
 }
 
@@ -587,6 +595,7 @@ void CoordinatedPlatformLayer::setContentsTileSize(const FloatSize& contentsTile
 
     m_contentsTileSize = contentsTileSize;
     m_pendingChanges.add(Change::ContentsTiling);
+    damageWholeLayer();
     notifyCompositionRequired();
 }
 
@@ -598,6 +607,7 @@ void CoordinatedPlatformLayer::setContentsTilePhase(const FloatSize& contentsTil
 
     m_contentsTilePhase = contentsTilePhase;
     m_pendingChanges.add(Change::ContentsTiling);
+    damageWholeLayer();
     notifyCompositionRequired();
 }
 
@@ -626,6 +636,17 @@ void CoordinatedPlatformLayer::addDamage(Damage&& damage)
 }
 #endif
 
+void CoordinatedPlatformLayer::damageWholeLayer()
+{
+#if ENABLE(DAMAGE_TRACKING)
+    // An empty Damage rejects everything added to it later, so it must never become the layer's damage.
+    if (!m_damagePropagationEnabled || m_size.isEmpty())
+        return;
+
+    addDamage(Damage { m_size, Damage::Mode::Full });
+#endif
+}
+
 void CoordinatedPlatformLayer::setFilters(const FilterOperations& filters)
 {
     ASSERT(m_lock.isHeld());
@@ -634,6 +655,7 @@ void CoordinatedPlatformLayer::setFilters(const FilterOperations& filters)
 
     m_filters = filters;
     m_pendingChanges.add(Change::Filters);
+    damageWholeLayer();
     notifyCompositionRequired();
 }
 
@@ -645,6 +667,7 @@ void CoordinatedPlatformLayer::setMask(CoordinatedPlatformLayer* mask)
 
     m_mask = mask;
     m_pendingChanges.add(Change::Mask);
+    damageWholeLayer();
     notifyCompositionRequired();
 }
 
@@ -656,6 +679,7 @@ void CoordinatedPlatformLayer::setReplica(CoordinatedPlatformLayer* replica)
 
     m_replica = replica;
     m_pendingChanges.add(Change::Replica);
+    damageWholeLayer();
     notifyCompositionRequired();
 }
 
@@ -673,6 +697,7 @@ void CoordinatedPlatformLayer::notifyBackdropFiltersChanged()
 {
     ASSERT(m_lock.isHeld());
     m_pendingChanges.add(Change::Backdrop);
+    damageWholeLayer();
     notifyCompositionRequired();
 }
 
@@ -684,6 +709,7 @@ void CoordinatedPlatformLayer::setBackdropRect(const FloatRoundedRect& backdropR
 
     m_backdropRect = backdropRect;
     m_pendingChanges.add(Change::BackdropRect);
+    damageWholeLayer();
     notifyCompositionRequired();
 }
 
@@ -741,6 +767,7 @@ void CoordinatedPlatformLayer::setClipPath(const Path& path, WindRule windRule)
     m_clipPath.path = path;
     m_clipPath.windRule = windRule;
     m_pendingChanges.add(Change::ClipPath);
+    damageWholeLayer();
 }
 
 void CoordinatedPlatformLayer::setDebugBorder(Color&& borderColor, float borderWidth)

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
@@ -228,6 +228,7 @@ private:
 #if ENABLE(DAMAGE_TRACKING)
     void addDamage(Damage&&);
 #endif
+    void damageWholeLayer();
 
     void flushCompositingStateOnTarget(const OptionSet<CompositionReason>&, TextureMapperLayer&);
 #if USE(SKIA)


### PR DESCRIPTION
#### b825954ee089fbe3cbc58dabc71e132e14d45c12
<pre>
[Coordinated] Damage a layer when its state changes the composited result
<a href="https://bugs.webkit.org/show_bug.cgi?id=319375">https://bugs.webkit.org/show_bug.cgi?id=319375</a>

Reviewed by Carlos Garcia Campos.

A layer records damage when its backing store re-renders and when a new contents
buffer arrives, and the compositor layers damage the whole layer themselves when
it is resized or its opacity or transform changes. Nothing records damage for the
rest of the state the compositor applies while drawing the layer: the contents
rect, the contents tiling, filters, masks, the clip path, the blend mode and
contents visibility. Changing any of those changes the pixels the compositor
produces for the layer, but none of them dirties a tile, so the backing store is
never re-rendered and no damage is recorded on their behalf.

A compositor that draws just the damaged rects therefore leaves the previous
frame&apos;s pixels on screen. e.g. An animated background-position on a directly
composited image only changes the contents tile phase, so the frame currently
carries no damage at all and the animation freezes.

Therefore damage the whole layer from those setters.

* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp:
(WebCore::CoordinatedPlatformLayer::setMasksToBounds):
(WebCore::CoordinatedPlatformLayer::setBlendMode):
(WebCore::CoordinatedPlatformLayer::setContentsVisible):
(WebCore::CoordinatedPlatformLayer::setContentsOpaque):
(WebCore::CoordinatedPlatformLayer::setContentsRect):
(WebCore::CoordinatedPlatformLayer::setContentsRectClipsDescendants):
(WebCore::CoordinatedPlatformLayer::setContentsClippingRect):
(WebCore::CoordinatedPlatformLayer::setContentsBuffer):
(WebCore::CoordinatedPlatformLayer::setContentsImage):
(WebCore::CoordinatedPlatformLayer::setContentsTileSize):
(WebCore::CoordinatedPlatformLayer::setContentsTilePhase):
(WebCore::CoordinatedPlatformLayer::damageWholeLayer):
(WebCore::CoordinatedPlatformLayer::setFilters):
(WebCore::CoordinatedPlatformLayer::setMask):
(WebCore::CoordinatedPlatformLayer::setReplica):
(WebCore::CoordinatedPlatformLayer::notifyBackdropFiltersChanged):
(WebCore::CoordinatedPlatformLayer::setBackdropRect):
(WebCore::CoordinatedPlatformLayer::setClipPath):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h:

Canonical link: <a href="https://commits.webkit.org/317142@main">https://commits.webkit.org/317142@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd625b4fe9d08b09a38fac3ef8213d3f287acb34

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174458 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48391 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42172 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184035 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132326 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176323 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49683 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48074 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135720 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177416 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39155 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/156516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116198 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37796 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32516 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148219 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36008 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186461 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/39691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144635 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48058 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144493 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48737 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114314 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26515 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39392 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/120702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47244 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10972 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46646 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46877 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46704 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->