### PR TITLE
[JSC] Use overflow-safe range when choosing a switch jump table

### DIFF
--- a/Source/JavaScriptCore/b3/B3LowerMacros.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerMacros.cpp
@@ -1209,11 +1209,12 @@ private:
         const unsigned minCasesForTable = 7;
         const unsigned densityLimit = 4;
         if (end - start >= minCasesForTable) {
-            int64_t firstValue = cases[start].caseValue();
-            int64_t lastValue = cases[end - 1].caseValue();
-            if ((lastValue - firstValue + 1) / (end - start) < densityLimit) {
-                size_t tableSize = lastValue - firstValue + 1 + 1; // + 1 for fallthrough
-                Value* index = before->appendNew<Value>(m_proc, Sub, m_origin, child, before->appendIntConstant(m_proc, m_origin, type, firstValue));
+            CheckedInt64 firstValue = cases[start].caseValue();
+            CheckedInt64 lastValue = cases[end - 1].caseValue();
+            CheckedInt64 range = lastValue - firstValue + 1;
+            if (!range.hasOverflowed() && static_cast<uint64_t>(range.value()) / (end - start) < densityLimit) {
+                size_t tableSize = static_cast<size_t>(range.value()) + 1; // + 1 for fallthrough
+                Value* index = before->appendNew<Value>(m_proc, Sub, m_origin, child, before->appendIntConstant(m_proc, m_origin, type, firstValue.value()));
                 Value* fallthroughIndex = before->appendIntConstant(m_proc, m_origin, type, tableSize - 1);
                 index = before->appendNew<B3::Value>(m_proc, Select, m_origin, before->appendNew<Value>(m_proc, AboveEqual, m_origin, index, fallthroughIndex), fallthroughIndex, index);
 
@@ -1242,7 +1243,7 @@ private:
                     FrequentedBlock block = cases[i].target();
                     int64_t value = cases[i].caseValue();
                     before->appendSuccessor(block);
-                    size_t index = value - firstValue;
+                    size_t index = value - firstValue.value();
                     ASSERT(!handledIndices.get(index));
                     handledIndices.set(index);
                 }

--- a/Source/JavaScriptCore/b3/testb3.h
+++ b/Source/JavaScriptCore/b3/testb3.h
@@ -1227,6 +1227,7 @@ void testSwitchSameCaseAsDefault();
 void testSwitchChillDiv(unsigned degree, unsigned gap);
 void testSwitchTargettingSameBlock();
 void testSwitchTargettingSameBlockFoldPathConstant();
+void testSwitchSparseI64RangeOverflow();
 void testTruncFold(int64_t value);
 void testZExt32(int32_t value);
 void testZExt32Fold(int32_t value);

--- a/Source/JavaScriptCore/b3/testb3_1.cpp
+++ b/Source/JavaScriptCore/b3/testb3_1.cpp
@@ -924,6 +924,7 @@ void run(const TestConfig* config)
 
     RUN(testSwitchTargettingSameBlock());
     RUN(testSwitchTargettingSameBlockFoldPathConstant());
+    RUN(testSwitchSparseI64RangeOverflow());
 
     RUN(testTrunc(0));
     RUN(testTrunc(1));

--- a/Source/JavaScriptCore/b3/testb3_5.cpp
+++ b/Source/JavaScriptCore/b3/testb3_5.cpp
@@ -2967,6 +2967,51 @@ void testSwitchTargettingSameBlockFoldPathConstant()
     }
 }
 
+void testSwitchSparseI64RangeOverflow()
+{
+    static constexpr auto caseValues = WTF::toArray<int64_t>({
+        -7554636318383037360LL, -7454801818899625434LL, -7429423314461979223LL,
+        -7207276661950557992LL, -7131803591814180821LL, -6019758777144226059LL,
+        -5780275611666609265LL, -4358396017616483017LL, -4143042619558893734LL,
+        -2917486167113271335LL, -2784610183734848337LL, -2624729345222129160LL,
+        -2622802681898502475LL, -2183502553742430119LL, -425081688584147149LL,
+        457380681191578133LL, 898638452777906692LL, 950521141494289804LL,
+        1228320887535867596LL, 1732804360746816840LL, 2039119943687723725LL,
+        3865875329656804759LL, 4986947095633979045LL, 5134327459162675121LL,
+        5167461299025127993LL, 5265749391392088513LL, 5268430586848198546LL,
+        5400666402170143952LL, 6290364617955584048LL, 6568062526259002154LL,
+    });
+    static constexpr unsigned numCases = caseValues.size();
+
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    auto arguments = cCallArgumentValues<int64_t>(proc, root);
+
+    BasicBlock* fallThrough = proc.addBlock();
+    fallThrough->appendNewControlValue(
+        proc, Return, Origin(),
+        fallThrough->appendNew<Const64Value>(proc, Origin(), -1));
+
+    SwitchValue* switchValue = root->appendNew<SwitchValue>(proc, Origin(), arguments[0]);
+    switchValue->setFallThrough(FrequentedBlock(fallThrough));
+
+    for (unsigned i = 0; i < numCases; ++i) {
+        BasicBlock* target = proc.addBlock();
+        target->appendNewControlValue(
+            proc, Return, Origin(),
+            target->appendNew<Const64Value>(proc, Origin(), static_cast<int64_t>(i)));
+        switchValue->appendCase(SwitchCase(caseValues[i], FrequentedBlock(target)));
+    }
+
+    auto code = compileProc(proc);
+
+    for (unsigned i = 0; i < numCases; ++i)
+        CHECK_EQ(invoke<int64_t>(*code, caseValues[i]), static_cast<int64_t>(i));
+    CHECK_EQ(invoke<int64_t>(*code, 0), static_cast<int64_t>(-1));
+    CHECK_EQ(invoke<int64_t>(*code, std::numeric_limits<int64_t>::min()), static_cast<int64_t>(-1));
+    CHECK_EQ(invoke<int64_t>(*code, std::numeric_limits<int64_t>::max()), static_cast<int64_t>(-1));
+}
+
 void testTruncFold(int64_t value)
 {
     Procedure proc;


### PR DESCRIPTION
#### 72ea806faa2186f39c48899724ad6c2f336270ac
<pre>
[JSC] Use overflow-safe range when choosing a switch jump table
<a href="https://bugs.webkit.org/show_bug.cgi?id=317022">https://bugs.webkit.org/show_bug.cgi?id=317022</a>

Reviewed by Keith Miller.

recursivelyBuildSwitch picks a jump table when (last - first + 1) / n is
below a density limit. When case values span more than 2^63, that
subtraction overflows signed int64; the wrapped result can look dense and
tableSize becomes enormous, OOMing in BitVector / data-section allocation.

Compute the span with CheckedInt64 and skip the table path on overflow.
Add a testb3 case with the sparse i64 values from the bug report.

* Source/JavaScriptCore/b3/B3LowerMacros.cpp:
(JSC::B3::LowerMacros::recursivelyBuildSwitch): Checked span for density.
* Source/JavaScriptCore/b3/testb3.h:
* Source/JavaScriptCore/b3/testb3_1.cpp:
* Source/JavaScriptCore/b3/testb3_5.cpp:
(testSwitchSparseI64RangeOverflow): Added.

Canonical link: <a href="https://commits.webkit.org/318166@main">https://commits.webkit.org/318166@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61a37ad10005728aa4cd8bedea8efe1d39e615fc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175027 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48960 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42741 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184608 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132935 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50252 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48643 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136220 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96105 "1 flakes 5 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177985 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39666 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157015 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116699 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38307 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36689 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5524 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148730 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36507 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33085 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/36289 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/40773 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40891 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187032 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48627 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145166 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49307 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33128 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145021 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26920 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39884 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121453 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/115125 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47813 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11480 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47216 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47446 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47273 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->