### PR TITLE
[WPE][GTK] Implement `UIScriptController.sendEventStream()` for wheel events

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1628,9 +1628,6 @@ webkit.org/b/218931 fast/events/wheel/wheel-events-become-non-cancelable.html [ 
 # We draw the focus ring of focused links on keydown event.
 imported/blink/fast/events/click-focus-keydown-no-ring.html [ ImageOnlyFailure ]
 
-# WTR doesn't implement yet UIScriptController::sendEventStream(), skip.
-webkit.org/b/233092 imported/w3c/web-platform-tests/html/user-activation/activation-trigger-pointerevent.html?touch [ Skip ]
-
 webkit.org/b/313980 imported/w3c/web-platform-tests/html/user-activation/propagation-crossorigin.sub.html [ Failure Pass ]
 
 # `scrollend` events are not supported on gtk/wpe
@@ -1647,13 +1644,8 @@ webkit.org/b/201556 imported/w3c/web-platform-tests/dom/events/scrolling/scrolle
 
 webkit.org/b/219248 imported/w3c/web-platform-tests/uievents/mouse/mouseevent_move_button.html [ Failure ]
 
-# WTR::UIScriptController::sendEventStream isn't implemented
-# Crash mentioning WTR::UIScriptController::notImplemented() with the EventTimingEnabled feature flag
-webkit.org/b/296246 imported/w3c/web-platform-tests/event-timing/first-input-interactionid-key.html [ Skip ]
-webkit.org/b/296246 imported/w3c/web-platform-tests/event-timing/interaction-count-tap.html [ Skip ]
-webkit.org/b/296246 imported/w3c/web-platform-tests/event-timing/TapToStopFling.html [ Skip ]
+imported/w3c/web-platform-tests/event-timing/TapToStopFling.html [ Skip ]
 
-# Crash mentioning WTR::UIScriptController::notImplemented()
 imported/w3c/web-platform-tests/dom/events/scrolling/scrollIntoView-in-onscroll-to-sticky.html [ Skip ]
 imported/w3c/web-platform-tests/dom/events/scrolling/wheel-event-composed.html [ Skip ]
 imported/w3c/web-platform-tests/dom/events/scrolling/wheel-event-no-scroll-after-prevent-default.html [ Skip ]
@@ -4357,7 +4349,6 @@ imported/w3c/web-platform-tests/html/canvas/offscreen/wide-gamut-canvas/ [ Skip 
 
 storage/indexeddb/structured-clone-image-data-display-p3.html [ Skip ]
 
-# UIScriptController::sendEventStream
 webkit.org/b/205159 fast/scrolling/overflow-scroll-past-max.html [ Skip ]
 
 # Timing out due to missing functionality.
@@ -4818,9 +4809,6 @@ webkit.org/b/278719 imported/w3c/web-platform-tests/touch-events/historical.html
 webkit.org/b/278719 imported/w3c/web-platform-tests/touch-events/touch-retargeting.html [ Failure ]
 webkit.org/b/278719 imported/w3c/web-platform-tests/touch-events/touch-touchevent-constructor.html [ Failure ]
 
-# UIScriptController::sendEventStream
-webkit.org/b/278719 fast/events/touch/prevent-default-touchmove-prevents-scrolling.html [ Skip ]
-
 # EWS indicates this test is too slow on bots.
 security/decode-buffer-size.html [ Skip ]
 
@@ -4964,39 +4952,11 @@ webkit.org/b/204115 imported/w3c/web-platform-tests/pointerevents/pointerevent_s
 webkit.org/b/204115 imported/w3c/web-platform-tests/pointerevents/pointerevent_setpointercapture_to_same_element_twice.html?touch [ Skip ]
 webkit.org/b/204115 imported/w3c/web-platform-tests/pointerevents/pointerevent_pointerrawupdate_changes_pointer_capture.https.html [ Skip ]
 
-# These tests crash because UIScriptController.sendEventStream is not implemented on GTK nor WPE.
-# Implement wheel WPT actions in WebKit's test vendor JS without UIScriptController.sendEventStream.
-webkit.org/b/263473 imported/w3c/web-platform-tests/pointerevents/pointerevent_hit_test_scroll.html [ Skip ]
-webkit.org/b/263473 imported/w3c/web-platform-tests/pointerevents/pointerevent_hit_test_scroll_visible_descendant.html [ Skip ]
-webkit.org/b/263473 imported/w3c/web-platform-tests/pointerevents/pointerevent_touch-action-mouse.html [ Skip ]
-webkit.org/b/263473 imported/w3c/web-platform-tests/pointerevents/compat/pointerevent_touch_target_after_pointerdown_target_removed.tentative.html [ Skip ]
-webkit.org/b/263473 imported/w3c/web-platform-tests/pointerevents/pointer-events-none-skip-scroll-in-iframe.html [ Skip ]
-webkit.org/b/263473 imported/w3c/web-platform-tests/pointerevents/pointer-events-none-skip-scroll-scrollbar.html [ Skip ]
-webkit.org/b/263473 imported/w3c/web-platform-tests/pointerevents/pointer-events-none-skip-scroll-will-change-in-iframe.html [ Skip ]
-webkit.org/b/263473 imported/w3c/web-platform-tests/pointerevents/pointer-events-none-skip-scroll-will-change-scrollbar.html [ Skip ]
-webkit.org/b/263473 imported/w3c/web-platform-tests/pointerevents/pointer-events-none-skip-scroll-will-change.html [ Skip ]
-webkit.org/b/263473 imported/w3c/web-platform-tests/pointerevents/pointer-events-none-skip-scroll.html [ Skip ]
-webkit.org/b/263473 imported/w3c/web-platform-tests/pointerevents/pointerevent_after_target_appended_interleaved.tentative.html?touch [ Skip ]
-webkit.org/b/263473 imported/w3c/web-platform-tests/pointerevents/pointerevent_after_target_removed_interleaved.tentative.html?touch [ Skip ]
-webkit.org/b/263473 imported/w3c/web-platform-tests/pointerevents/pointerevent_attributes.html?mouse [ Skip ]
-webkit.org/b/263473 imported/w3c/web-platform-tests/pointerevents/pointerevent_attributes.html?mouse-nonstandard [ Skip ]
-webkit.org/b/263473 imported/w3c/web-platform-tests/pointerevents/pointerevent_attributes.html?mouse-right [ Skip ]
-webkit.org/b/263473 imported/w3c/web-platform-tests/pointerevents/pointerevent_attributes.html?mouse-right-nonstandard [ Skip ]
-webkit.org/b/263473 imported/w3c/web-platform-tests/pointerevents/pointerevent_attributes.html?pen [ Skip ]
-webkit.org/b/263473 imported/w3c/web-platform-tests/pointerevents/pointerevent_attributes.html?pen-nonstandard [ Skip ]
-webkit.org/b/263473 imported/w3c/web-platform-tests/pointerevents/pointerevent_attributes.html?pen-right [ Skip ]
-webkit.org/b/263473 imported/w3c/web-platform-tests/pointerevents/pointerevent_attributes.html?pen-right-nonstandard [ Skip ]
-webkit.org/b/263473 imported/w3c/web-platform-tests/pointerevents/pointerevent_attributes.html?touch [ Skip ]
-webkit.org/b/263473 imported/w3c/web-platform-tests/pointerevents/pointerevent_attributes.html?touch-nonstandard [ Skip ]
+imported/w3c/web-platform-tests/pointerevents/pointerevent_hit_test_scroll_visible_descendant.html [ Skip ]
+imported/w3c/web-platform-tests/pointerevents/pointer-events-none-skip-scroll-in-iframe.html [ Skip ]
+imported/w3c/web-platform-tests/pointerevents/pointer-events-none-skip-scroll-will-change-in-iframe.html [ Skip ]
+imported/w3c/web-platform-tests/pointerevents/pointerevent_attributes.html?pen [ Skip ]
 webkit.org/b/274686 imported/w3c/web-platform-tests/pointerevents/pointerevent_capture_mouse_and_release_and_capture_again.html [ Skip ]
-webkit.org/b/263473 imported/w3c/web-platform-tests/pointerevents/pointerevent_capture_touch_and_release_at_got_capture.html [ Skip ]
-webkit.org/b/263473 imported/w3c/web-platform-tests/pointerevents/pointerevent_pointermove_isprimary_same_as_pointerdown.html?touch [ Skip ]
-webkit.org/b/263473 imported/w3c/web-platform-tests/pointerevents/coalesced_events_attributes_on_redispatch.https.html?touch [ Skip ]
-webkit.org/b/263473 imported/w3c/web-platform-tests/pointerevents/crashtests/longpress-crash.html [ Skip ]
-webkit.org/b/263473 imported/w3c/web-platform-tests/pointerevents/pointerevent_click_during_parent_capture.html?pointerType=touch&preventDefault= [ Skip ]
-webkit.org/b/263473 imported/w3c/web-platform-tests/pointerevents/pointerevent_click_during_parent_capture.html?pointerType=touch&preventDefault=pointerdown [ Skip ]
-webkit.org/b/263473 imported/w3c/web-platform-tests/pointerevents/pointerevent_click_during_parent_capture.html?pointerType=touch&preventDefault=touchstart [ Skip ]
-webkit.org/b/263473 imported/w3c/web-platform-tests/pointerevents/pointerevent_touch-propagates-when-target-is-video_touch.html [ Skip ]
 
 webkit.org/b/290133 svg/dom/SVGGeometry-isPointInFill-with-null-path.html [ Skip ]
 
@@ -5030,9 +4990,6 @@ imported/w3c/web-platform-tests/css/css-view-transitions/transition-in-hidden-pa
 webkit.org/b/204001 imported/w3c/web-platform-tests/pointerevents/pointerlock/pointerevent_coordinates_when_locked.html [ Skip ]
 
 imported/w3c/web-platform-tests/uievents/interface/keyboard-accesskey-click-event.html [ Failure ]
-
-imported/w3c/web-platform-tests/visual-viewport/page-and-offset-in-iframe.html [ Skip ]
-imported/w3c/web-platform-tests/visual-viewport/scroll-event-order.html [ Skip ]
 
 fast/canvas/webgl/tex-image-and-sub-image-2d-with-video-rgb565.html [ Failure Pass ]
 

--- a/Tools/WebKitTestRunner/EventSenderProxy.h
+++ b/Tools/WebKitTestRunner/EventSenderProxy.h
@@ -39,6 +39,10 @@
 OBJC_CLASS NSEvent;
 #endif
 
+#if PLATFORM(GTK)
+enum class WheelEventPhase;
+#endif
+
 namespace WebCore {
 enum class MouseButton : int8_t;
 }
@@ -73,6 +77,7 @@ public:
     void mouseScrollByWithWheelAndMomentumPhases(int x, int y, int phase, int momentum);
 #if PLATFORM(GTK)
     void setWheelHasPreciseDeltas(bool);
+    void sendWheelEvent(double x, double y, double deltaX, double deltaY, WheelEventPhase, WheelEventPhase momentumPhase);
 #endif
     void continuousMouseScrollBy(int x, int y, bool paged);
 
@@ -89,6 +94,19 @@ public:
     using EventTimestamp = uint64_t; // mach_absolute_time units.
 
     void sendWheelEvent(EventTimestamp, double globalX, double globalY, double deltaX, double deltaY, WheelEventPhase, WheelEventPhase momentumPhase);
+#endif
+
+#if PLATFORM(WPE)
+    enum class WheelEventPhase : uint8_t {
+        None,
+        Began,
+        Changed,
+        Ended,
+        Cancelled,
+        MayBegin,
+    };
+
+    void sendWheelEvent(double time, double x, double y, double deltaX, double deltaY, WheelEventPhase, WheelEventPhase momentumPhase);
 #endif
 
     void leapForward(int milliseconds);

--- a/Tools/WebKitTestRunner/gtk/EventSenderProxyGtk.cpp
+++ b/Tools/WebKitTestRunner/gtk/EventSenderProxyGtk.cpp
@@ -394,6 +394,12 @@ void EventSenderProxy::setWheelHasPreciseDeltas(bool hasPreciseDeltas)
     m_hasPreciseDeltas = hasPreciseDeltas;
 }
 
+void EventSenderProxy::sendWheelEvent(double x, double y, double deltaX, double deltaY, WheelEventPhase phase, WheelEventPhase momentumPhase)
+{
+    webkitWebViewBaseSynthesizeWheelEvent(toWebKitGLibAPI(m_testController->targetView()->platformView()),
+        deltaX, deltaY, x, y, phase, momentumPhase, true);
+}
+
 void EventSenderProxy::leapForward(int milliseconds)
 {
     m_time += milliseconds / 1000.0;

--- a/Tools/WebKitTestRunner/gtk/UIScriptControllerGtk.cpp
+++ b/Tools/WebKitTestRunner/gtk/UIScriptControllerGtk.cpp
@@ -36,6 +36,7 @@
 #include <WebKit/WKTextCheckerGLib.h>
 #include <WebKit/WKViewPrivate.h>
 #include <gtk/gtk.h>
+#include <webkit/WebKitWebViewBaseInternal.h>
 #include <wtf/JSONValues.h>
 #include <wtf/RunLoop.h>
 
@@ -226,6 +227,97 @@ double UIScriptControllerGtk::zoomScale() const
 {
     auto page = TestController::singleton().mainWebView()->page();
     return WKPageGetScaleFactor(page);
+}
+
+static WheelEventPhase wheelEventPhaseFromString(const String& phase)
+{
+    if (phase == "began"_s)
+        return WheelEventPhase::Began;
+    if (phase == "changed"_s || phase == "continue"_s) // Allow "continue" for ease of conversion from mouseScrollByWithWheelAndMomentumPhases values.
+        return WheelEventPhase::Changed;
+    if (phase == "ended"_s)
+        return WheelEventPhase::Ended;
+    if (phase == "cancelled"_s)
+        return WheelEventPhase::Cancelled;
+    if (phase == "maybegin"_s)
+        return WheelEventPhase::MayBegin;
+
+    ASSERT_NOT_REACHED();
+    return WheelEventPhase::NoPhase;
+}
+
+void UIScriptControllerGtk::sendEventStream(JSStringRef eventsJSON, JSValueRef callback)
+{
+    auto* eventSender = TestController::singleton().eventSenderProxy();
+    if (!eventSender) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    unsigned callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);
+
+    auto jsonValue = JSON::Value::parseJSON(eventsJSON->string());
+    auto jsonObject = jsonValue ? jsonValue->asObject() : nullptr;
+    auto eventsArray = jsonObject ? jsonObject->getArray("events"_s) : nullptr;
+    if (!eventsArray) {
+        WTFLogAlways("JSON is not convertible to a dictionary with an `events` array");
+        return;
+    }
+
+    double currentViewRelativeX = 0;
+    double currentViewRelativeY = 0;
+
+    for (unsigned i = 0; i < eventsArray->length(); ++i) {
+        auto eventObject = eventsArray->get(i)->asObject();
+        if (!eventObject) {
+            WTFLogAlways("Event is not a dictionary");
+            break;
+        }
+
+        auto eventTypeString = eventObject->getString("type"_s);
+        if (!eventTypeString) {
+            WTFLogAlways("Failed to find type key in %s", eventTypeString.utf8().data());
+            break;
+        }
+
+        if (eventTypeString == "wheel"_s) {
+            auto phase = WheelEventPhase::NoPhase;
+            auto momentumPhase = WheelEventPhase::NoPhase;
+
+            auto phaseString = eventObject->getString("phase"_s);
+            if (!phaseString.isNull())
+                phase = wheelEventPhaseFromString(phaseString);
+
+            auto momentumPhaseString = eventObject->getString("momentumPhase"_s);
+            if (!momentumPhaseString.isNull()) {
+                momentumPhase = wheelEventPhaseFromString(momentumPhaseString);
+                if (momentumPhase == WheelEventPhase::Cancelled || momentumPhase == WheelEventPhase::MayBegin) {
+                    WTFLogAlways("Invalid value %s for momentumPhase", momentumPhaseString.utf8().data());
+                    break;
+                }
+            }
+
+            ASSERT_IMPLIES(phase == WheelEventPhase::NoPhase, momentumPhase != WheelEventPhase::NoPhase);
+            ASSERT_IMPLIES(momentumPhase == WheelEventPhase::NoPhase, phase != WheelEventPhase::NoPhase);
+
+            if (auto x = eventObject->getDouble("viewX"_s))
+                currentViewRelativeX = *x;
+
+            if (auto y = eventObject->getDouble("viewY"_s))
+                currentViewRelativeY = *y;
+
+            double deltaX = eventObject->getDouble("deltaX"_s).value_or(0);
+            double deltaY = eventObject->getDouble("deltaY"_s).value_or(0);
+
+            eventSender->sendWheelEvent(currentViewRelativeX, currentViewRelativeY, deltaX, deltaY, phase, momentumPhase);
+        }
+    }
+
+    RunLoop::mainSingleton().dispatch([this, protectedThis = Ref { *this }, callbackID] {
+        if (!m_context)
+            return;
+        m_context->asyncTaskComplete(callbackID);
+    });
 }
 
 } // namespace WTR

--- a/Tools/WebKitTestRunner/gtk/UIScriptControllerGtk.h
+++ b/Tools/WebKitTestRunner/gtk/UIScriptControllerGtk.h
@@ -56,6 +56,7 @@ public:
     void setWebViewEditable(bool) override;
     double zoomScale() const override;
     void zoomToScale(double, JSValueRef) override;
+    void sendEventStream(JSStringRef, JSValueRef) override;
 
 private:
     void overridePreference(JSStringRef, JSStringRef) override;

--- a/Tools/WebKitTestRunner/libwpe/EventSenderProxyClient.h
+++ b/Tools/WebKitTestRunner/libwpe/EventSenderProxyClient.h
@@ -40,6 +40,7 @@ public:
     virtual void mouseUp(unsigned, double, WKEventModifiers, double, double, unsigned&) = 0;
     virtual void mouseMoveTo(double, double, double, WKEventMouseButton, unsigned) = 0;
     virtual void mouseScrollBy(int, int, double, double, double) = 0;
+    virtual void sendWheelEvent(double, double, double, double, double, bool) = 0;
 
     virtual void keyDown(WKStringRef, double, WKEventModifiers, unsigned) = 0;
     virtual void rawKeyDown(WKStringRef, WKEventModifiers, unsigned) = 0;

--- a/Tools/WebKitTestRunner/libwpe/EventSenderProxyClientLibWPE.cpp
+++ b/Tools/WebKitTestRunner/libwpe/EventSenderProxyClientLibWPE.cpp
@@ -165,6 +165,18 @@ void EventSenderProxyClientLibWPE::mouseScrollBy(int horizontal, int vertical, d
     }
 }
 
+void EventSenderProxyClientLibWPE::sendWheelEvent(double deltaX, double deltaY, double time, double x, double y, bool)
+{
+    if (deltaX) {
+        struct wpe_input_axis_event event = { wpe_input_axis_event_type_motion, secToMsTimestamp(time), static_cast<int>(x), static_cast<int>(y), HorizontalScroll, static_cast<int>(deltaX), 0 };
+        wpe_view_backend_dispatch_axis_event(viewBackend(m_testController), &event);
+    }
+    if (deltaY) {
+        struct wpe_input_axis_event event = { wpe_input_axis_event_type_motion, secToMsTimestamp(time), static_cast<int>(x), static_cast<int>(y), VerticalScroll, static_cast<int>(deltaY), 0 };
+        wpe_view_backend_dispatch_axis_event(viewBackend(m_testController), &event);
+    }
+}
+
 static uint32_t wpeKeySymForKeyRef(WKStringRef keyRef, unsigned location, uint32_t* modifiers)
 {
     if (location == DOMKeyLocationNumpad) {

--- a/Tools/WebKitTestRunner/libwpe/EventSenderProxyClientLibWPE.h
+++ b/Tools/WebKitTestRunner/libwpe/EventSenderProxyClientLibWPE.h
@@ -48,6 +48,7 @@ private:
     void mouseUp(unsigned, double, WKEventModifiers, double, double, unsigned&) override;
     void mouseMoveTo(double, double, double, WKEventMouseButton, unsigned) override;
     void mouseScrollBy(int, int, double, double, double) override;
+    void sendWheelEvent(double, double, double, double, double, bool) override;
 
     void keyDown(WKStringRef, double, WKEventModifiers, unsigned) override;
     void rawKeyDown(WKStringRef, WKEventModifiers, unsigned) override;

--- a/Tools/WebKitTestRunner/libwpe/EventSenderProxyLibWPE.cpp
+++ b/Tools/WebKitTestRunner/libwpe/EventSenderProxyLibWPE.cpp
@@ -129,6 +129,15 @@ void EventSenderProxy::continuousMouseScrollBy(int, int, bool)
 {
 }
 
+void EventSenderProxy::sendWheelEvent(double time, double x, double y, double deltaX, double deltaY, WheelEventPhase phase, WheelEventPhase momentumPhase)
+{
+    auto endsScroll = [](WheelEventPhase phase) {
+        return phase == WheelEventPhase::Ended || phase == WheelEventPhase::Cancelled;
+    };
+    bool isEnd = phase != WheelEventPhase::None ? endsScroll(phase) : endsScroll(momentumPhase);
+    m_client->sendWheelEvent(deltaX, deltaY, time, x, y, isEnd);
+}
+
 void EventSenderProxy::leapForward(int milliseconds)
 {
     m_time += milliseconds / 1000.0;

--- a/Tools/WebKitTestRunner/wpe/EventSenderProxyClientWPE.cpp
+++ b/Tools/WebKitTestRunner/wpe/EventSenderProxyClientWPE.cpp
@@ -173,6 +173,14 @@ void EventSenderProxyClientWPE::mouseScrollBy(int horizontal, int vertical, doub
     wpe_event_unref(event);
 }
 
+void EventSenderProxyClientWPE::sendWheelEvent(double deltaX, double deltaY, double time, double x, double y, bool isEnd)
+{
+    auto* view = WKViewGetView(m_testController.targetView()->platformView());
+    auto* event = wpe_event_scroll_new(view, WPE_INPUT_SOURCE_MOUSE, secToMsTimestamp(time), static_cast<WPEModifiers>(0), deltaX, deltaY, TRUE, isEnd, x, y);
+    wpe_view_event(view, event);
+    wpe_event_unref(event);
+}
+
 static unsigned wpeKeyvalForKeyRef(WKStringRef keyRef, unsigned location, unsigned& modifiers)
 {
     if (location == DOMKeyLocationNumpad) {

--- a/Tools/WebKitTestRunner/wpe/EventSenderProxyClientWPE.h
+++ b/Tools/WebKitTestRunner/wpe/EventSenderProxyClientWPE.h
@@ -43,6 +43,7 @@ private:
     void mouseUp(unsigned, double, WKEventModifiers, double, double, unsigned&) override;
     void mouseMoveTo(double, double, double, WKEventMouseButton, unsigned) override;
     void mouseScrollBy(int, int, double, double, double) override;
+    void sendWheelEvent(double, double, double, double, double, bool) override;
 
     void keyDown(WKStringRef, double, WKEventModifiers, unsigned) override;
     void rawKeyDown(WKStringRef, WKEventModifiers, unsigned) override;

--- a/Tools/WebKitTestRunner/wpe/UIScriptControllerWPE.cpp
+++ b/Tools/WebKitTestRunner/wpe/UIScriptControllerWPE.cpp
@@ -32,6 +32,8 @@
 #include "UIScriptContext.h"
 #include <JavaScriptCore/OpaqueJSString.h>
 #include <WebKit/WKTextCheckerGLib.h>
+#include <wtf/JSONValues.h>
+#include <wtf/MonotonicTime.h>
 #include <wtf/RunLoop.h>
 
 #if ENABLE(WPE_PLATFORM)
@@ -155,6 +157,102 @@ double UIScriptControllerWPE::zoomScale() const
 {
     auto page = TestController::singleton().mainWebView()->page();
     return WKPageGetScaleFactor(page);
+}
+
+static EventSenderProxy::WheelEventPhase wheelEventPhaseFromString(const String& phase)
+{
+    if (phase == "began"_s)
+        return EventSenderProxy::WheelEventPhase::Began;
+    if (phase == "changed"_s || phase == "continue"_s) // Allow "continue" for ease of conversion from mouseScrollByWithWheelAndMomentumPhases values.
+        return EventSenderProxy::WheelEventPhase::Changed;
+    if (phase == "ended"_s)
+        return EventSenderProxy::WheelEventPhase::Ended;
+    if (phase == "cancelled"_s)
+        return EventSenderProxy::WheelEventPhase::Cancelled;
+    if (phase == "maybegin"_s)
+        return EventSenderProxy::WheelEventPhase::MayBegin;
+
+    ASSERT_NOT_REACHED();
+    return EventSenderProxy::WheelEventPhase::None;
+}
+
+void UIScriptControllerWPE::sendEventStream(JSStringRef eventsJSON, JSValueRef callback)
+{
+    auto* eventSender = TestController::singleton().eventSenderProxy();
+    if (!eventSender) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    unsigned callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);
+
+    auto jsonValue = JSON::Value::parseJSON(eventsJSON->string());
+    auto jsonObject = jsonValue ? jsonValue->asObject() : nullptr;
+    auto eventsArray = jsonObject ? jsonObject->getArray("events"_s) : nullptr;
+    if (!eventsArray) {
+        WTFLogAlways("JSON is not convertible to a dictionary with an `events` array");
+        return;
+    }
+
+    double currentViewRelativeX = 0;
+    double currentViewRelativeY = 0;
+
+    constexpr double secondsPerEvent = 1.0 / 60;
+    double currentTime = MonotonicTime::now().secondsSinceEpoch().value();
+
+    for (unsigned i = 0; i < eventsArray->length(); ++i) {
+        auto eventObject = eventsArray->get(i)->asObject();
+        if (!eventObject) {
+            WTFLogAlways("Event is not a dictionary");
+            break;
+        }
+
+        auto eventTypeString = eventObject->getString("type"_s);
+        if (!eventTypeString) {
+            WTFLogAlways("Failed to find type key in %s", eventTypeString.utf8().data());
+            break;
+        }
+
+        if (eventTypeString == "wheel"_s) {
+            auto phase = EventSenderProxy::WheelEventPhase::None;
+            auto momentumPhase = EventSenderProxy::WheelEventPhase::None;
+
+            auto phaseString = eventObject->getString("phase"_s);
+            if (!phaseString.isNull())
+                phase = wheelEventPhaseFromString(phaseString);
+
+            auto momentumPhaseString = eventObject->getString("momentumPhase"_s);
+            if (!momentumPhaseString.isNull()) {
+                momentumPhase = wheelEventPhaseFromString(momentumPhaseString);
+                if (momentumPhase == EventSenderProxy::WheelEventPhase::Cancelled || momentumPhase == EventSenderProxy::WheelEventPhase::MayBegin) {
+                    WTFLogAlways("Invalid value %s for momentumPhase", momentumPhaseString.utf8().data());
+                    break;
+                }
+            }
+
+            ASSERT_IMPLIES(phase == EventSenderProxy::WheelEventPhase::None, momentumPhase != EventSenderProxy::WheelEventPhase::None);
+            ASSERT_IMPLIES(momentumPhase == EventSenderProxy::WheelEventPhase::None, phase != EventSenderProxy::WheelEventPhase::None);
+
+            if (auto x = eventObject->getDouble("viewX"_s))
+                currentViewRelativeX = *x;
+
+            if (auto y = eventObject->getDouble("viewY"_s))
+                currentViewRelativeY = *y;
+
+            double deltaX = eventObject->getDouble("deltaX"_s).value_or(0);
+            double deltaY = eventObject->getDouble("deltaY"_s).value_or(0);
+
+            eventSender->sendWheelEvent(currentTime, currentViewRelativeX, currentViewRelativeY, deltaX, deltaY, phase, momentumPhase);
+        }
+
+        currentTime += secondsPerEvent;
+    }
+
+    RunLoop::mainSingleton().dispatch([this, protectedThis = Ref { *this }, callbackID] {
+        if (!m_context)
+            return;
+        m_context->asyncTaskComplete(callbackID);
+    });
 }
 
 } // namespace WTR

--- a/Tools/WebKitTestRunner/wpe/UIScriptControllerWPE.h
+++ b/Tools/WebKitTestRunner/wpe/UIScriptControllerWPE.h
@@ -50,6 +50,7 @@ public:
     void addViewToWindow(JSValueRef) override;
     double zoomScale() const override;
     void zoomToScale(double, JSValueRef) override;
+    void sendEventStream(JSStringRef, JSValueRef) override;
 };
 
 } // namespace WTR


### PR DESCRIPTION
#### 24238837ecefc220816b222e85e20bfc17c7c043
<pre>
[WPE][GTK] Implement `UIScriptController.sendEventStream()` for wheel events
<a href="https://bugs.webkit.org/show_bug.cgi?id=233092">https://bugs.webkit.org/show_bug.cgi?id=233092</a>

Reviewed by Carlos Garcia Campos.

Port `UIScriptControllerMac::sendEventStream()` to WPE and GTK as close
as possible.

* Tools/WebKitTestRunner/EventSenderProxy.h:
* Tools/WebKitTestRunner/libwpe/EventSenderProxyClient.h:
(WTR::EventSenderProxyClient::sendWheelEvent):
* Tools/WebKitTestRunner/libwpe/EventSenderProxyLibWPE.cpp:
(WTR::EventSenderProxy::sendWheelEvent):
* Tools/WebKitTestRunner/wpe/EventSenderProxyClientWPE.cpp:
(WTR::EventSenderProxyClientWPE::sendWheelEvent):
(WTR::EventSenderProxyClientWPE::mouseScrollBy):
* Tools/WebKitTestRunner/wpe/EventSenderProxyClientWPE.h:
* Tools/WebKitTestRunner/wpe/UIScriptControllerWPE.cpp:
(WTR::wheelEventPhaseFromString):
(WTR::UIScriptControllerWPE::sendEventStream):
* Tools/WebKitTestRunner/wpe/UIScriptControllerWPE.h:
* LayoutTests/platform/glib/TestExpectations:
* Tools/WebKitTestRunner/libwpe/EventSenderProxyClientLibWPE.cpp:
(WTR::EventSenderProxyClientLibWPE::mouseScrollBy):
(WTR::EventSenderProxyClientLibWPE::sendWheelEvent):
* Tools/WebKitTestRunner/libwpe/EventSenderProxyClientLibWPE.h:
* Tools/WebKitTestRunner/gtk/EventSenderProxyGtk.cpp:
(WTR::EventSenderProxy::sendWheelEvent):
* Tools/WebKitTestRunner/gtk/UIScriptControllerGtk.cpp:
(WTR::wheelEventPhaseFromString):
(WTR::UIScriptControllerGtk::sendEventStream):
* Tools/WebKitTestRunner/gtk/UIScriptControllerGtk.h:

Canonical link: <a href="https://commits.webkit.org/317551@main">https://commits.webkit.org/317551@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a6b0b63845c76b5f6b64f3d2bd69b44df62eb59

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175587 "8 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49519 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43300 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185173 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177451 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50811 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49202 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136727 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178544 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40149 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157488 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117205 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38798 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37176 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149211 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36981 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33648 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41379 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187598 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49186 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145696 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39211 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49866 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33605 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145534 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40354 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115877 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48374 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11959 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47775 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48005 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47832 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->