### PR TITLE
[Damage][Skia] Add the helpers that restrict painting to a damage region

### DIFF
--- a/Source/WebCore/platform/Skia.cmake
+++ b/Source/WebCore/platform/Skia.cmake
@@ -21,6 +21,7 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/skia/SkiaCompositingLayerFilters.h
     platform/graphics/skia/SkiaCompositingLayerImageSetBatch.h
     platform/graphics/skia/SkiaCompositingLayerOverlapRegions.h
+    platform/graphics/skia/SkiaDamageRestriction.h
     platform/graphics/skia/SkiaGPUAtlas.h
     platform/graphics/skia/SkiaHarfBuzzFont.h
     platform/graphics/skia/SkiaHarfBuzzFontCache.h

--- a/Source/WebCore/platform/graphics/skia/SkiaDamageRestriction.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaDamageRestriction.h
@@ -1,0 +1,225 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "Damage.h"
+#include "FloatRect.h"
+#include "IntRect.h"
+
+#include <optional>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/core/SkCanvas.h>
+#include <skia/core/SkMatrix.h>
+#include <skia/core/SkRect.h>
+#include <skia/core/SkRegion.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
+
+#include <wtf/Vector.h>
+
+namespace WebCore {
+
+// The damage to repaint, in device space, held twice: as rects for the draws that split, and as a region
+// for the draws that clip and for culling. Built once per frame, so no draw site rebuilds the region.
+// Damage bounds the rect count by its grid cells, which keeps the per-rect work bounded as well.
+struct DamageRegion {
+    Vector<SkRect> rects;
+    SkRegion region;
+
+    // The rects must never overlap, otherwise a split draw would composite translucent content twice.
+    // Damage::rectsForPainting() guarantees that.
+    static DamageRegion create(const Damage& damage)
+    {
+        const auto damageRects = damage.rectsForPainting().map([](const IntRect& rect) -> SkIRect {
+            return rect;
+        });
+
+        // Convert to the Skia rect types once here, never per draw.
+        DamageRegion damageRegion;
+        damageRegion.region.setRects(damageRects.span().data(), damageRects.size());
+        damageRegion.rects = damageRects.map([](const SkIRect& rect) -> SkRect {
+            return SkRect::Make(rect);
+        });
+
+        return damageRegion;
+    }
+
+    bool isEmpty() const { return rects.isEmpty(); }
+
+    // roundOut() applies floor to left/top, and ceil to right/bottom. Make sure a deviceRect touching the
+    // region along an edge triggers an intersection - this is conservative, but for sure not wrong.
+    bool intersects(const SkRect& deviceRect) const { return region.intersects(deviceRect.roundOut()); }
+};
+
+// Plans a frame, given everything the render target being drawn into must repaint to become current. That
+// is not the damage of the frame being drawn: the swap chain hands back whichever buffer is free, and one
+// that is a frame or more behind still misses every change since it was last presented. So the restriction
+// is planned per target, never per frame.
+inline std::optional<DamageRegion> planFrameRestriction(const std::optional<Damage>& repaintRegion, const IntSize& surfaceSize)
+{
+    // Nothing known about the target's contents -> repaint everything.
+    if (!repaintRegion)
+        return std::nullopt;
+
+    // The target misses nothing -> it is already up-to-date, so there is nothing to repaint.
+    if (repaintRegion->isEmpty())
+        return DamageRegion { };
+
+    // The damage covers the whole surface -> restricting the draws would only cost time.
+    if (repaintRegion->bounds().contains(IntRect { { }, surfaceSize }))
+        return std::nullopt;
+
+    // Everything else: restrict the draws to the region's rects.
+    return DamageRegion::create(*repaintRegion);
+}
+
+// How a single draw (an image or a rect) gets restricted to the damage. The preferred way is to split the
+// draw into one sub-draw per damage rect it touches (with no cap on the count!). The sub-draws share a
+// paint, so Skia batches them into one operation. A device-space clip is only the fallback, since a clip
+// of more than one rect cannot become a scissor: Skia then needs a stencil buffer or a mask texture,
+// and batching is lost.
+struct DrawRestrictionPlan {
+    enum class Mode : uint8_t {
+        SkipDraw, // The draw misses the damage.
+        PerRect, // One draw per touched damage rect.
+        ClipFallback // One draw under a device-space clip (CTM rotated/skewed, misaligning rects).
+    };
+
+    Mode mode { Mode::SkipDraw };
+    SkMatrix inverse; // Optimization for PerRect mode: maps device rects back to local coordinates.
+};
+
+inline DrawRestrictionPlan planDrawRestriction(const SkMatrix& ctm, const SkRect& deviceRect, const DamageRegion& damageRegion)
+{
+    DrawRestrictionPlan plan;
+    if (!damageRegion.intersects(deviceRect))
+        return plan;
+
+    if (!ctm.rectStaysRect() || !ctm.invert(&plan.inverse))
+        plan.mode = DrawRestrictionPlan::Mode::ClipFallback;
+    else
+        plan.mode = DrawRestrictionPlan::Mode::PerRect;
+
+    return plan;
+}
+
+// Receives a callback 'emit' and calls emit(srcSubRect, dstSubRect) _once per damage rect_ that touches deviceRect,
+// narrowing the source sampling region to the damaged sub-rect. deviceRect is dstRectFull under the rectilinear ctm,
+// and inverseCtm maps device rects back.
+template<typename EmitFunction>
+void forEachDamagedSubRect(const SkRect& deviceRect, const SkRect& dstRectFull, const SkRect& srcRectFull, const SkMatrix& inverseCtm, const DamageRegion& damageRegion, NOESCAPE const EmitFunction& emit)
+{
+    const auto dstToSrc = SkMatrix::RectToRect(dstRectFull, srcRectFull);
+
+    for (const auto& rect : damageRegion.rects) {
+        auto damaged = rect;
+        if (!damaged.intersect(deviceRect))
+            continue;
+        if (damaged == deviceRect) {
+            emit(srcRectFull, dstRectFull);
+            return;
+        }
+        SkRect dstSubRect;
+        inverseCtm.mapRect(&dstSubRect, damaged);
+        emit(dstToSrc.mapRect(dstSubRect), dstSubRect);
+    }
+}
+
+inline void clipToDamageInDeviceSpace(SkCanvas& canvas, const DamageRegion& damageRegion)
+{
+    // An empty region would clip everything out, which no caller wants.
+    ASSERT(!damageRegion.isEmpty());
+
+    // The region is in device space, so it clips without inverting the CTM!
+    canvas.clipRegion(damageRegion.region, SkClipOp::kIntersect);
+}
+
+// Overwrites the damaged pixels with color, the way a regular clear would. The region is drawn in kSrc mode
+// rather than clearing under it as a clip, for the same reason the draws split: a clip of more than one
+// rect cannot be a scissor, and Skia would build a clip mask for it. Without a region, clear everything.
+inline void clearRestrictedToDamage(SkCanvas& canvas, SkColor color, const DamageRegion* damageRegion)
+{
+    if (!damageRegion) {
+        canvas.clear(color);
+        return;
+    }
+
+    ASSERT(!damageRegion->isEmpty());
+
+    SkPaint paint;
+    paint.setColor(color);
+    paint.setBlendMode(SkBlendMode::kSrc);
+
+    // The region is in device space, and the canvas has no transform at this point.
+    canvas.drawRegion(damageRegion->region, paint);
+}
+
+// Runs draw(srcSubRect, dstSubRect) restricted to the damage, picking the strategy per DrawRestrictionPlan.
+template<typename DrawFunction>
+void drawRestrictedToDamage(SkCanvas& canvas, const DamageRegion* damageRegion, const SkRect& srcRectFull, const SkRect& dstRectFull, NOESCAPE const DrawFunction& draw)
+{
+    // Without a region, the draw runs once, unrestricted.
+    if (!damageRegion) {
+        draw(srcRectFull, dstRectFull);
+        return;
+    }
+
+    ASSERT(!damageRegion->isEmpty());
+
+    const auto ctm = canvas.getLocalToDeviceAs3x3();
+    SkRect deviceRect;
+    ctm.mapRect(&deviceRect, dstRectFull);
+
+    const auto plan = planDrawRestriction(ctm, deviceRect, *damageRegion);
+    switch (plan.mode) {
+    case DrawRestrictionPlan::Mode::SkipDraw:
+        return;
+    case DrawRestrictionPlan::Mode::PerRect:
+        forEachDamagedSubRect(deviceRect, dstRectFull, srcRectFull, plan.inverse, *damageRegion, draw);
+        return;
+    case DrawRestrictionPlan::Mode::ClipFallback: {
+        SkAutoCanvasRestore autoRestore(&canvas, true);
+        clipToDamageInDeviceSpace(canvas, *damageRegion);
+        draw(srcRectFull, dstRectFull);
+        return;
+    }
+    }
+}
+
+inline void drawRectRestrictedToDamage(SkCanvas& canvas, const DamageRegion* damageRegion, const SkRect& localRect, const SkPaint& paint)
+{
+    drawRestrictedToDamage(canvas, damageRegion, localRect, localRect, [&](const SkRect&, const SkRect& dstSubRect) {
+        canvas.drawRect(dstSubRect, paint);
+    });
+}
+
+inline void drawImageRectRestrictedToDamage(SkCanvas& canvas, const SkImage* image, const SkRect& srcRectFull, const SkRect& dstRectFull, const SkSamplingOptions& sampling, const SkPaint* paint, const DamageRegion* damageRegion)
+{
+    drawRestrictedToDamage(canvas, damageRegion, srcRectFull, dstRectFull, [&](const SkRect& srcSubRect, const SkRect& dstSubRect) {
+        canvas.drawImageRect(image, srcSubRect, dstSubRect, sampling, paint, SkCanvas::kFast_SrcRectConstraint);
+    });
+}
+
+} // namespace WebCore


### PR DESCRIPTION
#### 3eb68b91cdf2307c70707eb68c78ed555e4ff375
<pre>
[Damage][Skia] Add the helpers that restrict painting to a damage region
<a href="https://bugs.webkit.org/show_bug.cgi?id=319378">https://bugs.webkit.org/show_bug.cgi?id=319378</a>

Reviewed by NOBODY (OOPS!).

Prepare for enabling damage support in the composition, when using Skia compositor:
Add SkiaDamageRestriction.h, which turns a damage region into what the Skia
compositor needs to paint only what changed.

DamageRegion holds the damage rects in device space, plus the same rects as an
SkRegion for the draws that clip and for culling, built once per frame from
Damage::rectsForPainting(). planFrameRestriction() builds it, from everything the
render target must repaint to become current rather than from the damage of the frame
being drawn. The two differ whenever the swap chain hands back a buffer that is a
frame or more behind, which is why the restriction is planned per target and not per
frame. It returns nothing to mean &quot;no restriction, paint everything&quot;, both when the
target&apos;s contents are unknown and when the damage already covers the whole surface,
where restricting the draws would only cost time. An empty DamageRegion means the
target is already up to date and nothing needs painting. Anything else restricts the
painting to the region&apos;s rects.

A single draw is &quot;narrowed&quot; by planDrawRestriction(), which either skips it, splits
it into one draw per damage rect it touches, or, when the CTM does not keep rects
as rects and the sub-rects cannot be computed, has it drawn under a device-space
clip. Splitting is deliberately uncapped: the sub-quads share a paint, so Skia
batches them into one op, while a clip of more than one rect cannot be a scissor
and so costs a stencil buffer or a mask texture and breaks batching. A
full-viewport layer is touched by every rect in the frame, so a cap would send
exactly the biggest draws down the expensive path -- avoid that.

For the same reason, clearRestrictedToDamage() overwrites the damaged pixels by
drawing the region in kSrc blend mode, rather than clearing under a clip.

There are no callers yet.

* Source/WebCore/platform/Skia.cmake:
* Source/WebCore/platform/graphics/skia/SkiaDamageRestriction.h: Added.
(WebCore::DamageRegion::create):
(WebCore::DamageRegion::isEmpty const):
(WebCore::DamageRegion::intersects const):
(WebCore::planFrameRestriction):
(WebCore::planDrawRestriction):
(WebCore::forEachDamagedSubRect):
(WebCore::clipToDamageInDeviceSpace):
(WebCore::clearRestrictedToDamage):
(WebCore::drawRestrictedToDamage):
(WebCore::drawRectRestrictedToDamage):
(WebCore::drawImageRectRestrictedToDamage):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3eb68b91cdf2307c70707eb68c78ed555e4ff375

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174478 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48411 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42192 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184055 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132346 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176343 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49703 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48094 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135739 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177436 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39174 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156535 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116217 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37815 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36185 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32536 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148238 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36027 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186481 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39712 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40382 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144654 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48078 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144512 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48757 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32647 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114351 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39410 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120722 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47264 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10991 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46666 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46897 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46724 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->