### PR TITLE
[JSC] Gate WebAssembly type() methods behind useWasmJSTypes

### DIFF
--- a/JSTests/wasm/gc/js-api.js
+++ b/JSTests/wasm/gc/js-api.js
@@ -1,3 +1,4 @@
+//@ requireOptions("--useWasmJSTypes=true")
 import * as assert from "../assert.js";
 import { compile, instantiate } from "./wast-wrapper.js";
 

--- a/JSTests/wasm/js-api/global.js
+++ b/JSTests/wasm/js-api/global.js
@@ -1,3 +1,4 @@
+//@ requireOptions("--useWasmJSTypes=true")
 import * as assert from '../assert.js';
 {
     assert.throws(() => {

--- a/JSTests/wasm/js-api/memory64-js-api.js
+++ b/JSTests/wasm/js-api/memory64-js-api.js
@@ -1,3 +1,4 @@
+//@ requireOptions("--useWasmJSTypes=true")
 //@ runDefaultWasm("-m", "--useWasmMemory64=1")
 import * as assert from '../assert.js';
 

--- a/JSTests/wasm/js-api/table.js
+++ b/JSTests/wasm/js-api/table.js
@@ -1,3 +1,4 @@
+//@ requireOptions("--useWasmJSTypes=true")
 import Builder from '../Builder.js';
 import * as assert from '../assert.js';
 

--- a/JSTests/wasm/js-api/table64-js-api.js
+++ b/JSTests/wasm/js-api/table64-js-api.js
@@ -1,3 +1,4 @@
+//@ requireOptions("--useWasmJSTypes=true")
 //@ runDefaultWasm("-m", "--useWasmMemory64=1")
 import * as assert from "../assert.js";
 

--- a/JSTests/wasm/js-api/test_memory.js
+++ b/JSTests/wasm/js-api/test_memory.js
@@ -1,3 +1,4 @@
+//@ requireOptions("--useWasmJSTypes=true")
 import Builder from '../Builder.js';
 import * as assert from '../assert.js';
 

--- a/JSTests/wasm/stress/create-tag-from.js
+++ b/JSTests/wasm/stress/create-tag-from.js
@@ -1,3 +1,4 @@
+//@ requireOptions("--useWasmJSTypes=true")
 import * as assert from '../assert.js'
 
 let parameters = ["i32", "f32", "externref"];

--- a/JSTests/wasm/v8/exceptions-type-reflection.js
+++ b/JSTests/wasm/v8/exceptions-type-reflection.js
@@ -1,3 +1,4 @@
+//@ requireOptions("--useWasmJSTypes=true")
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyGlobalPrototype.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyGlobalPrototype.cpp
@@ -50,8 +50,6 @@ const ClassInfo WebAssemblyGlobalPrototype::s_info = { "WebAssembly.Global"_s, &
 /* Source for WebAssemblyGlobalPrototype.lut.h
  @begin prototypeGlobalWebAssemblyGlobal
  valueOf webAssemblyGlobalProtoFuncValueOf Function 0
- type    webAssemblyGlobalProtoFuncType    Function 0
-
  @end
  */
 
@@ -145,6 +143,9 @@ void WebAssemblyGlobalPrototype::finishCreation(VM& vm, JSGlobalObject* globalOb
     GetterSetter* valueAccessor = GetterSetter::create(vm, globalObject, valueGetterFunction, valueSetterFunction);
     putDirectNonIndexAccessorWithoutTransition(vm, Identifier::fromString(vm, "value"_s), valueAccessor, static_cast<unsigned>(PropertyAttribute::Accessor));
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
+
+    if (Options::useWasmJSTypes())
+        JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("type"_s, webAssemblyGlobalProtoFuncType, static_cast<unsigned>(PropertyAttribute::None), 0, ImplementationVisibility::Public);
 }
 
 WebAssemblyGlobalPrototype::WebAssemblyGlobalPrototype(VM& vm, Structure* structure)

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyMemoryPrototype.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyMemoryPrototype.cpp
@@ -56,7 +56,6 @@ const ClassInfo WebAssemblyMemoryPrototype::s_info = { "WebAssembly.Memory"_s, &
 @begin prototypeTableWebAssemblyMemory
  grow   webAssemblyMemoryProtoFuncGrow      Function 1
  buffer webAssemblyMemoryProtoGetterBuffer  ReadOnly|CustomAccessor
- type   webAssemblyMemoryProtoFuncType      Function 0
 @end
 */
 // two more functions are added if Options::useWasmMemoryToBufferAPIs() is true; see finishCreation()
@@ -154,6 +153,9 @@ void WebAssemblyMemoryPrototype::finishCreation(VM& vm, JSGlobalObject* globalOb
     Base::finishCreation(vm);
     ASSERT(inherits(info()));
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
+
+    if (Options::useWasmJSTypes())
+        JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("type"_s, webAssemblyMemoryProtoFuncType, static_cast<unsigned>(PropertyAttribute::None), 0, ImplementationVisibility::Public);
 
     if (Options::useWasmMemoryToBufferAPIs()) {
         JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("toFixedLengthBuffer"_s, webAssemblyMemoryProtoFuncToFixedLengthBuffer, static_cast<unsigned>(PropertyAttribute::None), 0, ImplementationVisibility::Public);

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyTablePrototype.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyTablePrototype.cpp
@@ -59,7 +59,6 @@ const ClassInfo WebAssemblyTablePrototype::s_info = { "WebAssembly.Table"_s, &Ba
  grow   webAssemblyTableProtoFuncGrow   Function 1
  get    webAssemblyTableProtoFuncGet    Function 1
  set    webAssemblyTableProtoFuncSet    Function 1
- type   webAssemblyTableProtoFuncType   Function 0
  @end
  */
 
@@ -178,10 +177,10 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyTableProtoFuncType, (JSGlobalObject* globalO
     RELEASE_AND_RETURN(throwScope, JSValue::encode(typeDescriptor));
 }
 
-WebAssemblyTablePrototype* WebAssemblyTablePrototype::create(VM& vm, JSGlobalObject*, Structure* structure)
+WebAssemblyTablePrototype* WebAssemblyTablePrototype::create(VM& vm, JSGlobalObject* globalObject, Structure* structure)
 {
     auto* object = new (NotNull, allocateCell<WebAssemblyTablePrototype>(vm)) WebAssemblyTablePrototype(vm, structure);
-    object->finishCreation(vm);
+    object->finishCreation(vm, globalObject);
     return object;
 }
 
@@ -190,11 +189,14 @@ Structure* WebAssemblyTablePrototype::createStructure(VM& vm, JSGlobalObject* gl
     return Structure::create(vm, globalObject, prototype, TypeInfo(ObjectType, StructureFlags), info());
 }
 
-void WebAssemblyTablePrototype::finishCreation(VM& vm)
+void WebAssemblyTablePrototype::finishCreation(VM& vm, JSGlobalObject* globalObject)
 {
     Base::finishCreation(vm);
     ASSERT(inherits(info()));
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
+
+    if (Options::useWasmJSTypes())
+        JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("type"_s, webAssemblyTableProtoFuncType, static_cast<unsigned>(PropertyAttribute::None), 0, ImplementationVisibility::Public);
 }
 
 WebAssemblyTablePrototype::WebAssemblyTablePrototype(VM& vm, Structure* structure)

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyTablePrototype.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyTablePrototype.h
@@ -51,7 +51,7 @@ public:
 
 private:
     WebAssemblyTablePrototype(VM&, Structure*);
-    void finishCreation(VM&);
+    void finishCreation(VM&, JSGlobalObject*);
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyTagPrototype.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyTagPrototype.cpp
@@ -32,30 +32,20 @@
 #include "JSObjectInlines.h"
 #include "JSWebAssemblyTag.h"
 #include "ObjectConstructor.h"
+#include "Options.h"
 #include "StructureInlines.h"
 #include "WasmFormat.h"
 
 namespace JSC {
+
 static JSC_DECLARE_HOST_FUNCTION(webAssemblyTagProtoFuncType);
-}
 
-#include "WebAssemblyTagPrototype.lut.h"
+const ClassInfo WebAssemblyTagPrototype::s_info = { "WebAssembly.Tag"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(WebAssemblyTagPrototype) };
 
-namespace JSC {
-
-const ClassInfo WebAssemblyTagPrototype::s_info = { "WebAssembly.Tag"_s, &Base::s_info, &prototypeTableWebAssemblyTag, nullptr, CREATE_METHOD_TABLE(WebAssemblyTagPrototype) };
-
-/* Source for WebAssemblyTagPrototype.lut.h
- @begin prototypeTableWebAssemblyTag
- type   webAssemblyTagProtoFuncType   Function 0
- @end
- */
-
-
-WebAssemblyTagPrototype* WebAssemblyTagPrototype::create(VM& vm, JSGlobalObject*, Structure* structure)
+WebAssemblyTagPrototype* WebAssemblyTagPrototype::create(VM& vm, JSGlobalObject* globalObject, Structure* structure)
 {
     auto* object = new (NotNull, allocateCell<WebAssemblyTagPrototype>(vm)) WebAssemblyTagPrototype(vm, structure);
-    object->finishCreation(vm);
+    object->finishCreation(vm, globalObject);
     return object;
 }
 
@@ -64,11 +54,14 @@ Structure* WebAssemblyTagPrototype::createStructure(VM& vm, JSGlobalObject* glob
     return Structure::create(vm, globalObject, prototype, TypeInfo(ObjectType, StructureFlags), info());
 }
 
-void WebAssemblyTagPrototype::finishCreation(VM& vm)
+void WebAssemblyTagPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject)
 {
     Base::finishCreation(vm);
     ASSERT(inherits(info()));
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
+
+    if (Options::useWasmJSTypes())
+        JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("type"_s, webAssemblyTagProtoFuncType, static_cast<unsigned>(PropertyAttribute::None), 0, ImplementationVisibility::Public);
 }
 
 WebAssemblyTagPrototype::WebAssemblyTagPrototype(VM& vm, Structure* structure)

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyTagPrototype.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyTagPrototype.h
@@ -34,7 +34,7 @@ namespace JSC {
 class WebAssemblyTagPrototype final : public JSNonFinalObject {
 public:
     using Base = JSNonFinalObject;
-    static constexpr unsigned StructureFlags = Base::StructureFlags | HasStaticPropertyTable;
+    static constexpr unsigned StructureFlags = Base::StructureFlags;
 
     template<typename CellType, SubspaceAccess>
     static GCClient::IsoSubspace* subspaceFor(VM& vm)
@@ -50,7 +50,7 @@ public:
 
 private:
     WebAssemblyTagPrototype(VM&, Structure*);
-    void finishCreation(VM&);
+    void finishCreation(VM&, JSGlobalObject*);
 };
 
 } // namespace JSC

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -9663,6 +9663,19 @@ WasmJSStringBuiltinsEnabled:
     WebKit:
       default: true
 
+WasmJSTypesEnabled:
+  type: bool
+  status: testable
+  category: javascript
+  humanReadableName: "WebAssembly JS Types"
+  humanReadableDescription: "Enable the js-types proposal type() methods on WebAssembly.Memory/Table/Global/Tag prototypes."
+  webcoreBinding: none
+  jscOptionName: useWasmJSTypes
+  sharedPreferenceForWebProcess: true
+  defaultValue:
+    WebKit:
+      default: false
+
 WasmMemory64Enabled:
   type: bool
   status: testable


### PR DESCRIPTION
#### 76340acb4d382e75459d2814e31cb803eff4f4de
<pre>
[JSC] Gate WebAssembly type() methods behind useWasmJSTypes
<a href="https://bugs.webkit.org/show_bug.cgi?id=317707">https://bugs.webkit.org/show_bug.cgi?id=317707</a>

Reviewed by Keith Miller.

Memory.prototype.type and the matching methods on Table, Global, and Tag
come from the js-types proposal, not the core WebAssembly JS API. They
were always installed before. Install them only when
Options::useWasmJSTypes is enabled, which defaults to false.

Declare the option in UnifiedWebPreferences.yaml (jscOptionName
useWasmJSTypes). Layout tests enable it via status: testable; JSTests
use requireOptions(&quot;--useWasmJSTypes=true&quot;).

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/JavaScriptCore/wasm/js/WebAssemblyMemoryPrototype.cpp:
* Source/JavaScriptCore/wasm/js/WebAssemblyTablePrototype.cpp:
* Source/JavaScriptCore/wasm/js/WebAssemblyTablePrototype.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyGlobalPrototype.cpp:
* Source/JavaScriptCore/wasm/js/WebAssemblyTagPrototype.cpp:
* Source/JavaScriptCore/wasm/js/WebAssemblyTagPrototype.h:
* JSTests/wasm/js-api/test_memory.js:
* JSTests/wasm/js-api/table.js:
* JSTests/wasm/js-api/global.js:
* JSTests/wasm/js-api/memory64-js-api.js:
* JSTests/wasm/js-api/table64-js-api.js:
* JSTests/wasm/gc/js-api.js:
* JSTests/wasm/stress/create-tag-from.js:
* JSTests/wasm/v8/exceptions-type-reflection.js:

Canonical link: <a href="https://commits.webkit.org/317366@main">https://commits.webkit.org/317366@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c03036c4e8768e5d3e402c6145145ba74140b9f0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175102 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49035 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42816 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184687 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/133010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50327 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48718 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/136303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/133010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178060 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/39739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/157091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116782 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/38380 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33161 "Built successfully") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/218/builds/5600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/148803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36584 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187108 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/36364 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/40689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/145242 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48702 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145098 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39093 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49382 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/115216 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39960 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/121546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/212194 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47888 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/11557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55353 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47291 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47521 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47348 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->