### PR TITLE
[Damage][Skia] Split the compositing walk into a damage pass and a paint pass

### DIFF
--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
@@ -51,6 +51,7 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/gpu/ganesh/SkSurfaceGanesh.h>
 #include <skia/gpu/ganesh/gl/GrGLBackendSurface.h>
 #include <skia/gpu/ganesh/gl/GrGLDirectContext.h>
+#include <skia/utils/SkNoDrawCanvas.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #include <wtf/Scope.h>
 #include <wtf/SetForScope.h>
@@ -431,23 +432,42 @@ bool SkiaCompositingLayer::computeTransformsAndAnimations(const TransformationMa
     return hasRunningAnimations;
 }
 
-bool SkiaCompositingLayer::paint(SkCanvas& canvas, std::optional<Damage>& damage)
+bool SkiaCompositingLayer::paint(SkCanvas& canvas, std::optional<Damage>& frameDamage)
 {
+    // Both walks below assume the animations have been applied and the transforms computed.
     bool hasRunningAnimations = computeTransformsAndAnimations({ }, { }, MonotonicTime::now());
-    PaintContext context(damage);
 
-    context.mode = PaintMode::Paint;
+    std::optional<Damage> collectingDamage;
+    PaintContext context { collectingDamage };
+
+#if ENABLE(DAMAGE_TRACKING)
+    // When a frame damage is passed, collect it first in a walk of its own, which draws nothing, so the
+    // damage is complete before the walk that draws. Each layer's damage stays until
+    // recursiveCleanUpAfterPaint() clears it at the end of the frame. The optional marks the
+    // collecting walk, then resetting it to nullopt switches the context to the walk that draws.
+    if (frameDamage) {
+        collectingDamage = WTF::move(frameDamage);
+
+        const auto canvasSize = expandedIntSize(m_size);
+        SkNoDrawCanvas noDrawCanvas(canvasSize.width(), canvasSize.height());
+        recursivePaint(noDrawCanvas, context);
+
+        if (frameDamagePropagationEnabled()) {
+            collectingDamage->add(*m_sharedFrameDamage);
+            *m_sharedFrameDamage = Damage(m_size);
+        }
+
+        frameDamage = WTF::move(collectingDamage);
+        collectingDamage.reset();
+    }
+#else
+    UNUSED_PARAM(frameDamage);
+#endif
+
     recursivePaint(canvas, context);
     context.imageSetBatch.flushIfNeeded(canvas);
 
     recursiveCleanUpAfterPaint();
-
-#if ENABLE(DAMAGE_TRACKING)
-    if (damage && frameDamagePropagationEnabled()) {
-        damage->add(*m_sharedFrameDamage);
-        *m_sharedFrameDamage = Damage(m_size);
-    }
-#endif
 
     return hasRunningAnimations;
 }
@@ -473,15 +493,29 @@ void SkiaCompositingLayer::clipRect(SkCanvas& canvas, const FloatRoundedRect& re
 
 void SkiaCompositingLayer::paintSelf(SkCanvas& canvas, PaintContext& context)
 {
-    if (m_size.isEmpty() || !m_visible || !m_contentsVisible || !hasVisualContent())
+    if (!hasVisiblePaintableContent())
         return;
 
-    if (context.mode == PaintMode::Paint) {
-        paintContents(canvas, context);
+    if (!context.shouldDraw()) {
 #if ENABLE(DAMAGE_TRACKING)
         collectFrameDamage(canvas, context);
 #endif
+        return;
     }
+
+    paintContents(canvas, context);
+
+    // Drawn in the content stream, so content above hides the border and it shares
+    // the group's opacity, filter and mask - similar to the Viz design.
+    if (m_debugBorder)
+        paintDebugBorder(canvas, context);
+}
+
+TransformationMatrix SkiaCompositingLayer::combinedTransform(const PaintContext& context) const
+{
+    TransformationMatrix transform(context.accumulatedReplicaTransform);
+    transform.multiply(m_transforms.combined);
+    return transform;
 }
 
 void SkiaCompositingLayer::paintContents(SkCanvas& canvas, PaintContext& context)
@@ -626,35 +660,36 @@ void SkiaCompositingLayer::collectFrameDamage(SkCanvas& canvas, PaintContext& co
 
 #endif
 
-void SkiaCompositingLayer::paintDebugIndicators(SkCanvas& canvas, PaintContext& context)
+void SkiaCompositingLayer::paintDebugBorder(SkCanvas& canvas, PaintContext& context)
 {
-    if (m_size.isEmpty() || !m_visible || !m_contentsVisible || !hasVisualContent())
+    ASSERT(m_debugBorder);
+
+    ScopedFlush autoFlush(canvas, context.imageSetBatch, ScopedFlush::Mode::FlushBefore);
+    canvas.concat(SkM44(combinedTransform(context)));
+
+    SkPaint borderPaint;
+    borderPaint.setStyle(SkPaint::kStroke_Style);
+    borderPaint.setColor(SkColor(m_debugBorder->color));
+    borderPaint.setStrokeWidth(m_debugBorder->width);
+    borderPaint.setAntiAlias(true);
+
+    if (m_backingStore)
+        m_backingStore->drawDebugBorders(canvas, borderPaint);
+    if (paintsContentsRect())
+        canvas.drawRect(SkRect(m_contentsRect), borderPaint);
+}
+
+void SkiaCompositingLayer::paintRepaintCounter(SkCanvas& canvas, PaintContext& context)
+{
+    ASSERT(m_repaintCount);
+
+    if (!hasVisiblePaintableContent())
         return;
 
-    const auto transform = combinedTransform(context);
-
-    if (m_debugBorder) {
-        SkAutoCanvasRestore autoRestore(&canvas, true);
-        canvas.concat(SkM44(transform));
-
-        SkPaint borderPaint;
-        borderPaint.setStyle(SkPaint::kStroke_Style);
-        borderPaint.setColor(SkColor(m_debugBorder->color));
-        borderPaint.setStrokeWidth(m_debugBorder->width);
-        borderPaint.setAntiAlias(true);
-
-        if (m_backingStore)
-            m_backingStore->drawDebugBorders(canvas, borderPaint);
-        if (m_contentsBuffer || m_imageBackingStore || (m_contentsSolidColor.isValid() && m_contentsSolidColor.isVisible()))
-            canvas.drawRect(SkRect(m_contentsRect), borderPaint);
-    }
-
-    if (!m_repaintCount)
-        return;
-
-    // Capture the full canvas-to-device position while the layer transform is still active.
+    // The counter is drawn in device space, so compose the layer transform here rather than concatenating
+    // it onto the canvas only to reset the matrix again below.
     SkPoint deviceOrigin { 0, 0 };
-    auto mapped = canvas.getLocalToDevice().map(0, 0, 0, 1);
+    const auto mapped = (canvas.getLocalToDevice() * SkM44(combinedTransform(context))).map(0, 0, 0, 1);
     if (std::abs(mapped.w) > std::numeric_limits<float>::epsilon())
         deviceOrigin = { mapped.x / mapped.w, mapped.y / mapped.w };
     else
@@ -681,7 +716,8 @@ void SkiaCompositingLayer::paintDebugIndicators(SkCanvas& canvas, PaintContext& 
         m_repaintCountOverlay.baselineOffset = -textBounds.fTop + padding;
     }
 
-    SkAutoCanvasRestore autoRestore(&canvas, true);
+    ScopedFlush autoFlush(canvas, context.imageSetBatch, ScopedFlush::Mode::FlushBefore);
+    canvas.resetMatrix();
 
     SkPaint backgroundPaint;
     backgroundPaint.setColor(m_debugBorder ? SkColor(m_debugBorder->color) : SK_ColorBLACK);
@@ -784,13 +820,6 @@ TransformationMatrix SkiaCompositingLayer::replicaTransform() const
         .multiply(m_transforms.combined.inverse().value_or(TransformationMatrix()));
 }
 
-TransformationMatrix SkiaCompositingLayer::combinedTransform(const PaintContext& context) const
-{
-    TransformationMatrix transform(context.accumulatedReplicaTransform);
-    transform.multiply(m_transforms.combined);
-    return transform;
-}
-
 IntRect SkiaCompositingLayer::clipBounds(const SkCanvas& canvas, const PaintContext& context) const
 {
     IntRect clip = canvas.getDeviceClipBounds();
@@ -840,7 +869,7 @@ void SkiaCompositingLayer::paintWithIntermediateSurface(SkCanvas& canvas, PaintC
     if (surfaceRect.isEmpty())
         return;
 
-    if (context.mode != PaintMode::Paint) {
+    if (!context.shouldDraw()) {
         paintFunction(canvas, context);
         return;
     }
@@ -906,12 +935,11 @@ void SkiaCompositingLayer::paintWithMaskAndBackdrop(SkCanvas& canvas, PaintConte
     if (m_mask && m_mask->m_clipPath && m_mask->m_clipPath->isEmpty())
         return;
 
-    // Otherwise the mask only affects the painted result, so apply it (clip path
-    // or mask image) only in PaintMode::Paint. Damage collection and debug
-    // indicators walk the tree unmasked.
+    // The mask only affects the drawn result, so apply it in the draw pass only. Damage collection
+    // and debug indicators walk the tree unmasked.
     bool shouldClipPath = false;
     sk_sp<SkImage> maskImage;
-    if (context.mode == PaintMode::Paint && m_mask) {
+    if (context.shouldDraw() && m_mask) {
         shouldClipPath = m_mask->m_clipPath.has_value();
         if (!shouldClipPath)
             maskImage = m_mask->maskImage();
@@ -960,23 +988,26 @@ void SkiaCompositingLayer::paintWithFilterAndMask(SkCanvas& canvas, PaintContext
     auto mode = m_mask ? ComputeOverlapRegionMode::Mask : ComputeOverlapRegionMode::Union;
     auto overlapRects = computeConsolidatedOverlapRegionRects(canvas, context, mode);
 
+    if (!context.shouldDraw()) {
 #if ENABLE(DAMAGE_TRACKING)
-    auto clipBounds = FloatRect(this->clipBounds(canvas, context));
-    const bool collectsDamage = context.mode == PaintMode::Paint;
-    const bool needToProcessFrameDamage = collectsDamage && frameDamagePropagationEnabled() && context.frameDamage;
-#endif
+        // The filter samples outside the layer, so the whole overlap region is damaged, not just what
+        // the subtree drew into it. Accumulated per frame, not across frames, or a layer that moves would
+        // keep damaging every region it has ever overlapped.
+        // FIXME: Unlike the plain damage path, the previous overlap region is not added here, so a moved
+        // or resized filtered layer leaves its old overlap undamaged. Once this damage feeds composition,
+        // that could leave artifacts for blurred overlapping elements.
+        if (frameDamagePropagationEnabled()) {
+            const auto clipBounds = FloatRect(this->clipBounds(canvas, context));
 
-    if (context.mode != PaintMode::Paint) {
-#if ENABLE(DAMAGE_TRACKING)
-        if (needToProcessFrameDamage) {
+            FloatRect overlapRegionDamage;
             for (const auto& rect : overlapRects) {
                 FloatRect damageRect(rect);
-                if (!clipBounds.isEmpty())
-                    damageRect.intersect(clipBounds);
-                m_accumulatedOverlapRegionFrameDamage.unite(damageRect);
+                damageRect.intersect(clipBounds);
+                overlapRegionDamage.unite(damageRect);
             }
-            if (!m_accumulatedOverlapRegionFrameDamage.isEmpty())
-                context.frameDamage->add(m_accumulatedOverlapRegionFrameDamage);
+
+            if (!overlapRegionDamage.isEmpty())
+                context.frameDamage->add(overlapRegionDamage);
         }
 #endif
         paintSelfAndChildren(canvas, context);
@@ -987,16 +1018,6 @@ void SkiaCompositingLayer::paintWithFilterAndMask(SkCanvas& canvas, PaintContext
     paint.setImageFilter(filter->filter);
 
     for (const auto& rect : overlapRects) {
-#if ENABLE(DAMAGE_TRACKING)
-        if (needToProcessFrameDamage) {
-            FloatRect damageRect(rect);
-            if (!clipBounds.isEmpty())
-                damageRect.intersect(clipBounds);
-
-            m_accumulatedOverlapRegionFrameDamage.unite(damageRect);
-        }
-#endif
-
         if (m_mask) {
             // Mask and filter: the filter should be applied first and then the mask on the result.
             paintWithIntermediateSurface(canvas, context, rect, nullptr, [&](SkCanvas& canvas, PaintContext& context) {
@@ -1010,11 +1031,6 @@ void SkiaCompositingLayer::paintWithFilterAndMask(SkCanvas& canvas, PaintContext
             });
         }
     }
-
-#if ENABLE(DAMAGE_TRACKING)
-    if (needToProcessFrameDamage && !m_accumulatedOverlapRegionFrameDamage.isEmpty())
-        context.frameDamage->add(m_accumulatedOverlapRegionFrameDamage);
-#endif
 }
 
 Vector<IntRect, 1> SkiaCompositingLayer::computeConsolidatedOverlapRegionRects(const SkCanvas& canvas, const PaintContext& context, ComputeOverlapRegionMode mode)
@@ -1061,11 +1077,8 @@ void SkiaCompositingLayer::recursivePaint(SkCanvas& canvas, PaintContext& contex
     else
         paintWithOpacity(canvas, context);
 
-    // Drawn after the layer's own content, filters and masks have been composited
-    // into the parent, but still in tree order, so layers painted on top (e.g. a
-    // modal) occlude the indicators of the layers they cover.
-    if (context.mode == PaintMode::Paint && hasDebugIndicators())
-        paintDebugIndicators(canvas, context);
+    if (context.shouldDraw() && m_repaintCount)
+        paintRepaintCounter(canvas, context);
 }
 
 void SkiaCompositingLayer::computeOverlapRegions(ComputeOverlapRegionData& data, const TransformationMatrix& accumulatedReplicaTransform, IncludesReplica includesReplica)
@@ -1078,7 +1091,7 @@ void SkiaCompositingLayer::computeOverlapRegions(ComputeOverlapRegionData& data,
     FloatRect localBoundingRect;
     if (m_backingStore || m_masksToBounds || m_mask || filter || m_backdrop.filter)
         localBoundingRect = effectiveLayerRect();
-    else if (m_contentsBuffer || m_imageBackingStore || (m_contentsSolidColor.isValid() && m_contentsSolidColor.isVisible()))
+    else if (paintsContentsRect())
         localBoundingRect = m_contentsRect;
 
     if (filter && !filter->outsets.isZero() && !m_masksToBounds && !m_mask && !m_backdrop.filter) {
@@ -1116,6 +1129,14 @@ void SkiaCompositingLayer::computeOverlapRegions(ComputeOverlapRegionData& data,
 void SkiaCompositingLayer::paintWithOpacity(SkCanvas& canvas, PaintContext& context)
 {
     if (opacity() == 1) {
+        paintWithReplica(canvas, context);
+        return;
+    }
+
+    // The overlap regions below only exist to composite the group correctly, and the collecting walk
+    // composites nothing. Splitting there would narrow the clip, shrink the damage each sub-walk collects
+    // and walk the subtree once per region rect. One unsplit walk collects a superset of the same rects.
+    if (!context.shouldDraw()) {
         paintWithReplica(canvas, context);
         return;
     }
@@ -1170,6 +1191,13 @@ void SkiaCompositingLayer::paintWithBlendMode(SkCanvas& canvas, PaintContext& co
         return;
     }
 
+    // See paintWithOpacity(): the collecting walk composites nothing, so it needs neither the blend mode
+    // nor the overlap regions.
+    if (!context.shouldDraw()) {
+        paintWithFilterAndMask(canvas, context);
+        return;
+    }
+
     auto blendMode = m_blendMode;
     if (!blendMode && m_shouldBlend)
         blendMode = SkBlendMode::kSrcOver;
@@ -1217,12 +1245,6 @@ void SkiaCompositingLayer::paintWithBlendMode(SkCanvas& canvas, PaintContext& co
             paintWithFilterAndMask(canvas, context);
         });
     }
-}
-
-bool SkiaCompositingLayer::hasVisualContent() const
-{
-    return m_backingStore || m_imageBackingStore || m_contentsBuffer
-        || (m_contentsSolidColor.isValid() && m_contentsSolidColor.isVisible());
 }
 
 void SkiaCompositingLayer::collect3DRenderingContextLayers(Vector<Ref<SkiaCompositingLayer>>& layers)

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h
@@ -34,6 +34,7 @@
 #include "FloatPoint3D.h"
 #include "FloatRect.h"
 #include "FloatRoundedRect.h"
+#include "IntSize.h"
 #include "SkiaCompositingLayerImageSetBatch.h"
 #include "SkiaCompositingLayerOverlapRegions.h"
 #include "TextureMapperAnimation.h"
@@ -111,9 +112,10 @@ public:
     const TransformationMatrix& toSurfaceTransform() const { return m_transforms.combined; }
     FloatRect effectiveLayerRect() const { return FloatRect({ }, m_size); }
 
-    bool paint(SkCanvas&, std::optional<Damage>&);
-
-    bool hasDebugIndicators() const { return m_debugBorder.has_value() || m_repaintCount.has_value(); }
+    // Applies the animations, computes the transforms, then walks the tree. When a frame damage is passed,
+    // it is collected first in a walk that draws nothing, before the walk that draws into the canvas.
+    // Returns whether any animation is still running.
+    bool paint(SkCanvas&, std::optional<Damage>& frameDamage);
 
 private:
     using ScopedFlush = SkiaCompositingLayerImageSetBatch::ScopedFlush;
@@ -124,22 +126,21 @@ private:
     bool isVisible() const;
     bool isLeafOf3DRenderingContext() const { return !m_preserves3D && (m_parent && m_parent->m_preserves3D); }
     bool isReplica() const { return !!m_replicatedLayer; }
-    bool hasVisualContent() const;
+    bool paintsContentsRect() const { return m_contentsBuffer || m_imageBackingStore || (m_contentsSolidColor.isValid() && m_contentsSolidColor.isVisible()); }
+    bool hasVisualContent() const { return m_backingStore || paintsContentsRect(); }
+    bool hasVisiblePaintableContent() const { return !m_size.isEmpty() && m_visible && m_contentsVisible && hasVisualContent(); }
     Ref<SkiaCompositingLayer> backdropRoot();
 
     bool computeTransformsAndAnimations(const TransformationMatrix& parentTransform, const TransformationMatrix& futureParentTransform, MonotonicTime);
 
-    enum class PaintMode : bool {
-        Paint,
-    };
-
+    // The damage-collecting walk gathers damage and draws nothing.
     struct PaintContext {
         explicit PaintContext(std::optional<Damage>& damage)
-            : frameDamage(damage)
-        {
-        }
+            : frameDamage(damage) { }
 
-        PaintMode mode { PaintMode::Paint };
+        bool shouldDraw() const { return !frameDamage; }
+
+        std::optional<Damage>& frameDamage; // Set for the collecting walk only.
         float opacity { 1 };
         std::optional<SkBlendMode> blendMode;
         IntSize offset;
@@ -147,7 +148,6 @@ private:
         TransformationMatrix accumulatedReplicaTransform;
         RefPtr<SkiaCompositingLayer> paintingBackdropForLayer;
         bool skipAfterBackdrop { false };
-        std::optional<Damage>& frameDamage;
         SkiaCompositingLayerImageSetBatch imageSetBatch;
     };
 
@@ -165,7 +165,8 @@ private:
     void paintWithFilterAndMask(SkCanvas&, PaintContext&);
     void paintSelf(SkCanvas&, PaintContext&);
     void paintContents(SkCanvas&, PaintContext&);
-    void paintDebugIndicators(SkCanvas&, PaintContext&);
+    void paintDebugBorder(SkCanvas&, PaintContext&);
+    void paintRepaintCounter(SkCanvas&, PaintContext&);
 #if ENABLE(DAMAGE_TRACKING)
     void collectFrameDamage(SkCanvas&, PaintContext&);
 #endif
@@ -190,7 +191,6 @@ private:
     bool frameDamagePropagationEnabled() const { return !!m_sharedFrameDamage; }
     void damageWholeLayer()
     {
-        m_accumulatedOverlapRegionFrameDamage = { };
         if (m_size.isEmpty())
             return;
 
@@ -286,7 +286,6 @@ private:
     std::shared_ptr<Damage> m_sharedFrameDamage;
     std::optional<Damage> m_layerDamage;
     FloatRect m_previousLayerRectInFrameCoordinates;
-    FloatRect m_accumulatedOverlapRegionFrameDamage;
 #endif
 };
 

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
@@ -405,17 +405,17 @@ void ThreadedCompositor::paintToSkiaCanvas(const TransformationMatrix& matrix, c
     auto& rootLayer = m_sceneState->rootLayer().ensureSkiaTarget();
     rootLayer.setTransform(matrix);
 
-    m_surface->clear(reasons);
-
-    canvas->save();
-
     std::optional<Damage> frameDamage;
 #if ENABLE(DAMAGE_TRACKING)
+    // The damage is collected by a walk of its own, which draws nothing, before the walk that draws.
     if (m_damage.flags)
         frameDamage = Damage(size, m_damage.flags->contains(DamagePropagationFlags::Unified) ? Damage::Mode::BoundingBox : Damage::Mode::Rectangles);
 #endif
 
-    bool sceneHasRunningAnimations = rootLayer.paint(*canvas, frameDamage);
+    m_surface->clear(reasons);
+
+    canvas->save();
+    const bool hasRunningAnimations = rootLayer.paint(*canvas, frameDamage);
     canvas->restore();
 
 #if ENABLE(DAMAGE_TRACKING)
@@ -426,9 +426,7 @@ void ThreadedCompositor::paintToSkiaCanvas(const TransformationMatrix& matrix, c
         if (!frameDamage->isEmpty())
             m_surface->setFrameDamage(WTF::move(*frameDamage));
     }
-#endif
 
-#if ENABLE(DAMAGE_TRACKING)
     if (m_damage.showSkiaDamage) {
         if (auto damage = m_surface->frameDamage())
             drawSkiaDamage(*canvas, damage);
@@ -445,7 +443,7 @@ void ThreadedCompositor::paintToSkiaCanvas(const TransformationMatrix& matrix, c
     if (auto* surface = canvas->getSurface())
         PlatformDisplay::sharedDisplay().skiaGrContext()->flushAndSubmit(surface, GrSyncCpu::kNo);
 
-    if (sceneHasRunningAnimations)
+    if (hasRunningAnimations)
         requestComposition(CompositionReason::Animation);
 }
 


### PR DESCRIPTION
#### 271c923387563e1a51c21d2f4f1662d2c3af57b6
<pre>
[Damage][Skia] Split the compositing walk into a damage pass and a paint pass
<a href="https://bugs.webkit.org/show_bug.cgi?id=319379">https://bugs.webkit.org/show_bug.cgi?id=319379</a>

Reviewed by Alejandro G. Castro.

The Skia compositor collects the frame damage in the same walk that draws, so the
damage is only complete once everything has already been painted. A compositor that
paints only what changed has to know the damage before it draws anything.

Split the walk in two: a damage pass walks the tree without drawing, into an
SkNoDrawCanvas, and gathers the frame damage, then a paint pass draws. Both passes
run from a single paint(), which first applies the animations and computes the
transforms once, so the two passes see the same tree, and returns whether any
animation is still running. When paint() is given no frame damage it just draws.

PaintContext says which pass is running by whether it carries a frame damage, and
the damage-collecting pass skips the work that only exists to composite a group:
the overlap-region splitting in paintWithOpacity() and paintWithBlendMode(), and
the intermediate surfaces, none of which change the rects it collects.

The debug indicators split the same way: the border is a content draw, so it
moves into the content stream where content above hides it and it shares the group&apos;s
opacity, filter and mask. The repaint counter is a device-space overlay and stays
one, drawn after the layer&apos;s subtree.

* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp:
(WebCore::SkiaCompositingLayer::paint):
(WebCore::SkiaCompositingLayer::paintSelf):
(WebCore::SkiaCompositingLayer::combinedTransform const):
(WebCore::SkiaCompositingLayer::paintDebugBorder):
(WebCore::SkiaCompositingLayer::paintRepaintCounter):
(WebCore::SkiaCompositingLayer::paintWithIntermediateSurface):
(WebCore::SkiaCompositingLayer::paintWithMaskAndBackdrop):
(WebCore::SkiaCompositingLayer::paintWithFilterAndMask):
(WebCore::SkiaCompositingLayer::recursivePaint):
(WebCore::SkiaCompositingLayer::computeOverlapRegions):
(WebCore::SkiaCompositingLayer::paintWithOpacity):
(WebCore::SkiaCompositingLayer::paintWithBlendMode):
(WebCore::SkiaCompositingLayer::paintDebugIndicators): Deleted.
(WebCore::SkiaCompositingLayer::hasVisualContent const): Deleted.
* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp:
(WebKit::ThreadedCompositor::paintToSkiaCanvas):

Canonical link: <a href="https://commits.webkit.org/317256@main">https://commits.webkit.org/317256@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dfcd426b29b066384be516f680b57d2f41b692c2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174803 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48736 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/42517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184383 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/132711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176668 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50028 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48419 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/136024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/132711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177761 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/39464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/42517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116502 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/38105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32861 "Built successfully") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/42517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/148528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/42517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186808 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/40182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/144953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48403 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/42517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144812 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49083 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/42517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26558 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/39687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/121153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47589 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/42517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46991 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47222 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47049 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->