### PR TITLE
[libpas] Test zero_mode through split-then-recoalesce in LargeFreeHeapTests

### DIFF
--- a/Source/bmalloc/libpas/src/test/LargeFreeHeapTests.cpp
+++ b/Source/bmalloc/libpas/src/test/LargeFreeHeapTests.cpp
@@ -545,6 +545,48 @@ void testSplitPreservesZeroModeFromSource(pas_zero_mode mode, bool useFastHeap)
         testSimpleLargeFreeHeap(actions, frees, 1);
 }
 
+void testFragmentationSplitRecoalescePreservesZero(bool useFastHeap)
+{
+    // An all-is_all_zero region survives a split-then-recoalesce cycle. Seed [1000, 4000)
+    // is_all_zero, carve two sub-ranges out (splits preserve zero, so the results and the leftover
+    // stay zero), then free both back is_all_zero so everything recoalesces. The final single free
+    // region must still be is_all_zero.
+    vector<Action> actions = {
+        Action::deallocate(1000, 3000, trappingAllocator, trappingDeallocator, pas_zero_mode_is_all_zero),
+        Action::allocate(1000, alignSimple(1), 1000, trappingAllocator, trappingDeallocator, pas_zero_mode_is_all_zero),
+        Action::allocate(1000, alignSimple(1), 2000, trappingAllocator, trappingDeallocator, pas_zero_mode_is_all_zero),
+        Action::deallocate(1000, 1000, trappingAllocator, trappingDeallocator, pas_zero_mode_is_all_zero),
+        Action::deallocate(2000, 1000, trappingAllocator, trappingDeallocator, pas_zero_mode_is_all_zero),
+    };
+    set<Free> frees = { Free(1000, 4000, pas_zero_mode_is_all_zero) };
+    if (useFastHeap)
+        testFastLargeFreeHeap(actions, frees, 1);
+    else
+        testSimpleLargeFreeHeap(actions, frees, 1);
+}
+
+void testFragmentationSplitRecoalesceContaminatedByNonZero(bool useFastHeap)
+{
+    // Recoalescing a may_have_non_zero sub-range into an is_all_zero neighbor must yield
+    // may_have_non_zero. Seed [1000, 4000) is_all_zero, carve two sub-ranges out (splits preserve
+    // zero), then free them back may_have_non_zero so they recoalesce with the still-zero leftover
+    // [3000, 4000). Per pas_zero_mode_merge the recoalesced region must be may_have_non_zero --
+    // is_all_zero survives a coalesce only when every part is is_all_zero; otherwise a later
+    // zeroedMalloc that trusts is_all_zero would skip zeroing and return stale bytes.
+    vector<Action> actions = {
+        Action::deallocate(1000, 3000, trappingAllocator, trappingDeallocator, pas_zero_mode_is_all_zero),
+        Action::allocate(1000, alignSimple(1), 1000, trappingAllocator, trappingDeallocator, pas_zero_mode_is_all_zero),
+        Action::allocate(1000, alignSimple(1), 2000, trappingAllocator, trappingDeallocator, pas_zero_mode_is_all_zero),
+        Action::deallocate(1000, 1000, trappingAllocator, trappingDeallocator, pas_zero_mode_may_have_non_zero),
+        Action::deallocate(2000, 1000, trappingAllocator, trappingDeallocator, pas_zero_mode_may_have_non_zero),
+    };
+    set<Free> frees = { Free(1000, 4000, pas_zero_mode_may_have_non_zero) };
+    if (useFastHeap)
+        testFastLargeFreeHeap(actions, frees, 1);
+    else
+        testSimpleLargeFreeHeap(actions, frees, 1);
+}
+
 } // anonymous namespace
 
 void addLargeFreeHeapTests()
@@ -1371,6 +1413,14 @@ void addLargeFreeHeapTests()
         ADD_TEST(testSplitPreservesZeroMode(pas_zero_mode_may_have_non_zero, useFastHeap));
         ADD_TEST(testSplitPreservesZeroModeFromSource(pas_zero_mode_is_all_zero, useFastHeap));
         ADD_TEST(testSplitPreservesZeroModeFromSource(pas_zero_mode_may_have_non_zero, useFastHeap));
+    }
+
+    // zero_mode through a fragmentation split-then-recoalesce sequence: an all-is_all_zero region
+    // survives the cycle, while freeing a may_have_non_zero sub-range back into it makes the
+    // recoalesced whole may_have_non_zero.
+    for (bool useFastHeap : { false, true }) {
+        ADD_TEST(testFragmentationSplitRecoalescePreservesZero(useFastHeap));
+        ADD_TEST(testFragmentationSplitRecoalesceContaminatedByNonZero(useFastHeap));
     }
 }
 


### PR DESCRIPTION
#### 5abeb7534df8542262f9b5101cbd1c7f2323a521
<pre>
[libpas] Test zero_mode through split-then-recoalesce in LargeFreeHeapTests
<a href="https://bugs.webkit.org/show_bug.cgi?id=319382">https://bugs.webkit.org/show_bug.cgi?id=319382</a>
<a href="https://rdar.apple.com/182204529">rdar://182204529</a>

Reviewed by Marcus Plutowski.

Add two fragmentation sequences on the simple and fast heaps.
testFragmentationSplitRecoalescePreservesZero seeds an is_all_zero region,
splits it into sub-ranges, and frees them back is_all_zero -- the recoalesced
region must stay is_all_zero. testFragmentationSplitRecoalesceContaminatedByNonZero
does the same but frees the pieces back may_have_non_zero; the recoalesced whole
must then be may_have_non_zero (pas_zero_mode_merge), since a later zeroedMalloc
trusting is_all_zero would otherwise skip zeroing and return stale bytes.

Test: Source/bmalloc/libpas/src/test/LargeFreeHeapTests.cpp

* Source/bmalloc/libpas/src/test/LargeFreeHeapTests.cpp:
(std::testFragmentationSplitRecoalescePreservesZero):
(std::testFragmentationSplitRecoalesceContaminatedByNonZero):
(addLargeFreeHeapTests):

Canonical link: <a href="https://commits.webkit.org/317171@main">https://commits.webkit.org/317171@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e6c6f26cf9dfdbf7d46f4941018408091435315d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174493 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48426 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42207 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184070 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132361 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3a01385d-ba92-4241-aea4-b08dfe07d512) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49718 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48109 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135753 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d8563228-2f36-478f-8718-dfdb1cf5f7d7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177451 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39189 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/156551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116231 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f4831be3-b36b-4cc5-b998-ef1584cd0ba8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37830 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32551 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5060 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148253 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36043 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186496 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/35755 "Built successfully and passed tests") | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144667 "Found 1 new test failure: editing/selection/doubleclick-crash.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48093 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144525 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48772 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114372 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26521 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39426 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/211546 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47279 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11007 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55190 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46681 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46912 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46739 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->