### PR TITLE
(315905@main) Unable to access apple.com in Safari in recoveryOS RemoteMediaPlayerManagerProxy_CreateMediaPlayer

### DIFF
--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.cpp
@@ -97,7 +97,12 @@ void RemoteMediaPlayerManagerProxy::createMediaPlayer(MediaPlayerIdentifier iden
     ASSERT(RunLoop::isMain());
     ASSERT(!m_proxies.contains(identifier));
 
-    MESSAGE_CHECK(playbackEngineForConnection(engineIdentifier));
+    if (!playbackEngineForConnection(engineIdentifier)) {
+        // Terminate only for a containment bypass: the engine is registered here for capability
+        // queries (Supports scope) but not for playback. An entirely-absent engine (e.g. media
+        // framework unavailable in recoveryOS) degrades to a null player.
+        MESSAGE_CHECK(!MediaPlayer::mediaEngine({ .identifier = engineIdentifier, .scope = MediaPlayerScope::Supports }));
+    }
 
     auto proxy = RemoteMediaPlayerProxy::create(*this, identifier, clientIdentifier, connection->connection(), engineIdentifier, WTF::move(proxyConfiguration), Ref { connection->videoFrameObjectHeap() }, connection->webProcessIdentity());
     m_proxies.add(identifier, WTF::move(proxy));


### PR DESCRIPTION
#### 14878d1cdcb1713e69fb3d037ea878cbc0fb2218
<pre>
(315905@main) Unable to access apple.com in Safari in recoveryOS RemoteMediaPlayerManagerProxy_CreateMediaPlayer
<a href="https://bugs.webkit.org/show_bug.cgi?id=319383">https://bugs.webkit.org/show_bug.cgi?id=319383</a>
<a href="https://rdar.apple.com/181834735">rdar://181834735</a>

Reviewed by Jer Noble and Eric Carlson.

In an environment where AVFoundation/CoreMedia are not available (such as
recoveryOS), loading any page with a media element repeatedly killed the
WebContent process with:

    Received an invalid message RemoteMediaPlayerManagerProxy_CreateMediaPlayer
    from WebContent process N, requesting for it to be terminated.

WebContent registers a remote AVFoundation factory whenever GPU-media is
enabled, without regard to whether the framework is actually present, and ends
up sending CreateMediaPlayer(AVFoundation) to the GPU process. This path is
long-standing and, on its own, harmless.

315905@main replaced the identifier allowlist in
RemoteMediaPlayerManagerProxy::createMediaPlayer() with
MESSAGE_CHECK(playbackEngineForConnection(engineIdentifier)), turning the guard
into a registration-existence test. That conflates two distinct cases where the
lookup returns null:

- a contained engine (WebM/MSE) registered in the GPU process for capability
    queries only (Supports scope) — a genuine containment bypass that must
    terminate WebContent, and
- an engine that is entirely unregistered because its platform framework is
    unavailable (AVFoundation in recoveryOS) — which previously fell through and
    degraded to a null player.

The latter now fails the MESSAGE_CHECK and terminates WebContent, which respawns
and is killed again, surfacing as &quot;a problem repeatedly occurred&quot;.

Only terminate for the containment-bypass case: when playbackEngineForConnection()
returns null, terminate only if the engine is registered at Supports scope.
An entirely-absent engine falls through to RemoteMediaPlayerProxy::create(),
whose MediaPlayer resolves the identifier to a NullMediaPlayerPrivate and reports
&quot;not supported&quot; back to WebContent, as it did before 315905@main.

As a follow-up, WebContent should not register a remote player factory for an
engine whose underlying framework is unavailable, so that no doomed
CreateMediaPlayer message is sent to the GPU process in the first place (e.g. by
checking isAvailable() before RemoteMediaPlayerSupport::registerRemoteEngineIfAvailable()
in the Cocoa engines&apos; registerMediaEngine()).

* Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.cpp:
(WebKit::RemoteMediaPlayerManagerProxy::createMediaPlayer):

Canonical link: <a href="https://commits.webkit.org/317195@main">https://commits.webkit.org/317195@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b9ff89fdf6b5869398fd859c77fc7ee974ddb60

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174503 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48436 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42217 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184080 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132371 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/532c144b-4855-474f-8a52-7496c085460d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49728 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48119 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135763 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1b3502f7-5047-4c57-bbca-e3a82f121e6e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177461 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39202 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156562 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116241 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3ab946ff-fdde-4795-9896-62c6cfc55f40) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37843 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36209 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32561 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148266 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36054 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186506 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39746 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40406 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144677 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48103 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144535 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/38974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48782 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114427 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26534 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39434 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120755 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47289 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11018 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46691 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46922 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46749 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->