### PR TITLE
JSC feature flags should be driven by UnifiedWebPreferences.yaml

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/shadowrealm-promise-rejection.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/shadowrealm-promise-rejection.https-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Promise rejections within worker thread ShadowRealms are handled assert_not_equals: ShadowRealm should be defined. got disallowed value undefined
+PASS Promise rejections within worker thread ShadowRealms are handled
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/instance.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/instance.wast.js-expected.txt
@@ -1,62 +1,32 @@
 
 PASS #1 Reinitialize the default imports
 PASS #2 Test that WebAssembly compilation succeeds (instance.wast:3)
-FAIL #3 Test that WebAssembly compilation succeeds (instance.wast:15) assert_equals: expected false but got true
-FAIL #4 Test that WebAssembly compilation succeeds (instance.wast:62) assert_equals: expected false but got true
+PASS #3 Test that WebAssembly compilation succeeds (instance.wast:15)
+PASS #4 Test that WebAssembly compilation succeeds (instance.wast:62)
 PASS #5 Test that WebAssembly compilation succeeds (instance.wast:109)
-FAIL #6 Test that WebAssembly compilation succeeds (instance.wast:128) assert_equals: expected false but got true
+PASS #6 Test that WebAssembly compilation succeeds (instance.wast:128)
 PASS #7 Reinitialize the default imports
 PASS #8 Test that WebAssembly compilation succeeds (instance.wast:3)
 PASS #9 Test that WebAssembly instantiation succeeds (instance.wast:3)
 PASS #10 Test that WebAssembly instantiation succeeds (instance.wast:3)
-FAIL #11 Test that WebAssembly compilation succeeds (instance.wast:15) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 95: there can at most be one Memory section for now at {loc} expected true got false
-FAIL #12 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-instance_wast_js@http://web-platform.test:8800/wasm/core/js/instance.wast.js:25:18
-global code@http://web-platform.test:8800/wasm/core/js/instance.wast.js:86:3 expected true got false
-FAIL #13 Test that a WebAssembly code returns a specific result (instance.wast:54) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-instance_wast_js@http://web-platform.test:8800/wasm/core/js/instance.wast.js:28:14
-global code@http://web-platform.test:8800/wasm/core/js/instance.wast.js:86:3 expected true got false
-FAIL #14 Test that a WebAssembly code returns a specific result (instance.wast:55) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-instance_wast_js@http://web-platform.test:8800/wasm/core/js/instance.wast.js:31:14
-global code@http://web-platform.test:8800/wasm/core/js/instance.wast.js:86:3 expected true got false
-FAIL #15 Test that a WebAssembly code returns a specific result (instance.wast:56) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-instance_wast_js@http://web-platform.test:8800/wasm/core/js/instance.wast.js:34:14
-global code@http://web-platform.test:8800/wasm/core/js/instance.wast.js:86:3 expected true got false
-FAIL #16 Test that a WebAssembly code returns a specific result (instance.wast:57) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-instance_wast_js@http://web-platform.test:8800/wasm/core/js/instance.wast.js:37:14
-global code@http://web-platform.test:8800/wasm/core/js/instance.wast.js:86:3 expected true got false
-FAIL #17 Test that WebAssembly compilation succeeds (instance.wast:62) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 95: there can at most be one Memory section for now at {loc} expected true got false
-FAIL #18 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-instance_wast_js@http://web-platform.test:8800/wasm/core/js/instance.wast.js:43:18
-global code@http://web-platform.test:8800/wasm/core/js/instance.wast.js:86:3 expected true got false
-FAIL #19 Test that a WebAssembly code returns a specific result (instance.wast:101) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-instance_wast_js@http://web-platform.test:8800/wasm/core/js/instance.wast.js:46:14
-global code@http://web-platform.test:8800/wasm/core/js/instance.wast.js:86:3 expected true got false
-FAIL #20 Test that a WebAssembly code returns a specific result (instance.wast:102) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-instance_wast_js@http://web-platform.test:8800/wasm/core/js/instance.wast.js:49:14
-global code@http://web-platform.test:8800/wasm/core/js/instance.wast.js:86:3 expected true got false
-FAIL #21 Test that a WebAssembly code returns a specific result (instance.wast:103) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-instance_wast_js@http://web-platform.test:8800/wasm/core/js/instance.wast.js:52:14
-global code@http://web-platform.test:8800/wasm/core/js/instance.wast.js:86:3 expected true got false
-FAIL #22 Test that a WebAssembly code returns a specific result (instance.wast:104) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-instance_wast_js@http://web-platform.test:8800/wasm/core/js/instance.wast.js:55:14
-global code@http://web-platform.test:8800/wasm/core/js/instance.wast.js:86:3 expected true got false
+PASS #11 Test that WebAssembly compilation succeeds (instance.wast:15)
+PASS #12 Test that WebAssembly instantiation succeeds (instance.wast:15)
+PASS #13 Test that a WebAssembly code returns a specific result (instance.wast:54)
+PASS #14 Test that a WebAssembly code returns a specific result (instance.wast:55)
+PASS #15 Test that a WebAssembly code returns a specific result (instance.wast:56)
+PASS #16 Test that a WebAssembly code returns a specific result (instance.wast:57)
+PASS #17 Test that WebAssembly compilation succeeds (instance.wast:62)
+PASS #18 Test that WebAssembly instantiation succeeds (instance.wast:62)
+PASS #19 Test that a WebAssembly code returns a specific result (instance.wast:101)
+PASS #20 Test that a WebAssembly code returns a specific result (instance.wast:102)
+PASS #21 Test that a WebAssembly code returns a specific result (instance.wast:103)
+PASS #22 Test that a WebAssembly code returns a specific result (instance.wast:104)
 PASS #23 Test that WebAssembly compilation succeeds (instance.wast:109)
 PASS #24 Test that WebAssembly instantiation succeeds (instance.wast:109)
-FAIL #25 Test that WebAssembly compilation succeeds (instance.wast:128) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 95: there can at most be one Memory section for now at {loc} expected true got false
-FAIL #26 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-instance_wast_js@http://web-platform.test:8800/wasm/core/js/instance.wast.js:72:18
-global code@http://web-platform.test:8800/wasm/core/js/instance.wast.js:86:3 expected true got false
-FAIL #27 Test that a WebAssembly code returns a specific result (instance.wast:167) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-instance_wast_js@http://web-platform.test:8800/wasm/core/js/instance.wast.js:75:14
-global code@http://web-platform.test:8800/wasm/core/js/instance.wast.js:86:3 expected true got false
-FAIL #28 Test that a WebAssembly code returns a specific result (instance.wast:168) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-instance_wast_js@http://web-platform.test:8800/wasm/core/js/instance.wast.js:78:14
-global code@http://web-platform.test:8800/wasm/core/js/instance.wast.js:86:3 expected true got false
-FAIL #29 Test that a WebAssembly code returns a specific result (instance.wast:169) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-instance_wast_js@http://web-platform.test:8800/wasm/core/js/instance.wast.js:81:14
-global code@http://web-platform.test:8800/wasm/core/js/instance.wast.js:86:3 expected true got false
-FAIL #30 Test that a WebAssembly code returns a specific result (instance.wast:170) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-instance_wast_js@http://web-platform.test:8800/wasm/core/js/instance.wast.js:84:14
-global code@http://web-platform.test:8800/wasm/core/js/instance.wast.js:86:3 expected true got false
+PASS #25 Test that WebAssembly compilation succeeds (instance.wast:128)
+PASS #26 Test that WebAssembly instantiation succeeds (instance.wast:128)
+PASS #27 Test that a WebAssembly code returns a specific result (instance.wast:167)
+PASS #28 Test that a WebAssembly code returns a specific result (instance.wast:168)
+PASS #29 Test that a WebAssembly code returns a specific result (instance.wast:169)
+PASS #30 Test that a WebAssembly code returns a specific result (instance.wast:170)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/address64.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/address64.wast.js-expected.txt
@@ -1,8 +1,8 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (address64.wast:3) assert_equals: expected false but got true
-FAIL #3 Test that WebAssembly compilation succeeds (address64.wast:209) assert_equals: expected false but got true
-FAIL #4 Test that WebAssembly compilation succeeds (address64.wast:492) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (address64.wast:3)
+PASS #3 Test that WebAssembly compilation succeeds (address64.wast:209)
+PASS #4 Test that WebAssembly compilation succeeds (address64.wast:492)
 PASS #5 Test that WebAssembly compilation succeeds (wrapper)
 PASS #6 Test that WebAssembly compilation succeeds (wrapper)
 PASS #7 Test that WebAssembly compilation succeeds (wrapper)
@@ -18,7 +18,7 @@ PASS #16 Test that WebAssembly compilation succeeds (wrapper)
 PASS #17 Test that WebAssembly compilation succeeds (wrapper)
 PASS #18 Test that WebAssembly compilation succeeds (wrapper)
 PASS #19 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #20 Test that WebAssembly compilation succeeds (address64.wast:539) assert_equals: expected false but got true
+PASS #20 Test that WebAssembly compilation succeeds (address64.wast:539)
 PASS #21 Test that WebAssembly compilation succeeds (wrapper)
 PASS #22 Test that WebAssembly compilation succeeds (wrapper)
 PASS #23 Test that WebAssembly compilation succeeds (wrapper)
@@ -35,914 +35,310 @@ PASS #33 Test that WebAssembly compilation succeeds (wrapper)
 PASS #34 Test that WebAssembly compilation succeeds (wrapper)
 PASS #35 Test that WebAssembly compilation succeeds (wrapper)
 PASS #36 Reinitialize the default imports
-FAIL #37 Test that WebAssembly compilation succeeds (address64.wast:3) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 69: Memory64 is not enabled at {loc} expected true got false
-FAIL #38 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #39 Test that a WebAssembly code returns a specific result (address64.wast:104) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:10:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #40 Test that a WebAssembly code returns a specific result (address64.wast:105) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:13:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #41 Test that a WebAssembly code returns a specific result (address64.wast:106) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:16:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #42 Test that a WebAssembly code returns a specific result (address64.wast:107) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:19:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #43 Test that a WebAssembly code returns a specific result (address64.wast:108) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:22:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #44 Test that a WebAssembly code returns a specific result (address64.wast:110) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:25:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #45 Test that a WebAssembly code returns a specific result (address64.wast:111) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:28:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #46 Test that a WebAssembly code returns a specific result (address64.wast:112) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:31:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #47 Test that a WebAssembly code returns a specific result (address64.wast:113) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:34:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #48 Test that a WebAssembly code returns a specific result (address64.wast:114) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:37:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #49 Test that a WebAssembly code returns a specific result (address64.wast:116) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:40:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #50 Test that a WebAssembly code returns a specific result (address64.wast:117) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:43:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #51 Test that a WebAssembly code returns a specific result (address64.wast:118) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:46:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #52 Test that a WebAssembly code returns a specific result (address64.wast:119) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:49:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #53 Test that a WebAssembly code returns a specific result (address64.wast:120) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:52:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #54 Test that a WebAssembly code returns a specific result (address64.wast:122) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:55:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #55 Test that a WebAssembly code returns a specific result (address64.wast:123) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:58:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #56 Test that a WebAssembly code returns a specific result (address64.wast:124) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:61:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #57 Test that a WebAssembly code returns a specific result (address64.wast:125) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:64:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #58 Test that a WebAssembly code returns a specific result (address64.wast:126) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:67:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #59 Test that a WebAssembly code returns a specific result (address64.wast:128) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:70:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #60 Test that a WebAssembly code returns a specific result (address64.wast:129) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:73:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #61 Test that a WebAssembly code returns a specific result (address64.wast:130) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:76:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #62 Test that a WebAssembly code returns a specific result (address64.wast:131) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:79:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #63 Test that a WebAssembly code returns a specific result (address64.wast:132) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:82:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #64 Test that a WebAssembly code returns a specific result (address64.wast:134) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:85:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #65 Test that a WebAssembly code returns a specific result (address64.wast:135) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:88:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #66 Test that a WebAssembly code returns a specific result (address64.wast:136) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:91:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #67 Test that a WebAssembly code returns a specific result (address64.wast:137) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:94:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #68 Test that a WebAssembly code returns a specific result (address64.wast:138) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:97:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #69 Test that a WebAssembly code returns a specific result (address64.wast:140) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:100:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #70 Test that a WebAssembly code returns a specific result (address64.wast:141) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:103:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #71 Test that a WebAssembly code returns a specific result (address64.wast:142) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:106:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #72 Test that a WebAssembly code returns a specific result (address64.wast:143) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:109:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #73 Test that a WebAssembly code returns a specific result (address64.wast:144) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:112:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #74 Test that a WebAssembly code returns a specific result (address64.wast:146) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:115:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #75 Test that a WebAssembly code returns a specific result (address64.wast:147) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:118:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #76 Test that a WebAssembly code returns a specific result (address64.wast:148) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:121:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #77 Test that a WebAssembly code returns a specific result (address64.wast:149) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:124:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #78 Test that a WebAssembly code returns a specific result (address64.wast:150) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:127:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #79 Test that a WebAssembly code returns a specific result (address64.wast:152) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:130:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #80 Test that a WebAssembly code returns a specific result (address64.wast:153) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:133:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #81 Test that a WebAssembly code returns a specific result (address64.wast:154) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:136:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #82 Test that a WebAssembly code returns a specific result (address64.wast:155) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:139:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #83 Test that a WebAssembly code returns a specific result (address64.wast:156) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:142:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #84 Test that a WebAssembly code returns a specific result (address64.wast:158) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:145:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #85 Test that a WebAssembly code returns a specific result (address64.wast:159) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:148:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #86 Test that a WebAssembly code returns a specific result (address64.wast:160) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:151:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #87 Test that a WebAssembly code returns a specific result (address64.wast:161) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:154:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #88 Test that a WebAssembly code returns a specific result (address64.wast:162) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:157:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #89 Test that a WebAssembly code returns a specific result (address64.wast:164) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:160:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #90 Test that a WebAssembly code returns a specific result (address64.wast:165) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:163:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #91 Test that a WebAssembly code returns a specific result (address64.wast:166) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:166:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #92 Test that a WebAssembly code returns a specific result (address64.wast:167) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:169:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #93 Test that a WebAssembly code returns a specific result (address64.wast:168) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:172:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #94 Test that a WebAssembly code returns a specific result (address64.wast:170) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:175:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #95 Test that a WebAssembly code returns a specific result (address64.wast:171) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:178:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #96 Test that a WebAssembly code returns a specific result (address64.wast:172) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:181:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #97 Test that a WebAssembly code returns a specific result (address64.wast:173) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:184:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #98 Test that a WebAssembly code returns a specific result (address64.wast:174) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:187:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #99 Test that a WebAssembly code returns a specific result (address64.wast:176) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:190:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #100 Test that a WebAssembly code returns a specific result (address64.wast:177) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:193:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #101 Test that a WebAssembly code returns a specific result (address64.wast:178) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:196:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #102 Test that a WebAssembly code returns a specific result (address64.wast:179) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:199:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #103 Test that a WebAssembly code returns a specific result (address64.wast:180) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:202:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #104 Test that a WebAssembly code returns a specific result (address64.wast:182) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:205:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #105 Test that a WebAssembly code returns a specific result (address64.wast:183) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:208:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #106 Test that a WebAssembly code returns a specific result (address64.wast:184) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:211:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #107 Test that a WebAssembly code returns a specific result (address64.wast:185) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:214:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #108 Test that a WebAssembly code returns a specific result (address64.wast:186) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:217:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #109 Test that a WebAssembly code returns a specific result (address64.wast:188) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:220:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #110 Test that a WebAssembly code returns a specific result (address64.wast:189) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:223:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #111 Test that a WebAssembly code returns a specific result (address64.wast:190) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:226:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #112 Test that a WebAssembly code returns a specific result (address64.wast:191) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:229:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #113 Test that a WebAssembly code traps (address64.wast:192) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:232:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #114 Test that a WebAssembly code traps (address64.wast:194) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:235:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #115 Test that a WebAssembly code traps (address64.wast:195) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:238:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #116 Test that a WebAssembly code traps (address64.wast:196) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:241:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #117 Test that a WebAssembly code traps (address64.wast:197) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:244:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #118 Test that a WebAssembly code traps (address64.wast:198) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:247:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #119 Test that a WebAssembly code traps (address64.wast:200) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:250:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #120 Test that a WebAssembly code traps (address64.wast:201) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:253:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #121 Test that a WebAssembly code traps (address64.wast:202) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:256:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #122 Test that a WebAssembly code traps (address64.wast:203) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:259:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #123 Test that a WebAssembly code traps (address64.wast:204) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:262:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #124 Test that WebAssembly compilation succeeds (address64.wast:209) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 81: Memory64 is not enabled at {loc} expected true got false
-FAIL #125 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:268:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #126 Test that a WebAssembly code returns a specific result (address64.wast:348) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:271:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #127 Test that a WebAssembly code returns a specific result (address64.wast:349) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:274:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #128 Test that a WebAssembly code returns a specific result (address64.wast:350) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:277:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #129 Test that a WebAssembly code returns a specific result (address64.wast:351) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:280:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #130 Test that a WebAssembly code returns a specific result (address64.wast:352) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:283:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #131 Test that a WebAssembly code returns a specific result (address64.wast:354) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:286:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #132 Test that a WebAssembly code returns a specific result (address64.wast:355) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:289:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #133 Test that a WebAssembly code returns a specific result (address64.wast:356) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:292:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #134 Test that a WebAssembly code returns a specific result (address64.wast:357) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:295:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #135 Test that a WebAssembly code returns a specific result (address64.wast:358) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:298:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #136 Test that a WebAssembly code returns a specific result (address64.wast:360) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:301:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #137 Test that a WebAssembly code returns a specific result (address64.wast:361) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:304:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #138 Test that a WebAssembly code returns a specific result (address64.wast:362) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:307:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #139 Test that a WebAssembly code returns a specific result (address64.wast:363) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:310:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #140 Test that a WebAssembly code returns a specific result (address64.wast:364) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:313:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #141 Test that a WebAssembly code returns a specific result (address64.wast:366) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:316:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #142 Test that a WebAssembly code returns a specific result (address64.wast:367) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:319:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #143 Test that a WebAssembly code returns a specific result (address64.wast:368) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:322:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #144 Test that a WebAssembly code returns a specific result (address64.wast:369) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:325:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #145 Test that a WebAssembly code returns a specific result (address64.wast:370) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:328:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #146 Test that a WebAssembly code returns a specific result (address64.wast:372) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:331:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #147 Test that a WebAssembly code returns a specific result (address64.wast:373) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:334:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #148 Test that a WebAssembly code returns a specific result (address64.wast:374) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:337:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #149 Test that a WebAssembly code returns a specific result (address64.wast:375) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:340:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #150 Test that a WebAssembly code returns a specific result (address64.wast:376) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:343:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #151 Test that a WebAssembly code returns a specific result (address64.wast:378) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:346:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #152 Test that a WebAssembly code returns a specific result (address64.wast:379) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:349:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #153 Test that a WebAssembly code returns a specific result (address64.wast:380) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:352:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #154 Test that a WebAssembly code returns a specific result (address64.wast:381) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:355:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #155 Test that a WebAssembly code returns a specific result (address64.wast:382) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:358:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #156 Test that a WebAssembly code returns a specific result (address64.wast:384) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:361:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #157 Test that a WebAssembly code returns a specific result (address64.wast:385) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:364:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #158 Test that a WebAssembly code returns a specific result (address64.wast:386) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:367:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #159 Test that a WebAssembly code returns a specific result (address64.wast:387) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:370:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #160 Test that a WebAssembly code returns a specific result (address64.wast:388) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:373:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #161 Test that a WebAssembly code returns a specific result (address64.wast:390) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:376:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #162 Test that a WebAssembly code returns a specific result (address64.wast:391) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:379:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #163 Test that a WebAssembly code returns a specific result (address64.wast:392) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:382:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #164 Test that a WebAssembly code returns a specific result (address64.wast:393) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:385:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #165 Test that a WebAssembly code returns a specific result (address64.wast:394) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:388:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #166 Test that a WebAssembly code returns a specific result (address64.wast:396) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:391:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #167 Test that a WebAssembly code returns a specific result (address64.wast:397) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:394:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #168 Test that a WebAssembly code returns a specific result (address64.wast:398) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:397:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #169 Test that a WebAssembly code returns a specific result (address64.wast:399) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:400:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #170 Test that a WebAssembly code returns a specific result (address64.wast:400) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:403:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #171 Test that a WebAssembly code returns a specific result (address64.wast:402) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:406:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #172 Test that a WebAssembly code returns a specific result (address64.wast:403) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:409:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #173 Test that a WebAssembly code returns a specific result (address64.wast:404) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:412:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #174 Test that a WebAssembly code returns a specific result (address64.wast:405) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:415:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #175 Test that a WebAssembly code returns a specific result (address64.wast:406) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:418:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #176 Test that a WebAssembly code returns a specific result (address64.wast:408) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:421:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #177 Test that a WebAssembly code returns a specific result (address64.wast:409) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:424:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #178 Test that a WebAssembly code returns a specific result (address64.wast:410) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:427:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #179 Test that a WebAssembly code returns a specific result (address64.wast:411) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:430:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #180 Test that a WebAssembly code returns a specific result (address64.wast:412) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:433:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #181 Test that a WebAssembly code returns a specific result (address64.wast:414) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:436:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #182 Test that a WebAssembly code returns a specific result (address64.wast:415) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:439:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #183 Test that a WebAssembly code returns a specific result (address64.wast:416) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:442:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #184 Test that a WebAssembly code returns a specific result (address64.wast:417) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:445:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #185 Test that a WebAssembly code returns a specific result (address64.wast:418) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:448:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #186 Test that a WebAssembly code returns a specific result (address64.wast:420) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:451:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #187 Test that a WebAssembly code returns a specific result (address64.wast:421) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:454:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #188 Test that a WebAssembly code returns a specific result (address64.wast:422) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:457:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #189 Test that a WebAssembly code returns a specific result (address64.wast:423) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:460:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #190 Test that a WebAssembly code returns a specific result (address64.wast:424) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:463:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #191 Test that a WebAssembly code returns a specific result (address64.wast:426) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:466:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #192 Test that a WebAssembly code returns a specific result (address64.wast:427) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:469:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #193 Test that a WebAssembly code returns a specific result (address64.wast:428) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:472:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #194 Test that a WebAssembly code returns a specific result (address64.wast:429) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:475:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #195 Test that a WebAssembly code returns a specific result (address64.wast:430) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:478:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #196 Test that a WebAssembly code returns a specific result (address64.wast:432) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:481:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #197 Test that a WebAssembly code returns a specific result (address64.wast:433) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:484:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #198 Test that a WebAssembly code returns a specific result (address64.wast:434) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:487:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #199 Test that a WebAssembly code returns a specific result (address64.wast:435) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:490:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #200 Test that a WebAssembly code returns a specific result (address64.wast:436) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:493:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #201 Test that a WebAssembly code returns a specific result (address64.wast:438) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:496:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #202 Test that a WebAssembly code returns a specific result (address64.wast:439) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:499:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #203 Test that a WebAssembly code returns a specific result (address64.wast:440) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:502:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #204 Test that a WebAssembly code returns a specific result (address64.wast:441) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:505:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #205 Test that a WebAssembly code returns a specific result (address64.wast:442) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:508:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #206 Test that a WebAssembly code returns a specific result (address64.wast:444) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:511:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #207 Test that a WebAssembly code returns a specific result (address64.wast:445) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:514:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #208 Test that a WebAssembly code returns a specific result (address64.wast:446) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:517:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #209 Test that a WebAssembly code returns a specific result (address64.wast:447) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:520:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #210 Test that a WebAssembly code returns a specific result (address64.wast:448) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:523:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #211 Test that a WebAssembly code returns a specific result (address64.wast:450) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:526:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #212 Test that a WebAssembly code returns a specific result (address64.wast:451) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:529:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #213 Test that a WebAssembly code returns a specific result (address64.wast:452) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:532:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #214 Test that a WebAssembly code returns a specific result (address64.wast:453) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:535:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #215 Test that a WebAssembly code returns a specific result (address64.wast:454) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:538:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #216 Test that a WebAssembly code returns a specific result (address64.wast:456) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:541:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #217 Test that a WebAssembly code returns a specific result (address64.wast:457) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:544:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #218 Test that a WebAssembly code returns a specific result (address64.wast:458) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:547:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #219 Test that a WebAssembly code returns a specific result (address64.wast:459) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:550:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #220 Test that a WebAssembly code returns a specific result (address64.wast:460) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:553:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #221 Test that a WebAssembly code returns a specific result (address64.wast:462) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:556:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #222 Test that a WebAssembly code returns a specific result (address64.wast:463) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:559:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #223 Test that a WebAssembly code returns a specific result (address64.wast:464) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:562:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #224 Test that a WebAssembly code returns a specific result (address64.wast:465) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:565:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #225 Test that a WebAssembly code returns a specific result (address64.wast:466) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:568:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #226 Test that a WebAssembly code returns a specific result (address64.wast:468) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:571:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #227 Test that a WebAssembly code returns a specific result (address64.wast:469) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:574:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #228 Test that a WebAssembly code returns a specific result (address64.wast:470) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:577:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #229 Test that a WebAssembly code returns a specific result (address64.wast:471) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:580:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #230 Test that a WebAssembly code traps (address64.wast:472) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:583:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #231 Test that a WebAssembly code traps (address64.wast:474) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:586:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #232 Test that a WebAssembly code traps (address64.wast:475) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:589:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #233 Test that a WebAssembly code traps (address64.wast:476) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:592:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #234 Test that a WebAssembly code traps (address64.wast:477) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:595:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #235 Test that a WebAssembly code traps (address64.wast:478) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:598:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #236 Test that a WebAssembly code traps (address64.wast:479) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:601:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #237 Test that a WebAssembly code traps (address64.wast:480) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:604:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #238 Test that a WebAssembly code traps (address64.wast:482) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:607:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #239 Test that a WebAssembly code traps (address64.wast:483) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:610:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #240 Test that a WebAssembly code traps (address64.wast:484) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:613:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #241 Test that a WebAssembly code traps (address64.wast:485) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:616:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #242 Test that a WebAssembly code traps (address64.wast:486) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:619:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #243 Test that a WebAssembly code traps (address64.wast:487) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:622:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #244 Test that a WebAssembly code traps (address64.wast:488) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:625:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #245 Test that WebAssembly compilation succeeds (address64.wast:492) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 45: Memory64 is not enabled at {loc} expected true got false
-FAIL #246 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:631:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #37 Test that WebAssembly compilation succeeds (address64.wast:3)
+PASS #38 Test that WebAssembly instantiation succeeds (address64.wast:3)
+PASS #39 Test that a WebAssembly code returns a specific result (address64.wast:104)
+PASS #40 Test that a WebAssembly code returns a specific result (address64.wast:105)
+PASS #41 Test that a WebAssembly code returns a specific result (address64.wast:106)
+PASS #42 Test that a WebAssembly code returns a specific result (address64.wast:107)
+PASS #43 Test that a WebAssembly code returns a specific result (address64.wast:108)
+PASS #44 Test that a WebAssembly code returns a specific result (address64.wast:110)
+PASS #45 Test that a WebAssembly code returns a specific result (address64.wast:111)
+PASS #46 Test that a WebAssembly code returns a specific result (address64.wast:112)
+PASS #47 Test that a WebAssembly code returns a specific result (address64.wast:113)
+PASS #48 Test that a WebAssembly code returns a specific result (address64.wast:114)
+PASS #49 Test that a WebAssembly code returns a specific result (address64.wast:116)
+PASS #50 Test that a WebAssembly code returns a specific result (address64.wast:117)
+PASS #51 Test that a WebAssembly code returns a specific result (address64.wast:118)
+PASS #52 Test that a WebAssembly code returns a specific result (address64.wast:119)
+PASS #53 Test that a WebAssembly code returns a specific result (address64.wast:120)
+PASS #54 Test that a WebAssembly code returns a specific result (address64.wast:122)
+PASS #55 Test that a WebAssembly code returns a specific result (address64.wast:123)
+PASS #56 Test that a WebAssembly code returns a specific result (address64.wast:124)
+PASS #57 Test that a WebAssembly code returns a specific result (address64.wast:125)
+PASS #58 Test that a WebAssembly code returns a specific result (address64.wast:126)
+PASS #59 Test that a WebAssembly code returns a specific result (address64.wast:128)
+PASS #60 Test that a WebAssembly code returns a specific result (address64.wast:129)
+PASS #61 Test that a WebAssembly code returns a specific result (address64.wast:130)
+PASS #62 Test that a WebAssembly code returns a specific result (address64.wast:131)
+PASS #63 Test that a WebAssembly code returns a specific result (address64.wast:132)
+PASS #64 Test that a WebAssembly code returns a specific result (address64.wast:134)
+PASS #65 Test that a WebAssembly code returns a specific result (address64.wast:135)
+PASS #66 Test that a WebAssembly code returns a specific result (address64.wast:136)
+PASS #67 Test that a WebAssembly code returns a specific result (address64.wast:137)
+PASS #68 Test that a WebAssembly code returns a specific result (address64.wast:138)
+PASS #69 Test that a WebAssembly code returns a specific result (address64.wast:140)
+PASS #70 Test that a WebAssembly code returns a specific result (address64.wast:141)
+PASS #71 Test that a WebAssembly code returns a specific result (address64.wast:142)
+PASS #72 Test that a WebAssembly code returns a specific result (address64.wast:143)
+PASS #73 Test that a WebAssembly code returns a specific result (address64.wast:144)
+PASS #74 Test that a WebAssembly code returns a specific result (address64.wast:146)
+PASS #75 Test that a WebAssembly code returns a specific result (address64.wast:147)
+PASS #76 Test that a WebAssembly code returns a specific result (address64.wast:148)
+PASS #77 Test that a WebAssembly code returns a specific result (address64.wast:149)
+PASS #78 Test that a WebAssembly code returns a specific result (address64.wast:150)
+PASS #79 Test that a WebAssembly code returns a specific result (address64.wast:152)
+PASS #80 Test that a WebAssembly code returns a specific result (address64.wast:153)
+PASS #81 Test that a WebAssembly code returns a specific result (address64.wast:154)
+PASS #82 Test that a WebAssembly code returns a specific result (address64.wast:155)
+PASS #83 Test that a WebAssembly code returns a specific result (address64.wast:156)
+PASS #84 Test that a WebAssembly code returns a specific result (address64.wast:158)
+PASS #85 Test that a WebAssembly code returns a specific result (address64.wast:159)
+PASS #86 Test that a WebAssembly code returns a specific result (address64.wast:160)
+PASS #87 Test that a WebAssembly code returns a specific result (address64.wast:161)
+PASS #88 Test that a WebAssembly code returns a specific result (address64.wast:162)
+PASS #89 Test that a WebAssembly code returns a specific result (address64.wast:164)
+PASS #90 Test that a WebAssembly code returns a specific result (address64.wast:165)
+PASS #91 Test that a WebAssembly code returns a specific result (address64.wast:166)
+PASS #92 Test that a WebAssembly code returns a specific result (address64.wast:167)
+PASS #93 Test that a WebAssembly code returns a specific result (address64.wast:168)
+PASS #94 Test that a WebAssembly code returns a specific result (address64.wast:170)
+PASS #95 Test that a WebAssembly code returns a specific result (address64.wast:171)
+PASS #96 Test that a WebAssembly code returns a specific result (address64.wast:172)
+PASS #97 Test that a WebAssembly code returns a specific result (address64.wast:173)
+PASS #98 Test that a WebAssembly code returns a specific result (address64.wast:174)
+PASS #99 Test that a WebAssembly code returns a specific result (address64.wast:176)
+PASS #100 Test that a WebAssembly code returns a specific result (address64.wast:177)
+PASS #101 Test that a WebAssembly code returns a specific result (address64.wast:178)
+PASS #102 Test that a WebAssembly code returns a specific result (address64.wast:179)
+PASS #103 Test that a WebAssembly code returns a specific result (address64.wast:180)
+PASS #104 Test that a WebAssembly code returns a specific result (address64.wast:182)
+PASS #105 Test that a WebAssembly code returns a specific result (address64.wast:183)
+PASS #106 Test that a WebAssembly code returns a specific result (address64.wast:184)
+PASS #107 Test that a WebAssembly code returns a specific result (address64.wast:185)
+PASS #108 Test that a WebAssembly code returns a specific result (address64.wast:186)
+PASS #109 Test that a WebAssembly code returns a specific result (address64.wast:188)
+PASS #110 Test that a WebAssembly code returns a specific result (address64.wast:189)
+PASS #111 Test that a WebAssembly code returns a specific result (address64.wast:190)
+PASS #112 Test that a WebAssembly code returns a specific result (address64.wast:191)
+PASS #113 Test that a WebAssembly code traps (address64.wast:192)
+PASS #114 Test that a WebAssembly code traps (address64.wast:194)
+PASS #115 Test that a WebAssembly code traps (address64.wast:195)
+PASS #116 Test that a WebAssembly code traps (address64.wast:196)
+PASS #117 Test that a WebAssembly code traps (address64.wast:197)
+PASS #118 Test that a WebAssembly code traps (address64.wast:198)
+PASS #119 Test that a WebAssembly code traps (address64.wast:200)
+PASS #120 Test that a WebAssembly code traps (address64.wast:201)
+PASS #121 Test that a WebAssembly code traps (address64.wast:202)
+PASS #122 Test that a WebAssembly code traps (address64.wast:203)
+PASS #123 Test that a WebAssembly code traps (address64.wast:204)
+PASS #124 Test that WebAssembly compilation succeeds (address64.wast:209)
+PASS #125 Test that WebAssembly instantiation succeeds (address64.wast:209)
+PASS #126 Test that a WebAssembly code returns a specific result (address64.wast:348)
+PASS #127 Test that a WebAssembly code returns a specific result (address64.wast:349)
+PASS #128 Test that a WebAssembly code returns a specific result (address64.wast:350)
+PASS #129 Test that a WebAssembly code returns a specific result (address64.wast:351)
+PASS #130 Test that a WebAssembly code returns a specific result (address64.wast:352)
+PASS #131 Test that a WebAssembly code returns a specific result (address64.wast:354)
+PASS #132 Test that a WebAssembly code returns a specific result (address64.wast:355)
+PASS #133 Test that a WebAssembly code returns a specific result (address64.wast:356)
+PASS #134 Test that a WebAssembly code returns a specific result (address64.wast:357)
+PASS #135 Test that a WebAssembly code returns a specific result (address64.wast:358)
+PASS #136 Test that a WebAssembly code returns a specific result (address64.wast:360)
+PASS #137 Test that a WebAssembly code returns a specific result (address64.wast:361)
+PASS #138 Test that a WebAssembly code returns a specific result (address64.wast:362)
+PASS #139 Test that a WebAssembly code returns a specific result (address64.wast:363)
+PASS #140 Test that a WebAssembly code returns a specific result (address64.wast:364)
+PASS #141 Test that a WebAssembly code returns a specific result (address64.wast:366)
+PASS #142 Test that a WebAssembly code returns a specific result (address64.wast:367)
+PASS #143 Test that a WebAssembly code returns a specific result (address64.wast:368)
+PASS #144 Test that a WebAssembly code returns a specific result (address64.wast:369)
+PASS #145 Test that a WebAssembly code returns a specific result (address64.wast:370)
+PASS #146 Test that a WebAssembly code returns a specific result (address64.wast:372)
+PASS #147 Test that a WebAssembly code returns a specific result (address64.wast:373)
+PASS #148 Test that a WebAssembly code returns a specific result (address64.wast:374)
+PASS #149 Test that a WebAssembly code returns a specific result (address64.wast:375)
+PASS #150 Test that a WebAssembly code returns a specific result (address64.wast:376)
+PASS #151 Test that a WebAssembly code returns a specific result (address64.wast:378)
+PASS #152 Test that a WebAssembly code returns a specific result (address64.wast:379)
+PASS #153 Test that a WebAssembly code returns a specific result (address64.wast:380)
+PASS #154 Test that a WebAssembly code returns a specific result (address64.wast:381)
+PASS #155 Test that a WebAssembly code returns a specific result (address64.wast:382)
+PASS #156 Test that a WebAssembly code returns a specific result (address64.wast:384)
+PASS #157 Test that a WebAssembly code returns a specific result (address64.wast:385)
+PASS #158 Test that a WebAssembly code returns a specific result (address64.wast:386)
+PASS #159 Test that a WebAssembly code returns a specific result (address64.wast:387)
+PASS #160 Test that a WebAssembly code returns a specific result (address64.wast:388)
+PASS #161 Test that a WebAssembly code returns a specific result (address64.wast:390)
+PASS #162 Test that a WebAssembly code returns a specific result (address64.wast:391)
+PASS #163 Test that a WebAssembly code returns a specific result (address64.wast:392)
+PASS #164 Test that a WebAssembly code returns a specific result (address64.wast:393)
+PASS #165 Test that a WebAssembly code returns a specific result (address64.wast:394)
+PASS #166 Test that a WebAssembly code returns a specific result (address64.wast:396)
+PASS #167 Test that a WebAssembly code returns a specific result (address64.wast:397)
+PASS #168 Test that a WebAssembly code returns a specific result (address64.wast:398)
+PASS #169 Test that a WebAssembly code returns a specific result (address64.wast:399)
+PASS #170 Test that a WebAssembly code returns a specific result (address64.wast:400)
+PASS #171 Test that a WebAssembly code returns a specific result (address64.wast:402)
+PASS #172 Test that a WebAssembly code returns a specific result (address64.wast:403)
+PASS #173 Test that a WebAssembly code returns a specific result (address64.wast:404)
+PASS #174 Test that a WebAssembly code returns a specific result (address64.wast:405)
+PASS #175 Test that a WebAssembly code returns a specific result (address64.wast:406)
+PASS #176 Test that a WebAssembly code returns a specific result (address64.wast:408)
+PASS #177 Test that a WebAssembly code returns a specific result (address64.wast:409)
+PASS #178 Test that a WebAssembly code returns a specific result (address64.wast:410)
+PASS #179 Test that a WebAssembly code returns a specific result (address64.wast:411)
+PASS #180 Test that a WebAssembly code returns a specific result (address64.wast:412)
+PASS #181 Test that a WebAssembly code returns a specific result (address64.wast:414)
+PASS #182 Test that a WebAssembly code returns a specific result (address64.wast:415)
+PASS #183 Test that a WebAssembly code returns a specific result (address64.wast:416)
+PASS #184 Test that a WebAssembly code returns a specific result (address64.wast:417)
+PASS #185 Test that a WebAssembly code returns a specific result (address64.wast:418)
+PASS #186 Test that a WebAssembly code returns a specific result (address64.wast:420)
+PASS #187 Test that a WebAssembly code returns a specific result (address64.wast:421)
+PASS #188 Test that a WebAssembly code returns a specific result (address64.wast:422)
+PASS #189 Test that a WebAssembly code returns a specific result (address64.wast:423)
+PASS #190 Test that a WebAssembly code returns a specific result (address64.wast:424)
+PASS #191 Test that a WebAssembly code returns a specific result (address64.wast:426)
+PASS #192 Test that a WebAssembly code returns a specific result (address64.wast:427)
+PASS #193 Test that a WebAssembly code returns a specific result (address64.wast:428)
+PASS #194 Test that a WebAssembly code returns a specific result (address64.wast:429)
+PASS #195 Test that a WebAssembly code returns a specific result (address64.wast:430)
+PASS #196 Test that a WebAssembly code returns a specific result (address64.wast:432)
+PASS #197 Test that a WebAssembly code returns a specific result (address64.wast:433)
+PASS #198 Test that a WebAssembly code returns a specific result (address64.wast:434)
+PASS #199 Test that a WebAssembly code returns a specific result (address64.wast:435)
+PASS #200 Test that a WebAssembly code returns a specific result (address64.wast:436)
+PASS #201 Test that a WebAssembly code returns a specific result (address64.wast:438)
+PASS #202 Test that a WebAssembly code returns a specific result (address64.wast:439)
+PASS #203 Test that a WebAssembly code returns a specific result (address64.wast:440)
+PASS #204 Test that a WebAssembly code returns a specific result (address64.wast:441)
+PASS #205 Test that a WebAssembly code returns a specific result (address64.wast:442)
+PASS #206 Test that a WebAssembly code returns a specific result (address64.wast:444)
+PASS #207 Test that a WebAssembly code returns a specific result (address64.wast:445)
+PASS #208 Test that a WebAssembly code returns a specific result (address64.wast:446)
+PASS #209 Test that a WebAssembly code returns a specific result (address64.wast:447)
+PASS #210 Test that a WebAssembly code returns a specific result (address64.wast:448)
+PASS #211 Test that a WebAssembly code returns a specific result (address64.wast:450)
+PASS #212 Test that a WebAssembly code returns a specific result (address64.wast:451)
+PASS #213 Test that a WebAssembly code returns a specific result (address64.wast:452)
+PASS #214 Test that a WebAssembly code returns a specific result (address64.wast:453)
+PASS #215 Test that a WebAssembly code returns a specific result (address64.wast:454)
+PASS #216 Test that a WebAssembly code returns a specific result (address64.wast:456)
+PASS #217 Test that a WebAssembly code returns a specific result (address64.wast:457)
+PASS #218 Test that a WebAssembly code returns a specific result (address64.wast:458)
+PASS #219 Test that a WebAssembly code returns a specific result (address64.wast:459)
+PASS #220 Test that a WebAssembly code returns a specific result (address64.wast:460)
+PASS #221 Test that a WebAssembly code returns a specific result (address64.wast:462)
+PASS #222 Test that a WebAssembly code returns a specific result (address64.wast:463)
+PASS #223 Test that a WebAssembly code returns a specific result (address64.wast:464)
+PASS #224 Test that a WebAssembly code returns a specific result (address64.wast:465)
+PASS #225 Test that a WebAssembly code returns a specific result (address64.wast:466)
+PASS #226 Test that a WebAssembly code returns a specific result (address64.wast:468)
+PASS #227 Test that a WebAssembly code returns a specific result (address64.wast:469)
+PASS #228 Test that a WebAssembly code returns a specific result (address64.wast:470)
+PASS #229 Test that a WebAssembly code returns a specific result (address64.wast:471)
+PASS #230 Test that a WebAssembly code traps (address64.wast:472)
+PASS #231 Test that a WebAssembly code traps (address64.wast:474)
+PASS #232 Test that a WebAssembly code traps (address64.wast:475)
+PASS #233 Test that a WebAssembly code traps (address64.wast:476)
+PASS #234 Test that a WebAssembly code traps (address64.wast:477)
+PASS #235 Test that a WebAssembly code traps (address64.wast:478)
+PASS #236 Test that a WebAssembly code traps (address64.wast:479)
+PASS #237 Test that a WebAssembly code traps (address64.wast:480)
+PASS #238 Test that a WebAssembly code traps (address64.wast:482)
+PASS #239 Test that a WebAssembly code traps (address64.wast:483)
+PASS #240 Test that a WebAssembly code traps (address64.wast:484)
+PASS #241 Test that a WebAssembly code traps (address64.wast:485)
+PASS #242 Test that a WebAssembly code traps (address64.wast:486)
+PASS #243 Test that a WebAssembly code traps (address64.wast:487)
+PASS #244 Test that a WebAssembly code traps (address64.wast:488)
+PASS #245 Test that WebAssembly compilation succeeds (address64.wast:492)
+PASS #246 Test that WebAssembly instantiation succeeds (address64.wast:492)
 PASS #247 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #248 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:32_good1 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:634:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:634:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #249 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:634:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #248 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #249 Run a WebAssembly test without special assertions (address64.wast:516)
 PASS #250 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #251 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:32_good2 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:637:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:637:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #252 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:637:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #251 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #252 Run a WebAssembly test without special assertions (address64.wast:517)
 PASS #253 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #254 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:32_good3 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:640:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:640:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #255 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:640:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #254 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #255 Run a WebAssembly test without special assertions (address64.wast:518)
 PASS #256 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #257 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:32_good4 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:643:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:643:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #258 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:643:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #257 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #258 Run a WebAssembly test without special assertions (address64.wast:519)
 PASS #259 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #260 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:32_good5 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:646:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:646:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #261 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:646:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #260 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #261 Run a WebAssembly test without special assertions (address64.wast:520)
 PASS #262 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #263 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:32_good1 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:649:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:649:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #264 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:649:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #263 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #264 Run a WebAssembly test without special assertions (address64.wast:522)
 PASS #265 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #266 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:32_good2 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:652:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:652:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #267 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:652:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #266 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #267 Run a WebAssembly test without special assertions (address64.wast:523)
 PASS #268 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #269 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:32_good3 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:655:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:655:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #270 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:655:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #269 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #270 Run a WebAssembly test without special assertions (address64.wast:524)
 PASS #271 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #272 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:32_good4 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:658:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:658:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #273 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:658:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #272 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #273 Run a WebAssembly test without special assertions (address64.wast:525)
 PASS #274 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #275 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:32_good5 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:661:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:661:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #276 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:661:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #275 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #276 Run a WebAssembly test without special assertions (address64.wast:526)
 PASS #277 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #278 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:32_good1 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:664:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:664:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #279 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:664:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #278 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #279 Run a WebAssembly test without special assertions (address64.wast:528)
 PASS #280 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #281 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:32_good2 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:667:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:667:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #282 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:667:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #281 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #282 Run a WebAssembly test without special assertions (address64.wast:529)
 PASS #283 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #284 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:32_good3 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:670:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:670:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #285 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:670:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #284 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #285 Run a WebAssembly test without special assertions (address64.wast:530)
 PASS #286 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #287 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:32_good4 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:673:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:673:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #288 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:673:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #287 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #288 Run a WebAssembly test without special assertions (address64.wast:531)
 PASS #289 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #290 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:32_good5 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:676:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:676:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #291 Test that a WebAssembly code traps (address64.wast:532) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:676:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #292 Test that a WebAssembly code traps (address64.wast:534) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:679:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #293 Test that a WebAssembly code traps (address64.wast:535) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:682:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #294 Test that WebAssembly compilation succeeds (address64.wast:539) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 45: Memory64 is not enabled at {loc} expected true got false
-FAIL #295 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:688:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #290 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #291 Test that a WebAssembly code traps (address64.wast:532)
+PASS #292 Test that a WebAssembly code traps (address64.wast:534)
+PASS #293 Test that a WebAssembly code traps (address64.wast:535)
+PASS #294 Test that WebAssembly compilation succeeds (address64.wast:539)
+PASS #295 Test that WebAssembly instantiation succeeds (address64.wast:539)
 PASS #296 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #297 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:64_good1 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:691:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:691:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #298 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:691:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #297 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #298 Run a WebAssembly test without special assertions (address64.wast:563)
 PASS #299 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #300 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:64_good2 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:694:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:694:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #301 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:694:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #300 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #301 Run a WebAssembly test without special assertions (address64.wast:564)
 PASS #302 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #303 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:64_good3 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:697:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:697:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #304 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:697:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #303 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #304 Run a WebAssembly test without special assertions (address64.wast:565)
 PASS #305 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #306 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:64_good4 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:700:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:700:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #307 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:700:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #306 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #307 Run a WebAssembly test without special assertions (address64.wast:566)
 PASS #308 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #309 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:64_good5 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:703:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:703:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #310 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:703:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #309 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #310 Run a WebAssembly test without special assertions (address64.wast:567)
 PASS #311 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #312 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:64_good1 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:706:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:706:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #313 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:706:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #312 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #313 Run a WebAssembly test without special assertions (address64.wast:569)
 PASS #314 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #315 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:64_good2 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:709:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:709:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #316 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:709:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #315 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #316 Run a WebAssembly test without special assertions (address64.wast:570)
 PASS #317 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #318 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:64_good3 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:712:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:712:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #319 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:712:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #318 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #319 Run a WebAssembly test without special assertions (address64.wast:571)
 PASS #320 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #321 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:64_good4 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:715:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:715:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #322 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:715:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #321 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #322 Run a WebAssembly test without special assertions (address64.wast:572)
 PASS #323 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #324 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:64_good5 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:718:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:718:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #325 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:718:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #324 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #325 Run a WebAssembly test without special assertions (address64.wast:573)
 PASS #326 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #327 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:64_good1 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:721:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:721:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #328 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:721:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #327 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #328 Run a WebAssembly test without special assertions (address64.wast:575)
 PASS #329 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #330 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:64_good2 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:724:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:724:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #331 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:724:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #330 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #331 Run a WebAssembly test without special assertions (address64.wast:576)
 PASS #332 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #333 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:64_good3 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:727:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:727:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #334 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:727:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #333 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #334 Run a WebAssembly test without special assertions (address64.wast:577)
 PASS #335 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #336 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:64_good4 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:730:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:730:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #337 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:730:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #336 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #337 Run a WebAssembly test without special assertions (address64.wast:578)
 PASS #338 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #339 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:64_good5 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:733:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:733:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #340 Test that a WebAssembly code traps (address64.wast:579) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:733:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #341 Test that a WebAssembly code traps (address64.wast:581) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:736:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #342 Test that a WebAssembly code traps (address64.wast:582) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:739:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #339 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #340 Test that a WebAssembly code traps (address64.wast:579)
+PASS #341 Test that a WebAssembly code traps (address64.wast:581)
+PASS #342 Test that a WebAssembly code traps (address64.wast:582)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/align64.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/align64.wast.js-expected.txt
@@ -1,28 +1,28 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (align64.wast:3) assert_equals: expected false but got true
-FAIL #3 Test that WebAssembly compilation succeeds (align64.wast:4) assert_equals: expected false but got true
-FAIL #4 Test that WebAssembly compilation succeeds (align64.wast:5) assert_equals: expected false but got true
-FAIL #5 Test that WebAssembly compilation succeeds (align64.wast:6) assert_equals: expected false but got true
-FAIL #6 Test that WebAssembly compilation succeeds (align64.wast:7) assert_equals: expected false but got true
-FAIL #7 Test that WebAssembly compilation succeeds (align64.wast:8) assert_equals: expected false but got true
-FAIL #8 Test that WebAssembly compilation succeeds (align64.wast:9) assert_equals: expected false but got true
-FAIL #9 Test that WebAssembly compilation succeeds (align64.wast:10) assert_equals: expected false but got true
-FAIL #10 Test that WebAssembly compilation succeeds (align64.wast:11) assert_equals: expected false but got true
-FAIL #11 Test that WebAssembly compilation succeeds (align64.wast:12) assert_equals: expected false but got true
-FAIL #12 Test that WebAssembly compilation succeeds (align64.wast:13) assert_equals: expected false but got true
-FAIL #13 Test that WebAssembly compilation succeeds (align64.wast:14) assert_equals: expected false but got true
-FAIL #14 Test that WebAssembly compilation succeeds (align64.wast:15) assert_equals: expected false but got true
-FAIL #15 Test that WebAssembly compilation succeeds (align64.wast:16) assert_equals: expected false but got true
-FAIL #16 Test that WebAssembly compilation succeeds (align64.wast:17) assert_equals: expected false but got true
-FAIL #17 Test that WebAssembly compilation succeeds (align64.wast:18) assert_equals: expected false but got true
-FAIL #18 Test that WebAssembly compilation succeeds (align64.wast:19) assert_equals: expected false but got true
-FAIL #19 Test that WebAssembly compilation succeeds (align64.wast:20) assert_equals: expected false but got true
-FAIL #20 Test that WebAssembly compilation succeeds (align64.wast:21) assert_equals: expected false but got true
-FAIL #21 Test that WebAssembly compilation succeeds (align64.wast:22) assert_equals: expected false but got true
-FAIL #22 Test that WebAssembly compilation succeeds (align64.wast:23) assert_equals: expected false but got true
-FAIL #23 Test that WebAssembly compilation succeeds (align64.wast:24) assert_equals: expected false but got true
-FAIL #24 Test that WebAssembly compilation succeeds (align64.wast:25) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (align64.wast:3)
+PASS #3 Test that WebAssembly compilation succeeds (align64.wast:4)
+PASS #4 Test that WebAssembly compilation succeeds (align64.wast:5)
+PASS #5 Test that WebAssembly compilation succeeds (align64.wast:6)
+PASS #6 Test that WebAssembly compilation succeeds (align64.wast:7)
+PASS #7 Test that WebAssembly compilation succeeds (align64.wast:8)
+PASS #8 Test that WebAssembly compilation succeeds (align64.wast:9)
+PASS #9 Test that WebAssembly compilation succeeds (align64.wast:10)
+PASS #10 Test that WebAssembly compilation succeeds (align64.wast:11)
+PASS #11 Test that WebAssembly compilation succeeds (align64.wast:12)
+PASS #12 Test that WebAssembly compilation succeeds (align64.wast:13)
+PASS #13 Test that WebAssembly compilation succeeds (align64.wast:14)
+PASS #14 Test that WebAssembly compilation succeeds (align64.wast:15)
+PASS #15 Test that WebAssembly compilation succeeds (align64.wast:16)
+PASS #16 Test that WebAssembly compilation succeeds (align64.wast:17)
+PASS #17 Test that WebAssembly compilation succeeds (align64.wast:18)
+PASS #18 Test that WebAssembly compilation succeeds (align64.wast:19)
+PASS #19 Test that WebAssembly compilation succeeds (align64.wast:20)
+PASS #20 Test that WebAssembly compilation succeeds (align64.wast:21)
+PASS #21 Test that WebAssembly compilation succeeds (align64.wast:22)
+PASS #22 Test that WebAssembly compilation succeeds (align64.wast:23)
+PASS #23 Test that WebAssembly compilation succeeds (align64.wast:24)
+PASS #24 Test that WebAssembly compilation succeeds (align64.wast:25)
 PASS #25 Test that WebAssembly compilation fails (align64.wast:27)
 PASS #26 Test that WebAssembly compilation fails (align64.wast:33)
 PASS #27 Test that WebAssembly compilation fails (align64.wast:39)
@@ -106,7 +106,7 @@ PASS #104 Test that WebAssembly compilation fails (align64.wast:439)
 PASS #105 Test that WebAssembly compilation fails (align64.wast:443)
 PASS #106 Test that WebAssembly compilation fails (align64.wast:447)
 PASS #107 Test that WebAssembly compilation fails (align64.wast:451)
-FAIL #108 Test that WebAssembly compilation succeeds (align64.wast:458) assert_equals: expected false but got true
+PASS #108 Test that WebAssembly compilation succeeds (align64.wast:458)
 PASS #109 Test that WebAssembly compilation succeeds (wrapper)
 PASS #110 Test that WebAssembly compilation succeeds (wrapper)
 PASS #111 Test that WebAssembly compilation succeeds (wrapper)
@@ -116,101 +116,55 @@ PASS #114 Test that WebAssembly compilation succeeds (wrapper)
 PASS #115 Test that WebAssembly compilation succeeds (wrapper)
 PASS #116 Test that WebAssembly compilation succeeds (wrapper)
 PASS #117 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #118 Test that WebAssembly compilation succeeds (align64.wast:854) assert_equals: expected false but got true
-FAIL #119 Test that WebAssembly compilation succeeds (align64.wast:869) assert_equals: expected false but got true
+PASS #118 Test that WebAssembly compilation succeeds (align64.wast:854)
+PASS #119 Test that WebAssembly compilation succeeds (align64.wast:869)
 PASS #120 Reinitialize the default imports
-FAIL #121 Test that WebAssembly compilation succeeds (align64.wast:3) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 34: Memory64 is not enabled at {loc} expected true got false
-FAIL #122 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #123 Test that WebAssembly compilation succeeds (align64.wast:4) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 34: Memory64 is not enabled at {loc} expected true got false
-FAIL #124 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:13:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #125 Test that WebAssembly compilation succeeds (align64.wast:5) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 34: Memory64 is not enabled at {loc} expected true got false
-FAIL #126 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:19:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #127 Test that WebAssembly compilation succeeds (align64.wast:6) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 34: Memory64 is not enabled at {loc} expected true got false
-FAIL #128 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:25:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #129 Test that WebAssembly compilation succeeds (align64.wast:7) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 34: Memory64 is not enabled at {loc} expected true got false
-FAIL #130 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:31:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #131 Test that WebAssembly compilation succeeds (align64.wast:8) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 34: Memory64 is not enabled at {loc} expected true got false
-FAIL #132 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:37:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #133 Test that WebAssembly compilation succeeds (align64.wast:9) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 34: Memory64 is not enabled at {loc} expected true got false
-FAIL #134 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:43:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #135 Test that WebAssembly compilation succeeds (align64.wast:10) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 34: Memory64 is not enabled at {loc} expected true got false
-FAIL #136 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:49:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #137 Test that WebAssembly compilation succeeds (align64.wast:11) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 34: Memory64 is not enabled at {loc} expected true got false
-FAIL #138 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:55:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #139 Test that WebAssembly compilation succeeds (align64.wast:12) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 34: Memory64 is not enabled at {loc} expected true got false
-FAIL #140 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:61:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #141 Test that WebAssembly compilation succeeds (align64.wast:13) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 34: Memory64 is not enabled at {loc} expected true got false
-FAIL #142 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:67:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #143 Test that WebAssembly compilation succeeds (align64.wast:14) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 34: Memory64 is not enabled at {loc} expected true got false
-FAIL #144 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:73:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #145 Test that WebAssembly compilation succeeds (align64.wast:15) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 34: Memory64 is not enabled at {loc} expected true got false
-FAIL #146 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:79:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #147 Test that WebAssembly compilation succeeds (align64.wast:16) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 34: Memory64 is not enabled at {loc} expected true got false
-FAIL #148 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:85:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #149 Test that WebAssembly compilation succeeds (align64.wast:17) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 34: Memory64 is not enabled at {loc} expected true got false
-FAIL #150 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:91:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #151 Test that WebAssembly compilation succeeds (align64.wast:18) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 34: Memory64 is not enabled at {loc} expected true got false
-FAIL #152 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:97:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #153 Test that WebAssembly compilation succeeds (align64.wast:19) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 34: Memory64 is not enabled at {loc} expected true got false
-FAIL #154 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:103:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #155 Test that WebAssembly compilation succeeds (align64.wast:20) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 34: Memory64 is not enabled at {loc} expected true got false
-FAIL #156 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:109:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #157 Test that WebAssembly compilation succeeds (align64.wast:21) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 34: Memory64 is not enabled at {loc} expected true got false
-FAIL #158 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:115:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #159 Test that WebAssembly compilation succeeds (align64.wast:22) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 34: Memory64 is not enabled at {loc} expected true got false
-FAIL #160 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:121:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #161 Test that WebAssembly compilation succeeds (align64.wast:23) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 34: Memory64 is not enabled at {loc} expected true got false
-FAIL #162 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:127:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #163 Test that WebAssembly compilation succeeds (align64.wast:24) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 34: Memory64 is not enabled at {loc} expected true got false
-FAIL #164 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:133:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #165 Test that WebAssembly compilation succeeds (align64.wast:25) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 34: Memory64 is not enabled at {loc} expected true got false
-FAIL #166 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:139:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
+PASS #121 Test that WebAssembly compilation succeeds (align64.wast:3)
+PASS #122 Test that WebAssembly instantiation succeeds (align64.wast:3)
+PASS #123 Test that WebAssembly compilation succeeds (align64.wast:4)
+PASS #124 Test that WebAssembly instantiation succeeds (align64.wast:4)
+PASS #125 Test that WebAssembly compilation succeeds (align64.wast:5)
+PASS #126 Test that WebAssembly instantiation succeeds (align64.wast:5)
+PASS #127 Test that WebAssembly compilation succeeds (align64.wast:6)
+PASS #128 Test that WebAssembly instantiation succeeds (align64.wast:6)
+PASS #129 Test that WebAssembly compilation succeeds (align64.wast:7)
+PASS #130 Test that WebAssembly instantiation succeeds (align64.wast:7)
+PASS #131 Test that WebAssembly compilation succeeds (align64.wast:8)
+PASS #132 Test that WebAssembly instantiation succeeds (align64.wast:8)
+PASS #133 Test that WebAssembly compilation succeeds (align64.wast:9)
+PASS #134 Test that WebAssembly instantiation succeeds (align64.wast:9)
+PASS #135 Test that WebAssembly compilation succeeds (align64.wast:10)
+PASS #136 Test that WebAssembly instantiation succeeds (align64.wast:10)
+PASS #137 Test that WebAssembly compilation succeeds (align64.wast:11)
+PASS #138 Test that WebAssembly instantiation succeeds (align64.wast:11)
+PASS #139 Test that WebAssembly compilation succeeds (align64.wast:12)
+PASS #140 Test that WebAssembly instantiation succeeds (align64.wast:12)
+PASS #141 Test that WebAssembly compilation succeeds (align64.wast:13)
+PASS #142 Test that WebAssembly instantiation succeeds (align64.wast:13)
+PASS #143 Test that WebAssembly compilation succeeds (align64.wast:14)
+PASS #144 Test that WebAssembly instantiation succeeds (align64.wast:14)
+PASS #145 Test that WebAssembly compilation succeeds (align64.wast:15)
+PASS #146 Test that WebAssembly instantiation succeeds (align64.wast:15)
+PASS #147 Test that WebAssembly compilation succeeds (align64.wast:16)
+PASS #148 Test that WebAssembly instantiation succeeds (align64.wast:16)
+PASS #149 Test that WebAssembly compilation succeeds (align64.wast:17)
+PASS #150 Test that WebAssembly instantiation succeeds (align64.wast:17)
+PASS #151 Test that WebAssembly compilation succeeds (align64.wast:18)
+PASS #152 Test that WebAssembly instantiation succeeds (align64.wast:18)
+PASS #153 Test that WebAssembly compilation succeeds (align64.wast:19)
+PASS #154 Test that WebAssembly instantiation succeeds (align64.wast:19)
+PASS #155 Test that WebAssembly compilation succeeds (align64.wast:20)
+PASS #156 Test that WebAssembly instantiation succeeds (align64.wast:20)
+PASS #157 Test that WebAssembly compilation succeeds (align64.wast:21)
+PASS #158 Test that WebAssembly instantiation succeeds (align64.wast:21)
+PASS #159 Test that WebAssembly compilation succeeds (align64.wast:22)
+PASS #160 Test that WebAssembly instantiation succeeds (align64.wast:22)
+PASS #161 Test that WebAssembly compilation succeeds (align64.wast:23)
+PASS #162 Test that WebAssembly instantiation succeeds (align64.wast:23)
+PASS #163 Test that WebAssembly compilation succeeds (align64.wast:24)
+PASS #164 Test that WebAssembly instantiation succeeds (align64.wast:24)
+PASS #165 Test that WebAssembly compilation succeeds (align64.wast:25)
+PASS #166 Test that WebAssembly instantiation succeeds (align64.wast:25)
 PASS #167 Test that WebAssembly compilation fails (align64.wast:27)
 PASS #168 Test that WebAssembly compilation fails (align64.wast:33)
 PASS #169 Test that WebAssembly compilation fails (align64.wast:39)
@@ -294,214 +248,76 @@ PASS #246 Test that WebAssembly compilation fails (align64.wast:439)
 PASS #247 Test that WebAssembly compilation fails (align64.wast:443)
 PASS #248 Test that WebAssembly compilation fails (align64.wast:447)
 PASS #249 Test that WebAssembly compilation fails (align64.wast:451)
-FAIL #250 Test that WebAssembly compilation succeeds (align64.wast:458) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 56: Memory64 is not enabled at {loc} expected true got false
-FAIL #251 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:394:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
+PASS #250 Test that WebAssembly compilation succeeds (align64.wast:458)
+PASS #251 Test that WebAssembly instantiation succeeds (align64.wast:458)
 PASS #252 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #253 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32_align_switch must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:397:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:397:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #254 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:397:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
+PASS #253 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #254 Run a WebAssembly test without special assertions (align64.wast:802)
 PASS #255 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #256 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32_align_switch must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:400:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:400:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #257 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:400:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
+PASS #256 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #257 Run a WebAssembly test without special assertions (align64.wast:803)
 PASS #258 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #259 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32_align_switch must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:403:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:403:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #260 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:403:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
+PASS #259 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #260 Run a WebAssembly test without special assertions (align64.wast:804)
 PASS #261 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #262 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32_align_switch must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:406:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:406:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #263 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:406:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
+PASS #262 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #263 Run a WebAssembly test without special assertions (align64.wast:805)
 PASS #264 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #265 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64_align_switch must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:409:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:409:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #266 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:409:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
+PASS #265 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #266 Run a WebAssembly test without special assertions (align64.wast:807)
 PASS #267 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #268 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64_align_switch must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:412:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:412:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #269 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:412:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
+PASS #268 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #269 Run a WebAssembly test without special assertions (align64.wast:808)
 PASS #270 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #271 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64_align_switch must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:415:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:415:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #272 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:415:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
+PASS #271 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #272 Run a WebAssembly test without special assertions (align64.wast:809)
 PASS #273 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #274 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64_align_switch must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:418:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:418:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #275 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:418:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
+PASS #274 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #275 Run a WebAssembly test without special assertions (align64.wast:810)
 PASS #276 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #277 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64_align_switch must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:421:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:421:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #278 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:421:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #279 Test that a WebAssembly code returns a specific result (align64.wast:813) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:424:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #280 Test that a WebAssembly code returns a specific result (align64.wast:814) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:427:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #281 Test that a WebAssembly code returns a specific result (align64.wast:815) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:430:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #282 Test that a WebAssembly code returns a specific result (align64.wast:816) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:433:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #283 Test that a WebAssembly code returns a specific result (align64.wast:817) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:436:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #284 Test that a WebAssembly code returns a specific result (align64.wast:818) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:439:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #285 Test that a WebAssembly code returns a specific result (align64.wast:819) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:442:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #286 Test that a WebAssembly code returns a specific result (align64.wast:820) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:445:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #287 Test that a WebAssembly code returns a specific result (align64.wast:821) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:448:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #288 Test that a WebAssembly code returns a specific result (align64.wast:822) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:451:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #289 Test that a WebAssembly code returns a specific result (align64.wast:823) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:454:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #290 Test that a WebAssembly code returns a specific result (align64.wast:824) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:457:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #291 Test that a WebAssembly code returns a specific result (align64.wast:825) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:460:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #292 Test that a WebAssembly code returns a specific result (align64.wast:826) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:463:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #293 Test that a WebAssembly code returns a specific result (align64.wast:828) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:466:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #294 Test that a WebAssembly code returns a specific result (align64.wast:829) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:469:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #295 Test that a WebAssembly code returns a specific result (align64.wast:830) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:472:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #296 Test that a WebAssembly code returns a specific result (align64.wast:831) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:475:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #297 Test that a WebAssembly code returns a specific result (align64.wast:832) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:478:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #298 Test that a WebAssembly code returns a specific result (align64.wast:833) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:481:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #299 Test that a WebAssembly code returns a specific result (align64.wast:834) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:484:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #300 Test that a WebAssembly code returns a specific result (align64.wast:835) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:487:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #301 Test that a WebAssembly code returns a specific result (align64.wast:836) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:490:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #302 Test that a WebAssembly code returns a specific result (align64.wast:837) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:493:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #303 Test that a WebAssembly code returns a specific result (align64.wast:838) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:496:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #304 Test that a WebAssembly code returns a specific result (align64.wast:839) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:499:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #305 Test that a WebAssembly code returns a specific result (align64.wast:840) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:502:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #306 Test that a WebAssembly code returns a specific result (align64.wast:841) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:505:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #307 Test that a WebAssembly code returns a specific result (align64.wast:842) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:508:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #308 Test that a WebAssembly code returns a specific result (align64.wast:843) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:511:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #309 Test that a WebAssembly code returns a specific result (align64.wast:844) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:514:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #310 Test that a WebAssembly code returns a specific result (align64.wast:845) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:517:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #311 Test that a WebAssembly code returns a specific result (align64.wast:846) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:520:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #312 Test that a WebAssembly code returns a specific result (align64.wast:847) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:523:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #313 Test that a WebAssembly code returns a specific result (align64.wast:848) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:526:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #314 Test that a WebAssembly code returns a specific result (align64.wast:849) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:529:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #315 Test that a WebAssembly code returns a specific result (align64.wast:850) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:532:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #316 Test that WebAssembly compilation succeeds (align64.wast:854) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 42: Memory64 is not enabled at {loc} expected true got false
-FAIL #317 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:538:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #318 Test that a WebAssembly code traps (align64.wast:864) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:541:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #319 Test that a WebAssembly code returns a specific result (align64.wast:866) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:544:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
-FAIL #320 Test that WebAssembly compilation succeeds (align64.wast:869) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 34: Memory64 is not enabled at {loc} expected true got false
-FAIL #321 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-align64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:550:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/align64.wast.js:552:3 expected true got false
+PASS #277 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #278 Run a WebAssembly test without special assertions (align64.wast:811)
+PASS #279 Test that a WebAssembly code returns a specific result (align64.wast:813)
+PASS #280 Test that a WebAssembly code returns a specific result (align64.wast:814)
+PASS #281 Test that a WebAssembly code returns a specific result (align64.wast:815)
+PASS #282 Test that a WebAssembly code returns a specific result (align64.wast:816)
+PASS #283 Test that a WebAssembly code returns a specific result (align64.wast:817)
+PASS #284 Test that a WebAssembly code returns a specific result (align64.wast:818)
+PASS #285 Test that a WebAssembly code returns a specific result (align64.wast:819)
+PASS #286 Test that a WebAssembly code returns a specific result (align64.wast:820)
+PASS #287 Test that a WebAssembly code returns a specific result (align64.wast:821)
+PASS #288 Test that a WebAssembly code returns a specific result (align64.wast:822)
+PASS #289 Test that a WebAssembly code returns a specific result (align64.wast:823)
+PASS #290 Test that a WebAssembly code returns a specific result (align64.wast:824)
+PASS #291 Test that a WebAssembly code returns a specific result (align64.wast:825)
+PASS #292 Test that a WebAssembly code returns a specific result (align64.wast:826)
+PASS #293 Test that a WebAssembly code returns a specific result (align64.wast:828)
+PASS #294 Test that a WebAssembly code returns a specific result (align64.wast:829)
+PASS #295 Test that a WebAssembly code returns a specific result (align64.wast:830)
+PASS #296 Test that a WebAssembly code returns a specific result (align64.wast:831)
+PASS #297 Test that a WebAssembly code returns a specific result (align64.wast:832)
+PASS #298 Test that a WebAssembly code returns a specific result (align64.wast:833)
+PASS #299 Test that a WebAssembly code returns a specific result (align64.wast:834)
+PASS #300 Test that a WebAssembly code returns a specific result (align64.wast:835)
+PASS #301 Test that a WebAssembly code returns a specific result (align64.wast:836)
+PASS #302 Test that a WebAssembly code returns a specific result (align64.wast:837)
+PASS #303 Test that a WebAssembly code returns a specific result (align64.wast:838)
+PASS #304 Test that a WebAssembly code returns a specific result (align64.wast:839)
+PASS #305 Test that a WebAssembly code returns a specific result (align64.wast:840)
+PASS #306 Test that a WebAssembly code returns a specific result (align64.wast:841)
+PASS #307 Test that a WebAssembly code returns a specific result (align64.wast:842)
+PASS #308 Test that a WebAssembly code returns a specific result (align64.wast:843)
+PASS #309 Test that a WebAssembly code returns a specific result (align64.wast:844)
+PASS #310 Test that a WebAssembly code returns a specific result (align64.wast:845)
+PASS #311 Test that a WebAssembly code returns a specific result (align64.wast:846)
+PASS #312 Test that a WebAssembly code returns a specific result (align64.wast:847)
+PASS #313 Test that a WebAssembly code returns a specific result (align64.wast:848)
+PASS #314 Test that a WebAssembly code returns a specific result (align64.wast:849)
+PASS #315 Test that a WebAssembly code returns a specific result (align64.wast:850)
+PASS #316 Test that WebAssembly compilation succeeds (align64.wast:854)
+PASS #317 Test that WebAssembly instantiation succeeds (align64.wast:854)
+PASS #318 Test that a WebAssembly code traps (align64.wast:864)
+PASS #319 Test that a WebAssembly code returns a specific result (align64.wast:866)
+PASS #320 Test that WebAssembly compilation succeeds (align64.wast:869)
+PASS #321 Test that WebAssembly instantiation succeeds (align64.wast:869)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/binary_leb128_64.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/binary_leb128_64.wast.js-expected.txt
@@ -1,11 +1,9 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (binary_leb128_64.wast:1) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (binary_leb128_64.wast:1)
 PASS #3 Test that WebAssembly compilation fails (binary_leb128_64.wast:16)
 PASS #4 Reinitialize the default imports
-FAIL #5 Test that WebAssembly compilation succeeds (binary_leb128_64.wast:1) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 22: Memory64 is not enabled at {loc} expected true got false
-FAIL #6 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-binary_leb128_64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/binary_leb128_64.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/binary_leb128_64.wast.js:12:3 expected true got false
+PASS #5 Test that WebAssembly compilation succeeds (binary_leb128_64.wast:1)
+PASS #6 Test that WebAssembly instantiation succeeds (binary_leb128_64.wast:1)
 PASS #7 Test that WebAssembly compilation fails (binary_leb128_64.wast:16)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/bulk64.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/bulk64.wast.js-expected.txt
@@ -1,224 +1,84 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (bulk64.wast:2) assert_equals: expected false but got true
-FAIL #3 Test that WebAssembly compilation succeeds (bulk64.wast:7) assert_equals: expected false but got true
-FAIL #4 Test that WebAssembly compilation succeeds (bulk64.wast:45) assert_equals: expected false but got true
-FAIL #5 Test that WebAssembly compilation succeeds (bulk64.wast:117) assert_equals: expected false but got true
-FAIL #6 Test that WebAssembly compilation succeeds (bulk64.wast:161) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (bulk64.wast:2)
+PASS #3 Test that WebAssembly compilation succeeds (bulk64.wast:7)
+PASS #4 Test that WebAssembly compilation succeeds (bulk64.wast:45)
+PASS #5 Test that WebAssembly compilation succeeds (bulk64.wast:117)
+PASS #6 Test that WebAssembly compilation succeeds (bulk64.wast:161)
 PASS #7 Reinitialize the default imports
-FAIL #8 Test that WebAssembly compilation succeeds (bulk64.wast:2) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 16: Memory64 is not enabled at {loc} expected true got false
-FAIL #9 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #10 Test that WebAssembly compilation succeeds (bulk64.wast:7) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 43: Memory64 is not enabled at {loc} expected true got false
-FAIL #11 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:13:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #12 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:16:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #13 Test that a WebAssembly code returns a specific result (bulk64.wast:22) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:19:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #14 Test that a WebAssembly code returns a specific result (bulk64.wast:23) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:22:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #15 Test that a WebAssembly code returns a specific result (bulk64.wast:24) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:25:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #16 Test that a WebAssembly code returns a specific result (bulk64.wast:25) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:28:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #17 Test that a WebAssembly code returns a specific result (bulk64.wast:26) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:31:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #18 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:34:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #19 Test that a WebAssembly code returns a specific result (bulk64.wast:30) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:37:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #20 Test that a WebAssembly code returns a specific result (bulk64.wast:31) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:40:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #21 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:43:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #22 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:46:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #23 Test that a WebAssembly code traps (bulk64.wast:40) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:49:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #24 Test that WebAssembly compilation succeeds (bulk64.wast:45) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 43: Memory64 is not enabled at {loc} expected true got false
-FAIL #25 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:55:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #26 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:58:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #27 Test that a WebAssembly code returns a specific result (bulk64.wast:62) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:61:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #28 Test that a WebAssembly code returns a specific result (bulk64.wast:63) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:64:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #29 Test that a WebAssembly code returns a specific result (bulk64.wast:64) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:67:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #30 Test that a WebAssembly code returns a specific result (bulk64.wast:65) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:70:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #31 Test that a WebAssembly code returns a specific result (bulk64.wast:66) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:73:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #32 Test that a WebAssembly code returns a specific result (bulk64.wast:67) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:76:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #33 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:79:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #34 Test that a WebAssembly code returns a specific result (bulk64.wast:71) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:82:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #35 Test that a WebAssembly code returns a specific result (bulk64.wast:72) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:85:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #36 Test that a WebAssembly code returns a specific result (bulk64.wast:73) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:88:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #37 Test that a WebAssembly code returns a specific result (bulk64.wast:74) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:91:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #38 Test that a WebAssembly code returns a specific result (bulk64.wast:75) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:94:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #39 Test that a WebAssembly code returns a specific result (bulk64.wast:76) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:97:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #40 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:100:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #41 Test that a WebAssembly code returns a specific result (bulk64.wast:80) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:103:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #42 Test that a WebAssembly code returns a specific result (bulk64.wast:81) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:106:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #43 Test that a WebAssembly code returns a specific result (bulk64.wast:82) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:109:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #44 Test that a WebAssembly code returns a specific result (bulk64.wast:83) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:112:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #45 Test that a WebAssembly code returns a specific result (bulk64.wast:84) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:115:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #46 Test that a WebAssembly code returns a specific result (bulk64.wast:85) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:118:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #47 Test that a WebAssembly code returns a specific result (bulk64.wast:86) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:121:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #48 Test that a WebAssembly code traps (bulk64.wast:89) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:124:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #49 Test that a WebAssembly code returns a specific result (bulk64.wast:92) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:127:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #50 Test that a WebAssembly code returns a specific result (bulk64.wast:93) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:130:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #51 Test that a WebAssembly code returns a specific result (bulk64.wast:94) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:133:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #52 Test that a WebAssembly code returns a specific result (bulk64.wast:95) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:136:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #53 Test that a WebAssembly code returns a specific result (bulk64.wast:96) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:139:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #54 Test that a WebAssembly code returns a specific result (bulk64.wast:97) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:142:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #55 Test that a WebAssembly code returns a specific result (bulk64.wast:98) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:145:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #56 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:148:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #57 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:151:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #58 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:154:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #59 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:157:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #60 Test that a WebAssembly code traps (bulk64.wast:109) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:160:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #61 Test that a WebAssembly code traps (bulk64.wast:112) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:163:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #62 Test that WebAssembly compilation succeeds (bulk64.wast:117) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 43: Memory64 is not enabled at {loc} expected true got false
-FAIL #63 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:169:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #64 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:172:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #65 Test that a WebAssembly code returns a specific result (bulk64.wast:132) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:175:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #66 Test that a WebAssembly code returns a specific result (bulk64.wast:133) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:178:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #67 Test that a WebAssembly code returns a specific result (bulk64.wast:134) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:181:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #68 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:184:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #69 Test that a WebAssembly code traps (bulk64.wast:140) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:187:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #70 Test that a WebAssembly code returns a specific result (bulk64.wast:142) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:190:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #71 Test that a WebAssembly code returns a specific result (bulk64.wast:143) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:193:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #72 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:196:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #73 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:199:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #74 Test that a WebAssembly code traps (bulk64.wast:150) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:202:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #75 Test that a WebAssembly code traps (bulk64.wast:153) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:205:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #76 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:208:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #77 Test that WebAssembly compilation succeeds (bulk64.wast:161) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 37: Memory64 is not enabled at {loc} expected true got false
-FAIL #78 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:214:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #79 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:217:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #80 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:220:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #81 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:223:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #82 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:226:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
+PASS #8 Test that WebAssembly compilation succeeds (bulk64.wast:2)
+PASS #9 Test that WebAssembly instantiation succeeds (bulk64.wast:2)
+PASS #10 Test that WebAssembly compilation succeeds (bulk64.wast:7)
+PASS #11 Test that WebAssembly instantiation succeeds (bulk64.wast:7)
+PASS #12 Run a WebAssembly test without special assertions (bulk64.wast:21)
+PASS #13 Test that a WebAssembly code returns a specific result (bulk64.wast:22)
+PASS #14 Test that a WebAssembly code returns a specific result (bulk64.wast:23)
+PASS #15 Test that a WebAssembly code returns a specific result (bulk64.wast:24)
+PASS #16 Test that a WebAssembly code returns a specific result (bulk64.wast:25)
+PASS #17 Test that a WebAssembly code returns a specific result (bulk64.wast:26)
+PASS #18 Run a WebAssembly test without special assertions (bulk64.wast:29)
+PASS #19 Test that a WebAssembly code returns a specific result (bulk64.wast:30)
+PASS #20 Test that a WebAssembly code returns a specific result (bulk64.wast:31)
+PASS #21 Run a WebAssembly test without special assertions (bulk64.wast:34)
+PASS #22 Run a WebAssembly test without special assertions (bulk64.wast:37)
+PASS #23 Test that a WebAssembly code traps (bulk64.wast:40)
+PASS #24 Test that WebAssembly compilation succeeds (bulk64.wast:45)
+PASS #25 Test that WebAssembly instantiation succeeds (bulk64.wast:45)
+PASS #26 Run a WebAssembly test without special assertions (bulk64.wast:60)
+PASS #27 Test that a WebAssembly code returns a specific result (bulk64.wast:62)
+PASS #28 Test that a WebAssembly code returns a specific result (bulk64.wast:63)
+PASS #29 Test that a WebAssembly code returns a specific result (bulk64.wast:64)
+PASS #30 Test that a WebAssembly code returns a specific result (bulk64.wast:65)
+PASS #31 Test that a WebAssembly code returns a specific result (bulk64.wast:66)
+PASS #32 Test that a WebAssembly code returns a specific result (bulk64.wast:67)
+PASS #33 Run a WebAssembly test without special assertions (bulk64.wast:70)
+PASS #34 Test that a WebAssembly code returns a specific result (bulk64.wast:71)
+PASS #35 Test that a WebAssembly code returns a specific result (bulk64.wast:72)
+PASS #36 Test that a WebAssembly code returns a specific result (bulk64.wast:73)
+PASS #37 Test that a WebAssembly code returns a specific result (bulk64.wast:74)
+PASS #38 Test that a WebAssembly code returns a specific result (bulk64.wast:75)
+PASS #39 Test that a WebAssembly code returns a specific result (bulk64.wast:76)
+PASS #40 Run a WebAssembly test without special assertions (bulk64.wast:79)
+PASS #41 Test that a WebAssembly code returns a specific result (bulk64.wast:80)
+PASS #42 Test that a WebAssembly code returns a specific result (bulk64.wast:81)
+PASS #43 Test that a WebAssembly code returns a specific result (bulk64.wast:82)
+PASS #44 Test that a WebAssembly code returns a specific result (bulk64.wast:83)
+PASS #45 Test that a WebAssembly code returns a specific result (bulk64.wast:84)
+PASS #46 Test that a WebAssembly code returns a specific result (bulk64.wast:85)
+PASS #47 Test that a WebAssembly code returns a specific result (bulk64.wast:86)
+PASS #48 Test that a WebAssembly code traps (bulk64.wast:89)
+PASS #49 Test that a WebAssembly code returns a specific result (bulk64.wast:92)
+PASS #50 Test that a WebAssembly code returns a specific result (bulk64.wast:93)
+PASS #51 Test that a WebAssembly code returns a specific result (bulk64.wast:94)
+PASS #52 Test that a WebAssembly code returns a specific result (bulk64.wast:95)
+PASS #53 Test that a WebAssembly code returns a specific result (bulk64.wast:96)
+PASS #54 Test that a WebAssembly code returns a specific result (bulk64.wast:97)
+PASS #55 Test that a WebAssembly code returns a specific result (bulk64.wast:98)
+PASS #56 Run a WebAssembly test without special assertions (bulk64.wast:101)
+PASS #57 Run a WebAssembly test without special assertions (bulk64.wast:102)
+PASS #58 Run a WebAssembly test without special assertions (bulk64.wast:105)
+PASS #59 Run a WebAssembly test without special assertions (bulk64.wast:106)
+PASS #60 Test that a WebAssembly code traps (bulk64.wast:109)
+PASS #61 Test that a WebAssembly code traps (bulk64.wast:112)
+PASS #62 Test that WebAssembly compilation succeeds (bulk64.wast:117)
+PASS #63 Test that WebAssembly instantiation succeeds (bulk64.wast:117)
+PASS #64 Run a WebAssembly test without special assertions (bulk64.wast:131)
+PASS #65 Test that a WebAssembly code returns a specific result (bulk64.wast:132)
+PASS #66 Test that a WebAssembly code returns a specific result (bulk64.wast:133)
+PASS #67 Test that a WebAssembly code returns a specific result (bulk64.wast:134)
+PASS #68 Run a WebAssembly test without special assertions (bulk64.wast:137)
+PASS #69 Test that a WebAssembly code traps (bulk64.wast:140)
+PASS #70 Test that a WebAssembly code returns a specific result (bulk64.wast:142)
+PASS #71 Test that a WebAssembly code returns a specific result (bulk64.wast:143)
+PASS #72 Run a WebAssembly test without special assertions (bulk64.wast:146)
+PASS #73 Run a WebAssembly test without special assertions (bulk64.wast:147)
+PASS #74 Test that a WebAssembly code traps (bulk64.wast:150)
+PASS #75 Test that a WebAssembly code traps (bulk64.wast:153)
+PASS #76 Run a WebAssembly test without special assertions (bulk64.wast:158)
+PASS #77 Test that WebAssembly compilation succeeds (bulk64.wast:161)
+PASS #78 Test that WebAssembly instantiation succeeds (bulk64.wast:161)
+PASS #79 Run a WebAssembly test without special assertions (bulk64.wast:176)
+PASS #80 Run a WebAssembly test without special assertions (bulk64.wast:177)
+PASS #81 Run a WebAssembly test without special assertions (bulk64.wast:178)
+PASS #82 Run a WebAssembly test without special assertions (bulk64.wast:179)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/call_indirect64.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/call_indirect64.wast.js-expected.txt
@@ -2,7 +2,7 @@
 PASS #1 Reinitialize the default imports
 FAIL #2 Test that WebAssembly compilation succeeds (call_indirect64.wast:3) assert_equals: expected false but got true
 PASS #3 Reinitialize the default imports
-FAIL #4 Test that WebAssembly compilation succeeds (call_indirect64.wast:3) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 41: Memory64 is not enabled at {loc} expected true got false
+FAIL #4 Test that WebAssembly compilation succeeds (call_indirect64.wast:3) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 76: Element init_expr must produce an i32 at {loc} expected true got false
 FAIL #5 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
 call_indirect64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/call_indirect64.wast.js:7:18
 global code@http://web-platform.test:8800/wasm/core/js/memory64/call_indirect64.wast.js:12:3 expected true got false

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/endianness64.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/endianness64.wast.js-expected.txt
@@ -1,6 +1,6 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (endianness64.wast:1) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (endianness64.wast:1)
 PASS #3 Test that WebAssembly compilation succeeds (wrapper)
 PASS #4 Test that WebAssembly compilation succeeds (wrapper)
 PASS #5 Test that WebAssembly compilation succeeds (wrapper)
@@ -18,308 +18,106 @@ PASS #16 Test that WebAssembly compilation succeeds (wrapper)
 PASS #17 Test that WebAssembly compilation succeeds (wrapper)
 PASS #18 Test that WebAssembly compilation succeeds (wrapper)
 PASS #19 Reinitialize the default imports
-FAIL #20 Test that WebAssembly compilation succeeds (endianness64.wast:1) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 88: Memory64 is not enabled at {loc} expected true got false
-FAIL #21 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #22 Test that a WebAssembly code returns a specific result (endianness64.wast:133) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:10:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #23 Test that a WebAssembly code returns a specific result (endianness64.wast:134) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:13:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #24 Test that a WebAssembly code returns a specific result (endianness64.wast:135) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:16:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #25 Test that a WebAssembly code returns a specific result (endianness64.wast:136) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:19:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #26 Test that a WebAssembly code returns a specific result (endianness64.wast:138) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:22:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #27 Test that a WebAssembly code returns a specific result (endianness64.wast:139) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:25:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #28 Test that a WebAssembly code returns a specific result (endianness64.wast:140) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:28:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #29 Test that a WebAssembly code returns a specific result (endianness64.wast:141) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:31:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #30 Test that a WebAssembly code returns a specific result (endianness64.wast:143) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:34:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #31 Test that a WebAssembly code returns a specific result (endianness64.wast:144) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:37:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #32 Test that a WebAssembly code returns a specific result (endianness64.wast:145) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:40:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #33 Test that a WebAssembly code returns a specific result (endianness64.wast:146) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:43:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #34 Test that a WebAssembly code returns a specific result (endianness64.wast:148) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:46:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #35 Test that a WebAssembly code returns a specific result (endianness64.wast:149) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:49:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #36 Test that a WebAssembly code returns a specific result (endianness64.wast:150) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:52:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #37 Test that a WebAssembly code returns a specific result (endianness64.wast:151) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:55:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #38 Test that a WebAssembly code returns a specific result (endianness64.wast:153) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:58:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #39 Test that a WebAssembly code returns a specific result (endianness64.wast:154) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:61:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #40 Test that a WebAssembly code returns a specific result (endianness64.wast:155) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:64:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #41 Test that a WebAssembly code returns a specific result (endianness64.wast:156) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:67:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #42 Test that a WebAssembly code returns a specific result (endianness64.wast:158) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:70:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #43 Test that a WebAssembly code returns a specific result (endianness64.wast:159) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:73:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #44 Test that a WebAssembly code returns a specific result (endianness64.wast:160) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:76:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #45 Test that a WebAssembly code returns a specific result (endianness64.wast:161) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:79:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #46 Test that a WebAssembly code returns a specific result (endianness64.wast:163) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:82:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #47 Test that a WebAssembly code returns a specific result (endianness64.wast:164) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:85:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #48 Test that a WebAssembly code returns a specific result (endianness64.wast:165) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:88:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #49 Test that a WebAssembly code returns a specific result (endianness64.wast:166) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:91:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #50 Test that a WebAssembly code returns a specific result (endianness64.wast:168) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:94:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #51 Test that a WebAssembly code returns a specific result (endianness64.wast:169) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:97:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #52 Test that a WebAssembly code returns a specific result (endianness64.wast:170) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:100:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #53 Test that a WebAssembly code returns a specific result (endianness64.wast:171) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:103:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
+PASS #20 Test that WebAssembly compilation succeeds (endianness64.wast:1)
+PASS #21 Test that WebAssembly instantiation succeeds (endianness64.wast:1)
+PASS #22 Test that a WebAssembly code returns a specific result (endianness64.wast:133)
+PASS #23 Test that a WebAssembly code returns a specific result (endianness64.wast:134)
+PASS #24 Test that a WebAssembly code returns a specific result (endianness64.wast:135)
+PASS #25 Test that a WebAssembly code returns a specific result (endianness64.wast:136)
+PASS #26 Test that a WebAssembly code returns a specific result (endianness64.wast:138)
+PASS #27 Test that a WebAssembly code returns a specific result (endianness64.wast:139)
+PASS #28 Test that a WebAssembly code returns a specific result (endianness64.wast:140)
+PASS #29 Test that a WebAssembly code returns a specific result (endianness64.wast:141)
+PASS #30 Test that a WebAssembly code returns a specific result (endianness64.wast:143)
+PASS #31 Test that a WebAssembly code returns a specific result (endianness64.wast:144)
+PASS #32 Test that a WebAssembly code returns a specific result (endianness64.wast:145)
+PASS #33 Test that a WebAssembly code returns a specific result (endianness64.wast:146)
+PASS #34 Test that a WebAssembly code returns a specific result (endianness64.wast:148)
+PASS #35 Test that a WebAssembly code returns a specific result (endianness64.wast:149)
+PASS #36 Test that a WebAssembly code returns a specific result (endianness64.wast:150)
+PASS #37 Test that a WebAssembly code returns a specific result (endianness64.wast:151)
+PASS #38 Test that a WebAssembly code returns a specific result (endianness64.wast:153)
+PASS #39 Test that a WebAssembly code returns a specific result (endianness64.wast:154)
+PASS #40 Test that a WebAssembly code returns a specific result (endianness64.wast:155)
+PASS #41 Test that a WebAssembly code returns a specific result (endianness64.wast:156)
+PASS #42 Test that a WebAssembly code returns a specific result (endianness64.wast:158)
+PASS #43 Test that a WebAssembly code returns a specific result (endianness64.wast:159)
+PASS #44 Test that a WebAssembly code returns a specific result (endianness64.wast:160)
+PASS #45 Test that a WebAssembly code returns a specific result (endianness64.wast:161)
+PASS #46 Test that a WebAssembly code returns a specific result (endianness64.wast:163)
+PASS #47 Test that a WebAssembly code returns a specific result (endianness64.wast:164)
+PASS #48 Test that a WebAssembly code returns a specific result (endianness64.wast:165)
+PASS #49 Test that a WebAssembly code returns a specific result (endianness64.wast:166)
+PASS #50 Test that a WebAssembly code returns a specific result (endianness64.wast:168)
+PASS #51 Test that a WebAssembly code returns a specific result (endianness64.wast:169)
+PASS #52 Test that a WebAssembly code returns a specific result (endianness64.wast:170)
+PASS #53 Test that a WebAssembly code returns a specific result (endianness64.wast:171)
 PASS #54 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #55 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32_load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:106:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:106:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #56 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:106:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
+PASS #55 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #56 Run a WebAssembly test without special assertions (endianness64.wast:173)
 PASS #57 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #58 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32_load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:109:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:109:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #59 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:109:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
+PASS #58 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #59 Run a WebAssembly test without special assertions (endianness64.wast:174)
 PASS #60 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #61 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32_load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:112:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:112:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #62 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:112:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
+PASS #61 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #62 Run a WebAssembly test without special assertions (endianness64.wast:175)
 PASS #63 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #64 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32_load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:115:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:115:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #65 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:115:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
+PASS #64 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #65 Run a WebAssembly test without special assertions (endianness64.wast:176)
 PASS #66 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #67 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64_load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:118:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:118:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #68 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:118:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
+PASS #67 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #68 Run a WebAssembly test without special assertions (endianness64.wast:178)
 PASS #69 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #70 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64_load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:121:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:121:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #71 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:121:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
+PASS #70 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #71 Run a WebAssembly test without special assertions (endianness64.wast:179)
 PASS #72 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #73 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64_load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:124:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:124:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #74 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:124:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
+PASS #73 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #74 Run a WebAssembly test without special assertions (endianness64.wast:180)
 PASS #75 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #76 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64_load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:127:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:127:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #77 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:127:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #78 Test that a WebAssembly code returns a specific result (endianness64.wast:184) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:130:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #79 Test that a WebAssembly code returns a specific result (endianness64.wast:185) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:133:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #80 Test that a WebAssembly code returns a specific result (endianness64.wast:186) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:136:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #81 Test that a WebAssembly code returns a specific result (endianness64.wast:187) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:139:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #82 Test that a WebAssembly code returns a specific result (endianness64.wast:189) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:142:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #83 Test that a WebAssembly code returns a specific result (endianness64.wast:190) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:145:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #84 Test that a WebAssembly code returns a specific result (endianness64.wast:191) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:148:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #85 Test that a WebAssembly code returns a specific result (endianness64.wast:192) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:151:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #86 Test that a WebAssembly code returns a specific result (endianness64.wast:194) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:154:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #87 Test that a WebAssembly code returns a specific result (endianness64.wast:195) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:157:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #88 Test that a WebAssembly code returns a specific result (endianness64.wast:196) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:160:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #89 Test that a WebAssembly code returns a specific result (endianness64.wast:197) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:163:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #90 Test that a WebAssembly code returns a specific result (endianness64.wast:199) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:166:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #91 Test that a WebAssembly code returns a specific result (endianness64.wast:200) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:169:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #92 Test that a WebAssembly code returns a specific result (endianness64.wast:201) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:172:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #93 Test that a WebAssembly code returns a specific result (endianness64.wast:202) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:175:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #94 Test that a WebAssembly code returns a specific result (endianness64.wast:204) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:178:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #95 Test that a WebAssembly code returns a specific result (endianness64.wast:205) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:181:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #96 Test that a WebAssembly code returns a specific result (endianness64.wast:206) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:184:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #97 Test that a WebAssembly code returns a specific result (endianness64.wast:207) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:187:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
+PASS #76 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #77 Run a WebAssembly test without special assertions (endianness64.wast:181)
+PASS #78 Test that a WebAssembly code returns a specific result (endianness64.wast:184)
+PASS #79 Test that a WebAssembly code returns a specific result (endianness64.wast:185)
+PASS #80 Test that a WebAssembly code returns a specific result (endianness64.wast:186)
+PASS #81 Test that a WebAssembly code returns a specific result (endianness64.wast:187)
+PASS #82 Test that a WebAssembly code returns a specific result (endianness64.wast:189)
+PASS #83 Test that a WebAssembly code returns a specific result (endianness64.wast:190)
+PASS #84 Test that a WebAssembly code returns a specific result (endianness64.wast:191)
+PASS #85 Test that a WebAssembly code returns a specific result (endianness64.wast:192)
+PASS #86 Test that a WebAssembly code returns a specific result (endianness64.wast:194)
+PASS #87 Test that a WebAssembly code returns a specific result (endianness64.wast:195)
+PASS #88 Test that a WebAssembly code returns a specific result (endianness64.wast:196)
+PASS #89 Test that a WebAssembly code returns a specific result (endianness64.wast:197)
+PASS #90 Test that a WebAssembly code returns a specific result (endianness64.wast:199)
+PASS #91 Test that a WebAssembly code returns a specific result (endianness64.wast:200)
+PASS #92 Test that a WebAssembly code returns a specific result (endianness64.wast:201)
+PASS #93 Test that a WebAssembly code returns a specific result (endianness64.wast:202)
+PASS #94 Test that a WebAssembly code returns a specific result (endianness64.wast:204)
+PASS #95 Test that a WebAssembly code returns a specific result (endianness64.wast:205)
+PASS #96 Test that a WebAssembly code returns a specific result (endianness64.wast:206)
+PASS #97 Test that a WebAssembly code returns a specific result (endianness64.wast:207)
 PASS #98 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #99 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32_store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:190:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:190:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #100 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:190:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
+PASS #99 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #100 Run a WebAssembly test without special assertions (endianness64.wast:209)
 PASS #101 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #102 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32_store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:193:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:193:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #103 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:193:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
+PASS #102 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #103 Run a WebAssembly test without special assertions (endianness64.wast:210)
 PASS #104 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #105 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32_store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:196:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:196:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #106 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:196:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
+PASS #105 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #106 Run a WebAssembly test without special assertions (endianness64.wast:211)
 PASS #107 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #108 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32_store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:199:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:199:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #109 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:199:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
+PASS #108 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #109 Run a WebAssembly test without special assertions (endianness64.wast:212)
 PASS #110 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #111 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64_store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:202:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:202:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #112 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:202:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
+PASS #111 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #112 Run a WebAssembly test without special assertions (endianness64.wast:214)
 PASS #113 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #114 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64_store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:205:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:205:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #115 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:205:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
+PASS #114 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #115 Run a WebAssembly test without special assertions (endianness64.wast:215)
 PASS #116 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #117 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64_store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:208:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:208:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #118 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:208:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
+PASS #117 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #118 Run a WebAssembly test without special assertions (endianness64.wast:216)
 PASS #119 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #120 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64_store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:211:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:211:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
-FAIL #121 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-endianness64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:211:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/endianness64.wast.js:213:3 expected true got false
+PASS #120 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #121 Run a WebAssembly test without special assertions (endianness64.wast:217)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/float_memory64.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/float_memory64.wast.js-expected.txt
@@ -1,496 +1,196 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (float_memory64.wast:5) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (float_memory64.wast:5)
 PASS #3 Test that WebAssembly compilation succeeds (wrapper)
 PASS #4 Test that WebAssembly compilation succeeds (wrapper)
 PASS #5 Test that WebAssembly compilation succeeds (wrapper)
 PASS #6 Test that WebAssembly compilation succeeds (wrapper)
 PASS #7 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #8 Test that WebAssembly compilation succeeds (float_memory64.wast:30) assert_equals: expected false but got true
+PASS #8 Test that WebAssembly compilation succeeds (float_memory64.wast:30)
 PASS #9 Test that WebAssembly compilation succeeds (wrapper)
 PASS #10 Test that WebAssembly compilation succeeds (wrapper)
 PASS #11 Test that WebAssembly compilation succeeds (wrapper)
 PASS #12 Test that WebAssembly compilation succeeds (wrapper)
 PASS #13 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #14 Test that WebAssembly compilation succeeds (float_memory64.wast:57) assert_equals: expected false but got true
+PASS #14 Test that WebAssembly compilation succeeds (float_memory64.wast:57)
 PASS #15 Test that WebAssembly compilation succeeds (wrapper)
 PASS #16 Test that WebAssembly compilation succeeds (wrapper)
 PASS #17 Test that WebAssembly compilation succeeds (wrapper)
 PASS #18 Test that WebAssembly compilation succeeds (wrapper)
 PASS #19 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #20 Test that WebAssembly compilation succeeds (float_memory64.wast:82) assert_equals: expected false but got true
+PASS #20 Test that WebAssembly compilation succeeds (float_memory64.wast:82)
 PASS #21 Test that WebAssembly compilation succeeds (wrapper)
 PASS #22 Test that WebAssembly compilation succeeds (wrapper)
 PASS #23 Test that WebAssembly compilation succeeds (wrapper)
 PASS #24 Test that WebAssembly compilation succeeds (wrapper)
 PASS #25 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #26 Test that WebAssembly compilation succeeds (float_memory64.wast:109) assert_equals: expected false but got true
+PASS #26 Test that WebAssembly compilation succeeds (float_memory64.wast:109)
 PASS #27 Test that WebAssembly compilation succeeds (wrapper)
 PASS #28 Test that WebAssembly compilation succeeds (wrapper)
 PASS #29 Test that WebAssembly compilation succeeds (wrapper)
 PASS #30 Test that WebAssembly compilation succeeds (wrapper)
 PASS #31 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #32 Test that WebAssembly compilation succeeds (float_memory64.wast:134) assert_equals: expected false but got true
+PASS #32 Test that WebAssembly compilation succeeds (float_memory64.wast:134)
 PASS #33 Test that WebAssembly compilation succeeds (wrapper)
 PASS #34 Test that WebAssembly compilation succeeds (wrapper)
 PASS #35 Test that WebAssembly compilation succeeds (wrapper)
 PASS #36 Test that WebAssembly compilation succeeds (wrapper)
 PASS #37 Test that WebAssembly compilation succeeds (wrapper)
 PASS #38 Reinitialize the default imports
-FAIL #39 Test that WebAssembly compilation succeeds (float_memory64.wast:5) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 46: Memory64 is not enabled at {loc} expected true got false
-FAIL #40 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #41 Test that a WebAssembly code returns a specific result (float_memory64.wast:15) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:10:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #39 Test that WebAssembly compilation succeeds (float_memory64.wast:5)
+PASS #40 Test that WebAssembly instantiation succeeds (float_memory64.wast:5)
+PASS #41 Test that a WebAssembly code returns a specific result (float_memory64.wast:15)
 PASS #42 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #43 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:13:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:13:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #44 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:13:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #45 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:16:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #46 Test that a WebAssembly code returns a specific result (float_memory64.wast:18) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:19:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #43 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #44 Run a WebAssembly test without special assertions (float_memory64.wast:16)
+PASS #45 Run a WebAssembly test without special assertions (float_memory64.wast:17)
+PASS #46 Test that a WebAssembly code returns a specific result (float_memory64.wast:18)
 PASS #47 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #48 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:22:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:22:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #49 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:22:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #50 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:25:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #51 Test that a WebAssembly code returns a specific result (float_memory64.wast:21) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:28:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #48 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #49 Run a WebAssembly test without special assertions (float_memory64.wast:19)
+PASS #50 Run a WebAssembly test without special assertions (float_memory64.wast:20)
+PASS #51 Test that a WebAssembly code returns a specific result (float_memory64.wast:21)
 PASS #52 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #53 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:31:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:31:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #54 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:31:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #55 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:34:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #56 Test that a WebAssembly code returns a specific result (float_memory64.wast:24) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:37:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #53 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #54 Run a WebAssembly test without special assertions (float_memory64.wast:22)
+PASS #55 Run a WebAssembly test without special assertions (float_memory64.wast:23)
+PASS #56 Test that a WebAssembly code returns a specific result (float_memory64.wast:24)
 PASS #57 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #58 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:40:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:40:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #59 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:40:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #60 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:43:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #61 Test that a WebAssembly code returns a specific result (float_memory64.wast:27) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:46:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #58 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #59 Run a WebAssembly test without special assertions (float_memory64.wast:25)
+PASS #60 Run a WebAssembly test without special assertions (float_memory64.wast:26)
+PASS #61 Test that a WebAssembly code returns a specific result (float_memory64.wast:27)
 PASS #62 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #63 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:49:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:49:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #64 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:49:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #65 Test that WebAssembly compilation succeeds (float_memory64.wast:30) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 46: Memory64 is not enabled at {loc} expected true got false
-FAIL #66 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:55:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #67 Test that a WebAssembly code returns a specific result (float_memory64.wast:40) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:58:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #63 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #64 Run a WebAssembly test without special assertions (float_memory64.wast:28)
+PASS #65 Test that WebAssembly compilation succeeds (float_memory64.wast:30)
+PASS #66 Test that WebAssembly instantiation succeeds (float_memory64.wast:30)
+PASS #67 Test that a WebAssembly code returns a specific result (float_memory64.wast:40)
 PASS #68 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #69 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:61:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:61:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #70 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:61:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #71 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:64:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #72 Test that a WebAssembly code returns a specific result (float_memory64.wast:43) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:67:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #69 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #70 Run a WebAssembly test without special assertions (float_memory64.wast:41)
+PASS #71 Run a WebAssembly test without special assertions (float_memory64.wast:42)
+PASS #72 Test that a WebAssembly code returns a specific result (float_memory64.wast:43)
 PASS #73 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #74 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:70:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:70:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #75 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:70:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #76 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:73:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #77 Test that a WebAssembly code returns a specific result (float_memory64.wast:46) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:76:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #74 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #75 Run a WebAssembly test without special assertions (float_memory64.wast:44)
+PASS #76 Run a WebAssembly test without special assertions (float_memory64.wast:45)
+PASS #77 Test that a WebAssembly code returns a specific result (float_memory64.wast:46)
 PASS #78 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #79 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:79:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:79:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #80 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:79:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #81 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:82:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #82 Test that a WebAssembly code returns a specific result (float_memory64.wast:49) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:85:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #79 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #80 Run a WebAssembly test without special assertions (float_memory64.wast:47)
+PASS #81 Run a WebAssembly test without special assertions (float_memory64.wast:48)
+PASS #82 Test that a WebAssembly code returns a specific result (float_memory64.wast:49)
 PASS #83 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #84 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:88:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:88:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #85 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:88:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #86 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:91:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #87 Test that a WebAssembly code returns a specific result (float_memory64.wast:52) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:94:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #84 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #85 Run a WebAssembly test without special assertions (float_memory64.wast:50)
+PASS #86 Run a WebAssembly test without special assertions (float_memory64.wast:51)
+PASS #87 Test that a WebAssembly code returns a specific result (float_memory64.wast:52)
 PASS #88 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #89 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:97:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:97:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #90 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:97:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #91 Test that WebAssembly compilation succeeds (float_memory64.wast:57) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 46: Memory64 is not enabled at {loc} expected true got false
-FAIL #92 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:103:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #93 Test that a WebAssembly code returns a specific result (float_memory64.wast:67) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:106:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #89 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #90 Run a WebAssembly test without special assertions (float_memory64.wast:53)
+PASS #91 Test that WebAssembly compilation succeeds (float_memory64.wast:57)
+PASS #92 Test that WebAssembly instantiation succeeds (float_memory64.wast:57)
+PASS #93 Test that a WebAssembly code returns a specific result (float_memory64.wast:67)
 PASS #94 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #95 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:109:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:109:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #96 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:109:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #97 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:112:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #98 Test that a WebAssembly code returns a specific result (float_memory64.wast:70) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:115:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #95 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #96 Run a WebAssembly test without special assertions (float_memory64.wast:68)
+PASS #97 Run a WebAssembly test without special assertions (float_memory64.wast:69)
+PASS #98 Test that a WebAssembly code returns a specific result (float_memory64.wast:70)
 PASS #99 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #100 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:118:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:118:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #101 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:118:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #102 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:121:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #103 Test that a WebAssembly code returns a specific result (float_memory64.wast:73) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:124:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #100 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #101 Run a WebAssembly test without special assertions (float_memory64.wast:71)
+PASS #102 Run a WebAssembly test without special assertions (float_memory64.wast:72)
+PASS #103 Test that a WebAssembly code returns a specific result (float_memory64.wast:73)
 PASS #104 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #105 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:127:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:127:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #106 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:127:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #107 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:130:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #108 Test that a WebAssembly code returns a specific result (float_memory64.wast:76) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:133:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #105 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #106 Run a WebAssembly test without special assertions (float_memory64.wast:74)
+PASS #107 Run a WebAssembly test without special assertions (float_memory64.wast:75)
+PASS #108 Test that a WebAssembly code returns a specific result (float_memory64.wast:76)
 PASS #109 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #110 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:136:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:136:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #111 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:136:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #112 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:139:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #113 Test that a WebAssembly code returns a specific result (float_memory64.wast:79) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:142:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #110 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #111 Run a WebAssembly test without special assertions (float_memory64.wast:77)
+PASS #112 Run a WebAssembly test without special assertions (float_memory64.wast:78)
+PASS #113 Test that a WebAssembly code returns a specific result (float_memory64.wast:79)
 PASS #114 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #115 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:145:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:145:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #116 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:145:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #117 Test that WebAssembly compilation succeeds (float_memory64.wast:82) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 46: Memory64 is not enabled at {loc} expected true got false
-FAIL #118 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:151:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #119 Test that a WebAssembly code returns a specific result (float_memory64.wast:92) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:154:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #115 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #116 Run a WebAssembly test without special assertions (float_memory64.wast:80)
+PASS #117 Test that WebAssembly compilation succeeds (float_memory64.wast:82)
+PASS #118 Test that WebAssembly instantiation succeeds (float_memory64.wast:82)
+PASS #119 Test that a WebAssembly code returns a specific result (float_memory64.wast:92)
 PASS #120 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #121 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:157:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:157:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #122 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:157:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #123 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:160:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #124 Test that a WebAssembly code returns a specific result (float_memory64.wast:95) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:163:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #121 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #122 Run a WebAssembly test without special assertions (float_memory64.wast:93)
+PASS #123 Run a WebAssembly test without special assertions (float_memory64.wast:94)
+PASS #124 Test that a WebAssembly code returns a specific result (float_memory64.wast:95)
 PASS #125 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #126 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:166:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:166:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #127 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:166:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #128 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:169:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #129 Test that a WebAssembly code returns a specific result (float_memory64.wast:98) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:172:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #126 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #127 Run a WebAssembly test without special assertions (float_memory64.wast:96)
+PASS #128 Run a WebAssembly test without special assertions (float_memory64.wast:97)
+PASS #129 Test that a WebAssembly code returns a specific result (float_memory64.wast:98)
 PASS #130 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #131 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:175:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:175:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #132 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:175:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #133 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:178:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #134 Test that a WebAssembly code returns a specific result (float_memory64.wast:101) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:181:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #131 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #132 Run a WebAssembly test without special assertions (float_memory64.wast:99)
+PASS #133 Run a WebAssembly test without special assertions (float_memory64.wast:100)
+PASS #134 Test that a WebAssembly code returns a specific result (float_memory64.wast:101)
 PASS #135 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #136 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:184:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:184:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #137 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:184:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #138 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:187:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #139 Test that a WebAssembly code returns a specific result (float_memory64.wast:104) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:190:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #136 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #137 Run a WebAssembly test without special assertions (float_memory64.wast:102)
+PASS #138 Run a WebAssembly test without special assertions (float_memory64.wast:103)
+PASS #139 Test that a WebAssembly code returns a specific result (float_memory64.wast:104)
 PASS #140 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #141 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:193:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:193:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #142 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:193:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #143 Test that WebAssembly compilation succeeds (float_memory64.wast:109) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 46: Memory64 is not enabled at {loc} expected true got false
-FAIL #144 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:199:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #145 Test that a WebAssembly code returns a specific result (float_memory64.wast:119) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:202:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #141 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #142 Run a WebAssembly test without special assertions (float_memory64.wast:105)
+PASS #143 Test that WebAssembly compilation succeeds (float_memory64.wast:109)
+PASS #144 Test that WebAssembly instantiation succeeds (float_memory64.wast:109)
+PASS #145 Test that a WebAssembly code returns a specific result (float_memory64.wast:119)
 PASS #146 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #147 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:205:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:205:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #148 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:205:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #149 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:208:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #150 Test that a WebAssembly code returns a specific result (float_memory64.wast:122) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:211:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #147 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #148 Run a WebAssembly test without special assertions (float_memory64.wast:120)
+PASS #149 Run a WebAssembly test without special assertions (float_memory64.wast:121)
+PASS #150 Test that a WebAssembly code returns a specific result (float_memory64.wast:122)
 PASS #151 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #152 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:214:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:214:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #153 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:214:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #154 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:217:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #155 Test that a WebAssembly code returns a specific result (float_memory64.wast:125) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:220:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #152 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #153 Run a WebAssembly test without special assertions (float_memory64.wast:123)
+PASS #154 Run a WebAssembly test without special assertions (float_memory64.wast:124)
+PASS #155 Test that a WebAssembly code returns a specific result (float_memory64.wast:125)
 PASS #156 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #157 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:223:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:223:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #158 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:223:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #159 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:226:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #160 Test that a WebAssembly code returns a specific result (float_memory64.wast:128) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:229:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #157 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #158 Run a WebAssembly test without special assertions (float_memory64.wast:126)
+PASS #159 Run a WebAssembly test without special assertions (float_memory64.wast:127)
+PASS #160 Test that a WebAssembly code returns a specific result (float_memory64.wast:128)
 PASS #161 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #162 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:232:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:232:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #163 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:232:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #164 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:235:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #165 Test that a WebAssembly code returns a specific result (float_memory64.wast:131) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:238:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #162 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #163 Run a WebAssembly test without special assertions (float_memory64.wast:129)
+PASS #164 Run a WebAssembly test without special assertions (float_memory64.wast:130)
+PASS #165 Test that a WebAssembly code returns a specific result (float_memory64.wast:131)
 PASS #166 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #167 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:241:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:241:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #168 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:241:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #169 Test that WebAssembly compilation succeeds (float_memory64.wast:134) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 46: Memory64 is not enabled at {loc} expected true got false
-FAIL #170 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:247:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #171 Test that a WebAssembly code returns a specific result (float_memory64.wast:144) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:250:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #167 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #168 Run a WebAssembly test without special assertions (float_memory64.wast:132)
+PASS #169 Test that WebAssembly compilation succeeds (float_memory64.wast:134)
+PASS #170 Test that WebAssembly instantiation succeeds (float_memory64.wast:134)
+PASS #171 Test that a WebAssembly code returns a specific result (float_memory64.wast:144)
 PASS #172 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #173 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:253:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:253:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #174 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:253:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #175 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:256:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #176 Test that a WebAssembly code returns a specific result (float_memory64.wast:147) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:259:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #173 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #174 Run a WebAssembly test without special assertions (float_memory64.wast:145)
+PASS #175 Run a WebAssembly test without special assertions (float_memory64.wast:146)
+PASS #176 Test that a WebAssembly code returns a specific result (float_memory64.wast:147)
 PASS #177 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #178 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:262:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:262:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #179 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:262:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #180 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:265:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #181 Test that a WebAssembly code returns a specific result (float_memory64.wast:150) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:268:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #178 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #179 Run a WebAssembly test without special assertions (float_memory64.wast:148)
+PASS #180 Run a WebAssembly test without special assertions (float_memory64.wast:149)
+PASS #181 Test that a WebAssembly code returns a specific result (float_memory64.wast:150)
 PASS #182 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #183 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:271:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:271:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #184 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:271:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #185 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:274:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #186 Test that a WebAssembly code returns a specific result (float_memory64.wast:153) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:277:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #183 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #184 Run a WebAssembly test without special assertions (float_memory64.wast:151)
+PASS #185 Run a WebAssembly test without special assertions (float_memory64.wast:152)
+PASS #186 Test that a WebAssembly code returns a specific result (float_memory64.wast:153)
 PASS #187 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #188 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:280:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:280:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #189 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:280:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #190 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:283:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #191 Test that a WebAssembly code returns a specific result (float_memory64.wast:156) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:286:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #188 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #189 Run a WebAssembly test without special assertions (float_memory64.wast:154)
+PASS #190 Run a WebAssembly test without special assertions (float_memory64.wast:155)
+PASS #191 Test that a WebAssembly code returns a specific result (float_memory64.wast:156)
 PASS #192 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #193 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:289:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:289:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #194 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:289:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #193 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #194 Run a WebAssembly test without special assertions (float_memory64.wast:157)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/load64.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/load64.wast.js-expected.txt
@@ -1,6 +1,6 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (load64.wast:3) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (load64.wast:3)
 PASS #3 Test that WebAssembly compilation fails (load64.wast:213)
 PASS #4 Test that WebAssembly compilation fails (load64.wast:220)
 PASS #5 Test that WebAssembly compilation fails (load64.wast:227)
@@ -61,121 +61,45 @@ PASS #59 Test that WebAssembly compilation fails (load64.wast:541)
 PASS #60 Test that WebAssembly compilation fails (load64.wast:550)
 PASS #61 Test that WebAssembly compilation fails (load64.wast:559)
 PASS #62 Reinitialize the default imports
-FAIL #63 Test that WebAssembly compilation succeeds (load64.wast:3) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 103: Memory64 is not enabled at {loc} expected true got false
-FAIL #64 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-load64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:297:3 expected true got false
-FAIL #65 Test that a WebAssembly code returns a specific result (load64.wast:161) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:10:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:297:3 expected true got false
-FAIL #66 Test that a WebAssembly code returns a specific result (load64.wast:163) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:13:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:297:3 expected true got false
-FAIL #67 Test that a WebAssembly code returns a specific result (load64.wast:164) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:16:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:297:3 expected true got false
-FAIL #68 Test that a WebAssembly code returns a specific result (load64.wast:165) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:19:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:297:3 expected true got false
-FAIL #69 Test that a WebAssembly code returns a specific result (load64.wast:167) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:22:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:297:3 expected true got false
-FAIL #70 Test that a WebAssembly code returns a specific result (load64.wast:168) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:25:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:297:3 expected true got false
-FAIL #71 Test that a WebAssembly code returns a specific result (load64.wast:169) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:28:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:297:3 expected true got false
-FAIL #72 Test that a WebAssembly code returns a specific result (load64.wast:171) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:31:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:297:3 expected true got false
-FAIL #73 Test that a WebAssembly code returns a specific result (load64.wast:173) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:34:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:297:3 expected true got false
-FAIL #74 Test that a WebAssembly code returns a specific result (load64.wast:174) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:37:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:297:3 expected true got false
-FAIL #75 Test that a WebAssembly code returns a specific result (load64.wast:175) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:40:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:297:3 expected true got false
-FAIL #76 Test that a WebAssembly code returns a specific result (load64.wast:177) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:43:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:297:3 expected true got false
-FAIL #77 Test that a WebAssembly code returns a specific result (load64.wast:178) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:46:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:297:3 expected true got false
-FAIL #78 Test that a WebAssembly code returns a specific result (load64.wast:179) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:49:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:297:3 expected true got false
-FAIL #79 Test that a WebAssembly code returns a specific result (load64.wast:181) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:52:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:297:3 expected true got false
-FAIL #80 Test that a WebAssembly code returns a specific result (load64.wast:182) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:55:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:297:3 expected true got false
-FAIL #81 Test that a WebAssembly code returns a specific result (load64.wast:183) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:58:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:297:3 expected true got false
-FAIL #82 Test that a WebAssembly code returns a specific result (load64.wast:185) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:61:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:297:3 expected true got false
-FAIL #83 Test that a WebAssembly code returns a specific result (load64.wast:186) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:64:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:297:3 expected true got false
-FAIL #84 Test that a WebAssembly code returns a specific result (load64.wast:187) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:67:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:297:3 expected true got false
-FAIL #85 Test that a WebAssembly code returns a specific result (load64.wast:188) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:70:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:297:3 expected true got false
-FAIL #86 Test that a WebAssembly code returns a specific result (load64.wast:190) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:73:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:297:3 expected true got false
-FAIL #87 Test that a WebAssembly code returns a specific result (load64.wast:191) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:76:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:297:3 expected true got false
-FAIL #88 Test that a WebAssembly code returns a specific result (load64.wast:192) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:79:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:297:3 expected true got false
-FAIL #89 Test that a WebAssembly code returns a specific result (load64.wast:194) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:82:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:297:3 expected true got false
-FAIL #90 Test that a WebAssembly code returns a specific result (load64.wast:195) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:85:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:297:3 expected true got false
-FAIL #91 Test that a WebAssembly code returns a specific result (load64.wast:196) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:88:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:297:3 expected true got false
-FAIL #92 Test that a WebAssembly code returns a specific result (load64.wast:197) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:91:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:297:3 expected true got false
-FAIL #93 Test that a WebAssembly code returns a specific result (load64.wast:198) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:94:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:297:3 expected true got false
-FAIL #94 Test that a WebAssembly code returns a specific result (load64.wast:199) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:97:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:297:3 expected true got false
-FAIL #95 Test that a WebAssembly code returns a specific result (load64.wast:201) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:100:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:297:3 expected true got false
-FAIL #96 Test that a WebAssembly code returns a specific result (load64.wast:203) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:103:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:297:3 expected true got false
-FAIL #97 Test that a WebAssembly code returns a specific result (load64.wast:204) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:106:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:297:3 expected true got false
-FAIL #98 Test that a WebAssembly code returns a specific result (load64.wast:206) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:109:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:297:3 expected true got false
-FAIL #99 Test that a WebAssembly code returns a specific result (load64.wast:208) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:112:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:297:3 expected true got false
-FAIL #100 Test that a WebAssembly code returns a specific result (load64.wast:209) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:115:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:297:3 expected true got false
-FAIL #101 Test that a WebAssembly code returns a specific result (load64.wast:211) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:118:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/load64.wast.js:297:3 expected true got false
+PASS #63 Test that WebAssembly compilation succeeds (load64.wast:3)
+PASS #64 Test that WebAssembly instantiation succeeds (load64.wast:3)
+PASS #65 Test that a WebAssembly code returns a specific result (load64.wast:161)
+PASS #66 Test that a WebAssembly code returns a specific result (load64.wast:163)
+PASS #67 Test that a WebAssembly code returns a specific result (load64.wast:164)
+PASS #68 Test that a WebAssembly code returns a specific result (load64.wast:165)
+PASS #69 Test that a WebAssembly code returns a specific result (load64.wast:167)
+PASS #70 Test that a WebAssembly code returns a specific result (load64.wast:168)
+PASS #71 Test that a WebAssembly code returns a specific result (load64.wast:169)
+PASS #72 Test that a WebAssembly code returns a specific result (load64.wast:171)
+PASS #73 Test that a WebAssembly code returns a specific result (load64.wast:173)
+PASS #74 Test that a WebAssembly code returns a specific result (load64.wast:174)
+PASS #75 Test that a WebAssembly code returns a specific result (load64.wast:175)
+PASS #76 Test that a WebAssembly code returns a specific result (load64.wast:177)
+PASS #77 Test that a WebAssembly code returns a specific result (load64.wast:178)
+PASS #78 Test that a WebAssembly code returns a specific result (load64.wast:179)
+PASS #79 Test that a WebAssembly code returns a specific result (load64.wast:181)
+PASS #80 Test that a WebAssembly code returns a specific result (load64.wast:182)
+PASS #81 Test that a WebAssembly code returns a specific result (load64.wast:183)
+PASS #82 Test that a WebAssembly code returns a specific result (load64.wast:185)
+PASS #83 Test that a WebAssembly code returns a specific result (load64.wast:186)
+PASS #84 Test that a WebAssembly code returns a specific result (load64.wast:187)
+PASS #85 Test that a WebAssembly code returns a specific result (load64.wast:188)
+PASS #86 Test that a WebAssembly code returns a specific result (load64.wast:190)
+PASS #87 Test that a WebAssembly code returns a specific result (load64.wast:191)
+PASS #88 Test that a WebAssembly code returns a specific result (load64.wast:192)
+PASS #89 Test that a WebAssembly code returns a specific result (load64.wast:194)
+PASS #90 Test that a WebAssembly code returns a specific result (load64.wast:195)
+PASS #91 Test that a WebAssembly code returns a specific result (load64.wast:196)
+PASS #92 Test that a WebAssembly code returns a specific result (load64.wast:197)
+PASS #93 Test that a WebAssembly code returns a specific result (load64.wast:198)
+PASS #94 Test that a WebAssembly code returns a specific result (load64.wast:199)
+PASS #95 Test that a WebAssembly code returns a specific result (load64.wast:201)
+PASS #96 Test that a WebAssembly code returns a specific result (load64.wast:203)
+PASS #97 Test that a WebAssembly code returns a specific result (load64.wast:204)
+PASS #98 Test that a WebAssembly code returns a specific result (load64.wast:206)
+PASS #99 Test that a WebAssembly code returns a specific result (load64.wast:208)
+PASS #100 Test that a WebAssembly code returns a specific result (load64.wast:209)
+PASS #101 Test that a WebAssembly code returns a specific result (load64.wast:211)
 PASS #102 Test that WebAssembly compilation fails (load64.wast:213)
 PASS #103 Test that WebAssembly compilation fails (load64.wast:220)
 PASS #104 Test that WebAssembly compilation fails (load64.wast:227)

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory64-imports.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory64-imports.wast.js-expected.txt
@@ -4,71 +4,71 @@ PASS #2 Test that WebAssembly compilation succeeds (memory64-imports.wast:1)
 PASS #3 Test that WebAssembly compilation succeeds (memory64-imports.wast:3)
 PASS #4 Test that WebAssembly compilation succeeds (memory64-imports.wast:5)
 PASS #5 Test that WebAssembly compilation succeeds (memory64-imports.wast:7)
-FAIL #6 Test that WebAssembly compilation succeeds (memory64-imports.wast:10) assert_equals: expected false but got true
-FAIL #7 Test that WebAssembly compilation succeeds (memory64-imports.wast:12) assert_equals: expected false but got true
-FAIL #8 Test that WebAssembly compilation succeeds (memory64-imports.wast:14) assert_equals: expected false but got true
-FAIL #9 Test that WebAssembly compilation succeeds (memory64-imports.wast:16) assert_equals: expected false but got true
-FAIL #10 Test that WebAssembly compilation succeeds (memory64-imports.wast:18) assert_equals: expected false but got true
-FAIL #11 Test that WebAssembly compilation succeeds (memory64-imports.wast:19) assert_equals: expected false but got true
-FAIL #12 Test that WebAssembly compilation succeeds (memory64-imports.wast:20) assert_equals: expected false but got true
-FAIL #13 Test that WebAssembly compilation succeeds (memory64-imports.wast:21) assert_equals: expected false but got true
-FAIL #14 Test that WebAssembly compilation succeeds (memory64-imports.wast:22) assert_equals: expected false but got true
-FAIL #15 Test that WebAssembly compilation succeeds (memory64-imports.wast:23) assert_equals: expected false but got true
-FAIL #16 Test that WebAssembly compilation succeeds (memory64-imports.wast:24) assert_equals: expected false but got true
-FAIL #17 Test that WebAssembly compilation succeeds (memory64-imports.wast:25) assert_equals: expected false but got true
-FAIL #18 Test that WebAssembly compilation succeeds (memory64-imports.wast:26) assert_equals: expected false but got true
-FAIL #19 Test that WebAssembly compilation succeeds (memory64-imports.wast:27) assert_equals: expected false but got true
-FAIL #20 Test that WebAssembly compilation succeeds (memory64-imports.wast:28) assert_equals: expected false but got true
-FAIL #21 Test that WebAssembly compilation succeeds (memory64-imports.wast:29) assert_equals: expected false but got true
-FAIL #22 Test that WebAssembly compilation succeeds (memory64-imports.wast:30) assert_equals: expected false but got true
-FAIL #23 Test that WebAssembly compilation succeeds (memory64-imports.wast:31) assert_equals: expected false but got true
-FAIL #24 Test that WebAssembly compilation succeeds (memory64-imports.wast:32) assert_equals: expected false but got true
-FAIL #25 Test that WebAssembly compilation succeeds (memory64-imports.wast:33) assert_equals: expected false but got true
-FAIL #26 Test that WebAssembly compilation succeeds (memory64-imports.wast:34) assert_equals: expected false but got true
-FAIL #27 Test that WebAssembly compilation succeeds (memory64-imports.wast:35) assert_equals: expected false but got true
-FAIL #28 Test that WebAssembly compilation succeeds (memory64-imports.wast:37) assert_equals: expected false but got true
-FAIL #29 Test that WebAssembly compilation succeeds (memory64-imports.wast:41) assert_equals: expected false but got true
-FAIL #30 Test that WebAssembly compilation succeeds (memory64-imports.wast:45) assert_equals: expected false but got true
-FAIL #31 Test that WebAssembly compilation succeeds (memory64-imports.wast:49) assert_equals: expected false but got true
-FAIL #32 Test that WebAssembly compilation succeeds (memory64-imports.wast:53) assert_equals: expected false but got true
+PASS #6 Test that WebAssembly compilation succeeds (memory64-imports.wast:10)
+PASS #7 Test that WebAssembly compilation succeeds (memory64-imports.wast:12)
+PASS #8 Test that WebAssembly compilation succeeds (memory64-imports.wast:14)
+PASS #9 Test that WebAssembly compilation succeeds (memory64-imports.wast:16)
+PASS #10 Test that WebAssembly compilation succeeds (memory64-imports.wast:18)
+PASS #11 Test that WebAssembly compilation succeeds (memory64-imports.wast:19)
+PASS #12 Test that WebAssembly compilation succeeds (memory64-imports.wast:20)
+PASS #13 Test that WebAssembly compilation succeeds (memory64-imports.wast:21)
+PASS #14 Test that WebAssembly compilation succeeds (memory64-imports.wast:22)
+PASS #15 Test that WebAssembly compilation succeeds (memory64-imports.wast:23)
+PASS #16 Test that WebAssembly compilation succeeds (memory64-imports.wast:24)
+PASS #17 Test that WebAssembly compilation succeeds (memory64-imports.wast:25)
+PASS #18 Test that WebAssembly compilation succeeds (memory64-imports.wast:26)
+PASS #19 Test that WebAssembly compilation succeeds (memory64-imports.wast:27)
+PASS #20 Test that WebAssembly compilation succeeds (memory64-imports.wast:28)
+PASS #21 Test that WebAssembly compilation succeeds (memory64-imports.wast:29)
+PASS #22 Test that WebAssembly compilation succeeds (memory64-imports.wast:30)
+PASS #23 Test that WebAssembly compilation succeeds (memory64-imports.wast:31)
+PASS #24 Test that WebAssembly compilation succeeds (memory64-imports.wast:32)
+PASS #25 Test that WebAssembly compilation succeeds (memory64-imports.wast:33)
+PASS #26 Test that WebAssembly compilation succeeds (memory64-imports.wast:34)
+PASS #27 Test that WebAssembly compilation succeeds (memory64-imports.wast:35)
+PASS #28 Test that WebAssembly compilation succeeds (memory64-imports.wast:37)
+PASS #29 Test that WebAssembly compilation succeeds (memory64-imports.wast:41)
+PASS #30 Test that WebAssembly compilation succeeds (memory64-imports.wast:45)
+PASS #31 Test that WebAssembly compilation succeeds (memory64-imports.wast:49)
+PASS #32 Test that WebAssembly compilation succeeds (memory64-imports.wast:53)
 PASS #33 Test that WebAssembly compilation succeeds (memory64-imports.wast:57)
-FAIL #34 Test that WebAssembly compilation succeeds (memory64-imports.wast:61) assert_equals: expected false but got true
+PASS #34 Test that WebAssembly compilation succeeds (memory64-imports.wast:61)
 PASS #35 Test that WebAssembly compilation succeeds (memory64-imports.wast:65)
-FAIL #36 Test that WebAssembly compilation succeeds (memory64-imports.wast:68) assert_equals: expected false but got true
-FAIL #37 Test that WebAssembly compilation succeeds (memory64-imports.wast:69) assert_equals: expected false but got true
-FAIL #38 Test that WebAssembly compilation succeeds (memory64-imports.wast:70) assert_equals: expected false but got true
-FAIL #39 Test that WebAssembly compilation succeeds (memory64-imports.wast:71) assert_equals: expected false but got true
-FAIL #40 Test that WebAssembly compilation succeeds (memory64-imports.wast:72) assert_equals: expected false but got true
-FAIL #41 Test that WebAssembly compilation succeeds (memory64-imports.wast:73) assert_equals: expected false but got true
-FAIL #42 Test that WebAssembly compilation succeeds (memory64-imports.wast:74) assert_equals: expected false but got true
-FAIL #43 Test that WebAssembly compilation succeeds (memory64-imports.wast:75) assert_equals: expected false but got true
-FAIL #44 Test that WebAssembly compilation succeeds (memory64-imports.wast:76) assert_equals: expected false but got true
-FAIL #45 Test that WebAssembly compilation succeeds (memory64-imports.wast:77) assert_equals: expected false but got true
-FAIL #46 Test that WebAssembly compilation succeeds (memory64-imports.wast:78) assert_equals: expected false but got true
-FAIL #47 Test that WebAssembly compilation succeeds (memory64-imports.wast:79) assert_equals: expected false but got true
-FAIL #48 Test that WebAssembly compilation succeeds (memory64-imports.wast:80) assert_equals: expected false but got true
-FAIL #49 Test that WebAssembly compilation succeeds (memory64-imports.wast:81) assert_equals: expected false but got true
-FAIL #50 Test that WebAssembly compilation succeeds (memory64-imports.wast:83) assert_equals: expected false but got true
-FAIL #51 Test that WebAssembly compilation succeeds (memory64-imports.wast:87) assert_equals: expected false but got true
-FAIL #52 Test that WebAssembly compilation succeeds (memory64-imports.wast:91) assert_equals: expected false but got true
-FAIL #53 Test that WebAssembly compilation succeeds (memory64-imports.wast:95) assert_equals: expected false but got true
-FAIL #54 Test that WebAssembly compilation succeeds (memory64-imports.wast:99) assert_equals: expected false but got true
-FAIL #55 Test that WebAssembly compilation succeeds (memory64-imports.wast:103) assert_equals: expected false but got true
-FAIL #56 Test that WebAssembly compilation succeeds (memory64-imports.wast:107) assert_equals: expected false but got true
-FAIL #57 Test that WebAssembly compilation succeeds (memory64-imports.wast:111) assert_equals: expected false but got true
-FAIL #58 Test that WebAssembly compilation succeeds (memory64-imports.wast:115) assert_equals: expected false but got true
-FAIL #59 Test that WebAssembly compilation succeeds (memory64-imports.wast:119) assert_equals: expected false but got true
-FAIL #60 Test that WebAssembly compilation succeeds (memory64-imports.wast:123) assert_equals: expected false but got true
-FAIL #61 Test that WebAssembly compilation succeeds (memory64-imports.wast:127) assert_equals: expected false but got true
-FAIL #62 Test that WebAssembly compilation succeeds (memory64-imports.wast:131) assert_equals: expected false but got true
-FAIL #63 Test that WebAssembly compilation succeeds (memory64-imports.wast:135) assert_equals: expected false but got true
-FAIL #64 Test that WebAssembly compilation succeeds (memory64-imports.wast:139) assert_equals: expected false but got true
-FAIL #65 Test that WebAssembly compilation succeeds (memory64-imports.wast:143) assert_equals: expected false but got true
-FAIL #66 Test that WebAssembly compilation succeeds (memory64-imports.wast:147) assert_equals: expected false but got true
-FAIL #67 Test that WebAssembly compilation succeeds (memory64-imports.wast:151) assert_equals: expected false but got true
-FAIL #68 Test that WebAssembly compilation succeeds (memory64-imports.wast:155) assert_equals: expected false but got true
+PASS #36 Test that WebAssembly compilation succeeds (memory64-imports.wast:68)
+PASS #37 Test that WebAssembly compilation succeeds (memory64-imports.wast:69)
+PASS #38 Test that WebAssembly compilation succeeds (memory64-imports.wast:70)
+PASS #39 Test that WebAssembly compilation succeeds (memory64-imports.wast:71)
+PASS #40 Test that WebAssembly compilation succeeds (memory64-imports.wast:72)
+PASS #41 Test that WebAssembly compilation succeeds (memory64-imports.wast:73)
+PASS #42 Test that WebAssembly compilation succeeds (memory64-imports.wast:74)
+PASS #43 Test that WebAssembly compilation succeeds (memory64-imports.wast:75)
+PASS #44 Test that WebAssembly compilation succeeds (memory64-imports.wast:76)
+PASS #45 Test that WebAssembly compilation succeeds (memory64-imports.wast:77)
+PASS #46 Test that WebAssembly compilation succeeds (memory64-imports.wast:78)
+PASS #47 Test that WebAssembly compilation succeeds (memory64-imports.wast:79)
+PASS #48 Test that WebAssembly compilation succeeds (memory64-imports.wast:80)
+PASS #49 Test that WebAssembly compilation succeeds (memory64-imports.wast:81)
+PASS #50 Test that WebAssembly compilation succeeds (memory64-imports.wast:83)
+PASS #51 Test that WebAssembly compilation succeeds (memory64-imports.wast:87)
+PASS #52 Test that WebAssembly compilation succeeds (memory64-imports.wast:91)
+PASS #53 Test that WebAssembly compilation succeeds (memory64-imports.wast:95)
+PASS #54 Test that WebAssembly compilation succeeds (memory64-imports.wast:99)
+PASS #55 Test that WebAssembly compilation succeeds (memory64-imports.wast:103)
+PASS #56 Test that WebAssembly compilation succeeds (memory64-imports.wast:107)
+PASS #57 Test that WebAssembly compilation succeeds (memory64-imports.wast:111)
+PASS #58 Test that WebAssembly compilation succeeds (memory64-imports.wast:115)
+PASS #59 Test that WebAssembly compilation succeeds (memory64-imports.wast:119)
+PASS #60 Test that WebAssembly compilation succeeds (memory64-imports.wast:123)
+PASS #61 Test that WebAssembly compilation succeeds (memory64-imports.wast:127)
+PASS #62 Test that WebAssembly compilation succeeds (memory64-imports.wast:131)
+PASS #63 Test that WebAssembly compilation succeeds (memory64-imports.wast:135)
+PASS #64 Test that WebAssembly compilation succeeds (memory64-imports.wast:139)
+PASS #65 Test that WebAssembly compilation succeeds (memory64-imports.wast:143)
+PASS #66 Test that WebAssembly compilation succeeds (memory64-imports.wast:147)
+PASS #67 Test that WebAssembly compilation succeeds (memory64-imports.wast:151)
+PASS #68 Test that WebAssembly compilation succeeds (memory64-imports.wast:155)
 PASS #69 Test that WebAssembly compilation succeeds (memory64-imports.wast:159)
-FAIL #70 Test that WebAssembly compilation succeeds (memory64-imports.wast:163) assert_equals: expected false but got true
+PASS #70 Test that WebAssembly compilation succeeds (memory64-imports.wast:163)
 PASS #71 Test that WebAssembly compilation succeeds (memory64-imports.wast:167)
 PASS #72 Reinitialize the default imports
 PASS #73 Test that WebAssembly compilation succeeds (memory64-imports.wast:1)
@@ -79,298 +79,186 @@ PASS #77 Test that WebAssembly compilation succeeds (memory64-imports.wast:5)
 PASS #78 Test that WebAssembly instantiation succeeds (memory64-imports.wast:5)
 PASS #79 Test that WebAssembly compilation succeeds (memory64-imports.wast:7)
 PASS #80 Test that WebAssembly instantiation succeeds (memory64-imports.wast:7)
-FAIL #81 Test that WebAssembly compilation succeeds (memory64-imports.wast:10) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 17: Memory64 is not enabled at {loc} expected true got false
-FAIL #82 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:43:18
+PASS #81 Test that WebAssembly compilation succeeds (memory64-imports.wast:10)
+PASS #82 Test that WebAssembly instantiation succeeds (memory64-imports.wast:10)
+PASS #83 Test that WebAssembly compilation succeeds (memory64-imports.wast:12)
+PASS #84 Test that WebAssembly instantiation succeeds (memory64-imports.wast:12)
+PASS #85 Test that WebAssembly compilation succeeds (memory64-imports.wast:14)
+PASS #86 Test that WebAssembly instantiation succeeds (memory64-imports.wast:14)
+PASS #87 Test that WebAssembly compilation succeeds (memory64-imports.wast:16)
+PASS #88 Test that WebAssembly instantiation succeeds (memory64-imports.wast:16)
+PASS #89 Test that WebAssembly compilation succeeds (memory64-imports.wast:18)
+PASS #90 Test that WebAssembly instantiation succeeds (memory64-imports.wast:18)
+PASS #91 Test that WebAssembly compilation succeeds (memory64-imports.wast:19)
+PASS #92 Test that WebAssembly instantiation succeeds (memory64-imports.wast:19)
+PASS #93 Test that WebAssembly compilation succeeds (memory64-imports.wast:20)
+PASS #94 Test that WebAssembly instantiation succeeds (memory64-imports.wast:20)
+PASS #95 Test that WebAssembly compilation succeeds (memory64-imports.wast:21)
+PASS #96 Test that WebAssembly instantiation succeeds (memory64-imports.wast:21)
+PASS #97 Test that WebAssembly compilation succeeds (memory64-imports.wast:22)
+PASS #98 Test that WebAssembly instantiation succeeds (memory64-imports.wast:22)
+PASS #99 Test that WebAssembly compilation succeeds (memory64-imports.wast:23)
+PASS #100 Test that WebAssembly instantiation succeeds (memory64-imports.wast:23)
+PASS #101 Test that WebAssembly compilation succeeds (memory64-imports.wast:24)
+PASS #102 Test that WebAssembly instantiation succeeds (memory64-imports.wast:24)
+PASS #103 Test that WebAssembly compilation succeeds (memory64-imports.wast:25)
+PASS #104 Test that WebAssembly instantiation succeeds (memory64-imports.wast:25)
+PASS #105 Test that WebAssembly compilation succeeds (memory64-imports.wast:26)
+PASS #106 Test that WebAssembly instantiation succeeds (memory64-imports.wast:26)
+PASS #107 Test that WebAssembly compilation succeeds (memory64-imports.wast:27)
+PASS #108 Test that WebAssembly instantiation succeeds (memory64-imports.wast:27)
+PASS #109 Test that WebAssembly compilation succeeds (memory64-imports.wast:28)
+PASS #110 Test that WebAssembly instantiation succeeds (memory64-imports.wast:28)
+PASS #111 Test that WebAssembly compilation succeeds (memory64-imports.wast:29)
+PASS #112 Test that WebAssembly instantiation succeeds (memory64-imports.wast:29)
+PASS #113 Test that WebAssembly compilation succeeds (memory64-imports.wast:30)
+PASS #114 Test that WebAssembly instantiation succeeds (memory64-imports.wast:30)
+PASS #115 Test that WebAssembly compilation succeeds (memory64-imports.wast:31)
+PASS #116 Test that WebAssembly instantiation succeeds (memory64-imports.wast:31)
+PASS #117 Test that WebAssembly compilation succeeds (memory64-imports.wast:32)
+PASS #118 Test that WebAssembly instantiation succeeds (memory64-imports.wast:32)
+PASS #119 Test that WebAssembly compilation succeeds (memory64-imports.wast:33)
+PASS #120 Test that WebAssembly instantiation succeeds (memory64-imports.wast:33)
+PASS #121 Test that WebAssembly compilation succeeds (memory64-imports.wast:34)
+PASS #122 Test that WebAssembly instantiation succeeds (memory64-imports.wast:34)
+PASS #123 Test that WebAssembly compilation succeeds (memory64-imports.wast:35)
+PASS #124 Test that WebAssembly instantiation succeeds (memory64-imports.wast:35)
+PASS #125 Test that WebAssembly compilation succeeds (memory64-imports.wast:37)
+PASS #126 Test that WebAssembly instantiation fails (memory64-imports.wast:37)
+PASS #127 Test that a WebAssembly module is unlinkable
+PASS #128 Test that WebAssembly compilation succeeds (memory64-imports.wast:41)
+PASS #129 Test that WebAssembly instantiation fails (memory64-imports.wast:41)
+PASS #130 Test that a WebAssembly module is unlinkable
+PASS #131 Test that WebAssembly compilation succeeds (memory64-imports.wast:45)
+PASS #132 Test that WebAssembly instantiation fails (memory64-imports.wast:45)
+PASS #133 Test that a WebAssembly module is unlinkable
+PASS #134 Test that WebAssembly compilation succeeds (memory64-imports.wast:49)
+PASS #135 Test that WebAssembly instantiation fails (memory64-imports.wast:49)
+PASS #136 Test that a WebAssembly module is unlinkable
+PASS #137 Test that WebAssembly compilation succeeds (memory64-imports.wast:53)
+FAIL #138 Test that WebAssembly instantiation fails (memory64-imports.wast:53) assert_true: instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
+assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:411:11
+memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:211:18
 global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #83 Test that WebAssembly compilation succeeds (memory64-imports.wast:12) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 17: Memory64 is not enabled at {loc} expected true got false
-FAIL #84 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:52:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #85 Test that WebAssembly compilation succeeds (memory64-imports.wast:14) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 16: Memory64 is not enabled at {loc} expected true got false
-FAIL #86 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:61:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #87 Test that WebAssembly compilation succeeds (memory64-imports.wast:16) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 16: Memory64 is not enabled at {loc} expected true got false
-FAIL #88 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:70:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #89 Test that WebAssembly compilation succeeds (memory64-imports.wast:18) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 53: Memory64 is not enabled at {loc} expected true got false
-FAIL #90 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:79:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #91 Test that WebAssembly compilation succeeds (memory64-imports.wast:19) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 53: Memory64 is not enabled at {loc} expected true got false
-FAIL #92 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:85:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #93 Test that WebAssembly compilation succeeds (memory64-imports.wast:20) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 53: Memory64 is not enabled at {loc} expected true got false
-FAIL #94 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:91:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #95 Test that WebAssembly compilation succeeds (memory64-imports.wast:21) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 53: Memory64 is not enabled at {loc} expected true got false
-FAIL #96 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:97:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #97 Test that WebAssembly compilation succeeds (memory64-imports.wast:22) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 17: Memory64 is not enabled at {loc} expected true got false
-FAIL #98 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:103:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #99 Test that WebAssembly compilation succeeds (memory64-imports.wast:23) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 17: Memory64 is not enabled at {loc} expected true got false
-FAIL #100 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:109:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #101 Test that WebAssembly compilation succeeds (memory64-imports.wast:24) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 53: Memory64 is not enabled at {loc} expected true got false
-FAIL #102 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:115:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #103 Test that WebAssembly compilation succeeds (memory64-imports.wast:25) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 53: Memory64 is not enabled at {loc} expected true got false
-FAIL #104 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:121:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #105 Test that WebAssembly compilation succeeds (memory64-imports.wast:26) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 53: Memory64 is not enabled at {loc} expected true got false
-FAIL #106 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:127:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #107 Test that WebAssembly compilation succeeds (memory64-imports.wast:27) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 51: Memory64 is not enabled at {loc} expected true got false
-FAIL #108 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:133:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #109 Test that WebAssembly compilation succeeds (memory64-imports.wast:28) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 51: Memory64 is not enabled at {loc} expected true got false
-FAIL #110 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:139:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #111 Test that WebAssembly compilation succeeds (memory64-imports.wast:29) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 51: Memory64 is not enabled at {loc} expected true got false
-FAIL #112 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:145:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #113 Test that WebAssembly compilation succeeds (memory64-imports.wast:30) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 51: Memory64 is not enabled at {loc} expected true got false
-FAIL #114 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:151:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #115 Test that WebAssembly compilation succeeds (memory64-imports.wast:31) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 51: Memory64 is not enabled at {loc} expected true got false
-FAIL #116 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:157:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #117 Test that WebAssembly compilation succeeds (memory64-imports.wast:32) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 51: Memory64 is not enabled at {loc} expected true got false
-FAIL #118 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:163:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #119 Test that WebAssembly compilation succeeds (memory64-imports.wast:33) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 51: Memory64 is not enabled at {loc} expected true got false
-FAIL #120 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:169:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #121 Test that WebAssembly compilation succeeds (memory64-imports.wast:34) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 51: Memory64 is not enabled at {loc} expected true got false
-FAIL #122 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:175:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #123 Test that WebAssembly compilation succeeds (memory64-imports.wast:35) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 51: Memory64 is not enabled at {loc} expected true got false
-FAIL #124 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:181:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #125 Test that WebAssembly compilation succeeds (memory64-imports.wast:37) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 53: Memory64 is not enabled at {loc} expected true got false
-PASS #126 Test that WebAssembly instantiation fails
-FAIL #127 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed TypeError: undefined is not an object (evaluating 'values[0].source') assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:187:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #128 Test that WebAssembly compilation succeeds (memory64-imports.wast:41) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 53: Memory64 is not enabled at {loc} expected true got false
-PASS #129 Test that WebAssembly instantiation fails
-FAIL #130 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed TypeError: undefined is not an object (evaluating 'values[0].source') assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:193:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #131 Test that WebAssembly compilation succeeds (memory64-imports.wast:45) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 51: Memory64 is not enabled at {loc} expected true got false
-PASS #132 Test that WebAssembly instantiation fails
-FAIL #133 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed TypeError: undefined is not an object (evaluating 'values[0].source') assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:199:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #134 Test that WebAssembly compilation succeeds (memory64-imports.wast:49) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 51: Memory64 is not enabled at {loc} expected true got false
-PASS #135 Test that WebAssembly instantiation fails
-FAIL #136 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed TypeError: undefined is not an object (evaluating 'values[0].source') assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:205:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #137 Test that WebAssembly compilation succeeds (memory64-imports.wast:53) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 49: Memory64 is not enabled at {loc} expected true got false
-PASS #138 Test that WebAssembly instantiation fails
-FAIL #139 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed TypeError: undefined is not an object (evaluating 'values[0].source') assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
+FAIL #139 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed [object WebAssembly.Instance] assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
 memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:211:18
 global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
 PASS #140 Test that WebAssembly compilation succeeds (memory64-imports.wast:57)
-PASS #141 Test that WebAssembly instantiation fails (memory64-imports.wast:57)
-FAIL #142 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed TypeError: import test-table64-10-inf:table64-10-inf must be an object assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
+FAIL #141 Test that WebAssembly instantiation fails (memory64-imports.wast:57) assert_true: instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
+assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:411:11
 memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:217:18
 global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #143 Test that WebAssembly compilation succeeds (memory64-imports.wast:61) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 47: Memory64 is not enabled at {loc} expected true got false
-PASS #144 Test that WebAssembly instantiation fails
-FAIL #145 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed TypeError: undefined is not an object (evaluating 'values[0].source') assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
+FAIL #142 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed [object WebAssembly.Instance] assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
+memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:217:18
+global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
+PASS #143 Test that WebAssembly compilation succeeds (memory64-imports.wast:61)
+FAIL #144 Test that WebAssembly instantiation fails (memory64-imports.wast:61) assert_true: instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
+assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:411:11
+memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:223:18
+global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
+FAIL #145 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed [object WebAssembly.Instance] assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
 memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:223:18
 global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
 PASS #146 Test that WebAssembly compilation succeeds (memory64-imports.wast:65)
-PASS #147 Test that WebAssembly instantiation fails (memory64-imports.wast:65)
-FAIL #148 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed TypeError: import test-table64-10-20:table64-10-20 must be an object assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
+FAIL #147 Test that WebAssembly instantiation fails (memory64-imports.wast:65) assert_true: instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
+assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:411:11
 memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:229:18
 global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #149 Test that WebAssembly compilation succeeds (memory64-imports.wast:68) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 52: Memory64 is not enabled at {loc} expected true got false
-FAIL #150 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:235:19
+FAIL #148 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed [object WebAssembly.Instance] assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
+memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:229:18
 global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #151 Test that WebAssembly compilation succeeds (memory64-imports.wast:69) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 52: Memory64 is not enabled at {loc} expected true got false
-FAIL #152 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:241:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #153 Test that WebAssembly compilation succeeds (memory64-imports.wast:70) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 52: Memory64 is not enabled at {loc} expected true got false
-FAIL #154 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:247:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #155 Test that WebAssembly compilation succeeds (memory64-imports.wast:71) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 52: Memory64 is not enabled at {loc} expected true got false
-FAIL #156 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:253:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #157 Test that WebAssembly compilation succeeds (memory64-imports.wast:72) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 52: Memory64 is not enabled at {loc} expected true got false
-FAIL #158 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:259:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #159 Test that WebAssembly compilation succeeds (memory64-imports.wast:73) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 48: Memory64 is not enabled at {loc} expected true got false
-FAIL #160 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:265:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #161 Test that WebAssembly compilation succeeds (memory64-imports.wast:74) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 48: Memory64 is not enabled at {loc} expected true got false
-FAIL #162 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:271:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #163 Test that WebAssembly compilation succeeds (memory64-imports.wast:75) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 48: Memory64 is not enabled at {loc} expected true got false
-FAIL #164 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:277:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #165 Test that WebAssembly compilation succeeds (memory64-imports.wast:76) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 48: Memory64 is not enabled at {loc} expected true got false
-FAIL #166 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:283:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #167 Test that WebAssembly compilation succeeds (memory64-imports.wast:77) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 48: Memory64 is not enabled at {loc} expected true got false
-FAIL #168 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:289:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #169 Test that WebAssembly compilation succeeds (memory64-imports.wast:78) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 48: Memory64 is not enabled at {loc} expected true got false
-FAIL #170 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:295:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #171 Test that WebAssembly compilation succeeds (memory64-imports.wast:79) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 48: Memory64 is not enabled at {loc} expected true got false
-FAIL #172 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:301:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #173 Test that WebAssembly compilation succeeds (memory64-imports.wast:80) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 48: Memory64 is not enabled at {loc} expected true got false
-FAIL #174 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:307:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #175 Test that WebAssembly compilation succeeds (memory64-imports.wast:81) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 48: Memory64 is not enabled at {loc} expected true got false
-FAIL #176 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:313:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #177 Test that WebAssembly compilation succeeds (memory64-imports.wast:83) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 52: Memory64 is not enabled at {loc} expected true got false
-PASS #178 Test that WebAssembly instantiation fails
-FAIL #179 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed TypeError: undefined is not an object (evaluating 'values[0].source') assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:319:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #180 Test that WebAssembly compilation succeeds (memory64-imports.wast:87) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 52: Memory64 is not enabled at {loc} expected true got false
-PASS #181 Test that WebAssembly instantiation fails
-FAIL #182 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed TypeError: undefined is not an object (evaluating 'values[0].source') assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:325:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #183 Test that WebAssembly compilation succeeds (memory64-imports.wast:91) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 52: Memory64 is not enabled at {loc} expected true got false
-PASS #184 Test that WebAssembly instantiation fails
-FAIL #185 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed TypeError: undefined is not an object (evaluating 'values[0].source') assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:331:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #186 Test that WebAssembly compilation succeeds (memory64-imports.wast:95) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 52: Memory64 is not enabled at {loc} expected true got false
-PASS #187 Test that WebAssembly instantiation fails
-FAIL #188 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed TypeError: undefined is not an object (evaluating 'values[0].source') assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:337:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #189 Test that WebAssembly compilation succeeds (memory64-imports.wast:99) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 52: Memory64 is not enabled at {loc} expected true got false
-PASS #190 Test that WebAssembly instantiation fails
-FAIL #191 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed TypeError: undefined is not an object (evaluating 'values[0].source') assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:343:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #192 Test that WebAssembly compilation succeeds (memory64-imports.wast:103) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 48: Memory64 is not enabled at {loc} expected true got false
-PASS #193 Test that WebAssembly instantiation fails
-FAIL #194 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed TypeError: undefined is not an object (evaluating 'values[0].source') assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:349:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #195 Test that WebAssembly compilation succeeds (memory64-imports.wast:107) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 48: Memory64 is not enabled at {loc} expected true got false
-PASS #196 Test that WebAssembly instantiation fails
-FAIL #197 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed TypeError: undefined is not an object (evaluating 'values[0].source') assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:355:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #198 Test that WebAssembly compilation succeeds (memory64-imports.wast:111) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 48: Memory64 is not enabled at {loc} expected true got false
-PASS #199 Test that WebAssembly instantiation fails
-FAIL #200 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed TypeError: undefined is not an object (evaluating 'values[0].source') assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:361:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #201 Test that WebAssembly compilation succeeds (memory64-imports.wast:115) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 48: Memory64 is not enabled at {loc} expected true got false
-PASS #202 Test that WebAssembly instantiation fails
-FAIL #203 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed TypeError: undefined is not an object (evaluating 'values[0].source') assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:367:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #204 Test that WebAssembly compilation succeeds (memory64-imports.wast:119) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 48: Memory64 is not enabled at {loc} expected true got false
-PASS #205 Test that WebAssembly instantiation fails
-FAIL #206 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed TypeError: undefined is not an object (evaluating 'values[0].source') assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:373:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #207 Test that WebAssembly compilation succeeds (memory64-imports.wast:123) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 48: Memory64 is not enabled at {loc} expected true got false
-PASS #208 Test that WebAssembly instantiation fails
-FAIL #209 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed TypeError: undefined is not an object (evaluating 'values[0].source') assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:379:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #210 Test that WebAssembly compilation succeeds (memory64-imports.wast:127) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 48: Memory64 is not enabled at {loc} expected true got false
-PASS #211 Test that WebAssembly instantiation fails
-FAIL #212 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed TypeError: undefined is not an object (evaluating 'values[0].source') assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:385:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #213 Test that WebAssembly compilation succeeds (memory64-imports.wast:131) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 48: Memory64 is not enabled at {loc} expected true got false
-PASS #214 Test that WebAssembly instantiation fails
-FAIL #215 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed TypeError: undefined is not an object (evaluating 'values[0].source') assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:391:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #216 Test that WebAssembly compilation succeeds (memory64-imports.wast:135) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 48: Memory64 is not enabled at {loc} expected true got false
-PASS #217 Test that WebAssembly instantiation fails
-FAIL #218 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed TypeError: undefined is not an object (evaluating 'values[0].source') assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:397:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #219 Test that WebAssembly compilation succeeds (memory64-imports.wast:139) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 48: Memory64 is not enabled at {loc} expected true got false
-PASS #220 Test that WebAssembly instantiation fails
-FAIL #221 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed TypeError: undefined is not an object (evaluating 'values[0].source') assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:403:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #222 Test that WebAssembly compilation succeeds (memory64-imports.wast:143) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 48: Memory64 is not enabled at {loc} expected true got false
-PASS #223 Test that WebAssembly instantiation fails
-FAIL #224 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed TypeError: undefined is not an object (evaluating 'values[0].source') assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:409:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #225 Test that WebAssembly compilation succeeds (memory64-imports.wast:147) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 48: Memory64 is not enabled at {loc} expected true got false
-PASS #226 Test that WebAssembly instantiation fails
-FAIL #227 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed TypeError: undefined is not an object (evaluating 'values[0].source') assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:415:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #228 Test that WebAssembly compilation succeeds (memory64-imports.wast:151) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 48: Memory64 is not enabled at {loc} expected true got false
-PASS #229 Test that WebAssembly instantiation fails
-FAIL #230 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed TypeError: undefined is not an object (evaluating 'values[0].source') assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:421:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #231 Test that WebAssembly compilation succeeds (memory64-imports.wast:155) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 48: Memory64 is not enabled at {loc} expected true got false
-PASS #232 Test that WebAssembly instantiation fails
-FAIL #233 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed TypeError: undefined is not an object (evaluating 'values[0].source') assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:427:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
+PASS #149 Test that WebAssembly compilation succeeds (memory64-imports.wast:68)
+PASS #150 Test that WebAssembly instantiation succeeds (memory64-imports.wast:68)
+PASS #151 Test that WebAssembly compilation succeeds (memory64-imports.wast:69)
+PASS #152 Test that WebAssembly instantiation succeeds (memory64-imports.wast:69)
+PASS #153 Test that WebAssembly compilation succeeds (memory64-imports.wast:70)
+PASS #154 Test that WebAssembly instantiation succeeds (memory64-imports.wast:70)
+PASS #155 Test that WebAssembly compilation succeeds (memory64-imports.wast:71)
+PASS #156 Test that WebAssembly instantiation succeeds (memory64-imports.wast:71)
+PASS #157 Test that WebAssembly compilation succeeds (memory64-imports.wast:72)
+PASS #158 Test that WebAssembly instantiation succeeds (memory64-imports.wast:72)
+PASS #159 Test that WebAssembly compilation succeeds (memory64-imports.wast:73)
+PASS #160 Test that WebAssembly instantiation succeeds (memory64-imports.wast:73)
+PASS #161 Test that WebAssembly compilation succeeds (memory64-imports.wast:74)
+PASS #162 Test that WebAssembly instantiation succeeds (memory64-imports.wast:74)
+PASS #163 Test that WebAssembly compilation succeeds (memory64-imports.wast:75)
+PASS #164 Test that WebAssembly instantiation succeeds (memory64-imports.wast:75)
+PASS #165 Test that WebAssembly compilation succeeds (memory64-imports.wast:76)
+PASS #166 Test that WebAssembly instantiation succeeds (memory64-imports.wast:76)
+PASS #167 Test that WebAssembly compilation succeeds (memory64-imports.wast:77)
+PASS #168 Test that WebAssembly instantiation succeeds (memory64-imports.wast:77)
+PASS #169 Test that WebAssembly compilation succeeds (memory64-imports.wast:78)
+PASS #170 Test that WebAssembly instantiation succeeds (memory64-imports.wast:78)
+PASS #171 Test that WebAssembly compilation succeeds (memory64-imports.wast:79)
+PASS #172 Test that WebAssembly instantiation succeeds (memory64-imports.wast:79)
+PASS #173 Test that WebAssembly compilation succeeds (memory64-imports.wast:80)
+PASS #174 Test that WebAssembly instantiation succeeds (memory64-imports.wast:80)
+PASS #175 Test that WebAssembly compilation succeeds (memory64-imports.wast:81)
+PASS #176 Test that WebAssembly instantiation succeeds (memory64-imports.wast:81)
+PASS #177 Test that WebAssembly compilation succeeds (memory64-imports.wast:83)
+PASS #178 Test that WebAssembly instantiation fails (memory64-imports.wast:83)
+PASS #179 Test that a WebAssembly module is unlinkable
+PASS #180 Test that WebAssembly compilation succeeds (memory64-imports.wast:87)
+PASS #181 Test that WebAssembly instantiation fails (memory64-imports.wast:87)
+PASS #182 Test that a WebAssembly module is unlinkable
+PASS #183 Test that WebAssembly compilation succeeds (memory64-imports.wast:91)
+PASS #184 Test that WebAssembly instantiation fails (memory64-imports.wast:91)
+PASS #185 Test that a WebAssembly module is unlinkable
+PASS #186 Test that WebAssembly compilation succeeds (memory64-imports.wast:95)
+PASS #187 Test that WebAssembly instantiation fails (memory64-imports.wast:95)
+PASS #188 Test that a WebAssembly module is unlinkable
+PASS #189 Test that WebAssembly compilation succeeds (memory64-imports.wast:99)
+PASS #190 Test that WebAssembly instantiation fails (memory64-imports.wast:99)
+PASS #191 Test that a WebAssembly module is unlinkable
+PASS #192 Test that WebAssembly compilation succeeds (memory64-imports.wast:103)
+PASS #193 Test that WebAssembly instantiation fails (memory64-imports.wast:103)
+PASS #194 Test that a WebAssembly module is unlinkable
+PASS #195 Test that WebAssembly compilation succeeds (memory64-imports.wast:107)
+PASS #196 Test that WebAssembly instantiation fails (memory64-imports.wast:107)
+PASS #197 Test that a WebAssembly module is unlinkable
+PASS #198 Test that WebAssembly compilation succeeds (memory64-imports.wast:111)
+PASS #199 Test that WebAssembly instantiation fails (memory64-imports.wast:111)
+PASS #200 Test that a WebAssembly module is unlinkable
+PASS #201 Test that WebAssembly compilation succeeds (memory64-imports.wast:115)
+PASS #202 Test that WebAssembly instantiation fails (memory64-imports.wast:115)
+PASS #203 Test that a WebAssembly module is unlinkable
+PASS #204 Test that WebAssembly compilation succeeds (memory64-imports.wast:119)
+PASS #205 Test that WebAssembly instantiation fails (memory64-imports.wast:119)
+PASS #206 Test that a WebAssembly module is unlinkable
+PASS #207 Test that WebAssembly compilation succeeds (memory64-imports.wast:123)
+PASS #208 Test that WebAssembly instantiation fails (memory64-imports.wast:123)
+PASS #209 Test that a WebAssembly module is unlinkable
+PASS #210 Test that WebAssembly compilation succeeds (memory64-imports.wast:127)
+PASS #211 Test that WebAssembly instantiation fails (memory64-imports.wast:127)
+PASS #212 Test that a WebAssembly module is unlinkable
+PASS #213 Test that WebAssembly compilation succeeds (memory64-imports.wast:131)
+PASS #214 Test that WebAssembly instantiation fails (memory64-imports.wast:131)
+PASS #215 Test that a WebAssembly module is unlinkable
+PASS #216 Test that WebAssembly compilation succeeds (memory64-imports.wast:135)
+PASS #217 Test that WebAssembly instantiation fails (memory64-imports.wast:135)
+PASS #218 Test that a WebAssembly module is unlinkable
+PASS #219 Test that WebAssembly compilation succeeds (memory64-imports.wast:139)
+PASS #220 Test that WebAssembly instantiation fails (memory64-imports.wast:139)
+PASS #221 Test that a WebAssembly module is unlinkable
+PASS #222 Test that WebAssembly compilation succeeds (memory64-imports.wast:143)
+PASS #223 Test that WebAssembly instantiation fails (memory64-imports.wast:143)
+PASS #224 Test that a WebAssembly module is unlinkable
+PASS #225 Test that WebAssembly compilation succeeds (memory64-imports.wast:147)
+PASS #226 Test that WebAssembly instantiation fails (memory64-imports.wast:147)
+PASS #227 Test that a WebAssembly module is unlinkable
+PASS #228 Test that WebAssembly compilation succeeds (memory64-imports.wast:151)
+PASS #229 Test that WebAssembly instantiation fails (memory64-imports.wast:151)
+PASS #230 Test that a WebAssembly module is unlinkable
+PASS #231 Test that WebAssembly compilation succeeds (memory64-imports.wast:155)
+PASS #232 Test that WebAssembly instantiation fails (memory64-imports.wast:155)
+PASS #233 Test that a WebAssembly module is unlinkable
 PASS #234 Test that WebAssembly compilation succeeds (memory64-imports.wast:159)
 PASS #235 Test that WebAssembly instantiation fails (memory64-imports.wast:159)
-FAIL #236 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed TypeError: import test-memory64-2-inf:memory64-2-inf must be an object assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:433:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
-FAIL #237 Test that WebAssembly compilation succeeds (memory64-imports.wast:163) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 44: Memory64 is not enabled at {loc} expected true got false
-PASS #238 Test that WebAssembly instantiation fails
-FAIL #239 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed TypeError: undefined is not an object (evaluating 'values[0].source') assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:439:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
+PASS #236 Test that a WebAssembly module is unlinkable
+PASS #237 Test that WebAssembly compilation succeeds (memory64-imports.wast:163)
+PASS #238 Test that WebAssembly instantiation fails (memory64-imports.wast:163)
+PASS #239 Test that a WebAssembly module is unlinkable
 PASS #240 Test that WebAssembly compilation succeeds (memory64-imports.wast:167)
 PASS #241 Test that WebAssembly instantiation fails (memory64-imports.wast:167)
-FAIL #242 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed TypeError: import test-memory64-2-4:memory64-2-4 must be an object assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
-memory64_imports_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:445:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64-imports.wast.js:447:3 expected true got false
+PASS #242 Test that a WebAssembly module is unlinkable
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory64.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory64.wast.js-expected.txt
@@ -1,14 +1,14 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (memory64.wast:4) assert_equals: expected false but got true
-FAIL #3 Test that WebAssembly compilation succeeds (memory64.wast:5) assert_equals: expected false but got true
-FAIL #4 Test that WebAssembly compilation succeeds (memory64.wast:6) assert_equals: expected false but got true
-FAIL #5 Test that WebAssembly compilation succeeds (memory64.wast:7) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (memory64.wast:4)
+PASS #3 Test that WebAssembly compilation succeeds (memory64.wast:5)
+PASS #4 Test that WebAssembly compilation succeeds (memory64.wast:6)
+PASS #5 Test that WebAssembly compilation succeeds (memory64.wast:7)
 FAIL #6 Test that WebAssembly compilation succeeds (memory64.wast:8) assert_equals: expected false but got true
 FAIL #7 Test that WebAssembly compilation succeeds (memory64.wast:9) assert_equals: expected false but got true
-FAIL #8 Test that WebAssembly compilation succeeds (memory64.wast:11) assert_equals: expected false but got true
-FAIL #9 Test that WebAssembly compilation succeeds (memory64.wast:13) assert_equals: expected false but got true
-FAIL #10 Test that WebAssembly compilation succeeds (memory64.wast:15) assert_equals: expected false but got true
+PASS #8 Test that WebAssembly compilation succeeds (memory64.wast:11)
+PASS #9 Test that WebAssembly compilation succeeds (memory64.wast:13)
+PASS #10 Test that WebAssembly compilation succeeds (memory64.wast:15)
 PASS #11 Test that WebAssembly compilation fails (memory64.wast:18)
 PASS #12 Test that WebAssembly compilation fails (memory64.wast:19)
 PASS #13 Test that WebAssembly compilation fails (memory64.wast:20)
@@ -23,51 +23,31 @@ PASS #21 Test that WebAssembly compilation fails (memory64.wast:53)
 PASS #22 Test that WebAssembly compilation fails (memory64.wast:57)
 PASS #23 Test that WebAssembly compilation fails (memory64.wast:62)
 PASS #24 Test that WebAssembly compilation fails (memory64.wast:66)
-FAIL #25 Test that WebAssembly compilation succeeds (memory64.wast:71) assert_equals: expected false but got true
+PASS #25 Test that WebAssembly compilation succeeds (memory64.wast:71)
 PASS #26 Test that WebAssembly compilation succeeds (wrapper)
 PASS #27 Reinitialize the default imports
-FAIL #28 Test that WebAssembly compilation succeeds (memory64.wast:4) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 16: Memory64 is not enabled at {loc} expected true got false
-FAIL #29 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #30 Test that WebAssembly compilation succeeds (memory64.wast:5) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 16: Memory64 is not enabled at {loc} expected true got false
-FAIL #31 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:13:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #32 Test that WebAssembly compilation succeeds (memory64.wast:6) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 16: Memory64 is not enabled at {loc} expected true got false
-FAIL #33 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:19:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #34 Test that WebAssembly compilation succeeds (memory64.wast:7) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 16: Memory64 is not enabled at {loc} expected true got false
-FAIL #35 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:25:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #36 Test that WebAssembly compilation succeeds (memory64.wast:8) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 16: Memory64 is not enabled at {loc} expected true got false
-FAIL #37 Test that WebAssembly compilation succeeds (memory64.wast:9) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 16: Memory64 is not enabled at {loc} expected true got false
+PASS #28 Test that WebAssembly compilation succeeds (memory64.wast:4)
+PASS #29 Test that WebAssembly instantiation succeeds (memory64.wast:4)
+PASS #30 Test that WebAssembly compilation succeeds (memory64.wast:5)
+PASS #31 Test that WebAssembly instantiation succeeds (memory64.wast:5)
+PASS #32 Test that WebAssembly compilation succeeds (memory64.wast:6)
+PASS #33 Test that WebAssembly instantiation succeeds (memory64.wast:6)
+PASS #34 Test that WebAssembly compilation succeeds (memory64.wast:7)
+PASS #35 Test that WebAssembly instantiation succeeds (memory64.wast:7)
+FAIL #36 Test that WebAssembly compilation succeeds (memory64.wast:8) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 23: Memory's initial page count of 281474976710656 is invalid at {loc} expected true got false
+FAIL #37 Test that WebAssembly compilation succeeds (memory64.wast:9) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 24: Memory's maximum page count of 281474976710656 is invalid at {loc} expected true got false
 FAIL #38 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
 memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:34:18
 global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #39 Test that WebAssembly compilation succeeds (memory64.wast:11) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 35: Memory64 is not enabled at {loc} expected true got false
-FAIL #40 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:40:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #41 Test that a WebAssembly code returns a specific result (memory64.wast:12) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:43:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #42 Test that WebAssembly compilation succeeds (memory64.wast:13) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 35: Memory64 is not enabled at {loc} expected true got false
-FAIL #43 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:49:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #44 Test that a WebAssembly code returns a specific result (memory64.wast:14) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:52:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #45 Test that WebAssembly compilation succeeds (memory64.wast:15) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 35: Memory64 is not enabled at {loc} expected true got false
-FAIL #46 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:58:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #47 Test that a WebAssembly code returns a specific result (memory64.wast:16) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:61:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
+PASS #39 Test that WebAssembly compilation succeeds (memory64.wast:11)
+PASS #40 Test that WebAssembly instantiation succeeds (memory64.wast:11)
+PASS #41 Test that a WebAssembly code returns a specific result (memory64.wast:12)
+PASS #42 Test that WebAssembly compilation succeeds (memory64.wast:13)
+PASS #43 Test that WebAssembly instantiation succeeds (memory64.wast:13)
+PASS #44 Test that a WebAssembly code returns a specific result (memory64.wast:14)
+PASS #45 Test that WebAssembly compilation succeeds (memory64.wast:15)
+PASS #46 Test that WebAssembly instantiation succeeds (memory64.wast:15)
+PASS #47 Test that a WebAssembly code returns a specific result (memory64.wast:16)
 PASS #48 Test that WebAssembly compilation fails (memory64.wast:18)
 PASS #49 Test that WebAssembly compilation fails (memory64.wast:19)
 PASS #50 Test that WebAssembly compilation fails (memory64.wast:20)
@@ -82,140 +62,50 @@ PASS #58 Test that WebAssembly compilation fails (memory64.wast:53)
 PASS #59 Test that WebAssembly compilation fails (memory64.wast:57)
 PASS #60 Test that WebAssembly compilation fails (memory64.wast:62)
 PASS #61 Test that WebAssembly compilation fails (memory64.wast:66)
-FAIL #62 Test that WebAssembly compilation succeeds (memory64.wast:71) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 60: Memory64 is not enabled at {loc} expected true got false
-FAIL #63 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:109:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #64 Test that a WebAssembly code returns a specific result (memory64.wast:159) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:112:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
+PASS #62 Test that WebAssembly compilation succeeds (memory64.wast:71)
+PASS #63 Test that WebAssembly instantiation succeeds (memory64.wast:71)
+PASS #64 Test that a WebAssembly code returns a specific result (memory64.wast:159)
 PASS #65 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #66 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:cast must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:115:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:115:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #67 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:115:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #68 Test that a WebAssembly code returns a specific result (memory64.wast:162) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:118:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #69 Test that a WebAssembly code returns a specific result (memory64.wast:163) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:121:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #70 Test that a WebAssembly code returns a specific result (memory64.wast:164) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:124:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #71 Test that a WebAssembly code returns a specific result (memory64.wast:165) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:127:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #72 Test that a WebAssembly code returns a specific result (memory64.wast:167) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:130:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #73 Test that a WebAssembly code returns a specific result (memory64.wast:168) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:133:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #74 Test that a WebAssembly code returns a specific result (memory64.wast:169) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:136:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #75 Test that a WebAssembly code returns a specific result (memory64.wast:170) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:139:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #76 Test that a WebAssembly code returns a specific result (memory64.wast:172) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:142:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #77 Test that a WebAssembly code returns a specific result (memory64.wast:173) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:145:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #78 Test that a WebAssembly code returns a specific result (memory64.wast:174) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:148:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #79 Test that a WebAssembly code returns a specific result (memory64.wast:175) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:151:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #80 Test that a WebAssembly code returns a specific result (memory64.wast:176) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:154:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #81 Test that a WebAssembly code returns a specific result (memory64.wast:177) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:157:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #82 Test that a WebAssembly code returns a specific result (memory64.wast:178) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:160:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #83 Test that a WebAssembly code returns a specific result (memory64.wast:179) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:163:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #84 Test that a WebAssembly code returns a specific result (memory64.wast:181) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:166:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #85 Test that a WebAssembly code returns a specific result (memory64.wast:182) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:169:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #86 Test that a WebAssembly code returns a specific result (memory64.wast:183) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:172:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #87 Test that a WebAssembly code returns a specific result (memory64.wast:184) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:175:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #88 Test that a WebAssembly code returns a specific result (memory64.wast:185) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:178:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #89 Test that a WebAssembly code returns a specific result (memory64.wast:186) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:181:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #90 Test that a WebAssembly code returns a specific result (memory64.wast:188) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:184:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #91 Test that a WebAssembly code returns a specific result (memory64.wast:189) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:187:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #92 Test that a WebAssembly code returns a specific result (memory64.wast:190) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:190:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #93 Test that a WebAssembly code returns a specific result (memory64.wast:191) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:193:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #94 Test that a WebAssembly code returns a specific result (memory64.wast:192) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:196:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #95 Test that a WebAssembly code returns a specific result (memory64.wast:193) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:199:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #96 Test that a WebAssembly code returns a specific result (memory64.wast:195) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:202:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #97 Test that a WebAssembly code returns a specific result (memory64.wast:196) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:205:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #98 Test that a WebAssembly code returns a specific result (memory64.wast:197) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:208:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #99 Test that a WebAssembly code returns a specific result (memory64.wast:198) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:211:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #100 Test that a WebAssembly code returns a specific result (memory64.wast:199) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:214:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #101 Test that a WebAssembly code returns a specific result (memory64.wast:200) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:217:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #102 Test that a WebAssembly code returns a specific result (memory64.wast:201) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:220:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #103 Test that a WebAssembly code returns a specific result (memory64.wast:202) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:223:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #104 Test that a WebAssembly code returns a specific result (memory64.wast:203) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:226:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #105 Test that a WebAssembly code returns a specific result (memory64.wast:204) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:229:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #106 Test that a WebAssembly code returns a specific result (memory64.wast:205) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:232:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #107 Test that a WebAssembly code returns a specific result (memory64.wast:206) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:235:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
+PASS #66 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #67 Run a WebAssembly test without special assertions (memory64.wast:160)
+PASS #68 Test that a WebAssembly code returns a specific result (memory64.wast:162)
+PASS #69 Test that a WebAssembly code returns a specific result (memory64.wast:163)
+PASS #70 Test that a WebAssembly code returns a specific result (memory64.wast:164)
+PASS #71 Test that a WebAssembly code returns a specific result (memory64.wast:165)
+PASS #72 Test that a WebAssembly code returns a specific result (memory64.wast:167)
+PASS #73 Test that a WebAssembly code returns a specific result (memory64.wast:168)
+PASS #74 Test that a WebAssembly code returns a specific result (memory64.wast:169)
+PASS #75 Test that a WebAssembly code returns a specific result (memory64.wast:170)
+PASS #76 Test that a WebAssembly code returns a specific result (memory64.wast:172)
+PASS #77 Test that a WebAssembly code returns a specific result (memory64.wast:173)
+PASS #78 Test that a WebAssembly code returns a specific result (memory64.wast:174)
+PASS #79 Test that a WebAssembly code returns a specific result (memory64.wast:175)
+PASS #80 Test that a WebAssembly code returns a specific result (memory64.wast:176)
+PASS #81 Test that a WebAssembly code returns a specific result (memory64.wast:177)
+PASS #82 Test that a WebAssembly code returns a specific result (memory64.wast:178)
+PASS #83 Test that a WebAssembly code returns a specific result (memory64.wast:179)
+PASS #84 Test that a WebAssembly code returns a specific result (memory64.wast:181)
+PASS #85 Test that a WebAssembly code returns a specific result (memory64.wast:182)
+PASS #86 Test that a WebAssembly code returns a specific result (memory64.wast:183)
+PASS #87 Test that a WebAssembly code returns a specific result (memory64.wast:184)
+PASS #88 Test that a WebAssembly code returns a specific result (memory64.wast:185)
+PASS #89 Test that a WebAssembly code returns a specific result (memory64.wast:186)
+PASS #90 Test that a WebAssembly code returns a specific result (memory64.wast:188)
+PASS #91 Test that a WebAssembly code returns a specific result (memory64.wast:189)
+PASS #92 Test that a WebAssembly code returns a specific result (memory64.wast:190)
+PASS #93 Test that a WebAssembly code returns a specific result (memory64.wast:191)
+PASS #94 Test that a WebAssembly code returns a specific result (memory64.wast:192)
+PASS #95 Test that a WebAssembly code returns a specific result (memory64.wast:193)
+PASS #96 Test that a WebAssembly code returns a specific result (memory64.wast:195)
+PASS #97 Test that a WebAssembly code returns a specific result (memory64.wast:196)
+PASS #98 Test that a WebAssembly code returns a specific result (memory64.wast:197)
+PASS #99 Test that a WebAssembly code returns a specific result (memory64.wast:198)
+PASS #100 Test that a WebAssembly code returns a specific result (memory64.wast:199)
+PASS #101 Test that a WebAssembly code returns a specific result (memory64.wast:200)
+PASS #102 Test that a WebAssembly code returns a specific result (memory64.wast:201)
+PASS #103 Test that a WebAssembly code returns a specific result (memory64.wast:202)
+PASS #104 Test that a WebAssembly code returns a specific result (memory64.wast:203)
+PASS #105 Test that a WebAssembly code returns a specific result (memory64.wast:204)
+PASS #106 Test that a WebAssembly code returns a specific result (memory64.wast:205)
+PASS #107 Test that a WebAssembly code returns a specific result (memory64.wast:206)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_copy64.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_copy64.wast.js-expected.txt
@@ -1,13 +1,13 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (memory_copy64.wast:6) assert_equals: expected false but got true
-FAIL #3 Test that WebAssembly compilation succeeds (memory_copy64.wast:48) assert_equals: expected false but got true
-FAIL #4 Test that WebAssembly compilation succeeds (memory_copy64.wast:90) assert_equals: expected false but got true
-FAIL #5 Test that WebAssembly compilation succeeds (memory_copy64.wast:132) assert_equals: expected false but got true
-FAIL #6 Test that WebAssembly compilation succeeds (memory_copy64.wast:174) assert_equals: expected false but got true
-FAIL #7 Test that WebAssembly compilation succeeds (memory_copy64.wast:216) assert_equals: expected false but got true
-FAIL #8 Test that WebAssembly compilation succeeds (memory_copy64.wast:258) assert_equals: expected false but got true
-FAIL #9 Test that WebAssembly compilation succeeds (memory_copy64.wast:300) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (memory_copy64.wast:6)
+PASS #3 Test that WebAssembly compilation succeeds (memory_copy64.wast:48)
+PASS #4 Test that WebAssembly compilation succeeds (memory_copy64.wast:90)
+PASS #5 Test that WebAssembly compilation succeeds (memory_copy64.wast:132)
+PASS #6 Test that WebAssembly compilation succeeds (memory_copy64.wast:174)
+PASS #7 Test that WebAssembly compilation succeeds (memory_copy64.wast:216)
+PASS #8 Test that WebAssembly compilation succeeds (memory_copy64.wast:258)
+PASS #9 Test that WebAssembly compilation succeeds (memory_copy64.wast:300)
 PASS #10 Test that WebAssembly compilation succeeds (memory_copy64.wast:342)
 PASS #11 Test that WebAssembly compilation succeeds (memory_copy64.wast:703)
 PASS #12 Test that WebAssembly compilation succeeds (memory_copy64.wast:1065)
@@ -83,797 +83,285 @@ PASS #81 Test that WebAssembly compilation fails (memory_copy64.wast:4734)
 PASS #82 Test that WebAssembly compilation fails (memory_copy64.wast:4741)
 PASS #83 Test that WebAssembly compilation fails (memory_copy64.wast:4748)
 PASS #84 Test that WebAssembly compilation fails (memory_copy64.wast:4755)
-FAIL #85 Test that WebAssembly compilation succeeds (memory_copy64.wast:4763) assert_equals: expected false but got true
-FAIL #86 Test that WebAssembly compilation succeeds (memory_copy64.wast:4789) assert_equals: expected false but got true
-FAIL #87 Test that WebAssembly compilation succeeds (memory_copy64.wast:4815) assert_equals: expected false but got true
-FAIL #88 Test that WebAssembly compilation succeeds (memory_copy64.wast:4821) assert_equals: expected false but got true
-FAIL #89 Test that WebAssembly compilation succeeds (memory_copy64.wast:4827) assert_equals: expected false but got true
-FAIL #90 Test that WebAssembly compilation succeeds (memory_copy64.wast:4833) assert_equals: expected false but got true
-FAIL #91 Test that WebAssembly compilation succeeds (memory_copy64.wast:4839) assert_equals: expected false but got true
-FAIL #92 Test that WebAssembly compilation succeeds (memory_copy64.wast:4863) assert_equals: expected false but got true
-FAIL #93 Test that WebAssembly compilation succeeds (memory_copy64.wast:4869) assert_equals: expected false but got true
-FAIL #94 Test that WebAssembly compilation succeeds (memory_copy64.wast:4875) assert_equals: expected false but got true
-FAIL #95 Test that WebAssembly compilation succeeds (memory_copy64.wast:4881) assert_equals: expected false but got true
-FAIL #96 Test that WebAssembly compilation succeeds (memory_copy64.wast:4887) assert_equals: expected false but got true
-FAIL #97 Test that WebAssembly compilation succeeds (memory_copy64.wast:4893) assert_equals: expected false but got true
-FAIL #98 Test that WebAssembly compilation succeeds (memory_copy64.wast:4899) assert_equals: expected false but got true
+PASS #85 Test that WebAssembly compilation succeeds (memory_copy64.wast:4763)
+PASS #86 Test that WebAssembly compilation succeeds (memory_copy64.wast:4789)
+PASS #87 Test that WebAssembly compilation succeeds (memory_copy64.wast:4815)
+PASS #88 Test that WebAssembly compilation succeeds (memory_copy64.wast:4821)
+PASS #89 Test that WebAssembly compilation succeeds (memory_copy64.wast:4827)
+PASS #90 Test that WebAssembly compilation succeeds (memory_copy64.wast:4833)
+PASS #91 Test that WebAssembly compilation succeeds (memory_copy64.wast:4839)
+PASS #92 Test that WebAssembly compilation succeeds (memory_copy64.wast:4863)
+PASS #93 Test that WebAssembly compilation succeeds (memory_copy64.wast:4869)
+PASS #94 Test that WebAssembly compilation succeeds (memory_copy64.wast:4875)
+PASS #95 Test that WebAssembly compilation succeeds (memory_copy64.wast:4881)
+PASS #96 Test that WebAssembly compilation succeeds (memory_copy64.wast:4887)
+PASS #97 Test that WebAssembly compilation succeeds (memory_copy64.wast:4893)
+PASS #98 Test that WebAssembly compilation succeeds (memory_copy64.wast:4899)
 PASS #99 Reinitialize the default imports
-FAIL #100 Test that WebAssembly compilation succeeds (memory_copy64.wast:6) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 40: Memory64 is not enabled at {loc} expected true got false
-FAIL #101 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #102 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:10:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #103 Test that a WebAssembly code returns a specific result (memory_copy64.wast:17) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #104 Test that a WebAssembly code returns a specific result (memory_copy64.wast:18) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:16:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #105 Test that a WebAssembly code returns a specific result (memory_copy64.wast:19) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:19:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #106 Test that a WebAssembly code returns a specific result (memory_copy64.wast:20) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:22:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #107 Test that a WebAssembly code returns a specific result (memory_copy64.wast:21) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:25:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #108 Test that a WebAssembly code returns a specific result (memory_copy64.wast:22) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:28:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #109 Test that a WebAssembly code returns a specific result (memory_copy64.wast:23) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:31:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #110 Test that a WebAssembly code returns a specific result (memory_copy64.wast:24) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:34:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #111 Test that a WebAssembly code returns a specific result (memory_copy64.wast:25) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:37:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #112 Test that a WebAssembly code returns a specific result (memory_copy64.wast:26) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:40:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #113 Test that a WebAssembly code returns a specific result (memory_copy64.wast:27) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:43:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #114 Test that a WebAssembly code returns a specific result (memory_copy64.wast:28) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:46:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #115 Test that a WebAssembly code returns a specific result (memory_copy64.wast:29) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:49:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #116 Test that a WebAssembly code returns a specific result (memory_copy64.wast:30) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:52:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #117 Test that a WebAssembly code returns a specific result (memory_copy64.wast:31) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:55:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #118 Test that a WebAssembly code returns a specific result (memory_copy64.wast:32) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:58:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #119 Test that a WebAssembly code returns a specific result (memory_copy64.wast:33) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:61:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #120 Test that a WebAssembly code returns a specific result (memory_copy64.wast:34) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:64:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #121 Test that a WebAssembly code returns a specific result (memory_copy64.wast:35) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:67:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #122 Test that a WebAssembly code returns a specific result (memory_copy64.wast:36) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:70:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #123 Test that a WebAssembly code returns a specific result (memory_copy64.wast:37) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:73:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #124 Test that a WebAssembly code returns a specific result (memory_copy64.wast:38) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:76:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #125 Test that a WebAssembly code returns a specific result (memory_copy64.wast:39) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:79:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #126 Test that a WebAssembly code returns a specific result (memory_copy64.wast:40) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:82:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #127 Test that a WebAssembly code returns a specific result (memory_copy64.wast:41) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:85:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #128 Test that a WebAssembly code returns a specific result (memory_copy64.wast:42) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:88:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #129 Test that a WebAssembly code returns a specific result (memory_copy64.wast:43) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:91:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #130 Test that a WebAssembly code returns a specific result (memory_copy64.wast:44) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:94:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #131 Test that a WebAssembly code returns a specific result (memory_copy64.wast:45) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:97:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #132 Test that a WebAssembly code returns a specific result (memory_copy64.wast:46) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:100:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #133 Test that WebAssembly compilation succeeds (memory_copy64.wast:48) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 40: Memory64 is not enabled at {loc} expected true got false
-FAIL #134 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:106:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #135 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:109:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #136 Test that a WebAssembly code returns a specific result (memory_copy64.wast:59) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:112:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #137 Test that a WebAssembly code returns a specific result (memory_copy64.wast:60) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:115:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #138 Test that a WebAssembly code returns a specific result (memory_copy64.wast:61) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:118:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #139 Test that a WebAssembly code returns a specific result (memory_copy64.wast:62) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:121:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #140 Test that a WebAssembly code returns a specific result (memory_copy64.wast:63) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:124:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #141 Test that a WebAssembly code returns a specific result (memory_copy64.wast:64) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:127:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #142 Test that a WebAssembly code returns a specific result (memory_copy64.wast:65) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:130:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #143 Test that a WebAssembly code returns a specific result (memory_copy64.wast:66) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:133:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #144 Test that a WebAssembly code returns a specific result (memory_copy64.wast:67) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:136:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #145 Test that a WebAssembly code returns a specific result (memory_copy64.wast:68) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:139:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #146 Test that a WebAssembly code returns a specific result (memory_copy64.wast:69) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:142:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #147 Test that a WebAssembly code returns a specific result (memory_copy64.wast:70) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:145:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #148 Test that a WebAssembly code returns a specific result (memory_copy64.wast:71) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:148:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #149 Test that a WebAssembly code returns a specific result (memory_copy64.wast:72) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:151:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #150 Test that a WebAssembly code returns a specific result (memory_copy64.wast:73) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:154:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #151 Test that a WebAssembly code returns a specific result (memory_copy64.wast:74) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:157:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #152 Test that a WebAssembly code returns a specific result (memory_copy64.wast:75) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:160:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #153 Test that a WebAssembly code returns a specific result (memory_copy64.wast:76) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:163:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #154 Test that a WebAssembly code returns a specific result (memory_copy64.wast:77) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:166:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #155 Test that a WebAssembly code returns a specific result (memory_copy64.wast:78) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:169:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #156 Test that a WebAssembly code returns a specific result (memory_copy64.wast:79) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:172:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #157 Test that a WebAssembly code returns a specific result (memory_copy64.wast:80) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:175:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #158 Test that a WebAssembly code returns a specific result (memory_copy64.wast:81) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:178:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #159 Test that a WebAssembly code returns a specific result (memory_copy64.wast:82) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:181:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #160 Test that a WebAssembly code returns a specific result (memory_copy64.wast:83) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:184:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #161 Test that a WebAssembly code returns a specific result (memory_copy64.wast:84) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:187:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #162 Test that a WebAssembly code returns a specific result (memory_copy64.wast:85) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:190:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #163 Test that a WebAssembly code returns a specific result (memory_copy64.wast:86) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:193:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #164 Test that a WebAssembly code returns a specific result (memory_copy64.wast:87) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:196:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #165 Test that a WebAssembly code returns a specific result (memory_copy64.wast:88) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:199:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #166 Test that WebAssembly compilation succeeds (memory_copy64.wast:90) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 40: Memory64 is not enabled at {loc} expected true got false
-FAIL #167 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:205:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #168 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:208:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #169 Test that a WebAssembly code returns a specific result (memory_copy64.wast:101) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:211:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #170 Test that a WebAssembly code returns a specific result (memory_copy64.wast:102) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:214:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #171 Test that a WebAssembly code returns a specific result (memory_copy64.wast:103) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:217:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #172 Test that a WebAssembly code returns a specific result (memory_copy64.wast:104) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:220:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #173 Test that a WebAssembly code returns a specific result (memory_copy64.wast:105) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:223:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #174 Test that a WebAssembly code returns a specific result (memory_copy64.wast:106) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:226:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #175 Test that a WebAssembly code returns a specific result (memory_copy64.wast:107) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:229:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #176 Test that a WebAssembly code returns a specific result (memory_copy64.wast:108) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:232:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #177 Test that a WebAssembly code returns a specific result (memory_copy64.wast:109) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:235:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #178 Test that a WebAssembly code returns a specific result (memory_copy64.wast:110) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:238:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #179 Test that a WebAssembly code returns a specific result (memory_copy64.wast:111) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:241:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #180 Test that a WebAssembly code returns a specific result (memory_copy64.wast:112) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:244:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #181 Test that a WebAssembly code returns a specific result (memory_copy64.wast:113) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:247:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #182 Test that a WebAssembly code returns a specific result (memory_copy64.wast:114) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:250:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #183 Test that a WebAssembly code returns a specific result (memory_copy64.wast:115) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:253:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #184 Test that a WebAssembly code returns a specific result (memory_copy64.wast:116) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:256:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #185 Test that a WebAssembly code returns a specific result (memory_copy64.wast:117) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:259:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #186 Test that a WebAssembly code returns a specific result (memory_copy64.wast:118) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:262:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #187 Test that a WebAssembly code returns a specific result (memory_copy64.wast:119) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:265:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #188 Test that a WebAssembly code returns a specific result (memory_copy64.wast:120) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:268:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #189 Test that a WebAssembly code returns a specific result (memory_copy64.wast:121) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:271:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #190 Test that a WebAssembly code returns a specific result (memory_copy64.wast:122) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:274:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #191 Test that a WebAssembly code returns a specific result (memory_copy64.wast:123) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:277:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #192 Test that a WebAssembly code returns a specific result (memory_copy64.wast:124) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:280:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #193 Test that a WebAssembly code returns a specific result (memory_copy64.wast:125) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:283:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #194 Test that a WebAssembly code returns a specific result (memory_copy64.wast:126) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:286:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #195 Test that a WebAssembly code returns a specific result (memory_copy64.wast:127) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:289:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #196 Test that a WebAssembly code returns a specific result (memory_copy64.wast:128) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:292:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #197 Test that a WebAssembly code returns a specific result (memory_copy64.wast:129) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:295:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #198 Test that a WebAssembly code returns a specific result (memory_copy64.wast:130) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:298:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #199 Test that WebAssembly compilation succeeds (memory_copy64.wast:132) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 40: Memory64 is not enabled at {loc} expected true got false
-FAIL #200 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:304:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #201 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:307:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #202 Test that a WebAssembly code returns a specific result (memory_copy64.wast:143) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:310:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #203 Test that a WebAssembly code returns a specific result (memory_copy64.wast:144) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:313:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #204 Test that a WebAssembly code returns a specific result (memory_copy64.wast:145) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:316:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #205 Test that a WebAssembly code returns a specific result (memory_copy64.wast:146) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:319:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #206 Test that a WebAssembly code returns a specific result (memory_copy64.wast:147) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:322:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #207 Test that a WebAssembly code returns a specific result (memory_copy64.wast:148) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:325:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #208 Test that a WebAssembly code returns a specific result (memory_copy64.wast:149) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:328:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #209 Test that a WebAssembly code returns a specific result (memory_copy64.wast:150) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:331:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #210 Test that a WebAssembly code returns a specific result (memory_copy64.wast:151) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:334:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #211 Test that a WebAssembly code returns a specific result (memory_copy64.wast:152) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:337:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #212 Test that a WebAssembly code returns a specific result (memory_copy64.wast:153) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:340:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #213 Test that a WebAssembly code returns a specific result (memory_copy64.wast:154) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:343:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #214 Test that a WebAssembly code returns a specific result (memory_copy64.wast:155) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:346:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #215 Test that a WebAssembly code returns a specific result (memory_copy64.wast:156) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:349:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #216 Test that a WebAssembly code returns a specific result (memory_copy64.wast:157) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:352:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #217 Test that a WebAssembly code returns a specific result (memory_copy64.wast:158) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:355:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #218 Test that a WebAssembly code returns a specific result (memory_copy64.wast:159) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:358:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #219 Test that a WebAssembly code returns a specific result (memory_copy64.wast:160) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:361:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #220 Test that a WebAssembly code returns a specific result (memory_copy64.wast:161) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:364:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #221 Test that a WebAssembly code returns a specific result (memory_copy64.wast:162) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:367:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #222 Test that a WebAssembly code returns a specific result (memory_copy64.wast:163) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:370:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #223 Test that a WebAssembly code returns a specific result (memory_copy64.wast:164) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:373:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #224 Test that a WebAssembly code returns a specific result (memory_copy64.wast:165) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:376:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #225 Test that a WebAssembly code returns a specific result (memory_copy64.wast:166) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:379:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #226 Test that a WebAssembly code returns a specific result (memory_copy64.wast:167) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:382:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #227 Test that a WebAssembly code returns a specific result (memory_copy64.wast:168) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:385:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #228 Test that a WebAssembly code returns a specific result (memory_copy64.wast:169) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:388:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #229 Test that a WebAssembly code returns a specific result (memory_copy64.wast:170) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:391:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #230 Test that a WebAssembly code returns a specific result (memory_copy64.wast:171) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:394:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #231 Test that a WebAssembly code returns a specific result (memory_copy64.wast:172) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:397:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #232 Test that WebAssembly compilation succeeds (memory_copy64.wast:174) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 40: Memory64 is not enabled at {loc} expected true got false
-FAIL #233 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:403:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #234 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:406:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #235 Test that a WebAssembly code returns a specific result (memory_copy64.wast:185) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:409:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #236 Test that a WebAssembly code returns a specific result (memory_copy64.wast:186) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:412:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #237 Test that a WebAssembly code returns a specific result (memory_copy64.wast:187) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:415:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #238 Test that a WebAssembly code returns a specific result (memory_copy64.wast:188) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:418:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #239 Test that a WebAssembly code returns a specific result (memory_copy64.wast:189) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:421:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #240 Test that a WebAssembly code returns a specific result (memory_copy64.wast:190) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:424:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #241 Test that a WebAssembly code returns a specific result (memory_copy64.wast:191) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:427:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #242 Test that a WebAssembly code returns a specific result (memory_copy64.wast:192) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:430:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #243 Test that a WebAssembly code returns a specific result (memory_copy64.wast:193) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:433:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #244 Test that a WebAssembly code returns a specific result (memory_copy64.wast:194) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:436:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #245 Test that a WebAssembly code returns a specific result (memory_copy64.wast:195) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:439:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #246 Test that a WebAssembly code returns a specific result (memory_copy64.wast:196) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:442:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #247 Test that a WebAssembly code returns a specific result (memory_copy64.wast:197) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:445:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #248 Test that a WebAssembly code returns a specific result (memory_copy64.wast:198) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:448:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #249 Test that a WebAssembly code returns a specific result (memory_copy64.wast:199) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:451:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #250 Test that a WebAssembly code returns a specific result (memory_copy64.wast:200) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:454:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #251 Test that a WebAssembly code returns a specific result (memory_copy64.wast:201) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:457:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #252 Test that a WebAssembly code returns a specific result (memory_copy64.wast:202) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:460:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #253 Test that a WebAssembly code returns a specific result (memory_copy64.wast:203) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:463:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #254 Test that a WebAssembly code returns a specific result (memory_copy64.wast:204) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:466:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #255 Test that a WebAssembly code returns a specific result (memory_copy64.wast:205) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:469:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #256 Test that a WebAssembly code returns a specific result (memory_copy64.wast:206) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:472:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #257 Test that a WebAssembly code returns a specific result (memory_copy64.wast:207) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:475:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #258 Test that a WebAssembly code returns a specific result (memory_copy64.wast:208) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:478:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #259 Test that a WebAssembly code returns a specific result (memory_copy64.wast:209) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:481:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #260 Test that a WebAssembly code returns a specific result (memory_copy64.wast:210) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:484:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #261 Test that a WebAssembly code returns a specific result (memory_copy64.wast:211) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:487:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #262 Test that a WebAssembly code returns a specific result (memory_copy64.wast:212) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:490:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #263 Test that a WebAssembly code returns a specific result (memory_copy64.wast:213) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:493:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #264 Test that a WebAssembly code returns a specific result (memory_copy64.wast:214) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:496:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #265 Test that WebAssembly compilation succeeds (memory_copy64.wast:216) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 40: Memory64 is not enabled at {loc} expected true got false
-FAIL #266 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:502:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #267 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:505:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #268 Test that a WebAssembly code returns a specific result (memory_copy64.wast:227) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:508:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #269 Test that a WebAssembly code returns a specific result (memory_copy64.wast:228) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:511:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #270 Test that a WebAssembly code returns a specific result (memory_copy64.wast:229) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:514:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #271 Test that a WebAssembly code returns a specific result (memory_copy64.wast:230) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:517:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #272 Test that a WebAssembly code returns a specific result (memory_copy64.wast:231) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:520:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #273 Test that a WebAssembly code returns a specific result (memory_copy64.wast:232) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:523:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #274 Test that a WebAssembly code returns a specific result (memory_copy64.wast:233) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:526:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #275 Test that a WebAssembly code returns a specific result (memory_copy64.wast:234) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:529:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #276 Test that a WebAssembly code returns a specific result (memory_copy64.wast:235) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:532:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #277 Test that a WebAssembly code returns a specific result (memory_copy64.wast:236) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:535:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #278 Test that a WebAssembly code returns a specific result (memory_copy64.wast:237) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:538:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #279 Test that a WebAssembly code returns a specific result (memory_copy64.wast:238) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:541:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #280 Test that a WebAssembly code returns a specific result (memory_copy64.wast:239) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:544:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #281 Test that a WebAssembly code returns a specific result (memory_copy64.wast:240) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:547:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #282 Test that a WebAssembly code returns a specific result (memory_copy64.wast:241) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:550:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #283 Test that a WebAssembly code returns a specific result (memory_copy64.wast:242) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:553:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #284 Test that a WebAssembly code returns a specific result (memory_copy64.wast:243) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:556:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #285 Test that a WebAssembly code returns a specific result (memory_copy64.wast:244) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:559:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #286 Test that a WebAssembly code returns a specific result (memory_copy64.wast:245) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:562:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #287 Test that a WebAssembly code returns a specific result (memory_copy64.wast:246) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:565:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #288 Test that a WebAssembly code returns a specific result (memory_copy64.wast:247) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:568:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #289 Test that a WebAssembly code returns a specific result (memory_copy64.wast:248) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:571:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #290 Test that a WebAssembly code returns a specific result (memory_copy64.wast:249) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:574:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #291 Test that a WebAssembly code returns a specific result (memory_copy64.wast:250) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:577:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #292 Test that a WebAssembly code returns a specific result (memory_copy64.wast:251) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:580:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #293 Test that a WebAssembly code returns a specific result (memory_copy64.wast:252) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:583:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #294 Test that a WebAssembly code returns a specific result (memory_copy64.wast:253) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:586:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #295 Test that a WebAssembly code returns a specific result (memory_copy64.wast:254) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:589:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #296 Test that a WebAssembly code returns a specific result (memory_copy64.wast:255) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:592:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #297 Test that a WebAssembly code returns a specific result (memory_copy64.wast:256) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:595:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #298 Test that WebAssembly compilation succeeds (memory_copy64.wast:258) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 40: Memory64 is not enabled at {loc} expected true got false
-FAIL #299 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:601:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #300 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:604:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #301 Test that a WebAssembly code returns a specific result (memory_copy64.wast:269) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:607:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #302 Test that a WebAssembly code returns a specific result (memory_copy64.wast:270) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:610:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #303 Test that a WebAssembly code returns a specific result (memory_copy64.wast:271) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:613:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #304 Test that a WebAssembly code returns a specific result (memory_copy64.wast:272) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:616:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #305 Test that a WebAssembly code returns a specific result (memory_copy64.wast:273) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:619:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #306 Test that a WebAssembly code returns a specific result (memory_copy64.wast:274) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:622:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #307 Test that a WebAssembly code returns a specific result (memory_copy64.wast:275) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:625:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #308 Test that a WebAssembly code returns a specific result (memory_copy64.wast:276) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:628:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #309 Test that a WebAssembly code returns a specific result (memory_copy64.wast:277) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:631:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #310 Test that a WebAssembly code returns a specific result (memory_copy64.wast:278) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:634:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #311 Test that a WebAssembly code returns a specific result (memory_copy64.wast:279) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:637:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #312 Test that a WebAssembly code returns a specific result (memory_copy64.wast:280) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:640:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #313 Test that a WebAssembly code returns a specific result (memory_copy64.wast:281) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:643:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #314 Test that a WebAssembly code returns a specific result (memory_copy64.wast:282) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:646:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #315 Test that a WebAssembly code returns a specific result (memory_copy64.wast:283) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:649:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #316 Test that a WebAssembly code returns a specific result (memory_copy64.wast:284) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:652:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #317 Test that a WebAssembly code returns a specific result (memory_copy64.wast:285) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:655:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #318 Test that a WebAssembly code returns a specific result (memory_copy64.wast:286) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:658:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #319 Test that a WebAssembly code returns a specific result (memory_copy64.wast:287) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:661:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #320 Test that a WebAssembly code returns a specific result (memory_copy64.wast:288) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:664:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #321 Test that a WebAssembly code returns a specific result (memory_copy64.wast:289) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:667:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #322 Test that a WebAssembly code returns a specific result (memory_copy64.wast:290) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:670:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #323 Test that a WebAssembly code returns a specific result (memory_copy64.wast:291) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:673:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #324 Test that a WebAssembly code returns a specific result (memory_copy64.wast:292) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:676:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #325 Test that a WebAssembly code returns a specific result (memory_copy64.wast:293) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:679:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #326 Test that a WebAssembly code returns a specific result (memory_copy64.wast:294) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:682:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #327 Test that a WebAssembly code returns a specific result (memory_copy64.wast:295) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:685:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #328 Test that a WebAssembly code returns a specific result (memory_copy64.wast:296) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:688:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #329 Test that a WebAssembly code returns a specific result (memory_copy64.wast:297) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:691:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #330 Test that a WebAssembly code returns a specific result (memory_copy64.wast:298) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:694:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #331 Test that WebAssembly compilation succeeds (memory_copy64.wast:300) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 40: Memory64 is not enabled at {loc} expected true got false
-FAIL #332 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:700:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #333 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:703:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #334 Test that a WebAssembly code returns a specific result (memory_copy64.wast:311) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:706:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #335 Test that a WebAssembly code returns a specific result (memory_copy64.wast:312) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:709:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #336 Test that a WebAssembly code returns a specific result (memory_copy64.wast:313) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:712:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #337 Test that a WebAssembly code returns a specific result (memory_copy64.wast:314) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:715:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #338 Test that a WebAssembly code returns a specific result (memory_copy64.wast:315) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:718:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #339 Test that a WebAssembly code returns a specific result (memory_copy64.wast:316) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:721:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #340 Test that a WebAssembly code returns a specific result (memory_copy64.wast:317) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:724:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #341 Test that a WebAssembly code returns a specific result (memory_copy64.wast:318) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:727:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #342 Test that a WebAssembly code returns a specific result (memory_copy64.wast:319) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:730:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #343 Test that a WebAssembly code returns a specific result (memory_copy64.wast:320) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:733:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #344 Test that a WebAssembly code returns a specific result (memory_copy64.wast:321) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:736:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #345 Test that a WebAssembly code returns a specific result (memory_copy64.wast:322) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:739:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #346 Test that a WebAssembly code returns a specific result (memory_copy64.wast:323) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:742:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #347 Test that a WebAssembly code returns a specific result (memory_copy64.wast:324) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:745:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #348 Test that a WebAssembly code returns a specific result (memory_copy64.wast:325) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:748:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #349 Test that a WebAssembly code returns a specific result (memory_copy64.wast:326) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:751:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #350 Test that a WebAssembly code returns a specific result (memory_copy64.wast:327) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:754:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #351 Test that a WebAssembly code returns a specific result (memory_copy64.wast:328) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:757:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #352 Test that a WebAssembly code returns a specific result (memory_copy64.wast:329) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:760:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #353 Test that a WebAssembly code returns a specific result (memory_copy64.wast:330) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:763:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #354 Test that a WebAssembly code returns a specific result (memory_copy64.wast:331) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:766:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #355 Test that a WebAssembly code returns a specific result (memory_copy64.wast:332) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:769:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #356 Test that a WebAssembly code returns a specific result (memory_copy64.wast:333) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:772:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #357 Test that a WebAssembly code returns a specific result (memory_copy64.wast:334) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:775:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #358 Test that a WebAssembly code returns a specific result (memory_copy64.wast:335) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:778:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #359 Test that a WebAssembly code returns a specific result (memory_copy64.wast:336) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:781:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #360 Test that a WebAssembly code returns a specific result (memory_copy64.wast:337) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:784:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #361 Test that a WebAssembly code returns a specific result (memory_copy64.wast:338) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:787:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #362 Test that a WebAssembly code returns a specific result (memory_copy64.wast:339) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:790:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #363 Test that a WebAssembly code returns a specific result (memory_copy64.wast:340) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:793:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
+PASS #100 Test that WebAssembly compilation succeeds (memory_copy64.wast:6)
+PASS #101 Test that WebAssembly instantiation succeeds (memory_copy64.wast:6)
+PASS #102 Run a WebAssembly test without special assertions (memory_copy64.wast:15)
+PASS #103 Test that a WebAssembly code returns a specific result (memory_copy64.wast:17)
+PASS #104 Test that a WebAssembly code returns a specific result (memory_copy64.wast:18)
+PASS #105 Test that a WebAssembly code returns a specific result (memory_copy64.wast:19)
+PASS #106 Test that a WebAssembly code returns a specific result (memory_copy64.wast:20)
+PASS #107 Test that a WebAssembly code returns a specific result (memory_copy64.wast:21)
+PASS #108 Test that a WebAssembly code returns a specific result (memory_copy64.wast:22)
+PASS #109 Test that a WebAssembly code returns a specific result (memory_copy64.wast:23)
+PASS #110 Test that a WebAssembly code returns a specific result (memory_copy64.wast:24)
+PASS #111 Test that a WebAssembly code returns a specific result (memory_copy64.wast:25)
+PASS #112 Test that a WebAssembly code returns a specific result (memory_copy64.wast:26)
+PASS #113 Test that a WebAssembly code returns a specific result (memory_copy64.wast:27)
+PASS #114 Test that a WebAssembly code returns a specific result (memory_copy64.wast:28)
+PASS #115 Test that a WebAssembly code returns a specific result (memory_copy64.wast:29)
+PASS #116 Test that a WebAssembly code returns a specific result (memory_copy64.wast:30)
+PASS #117 Test that a WebAssembly code returns a specific result (memory_copy64.wast:31)
+PASS #118 Test that a WebAssembly code returns a specific result (memory_copy64.wast:32)
+PASS #119 Test that a WebAssembly code returns a specific result (memory_copy64.wast:33)
+PASS #120 Test that a WebAssembly code returns a specific result (memory_copy64.wast:34)
+PASS #121 Test that a WebAssembly code returns a specific result (memory_copy64.wast:35)
+PASS #122 Test that a WebAssembly code returns a specific result (memory_copy64.wast:36)
+PASS #123 Test that a WebAssembly code returns a specific result (memory_copy64.wast:37)
+PASS #124 Test that a WebAssembly code returns a specific result (memory_copy64.wast:38)
+PASS #125 Test that a WebAssembly code returns a specific result (memory_copy64.wast:39)
+PASS #126 Test that a WebAssembly code returns a specific result (memory_copy64.wast:40)
+PASS #127 Test that a WebAssembly code returns a specific result (memory_copy64.wast:41)
+PASS #128 Test that a WebAssembly code returns a specific result (memory_copy64.wast:42)
+PASS #129 Test that a WebAssembly code returns a specific result (memory_copy64.wast:43)
+PASS #130 Test that a WebAssembly code returns a specific result (memory_copy64.wast:44)
+PASS #131 Test that a WebAssembly code returns a specific result (memory_copy64.wast:45)
+PASS #132 Test that a WebAssembly code returns a specific result (memory_copy64.wast:46)
+PASS #133 Test that WebAssembly compilation succeeds (memory_copy64.wast:48)
+PASS #134 Test that WebAssembly instantiation succeeds (memory_copy64.wast:48)
+PASS #135 Run a WebAssembly test without special assertions (memory_copy64.wast:57)
+PASS #136 Test that a WebAssembly code returns a specific result (memory_copy64.wast:59)
+PASS #137 Test that a WebAssembly code returns a specific result (memory_copy64.wast:60)
+PASS #138 Test that a WebAssembly code returns a specific result (memory_copy64.wast:61)
+PASS #139 Test that a WebAssembly code returns a specific result (memory_copy64.wast:62)
+PASS #140 Test that a WebAssembly code returns a specific result (memory_copy64.wast:63)
+PASS #141 Test that a WebAssembly code returns a specific result (memory_copy64.wast:64)
+PASS #142 Test that a WebAssembly code returns a specific result (memory_copy64.wast:65)
+PASS #143 Test that a WebAssembly code returns a specific result (memory_copy64.wast:66)
+PASS #144 Test that a WebAssembly code returns a specific result (memory_copy64.wast:67)
+PASS #145 Test that a WebAssembly code returns a specific result (memory_copy64.wast:68)
+PASS #146 Test that a WebAssembly code returns a specific result (memory_copy64.wast:69)
+PASS #147 Test that a WebAssembly code returns a specific result (memory_copy64.wast:70)
+PASS #148 Test that a WebAssembly code returns a specific result (memory_copy64.wast:71)
+PASS #149 Test that a WebAssembly code returns a specific result (memory_copy64.wast:72)
+PASS #150 Test that a WebAssembly code returns a specific result (memory_copy64.wast:73)
+PASS #151 Test that a WebAssembly code returns a specific result (memory_copy64.wast:74)
+PASS #152 Test that a WebAssembly code returns a specific result (memory_copy64.wast:75)
+PASS #153 Test that a WebAssembly code returns a specific result (memory_copy64.wast:76)
+PASS #154 Test that a WebAssembly code returns a specific result (memory_copy64.wast:77)
+PASS #155 Test that a WebAssembly code returns a specific result (memory_copy64.wast:78)
+PASS #156 Test that a WebAssembly code returns a specific result (memory_copy64.wast:79)
+PASS #157 Test that a WebAssembly code returns a specific result (memory_copy64.wast:80)
+PASS #158 Test that a WebAssembly code returns a specific result (memory_copy64.wast:81)
+PASS #159 Test that a WebAssembly code returns a specific result (memory_copy64.wast:82)
+PASS #160 Test that a WebAssembly code returns a specific result (memory_copy64.wast:83)
+PASS #161 Test that a WebAssembly code returns a specific result (memory_copy64.wast:84)
+PASS #162 Test that a WebAssembly code returns a specific result (memory_copy64.wast:85)
+PASS #163 Test that a WebAssembly code returns a specific result (memory_copy64.wast:86)
+PASS #164 Test that a WebAssembly code returns a specific result (memory_copy64.wast:87)
+PASS #165 Test that a WebAssembly code returns a specific result (memory_copy64.wast:88)
+PASS #166 Test that WebAssembly compilation succeeds (memory_copy64.wast:90)
+PASS #167 Test that WebAssembly instantiation succeeds (memory_copy64.wast:90)
+PASS #168 Run a WebAssembly test without special assertions (memory_copy64.wast:99)
+PASS #169 Test that a WebAssembly code returns a specific result (memory_copy64.wast:101)
+PASS #170 Test that a WebAssembly code returns a specific result (memory_copy64.wast:102)
+PASS #171 Test that a WebAssembly code returns a specific result (memory_copy64.wast:103)
+PASS #172 Test that a WebAssembly code returns a specific result (memory_copy64.wast:104)
+PASS #173 Test that a WebAssembly code returns a specific result (memory_copy64.wast:105)
+PASS #174 Test that a WebAssembly code returns a specific result (memory_copy64.wast:106)
+PASS #175 Test that a WebAssembly code returns a specific result (memory_copy64.wast:107)
+PASS #176 Test that a WebAssembly code returns a specific result (memory_copy64.wast:108)
+PASS #177 Test that a WebAssembly code returns a specific result (memory_copy64.wast:109)
+PASS #178 Test that a WebAssembly code returns a specific result (memory_copy64.wast:110)
+PASS #179 Test that a WebAssembly code returns a specific result (memory_copy64.wast:111)
+PASS #180 Test that a WebAssembly code returns a specific result (memory_copy64.wast:112)
+PASS #181 Test that a WebAssembly code returns a specific result (memory_copy64.wast:113)
+PASS #182 Test that a WebAssembly code returns a specific result (memory_copy64.wast:114)
+PASS #183 Test that a WebAssembly code returns a specific result (memory_copy64.wast:115)
+PASS #184 Test that a WebAssembly code returns a specific result (memory_copy64.wast:116)
+PASS #185 Test that a WebAssembly code returns a specific result (memory_copy64.wast:117)
+PASS #186 Test that a WebAssembly code returns a specific result (memory_copy64.wast:118)
+PASS #187 Test that a WebAssembly code returns a specific result (memory_copy64.wast:119)
+PASS #188 Test that a WebAssembly code returns a specific result (memory_copy64.wast:120)
+PASS #189 Test that a WebAssembly code returns a specific result (memory_copy64.wast:121)
+PASS #190 Test that a WebAssembly code returns a specific result (memory_copy64.wast:122)
+PASS #191 Test that a WebAssembly code returns a specific result (memory_copy64.wast:123)
+PASS #192 Test that a WebAssembly code returns a specific result (memory_copy64.wast:124)
+PASS #193 Test that a WebAssembly code returns a specific result (memory_copy64.wast:125)
+PASS #194 Test that a WebAssembly code returns a specific result (memory_copy64.wast:126)
+PASS #195 Test that a WebAssembly code returns a specific result (memory_copy64.wast:127)
+PASS #196 Test that a WebAssembly code returns a specific result (memory_copy64.wast:128)
+PASS #197 Test that a WebAssembly code returns a specific result (memory_copy64.wast:129)
+PASS #198 Test that a WebAssembly code returns a specific result (memory_copy64.wast:130)
+PASS #199 Test that WebAssembly compilation succeeds (memory_copy64.wast:132)
+PASS #200 Test that WebAssembly instantiation succeeds (memory_copy64.wast:132)
+PASS #201 Run a WebAssembly test without special assertions (memory_copy64.wast:141)
+PASS #202 Test that a WebAssembly code returns a specific result (memory_copy64.wast:143)
+PASS #203 Test that a WebAssembly code returns a specific result (memory_copy64.wast:144)
+PASS #204 Test that a WebAssembly code returns a specific result (memory_copy64.wast:145)
+PASS #205 Test that a WebAssembly code returns a specific result (memory_copy64.wast:146)
+PASS #206 Test that a WebAssembly code returns a specific result (memory_copy64.wast:147)
+PASS #207 Test that a WebAssembly code returns a specific result (memory_copy64.wast:148)
+PASS #208 Test that a WebAssembly code returns a specific result (memory_copy64.wast:149)
+PASS #209 Test that a WebAssembly code returns a specific result (memory_copy64.wast:150)
+PASS #210 Test that a WebAssembly code returns a specific result (memory_copy64.wast:151)
+PASS #211 Test that a WebAssembly code returns a specific result (memory_copy64.wast:152)
+PASS #212 Test that a WebAssembly code returns a specific result (memory_copy64.wast:153)
+PASS #213 Test that a WebAssembly code returns a specific result (memory_copy64.wast:154)
+PASS #214 Test that a WebAssembly code returns a specific result (memory_copy64.wast:155)
+PASS #215 Test that a WebAssembly code returns a specific result (memory_copy64.wast:156)
+PASS #216 Test that a WebAssembly code returns a specific result (memory_copy64.wast:157)
+PASS #217 Test that a WebAssembly code returns a specific result (memory_copy64.wast:158)
+PASS #218 Test that a WebAssembly code returns a specific result (memory_copy64.wast:159)
+PASS #219 Test that a WebAssembly code returns a specific result (memory_copy64.wast:160)
+PASS #220 Test that a WebAssembly code returns a specific result (memory_copy64.wast:161)
+PASS #221 Test that a WebAssembly code returns a specific result (memory_copy64.wast:162)
+PASS #222 Test that a WebAssembly code returns a specific result (memory_copy64.wast:163)
+PASS #223 Test that a WebAssembly code returns a specific result (memory_copy64.wast:164)
+PASS #224 Test that a WebAssembly code returns a specific result (memory_copy64.wast:165)
+PASS #225 Test that a WebAssembly code returns a specific result (memory_copy64.wast:166)
+PASS #226 Test that a WebAssembly code returns a specific result (memory_copy64.wast:167)
+PASS #227 Test that a WebAssembly code returns a specific result (memory_copy64.wast:168)
+PASS #228 Test that a WebAssembly code returns a specific result (memory_copy64.wast:169)
+PASS #229 Test that a WebAssembly code returns a specific result (memory_copy64.wast:170)
+PASS #230 Test that a WebAssembly code returns a specific result (memory_copy64.wast:171)
+PASS #231 Test that a WebAssembly code returns a specific result (memory_copy64.wast:172)
+PASS #232 Test that WebAssembly compilation succeeds (memory_copy64.wast:174)
+PASS #233 Test that WebAssembly instantiation succeeds (memory_copy64.wast:174)
+PASS #234 Run a WebAssembly test without special assertions (memory_copy64.wast:183)
+PASS #235 Test that a WebAssembly code returns a specific result (memory_copy64.wast:185)
+PASS #236 Test that a WebAssembly code returns a specific result (memory_copy64.wast:186)
+PASS #237 Test that a WebAssembly code returns a specific result (memory_copy64.wast:187)
+PASS #238 Test that a WebAssembly code returns a specific result (memory_copy64.wast:188)
+PASS #239 Test that a WebAssembly code returns a specific result (memory_copy64.wast:189)
+PASS #240 Test that a WebAssembly code returns a specific result (memory_copy64.wast:190)
+PASS #241 Test that a WebAssembly code returns a specific result (memory_copy64.wast:191)
+PASS #242 Test that a WebAssembly code returns a specific result (memory_copy64.wast:192)
+PASS #243 Test that a WebAssembly code returns a specific result (memory_copy64.wast:193)
+PASS #244 Test that a WebAssembly code returns a specific result (memory_copy64.wast:194)
+PASS #245 Test that a WebAssembly code returns a specific result (memory_copy64.wast:195)
+PASS #246 Test that a WebAssembly code returns a specific result (memory_copy64.wast:196)
+PASS #247 Test that a WebAssembly code returns a specific result (memory_copy64.wast:197)
+PASS #248 Test that a WebAssembly code returns a specific result (memory_copy64.wast:198)
+PASS #249 Test that a WebAssembly code returns a specific result (memory_copy64.wast:199)
+PASS #250 Test that a WebAssembly code returns a specific result (memory_copy64.wast:200)
+PASS #251 Test that a WebAssembly code returns a specific result (memory_copy64.wast:201)
+PASS #252 Test that a WebAssembly code returns a specific result (memory_copy64.wast:202)
+PASS #253 Test that a WebAssembly code returns a specific result (memory_copy64.wast:203)
+PASS #254 Test that a WebAssembly code returns a specific result (memory_copy64.wast:204)
+PASS #255 Test that a WebAssembly code returns a specific result (memory_copy64.wast:205)
+PASS #256 Test that a WebAssembly code returns a specific result (memory_copy64.wast:206)
+PASS #257 Test that a WebAssembly code returns a specific result (memory_copy64.wast:207)
+PASS #258 Test that a WebAssembly code returns a specific result (memory_copy64.wast:208)
+PASS #259 Test that a WebAssembly code returns a specific result (memory_copy64.wast:209)
+PASS #260 Test that a WebAssembly code returns a specific result (memory_copy64.wast:210)
+PASS #261 Test that a WebAssembly code returns a specific result (memory_copy64.wast:211)
+PASS #262 Test that a WebAssembly code returns a specific result (memory_copy64.wast:212)
+PASS #263 Test that a WebAssembly code returns a specific result (memory_copy64.wast:213)
+PASS #264 Test that a WebAssembly code returns a specific result (memory_copy64.wast:214)
+PASS #265 Test that WebAssembly compilation succeeds (memory_copy64.wast:216)
+PASS #266 Test that WebAssembly instantiation succeeds (memory_copy64.wast:216)
+PASS #267 Run a WebAssembly test without special assertions (memory_copy64.wast:225)
+PASS #268 Test that a WebAssembly code returns a specific result (memory_copy64.wast:227)
+PASS #269 Test that a WebAssembly code returns a specific result (memory_copy64.wast:228)
+PASS #270 Test that a WebAssembly code returns a specific result (memory_copy64.wast:229)
+PASS #271 Test that a WebAssembly code returns a specific result (memory_copy64.wast:230)
+PASS #272 Test that a WebAssembly code returns a specific result (memory_copy64.wast:231)
+PASS #273 Test that a WebAssembly code returns a specific result (memory_copy64.wast:232)
+PASS #274 Test that a WebAssembly code returns a specific result (memory_copy64.wast:233)
+PASS #275 Test that a WebAssembly code returns a specific result (memory_copy64.wast:234)
+PASS #276 Test that a WebAssembly code returns a specific result (memory_copy64.wast:235)
+PASS #277 Test that a WebAssembly code returns a specific result (memory_copy64.wast:236)
+PASS #278 Test that a WebAssembly code returns a specific result (memory_copy64.wast:237)
+PASS #279 Test that a WebAssembly code returns a specific result (memory_copy64.wast:238)
+PASS #280 Test that a WebAssembly code returns a specific result (memory_copy64.wast:239)
+PASS #281 Test that a WebAssembly code returns a specific result (memory_copy64.wast:240)
+PASS #282 Test that a WebAssembly code returns a specific result (memory_copy64.wast:241)
+PASS #283 Test that a WebAssembly code returns a specific result (memory_copy64.wast:242)
+PASS #284 Test that a WebAssembly code returns a specific result (memory_copy64.wast:243)
+PASS #285 Test that a WebAssembly code returns a specific result (memory_copy64.wast:244)
+PASS #286 Test that a WebAssembly code returns a specific result (memory_copy64.wast:245)
+PASS #287 Test that a WebAssembly code returns a specific result (memory_copy64.wast:246)
+PASS #288 Test that a WebAssembly code returns a specific result (memory_copy64.wast:247)
+PASS #289 Test that a WebAssembly code returns a specific result (memory_copy64.wast:248)
+PASS #290 Test that a WebAssembly code returns a specific result (memory_copy64.wast:249)
+PASS #291 Test that a WebAssembly code returns a specific result (memory_copy64.wast:250)
+PASS #292 Test that a WebAssembly code returns a specific result (memory_copy64.wast:251)
+PASS #293 Test that a WebAssembly code returns a specific result (memory_copy64.wast:252)
+PASS #294 Test that a WebAssembly code returns a specific result (memory_copy64.wast:253)
+PASS #295 Test that a WebAssembly code returns a specific result (memory_copy64.wast:254)
+PASS #296 Test that a WebAssembly code returns a specific result (memory_copy64.wast:255)
+PASS #297 Test that a WebAssembly code returns a specific result (memory_copy64.wast:256)
+PASS #298 Test that WebAssembly compilation succeeds (memory_copy64.wast:258)
+PASS #299 Test that WebAssembly instantiation succeeds (memory_copy64.wast:258)
+PASS #300 Run a WebAssembly test without special assertions (memory_copy64.wast:267)
+PASS #301 Test that a WebAssembly code returns a specific result (memory_copy64.wast:269)
+PASS #302 Test that a WebAssembly code returns a specific result (memory_copy64.wast:270)
+PASS #303 Test that a WebAssembly code returns a specific result (memory_copy64.wast:271)
+PASS #304 Test that a WebAssembly code returns a specific result (memory_copy64.wast:272)
+PASS #305 Test that a WebAssembly code returns a specific result (memory_copy64.wast:273)
+PASS #306 Test that a WebAssembly code returns a specific result (memory_copy64.wast:274)
+PASS #307 Test that a WebAssembly code returns a specific result (memory_copy64.wast:275)
+PASS #308 Test that a WebAssembly code returns a specific result (memory_copy64.wast:276)
+PASS #309 Test that a WebAssembly code returns a specific result (memory_copy64.wast:277)
+PASS #310 Test that a WebAssembly code returns a specific result (memory_copy64.wast:278)
+PASS #311 Test that a WebAssembly code returns a specific result (memory_copy64.wast:279)
+PASS #312 Test that a WebAssembly code returns a specific result (memory_copy64.wast:280)
+PASS #313 Test that a WebAssembly code returns a specific result (memory_copy64.wast:281)
+PASS #314 Test that a WebAssembly code returns a specific result (memory_copy64.wast:282)
+PASS #315 Test that a WebAssembly code returns a specific result (memory_copy64.wast:283)
+PASS #316 Test that a WebAssembly code returns a specific result (memory_copy64.wast:284)
+PASS #317 Test that a WebAssembly code returns a specific result (memory_copy64.wast:285)
+PASS #318 Test that a WebAssembly code returns a specific result (memory_copy64.wast:286)
+PASS #319 Test that a WebAssembly code returns a specific result (memory_copy64.wast:287)
+PASS #320 Test that a WebAssembly code returns a specific result (memory_copy64.wast:288)
+PASS #321 Test that a WebAssembly code returns a specific result (memory_copy64.wast:289)
+PASS #322 Test that a WebAssembly code returns a specific result (memory_copy64.wast:290)
+PASS #323 Test that a WebAssembly code returns a specific result (memory_copy64.wast:291)
+PASS #324 Test that a WebAssembly code returns a specific result (memory_copy64.wast:292)
+PASS #325 Test that a WebAssembly code returns a specific result (memory_copy64.wast:293)
+PASS #326 Test that a WebAssembly code returns a specific result (memory_copy64.wast:294)
+PASS #327 Test that a WebAssembly code returns a specific result (memory_copy64.wast:295)
+PASS #328 Test that a WebAssembly code returns a specific result (memory_copy64.wast:296)
+PASS #329 Test that a WebAssembly code returns a specific result (memory_copy64.wast:297)
+PASS #330 Test that a WebAssembly code returns a specific result (memory_copy64.wast:298)
+PASS #331 Test that WebAssembly compilation succeeds (memory_copy64.wast:300)
+PASS #332 Test that WebAssembly instantiation succeeds (memory_copy64.wast:300)
+PASS #333 Run a WebAssembly test without special assertions (memory_copy64.wast:309)
+PASS #334 Test that a WebAssembly code returns a specific result (memory_copy64.wast:311)
+PASS #335 Test that a WebAssembly code returns a specific result (memory_copy64.wast:312)
+PASS #336 Test that a WebAssembly code returns a specific result (memory_copy64.wast:313)
+PASS #337 Test that a WebAssembly code returns a specific result (memory_copy64.wast:314)
+PASS #338 Test that a WebAssembly code returns a specific result (memory_copy64.wast:315)
+PASS #339 Test that a WebAssembly code returns a specific result (memory_copy64.wast:316)
+PASS #340 Test that a WebAssembly code returns a specific result (memory_copy64.wast:317)
+PASS #341 Test that a WebAssembly code returns a specific result (memory_copy64.wast:318)
+PASS #342 Test that a WebAssembly code returns a specific result (memory_copy64.wast:319)
+PASS #343 Test that a WebAssembly code returns a specific result (memory_copy64.wast:320)
+PASS #344 Test that a WebAssembly code returns a specific result (memory_copy64.wast:321)
+PASS #345 Test that a WebAssembly code returns a specific result (memory_copy64.wast:322)
+PASS #346 Test that a WebAssembly code returns a specific result (memory_copy64.wast:323)
+PASS #347 Test that a WebAssembly code returns a specific result (memory_copy64.wast:324)
+PASS #348 Test that a WebAssembly code returns a specific result (memory_copy64.wast:325)
+PASS #349 Test that a WebAssembly code returns a specific result (memory_copy64.wast:326)
+PASS #350 Test that a WebAssembly code returns a specific result (memory_copy64.wast:327)
+PASS #351 Test that a WebAssembly code returns a specific result (memory_copy64.wast:328)
+PASS #352 Test that a WebAssembly code returns a specific result (memory_copy64.wast:329)
+PASS #353 Test that a WebAssembly code returns a specific result (memory_copy64.wast:330)
+PASS #354 Test that a WebAssembly code returns a specific result (memory_copy64.wast:331)
+PASS #355 Test that a WebAssembly code returns a specific result (memory_copy64.wast:332)
+PASS #356 Test that a WebAssembly code returns a specific result (memory_copy64.wast:333)
+PASS #357 Test that a WebAssembly code returns a specific result (memory_copy64.wast:334)
+PASS #358 Test that a WebAssembly code returns a specific result (memory_copy64.wast:335)
+PASS #359 Test that a WebAssembly code returns a specific result (memory_copy64.wast:336)
+PASS #360 Test that a WebAssembly code returns a specific result (memory_copy64.wast:337)
+PASS #361 Test that a WebAssembly code returns a specific result (memory_copy64.wast:338)
+PASS #362 Test that a WebAssembly code returns a specific result (memory_copy64.wast:339)
+PASS #363 Test that a WebAssembly code returns a specific result (memory_copy64.wast:340)
 PASS #364 Test that WebAssembly compilation succeeds (memory_copy64.wast:342)
 PASS #365 Test that WebAssembly instantiation succeeds (memory_copy64.wast:342)
 PASS #366 Test that a WebAssembly code traps (memory_copy64.wast:350)
@@ -4812,819 +4300,285 @@ PASS #4298 Test that WebAssembly compilation fails (memory_copy64.wast:4734)
 PASS #4299 Test that WebAssembly compilation fails (memory_copy64.wast:4741)
 PASS #4300 Test that WebAssembly compilation fails (memory_copy64.wast:4748)
 PASS #4301 Test that WebAssembly compilation fails (memory_copy64.wast:4755)
-FAIL #4302 Test that WebAssembly compilation succeeds (memory_copy64.wast:4763) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 42: Memory64 is not enabled at {loc} expected true got false
-FAIL #4303 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12613:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4304 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12616:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4305 Test that a WebAssembly code returns a specific result (memory_copy64.wast:4782) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12619:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4306 Test that a WebAssembly code returns a specific result (memory_copy64.wast:4784) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12622:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4307 Test that a WebAssembly code returns a specific result (memory_copy64.wast:4786) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12625:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4308 Test that WebAssembly compilation succeeds (memory_copy64.wast:4789) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 42: Memory64 is not enabled at {loc} expected true got false
-FAIL #4309 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12631:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4310 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12634:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4311 Test that a WebAssembly code returns a specific result (memory_copy64.wast:4808) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12637:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4312 Test that a WebAssembly code returns a specific result (memory_copy64.wast:4810) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12640:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4313 Test that a WebAssembly code returns a specific result (memory_copy64.wast:4812) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12643:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4314 Test that WebAssembly compilation succeeds (memory_copy64.wast:4815) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 34: Memory64 is not enabled at {loc} expected true got false
-FAIL #4315 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12649:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4316 Test that a WebAssembly code traps (memory_copy64.wast:4819) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12652:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4317 Test that WebAssembly compilation succeeds (memory_copy64.wast:4821) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 34: Memory64 is not enabled at {loc} expected true got false
-FAIL #4318 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12658:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4319 Test that a WebAssembly code traps (memory_copy64.wast:4825) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12661:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4320 Test that WebAssembly compilation succeeds (memory_copy64.wast:4827) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 34: Memory64 is not enabled at {loc} expected true got false
-FAIL #4321 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12667:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4322 Test that a WebAssembly code traps (memory_copy64.wast:4831) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12670:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4323 Test that WebAssembly compilation succeeds (memory_copy64.wast:4833) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 34: Memory64 is not enabled at {loc} expected true got false
-FAIL #4324 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12676:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4325 Test that a WebAssembly code traps (memory_copy64.wast:4837) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12679:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4326 Test that WebAssembly compilation succeeds (memory_copy64.wast:4839) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 42: Memory64 is not enabled at {loc} expected true got false
-FAIL #4327 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12685:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4328 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12688:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4329 Test that a WebAssembly code returns a specific result (memory_copy64.wast:4859) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12691:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4330 Test that a WebAssembly code returns a specific result (memory_copy64.wast:4861) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12694:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4331 Test that WebAssembly compilation succeeds (memory_copy64.wast:4863) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 34: Memory64 is not enabled at {loc} expected true got false
-FAIL #4332 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12700:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4333 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12703:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4334 Test that WebAssembly compilation succeeds (memory_copy64.wast:4869) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 34: Memory64 is not enabled at {loc} expected true got false
-FAIL #4335 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12709:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4336 Test that a WebAssembly code traps (memory_copy64.wast:4873) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12712:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4337 Test that WebAssembly compilation succeeds (memory_copy64.wast:4875) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 34: Memory64 is not enabled at {loc} expected true got false
-FAIL #4338 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12718:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4339 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12721:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4340 Test that WebAssembly compilation succeeds (memory_copy64.wast:4881) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 34: Memory64 is not enabled at {loc} expected true got false
-FAIL #4341 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12727:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4342 Test that a WebAssembly code traps (memory_copy64.wast:4885) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12730:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4343 Test that WebAssembly compilation succeeds (memory_copy64.wast:4887) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 34: Memory64 is not enabled at {loc} expected true got false
-FAIL #4344 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12736:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4345 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12739:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4346 Test that WebAssembly compilation succeeds (memory_copy64.wast:4893) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 34: Memory64 is not enabled at {loc} expected true got false
-FAIL #4347 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12745:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4348 Test that a WebAssembly code traps (memory_copy64.wast:4897) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12748:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4349 Test that WebAssembly compilation succeeds (memory_copy64.wast:4899) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 42: Memory64 is not enabled at {loc} expected true got false
-FAIL #4350 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12754:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4351 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12757:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4352 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5117) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12760:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4353 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5119) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12763:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4354 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5121) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12766:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4355 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5123) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12769:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4356 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5125) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12772:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4357 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5127) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12775:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4358 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5129) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12778:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4359 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5131) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12781:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4360 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5133) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12784:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4361 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5135) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12787:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4362 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5137) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12790:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4363 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5139) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12793:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4364 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5141) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12796:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4365 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5143) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12799:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4366 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5145) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12802:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4367 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5147) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12805:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4368 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5149) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12808:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4369 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5151) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12811:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4370 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5153) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12814:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4371 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5155) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12817:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4372 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5157) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12820:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4373 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5159) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12823:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4374 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5161) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12826:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4375 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5163) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12829:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4376 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5165) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12832:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4377 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5167) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12835:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4378 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5169) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12838:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4379 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5171) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12841:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4380 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5173) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12844:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4381 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5175) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12847:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4382 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5177) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12850:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4383 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5179) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12853:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4384 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5181) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12856:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4385 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5183) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12859:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4386 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5185) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12862:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4387 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5187) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12865:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4388 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5189) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12868:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4389 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5191) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12871:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4390 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5193) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12874:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4391 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5195) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12877:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4392 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5197) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12880:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4393 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5199) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12883:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4394 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5201) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12886:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4395 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5203) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12889:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4396 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5205) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12892:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4397 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5207) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12895:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4398 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5209) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12898:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4399 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5211) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12901:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4400 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5213) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12904:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4401 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5215) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12907:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4402 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5217) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12910:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4403 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5219) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12913:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4404 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5221) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12916:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4405 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5223) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12919:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4406 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5225) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12922:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4407 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5227) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12925:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4408 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5229) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12928:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4409 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5231) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12931:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4410 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5233) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12934:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4411 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5235) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12937:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4412 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5237) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12940:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4413 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5239) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12943:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4414 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5241) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12946:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4415 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5243) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12949:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4416 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5245) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12952:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4417 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5247) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12955:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4418 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5249) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12958:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4419 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5251) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12961:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4420 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5253) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12964:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4421 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5255) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12967:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4422 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5257) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12970:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4423 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5259) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12973:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4424 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5261) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12976:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4425 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5263) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12979:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4426 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5265) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12982:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4427 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5267) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12985:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4428 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5269) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12988:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4429 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5271) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12991:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4430 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5273) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12994:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4431 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5275) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:12997:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4432 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5277) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13000:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4433 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5279) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13003:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4434 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5281) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13006:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4435 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5283) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13009:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4436 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5285) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13012:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4437 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5287) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13015:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4438 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5289) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13018:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4439 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5291) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13021:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4440 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5293) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13024:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4441 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5295) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13027:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4442 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5297) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13030:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4443 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5299) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13033:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4444 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5301) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13036:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4445 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5303) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13039:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4446 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5305) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13042:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4447 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5307) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13045:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4448 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5309) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13048:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4449 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5311) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13051:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4450 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5313) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13054:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4451 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5315) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13057:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4452 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5317) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13060:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4453 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5319) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13063:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4454 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5321) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13066:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4455 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5323) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13069:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4456 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5325) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13072:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4457 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5327) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13075:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4458 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5329) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13078:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4459 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5331) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13081:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4460 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5333) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13084:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4461 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5335) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13087:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4462 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5337) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13090:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4463 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5339) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13093:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4464 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5341) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13096:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4465 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5343) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13099:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4466 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5345) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13102:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4467 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5347) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13105:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4468 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5349) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13108:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4469 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5351) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13111:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4470 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5353) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13114:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4471 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5355) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13117:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4472 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5357) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13120:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4473 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5359) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13123:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4474 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5361) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13126:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4475 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5363) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13129:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4476 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5365) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13132:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4477 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5367) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13135:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4478 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5369) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13138:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4479 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5371) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13141:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4480 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5373) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13144:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4481 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5375) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13147:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4482 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5377) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13150:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4483 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5379) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13153:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4484 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5381) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13156:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4485 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5383) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13159:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4486 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5385) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13162:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4487 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5387) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13165:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4488 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5389) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13168:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4489 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5391) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13171:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4490 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5393) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13174:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4491 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5395) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13177:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4492 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5397) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13180:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4493 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5399) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13183:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4494 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5401) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13186:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4495 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5403) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13189:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4496 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5405) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13192:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4497 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5407) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13195:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4498 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5409) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13198:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4499 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5411) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13201:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4500 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5413) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13204:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4501 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5415) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13207:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4502 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5417) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13210:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4503 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5419) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13213:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4504 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5421) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13216:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4505 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5423) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13219:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4506 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5425) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13222:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4507 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5427) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13225:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4508 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5429) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13228:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4509 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5431) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13231:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4510 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5433) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13234:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4511 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5435) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13237:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4512 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5437) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13240:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4513 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5439) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13243:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4514 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5441) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13246:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4515 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5443) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13249:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4516 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5445) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13252:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4517 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5447) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13255:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4518 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5449) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13258:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4519 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5451) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13261:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4520 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5453) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13264:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4521 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5455) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13267:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4522 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5457) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13270:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4523 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5459) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13273:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4524 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5461) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13276:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4525 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5463) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13279:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4526 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5465) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13282:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4527 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5467) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13285:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4528 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5469) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13288:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4529 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5471) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13291:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4530 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5473) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13294:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4531 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5475) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13297:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4532 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5477) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13300:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4533 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5479) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13303:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4534 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5481) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13306:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4535 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5483) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13309:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4536 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5485) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13312:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4537 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5487) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13315:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4538 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5489) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13318:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4539 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5491) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13321:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4540 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5493) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13324:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4541 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5495) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13327:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4542 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5497) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13330:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4543 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5499) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13333:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4544 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5501) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13336:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4545 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5503) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13339:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4546 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5505) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13342:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4547 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5507) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13345:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4548 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5509) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13348:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4549 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5511) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13351:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4550 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5513) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13354:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4551 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5515) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13357:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4552 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5517) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13360:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4553 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5519) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13363:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4554 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5521) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13366:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4555 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5523) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13369:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4556 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5525) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13372:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4557 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5527) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13375:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4558 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5529) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13378:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4559 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5531) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13381:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4560 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5533) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13384:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4561 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5535) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13387:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4562 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5537) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13390:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4563 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5539) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13393:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4564 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5541) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13396:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4565 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5543) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13399:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4566 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5545) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13402:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4567 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5547) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13405:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4568 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5549) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13408:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4569 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5551) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13411:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4570 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5553) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13414:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4571 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5555) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13417:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4572 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5557) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13420:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4573 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5559) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13423:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4574 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5561) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13426:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4575 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5563) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13429:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4576 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5565) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13432:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4577 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5567) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13435:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4578 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5569) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13438:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4579 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5571) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13441:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4580 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5573) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13444:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4581 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5575) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13447:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #4582 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5577) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13450:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
+PASS #4302 Test that WebAssembly compilation succeeds (memory_copy64.wast:4763)
+PASS #4303 Test that WebAssembly instantiation succeeds (memory_copy64.wast:4763)
+PASS #4304 Run a WebAssembly test without special assertions (memory_copy64.wast:4780)
+PASS #4305 Test that a WebAssembly code returns a specific result (memory_copy64.wast:4782)
+PASS #4306 Test that a WebAssembly code returns a specific result (memory_copy64.wast:4784)
+PASS #4307 Test that a WebAssembly code returns a specific result (memory_copy64.wast:4786)
+PASS #4308 Test that WebAssembly compilation succeeds (memory_copy64.wast:4789)
+PASS #4309 Test that WebAssembly instantiation succeeds (memory_copy64.wast:4789)
+PASS #4310 Run a WebAssembly test without special assertions (memory_copy64.wast:4806)
+PASS #4311 Test that a WebAssembly code returns a specific result (memory_copy64.wast:4808)
+PASS #4312 Test that a WebAssembly code returns a specific result (memory_copy64.wast:4810)
+PASS #4313 Test that a WebAssembly code returns a specific result (memory_copy64.wast:4812)
+PASS #4314 Test that WebAssembly compilation succeeds (memory_copy64.wast:4815)
+PASS #4315 Test that WebAssembly instantiation succeeds (memory_copy64.wast:4815)
+PASS #4316 Test that a WebAssembly code traps (memory_copy64.wast:4819)
+PASS #4317 Test that WebAssembly compilation succeeds (memory_copy64.wast:4821)
+PASS #4318 Test that WebAssembly instantiation succeeds (memory_copy64.wast:4821)
+PASS #4319 Test that a WebAssembly code traps (memory_copy64.wast:4825)
+PASS #4320 Test that WebAssembly compilation succeeds (memory_copy64.wast:4827)
+PASS #4321 Test that WebAssembly instantiation succeeds (memory_copy64.wast:4827)
+PASS #4322 Test that a WebAssembly code traps (memory_copy64.wast:4831)
+PASS #4323 Test that WebAssembly compilation succeeds (memory_copy64.wast:4833)
+PASS #4324 Test that WebAssembly instantiation succeeds (memory_copy64.wast:4833)
+PASS #4325 Test that a WebAssembly code traps (memory_copy64.wast:4837)
+PASS #4326 Test that WebAssembly compilation succeeds (memory_copy64.wast:4839)
+PASS #4327 Test that WebAssembly instantiation succeeds (memory_copy64.wast:4839)
+PASS #4328 Run a WebAssembly test without special assertions (memory_copy64.wast:4857)
+PASS #4329 Test that a WebAssembly code returns a specific result (memory_copy64.wast:4859)
+PASS #4330 Test that a WebAssembly code returns a specific result (memory_copy64.wast:4861)
+PASS #4331 Test that WebAssembly compilation succeeds (memory_copy64.wast:4863)
+PASS #4332 Test that WebAssembly instantiation succeeds (memory_copy64.wast:4863)
+PASS #4333 Run a WebAssembly test without special assertions (memory_copy64.wast:4867)
+PASS #4334 Test that WebAssembly compilation succeeds (memory_copy64.wast:4869)
+PASS #4335 Test that WebAssembly instantiation succeeds (memory_copy64.wast:4869)
+PASS #4336 Test that a WebAssembly code traps (memory_copy64.wast:4873)
+PASS #4337 Test that WebAssembly compilation succeeds (memory_copy64.wast:4875)
+PASS #4338 Test that WebAssembly instantiation succeeds (memory_copy64.wast:4875)
+PASS #4339 Run a WebAssembly test without special assertions (memory_copy64.wast:4879)
+PASS #4340 Test that WebAssembly compilation succeeds (memory_copy64.wast:4881)
+PASS #4341 Test that WebAssembly instantiation succeeds (memory_copy64.wast:4881)
+PASS #4342 Test that a WebAssembly code traps (memory_copy64.wast:4885)
+PASS #4343 Test that WebAssembly compilation succeeds (memory_copy64.wast:4887)
+PASS #4344 Test that WebAssembly instantiation succeeds (memory_copy64.wast:4887)
+PASS #4345 Run a WebAssembly test without special assertions (memory_copy64.wast:4891)
+PASS #4346 Test that WebAssembly compilation succeeds (memory_copy64.wast:4893)
+PASS #4347 Test that WebAssembly instantiation succeeds (memory_copy64.wast:4893)
+PASS #4348 Test that a WebAssembly code traps (memory_copy64.wast:4897)
+PASS #4349 Test that WebAssembly compilation succeeds (memory_copy64.wast:4899)
+PASS #4350 Test that WebAssembly instantiation succeeds (memory_copy64.wast:4899)
+PASS #4351 Run a WebAssembly test without special assertions (memory_copy64.wast:5115)
+PASS #4352 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5117)
+PASS #4353 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5119)
+PASS #4354 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5121)
+PASS #4355 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5123)
+PASS #4356 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5125)
+PASS #4357 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5127)
+PASS #4358 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5129)
+PASS #4359 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5131)
+PASS #4360 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5133)
+PASS #4361 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5135)
+PASS #4362 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5137)
+PASS #4363 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5139)
+PASS #4364 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5141)
+PASS #4365 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5143)
+PASS #4366 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5145)
+PASS #4367 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5147)
+PASS #4368 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5149)
+PASS #4369 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5151)
+PASS #4370 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5153)
+PASS #4371 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5155)
+PASS #4372 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5157)
+PASS #4373 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5159)
+PASS #4374 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5161)
+PASS #4375 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5163)
+PASS #4376 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5165)
+PASS #4377 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5167)
+PASS #4378 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5169)
+PASS #4379 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5171)
+PASS #4380 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5173)
+PASS #4381 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5175)
+PASS #4382 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5177)
+PASS #4383 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5179)
+PASS #4384 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5181)
+PASS #4385 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5183)
+PASS #4386 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5185)
+PASS #4387 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5187)
+PASS #4388 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5189)
+PASS #4389 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5191)
+PASS #4390 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5193)
+PASS #4391 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5195)
+PASS #4392 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5197)
+PASS #4393 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5199)
+PASS #4394 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5201)
+PASS #4395 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5203)
+PASS #4396 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5205)
+PASS #4397 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5207)
+PASS #4398 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5209)
+PASS #4399 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5211)
+PASS #4400 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5213)
+PASS #4401 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5215)
+PASS #4402 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5217)
+PASS #4403 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5219)
+PASS #4404 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5221)
+PASS #4405 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5223)
+PASS #4406 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5225)
+PASS #4407 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5227)
+PASS #4408 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5229)
+PASS #4409 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5231)
+PASS #4410 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5233)
+PASS #4411 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5235)
+PASS #4412 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5237)
+PASS #4413 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5239)
+PASS #4414 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5241)
+PASS #4415 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5243)
+PASS #4416 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5245)
+PASS #4417 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5247)
+PASS #4418 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5249)
+PASS #4419 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5251)
+PASS #4420 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5253)
+PASS #4421 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5255)
+PASS #4422 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5257)
+PASS #4423 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5259)
+PASS #4424 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5261)
+PASS #4425 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5263)
+PASS #4426 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5265)
+PASS #4427 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5267)
+PASS #4428 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5269)
+PASS #4429 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5271)
+PASS #4430 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5273)
+PASS #4431 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5275)
+PASS #4432 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5277)
+PASS #4433 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5279)
+PASS #4434 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5281)
+PASS #4435 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5283)
+PASS #4436 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5285)
+PASS #4437 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5287)
+PASS #4438 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5289)
+PASS #4439 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5291)
+PASS #4440 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5293)
+PASS #4441 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5295)
+PASS #4442 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5297)
+PASS #4443 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5299)
+PASS #4444 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5301)
+PASS #4445 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5303)
+PASS #4446 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5305)
+PASS #4447 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5307)
+PASS #4448 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5309)
+PASS #4449 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5311)
+PASS #4450 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5313)
+PASS #4451 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5315)
+PASS #4452 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5317)
+PASS #4453 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5319)
+PASS #4454 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5321)
+PASS #4455 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5323)
+PASS #4456 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5325)
+PASS #4457 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5327)
+PASS #4458 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5329)
+PASS #4459 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5331)
+PASS #4460 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5333)
+PASS #4461 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5335)
+PASS #4462 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5337)
+PASS #4463 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5339)
+PASS #4464 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5341)
+PASS #4465 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5343)
+PASS #4466 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5345)
+PASS #4467 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5347)
+PASS #4468 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5349)
+PASS #4469 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5351)
+PASS #4470 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5353)
+PASS #4471 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5355)
+PASS #4472 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5357)
+PASS #4473 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5359)
+PASS #4474 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5361)
+PASS #4475 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5363)
+PASS #4476 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5365)
+PASS #4477 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5367)
+PASS #4478 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5369)
+PASS #4479 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5371)
+PASS #4480 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5373)
+PASS #4481 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5375)
+PASS #4482 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5377)
+PASS #4483 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5379)
+PASS #4484 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5381)
+PASS #4485 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5383)
+PASS #4486 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5385)
+PASS #4487 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5387)
+PASS #4488 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5389)
+PASS #4489 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5391)
+PASS #4490 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5393)
+PASS #4491 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5395)
+PASS #4492 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5397)
+PASS #4493 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5399)
+PASS #4494 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5401)
+PASS #4495 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5403)
+PASS #4496 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5405)
+PASS #4497 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5407)
+PASS #4498 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5409)
+PASS #4499 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5411)
+PASS #4500 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5413)
+PASS #4501 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5415)
+PASS #4502 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5417)
+PASS #4503 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5419)
+PASS #4504 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5421)
+PASS #4505 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5423)
+PASS #4506 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5425)
+PASS #4507 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5427)
+PASS #4508 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5429)
+PASS #4509 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5431)
+PASS #4510 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5433)
+PASS #4511 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5435)
+PASS #4512 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5437)
+PASS #4513 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5439)
+PASS #4514 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5441)
+PASS #4515 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5443)
+PASS #4516 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5445)
+PASS #4517 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5447)
+PASS #4518 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5449)
+PASS #4519 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5451)
+PASS #4520 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5453)
+PASS #4521 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5455)
+PASS #4522 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5457)
+PASS #4523 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5459)
+PASS #4524 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5461)
+PASS #4525 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5463)
+PASS #4526 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5465)
+PASS #4527 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5467)
+PASS #4528 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5469)
+PASS #4529 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5471)
+PASS #4530 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5473)
+PASS #4531 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5475)
+PASS #4532 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5477)
+PASS #4533 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5479)
+PASS #4534 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5481)
+PASS #4535 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5483)
+PASS #4536 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5485)
+PASS #4537 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5487)
+PASS #4538 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5489)
+PASS #4539 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5491)
+PASS #4540 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5493)
+PASS #4541 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5495)
+PASS #4542 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5497)
+PASS #4543 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5499)
+PASS #4544 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5501)
+PASS #4545 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5503)
+PASS #4546 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5505)
+PASS #4547 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5507)
+PASS #4548 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5509)
+PASS #4549 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5511)
+PASS #4550 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5513)
+PASS #4551 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5515)
+PASS #4552 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5517)
+PASS #4553 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5519)
+PASS #4554 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5521)
+PASS #4555 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5523)
+PASS #4556 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5525)
+PASS #4557 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5527)
+PASS #4558 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5529)
+PASS #4559 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5531)
+PASS #4560 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5533)
+PASS #4561 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5535)
+PASS #4562 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5537)
+PASS #4563 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5539)
+PASS #4564 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5541)
+PASS #4565 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5543)
+PASS #4566 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5545)
+PASS #4567 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5547)
+PASS #4568 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5549)
+PASS #4569 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5551)
+PASS #4570 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5553)
+PASS #4571 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5555)
+PASS #4572 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5557)
+PASS #4573 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5559)
+PASS #4574 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5561)
+PASS #4575 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5563)
+PASS #4576 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5565)
+PASS #4577 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5567)
+PASS #4578 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5569)
+PASS #4579 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5571)
+PASS #4580 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5573)
+PASS #4581 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5575)
+PASS #4582 Test that a WebAssembly code returns a specific result (memory_copy64.wast:5577)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_fill64.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_fill64.wast.js-expected.txt
@@ -1,13 +1,13 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (memory_fill64.wast:6) assert_equals: expected false but got true
-FAIL #3 Test that WebAssembly compilation succeeds (memory_fill64.wast:28) assert_equals: expected false but got true
-FAIL #4 Test that WebAssembly compilation succeeds (memory_fill64.wast:46) assert_equals: expected false but got true
-FAIL #5 Test that WebAssembly compilation succeeds (memory_fill64.wast:64) assert_equals: expected false but got true
-FAIL #6 Test that WebAssembly compilation succeeds (memory_fill64.wast:84) assert_equals: expected false but got true
-FAIL #7 Test that WebAssembly compilation succeeds (memory_fill64.wast:102) assert_equals: expected false but got true
-FAIL #8 Test that WebAssembly compilation succeeds (memory_fill64.wast:120) assert_equals: expected false but got true
-FAIL #9 Test that WebAssembly compilation succeeds (memory_fill64.wast:145) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (memory_fill64.wast:6)
+PASS #3 Test that WebAssembly compilation succeeds (memory_fill64.wast:28)
+PASS #4 Test that WebAssembly compilation succeeds (memory_fill64.wast:46)
+PASS #5 Test that WebAssembly compilation succeeds (memory_fill64.wast:64)
+PASS #6 Test that WebAssembly compilation succeeds (memory_fill64.wast:84)
+PASS #7 Test that WebAssembly compilation succeeds (memory_fill64.wast:102)
+PASS #8 Test that WebAssembly compilation succeeds (memory_fill64.wast:120)
+PASS #9 Test that WebAssembly compilation succeeds (memory_fill64.wast:145)
 PASS #10 Test that WebAssembly compilation fails (memory_fill64.wast:174)
 PASS #11 Test that WebAssembly compilation fails (memory_fill64.wast:180)
 PASS #12 Test that WebAssembly compilation fails (memory_fill64.wast:187)
@@ -72,99 +72,45 @@ PASS #70 Test that WebAssembly compilation fails (memory_fill64.wast:593)
 PASS #71 Test that WebAssembly compilation fails (memory_fill64.wast:600)
 PASS #72 Test that WebAssembly compilation fails (memory_fill64.wast:607)
 PASS #73 Test that WebAssembly compilation fails (memory_fill64.wast:614)
-FAIL #74 Test that WebAssembly compilation succeeds (memory_fill64.wast:621) assert_equals: expected false but got true
-FAIL #75 Test that WebAssembly compilation succeeds (memory_fill64.wast:643) assert_equals: expected false but got true
-FAIL #76 Test that WebAssembly compilation succeeds (memory_fill64.wast:665) assert_equals: expected false but got true
+PASS #74 Test that WebAssembly compilation succeeds (memory_fill64.wast:621)
+PASS #75 Test that WebAssembly compilation succeeds (memory_fill64.wast:643)
+PASS #76 Test that WebAssembly compilation succeeds (memory_fill64.wast:665)
 PASS #77 Reinitialize the default imports
-FAIL #78 Test that WebAssembly compilation succeeds (memory_fill64.wast:6) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 42: Memory64 is not enabled at {loc} expected true got false
-FAIL #79 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:336:3 expected true got false
-FAIL #80 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:10:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:336:3 expected true got false
-FAIL #81 Test that a WebAssembly code returns a specific result (memory_fill64.wast:24) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:13:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:336:3 expected true got false
-FAIL #82 Test that a WebAssembly code returns a specific result (memory_fill64.wast:26) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:16:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:336:3 expected true got false
-FAIL #83 Test that WebAssembly compilation succeeds (memory_fill64.wast:28) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 42: Memory64 is not enabled at {loc} expected true got false
-FAIL #84 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:22:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:336:3 expected true got false
-FAIL #85 Test that a WebAssembly code traps (memory_fill64.wast:44) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:25:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:336:3 expected true got false
-FAIL #86 Test that WebAssembly compilation succeeds (memory_fill64.wast:46) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 42: Memory64 is not enabled at {loc} expected true got false
-FAIL #87 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:31:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:336:3 expected true got false
-FAIL #88 Test that a WebAssembly code traps (memory_fill64.wast:62) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:34:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:336:3 expected true got false
-FAIL #89 Test that WebAssembly compilation succeeds (memory_fill64.wast:64) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 42: Memory64 is not enabled at {loc} expected true got false
-FAIL #90 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:40:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:336:3 expected true got false
-FAIL #91 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:43:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:336:3 expected true got false
-FAIL #92 Test that a WebAssembly code returns a specific result (memory_fill64.wast:82) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:46:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:336:3 expected true got false
-FAIL #93 Test that WebAssembly compilation succeeds (memory_fill64.wast:84) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 42: Memory64 is not enabled at {loc} expected true got false
-FAIL #94 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:52:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:336:3 expected true got false
-FAIL #95 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:55:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:336:3 expected true got false
-FAIL #96 Test that WebAssembly compilation succeeds (memory_fill64.wast:102) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 42: Memory64 is not enabled at {loc} expected true got false
-FAIL #97 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:61:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:336:3 expected true got false
-FAIL #98 Test that a WebAssembly code traps (memory_fill64.wast:118) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:64:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:336:3 expected true got false
-FAIL #99 Test that WebAssembly compilation succeeds (memory_fill64.wast:120) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 42: Memory64 is not enabled at {loc} expected true got false
-FAIL #100 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:70:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:336:3 expected true got false
-FAIL #101 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:73:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:336:3 expected true got false
-FAIL #102 Test that a WebAssembly code returns a specific result (memory_fill64.wast:138) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:76:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:336:3 expected true got false
-FAIL #103 Test that a WebAssembly code returns a specific result (memory_fill64.wast:140) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:79:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:336:3 expected true got false
-FAIL #104 Test that a WebAssembly code returns a specific result (memory_fill64.wast:142) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:82:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:336:3 expected true got false
-FAIL #105 Test that WebAssembly compilation succeeds (memory_fill64.wast:145) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 42: Memory64 is not enabled at {loc} expected true got false
-FAIL #106 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:88:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:336:3 expected true got false
-FAIL #107 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:91:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:336:3 expected true got false
-FAIL #108 Test that a WebAssembly code returns a specific result (memory_fill64.wast:164) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:94:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:336:3 expected true got false
-FAIL #109 Test that a WebAssembly code returns a specific result (memory_fill64.wast:166) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:97:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:336:3 expected true got false
-FAIL #110 Test that a WebAssembly code returns a specific result (memory_fill64.wast:168) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:100:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:336:3 expected true got false
-FAIL #111 Test that a WebAssembly code returns a specific result (memory_fill64.wast:170) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:103:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:336:3 expected true got false
-FAIL #112 Test that a WebAssembly code returns a specific result (memory_fill64.wast:172) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:106:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:336:3 expected true got false
+PASS #78 Test that WebAssembly compilation succeeds (memory_fill64.wast:6)
+PASS #79 Test that WebAssembly instantiation succeeds (memory_fill64.wast:6)
+PASS #80 Run a WebAssembly test without special assertions (memory_fill64.wast:22)
+PASS #81 Test that a WebAssembly code returns a specific result (memory_fill64.wast:24)
+PASS #82 Test that a WebAssembly code returns a specific result (memory_fill64.wast:26)
+PASS #83 Test that WebAssembly compilation succeeds (memory_fill64.wast:28)
+PASS #84 Test that WebAssembly instantiation succeeds (memory_fill64.wast:28)
+PASS #85 Test that a WebAssembly code traps (memory_fill64.wast:44)
+PASS #86 Test that WebAssembly compilation succeeds (memory_fill64.wast:46)
+PASS #87 Test that WebAssembly instantiation succeeds (memory_fill64.wast:46)
+PASS #88 Test that a WebAssembly code traps (memory_fill64.wast:62)
+PASS #89 Test that WebAssembly compilation succeeds (memory_fill64.wast:64)
+PASS #90 Test that WebAssembly instantiation succeeds (memory_fill64.wast:64)
+PASS #91 Run a WebAssembly test without special assertions (memory_fill64.wast:80)
+PASS #92 Test that a WebAssembly code returns a specific result (memory_fill64.wast:82)
+PASS #93 Test that WebAssembly compilation succeeds (memory_fill64.wast:84)
+PASS #94 Test that WebAssembly instantiation succeeds (memory_fill64.wast:84)
+PASS #95 Run a WebAssembly test without special assertions (memory_fill64.wast:100)
+PASS #96 Test that WebAssembly compilation succeeds (memory_fill64.wast:102)
+PASS #97 Test that WebAssembly instantiation succeeds (memory_fill64.wast:102)
+PASS #98 Test that a WebAssembly code traps (memory_fill64.wast:118)
+PASS #99 Test that WebAssembly compilation succeeds (memory_fill64.wast:120)
+PASS #100 Test that WebAssembly instantiation succeeds (memory_fill64.wast:120)
+PASS #101 Run a WebAssembly test without special assertions (memory_fill64.wast:136)
+PASS #102 Test that a WebAssembly code returns a specific result (memory_fill64.wast:138)
+PASS #103 Test that a WebAssembly code returns a specific result (memory_fill64.wast:140)
+PASS #104 Test that a WebAssembly code returns a specific result (memory_fill64.wast:142)
+PASS #105 Test that WebAssembly compilation succeeds (memory_fill64.wast:145)
+PASS #106 Test that WebAssembly instantiation succeeds (memory_fill64.wast:145)
+PASS #107 Run a WebAssembly test without special assertions (memory_fill64.wast:162)
+PASS #108 Test that a WebAssembly code returns a specific result (memory_fill64.wast:164)
+PASS #109 Test that a WebAssembly code returns a specific result (memory_fill64.wast:166)
+PASS #110 Test that a WebAssembly code returns a specific result (memory_fill64.wast:168)
+PASS #111 Test that a WebAssembly code returns a specific result (memory_fill64.wast:170)
+PASS #112 Test that a WebAssembly code returns a specific result (memory_fill64.wast:172)
 PASS #113 Test that WebAssembly compilation fails (memory_fill64.wast:174)
 PASS #114 Test that WebAssembly compilation fails (memory_fill64.wast:180)
 PASS #115 Test that WebAssembly compilation fails (memory_fill64.wast:187)
@@ -229,34 +175,16 @@ PASS #173 Test that WebAssembly compilation fails (memory_fill64.wast:593)
 PASS #174 Test that WebAssembly compilation fails (memory_fill64.wast:600)
 PASS #175 Test that WebAssembly compilation fails (memory_fill64.wast:607)
 PASS #176 Test that WebAssembly compilation fails (memory_fill64.wast:614)
-FAIL #177 Test that WebAssembly compilation succeeds (memory_fill64.wast:621) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 45: Memory64 is not enabled at {loc} expected true got false
-FAIL #178 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:304:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:336:3 expected true got false
-FAIL #179 Test that a WebAssembly code traps (memory_fill64.wast:638) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:307:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:336:3 expected true got false
-FAIL #180 Test that a WebAssembly code returns a specific result (memory_fill64.wast:641) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:310:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:336:3 expected true got false
-FAIL #181 Test that WebAssembly compilation succeeds (memory_fill64.wast:643) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 45: Memory64 is not enabled at {loc} expected true got false
-FAIL #182 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:316:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:336:3 expected true got false
-FAIL #183 Test that a WebAssembly code traps (memory_fill64.wast:660) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:319:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:336:3 expected true got false
-FAIL #184 Test that a WebAssembly code returns a specific result (memory_fill64.wast:663) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:322:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:336:3 expected true got false
-FAIL #185 Test that WebAssembly compilation succeeds (memory_fill64.wast:665) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 45: Memory64 is not enabled at {loc} expected true got false
-FAIL #186 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:328:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:336:3 expected true got false
-FAIL #187 Test that a WebAssembly code traps (memory_fill64.wast:682) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:331:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:336:3 expected true got false
-FAIL #188 Test that a WebAssembly code returns a specific result (memory_fill64.wast:685) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:334:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_fill64.wast.js:336:3 expected true got false
+PASS #177 Test that WebAssembly compilation succeeds (memory_fill64.wast:621)
+PASS #178 Test that WebAssembly instantiation succeeds (memory_fill64.wast:621)
+PASS #179 Test that a WebAssembly code traps (memory_fill64.wast:638)
+PASS #180 Test that a WebAssembly code returns a specific result (memory_fill64.wast:641)
+PASS #181 Test that WebAssembly compilation succeeds (memory_fill64.wast:643)
+PASS #182 Test that WebAssembly instantiation succeeds (memory_fill64.wast:643)
+PASS #183 Test that a WebAssembly code traps (memory_fill64.wast:660)
+PASS #184 Test that a WebAssembly code returns a specific result (memory_fill64.wast:663)
+PASS #185 Test that WebAssembly compilation succeeds (memory_fill64.wast:665)
+PASS #186 Test that WebAssembly instantiation succeeds (memory_fill64.wast:665)
+PASS #187 Test that a WebAssembly code traps (memory_fill64.wast:682)
+PASS #188 Test that a WebAssembly code returns a specific result (memory_fill64.wast:685)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_grow64.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_grow64.wast.js-expected.txt
@@ -1,159 +1,61 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (memory_grow64.wast:1) assert_equals: expected false but got true
-FAIL #3 Test that WebAssembly compilation succeeds (memory_grow64.wast:36) assert_equals: expected false but got true
-FAIL #4 Test that WebAssembly compilation succeeds (memory_grow64.wast:48) assert_equals: expected false but got true
-FAIL #5 Test that WebAssembly compilation succeeds (memory_grow64.wast:64) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (memory_grow64.wast:1)
+PASS #3 Test that WebAssembly compilation succeeds (memory_grow64.wast:36)
+PASS #4 Test that WebAssembly compilation succeeds (memory_grow64.wast:48)
+PASS #5 Test that WebAssembly compilation succeeds (memory_grow64.wast:64)
 PASS #6 Reinitialize the default imports
-FAIL #7 Test that WebAssembly compilation succeeds (memory_grow64.wast:1) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 52: Memory64 is not enabled at {loc} expected true got false
-FAIL #8 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:162:3 expected true got false
-FAIL #9 Test that a WebAssembly code returns a specific result (memory_grow64.wast:14) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:10:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:162:3 expected true got false
-FAIL #10 Test that a WebAssembly code traps (memory_grow64.wast:15) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:13:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:162:3 expected true got false
-FAIL #11 Test that a WebAssembly code traps (memory_grow64.wast:16) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:16:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:162:3 expected true got false
-FAIL #12 Test that a WebAssembly code traps (memory_grow64.wast:17) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:19:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:162:3 expected true got false
-FAIL #13 Test that a WebAssembly code traps (memory_grow64.wast:18) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:22:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:162:3 expected true got false
-FAIL #14 Test that a WebAssembly code returns a specific result (memory_grow64.wast:19) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:25:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:162:3 expected true got false
-FAIL #15 Test that a WebAssembly code returns a specific result (memory_grow64.wast:20) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:28:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:162:3 expected true got false
-FAIL #16 Test that a WebAssembly code returns a specific result (memory_grow64.wast:21) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:31:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:162:3 expected true got false
-FAIL #17 Test that a WebAssembly code returns a specific result (memory_grow64.wast:22) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:34:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:162:3 expected true got false
-FAIL #18 Test that a WebAssembly code returns a specific result (memory_grow64.wast:23) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:37:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:162:3 expected true got false
-FAIL #19 Test that a WebAssembly code traps (memory_grow64.wast:24) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:40:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:162:3 expected true got false
-FAIL #20 Test that a WebAssembly code traps (memory_grow64.wast:25) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:43:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:162:3 expected true got false
-FAIL #21 Test that a WebAssembly code returns a specific result (memory_grow64.wast:26) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:46:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:162:3 expected true got false
-FAIL #22 Test that a WebAssembly code returns a specific result (memory_grow64.wast:27) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:49:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:162:3 expected true got false
-FAIL #23 Test that a WebAssembly code returns a specific result (memory_grow64.wast:28) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:52:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:162:3 expected true got false
-FAIL #24 Test that a WebAssembly code returns a specific result (memory_grow64.wast:29) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:55:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:162:3 expected true got false
-FAIL #25 Test that a WebAssembly code returns a specific result (memory_grow64.wast:30) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:58:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:162:3 expected true got false
-FAIL #26 Test that a WebAssembly code returns a specific result (memory_grow64.wast:31) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:61:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:162:3 expected true got false
-FAIL #27 Test that a WebAssembly code returns a specific result (memory_grow64.wast:32) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:64:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:162:3 expected true got false
-FAIL #28 Test that a WebAssembly code returns a specific result (memory_grow64.wast:33) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:67:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:162:3 expected true got false
-FAIL #29 Test that WebAssembly compilation succeeds (memory_grow64.wast:36) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 36: Memory64 is not enabled at {loc} expected true got false
-FAIL #30 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:73:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:162:3 expected true got false
-FAIL #31 Test that a WebAssembly code returns a specific result (memory_grow64.wast:41) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:76:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:162:3 expected true got false
-FAIL #32 Test that a WebAssembly code returns a specific result (memory_grow64.wast:42) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:79:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:162:3 expected true got false
-FAIL #33 Test that a WebAssembly code returns a specific result (memory_grow64.wast:43) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:82:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:162:3 expected true got false
-FAIL #34 Test that a WebAssembly code returns a specific result (memory_grow64.wast:44) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:85:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:162:3 expected true got false
-FAIL #35 Test that a WebAssembly code returns a specific result (memory_grow64.wast:45) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:88:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:162:3 expected true got false
-FAIL #36 Test that a WebAssembly code returns a specific result (memory_grow64.wast:46) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:91:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:162:3 expected true got false
-FAIL #37 Test that WebAssembly compilation succeeds (memory_grow64.wast:48) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 36: Memory64 is not enabled at {loc} expected true got false
-FAIL #38 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:97:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:162:3 expected true got false
-FAIL #39 Test that a WebAssembly code returns a specific result (memory_grow64.wast:53) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:100:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:162:3 expected true got false
-FAIL #40 Test that a WebAssembly code returns a specific result (memory_grow64.wast:54) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:103:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:162:3 expected true got false
-FAIL #41 Test that a WebAssembly code returns a specific result (memory_grow64.wast:55) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:106:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:162:3 expected true got false
-FAIL #42 Test that a WebAssembly code returns a specific result (memory_grow64.wast:56) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:109:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:162:3 expected true got false
-FAIL #43 Test that a WebAssembly code returns a specific result (memory_grow64.wast:57) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:112:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:162:3 expected true got false
-FAIL #44 Test that a WebAssembly code returns a specific result (memory_grow64.wast:58) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:115:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:162:3 expected true got false
-FAIL #45 Test that a WebAssembly code returns a specific result (memory_grow64.wast:59) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:118:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:162:3 expected true got false
-FAIL #46 Test that a WebAssembly code returns a specific result (memory_grow64.wast:60) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:121:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:162:3 expected true got false
-FAIL #47 Test that WebAssembly compilation succeeds (memory_grow64.wast:64) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 43: Memory64 is not enabled at {loc} expected true got false
-FAIL #48 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:127:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:162:3 expected true got false
-FAIL #49 Test that a WebAssembly code returns a specific result (memory_grow64.wast:85) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:130:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:162:3 expected true got false
-FAIL #50 Test that a WebAssembly code returns a specific result (memory_grow64.wast:86) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:133:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:162:3 expected true got false
-FAIL #51 Test that a WebAssembly code returns a specific result (memory_grow64.wast:87) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:136:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:162:3 expected true got false
-FAIL #52 Test that a WebAssembly code returns a specific result (memory_grow64.wast:88) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:139:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:162:3 expected true got false
-FAIL #53 Test that a WebAssembly code returns a specific result (memory_grow64.wast:89) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:142:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:162:3 expected true got false
-FAIL #54 Test that a WebAssembly code returns a specific result (memory_grow64.wast:90) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:145:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:162:3 expected true got false
-FAIL #55 Test that a WebAssembly code returns a specific result (memory_grow64.wast:91) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:148:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:162:3 expected true got false
-FAIL #56 Test that a WebAssembly code returns a specific result (memory_grow64.wast:92) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:151:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:162:3 expected true got false
-FAIL #57 Test that a WebAssembly code returns a specific result (memory_grow64.wast:93) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:154:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:162:3 expected true got false
-FAIL #58 Test that a WebAssembly code returns a specific result (memory_grow64.wast:94) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:157:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:162:3 expected true got false
-FAIL #59 Test that a WebAssembly code returns a specific result (memory_grow64.wast:95) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:160:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_grow64.wast.js:162:3 expected true got false
+PASS #7 Test that WebAssembly compilation succeeds (memory_grow64.wast:1)
+PASS #8 Test that WebAssembly instantiation succeeds (memory_grow64.wast:1)
+PASS #9 Test that a WebAssembly code returns a specific result (memory_grow64.wast:14)
+PASS #10 Test that a WebAssembly code traps (memory_grow64.wast:15)
+PASS #11 Test that a WebAssembly code traps (memory_grow64.wast:16)
+PASS #12 Test that a WebAssembly code traps (memory_grow64.wast:17)
+PASS #13 Test that a WebAssembly code traps (memory_grow64.wast:18)
+PASS #14 Test that a WebAssembly code returns a specific result (memory_grow64.wast:19)
+PASS #15 Test that a WebAssembly code returns a specific result (memory_grow64.wast:20)
+PASS #16 Test that a WebAssembly code returns a specific result (memory_grow64.wast:21)
+PASS #17 Test that a WebAssembly code returns a specific result (memory_grow64.wast:22)
+PASS #18 Test that a WebAssembly code returns a specific result (memory_grow64.wast:23)
+PASS #19 Test that a WebAssembly code traps (memory_grow64.wast:24)
+PASS #20 Test that a WebAssembly code traps (memory_grow64.wast:25)
+PASS #21 Test that a WebAssembly code returns a specific result (memory_grow64.wast:26)
+PASS #22 Test that a WebAssembly code returns a specific result (memory_grow64.wast:27)
+PASS #23 Test that a WebAssembly code returns a specific result (memory_grow64.wast:28)
+PASS #24 Test that a WebAssembly code returns a specific result (memory_grow64.wast:29)
+PASS #25 Test that a WebAssembly code returns a specific result (memory_grow64.wast:30)
+PASS #26 Test that a WebAssembly code returns a specific result (memory_grow64.wast:31)
+PASS #27 Test that a WebAssembly code returns a specific result (memory_grow64.wast:32)
+PASS #28 Test that a WebAssembly code returns a specific result (memory_grow64.wast:33)
+PASS #29 Test that WebAssembly compilation succeeds (memory_grow64.wast:36)
+PASS #30 Test that WebAssembly instantiation succeeds (memory_grow64.wast:36)
+PASS #31 Test that a WebAssembly code returns a specific result (memory_grow64.wast:41)
+PASS #32 Test that a WebAssembly code returns a specific result (memory_grow64.wast:42)
+PASS #33 Test that a WebAssembly code returns a specific result (memory_grow64.wast:43)
+PASS #34 Test that a WebAssembly code returns a specific result (memory_grow64.wast:44)
+PASS #35 Test that a WebAssembly code returns a specific result (memory_grow64.wast:45)
+PASS #36 Test that a WebAssembly code returns a specific result (memory_grow64.wast:46)
+PASS #37 Test that WebAssembly compilation succeeds (memory_grow64.wast:48)
+PASS #38 Test that WebAssembly instantiation succeeds (memory_grow64.wast:48)
+PASS #39 Test that a WebAssembly code returns a specific result (memory_grow64.wast:53)
+PASS #40 Test that a WebAssembly code returns a specific result (memory_grow64.wast:54)
+PASS #41 Test that a WebAssembly code returns a specific result (memory_grow64.wast:55)
+PASS #42 Test that a WebAssembly code returns a specific result (memory_grow64.wast:56)
+PASS #43 Test that a WebAssembly code returns a specific result (memory_grow64.wast:57)
+PASS #44 Test that a WebAssembly code returns a specific result (memory_grow64.wast:58)
+PASS #45 Test that a WebAssembly code returns a specific result (memory_grow64.wast:59)
+PASS #46 Test that a WebAssembly code returns a specific result (memory_grow64.wast:60)
+PASS #47 Test that WebAssembly compilation succeeds (memory_grow64.wast:64)
+PASS #48 Test that WebAssembly instantiation succeeds (memory_grow64.wast:64)
+PASS #49 Test that a WebAssembly code returns a specific result (memory_grow64.wast:85)
+PASS #50 Test that a WebAssembly code returns a specific result (memory_grow64.wast:86)
+PASS #51 Test that a WebAssembly code returns a specific result (memory_grow64.wast:87)
+PASS #52 Test that a WebAssembly code returns a specific result (memory_grow64.wast:88)
+PASS #53 Test that a WebAssembly code returns a specific result (memory_grow64.wast:89)
+PASS #54 Test that a WebAssembly code returns a specific result (memory_grow64.wast:90)
+PASS #55 Test that a WebAssembly code returns a specific result (memory_grow64.wast:91)
+PASS #56 Test that a WebAssembly code returns a specific result (memory_grow64.wast:92)
+PASS #57 Test that a WebAssembly code returns a specific result (memory_grow64.wast:93)
+PASS #58 Test that a WebAssembly code returns a specific result (memory_grow64.wast:94)
+PASS #59 Test that a WebAssembly code returns a specific result (memory_grow64.wast:95)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_init64.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_init64.wast.js-expected.txt
@@ -1,31 +1,31 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (memory_init64.wast:6) assert_equals: expected false but got true
-FAIL #3 Test that WebAssembly compilation succeeds (memory_init64.wast:50) assert_equals: expected false but got true
-FAIL #4 Test that WebAssembly compilation succeeds (memory_init64.wast:94) assert_equals: expected false but got true
-FAIL #5 Test that WebAssembly compilation succeeds (memory_init64.wast:138) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (memory_init64.wast:6)
+PASS #3 Test that WebAssembly compilation succeeds (memory_init64.wast:50)
+PASS #4 Test that WebAssembly compilation succeeds (memory_init64.wast:94)
+PASS #5 Test that WebAssembly compilation succeeds (memory_init64.wast:138)
 PASS #6 Test that WebAssembly compilation fails (memory_init64.wast:189)
 PASS #7 Test that WebAssembly compilation fails (memory_init64.wast:195)
-FAIL #8 Test that WebAssembly compilation succeeds (memory_init64.wast:203) assert_equals: expected false but got true
-FAIL #9 Test that WebAssembly compilation succeeds (memory_init64.wast:211) assert_equals: expected false but got true
-FAIL #10 Test that WebAssembly compilation succeeds (memory_init64.wast:218) assert_equals: expected false but got true
-FAIL #11 Test that WebAssembly compilation succeeds (memory_init64.wast:226) assert_equals: expected false but got true
-FAIL #12 Test that WebAssembly compilation succeeds (memory_init64.wast:234) assert_equals: expected false but got true
-FAIL #13 Test that WebAssembly compilation succeeds (memory_init64.wast:242) assert_equals: expected false but got true
-FAIL #14 Test that WebAssembly compilation succeeds (memory_init64.wast:250) assert_equals: expected false but got true
-FAIL #15 Test that WebAssembly compilation succeeds (memory_init64.wast:258) assert_equals: expected false but got true
+PASS #8 Test that WebAssembly compilation succeeds (memory_init64.wast:203)
+PASS #9 Test that WebAssembly compilation succeeds (memory_init64.wast:211)
+PASS #10 Test that WebAssembly compilation succeeds (memory_init64.wast:218)
+PASS #11 Test that WebAssembly compilation succeeds (memory_init64.wast:226)
+PASS #12 Test that WebAssembly compilation succeeds (memory_init64.wast:234)
+PASS #13 Test that WebAssembly compilation succeeds (memory_init64.wast:242)
+PASS #14 Test that WebAssembly compilation succeeds (memory_init64.wast:250)
+PASS #15 Test that WebAssembly compilation succeeds (memory_init64.wast:258)
 PASS #16 Test that WebAssembly compilation fails (memory_init64.wast:265)
 PASS #17 Test that WebAssembly compilation fails (memory_init64.wast:271)
-FAIL #18 Test that WebAssembly compilation succeeds (memory_init64.wast:279) assert_equals: expected false but got true
-FAIL #19 Test that WebAssembly compilation succeeds (memory_init64.wast:287) assert_equals: expected false but got true
-FAIL #20 Test that WebAssembly compilation succeeds (memory_init64.wast:294) assert_equals: expected false but got true
-FAIL #21 Test that WebAssembly compilation succeeds (memory_init64.wast:301) assert_equals: expected false but got true
-FAIL #22 Test that WebAssembly compilation succeeds (memory_init64.wast:308) assert_equals: expected false but got true
-FAIL #23 Test that WebAssembly compilation succeeds (memory_init64.wast:315) assert_equals: expected false but got true
-FAIL #24 Test that WebAssembly compilation succeeds (memory_init64.wast:322) assert_equals: expected false but got true
-FAIL #25 Test that WebAssembly compilation succeeds (memory_init64.wast:329) assert_equals: expected false but got true
-FAIL #26 Test that WebAssembly compilation succeeds (memory_init64.wast:336) assert_equals: expected false but got true
-FAIL #27 Test that WebAssembly compilation succeeds (memory_init64.wast:343) assert_equals: expected false but got true
+PASS #18 Test that WebAssembly compilation succeeds (memory_init64.wast:279)
+PASS #19 Test that WebAssembly compilation succeeds (memory_init64.wast:287)
+PASS #20 Test that WebAssembly compilation succeeds (memory_init64.wast:294)
+PASS #21 Test that WebAssembly compilation succeeds (memory_init64.wast:301)
+PASS #22 Test that WebAssembly compilation succeeds (memory_init64.wast:308)
+PASS #23 Test that WebAssembly compilation succeeds (memory_init64.wast:315)
+PASS #24 Test that WebAssembly compilation succeeds (memory_init64.wast:322)
+PASS #25 Test that WebAssembly compilation succeeds (memory_init64.wast:329)
+PASS #26 Test that WebAssembly compilation succeeds (memory_init64.wast:336)
+PASS #27 Test that WebAssembly compilation succeeds (memory_init64.wast:343)
 PASS #28 Test that WebAssembly compilation fails (memory_init64.wast:350)
 PASS #29 Test that WebAssembly compilation fails (memory_init64.wast:358)
 PASS #30 Test that WebAssembly compilation fails (memory_init64.wast:366)
@@ -89,532 +89,204 @@ PASS #87 Test that WebAssembly compilation fails (memory_init64.wast:822)
 PASS #88 Test that WebAssembly compilation fails (memory_init64.wast:830)
 PASS #89 Test that WebAssembly compilation fails (memory_init64.wast:838)
 PASS #90 Test that WebAssembly compilation fails (memory_init64.wast:846)
-FAIL #91 Test that WebAssembly compilation succeeds (memory_init64.wast:854) assert_equals: expected false but got true
-FAIL #92 Test that WebAssembly compilation succeeds (memory_init64.wast:877) assert_equals: expected false but got true
-FAIL #93 Test that WebAssembly compilation succeeds (memory_init64.wast:900) assert_equals: expected false but got true
-FAIL #94 Test that WebAssembly compilation succeeds (memory_init64.wast:923) assert_equals: expected false but got true
-FAIL #95 Test that WebAssembly compilation succeeds (memory_init64.wast:946) assert_equals: expected false but got true
-FAIL #96 Test that WebAssembly compilation succeeds (memory_init64.wast:969) assert_equals: expected false but got true
-FAIL #97 Test that WebAssembly compilation succeeds (memory_init64.wast:993) assert_equals: expected false but got true
+PASS #91 Test that WebAssembly compilation succeeds (memory_init64.wast:854)
+PASS #92 Test that WebAssembly compilation succeeds (memory_init64.wast:877)
+PASS #93 Test that WebAssembly compilation succeeds (memory_init64.wast:900)
+PASS #94 Test that WebAssembly compilation succeeds (memory_init64.wast:923)
+PASS #95 Test that WebAssembly compilation succeeds (memory_init64.wast:946)
+PASS #96 Test that WebAssembly compilation succeeds (memory_init64.wast:969)
+PASS #97 Test that WebAssembly compilation succeeds (memory_init64.wast:993)
 PASS #98 Reinitialize the default imports
-FAIL #99 Test that WebAssembly compilation succeeds (memory_init64.wast:6) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 40: Memory64 is not enabled at {loc} expected true got false
-FAIL #100 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #101 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:10:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #102 Test that a WebAssembly code returns a specific result (memory_init64.wast:19) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:13:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #103 Test that a WebAssembly code returns a specific result (memory_init64.wast:20) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:16:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #104 Test that a WebAssembly code returns a specific result (memory_init64.wast:21) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:19:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #105 Test that a WebAssembly code returns a specific result (memory_init64.wast:22) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:22:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #106 Test that a WebAssembly code returns a specific result (memory_init64.wast:23) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:25:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #107 Test that a WebAssembly code returns a specific result (memory_init64.wast:24) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:28:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #108 Test that a WebAssembly code returns a specific result (memory_init64.wast:25) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:31:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #109 Test that a WebAssembly code returns a specific result (memory_init64.wast:26) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:34:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #110 Test that a WebAssembly code returns a specific result (memory_init64.wast:27) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:37:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #111 Test that a WebAssembly code returns a specific result (memory_init64.wast:28) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:40:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #112 Test that a WebAssembly code returns a specific result (memory_init64.wast:29) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:43:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #113 Test that a WebAssembly code returns a specific result (memory_init64.wast:30) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:46:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #114 Test that a WebAssembly code returns a specific result (memory_init64.wast:31) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:49:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #115 Test that a WebAssembly code returns a specific result (memory_init64.wast:32) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:52:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #116 Test that a WebAssembly code returns a specific result (memory_init64.wast:33) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:55:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #117 Test that a WebAssembly code returns a specific result (memory_init64.wast:34) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:58:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #118 Test that a WebAssembly code returns a specific result (memory_init64.wast:35) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:61:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #119 Test that a WebAssembly code returns a specific result (memory_init64.wast:36) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:64:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #120 Test that a WebAssembly code returns a specific result (memory_init64.wast:37) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:67:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #121 Test that a WebAssembly code returns a specific result (memory_init64.wast:38) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:70:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #122 Test that a WebAssembly code returns a specific result (memory_init64.wast:39) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:73:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #123 Test that a WebAssembly code returns a specific result (memory_init64.wast:40) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:76:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #124 Test that a WebAssembly code returns a specific result (memory_init64.wast:41) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:79:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #125 Test that a WebAssembly code returns a specific result (memory_init64.wast:42) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:82:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #126 Test that a WebAssembly code returns a specific result (memory_init64.wast:43) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:85:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #127 Test that a WebAssembly code returns a specific result (memory_init64.wast:44) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:88:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #128 Test that a WebAssembly code returns a specific result (memory_init64.wast:45) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:91:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #129 Test that a WebAssembly code returns a specific result (memory_init64.wast:46) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:94:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #130 Test that a WebAssembly code returns a specific result (memory_init64.wast:47) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:97:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #131 Test that a WebAssembly code returns a specific result (memory_init64.wast:48) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:100:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #132 Test that WebAssembly compilation succeeds (memory_init64.wast:50) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 40: Memory64 is not enabled at {loc} expected true got false
-FAIL #133 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:106:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #134 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:109:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #135 Test that a WebAssembly code returns a specific result (memory_init64.wast:63) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:112:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #136 Test that a WebAssembly code returns a specific result (memory_init64.wast:64) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:115:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #137 Test that a WebAssembly code returns a specific result (memory_init64.wast:65) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:118:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #138 Test that a WebAssembly code returns a specific result (memory_init64.wast:66) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:121:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #139 Test that a WebAssembly code returns a specific result (memory_init64.wast:67) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:124:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #140 Test that a WebAssembly code returns a specific result (memory_init64.wast:68) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:127:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #141 Test that a WebAssembly code returns a specific result (memory_init64.wast:69) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:130:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #142 Test that a WebAssembly code returns a specific result (memory_init64.wast:70) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:133:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #143 Test that a WebAssembly code returns a specific result (memory_init64.wast:71) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:136:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #144 Test that a WebAssembly code returns a specific result (memory_init64.wast:72) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:139:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #145 Test that a WebAssembly code returns a specific result (memory_init64.wast:73) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:142:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #146 Test that a WebAssembly code returns a specific result (memory_init64.wast:74) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:145:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #147 Test that a WebAssembly code returns a specific result (memory_init64.wast:75) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:148:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #148 Test that a WebAssembly code returns a specific result (memory_init64.wast:76) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:151:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #149 Test that a WebAssembly code returns a specific result (memory_init64.wast:77) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:154:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #150 Test that a WebAssembly code returns a specific result (memory_init64.wast:78) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:157:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #151 Test that a WebAssembly code returns a specific result (memory_init64.wast:79) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:160:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #152 Test that a WebAssembly code returns a specific result (memory_init64.wast:80) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:163:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #153 Test that a WebAssembly code returns a specific result (memory_init64.wast:81) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:166:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #154 Test that a WebAssembly code returns a specific result (memory_init64.wast:82) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:169:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #155 Test that a WebAssembly code returns a specific result (memory_init64.wast:83) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:172:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #156 Test that a WebAssembly code returns a specific result (memory_init64.wast:84) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:175:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #157 Test that a WebAssembly code returns a specific result (memory_init64.wast:85) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:178:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #158 Test that a WebAssembly code returns a specific result (memory_init64.wast:86) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:181:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #159 Test that a WebAssembly code returns a specific result (memory_init64.wast:87) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:184:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #160 Test that a WebAssembly code returns a specific result (memory_init64.wast:88) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:187:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #161 Test that a WebAssembly code returns a specific result (memory_init64.wast:89) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:190:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #162 Test that a WebAssembly code returns a specific result (memory_init64.wast:90) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:193:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #163 Test that a WebAssembly code returns a specific result (memory_init64.wast:91) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:196:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #164 Test that a WebAssembly code returns a specific result (memory_init64.wast:92) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:199:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #165 Test that WebAssembly compilation succeeds (memory_init64.wast:94) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 40: Memory64 is not enabled at {loc} expected true got false
-FAIL #166 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:205:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #167 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:208:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #168 Test that a WebAssembly code returns a specific result (memory_init64.wast:107) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:211:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #169 Test that a WebAssembly code returns a specific result (memory_init64.wast:108) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:214:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #170 Test that a WebAssembly code returns a specific result (memory_init64.wast:109) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:217:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #171 Test that a WebAssembly code returns a specific result (memory_init64.wast:110) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:220:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #172 Test that a WebAssembly code returns a specific result (memory_init64.wast:111) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:223:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #173 Test that a WebAssembly code returns a specific result (memory_init64.wast:112) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:226:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #174 Test that a WebAssembly code returns a specific result (memory_init64.wast:113) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:229:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #175 Test that a WebAssembly code returns a specific result (memory_init64.wast:114) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:232:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #176 Test that a WebAssembly code returns a specific result (memory_init64.wast:115) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:235:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #177 Test that a WebAssembly code returns a specific result (memory_init64.wast:116) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:238:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #178 Test that a WebAssembly code returns a specific result (memory_init64.wast:117) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:241:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #179 Test that a WebAssembly code returns a specific result (memory_init64.wast:118) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:244:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #180 Test that a WebAssembly code returns a specific result (memory_init64.wast:119) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:247:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #181 Test that a WebAssembly code returns a specific result (memory_init64.wast:120) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:250:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #182 Test that a WebAssembly code returns a specific result (memory_init64.wast:121) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:253:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #183 Test that a WebAssembly code returns a specific result (memory_init64.wast:122) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:256:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #184 Test that a WebAssembly code returns a specific result (memory_init64.wast:123) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:259:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #185 Test that a WebAssembly code returns a specific result (memory_init64.wast:124) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:262:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #186 Test that a WebAssembly code returns a specific result (memory_init64.wast:125) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:265:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #187 Test that a WebAssembly code returns a specific result (memory_init64.wast:126) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:268:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #188 Test that a WebAssembly code returns a specific result (memory_init64.wast:127) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:271:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #189 Test that a WebAssembly code returns a specific result (memory_init64.wast:128) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:274:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #190 Test that a WebAssembly code returns a specific result (memory_init64.wast:129) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:277:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #191 Test that a WebAssembly code returns a specific result (memory_init64.wast:130) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:280:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #192 Test that a WebAssembly code returns a specific result (memory_init64.wast:131) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:283:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #193 Test that a WebAssembly code returns a specific result (memory_init64.wast:132) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:286:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #194 Test that a WebAssembly code returns a specific result (memory_init64.wast:133) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:289:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #195 Test that a WebAssembly code returns a specific result (memory_init64.wast:134) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:292:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #196 Test that a WebAssembly code returns a specific result (memory_init64.wast:135) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:295:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #197 Test that a WebAssembly code returns a specific result (memory_init64.wast:136) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:298:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #198 Test that WebAssembly compilation succeeds (memory_init64.wast:138) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 40: Memory64 is not enabled at {loc} expected true got false
-FAIL #199 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:304:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #200 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:307:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #201 Test that a WebAssembly code returns a specific result (memory_init64.wast:159) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:310:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #202 Test that a WebAssembly code returns a specific result (memory_init64.wast:160) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:313:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #203 Test that a WebAssembly code returns a specific result (memory_init64.wast:161) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:316:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #204 Test that a WebAssembly code returns a specific result (memory_init64.wast:162) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:319:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #205 Test that a WebAssembly code returns a specific result (memory_init64.wast:163) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:322:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #206 Test that a WebAssembly code returns a specific result (memory_init64.wast:164) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:325:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #207 Test that a WebAssembly code returns a specific result (memory_init64.wast:165) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:328:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #208 Test that a WebAssembly code returns a specific result (memory_init64.wast:166) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:331:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #209 Test that a WebAssembly code returns a specific result (memory_init64.wast:167) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:334:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #210 Test that a WebAssembly code returns a specific result (memory_init64.wast:168) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:337:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #211 Test that a WebAssembly code returns a specific result (memory_init64.wast:169) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:340:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #212 Test that a WebAssembly code returns a specific result (memory_init64.wast:170) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:343:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #213 Test that a WebAssembly code returns a specific result (memory_init64.wast:171) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:346:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #214 Test that a WebAssembly code returns a specific result (memory_init64.wast:172) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:349:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #215 Test that a WebAssembly code returns a specific result (memory_init64.wast:173) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:352:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #216 Test that a WebAssembly code returns a specific result (memory_init64.wast:174) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:355:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #217 Test that a WebAssembly code returns a specific result (memory_init64.wast:175) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:358:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #218 Test that a WebAssembly code returns a specific result (memory_init64.wast:176) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:361:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #219 Test that a WebAssembly code returns a specific result (memory_init64.wast:177) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:364:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #220 Test that a WebAssembly code returns a specific result (memory_init64.wast:178) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:367:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #221 Test that a WebAssembly code returns a specific result (memory_init64.wast:179) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:370:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #222 Test that a WebAssembly code returns a specific result (memory_init64.wast:180) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:373:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #223 Test that a WebAssembly code returns a specific result (memory_init64.wast:181) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:376:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #224 Test that a WebAssembly code returns a specific result (memory_init64.wast:182) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:379:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #225 Test that a WebAssembly code returns a specific result (memory_init64.wast:183) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:382:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #226 Test that a WebAssembly code returns a specific result (memory_init64.wast:184) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:385:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #227 Test that a WebAssembly code returns a specific result (memory_init64.wast:185) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:388:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #228 Test that a WebAssembly code returns a specific result (memory_init64.wast:186) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:391:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #229 Test that a WebAssembly code returns a specific result (memory_init64.wast:187) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:394:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #230 Test that a WebAssembly code returns a specific result (memory_init64.wast:188) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:397:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
+PASS #99 Test that WebAssembly compilation succeeds (memory_init64.wast:6)
+PASS #100 Test that WebAssembly instantiation succeeds (memory_init64.wast:6)
+PASS #101 Run a WebAssembly test without special assertions (memory_init64.wast:17)
+PASS #102 Test that a WebAssembly code returns a specific result (memory_init64.wast:19)
+PASS #103 Test that a WebAssembly code returns a specific result (memory_init64.wast:20)
+PASS #104 Test that a WebAssembly code returns a specific result (memory_init64.wast:21)
+PASS #105 Test that a WebAssembly code returns a specific result (memory_init64.wast:22)
+PASS #106 Test that a WebAssembly code returns a specific result (memory_init64.wast:23)
+PASS #107 Test that a WebAssembly code returns a specific result (memory_init64.wast:24)
+PASS #108 Test that a WebAssembly code returns a specific result (memory_init64.wast:25)
+PASS #109 Test that a WebAssembly code returns a specific result (memory_init64.wast:26)
+PASS #110 Test that a WebAssembly code returns a specific result (memory_init64.wast:27)
+PASS #111 Test that a WebAssembly code returns a specific result (memory_init64.wast:28)
+PASS #112 Test that a WebAssembly code returns a specific result (memory_init64.wast:29)
+PASS #113 Test that a WebAssembly code returns a specific result (memory_init64.wast:30)
+PASS #114 Test that a WebAssembly code returns a specific result (memory_init64.wast:31)
+PASS #115 Test that a WebAssembly code returns a specific result (memory_init64.wast:32)
+PASS #116 Test that a WebAssembly code returns a specific result (memory_init64.wast:33)
+PASS #117 Test that a WebAssembly code returns a specific result (memory_init64.wast:34)
+PASS #118 Test that a WebAssembly code returns a specific result (memory_init64.wast:35)
+PASS #119 Test that a WebAssembly code returns a specific result (memory_init64.wast:36)
+PASS #120 Test that a WebAssembly code returns a specific result (memory_init64.wast:37)
+PASS #121 Test that a WebAssembly code returns a specific result (memory_init64.wast:38)
+PASS #122 Test that a WebAssembly code returns a specific result (memory_init64.wast:39)
+PASS #123 Test that a WebAssembly code returns a specific result (memory_init64.wast:40)
+PASS #124 Test that a WebAssembly code returns a specific result (memory_init64.wast:41)
+PASS #125 Test that a WebAssembly code returns a specific result (memory_init64.wast:42)
+PASS #126 Test that a WebAssembly code returns a specific result (memory_init64.wast:43)
+PASS #127 Test that a WebAssembly code returns a specific result (memory_init64.wast:44)
+PASS #128 Test that a WebAssembly code returns a specific result (memory_init64.wast:45)
+PASS #129 Test that a WebAssembly code returns a specific result (memory_init64.wast:46)
+PASS #130 Test that a WebAssembly code returns a specific result (memory_init64.wast:47)
+PASS #131 Test that a WebAssembly code returns a specific result (memory_init64.wast:48)
+PASS #132 Test that WebAssembly compilation succeeds (memory_init64.wast:50)
+PASS #133 Test that WebAssembly instantiation succeeds (memory_init64.wast:50)
+PASS #134 Run a WebAssembly test without special assertions (memory_init64.wast:61)
+PASS #135 Test that a WebAssembly code returns a specific result (memory_init64.wast:63)
+PASS #136 Test that a WebAssembly code returns a specific result (memory_init64.wast:64)
+PASS #137 Test that a WebAssembly code returns a specific result (memory_init64.wast:65)
+PASS #138 Test that a WebAssembly code returns a specific result (memory_init64.wast:66)
+PASS #139 Test that a WebAssembly code returns a specific result (memory_init64.wast:67)
+PASS #140 Test that a WebAssembly code returns a specific result (memory_init64.wast:68)
+PASS #141 Test that a WebAssembly code returns a specific result (memory_init64.wast:69)
+PASS #142 Test that a WebAssembly code returns a specific result (memory_init64.wast:70)
+PASS #143 Test that a WebAssembly code returns a specific result (memory_init64.wast:71)
+PASS #144 Test that a WebAssembly code returns a specific result (memory_init64.wast:72)
+PASS #145 Test that a WebAssembly code returns a specific result (memory_init64.wast:73)
+PASS #146 Test that a WebAssembly code returns a specific result (memory_init64.wast:74)
+PASS #147 Test that a WebAssembly code returns a specific result (memory_init64.wast:75)
+PASS #148 Test that a WebAssembly code returns a specific result (memory_init64.wast:76)
+PASS #149 Test that a WebAssembly code returns a specific result (memory_init64.wast:77)
+PASS #150 Test that a WebAssembly code returns a specific result (memory_init64.wast:78)
+PASS #151 Test that a WebAssembly code returns a specific result (memory_init64.wast:79)
+PASS #152 Test that a WebAssembly code returns a specific result (memory_init64.wast:80)
+PASS #153 Test that a WebAssembly code returns a specific result (memory_init64.wast:81)
+PASS #154 Test that a WebAssembly code returns a specific result (memory_init64.wast:82)
+PASS #155 Test that a WebAssembly code returns a specific result (memory_init64.wast:83)
+PASS #156 Test that a WebAssembly code returns a specific result (memory_init64.wast:84)
+PASS #157 Test that a WebAssembly code returns a specific result (memory_init64.wast:85)
+PASS #158 Test that a WebAssembly code returns a specific result (memory_init64.wast:86)
+PASS #159 Test that a WebAssembly code returns a specific result (memory_init64.wast:87)
+PASS #160 Test that a WebAssembly code returns a specific result (memory_init64.wast:88)
+PASS #161 Test that a WebAssembly code returns a specific result (memory_init64.wast:89)
+PASS #162 Test that a WebAssembly code returns a specific result (memory_init64.wast:90)
+PASS #163 Test that a WebAssembly code returns a specific result (memory_init64.wast:91)
+PASS #164 Test that a WebAssembly code returns a specific result (memory_init64.wast:92)
+PASS #165 Test that WebAssembly compilation succeeds (memory_init64.wast:94)
+PASS #166 Test that WebAssembly instantiation succeeds (memory_init64.wast:94)
+PASS #167 Run a WebAssembly test without special assertions (memory_init64.wast:105)
+PASS #168 Test that a WebAssembly code returns a specific result (memory_init64.wast:107)
+PASS #169 Test that a WebAssembly code returns a specific result (memory_init64.wast:108)
+PASS #170 Test that a WebAssembly code returns a specific result (memory_init64.wast:109)
+PASS #171 Test that a WebAssembly code returns a specific result (memory_init64.wast:110)
+PASS #172 Test that a WebAssembly code returns a specific result (memory_init64.wast:111)
+PASS #173 Test that a WebAssembly code returns a specific result (memory_init64.wast:112)
+PASS #174 Test that a WebAssembly code returns a specific result (memory_init64.wast:113)
+PASS #175 Test that a WebAssembly code returns a specific result (memory_init64.wast:114)
+PASS #176 Test that a WebAssembly code returns a specific result (memory_init64.wast:115)
+PASS #177 Test that a WebAssembly code returns a specific result (memory_init64.wast:116)
+PASS #178 Test that a WebAssembly code returns a specific result (memory_init64.wast:117)
+PASS #179 Test that a WebAssembly code returns a specific result (memory_init64.wast:118)
+PASS #180 Test that a WebAssembly code returns a specific result (memory_init64.wast:119)
+PASS #181 Test that a WebAssembly code returns a specific result (memory_init64.wast:120)
+PASS #182 Test that a WebAssembly code returns a specific result (memory_init64.wast:121)
+PASS #183 Test that a WebAssembly code returns a specific result (memory_init64.wast:122)
+PASS #184 Test that a WebAssembly code returns a specific result (memory_init64.wast:123)
+PASS #185 Test that a WebAssembly code returns a specific result (memory_init64.wast:124)
+PASS #186 Test that a WebAssembly code returns a specific result (memory_init64.wast:125)
+PASS #187 Test that a WebAssembly code returns a specific result (memory_init64.wast:126)
+PASS #188 Test that a WebAssembly code returns a specific result (memory_init64.wast:127)
+PASS #189 Test that a WebAssembly code returns a specific result (memory_init64.wast:128)
+PASS #190 Test that a WebAssembly code returns a specific result (memory_init64.wast:129)
+PASS #191 Test that a WebAssembly code returns a specific result (memory_init64.wast:130)
+PASS #192 Test that a WebAssembly code returns a specific result (memory_init64.wast:131)
+PASS #193 Test that a WebAssembly code returns a specific result (memory_init64.wast:132)
+PASS #194 Test that a WebAssembly code returns a specific result (memory_init64.wast:133)
+PASS #195 Test that a WebAssembly code returns a specific result (memory_init64.wast:134)
+PASS #196 Test that a WebAssembly code returns a specific result (memory_init64.wast:135)
+PASS #197 Test that a WebAssembly code returns a specific result (memory_init64.wast:136)
+PASS #198 Test that WebAssembly compilation succeeds (memory_init64.wast:138)
+PASS #199 Test that WebAssembly instantiation succeeds (memory_init64.wast:138)
+PASS #200 Run a WebAssembly test without special assertions (memory_init64.wast:157)
+PASS #201 Test that a WebAssembly code returns a specific result (memory_init64.wast:159)
+PASS #202 Test that a WebAssembly code returns a specific result (memory_init64.wast:160)
+PASS #203 Test that a WebAssembly code returns a specific result (memory_init64.wast:161)
+PASS #204 Test that a WebAssembly code returns a specific result (memory_init64.wast:162)
+PASS #205 Test that a WebAssembly code returns a specific result (memory_init64.wast:163)
+PASS #206 Test that a WebAssembly code returns a specific result (memory_init64.wast:164)
+PASS #207 Test that a WebAssembly code returns a specific result (memory_init64.wast:165)
+PASS #208 Test that a WebAssembly code returns a specific result (memory_init64.wast:166)
+PASS #209 Test that a WebAssembly code returns a specific result (memory_init64.wast:167)
+PASS #210 Test that a WebAssembly code returns a specific result (memory_init64.wast:168)
+PASS #211 Test that a WebAssembly code returns a specific result (memory_init64.wast:169)
+PASS #212 Test that a WebAssembly code returns a specific result (memory_init64.wast:170)
+PASS #213 Test that a WebAssembly code returns a specific result (memory_init64.wast:171)
+PASS #214 Test that a WebAssembly code returns a specific result (memory_init64.wast:172)
+PASS #215 Test that a WebAssembly code returns a specific result (memory_init64.wast:173)
+PASS #216 Test that a WebAssembly code returns a specific result (memory_init64.wast:174)
+PASS #217 Test that a WebAssembly code returns a specific result (memory_init64.wast:175)
+PASS #218 Test that a WebAssembly code returns a specific result (memory_init64.wast:176)
+PASS #219 Test that a WebAssembly code returns a specific result (memory_init64.wast:177)
+PASS #220 Test that a WebAssembly code returns a specific result (memory_init64.wast:178)
+PASS #221 Test that a WebAssembly code returns a specific result (memory_init64.wast:179)
+PASS #222 Test that a WebAssembly code returns a specific result (memory_init64.wast:180)
+PASS #223 Test that a WebAssembly code returns a specific result (memory_init64.wast:181)
+PASS #224 Test that a WebAssembly code returns a specific result (memory_init64.wast:182)
+PASS #225 Test that a WebAssembly code returns a specific result (memory_init64.wast:183)
+PASS #226 Test that a WebAssembly code returns a specific result (memory_init64.wast:184)
+PASS #227 Test that a WebAssembly code returns a specific result (memory_init64.wast:185)
+PASS #228 Test that a WebAssembly code returns a specific result (memory_init64.wast:186)
+PASS #229 Test that a WebAssembly code returns a specific result (memory_init64.wast:187)
+PASS #230 Test that a WebAssembly code returns a specific result (memory_init64.wast:188)
 PASS #231 Test that WebAssembly compilation fails (memory_init64.wast:189)
 PASS #232 Test that WebAssembly compilation fails (memory_init64.wast:195)
-FAIL #233 Test that WebAssembly compilation succeeds (memory_init64.wast:203) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 34: Memory64 is not enabled at {loc} expected true got false
-FAIL #234 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:409:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #235 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:412:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #236 Test that WebAssembly compilation succeeds (memory_init64.wast:211) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 34: Memory64 is not enabled at {loc} expected true got false
-FAIL #237 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:418:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #238 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:421:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #239 Test that WebAssembly compilation succeeds (memory_init64.wast:218) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 34: Memory64 is not enabled at {loc} expected true got false
-FAIL #240 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:427:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #241 Test that a WebAssembly code traps (memory_init64.wast:224) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:430:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #242 Test that WebAssembly compilation succeeds (memory_init64.wast:226) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 34: Memory64 is not enabled at {loc} expected true got false
-FAIL #243 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:436:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #244 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:439:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #245 Test that WebAssembly compilation succeeds (memory_init64.wast:234) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 34: Memory64 is not enabled at {loc} expected true got false
-FAIL #246 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:445:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #247 Test that a WebAssembly code traps (memory_init64.wast:240) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:448:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #248 Test that WebAssembly compilation succeeds (memory_init64.wast:242) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 34: Memory64 is not enabled at {loc} expected true got false
-FAIL #249 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:454:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #250 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:457:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #251 Test that WebAssembly compilation succeeds (memory_init64.wast:250) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 34: Memory64 is not enabled at {loc} expected true got false
-FAIL #252 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:463:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #253 Test that a WebAssembly code traps (memory_init64.wast:256) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:466:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #254 Test that WebAssembly compilation succeeds (memory_init64.wast:258) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 34: Memory64 is not enabled at {loc} expected true got false
-FAIL #255 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:472:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #256 Test that a WebAssembly code traps (memory_init64.wast:263) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:475:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
+PASS #233 Test that WebAssembly compilation succeeds (memory_init64.wast:203)
+PASS #234 Test that WebAssembly instantiation succeeds (memory_init64.wast:203)
+PASS #235 Run a WebAssembly test without special assertions (memory_init64.wast:209)
+PASS #236 Test that WebAssembly compilation succeeds (memory_init64.wast:211)
+PASS #237 Test that WebAssembly instantiation succeeds (memory_init64.wast:211)
+PASS #238 Run a WebAssembly test without special assertions (memory_init64.wast:216)
+PASS #239 Test that WebAssembly compilation succeeds (memory_init64.wast:218)
+PASS #240 Test that WebAssembly instantiation succeeds (memory_init64.wast:218)
+PASS #241 Test that a WebAssembly code traps (memory_init64.wast:224)
+PASS #242 Test that WebAssembly compilation succeeds (memory_init64.wast:226)
+PASS #243 Test that WebAssembly instantiation succeeds (memory_init64.wast:226)
+PASS #244 Run a WebAssembly test without special assertions (memory_init64.wast:232)
+PASS #245 Test that WebAssembly compilation succeeds (memory_init64.wast:234)
+PASS #246 Test that WebAssembly instantiation succeeds (memory_init64.wast:234)
+PASS #247 Test that a WebAssembly code traps (memory_init64.wast:240)
+PASS #248 Test that WebAssembly compilation succeeds (memory_init64.wast:242)
+PASS #249 Test that WebAssembly instantiation succeeds (memory_init64.wast:242)
+PASS #250 Run a WebAssembly test without special assertions (memory_init64.wast:248)
+PASS #251 Test that WebAssembly compilation succeeds (memory_init64.wast:250)
+PASS #252 Test that WebAssembly instantiation succeeds (memory_init64.wast:250)
+PASS #253 Test that a WebAssembly code traps (memory_init64.wast:256)
+PASS #254 Test that WebAssembly compilation succeeds (memory_init64.wast:258)
+PASS #255 Test that WebAssembly instantiation succeeds (memory_init64.wast:258)
+PASS #256 Test that a WebAssembly code traps (memory_init64.wast:263)
 PASS #257 Test that WebAssembly compilation fails (memory_init64.wast:265)
 PASS #258 Test that WebAssembly compilation fails (memory_init64.wast:271)
-FAIL #259 Test that WebAssembly compilation succeeds (memory_init64.wast:279) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 34: Memory64 is not enabled at {loc} expected true got false
-FAIL #260 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:487:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #261 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:490:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #262 Test that WebAssembly compilation succeeds (memory_init64.wast:287) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 34: Memory64 is not enabled at {loc} expected true got false
-FAIL #263 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:496:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #264 Test that a WebAssembly code traps (memory_init64.wast:292) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:499:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #265 Test that WebAssembly compilation succeeds (memory_init64.wast:294) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 34: Memory64 is not enabled at {loc} expected true got false
-FAIL #266 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:505:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #267 Test that a WebAssembly code traps (memory_init64.wast:299) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:508:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #268 Test that WebAssembly compilation succeeds (memory_init64.wast:301) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 34: Memory64 is not enabled at {loc} expected true got false
-FAIL #269 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:514:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #270 Test that a WebAssembly code traps (memory_init64.wast:306) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:517:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #271 Test that WebAssembly compilation succeeds (memory_init64.wast:308) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 34: Memory64 is not enabled at {loc} expected true got false
-FAIL #272 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:523:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #273 Test that a WebAssembly code traps (memory_init64.wast:313) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:526:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #274 Test that WebAssembly compilation succeeds (memory_init64.wast:315) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 34: Memory64 is not enabled at {loc} expected true got false
-FAIL #275 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:532:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #276 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:535:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #277 Test that WebAssembly compilation succeeds (memory_init64.wast:322) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 34: Memory64 is not enabled at {loc} expected true got false
-FAIL #278 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:541:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #279 Test that a WebAssembly code traps (memory_init64.wast:327) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:544:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #280 Test that WebAssembly compilation succeeds (memory_init64.wast:329) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 34: Memory64 is not enabled at {loc} expected true got false
-FAIL #281 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:550:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #282 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:553:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #283 Test that WebAssembly compilation succeeds (memory_init64.wast:336) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 34: Memory64 is not enabled at {loc} expected true got false
-FAIL #284 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:559:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #285 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:562:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #286 Test that WebAssembly compilation succeeds (memory_init64.wast:343) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 34: Memory64 is not enabled at {loc} expected true got false
-FAIL #287 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:568:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #288 Test that a WebAssembly code traps (memory_init64.wast:348) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:571:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
+PASS #259 Test that WebAssembly compilation succeeds (memory_init64.wast:279)
+PASS #260 Test that WebAssembly instantiation succeeds (memory_init64.wast:279)
+PASS #261 Run a WebAssembly test without special assertions (memory_init64.wast:285)
+PASS #262 Test that WebAssembly compilation succeeds (memory_init64.wast:287)
+PASS #263 Test that WebAssembly instantiation succeeds (memory_init64.wast:287)
+PASS #264 Test that a WebAssembly code traps (memory_init64.wast:292)
+PASS #265 Test that WebAssembly compilation succeeds (memory_init64.wast:294)
+PASS #266 Test that WebAssembly instantiation succeeds (memory_init64.wast:294)
+PASS #267 Test that a WebAssembly code traps (memory_init64.wast:299)
+PASS #268 Test that WebAssembly compilation succeeds (memory_init64.wast:301)
+PASS #269 Test that WebAssembly instantiation succeeds (memory_init64.wast:301)
+PASS #270 Test that a WebAssembly code traps (memory_init64.wast:306)
+PASS #271 Test that WebAssembly compilation succeeds (memory_init64.wast:308)
+PASS #272 Test that WebAssembly instantiation succeeds (memory_init64.wast:308)
+PASS #273 Test that a WebAssembly code traps (memory_init64.wast:313)
+PASS #274 Test that WebAssembly compilation succeeds (memory_init64.wast:315)
+PASS #275 Test that WebAssembly instantiation succeeds (memory_init64.wast:315)
+PASS #276 Run a WebAssembly test without special assertions (memory_init64.wast:320)
+PASS #277 Test that WebAssembly compilation succeeds (memory_init64.wast:322)
+PASS #278 Test that WebAssembly instantiation succeeds (memory_init64.wast:322)
+PASS #279 Test that a WebAssembly code traps (memory_init64.wast:327)
+PASS #280 Test that WebAssembly compilation succeeds (memory_init64.wast:329)
+PASS #281 Test that WebAssembly instantiation succeeds (memory_init64.wast:329)
+PASS #282 Run a WebAssembly test without special assertions (memory_init64.wast:334)
+PASS #283 Test that WebAssembly compilation succeeds (memory_init64.wast:336)
+PASS #284 Test that WebAssembly instantiation succeeds (memory_init64.wast:336)
+PASS #285 Run a WebAssembly test without special assertions (memory_init64.wast:341)
+PASS #286 Test that WebAssembly compilation succeeds (memory_init64.wast:343)
+PASS #287 Test that WebAssembly instantiation succeeds (memory_init64.wast:343)
+PASS #288 Test that a WebAssembly code traps (memory_init64.wast:348)
 PASS #289 Test that WebAssembly compilation fails (memory_init64.wast:350)
 PASS #290 Test that WebAssembly compilation fails (memory_init64.wast:358)
 PASS #291 Test that WebAssembly compilation fails (memory_init64.wast:366)
@@ -678,68 +350,30 @@ PASS #348 Test that WebAssembly compilation fails (memory_init64.wast:822)
 PASS #349 Test that WebAssembly compilation fails (memory_init64.wast:830)
 PASS #350 Test that WebAssembly compilation fails (memory_init64.wast:838)
 PASS #351 Test that WebAssembly compilation fails (memory_init64.wast:846)
-FAIL #352 Test that WebAssembly compilation succeeds (memory_init64.wast:854) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 44: Memory64 is not enabled at {loc} expected true got false
-FAIL #353 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:766:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #354 Test that a WebAssembly code traps (memory_init64.wast:872) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:769:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #355 Test that a WebAssembly code returns a specific result (memory_init64.wast:875) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:772:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #356 Test that WebAssembly compilation succeeds (memory_init64.wast:877) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 44: Memory64 is not enabled at {loc} expected true got false
-FAIL #357 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:778:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #358 Test that a WebAssembly code traps (memory_init64.wast:895) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:781:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #359 Test that a WebAssembly code returns a specific result (memory_init64.wast:898) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:784:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #360 Test that WebAssembly compilation succeeds (memory_init64.wast:900) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 44: Memory64 is not enabled at {loc} expected true got false
-FAIL #361 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:790:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #362 Test that a WebAssembly code traps (memory_init64.wast:918) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:793:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #363 Test that a WebAssembly code returns a specific result (memory_init64.wast:921) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:796:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #364 Test that WebAssembly compilation succeeds (memory_init64.wast:923) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 44: Memory64 is not enabled at {loc} expected true got false
-FAIL #365 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:802:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #366 Test that a WebAssembly code traps (memory_init64.wast:941) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:805:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #367 Test that a WebAssembly code returns a specific result (memory_init64.wast:944) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:808:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #368 Test that WebAssembly compilation succeeds (memory_init64.wast:946) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 44: Memory64 is not enabled at {loc} expected true got false
-FAIL #369 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:814:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #370 Test that a WebAssembly code traps (memory_init64.wast:964) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:817:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #371 Test that a WebAssembly code returns a specific result (memory_init64.wast:967) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:820:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #372 Test that WebAssembly compilation succeeds (memory_init64.wast:969) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 44: Memory64 is not enabled at {loc} expected true got false
-FAIL #373 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:826:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #374 Test that a WebAssembly code traps (memory_init64.wast:987) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:829:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #375 Test that a WebAssembly code returns a specific result (memory_init64.wast:990) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:832:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
-FAIL #376 Test that WebAssembly compilation succeeds (memory_init64.wast:993) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 34: Memory64 is not enabled at {loc} expected true got false
-FAIL #377 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:838:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:840:3 expected true got false
+PASS #352 Test that WebAssembly compilation succeeds (memory_init64.wast:854)
+PASS #353 Test that WebAssembly instantiation succeeds (memory_init64.wast:854)
+PASS #354 Test that a WebAssembly code traps (memory_init64.wast:872)
+PASS #355 Test that a WebAssembly code returns a specific result (memory_init64.wast:875)
+PASS #356 Test that WebAssembly compilation succeeds (memory_init64.wast:877)
+PASS #357 Test that WebAssembly instantiation succeeds (memory_init64.wast:877)
+PASS #358 Test that a WebAssembly code traps (memory_init64.wast:895)
+PASS #359 Test that a WebAssembly code returns a specific result (memory_init64.wast:898)
+PASS #360 Test that WebAssembly compilation succeeds (memory_init64.wast:900)
+PASS #361 Test that WebAssembly instantiation succeeds (memory_init64.wast:900)
+PASS #362 Test that a WebAssembly code traps (memory_init64.wast:918)
+PASS #363 Test that a WebAssembly code returns a specific result (memory_init64.wast:921)
+PASS #364 Test that WebAssembly compilation succeeds (memory_init64.wast:923)
+PASS #365 Test that WebAssembly instantiation succeeds (memory_init64.wast:923)
+PASS #366 Test that a WebAssembly code traps (memory_init64.wast:941)
+PASS #367 Test that a WebAssembly code returns a specific result (memory_init64.wast:944)
+PASS #368 Test that WebAssembly compilation succeeds (memory_init64.wast:946)
+PASS #369 Test that WebAssembly instantiation succeeds (memory_init64.wast:946)
+PASS #370 Test that a WebAssembly code traps (memory_init64.wast:964)
+PASS #371 Test that a WebAssembly code returns a specific result (memory_init64.wast:967)
+PASS #372 Test that WebAssembly compilation succeeds (memory_init64.wast:969)
+PASS #373 Test that WebAssembly instantiation succeeds (memory_init64.wast:969)
+PASS #374 Test that a WebAssembly code traps (memory_init64.wast:987)
+PASS #375 Test that a WebAssembly code returns a specific result (memory_init64.wast:990)
+PASS #376 Test that WebAssembly compilation succeeds (memory_init64.wast:993)
+PASS #377 Test that WebAssembly instantiation succeeds (memory_init64.wast:993)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_redundancy64.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_redundancy64.wast.js-expected.txt
@@ -1,37 +1,17 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (memory_redundancy64.wast:5) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (memory_redundancy64.wast:5)
 PASS #3 Test that WebAssembly compilation succeeds (wrapper)
 PASS #4 Reinitialize the default imports
-FAIL #5 Test that WebAssembly compilation succeeds (memory_redundancy64.wast:5) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 52: Memory64 is not enabled at {loc} expected true got false
-FAIL #6 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_redundancy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_redundancy64.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_redundancy64.wast.js:30:3 expected true got false
-FAIL #7 Test that a WebAssembly code returns a specific result (memory_redundancy64.wast:59) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_redundancy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_redundancy64.wast.js:10:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_redundancy64.wast.js:30:3 expected true got false
-FAIL #8 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_redundancy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_redundancy64.wast.js:13:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_redundancy64.wast.js:30:3 expected true got false
-FAIL #9 Test that a WebAssembly code returns a specific result (memory_redundancy64.wast:61) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_redundancy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_redundancy64.wast.js:16:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_redundancy64.wast.js:30:3 expected true got false
-FAIL #10 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_redundancy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_redundancy64.wast.js:19:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_redundancy64.wast.js:30:3 expected true got false
+PASS #5 Test that WebAssembly compilation succeeds (memory_redundancy64.wast:5)
+PASS #6 Test that WebAssembly instantiation succeeds (memory_redundancy64.wast:5)
+PASS #7 Test that a WebAssembly code returns a specific result (memory_redundancy64.wast:59)
+PASS #8 Run a WebAssembly test without special assertions (memory_redundancy64.wast:60)
+PASS #9 Test that a WebAssembly code returns a specific result (memory_redundancy64.wast:61)
+PASS #10 Run a WebAssembly test without special assertions (memory_redundancy64.wast:62)
 PASS #11 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #12 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:test_dead_store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_redundancy64.wast.js:22:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-memory_redundancy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_redundancy64.wast.js:22:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_redundancy64.wast.js:30:3 expected true got false
-FAIL #13 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_redundancy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_redundancy64.wast.js:22:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_redundancy64.wast.js:30:3 expected true got false
-FAIL #14 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_redundancy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_redundancy64.wast.js:25:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_redundancy64.wast.js:30:3 expected true got false
-FAIL #15 Test that a WebAssembly code returns a specific result (memory_redundancy64.wast:65) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_redundancy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_redundancy64.wast.js:28:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_redundancy64.wast.js:30:3 expected true got false
+PASS #12 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #13 Run a WebAssembly test without special assertions (memory_redundancy64.wast:63)
+PASS #14 Run a WebAssembly test without special assertions (memory_redundancy64.wast:64)
+PASS #15 Test that a WebAssembly code returns a specific result (memory_redundancy64.wast:65)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_trap64.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_trap64.wast.js-expected.txt
@@ -1,7 +1,7 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (memory_trap64.wast:1) assert_equals: expected false but got true
-FAIL #3 Test that WebAssembly compilation succeeds (memory_trap64.wast:34) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (memory_trap64.wast:1)
+PASS #3 Test that WebAssembly compilation succeeds (memory_trap64.wast:34)
 PASS #4 Test that WebAssembly compilation succeeds (wrapper)
 PASS #5 Test that WebAssembly compilation succeeds (wrapper)
 PASS #6 Test that WebAssembly compilation succeeds (wrapper)
@@ -51,810 +51,274 @@ PASS #49 Test that WebAssembly compilation succeeds (wrapper)
 PASS #50 Test that WebAssembly compilation succeeds (wrapper)
 PASS #51 Test that WebAssembly compilation succeeds (wrapper)
 PASS #52 Reinitialize the default imports
-FAIL #53 Test that WebAssembly compilation succeeds (memory_trap64.wast:1) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 53: Memory64 is not enabled at {loc} expected true got false
-FAIL #54 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #55 Test that a WebAssembly code returns a specific result (memory_trap64.wast:21) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:10:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #56 Test that a WebAssembly code returns a specific result (memory_trap64.wast:22) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:13:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #57 Test that a WebAssembly code traps (memory_trap64.wast:23) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:16:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #58 Test that a WebAssembly code traps (memory_trap64.wast:24) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:19:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #59 Test that a WebAssembly code traps (memory_trap64.wast:25) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:22:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #60 Test that a WebAssembly code traps (memory_trap64.wast:26) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:25:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #61 Test that a WebAssembly code traps (memory_trap64.wast:27) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:28:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #62 Test that a WebAssembly code traps (memory_trap64.wast:28) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:31:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #63 Test that a WebAssembly code traps (memory_trap64.wast:29) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:34:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #64 Test that a WebAssembly code traps (memory_trap64.wast:30) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:37:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #65 Test that a WebAssembly code traps (memory_trap64.wast:31) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:40:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #66 Test that a WebAssembly code traps (memory_trap64.wast:32) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:43:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #67 Test that WebAssembly compilation succeeds (memory_trap64.wast:34) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 93: Memory64 is not enabled at {loc} expected true got false
-FAIL #68 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:49:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #69 Test that a WebAssembly code traps (memory_trap64.wast:110) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:52:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #70 Test that a WebAssembly code traps (memory_trap64.wast:111) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:55:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #71 Test that a WebAssembly code traps (memory_trap64.wast:112) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:58:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #72 Test that a WebAssembly code traps (memory_trap64.wast:113) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:61:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #73 Test that a WebAssembly code traps (memory_trap64.wast:114) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:64:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #74 Test that a WebAssembly code traps (memory_trap64.wast:115) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:67:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #75 Test that a WebAssembly code traps (memory_trap64.wast:116) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:70:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #76 Test that a WebAssembly code traps (memory_trap64.wast:117) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:73:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #77 Test that a WebAssembly code traps (memory_trap64.wast:118) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:76:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #78 Test that a WebAssembly code traps (memory_trap64.wast:119) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:79:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #79 Test that a WebAssembly code traps (memory_trap64.wast:120) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:82:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #80 Test that a WebAssembly code traps (memory_trap64.wast:121) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:85:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #81 Test that a WebAssembly code traps (memory_trap64.wast:122) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:88:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #82 Test that a WebAssembly code traps (memory_trap64.wast:123) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:91:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #83 Test that a WebAssembly code traps (memory_trap64.wast:124) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:94:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #84 Test that a WebAssembly code traps (memory_trap64.wast:125) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:97:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #85 Test that a WebAssembly code traps (memory_trap64.wast:126) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:100:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #86 Test that a WebAssembly code traps (memory_trap64.wast:127) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:103:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #87 Test that a WebAssembly code traps (memory_trap64.wast:128) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:106:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #88 Test that a WebAssembly code traps (memory_trap64.wast:129) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:109:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #89 Test that a WebAssembly code traps (memory_trap64.wast:130) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:112:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #90 Test that a WebAssembly code traps (memory_trap64.wast:131) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:115:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #91 Test that a WebAssembly code traps (memory_trap64.wast:132) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:118:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #92 Test that a WebAssembly code traps (memory_trap64.wast:133) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:121:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #53 Test that WebAssembly compilation succeeds (memory_trap64.wast:1)
+PASS #54 Test that WebAssembly instantiation succeeds (memory_trap64.wast:1)
+PASS #55 Test that a WebAssembly code returns a specific result (memory_trap64.wast:21)
+PASS #56 Test that a WebAssembly code returns a specific result (memory_trap64.wast:22)
+PASS #57 Test that a WebAssembly code traps (memory_trap64.wast:23)
+PASS #58 Test that a WebAssembly code traps (memory_trap64.wast:24)
+PASS #59 Test that a WebAssembly code traps (memory_trap64.wast:25)
+PASS #60 Test that a WebAssembly code traps (memory_trap64.wast:26)
+PASS #61 Test that a WebAssembly code traps (memory_trap64.wast:27)
+PASS #62 Test that a WebAssembly code traps (memory_trap64.wast:28)
+PASS #63 Test that a WebAssembly code traps (memory_trap64.wast:29)
+PASS #64 Test that a WebAssembly code traps (memory_trap64.wast:30)
+PASS #65 Test that a WebAssembly code traps (memory_trap64.wast:31)
+PASS #66 Test that a WebAssembly code traps (memory_trap64.wast:32)
+PASS #67 Test that WebAssembly compilation succeeds (memory_trap64.wast:34)
+PASS #68 Test that WebAssembly instantiation succeeds (memory_trap64.wast:34)
+PASS #69 Test that a WebAssembly code traps (memory_trap64.wast:110)
+PASS #70 Test that a WebAssembly code traps (memory_trap64.wast:111)
+PASS #71 Test that a WebAssembly code traps (memory_trap64.wast:112)
+PASS #72 Test that a WebAssembly code traps (memory_trap64.wast:113)
+PASS #73 Test that a WebAssembly code traps (memory_trap64.wast:114)
+PASS #74 Test that a WebAssembly code traps (memory_trap64.wast:115)
+PASS #75 Test that a WebAssembly code traps (memory_trap64.wast:116)
+PASS #76 Test that a WebAssembly code traps (memory_trap64.wast:117)
+PASS #77 Test that a WebAssembly code traps (memory_trap64.wast:118)
+PASS #78 Test that a WebAssembly code traps (memory_trap64.wast:119)
+PASS #79 Test that a WebAssembly code traps (memory_trap64.wast:120)
+PASS #80 Test that a WebAssembly code traps (memory_trap64.wast:121)
+PASS #81 Test that a WebAssembly code traps (memory_trap64.wast:122)
+PASS #82 Test that a WebAssembly code traps (memory_trap64.wast:123)
+PASS #83 Test that a WebAssembly code traps (memory_trap64.wast:124)
+PASS #84 Test that a WebAssembly code traps (memory_trap64.wast:125)
+PASS #85 Test that a WebAssembly code traps (memory_trap64.wast:126)
+PASS #86 Test that a WebAssembly code traps (memory_trap64.wast:127)
+PASS #87 Test that a WebAssembly code traps (memory_trap64.wast:128)
+PASS #88 Test that a WebAssembly code traps (memory_trap64.wast:129)
+PASS #89 Test that a WebAssembly code traps (memory_trap64.wast:130)
+PASS #90 Test that a WebAssembly code traps (memory_trap64.wast:131)
+PASS #91 Test that a WebAssembly code traps (memory_trap64.wast:132)
+PASS #92 Test that a WebAssembly code traps (memory_trap64.wast:133)
 PASS #93 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #94 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:124:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:124:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #95 Test that a WebAssembly code traps (memory_trap64.wast:134) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:124:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #94 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #95 Test that a WebAssembly code traps (memory_trap64.wast:134)
 PASS #96 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #97 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:127:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:127:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #98 Test that a WebAssembly code traps (memory_trap64.wast:135) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:127:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #97 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #98 Test that a WebAssembly code traps (memory_trap64.wast:135)
 PASS #99 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #100 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:130:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:130:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #101 Test that a WebAssembly code traps (memory_trap64.wast:136) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:130:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #100 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #101 Test that a WebAssembly code traps (memory_trap64.wast:136)
 PASS #102 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #103 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:133:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:133:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #104 Test that a WebAssembly code traps (memory_trap64.wast:137) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:133:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #103 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #104 Test that a WebAssembly code traps (memory_trap64.wast:137)
 PASS #105 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #106 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:136:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:136:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #107 Test that a WebAssembly code traps (memory_trap64.wast:138) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:136:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #106 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #107 Test that a WebAssembly code traps (memory_trap64.wast:138)
 PASS #108 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #109 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:139:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:139:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #110 Test that a WebAssembly code traps (memory_trap64.wast:139) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:139:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #109 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #110 Test that a WebAssembly code traps (memory_trap64.wast:139)
 PASS #111 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #112 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:142:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:142:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #113 Test that a WebAssembly code traps (memory_trap64.wast:140) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:142:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #112 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #113 Test that a WebAssembly code traps (memory_trap64.wast:140)
 PASS #114 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #115 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:145:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:145:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #116 Test that a WebAssembly code traps (memory_trap64.wast:141) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:145:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #115 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #116 Test that a WebAssembly code traps (memory_trap64.wast:141)
 PASS #117 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #118 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:148:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:148:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #119 Test that a WebAssembly code traps (memory_trap64.wast:142) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:148:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #118 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #119 Test that a WebAssembly code traps (memory_trap64.wast:142)
 PASS #120 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #121 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:151:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:151:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #122 Test that a WebAssembly code traps (memory_trap64.wast:143) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:151:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #121 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #122 Test that a WebAssembly code traps (memory_trap64.wast:143)
 PASS #123 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #124 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:154:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:154:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #125 Test that a WebAssembly code traps (memory_trap64.wast:144) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:154:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #124 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #125 Test that a WebAssembly code traps (memory_trap64.wast:144)
 PASS #126 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #127 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:157:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:157:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #128 Test that a WebAssembly code traps (memory_trap64.wast:145) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:157:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #127 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #128 Test that a WebAssembly code traps (memory_trap64.wast:145)
 PASS #129 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #130 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:160:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:160:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #131 Test that a WebAssembly code traps (memory_trap64.wast:146) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:160:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #130 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #131 Test that a WebAssembly code traps (memory_trap64.wast:146)
 PASS #132 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #133 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:163:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:163:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #134 Test that a WebAssembly code traps (memory_trap64.wast:147) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:163:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #133 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #134 Test that a WebAssembly code traps (memory_trap64.wast:147)
 PASS #135 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #136 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:166:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:166:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #137 Test that a WebAssembly code traps (memory_trap64.wast:148) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:166:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #136 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #137 Test that a WebAssembly code traps (memory_trap64.wast:148)
 PASS #138 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #139 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:169:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:169:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #140 Test that a WebAssembly code traps (memory_trap64.wast:149) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:169:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #139 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #140 Test that a WebAssembly code traps (memory_trap64.wast:149)
 PASS #141 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #142 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:172:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:172:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #143 Test that a WebAssembly code traps (memory_trap64.wast:150) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:172:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #142 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #143 Test that a WebAssembly code traps (memory_trap64.wast:150)
 PASS #144 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #145 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:175:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:175:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #146 Test that a WebAssembly code traps (memory_trap64.wast:151) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:175:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #145 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #146 Test that a WebAssembly code traps (memory_trap64.wast:151)
 PASS #147 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #148 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:178:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:178:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #149 Test that a WebAssembly code traps (memory_trap64.wast:152) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:178:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #148 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #149 Test that a WebAssembly code traps (memory_trap64.wast:152)
 PASS #150 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #151 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:181:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:181:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #152 Test that a WebAssembly code traps (memory_trap64.wast:153) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:181:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #151 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #152 Test that a WebAssembly code traps (memory_trap64.wast:153)
 PASS #153 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #154 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:184:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:184:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #155 Test that a WebAssembly code traps (memory_trap64.wast:154) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:184:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #154 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #155 Test that a WebAssembly code traps (memory_trap64.wast:154)
 PASS #156 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #157 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:187:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:187:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #158 Test that a WebAssembly code traps (memory_trap64.wast:155) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:187:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #157 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #158 Test that a WebAssembly code traps (memory_trap64.wast:155)
 PASS #159 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #160 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:190:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:190:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #161 Test that a WebAssembly code traps (memory_trap64.wast:156) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:190:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #160 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #161 Test that a WebAssembly code traps (memory_trap64.wast:156)
 PASS #162 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #163 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:193:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:193:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #164 Test that a WebAssembly code traps (memory_trap64.wast:157) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:193:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #165 Test that a WebAssembly code traps (memory_trap64.wast:158) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:196:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #166 Test that a WebAssembly code traps (memory_trap64.wast:159) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:199:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #167 Test that a WebAssembly code traps (memory_trap64.wast:160) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:202:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #168 Test that a WebAssembly code traps (memory_trap64.wast:161) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:205:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #169 Test that a WebAssembly code traps (memory_trap64.wast:162) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:208:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #170 Test that a WebAssembly code traps (memory_trap64.wast:163) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:211:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #171 Test that a WebAssembly code traps (memory_trap64.wast:164) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:214:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #172 Test that a WebAssembly code traps (memory_trap64.wast:165) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:217:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #173 Test that a WebAssembly code traps (memory_trap64.wast:166) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:220:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #174 Test that a WebAssembly code traps (memory_trap64.wast:167) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:223:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #175 Test that a WebAssembly code traps (memory_trap64.wast:168) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:226:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #176 Test that a WebAssembly code traps (memory_trap64.wast:169) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:229:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #177 Test that a WebAssembly code traps (memory_trap64.wast:170) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:232:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #178 Test that a WebAssembly code traps (memory_trap64.wast:171) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:235:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #179 Test that a WebAssembly code traps (memory_trap64.wast:172) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:238:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #180 Test that a WebAssembly code traps (memory_trap64.wast:173) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:241:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #181 Test that a WebAssembly code traps (memory_trap64.wast:174) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:244:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #182 Test that a WebAssembly code traps (memory_trap64.wast:175) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:247:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #183 Test that a WebAssembly code traps (memory_trap64.wast:176) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:250:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #184 Test that a WebAssembly code traps (memory_trap64.wast:177) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:253:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #185 Test that a WebAssembly code traps (memory_trap64.wast:178) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:256:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #186 Test that a WebAssembly code traps (memory_trap64.wast:179) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:259:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #187 Test that a WebAssembly code traps (memory_trap64.wast:180) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:262:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #188 Test that a WebAssembly code traps (memory_trap64.wast:181) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:265:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #189 Test that a WebAssembly code traps (memory_trap64.wast:182) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:268:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #190 Test that a WebAssembly code traps (memory_trap64.wast:183) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:271:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #191 Test that a WebAssembly code traps (memory_trap64.wast:184) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:274:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #192 Test that a WebAssembly code traps (memory_trap64.wast:185) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:277:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #193 Test that a WebAssembly code traps (memory_trap64.wast:186) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:280:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #194 Test that a WebAssembly code traps (memory_trap64.wast:187) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:283:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #195 Test that a WebAssembly code traps (memory_trap64.wast:188) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:286:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #196 Test that a WebAssembly code traps (memory_trap64.wast:189) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:289:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #197 Test that a WebAssembly code traps (memory_trap64.wast:190) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:292:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #198 Test that a WebAssembly code traps (memory_trap64.wast:191) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:295:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #199 Test that a WebAssembly code traps (memory_trap64.wast:192) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:298:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #200 Test that a WebAssembly code traps (memory_trap64.wast:193) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:301:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #201 Test that a WebAssembly code traps (memory_trap64.wast:194) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:304:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #202 Test that a WebAssembly code traps (memory_trap64.wast:195) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:307:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #203 Test that a WebAssembly code traps (memory_trap64.wast:196) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:310:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #204 Test that a WebAssembly code traps (memory_trap64.wast:197) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:313:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #205 Test that a WebAssembly code traps (memory_trap64.wast:198) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:316:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #206 Test that a WebAssembly code traps (memory_trap64.wast:199) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:319:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #207 Test that a WebAssembly code traps (memory_trap64.wast:200) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:322:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #208 Test that a WebAssembly code traps (memory_trap64.wast:201) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:325:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #163 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #164 Test that a WebAssembly code traps (memory_trap64.wast:157)
+PASS #165 Test that a WebAssembly code traps (memory_trap64.wast:158)
+PASS #166 Test that a WebAssembly code traps (memory_trap64.wast:159)
+PASS #167 Test that a WebAssembly code traps (memory_trap64.wast:160)
+PASS #168 Test that a WebAssembly code traps (memory_trap64.wast:161)
+PASS #169 Test that a WebAssembly code traps (memory_trap64.wast:162)
+PASS #170 Test that a WebAssembly code traps (memory_trap64.wast:163)
+PASS #171 Test that a WebAssembly code traps (memory_trap64.wast:164)
+PASS #172 Test that a WebAssembly code traps (memory_trap64.wast:165)
+PASS #173 Test that a WebAssembly code traps (memory_trap64.wast:166)
+PASS #174 Test that a WebAssembly code traps (memory_trap64.wast:167)
+PASS #175 Test that a WebAssembly code traps (memory_trap64.wast:168)
+PASS #176 Test that a WebAssembly code traps (memory_trap64.wast:169)
+PASS #177 Test that a WebAssembly code traps (memory_trap64.wast:170)
+PASS #178 Test that a WebAssembly code traps (memory_trap64.wast:171)
+PASS #179 Test that a WebAssembly code traps (memory_trap64.wast:172)
+PASS #180 Test that a WebAssembly code traps (memory_trap64.wast:173)
+PASS #181 Test that a WebAssembly code traps (memory_trap64.wast:174)
+PASS #182 Test that a WebAssembly code traps (memory_trap64.wast:175)
+PASS #183 Test that a WebAssembly code traps (memory_trap64.wast:176)
+PASS #184 Test that a WebAssembly code traps (memory_trap64.wast:177)
+PASS #185 Test that a WebAssembly code traps (memory_trap64.wast:178)
+PASS #186 Test that a WebAssembly code traps (memory_trap64.wast:179)
+PASS #187 Test that a WebAssembly code traps (memory_trap64.wast:180)
+PASS #188 Test that a WebAssembly code traps (memory_trap64.wast:181)
+PASS #189 Test that a WebAssembly code traps (memory_trap64.wast:182)
+PASS #190 Test that a WebAssembly code traps (memory_trap64.wast:183)
+PASS #191 Test that a WebAssembly code traps (memory_trap64.wast:184)
+PASS #192 Test that a WebAssembly code traps (memory_trap64.wast:185)
+PASS #193 Test that a WebAssembly code traps (memory_trap64.wast:186)
+PASS #194 Test that a WebAssembly code traps (memory_trap64.wast:187)
+PASS #195 Test that a WebAssembly code traps (memory_trap64.wast:188)
+PASS #196 Test that a WebAssembly code traps (memory_trap64.wast:189)
+PASS #197 Test that a WebAssembly code traps (memory_trap64.wast:190)
+PASS #198 Test that a WebAssembly code traps (memory_trap64.wast:191)
+PASS #199 Test that a WebAssembly code traps (memory_trap64.wast:192)
+PASS #200 Test that a WebAssembly code traps (memory_trap64.wast:193)
+PASS #201 Test that a WebAssembly code traps (memory_trap64.wast:194)
+PASS #202 Test that a WebAssembly code traps (memory_trap64.wast:195)
+PASS #203 Test that a WebAssembly code traps (memory_trap64.wast:196)
+PASS #204 Test that a WebAssembly code traps (memory_trap64.wast:197)
+PASS #205 Test that a WebAssembly code traps (memory_trap64.wast:198)
+PASS #206 Test that a WebAssembly code traps (memory_trap64.wast:199)
+PASS #207 Test that a WebAssembly code traps (memory_trap64.wast:200)
+PASS #208 Test that a WebAssembly code traps (memory_trap64.wast:201)
 PASS #209 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #210 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:328:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:328:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #211 Test that a WebAssembly code traps (memory_trap64.wast:202) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:328:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #210 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #211 Test that a WebAssembly code traps (memory_trap64.wast:202)
 PASS #212 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #213 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:331:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:331:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #214 Test that a WebAssembly code traps (memory_trap64.wast:203) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:331:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #213 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #214 Test that a WebAssembly code traps (memory_trap64.wast:203)
 PASS #215 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #216 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:334:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:334:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #217 Test that a WebAssembly code traps (memory_trap64.wast:204) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:334:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #216 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #217 Test that a WebAssembly code traps (memory_trap64.wast:204)
 PASS #218 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #219 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:337:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:337:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #220 Test that a WebAssembly code traps (memory_trap64.wast:205) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:337:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #219 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #220 Test that a WebAssembly code traps (memory_trap64.wast:205)
 PASS #221 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #222 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:340:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:340:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #223 Test that a WebAssembly code traps (memory_trap64.wast:206) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:340:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #222 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #223 Test that a WebAssembly code traps (memory_trap64.wast:206)
 PASS #224 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #225 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:343:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:343:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #226 Test that a WebAssembly code traps (memory_trap64.wast:207) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:343:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #225 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #226 Test that a WebAssembly code traps (memory_trap64.wast:207)
 PASS #227 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #228 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:346:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:346:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #229 Test that a WebAssembly code traps (memory_trap64.wast:208) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:346:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #228 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #229 Test that a WebAssembly code traps (memory_trap64.wast:208)
 PASS #230 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #231 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:349:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:349:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #232 Test that a WebAssembly code traps (memory_trap64.wast:209) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:349:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #231 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #232 Test that a WebAssembly code traps (memory_trap64.wast:209)
 PASS #233 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #234 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:352:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:352:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #235 Test that a WebAssembly code traps (memory_trap64.wast:210) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:352:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #234 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #235 Test that a WebAssembly code traps (memory_trap64.wast:210)
 PASS #236 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #237 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:355:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:355:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #238 Test that a WebAssembly code traps (memory_trap64.wast:211) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:355:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #237 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #238 Test that a WebAssembly code traps (memory_trap64.wast:211)
 PASS #239 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #240 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:358:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:358:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #241 Test that a WebAssembly code traps (memory_trap64.wast:212) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:358:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #240 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #241 Test that a WebAssembly code traps (memory_trap64.wast:212)
 PASS #242 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #243 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:361:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:361:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #244 Test that a WebAssembly code traps (memory_trap64.wast:213) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:361:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #243 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #244 Test that a WebAssembly code traps (memory_trap64.wast:213)
 PASS #245 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #246 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:364:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:364:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #247 Test that a WebAssembly code traps (memory_trap64.wast:214) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:364:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #246 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #247 Test that a WebAssembly code traps (memory_trap64.wast:214)
 PASS #248 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #249 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:367:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:367:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #250 Test that a WebAssembly code traps (memory_trap64.wast:215) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:367:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #249 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #250 Test that a WebAssembly code traps (memory_trap64.wast:215)
 PASS #251 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #252 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:370:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:370:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #253 Test that a WebAssembly code traps (memory_trap64.wast:216) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:370:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #252 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #253 Test that a WebAssembly code traps (memory_trap64.wast:216)
 PASS #254 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #255 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:373:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:373:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #256 Test that a WebAssembly code traps (memory_trap64.wast:217) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:373:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #255 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #256 Test that a WebAssembly code traps (memory_trap64.wast:217)
 PASS #257 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #258 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:376:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:376:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #259 Test that a WebAssembly code traps (memory_trap64.wast:218) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:376:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #258 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #259 Test that a WebAssembly code traps (memory_trap64.wast:218)
 PASS #260 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #261 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:379:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:379:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #262 Test that a WebAssembly code traps (memory_trap64.wast:219) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:379:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #261 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #262 Test that a WebAssembly code traps (memory_trap64.wast:219)
 PASS #263 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #264 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:382:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:382:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #265 Test that a WebAssembly code traps (memory_trap64.wast:220) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:382:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #264 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #265 Test that a WebAssembly code traps (memory_trap64.wast:220)
 PASS #266 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #267 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:385:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:385:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #268 Test that a WebAssembly code traps (memory_trap64.wast:221) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:385:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #267 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #268 Test that a WebAssembly code traps (memory_trap64.wast:221)
 PASS #269 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #270 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:388:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:388:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #271 Test that a WebAssembly code traps (memory_trap64.wast:222) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:388:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #270 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #271 Test that a WebAssembly code traps (memory_trap64.wast:222)
 PASS #272 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #273 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:391:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:391:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #274 Test that a WebAssembly code traps (memory_trap64.wast:223) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:391:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #273 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #274 Test that a WebAssembly code traps (memory_trap64.wast:223)
 PASS #275 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #276 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:394:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:394:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #277 Test that a WebAssembly code traps (memory_trap64.wast:224) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:394:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #276 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #277 Test that a WebAssembly code traps (memory_trap64.wast:224)
 PASS #278 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #279 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:397:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:397:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #280 Test that a WebAssembly code traps (memory_trap64.wast:225) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:397:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #281 Test that a WebAssembly code traps (memory_trap64.wast:226) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:400:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #282 Test that a WebAssembly code traps (memory_trap64.wast:227) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:403:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #283 Test that a WebAssembly code traps (memory_trap64.wast:228) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:406:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #284 Test that a WebAssembly code traps (memory_trap64.wast:229) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:409:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #285 Test that a WebAssembly code traps (memory_trap64.wast:230) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:412:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #286 Test that a WebAssembly code traps (memory_trap64.wast:231) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:415:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #287 Test that a WebAssembly code traps (memory_trap64.wast:232) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:418:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #288 Test that a WebAssembly code traps (memory_trap64.wast:233) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:421:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #289 Test that a WebAssembly code traps (memory_trap64.wast:234) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:424:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #290 Test that a WebAssembly code traps (memory_trap64.wast:235) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:427:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #291 Test that a WebAssembly code traps (memory_trap64.wast:236) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:430:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #292 Test that a WebAssembly code traps (memory_trap64.wast:237) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:433:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #293 Test that a WebAssembly code traps (memory_trap64.wast:238) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:436:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #294 Test that a WebAssembly code traps (memory_trap64.wast:239) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:439:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #295 Test that a WebAssembly code traps (memory_trap64.wast:240) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:442:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #296 Test that a WebAssembly code traps (memory_trap64.wast:241) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:445:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #297 Test that a WebAssembly code traps (memory_trap64.wast:242) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:448:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #298 Test that a WebAssembly code traps (memory_trap64.wast:243) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:451:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #299 Test that a WebAssembly code traps (memory_trap64.wast:244) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:454:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #300 Test that a WebAssembly code traps (memory_trap64.wast:245) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:457:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #301 Test that a WebAssembly code traps (memory_trap64.wast:246) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:460:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #302 Test that a WebAssembly code traps (memory_trap64.wast:247) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:463:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #303 Test that a WebAssembly code traps (memory_trap64.wast:248) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:466:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #304 Test that a WebAssembly code traps (memory_trap64.wast:249) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:469:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #305 Test that a WebAssembly code traps (memory_trap64.wast:250) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:472:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #306 Test that a WebAssembly code traps (memory_trap64.wast:251) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:475:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #307 Test that a WebAssembly code traps (memory_trap64.wast:252) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:478:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #308 Test that a WebAssembly code traps (memory_trap64.wast:253) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:481:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #309 Test that a WebAssembly code traps (memory_trap64.wast:254) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:484:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #310 Test that a WebAssembly code traps (memory_trap64.wast:255) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:487:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #311 Test that a WebAssembly code traps (memory_trap64.wast:256) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:490:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #312 Test that a WebAssembly code traps (memory_trap64.wast:257) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:493:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #313 Test that a WebAssembly code traps (memory_trap64.wast:258) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:496:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #314 Test that a WebAssembly code traps (memory_trap64.wast:259) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:499:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #315 Test that a WebAssembly code traps (memory_trap64.wast:260) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:502:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #316 Test that a WebAssembly code traps (memory_trap64.wast:261) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:505:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #317 Test that a WebAssembly code traps (memory_trap64.wast:262) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:508:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #318 Test that a WebAssembly code traps (memory_trap64.wast:263) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:511:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #319 Test that a WebAssembly code traps (memory_trap64.wast:264) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:514:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #320 Test that a WebAssembly code traps (memory_trap64.wast:265) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:517:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #321 Test that a WebAssembly code returns a specific result (memory_trap64.wast:268) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:520:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #322 Test that a WebAssembly code returns a specific result (memory_trap64.wast:269) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:523:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #279 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #280 Test that a WebAssembly code traps (memory_trap64.wast:225)
+PASS #281 Test that a WebAssembly code traps (memory_trap64.wast:226)
+PASS #282 Test that a WebAssembly code traps (memory_trap64.wast:227)
+PASS #283 Test that a WebAssembly code traps (memory_trap64.wast:228)
+PASS #284 Test that a WebAssembly code traps (memory_trap64.wast:229)
+PASS #285 Test that a WebAssembly code traps (memory_trap64.wast:230)
+PASS #286 Test that a WebAssembly code traps (memory_trap64.wast:231)
+PASS #287 Test that a WebAssembly code traps (memory_trap64.wast:232)
+PASS #288 Test that a WebAssembly code traps (memory_trap64.wast:233)
+PASS #289 Test that a WebAssembly code traps (memory_trap64.wast:234)
+PASS #290 Test that a WebAssembly code traps (memory_trap64.wast:235)
+PASS #291 Test that a WebAssembly code traps (memory_trap64.wast:236)
+PASS #292 Test that a WebAssembly code traps (memory_trap64.wast:237)
+PASS #293 Test that a WebAssembly code traps (memory_trap64.wast:238)
+PASS #294 Test that a WebAssembly code traps (memory_trap64.wast:239)
+PASS #295 Test that a WebAssembly code traps (memory_trap64.wast:240)
+PASS #296 Test that a WebAssembly code traps (memory_trap64.wast:241)
+PASS #297 Test that a WebAssembly code traps (memory_trap64.wast:242)
+PASS #298 Test that a WebAssembly code traps (memory_trap64.wast:243)
+PASS #299 Test that a WebAssembly code traps (memory_trap64.wast:244)
+PASS #300 Test that a WebAssembly code traps (memory_trap64.wast:245)
+PASS #301 Test that a WebAssembly code traps (memory_trap64.wast:246)
+PASS #302 Test that a WebAssembly code traps (memory_trap64.wast:247)
+PASS #303 Test that a WebAssembly code traps (memory_trap64.wast:248)
+PASS #304 Test that a WebAssembly code traps (memory_trap64.wast:249)
+PASS #305 Test that a WebAssembly code traps (memory_trap64.wast:250)
+PASS #306 Test that a WebAssembly code traps (memory_trap64.wast:251)
+PASS #307 Test that a WebAssembly code traps (memory_trap64.wast:252)
+PASS #308 Test that a WebAssembly code traps (memory_trap64.wast:253)
+PASS #309 Test that a WebAssembly code traps (memory_trap64.wast:254)
+PASS #310 Test that a WebAssembly code traps (memory_trap64.wast:255)
+PASS #311 Test that a WebAssembly code traps (memory_trap64.wast:256)
+PASS #312 Test that a WebAssembly code traps (memory_trap64.wast:257)
+PASS #313 Test that a WebAssembly code traps (memory_trap64.wast:258)
+PASS #314 Test that a WebAssembly code traps (memory_trap64.wast:259)
+PASS #315 Test that a WebAssembly code traps (memory_trap64.wast:260)
+PASS #316 Test that a WebAssembly code traps (memory_trap64.wast:261)
+PASS #317 Test that a WebAssembly code traps (memory_trap64.wast:262)
+PASS #318 Test that a WebAssembly code traps (memory_trap64.wast:263)
+PASS #319 Test that a WebAssembly code traps (memory_trap64.wast:264)
+PASS #320 Test that a WebAssembly code traps (memory_trap64.wast:265)
+PASS #321 Test that a WebAssembly code returns a specific result (memory_trap64.wast:268)
+PASS #322 Test that a WebAssembly code returns a specific result (memory_trap64.wast:269)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table64.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table64.wast.js-expected.txt
@@ -1,65 +1,43 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (table64.wast:1) assert_equals: expected false but got true
-FAIL #3 Test that WebAssembly compilation succeeds (table64.wast:2) assert_equals: expected false but got true
-FAIL #4 Test that WebAssembly compilation succeeds (table64.wast:3) assert_equals: expected false but got true
-FAIL #5 Test that WebAssembly compilation succeeds (table64.wast:4) assert_equals: expected false but got true
-FAIL #6 Test that WebAssembly compilation succeeds (table64.wast:5) assert_equals: expected false but got true
-FAIL #7 Test that WebAssembly compilation succeeds (table64.wast:6) assert_equals: expected false but got true
-FAIL #8 Test that WebAssembly compilation succeeds (table64.wast:7) assert_equals: expected false but got true
-FAIL #9 Test that WebAssembly compilation succeeds (table64.wast:8) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (table64.wast:1)
+PASS #3 Test that WebAssembly compilation succeeds (table64.wast:2)
+PASS #4 Test that WebAssembly compilation succeeds (table64.wast:3)
+PASS #5 Test that WebAssembly compilation succeeds (table64.wast:4)
+PASS #6 Test that WebAssembly compilation succeeds (table64.wast:5)
+PASS #7 Test that WebAssembly compilation succeeds (table64.wast:6)
+PASS #8 Test that WebAssembly compilation succeeds (table64.wast:7)
+PASS #9 Test that WebAssembly compilation succeeds (table64.wast:8)
 FAIL #10 Test that WebAssembly compilation succeeds (table64.wast:9) assert_equals: expected false but got true
-FAIL #11 Test that WebAssembly compilation succeeds (table64.wast:10) assert_equals: expected false but got true
-FAIL #12 Test that WebAssembly compilation succeeds (table64.wast:12) assert_equals: expected false but got true
-FAIL #13 Test that WebAssembly compilation succeeds (table64.wast:13) assert_equals: expected false but got true
+PASS #11 Test that WebAssembly compilation succeeds (table64.wast:10)
+PASS #12 Test that WebAssembly compilation succeeds (table64.wast:12)
+PASS #13 Test that WebAssembly compilation succeeds (table64.wast:13)
 PASS #14 Test that WebAssembly compilation fails (table64.wast:15)
 PASS #15 Test that WebAssembly compilation fails (table64.wast:19)
 PASS #16 Reinitialize the default imports
-FAIL #17 Test that WebAssembly compilation succeeds (table64.wast:1) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 17: Memory64 is not enabled at {loc} expected true got false
-FAIL #18 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-table64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table64.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table64.wast.js:78:3 expected true got false
-FAIL #19 Test that WebAssembly compilation succeeds (table64.wast:2) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 17: Memory64 is not enabled at {loc} expected true got false
-FAIL #20 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-table64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table64.wast.js:13:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table64.wast.js:78:3 expected true got false
-FAIL #21 Test that WebAssembly compilation succeeds (table64.wast:3) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 17: Memory64 is not enabled at {loc} expected true got false
-FAIL #22 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-table64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table64.wast.js:19:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table64.wast.js:78:3 expected true got false
-FAIL #23 Test that WebAssembly compilation succeeds (table64.wast:4) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 17: Memory64 is not enabled at {loc} expected true got false
-FAIL #24 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-table64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table64.wast.js:25:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table64.wast.js:78:3 expected true got false
-FAIL #25 Test that WebAssembly compilation succeeds (table64.wast:5) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 17: Memory64 is not enabled at {loc} expected true got false
-FAIL #26 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-table64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table64.wast.js:31:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table64.wast.js:78:3 expected true got false
-FAIL #27 Test that WebAssembly compilation succeeds (table64.wast:6) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 17: Memory64 is not enabled at {loc} expected true got false
-FAIL #28 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-table64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table64.wast.js:37:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table64.wast.js:78:3 expected true got false
-FAIL #29 Test that WebAssembly compilation succeeds (table64.wast:7) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 17: Memory64 is not enabled at {loc} expected true got false
-FAIL #30 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-table64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table64.wast.js:43:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table64.wast.js:78:3 expected true got false
-FAIL #31 Test that WebAssembly compilation succeeds (table64.wast:8) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 17: Memory64 is not enabled at {loc} expected true got false
-FAIL #32 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-table64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table64.wast.js:49:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table64.wast.js:78:3 expected true got false
-FAIL #33 Test that WebAssembly compilation succeeds (table64.wast:9) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 17: Memory64 is not enabled at {loc} expected true got false
-FAIL #34 Test that WebAssembly compilation succeeds (table64.wast:10) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 17: Memory64 is not enabled at {loc} expected true got false
-FAIL #35 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-table64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table64.wast.js:58:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table64.wast.js:78:3 expected true got false
-FAIL #36 Test that WebAssembly compilation succeeds (table64.wast:12) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 17: Memory64 is not enabled at {loc} expected true got false
-FAIL #37 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-table64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table64.wast.js:64:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table64.wast.js:78:3 expected true got false
-FAIL #38 Test that WebAssembly compilation succeeds (table64.wast:13) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 35: Memory64 is not enabled at {loc} expected true got false
-FAIL #39 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-table64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table64.wast.js:70:19
-global code@http://web-platform.test:8800/wasm/core/js/memory64/table64.wast.js:78:3 expected true got false
+PASS #17 Test that WebAssembly compilation succeeds (table64.wast:1)
+PASS #18 Test that WebAssembly instantiation succeeds (table64.wast:1)
+PASS #19 Test that WebAssembly compilation succeeds (table64.wast:2)
+PASS #20 Test that WebAssembly instantiation succeeds (table64.wast:2)
+PASS #21 Test that WebAssembly compilation succeeds (table64.wast:3)
+PASS #22 Test that WebAssembly instantiation succeeds (table64.wast:3)
+PASS #23 Test that WebAssembly compilation succeeds (table64.wast:4)
+PASS #24 Test that WebAssembly instantiation succeeds (table64.wast:4)
+PASS #25 Test that WebAssembly compilation succeeds (table64.wast:5)
+PASS #26 Test that WebAssembly instantiation succeeds (table64.wast:5)
+PASS #27 Test that WebAssembly compilation succeeds (table64.wast:6)
+PASS #28 Test that WebAssembly instantiation succeeds (table64.wast:6)
+PASS #29 Test that WebAssembly compilation succeeds (table64.wast:7)
+PASS #30 Test that WebAssembly instantiation succeeds (table64.wast:7)
+PASS #31 Test that WebAssembly compilation succeeds (table64.wast:8)
+PASS #32 Test that WebAssembly instantiation succeeds (table64.wast:8)
+FAIL #33 Test that WebAssembly compilation succeeds (table64.wast:9) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 27: Table's initial page count of 18446744073709551615 is too big, maximum 10000000 at {loc} expected true got false
+PASS #34 Test that WebAssembly compilation succeeds (table64.wast:10)
+PASS #35 Test that WebAssembly instantiation succeeds (table64.wast:10)
+PASS #36 Test that WebAssembly compilation succeeds (table64.wast:12)
+PASS #37 Test that WebAssembly instantiation succeeds (table64.wast:12)
+PASS #38 Test that WebAssembly compilation succeeds (table64.wast:13)
+PASS #39 Test that WebAssembly instantiation succeeds (table64.wast:13)
 PASS #40 Test that WebAssembly compilation fails (table64.wast:15)
 PASS #41 Test that WebAssembly compilation fails (table64.wast:19)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_copy64.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_copy64.wast.js-expected.txt
@@ -1189,154 +1189,154 @@ PASS #1187 Test that a WebAssembly code returns a specific result (table_copy64.
 PASS #1188 Test that a WebAssembly code traps (table_copy64.wast:1667)
 PASS #1189 Test that a WebAssembly code traps (table_copy64.wast:1668)
 PASS #1190 Test that a WebAssembly code traps (table_copy64.wast:1669)
-FAIL #1191 Test that WebAssembly compilation succeeds (table_copy64.wast:1671) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 49: Memory64 is not enabled at {loc} expected true got false
+FAIL #1191 Test that WebAssembly compilation succeeds (table_copy64.wast:1671) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
 FAIL #1192 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
 table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3418:19
 global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
 FAIL #1193 Test that a WebAssembly code traps (table_copy64.wast:1694) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
 table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3421:12
 global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
-FAIL #1194 Test that WebAssembly compilation succeeds (table_copy64.wast:1696) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 49: Memory64 is not enabled at {loc} expected true got false
+FAIL #1194 Test that WebAssembly compilation succeeds (table_copy64.wast:1696) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
 FAIL #1195 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
 table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3427:19
 global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
 FAIL #1196 Test that a WebAssembly code traps (table_copy64.wast:1719) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
 table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3430:12
 global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
-FAIL #1197 Test that WebAssembly compilation succeeds (table_copy64.wast:1721) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 49: Memory64 is not enabled at {loc} expected true got false
+FAIL #1197 Test that WebAssembly compilation succeeds (table_copy64.wast:1721) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
 FAIL #1198 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
 table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3436:19
 global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
 FAIL #1199 Test that a WebAssembly code traps (table_copy64.wast:1744) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
 table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3439:12
 global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
-FAIL #1200 Test that WebAssembly compilation succeeds (table_copy64.wast:1746) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 49: Memory64 is not enabled at {loc} expected true got false
+FAIL #1200 Test that WebAssembly compilation succeeds (table_copy64.wast:1746) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
 FAIL #1201 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
 table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3445:19
 global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
 FAIL #1202 Test that a WebAssembly code traps (table_copy64.wast:1769) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
 table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3448:12
 global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
-FAIL #1203 Test that WebAssembly compilation succeeds (table_copy64.wast:1771) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 49: Memory64 is not enabled at {loc} expected true got false
+FAIL #1203 Test that WebAssembly compilation succeeds (table_copy64.wast:1771) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
 FAIL #1204 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
 table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3454:19
 global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
 FAIL #1205 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
 table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3457:4
 global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
-FAIL #1206 Test that WebAssembly compilation succeeds (table_copy64.wast:1796) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 49: Memory64 is not enabled at {loc} expected true got false
+FAIL #1206 Test that WebAssembly compilation succeeds (table_copy64.wast:1796) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
 FAIL #1207 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
 table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3463:19
 global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
 FAIL #1208 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
 table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3466:4
 global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
-FAIL #1209 Test that WebAssembly compilation succeeds (table_copy64.wast:1821) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 49: Memory64 is not enabled at {loc} expected true got false
+FAIL #1209 Test that WebAssembly compilation succeeds (table_copy64.wast:1821) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
 FAIL #1210 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
 table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3472:19
 global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
 FAIL #1211 Test that a WebAssembly code traps (table_copy64.wast:1844) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
 table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3475:12
 global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
-FAIL #1212 Test that WebAssembly compilation succeeds (table_copy64.wast:1846) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 49: Memory64 is not enabled at {loc} expected true got false
+FAIL #1212 Test that WebAssembly compilation succeeds (table_copy64.wast:1846) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
 FAIL #1213 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
 table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3481:19
 global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
 FAIL #1214 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
 table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3484:4
 global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
-FAIL #1215 Test that WebAssembly compilation succeeds (table_copy64.wast:1871) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 49: Memory64 is not enabled at {loc} expected true got false
+FAIL #1215 Test that WebAssembly compilation succeeds (table_copy64.wast:1871) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
 FAIL #1216 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
 table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3490:19
 global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
 FAIL #1217 Test that a WebAssembly code traps (table_copy64.wast:1894) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
 table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3493:12
 global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
-FAIL #1218 Test that WebAssembly compilation succeeds (table_copy64.wast:1896) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 49: Memory64 is not enabled at {loc} expected true got false
+FAIL #1218 Test that WebAssembly compilation succeeds (table_copy64.wast:1896) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
 FAIL #1219 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
 table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3499:19
 global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
 FAIL #1220 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
 table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3502:4
 global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
-FAIL #1221 Test that WebAssembly compilation succeeds (table_copy64.wast:1921) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 49: Memory64 is not enabled at {loc} expected true got false
+FAIL #1221 Test that WebAssembly compilation succeeds (table_copy64.wast:1921) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
 FAIL #1222 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
 table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3508:19
 global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
 FAIL #1223 Test that a WebAssembly code traps (table_copy64.wast:1944) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
 table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3511:12
 global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
-FAIL #1224 Test that WebAssembly compilation succeeds (table_copy64.wast:1946) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 49: Memory64 is not enabled at {loc} expected true got false
+FAIL #1224 Test that WebAssembly compilation succeeds (table_copy64.wast:1946) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
 FAIL #1225 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
 table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3517:19
 global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
 FAIL #1226 Test that a WebAssembly code traps (table_copy64.wast:1969) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
 table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3520:12
 global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
-FAIL #1227 Test that WebAssembly compilation succeeds (table_copy64.wast:1971) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 49: Memory64 is not enabled at {loc} expected true got false
+FAIL #1227 Test that WebAssembly compilation succeeds (table_copy64.wast:1971) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
 FAIL #1228 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
 table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3526:19
 global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
 FAIL #1229 Test that a WebAssembly code traps (table_copy64.wast:1994) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
 table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3529:12
 global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
-FAIL #1230 Test that WebAssembly compilation succeeds (table_copy64.wast:1996) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 49: Memory64 is not enabled at {loc} expected true got false
+FAIL #1230 Test that WebAssembly compilation succeeds (table_copy64.wast:1996) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
 FAIL #1231 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
 table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3535:19
 global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
 FAIL #1232 Test that a WebAssembly code traps (table_copy64.wast:2019) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
 table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3538:12
 global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
-FAIL #1233 Test that WebAssembly compilation succeeds (table_copy64.wast:2021) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 49: Memory64 is not enabled at {loc} expected true got false
+FAIL #1233 Test that WebAssembly compilation succeeds (table_copy64.wast:2021) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
 FAIL #1234 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
 table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3544:19
 global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
 FAIL #1235 Test that a WebAssembly code traps (table_copy64.wast:2044) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
 table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3547:12
 global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
-FAIL #1236 Test that WebAssembly compilation succeeds (table_copy64.wast:2046) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 49: Memory64 is not enabled at {loc} expected true got false
+FAIL #1236 Test that WebAssembly compilation succeeds (table_copy64.wast:2046) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
 FAIL #1237 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
 table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3553:19
 global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
 FAIL #1238 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
 table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3556:4
 global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
-FAIL #1239 Test that WebAssembly compilation succeeds (table_copy64.wast:2071) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 49: Memory64 is not enabled at {loc} expected true got false
+FAIL #1239 Test that WebAssembly compilation succeeds (table_copy64.wast:2071) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
 FAIL #1240 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
 table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3562:19
 global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
 FAIL #1241 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
 table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3565:4
 global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
-FAIL #1242 Test that WebAssembly compilation succeeds (table_copy64.wast:2096) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 49: Memory64 is not enabled at {loc} expected true got false
+FAIL #1242 Test that WebAssembly compilation succeeds (table_copy64.wast:2096) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
 FAIL #1243 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
 table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3571:19
 global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
 FAIL #1244 Test that a WebAssembly code traps (table_copy64.wast:2119) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
 table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3574:12
 global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
-FAIL #1245 Test that WebAssembly compilation succeeds (table_copy64.wast:2121) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 49: Memory64 is not enabled at {loc} expected true got false
+FAIL #1245 Test that WebAssembly compilation succeeds (table_copy64.wast:2121) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
 FAIL #1246 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
 table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3580:19
 global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
 FAIL #1247 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
 table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3583:4
 global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
-FAIL #1248 Test that WebAssembly compilation succeeds (table_copy64.wast:2146) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 49: Memory64 is not enabled at {loc} expected true got false
+FAIL #1248 Test that WebAssembly compilation succeeds (table_copy64.wast:2146) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
 FAIL #1249 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
 table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3589:19
 global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
 FAIL #1250 Test that a WebAssembly code traps (table_copy64.wast:2169) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
 table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3592:12
 global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
-FAIL #1251 Test that WebAssembly compilation succeeds (table_copy64.wast:2171) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 49: Memory64 is not enabled at {loc} expected true got false
+FAIL #1251 Test that WebAssembly compilation succeeds (table_copy64.wast:2171) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
 FAIL #1252 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
 table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3598:19
 global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
 FAIL #1253 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
 table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3601:4
 global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false
-FAIL #1254 Test that WebAssembly compilation succeeds (table_copy64.wast:2196) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 49: Memory64 is not enabled at {loc} expected true got false
+FAIL #1254 Test that WebAssembly compilation succeeds (table_copy64.wast:2196) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
 FAIL #1255 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
 table_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:3607:19
 global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy64.wast.js:5343:3 expected true got false

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_copy_mixed.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_copy_mixed.wast.js-expected.txt
@@ -2,14 +2,17 @@
 PASS #1 Reinitialize the default imports
 FAIL #2 Test that WebAssembly compilation succeeds (table_copy_mixed.wast:2) assert_equals: expected false but got true
 PASS #3 Test that WebAssembly compilation fails (table_copy_mixed.wast:20)
-PASS #4 Test that WebAssembly compilation fails (table_copy_mixed.wast:30)
+FAIL #4 Test that WebAssembly compilation fails (table_copy_mixed.wast:30) assert_equals: expected true but got false
 PASS #5 Test that WebAssembly compilation fails (table_copy_mixed.wast:40)
 PASS #6 Reinitialize the default imports
-FAIL #7 Test that WebAssembly compilation succeeds (table_copy_mixed.wast:2) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 42: Memory64 is not enabled at {loc} expected true got false
+FAIL #7 Test that WebAssembly compilation succeeds (table_copy_mixed.wast:2) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't validate: table.copy dst_offset to type I64 expected I32, in function at index 1 at {loc} expected true got false
 FAIL #8 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
 table_copy_mixed_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy_mixed.wast.js:7:18
 global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy_mixed.wast.js:18:3 expected true got false
 PASS #9 Test that WebAssembly compilation fails (table_copy_mixed.wast:20)
-PASS #10 Test that WebAssembly compilation fails (table_copy_mixed.wast:30)
+FAIL #10 Test that WebAssembly compilation fails (table_copy_mixed.wast:30) assert_true: module@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:163:24
+assert_invalid@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:192:9
+table_copy_mixed_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_copy_mixed.wast.js:13:15
+global code@http://web-platform.test:8800/wasm/core/js/memory64/table_copy_mixed.wast.js:18:3 expected true got false
 PASS #11 Test that WebAssembly compilation fails (table_copy_mixed.wast:40)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_fill64.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_fill64.wast.js-expected.txt
@@ -11,7 +11,7 @@ PASS #9 Test that WebAssembly compilation fails (table_fill64.wast:193)
 PASS #10 Test that WebAssembly compilation fails (table_fill64.wast:203)
 PASS #11 Test that WebAssembly compilation fails (table_fill64.wast:214)
 PASS #12 Reinitialize the default imports
-FAIL #13 Test that WebAssembly compilation succeeds (table_fill64.wast:1) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 61: Memory64 is not enabled at {loc} expected true got false
+FAIL #13 Test that WebAssembly compilation succeeds (table_fill64.wast:1) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't validate: table.fill expects an i32 offset value, got I64, in function at index 3 at {loc} expected true got false
 FAIL #14 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
 table_fill64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:7:18
 global code@http://web-platform.test:8800/wasm/core/js/memory64/table_fill64.wast.js:246:3 expected true got false

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_get64.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_get64.wast.js-expected.txt
@@ -2,7 +2,7 @@
 PASS #1 Reinitialize the default imports
 FAIL #2 Test that WebAssembly compilation succeeds (table_get64.wast:1) assert_equals: expected false but got true
 PASS #3 Reinitialize the default imports
-FAIL #4 Test that WebAssembly compilation succeeds (table_get64.wast:1) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 58: Memory64 is not enabled at {loc} expected true got false
+FAIL #4 Test that WebAssembly compilation succeeds (table_get64.wast:1) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 136: Element init_expr must produce an i32 at {loc} expected true got false
 FAIL #5 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
 table_get64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_get64.wast.js:7:18
 global code@http://web-platform.test:8800/wasm/core/js/memory64/table_get64.wast.js:39:3 expected true got false

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_grow64.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_grow64.wast.js-expected.txt
@@ -2,7 +2,7 @@
 PASS #1 Reinitialize the default imports
 FAIL #2 Test that WebAssembly compilation succeeds (table_grow64.wast:1) assert_equals: expected false but got true
 PASS #3 Reinitialize the default imports
-FAIL #4 Test that WebAssembly compilation succeeds (table_grow64.wast:1) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 55: Memory64 is not enabled at {loc} expected true got false
+FAIL #4 Test that WebAssembly compilation succeeds (table_grow64.wast:1) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't validate: table.get index to type I64 expected I32, in function at index 0 at {loc} expected true got false
 FAIL #5 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
 table_grow64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_grow64.wast.js:7:18
 global code@http://web-platform.test:8800/wasm/core/js/memory64/table_grow64.wast.js:72:3 expected true got false

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_init64.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_init64.wast.js-expected.txt
@@ -312,7 +312,7 @@ PASS #310 Test that a WebAssembly code traps (table_init64.wast:380)
 PASS #311 Test that a WebAssembly code traps (table_init64.wast:381)
 PASS #312 Test that a WebAssembly code traps (table_init64.wast:382)
 PASS #313 Test that a WebAssembly code traps (table_init64.wast:383)
-FAIL #314 Test that WebAssembly compilation succeeds (table_init64.wast:385) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 105: Memory64 is not enabled at {loc} expected true got false
+FAIL #314 Test that WebAssembly compilation succeeds (table_init64.wast:385) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 141: Element init_expr must produce an i32 at {loc} expected true got false
 FAIL #315 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
 table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:610:18
 global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
@@ -409,7 +409,7 @@ global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.was
 FAIL #346 Test that a WebAssembly code traps (table_init64.wast:442) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
 table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:703:12
 global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #347 Test that WebAssembly compilation succeeds (table_init64.wast:444) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 105: Memory64 is not enabled at {loc} expected true got false
+FAIL #347 Test that WebAssembly compilation succeeds (table_init64.wast:444) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 141: Element init_expr must produce an i32 at {loc} expected true got false
 FAIL #348 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
 table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:709:18
 global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
@@ -506,7 +506,7 @@ global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.was
 FAIL #379 Test that a WebAssembly code traps (table_init64.wast:501) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
 table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:802:12
 global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
-FAIL #380 Test that WebAssembly compilation succeeds (table_init64.wast:503) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 105: Memory64 is not enabled at {loc} expected true got false
+FAIL #380 Test that WebAssembly compilation succeeds (table_init64.wast:503) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 141: Element init_expr must produce an i32 at {loc} expected true got false
 FAIL #381 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
 table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:808:19
 global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false
@@ -1232,7 +1232,7 @@ PASS #1038 Test that a WebAssembly code traps (table_init64.wast:2430)
 PASS #1039 Test that a WebAssembly code traps (table_init64.wast:2431)
 PASS #1040 Test that WebAssembly compilation succeeds (table_init64.wast:2433)
 PASS #1041 Test that WebAssembly instantiation succeeds (table_init64.wast:2433)
-FAIL #1042 Test that WebAssembly compilation succeeds (table_init64.wast:2457) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 39: Memory64 is not enabled at {loc} expected true got false
+FAIL #1042 Test that WebAssembly compilation succeeds (table_init64.wast:2457) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't validate: table.init dst_offset to type I64 expected I32, in function at index 0 at {loc} expected true got false
 FAIL #1043 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
 table_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2794:19
 global code@http://web-platform.test:8800/wasm/core/js/memory64/table_init64.wast.js:2799:3 expected true got false

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_set64.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_set64.wast.js-expected.txt
@@ -2,7 +2,7 @@
 PASS #1 Reinitialize the default imports
 FAIL #2 Test that WebAssembly compilation succeeds (table_set64.wast:1) assert_equals: expected false but got true
 PASS #3 Reinitialize the default imports
-FAIL #4 Test that WebAssembly compilation succeeds (table_set64.wast:1) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 71: Memory64 is not enabled at {loc} expected true got false
+FAIL #4 Test that WebAssembly compilation succeeds (table_set64.wast:1) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 191: Element init_expr must produce an i32 at {loc} expected true got false
 FAIL #5 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
 table_set64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_set64.wast.js:7:18
 global code@http://web-platform.test:8800/wasm/core/js/memory64/table_set64.wast.js:63:3 expected true got false

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_size64.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_size64.wast.js-expected.txt
@@ -2,7 +2,7 @@
 PASS #1 Reinitialize the default imports
 FAIL #2 Test that WebAssembly compilation succeeds (table_size64.wast:1) assert_equals: expected false but got true
 PASS #3 Reinitialize the default imports
-FAIL #4 Test that WebAssembly compilation succeeds (table_size64.wast:1) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 47: Memory64 is not enabled at {loc} expected true got false
+FAIL #4 Test that WebAssembly compilation succeeds (table_size64.wast:1) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't validate: control flow returns with unexpected type. I32 is not a I64, in function at index 0 at {loc} expected true got false
 FAIL #5 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
 table_size64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:7:18
 global code@http://web-platform.test:8800/wasm/core/js/memory64/table_size64.wast.js:117:3 expected true got false

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/address0.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/address0.wast.js-expected.txt
@@ -1,282 +1,98 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (address0.wast:3) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (address0.wast:3)
 PASS #3 Reinitialize the default imports
-FAIL #4 Test that WebAssembly compilation succeeds (address0.wast:3) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 68: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-FAIL #5 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #6 Test that a WebAssembly code returns a specific result (address0.wast:105) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:10:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #7 Test that a WebAssembly code returns a specific result (address0.wast:106) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:13:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #8 Test that a WebAssembly code returns a specific result (address0.wast:107) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:16:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #9 Test that a WebAssembly code returns a specific result (address0.wast:108) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:19:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #10 Test that a WebAssembly code returns a specific result (address0.wast:109) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:22:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #11 Test that a WebAssembly code returns a specific result (address0.wast:111) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:25:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #12 Test that a WebAssembly code returns a specific result (address0.wast:112) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:28:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #13 Test that a WebAssembly code returns a specific result (address0.wast:113) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:31:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #14 Test that a WebAssembly code returns a specific result (address0.wast:114) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:34:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #15 Test that a WebAssembly code returns a specific result (address0.wast:115) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:37:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #16 Test that a WebAssembly code returns a specific result (address0.wast:117) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:40:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #17 Test that a WebAssembly code returns a specific result (address0.wast:118) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:43:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #18 Test that a WebAssembly code returns a specific result (address0.wast:119) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:46:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #19 Test that a WebAssembly code returns a specific result (address0.wast:120) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:49:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #20 Test that a WebAssembly code returns a specific result (address0.wast:121) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:52:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #21 Test that a WebAssembly code returns a specific result (address0.wast:123) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:55:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #22 Test that a WebAssembly code returns a specific result (address0.wast:124) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:58:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #23 Test that a WebAssembly code returns a specific result (address0.wast:125) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:61:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #24 Test that a WebAssembly code returns a specific result (address0.wast:126) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:64:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #25 Test that a WebAssembly code returns a specific result (address0.wast:127) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:67:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #26 Test that a WebAssembly code returns a specific result (address0.wast:129) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:70:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #27 Test that a WebAssembly code returns a specific result (address0.wast:130) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:73:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #28 Test that a WebAssembly code returns a specific result (address0.wast:131) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:76:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #29 Test that a WebAssembly code returns a specific result (address0.wast:132) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:79:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #30 Test that a WebAssembly code returns a specific result (address0.wast:133) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:82:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #31 Test that a WebAssembly code returns a specific result (address0.wast:135) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:85:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #32 Test that a WebAssembly code returns a specific result (address0.wast:136) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:88:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #33 Test that a WebAssembly code returns a specific result (address0.wast:137) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:91:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #34 Test that a WebAssembly code returns a specific result (address0.wast:138) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:94:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #35 Test that a WebAssembly code returns a specific result (address0.wast:139) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:97:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #36 Test that a WebAssembly code returns a specific result (address0.wast:141) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:100:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #37 Test that a WebAssembly code returns a specific result (address0.wast:142) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:103:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #38 Test that a WebAssembly code returns a specific result (address0.wast:143) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:106:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #39 Test that a WebAssembly code returns a specific result (address0.wast:144) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:109:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #40 Test that a WebAssembly code returns a specific result (address0.wast:145) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:112:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #41 Test that a WebAssembly code returns a specific result (address0.wast:147) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:115:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #42 Test that a WebAssembly code returns a specific result (address0.wast:148) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:118:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #43 Test that a WebAssembly code returns a specific result (address0.wast:149) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:121:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #44 Test that a WebAssembly code returns a specific result (address0.wast:150) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:124:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #45 Test that a WebAssembly code returns a specific result (address0.wast:151) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:127:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #46 Test that a WebAssembly code returns a specific result (address0.wast:153) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:130:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #47 Test that a WebAssembly code returns a specific result (address0.wast:154) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:133:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #48 Test that a WebAssembly code returns a specific result (address0.wast:155) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:136:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #49 Test that a WebAssembly code returns a specific result (address0.wast:156) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:139:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #50 Test that a WebAssembly code returns a specific result (address0.wast:157) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:142:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #51 Test that a WebAssembly code returns a specific result (address0.wast:159) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:145:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #52 Test that a WebAssembly code returns a specific result (address0.wast:160) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:148:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #53 Test that a WebAssembly code returns a specific result (address0.wast:161) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:151:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #54 Test that a WebAssembly code returns a specific result (address0.wast:162) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:154:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #55 Test that a WebAssembly code returns a specific result (address0.wast:163) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:157:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #56 Test that a WebAssembly code returns a specific result (address0.wast:165) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:160:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #57 Test that a WebAssembly code returns a specific result (address0.wast:166) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:163:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #58 Test that a WebAssembly code returns a specific result (address0.wast:167) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:166:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #59 Test that a WebAssembly code returns a specific result (address0.wast:168) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:169:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #60 Test that a WebAssembly code returns a specific result (address0.wast:169) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:172:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #61 Test that a WebAssembly code returns a specific result (address0.wast:171) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:175:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #62 Test that a WebAssembly code returns a specific result (address0.wast:172) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:178:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #63 Test that a WebAssembly code returns a specific result (address0.wast:173) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:181:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #64 Test that a WebAssembly code returns a specific result (address0.wast:174) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:184:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #65 Test that a WebAssembly code returns a specific result (address0.wast:175) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:187:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #66 Test that a WebAssembly code returns a specific result (address0.wast:177) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:190:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #67 Test that a WebAssembly code returns a specific result (address0.wast:178) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:193:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #68 Test that a WebAssembly code returns a specific result (address0.wast:179) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:196:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #69 Test that a WebAssembly code returns a specific result (address0.wast:180) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:199:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #70 Test that a WebAssembly code returns a specific result (address0.wast:181) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:202:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #71 Test that a WebAssembly code returns a specific result (address0.wast:183) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:205:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #72 Test that a WebAssembly code returns a specific result (address0.wast:184) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:208:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #73 Test that a WebAssembly code returns a specific result (address0.wast:185) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:211:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #74 Test that a WebAssembly code returns a specific result (address0.wast:186) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:214:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #75 Test that a WebAssembly code returns a specific result (address0.wast:187) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:217:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #76 Test that a WebAssembly code returns a specific result (address0.wast:189) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:220:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #77 Test that a WebAssembly code returns a specific result (address0.wast:190) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:223:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #78 Test that a WebAssembly code returns a specific result (address0.wast:191) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:226:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #79 Test that a WebAssembly code returns a specific result (address0.wast:192) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:229:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #80 Test that a WebAssembly code traps (address0.wast:193) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:232:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #81 Test that a WebAssembly code traps (address0.wast:195) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:235:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #82 Test that a WebAssembly code traps (address0.wast:196) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:238:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #83 Test that a WebAssembly code traps (address0.wast:197) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:241:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #84 Test that a WebAssembly code traps (address0.wast:198) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:244:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #85 Test that a WebAssembly code traps (address0.wast:199) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:247:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #86 Test that a WebAssembly code traps (address0.wast:200) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:250:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #87 Test that a WebAssembly code traps (address0.wast:202) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:253:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #88 Test that a WebAssembly code traps (address0.wast:203) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:256:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #89 Test that a WebAssembly code traps (address0.wast:204) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:259:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #90 Test that a WebAssembly code traps (address0.wast:205) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:262:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #91 Test that a WebAssembly code traps (address0.wast:206) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:265:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #92 Test that a WebAssembly code traps (address0.wast:208) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:268:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #93 Test that a WebAssembly code traps (address0.wast:209) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:271:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #94 Test that a WebAssembly code traps (address0.wast:210) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:274:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #95 Test that a WebAssembly code traps (address0.wast:211) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:277:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
-FAIL #96 Test that a WebAssembly code traps (address0.wast:212) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:280:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address0.wast.js:282:3 expected true got false
+PASS #4 Test that WebAssembly compilation succeeds (address0.wast:3)
+PASS #5 Test that WebAssembly instantiation succeeds (address0.wast:3)
+PASS #6 Test that a WebAssembly code returns a specific result (address0.wast:105)
+PASS #7 Test that a WebAssembly code returns a specific result (address0.wast:106)
+PASS #8 Test that a WebAssembly code returns a specific result (address0.wast:107)
+PASS #9 Test that a WebAssembly code returns a specific result (address0.wast:108)
+PASS #10 Test that a WebAssembly code returns a specific result (address0.wast:109)
+PASS #11 Test that a WebAssembly code returns a specific result (address0.wast:111)
+PASS #12 Test that a WebAssembly code returns a specific result (address0.wast:112)
+PASS #13 Test that a WebAssembly code returns a specific result (address0.wast:113)
+PASS #14 Test that a WebAssembly code returns a specific result (address0.wast:114)
+PASS #15 Test that a WebAssembly code returns a specific result (address0.wast:115)
+PASS #16 Test that a WebAssembly code returns a specific result (address0.wast:117)
+PASS #17 Test that a WebAssembly code returns a specific result (address0.wast:118)
+PASS #18 Test that a WebAssembly code returns a specific result (address0.wast:119)
+PASS #19 Test that a WebAssembly code returns a specific result (address0.wast:120)
+PASS #20 Test that a WebAssembly code returns a specific result (address0.wast:121)
+PASS #21 Test that a WebAssembly code returns a specific result (address0.wast:123)
+PASS #22 Test that a WebAssembly code returns a specific result (address0.wast:124)
+PASS #23 Test that a WebAssembly code returns a specific result (address0.wast:125)
+PASS #24 Test that a WebAssembly code returns a specific result (address0.wast:126)
+PASS #25 Test that a WebAssembly code returns a specific result (address0.wast:127)
+PASS #26 Test that a WebAssembly code returns a specific result (address0.wast:129)
+PASS #27 Test that a WebAssembly code returns a specific result (address0.wast:130)
+PASS #28 Test that a WebAssembly code returns a specific result (address0.wast:131)
+PASS #29 Test that a WebAssembly code returns a specific result (address0.wast:132)
+PASS #30 Test that a WebAssembly code returns a specific result (address0.wast:133)
+PASS #31 Test that a WebAssembly code returns a specific result (address0.wast:135)
+PASS #32 Test that a WebAssembly code returns a specific result (address0.wast:136)
+PASS #33 Test that a WebAssembly code returns a specific result (address0.wast:137)
+PASS #34 Test that a WebAssembly code returns a specific result (address0.wast:138)
+PASS #35 Test that a WebAssembly code returns a specific result (address0.wast:139)
+PASS #36 Test that a WebAssembly code returns a specific result (address0.wast:141)
+PASS #37 Test that a WebAssembly code returns a specific result (address0.wast:142)
+PASS #38 Test that a WebAssembly code returns a specific result (address0.wast:143)
+PASS #39 Test that a WebAssembly code returns a specific result (address0.wast:144)
+PASS #40 Test that a WebAssembly code returns a specific result (address0.wast:145)
+PASS #41 Test that a WebAssembly code returns a specific result (address0.wast:147)
+PASS #42 Test that a WebAssembly code returns a specific result (address0.wast:148)
+PASS #43 Test that a WebAssembly code returns a specific result (address0.wast:149)
+PASS #44 Test that a WebAssembly code returns a specific result (address0.wast:150)
+PASS #45 Test that a WebAssembly code returns a specific result (address0.wast:151)
+PASS #46 Test that a WebAssembly code returns a specific result (address0.wast:153)
+PASS #47 Test that a WebAssembly code returns a specific result (address0.wast:154)
+PASS #48 Test that a WebAssembly code returns a specific result (address0.wast:155)
+PASS #49 Test that a WebAssembly code returns a specific result (address0.wast:156)
+PASS #50 Test that a WebAssembly code returns a specific result (address0.wast:157)
+PASS #51 Test that a WebAssembly code returns a specific result (address0.wast:159)
+PASS #52 Test that a WebAssembly code returns a specific result (address0.wast:160)
+PASS #53 Test that a WebAssembly code returns a specific result (address0.wast:161)
+PASS #54 Test that a WebAssembly code returns a specific result (address0.wast:162)
+PASS #55 Test that a WebAssembly code returns a specific result (address0.wast:163)
+PASS #56 Test that a WebAssembly code returns a specific result (address0.wast:165)
+PASS #57 Test that a WebAssembly code returns a specific result (address0.wast:166)
+PASS #58 Test that a WebAssembly code returns a specific result (address0.wast:167)
+PASS #59 Test that a WebAssembly code returns a specific result (address0.wast:168)
+PASS #60 Test that a WebAssembly code returns a specific result (address0.wast:169)
+PASS #61 Test that a WebAssembly code returns a specific result (address0.wast:171)
+PASS #62 Test that a WebAssembly code returns a specific result (address0.wast:172)
+PASS #63 Test that a WebAssembly code returns a specific result (address0.wast:173)
+PASS #64 Test that a WebAssembly code returns a specific result (address0.wast:174)
+PASS #65 Test that a WebAssembly code returns a specific result (address0.wast:175)
+PASS #66 Test that a WebAssembly code returns a specific result (address0.wast:177)
+PASS #67 Test that a WebAssembly code returns a specific result (address0.wast:178)
+PASS #68 Test that a WebAssembly code returns a specific result (address0.wast:179)
+PASS #69 Test that a WebAssembly code returns a specific result (address0.wast:180)
+PASS #70 Test that a WebAssembly code returns a specific result (address0.wast:181)
+PASS #71 Test that a WebAssembly code returns a specific result (address0.wast:183)
+PASS #72 Test that a WebAssembly code returns a specific result (address0.wast:184)
+PASS #73 Test that a WebAssembly code returns a specific result (address0.wast:185)
+PASS #74 Test that a WebAssembly code returns a specific result (address0.wast:186)
+PASS #75 Test that a WebAssembly code returns a specific result (address0.wast:187)
+PASS #76 Test that a WebAssembly code returns a specific result (address0.wast:189)
+PASS #77 Test that a WebAssembly code returns a specific result (address0.wast:190)
+PASS #78 Test that a WebAssembly code returns a specific result (address0.wast:191)
+PASS #79 Test that a WebAssembly code returns a specific result (address0.wast:192)
+PASS #80 Test that a WebAssembly code traps (address0.wast:193)
+PASS #81 Test that a WebAssembly code traps (address0.wast:195)
+PASS #82 Test that a WebAssembly code traps (address0.wast:196)
+PASS #83 Test that a WebAssembly code traps (address0.wast:197)
+PASS #84 Test that a WebAssembly code traps (address0.wast:198)
+PASS #85 Test that a WebAssembly code traps (address0.wast:199)
+PASS #86 Test that a WebAssembly code traps (address0.wast:200)
+PASS #87 Test that a WebAssembly code traps (address0.wast:202)
+PASS #88 Test that a WebAssembly code traps (address0.wast:203)
+PASS #89 Test that a WebAssembly code traps (address0.wast:204)
+PASS #90 Test that a WebAssembly code traps (address0.wast:205)
+PASS #91 Test that a WebAssembly code traps (address0.wast:206)
+PASS #92 Test that a WebAssembly code traps (address0.wast:208)
+PASS #93 Test that a WebAssembly code traps (address0.wast:209)
+PASS #94 Test that a WebAssembly code traps (address0.wast:210)
+PASS #95 Test that a WebAssembly code traps (address0.wast:211)
+PASS #96 Test that a WebAssembly code traps (address0.wast:212)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/address1.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/address1.wast.js-expected.txt
@@ -1,387 +1,133 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (address1.wast:3) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (address1.wast:3)
 PASS #3 Reinitialize the default imports
-FAIL #4 Test that WebAssembly compilation succeeds (address1.wast:3) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-FAIL #5 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #6 Test that a WebAssembly code returns a specific result (address1.wast:146) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:10:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #7 Test that a WebAssembly code returns a specific result (address1.wast:147) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:13:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #8 Test that a WebAssembly code returns a specific result (address1.wast:148) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:16:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #9 Test that a WebAssembly code returns a specific result (address1.wast:149) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:19:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #10 Test that a WebAssembly code returns a specific result (address1.wast:150) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:22:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #11 Test that a WebAssembly code returns a specific result (address1.wast:152) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:25:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #12 Test that a WebAssembly code returns a specific result (address1.wast:153) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:28:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #13 Test that a WebAssembly code returns a specific result (address1.wast:154) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:31:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #14 Test that a WebAssembly code returns a specific result (address1.wast:155) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:34:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #15 Test that a WebAssembly code returns a specific result (address1.wast:156) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:37:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #16 Test that a WebAssembly code returns a specific result (address1.wast:158) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:40:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #17 Test that a WebAssembly code returns a specific result (address1.wast:159) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:43:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #18 Test that a WebAssembly code returns a specific result (address1.wast:160) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:46:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #19 Test that a WebAssembly code returns a specific result (address1.wast:161) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:49:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #20 Test that a WebAssembly code returns a specific result (address1.wast:162) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:52:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #21 Test that a WebAssembly code returns a specific result (address1.wast:164) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:55:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #22 Test that a WebAssembly code returns a specific result (address1.wast:165) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:58:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #23 Test that a WebAssembly code returns a specific result (address1.wast:166) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:61:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #24 Test that a WebAssembly code returns a specific result (address1.wast:167) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:64:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #25 Test that a WebAssembly code returns a specific result (address1.wast:168) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:67:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #26 Test that a WebAssembly code returns a specific result (address1.wast:170) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:70:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #27 Test that a WebAssembly code returns a specific result (address1.wast:171) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:73:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #28 Test that a WebAssembly code returns a specific result (address1.wast:172) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:76:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #29 Test that a WebAssembly code returns a specific result (address1.wast:173) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:79:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #30 Test that a WebAssembly code returns a specific result (address1.wast:174) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:82:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #31 Test that a WebAssembly code returns a specific result (address1.wast:176) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:85:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #32 Test that a WebAssembly code returns a specific result (address1.wast:177) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:88:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #33 Test that a WebAssembly code returns a specific result (address1.wast:178) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:91:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #34 Test that a WebAssembly code returns a specific result (address1.wast:179) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:94:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #35 Test that a WebAssembly code returns a specific result (address1.wast:180) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:97:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #36 Test that a WebAssembly code returns a specific result (address1.wast:182) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:100:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #37 Test that a WebAssembly code returns a specific result (address1.wast:183) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:103:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #38 Test that a WebAssembly code returns a specific result (address1.wast:184) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:106:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #39 Test that a WebAssembly code returns a specific result (address1.wast:185) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:109:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #40 Test that a WebAssembly code returns a specific result (address1.wast:186) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:112:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #41 Test that a WebAssembly code returns a specific result (address1.wast:188) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:115:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #42 Test that a WebAssembly code returns a specific result (address1.wast:189) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:118:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #43 Test that a WebAssembly code returns a specific result (address1.wast:190) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:121:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #44 Test that a WebAssembly code returns a specific result (address1.wast:191) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:124:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #45 Test that a WebAssembly code returns a specific result (address1.wast:192) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:127:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #46 Test that a WebAssembly code returns a specific result (address1.wast:194) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:130:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #47 Test that a WebAssembly code returns a specific result (address1.wast:195) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:133:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #48 Test that a WebAssembly code returns a specific result (address1.wast:196) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:136:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #49 Test that a WebAssembly code returns a specific result (address1.wast:197) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:139:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #50 Test that a WebAssembly code returns a specific result (address1.wast:198) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:142:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #51 Test that a WebAssembly code returns a specific result (address1.wast:200) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:145:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #52 Test that a WebAssembly code returns a specific result (address1.wast:201) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:148:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #53 Test that a WebAssembly code returns a specific result (address1.wast:202) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:151:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #54 Test that a WebAssembly code returns a specific result (address1.wast:203) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:154:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #55 Test that a WebAssembly code returns a specific result (address1.wast:204) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:157:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #56 Test that a WebAssembly code returns a specific result (address1.wast:206) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:160:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #57 Test that a WebAssembly code returns a specific result (address1.wast:207) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:163:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #58 Test that a WebAssembly code returns a specific result (address1.wast:208) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:166:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #59 Test that a WebAssembly code returns a specific result (address1.wast:209) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:169:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #60 Test that a WebAssembly code returns a specific result (address1.wast:210) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:172:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #61 Test that a WebAssembly code returns a specific result (address1.wast:212) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:175:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #62 Test that a WebAssembly code returns a specific result (address1.wast:213) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:178:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #63 Test that a WebAssembly code returns a specific result (address1.wast:214) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:181:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #64 Test that a WebAssembly code returns a specific result (address1.wast:215) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:184:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #65 Test that a WebAssembly code returns a specific result (address1.wast:216) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:187:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #66 Test that a WebAssembly code returns a specific result (address1.wast:218) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:190:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #67 Test that a WebAssembly code returns a specific result (address1.wast:219) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:193:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #68 Test that a WebAssembly code returns a specific result (address1.wast:220) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:196:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #69 Test that a WebAssembly code returns a specific result (address1.wast:221) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:199:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #70 Test that a WebAssembly code returns a specific result (address1.wast:222) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:202:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #71 Test that a WebAssembly code returns a specific result (address1.wast:224) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:205:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #72 Test that a WebAssembly code returns a specific result (address1.wast:225) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:208:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #73 Test that a WebAssembly code returns a specific result (address1.wast:226) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:211:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #74 Test that a WebAssembly code returns a specific result (address1.wast:227) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:214:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #75 Test that a WebAssembly code returns a specific result (address1.wast:228) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:217:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #76 Test that a WebAssembly code returns a specific result (address1.wast:230) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:220:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #77 Test that a WebAssembly code returns a specific result (address1.wast:231) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:223:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #78 Test that a WebAssembly code returns a specific result (address1.wast:232) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:226:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #79 Test that a WebAssembly code returns a specific result (address1.wast:233) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:229:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #80 Test that a WebAssembly code returns a specific result (address1.wast:234) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:232:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #81 Test that a WebAssembly code returns a specific result (address1.wast:236) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:235:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #82 Test that a WebAssembly code returns a specific result (address1.wast:237) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:238:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #83 Test that a WebAssembly code returns a specific result (address1.wast:238) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:241:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #84 Test that a WebAssembly code returns a specific result (address1.wast:239) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:244:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #85 Test that a WebAssembly code returns a specific result (address1.wast:240) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:247:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #86 Test that a WebAssembly code returns a specific result (address1.wast:242) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:250:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #87 Test that a WebAssembly code returns a specific result (address1.wast:243) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:253:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #88 Test that a WebAssembly code returns a specific result (address1.wast:244) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:256:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #89 Test that a WebAssembly code returns a specific result (address1.wast:245) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:259:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #90 Test that a WebAssembly code returns a specific result (address1.wast:246) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:262:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #91 Test that a WebAssembly code returns a specific result (address1.wast:248) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:265:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #92 Test that a WebAssembly code returns a specific result (address1.wast:249) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:268:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #93 Test that a WebAssembly code returns a specific result (address1.wast:250) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:271:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #94 Test that a WebAssembly code returns a specific result (address1.wast:251) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:274:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #95 Test that a WebAssembly code returns a specific result (address1.wast:252) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:277:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #96 Test that a WebAssembly code returns a specific result (address1.wast:254) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:280:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #97 Test that a WebAssembly code returns a specific result (address1.wast:255) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:283:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #98 Test that a WebAssembly code returns a specific result (address1.wast:256) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:286:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #99 Test that a WebAssembly code returns a specific result (address1.wast:257) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:289:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #100 Test that a WebAssembly code returns a specific result (address1.wast:258) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:292:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #101 Test that a WebAssembly code returns a specific result (address1.wast:260) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:295:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #102 Test that a WebAssembly code returns a specific result (address1.wast:261) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:298:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #103 Test that a WebAssembly code returns a specific result (address1.wast:262) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:301:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #104 Test that a WebAssembly code returns a specific result (address1.wast:263) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:304:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #105 Test that a WebAssembly code returns a specific result (address1.wast:264) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:307:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #106 Test that a WebAssembly code returns a specific result (address1.wast:266) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:310:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #107 Test that a WebAssembly code returns a specific result (address1.wast:267) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:313:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #108 Test that a WebAssembly code returns a specific result (address1.wast:268) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:316:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #109 Test that a WebAssembly code returns a specific result (address1.wast:269) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:319:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #110 Test that a WebAssembly code traps (address1.wast:270) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:322:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #111 Test that a WebAssembly code traps (address1.wast:272) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:325:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #112 Test that a WebAssembly code traps (address1.wast:273) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:328:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #113 Test that a WebAssembly code traps (address1.wast:274) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:331:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #114 Test that a WebAssembly code traps (address1.wast:275) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:334:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #115 Test that a WebAssembly code traps (address1.wast:276) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:337:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #116 Test that a WebAssembly code traps (address1.wast:277) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:340:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #117 Test that a WebAssembly code traps (address1.wast:278) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:343:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #118 Test that a WebAssembly code traps (address1.wast:280) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:346:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #119 Test that a WebAssembly code traps (address1.wast:281) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:349:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #120 Test that a WebAssembly code traps (address1.wast:282) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:352:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #121 Test that a WebAssembly code traps (address1.wast:283) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:355:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #122 Test that a WebAssembly code traps (address1.wast:284) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:358:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #123 Test that a WebAssembly code traps (address1.wast:285) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:361:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #124 Test that a WebAssembly code traps (address1.wast:286) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:364:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #125 Test that a WebAssembly code traps (address1.wast:288) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:367:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #126 Test that a WebAssembly code traps (address1.wast:289) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:370:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #127 Test that a WebAssembly code traps (address1.wast:290) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:373:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #128 Test that a WebAssembly code traps (address1.wast:291) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:376:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #129 Test that a WebAssembly code traps (address1.wast:292) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:379:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #130 Test that a WebAssembly code traps (address1.wast:293) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:382:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
-FAIL #131 Test that a WebAssembly code traps (address1.wast:294) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-address1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:385:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/address1.wast.js:387:3 expected true got false
+PASS #4 Test that WebAssembly compilation succeeds (address1.wast:3)
+PASS #5 Test that WebAssembly instantiation succeeds (address1.wast:3)
+PASS #6 Test that a WebAssembly code returns a specific result (address1.wast:146)
+PASS #7 Test that a WebAssembly code returns a specific result (address1.wast:147)
+PASS #8 Test that a WebAssembly code returns a specific result (address1.wast:148)
+PASS #9 Test that a WebAssembly code returns a specific result (address1.wast:149)
+PASS #10 Test that a WebAssembly code returns a specific result (address1.wast:150)
+PASS #11 Test that a WebAssembly code returns a specific result (address1.wast:152)
+PASS #12 Test that a WebAssembly code returns a specific result (address1.wast:153)
+PASS #13 Test that a WebAssembly code returns a specific result (address1.wast:154)
+PASS #14 Test that a WebAssembly code returns a specific result (address1.wast:155)
+PASS #15 Test that a WebAssembly code returns a specific result (address1.wast:156)
+PASS #16 Test that a WebAssembly code returns a specific result (address1.wast:158)
+PASS #17 Test that a WebAssembly code returns a specific result (address1.wast:159)
+PASS #18 Test that a WebAssembly code returns a specific result (address1.wast:160)
+PASS #19 Test that a WebAssembly code returns a specific result (address1.wast:161)
+PASS #20 Test that a WebAssembly code returns a specific result (address1.wast:162)
+PASS #21 Test that a WebAssembly code returns a specific result (address1.wast:164)
+PASS #22 Test that a WebAssembly code returns a specific result (address1.wast:165)
+PASS #23 Test that a WebAssembly code returns a specific result (address1.wast:166)
+PASS #24 Test that a WebAssembly code returns a specific result (address1.wast:167)
+PASS #25 Test that a WebAssembly code returns a specific result (address1.wast:168)
+PASS #26 Test that a WebAssembly code returns a specific result (address1.wast:170)
+PASS #27 Test that a WebAssembly code returns a specific result (address1.wast:171)
+PASS #28 Test that a WebAssembly code returns a specific result (address1.wast:172)
+PASS #29 Test that a WebAssembly code returns a specific result (address1.wast:173)
+PASS #30 Test that a WebAssembly code returns a specific result (address1.wast:174)
+PASS #31 Test that a WebAssembly code returns a specific result (address1.wast:176)
+PASS #32 Test that a WebAssembly code returns a specific result (address1.wast:177)
+PASS #33 Test that a WebAssembly code returns a specific result (address1.wast:178)
+PASS #34 Test that a WebAssembly code returns a specific result (address1.wast:179)
+PASS #35 Test that a WebAssembly code returns a specific result (address1.wast:180)
+PASS #36 Test that a WebAssembly code returns a specific result (address1.wast:182)
+PASS #37 Test that a WebAssembly code returns a specific result (address1.wast:183)
+PASS #38 Test that a WebAssembly code returns a specific result (address1.wast:184)
+PASS #39 Test that a WebAssembly code returns a specific result (address1.wast:185)
+PASS #40 Test that a WebAssembly code returns a specific result (address1.wast:186)
+PASS #41 Test that a WebAssembly code returns a specific result (address1.wast:188)
+PASS #42 Test that a WebAssembly code returns a specific result (address1.wast:189)
+PASS #43 Test that a WebAssembly code returns a specific result (address1.wast:190)
+PASS #44 Test that a WebAssembly code returns a specific result (address1.wast:191)
+PASS #45 Test that a WebAssembly code returns a specific result (address1.wast:192)
+PASS #46 Test that a WebAssembly code returns a specific result (address1.wast:194)
+PASS #47 Test that a WebAssembly code returns a specific result (address1.wast:195)
+PASS #48 Test that a WebAssembly code returns a specific result (address1.wast:196)
+PASS #49 Test that a WebAssembly code returns a specific result (address1.wast:197)
+PASS #50 Test that a WebAssembly code returns a specific result (address1.wast:198)
+PASS #51 Test that a WebAssembly code returns a specific result (address1.wast:200)
+PASS #52 Test that a WebAssembly code returns a specific result (address1.wast:201)
+PASS #53 Test that a WebAssembly code returns a specific result (address1.wast:202)
+PASS #54 Test that a WebAssembly code returns a specific result (address1.wast:203)
+PASS #55 Test that a WebAssembly code returns a specific result (address1.wast:204)
+PASS #56 Test that a WebAssembly code returns a specific result (address1.wast:206)
+PASS #57 Test that a WebAssembly code returns a specific result (address1.wast:207)
+PASS #58 Test that a WebAssembly code returns a specific result (address1.wast:208)
+PASS #59 Test that a WebAssembly code returns a specific result (address1.wast:209)
+PASS #60 Test that a WebAssembly code returns a specific result (address1.wast:210)
+PASS #61 Test that a WebAssembly code returns a specific result (address1.wast:212)
+PASS #62 Test that a WebAssembly code returns a specific result (address1.wast:213)
+PASS #63 Test that a WebAssembly code returns a specific result (address1.wast:214)
+PASS #64 Test that a WebAssembly code returns a specific result (address1.wast:215)
+PASS #65 Test that a WebAssembly code returns a specific result (address1.wast:216)
+PASS #66 Test that a WebAssembly code returns a specific result (address1.wast:218)
+PASS #67 Test that a WebAssembly code returns a specific result (address1.wast:219)
+PASS #68 Test that a WebAssembly code returns a specific result (address1.wast:220)
+PASS #69 Test that a WebAssembly code returns a specific result (address1.wast:221)
+PASS #70 Test that a WebAssembly code returns a specific result (address1.wast:222)
+PASS #71 Test that a WebAssembly code returns a specific result (address1.wast:224)
+PASS #72 Test that a WebAssembly code returns a specific result (address1.wast:225)
+PASS #73 Test that a WebAssembly code returns a specific result (address1.wast:226)
+PASS #74 Test that a WebAssembly code returns a specific result (address1.wast:227)
+PASS #75 Test that a WebAssembly code returns a specific result (address1.wast:228)
+PASS #76 Test that a WebAssembly code returns a specific result (address1.wast:230)
+PASS #77 Test that a WebAssembly code returns a specific result (address1.wast:231)
+PASS #78 Test that a WebAssembly code returns a specific result (address1.wast:232)
+PASS #79 Test that a WebAssembly code returns a specific result (address1.wast:233)
+PASS #80 Test that a WebAssembly code returns a specific result (address1.wast:234)
+PASS #81 Test that a WebAssembly code returns a specific result (address1.wast:236)
+PASS #82 Test that a WebAssembly code returns a specific result (address1.wast:237)
+PASS #83 Test that a WebAssembly code returns a specific result (address1.wast:238)
+PASS #84 Test that a WebAssembly code returns a specific result (address1.wast:239)
+PASS #85 Test that a WebAssembly code returns a specific result (address1.wast:240)
+PASS #86 Test that a WebAssembly code returns a specific result (address1.wast:242)
+PASS #87 Test that a WebAssembly code returns a specific result (address1.wast:243)
+PASS #88 Test that a WebAssembly code returns a specific result (address1.wast:244)
+PASS #89 Test that a WebAssembly code returns a specific result (address1.wast:245)
+PASS #90 Test that a WebAssembly code returns a specific result (address1.wast:246)
+PASS #91 Test that a WebAssembly code returns a specific result (address1.wast:248)
+PASS #92 Test that a WebAssembly code returns a specific result (address1.wast:249)
+PASS #93 Test that a WebAssembly code returns a specific result (address1.wast:250)
+PASS #94 Test that a WebAssembly code returns a specific result (address1.wast:251)
+PASS #95 Test that a WebAssembly code returns a specific result (address1.wast:252)
+PASS #96 Test that a WebAssembly code returns a specific result (address1.wast:254)
+PASS #97 Test that a WebAssembly code returns a specific result (address1.wast:255)
+PASS #98 Test that a WebAssembly code returns a specific result (address1.wast:256)
+PASS #99 Test that a WebAssembly code returns a specific result (address1.wast:257)
+PASS #100 Test that a WebAssembly code returns a specific result (address1.wast:258)
+PASS #101 Test that a WebAssembly code returns a specific result (address1.wast:260)
+PASS #102 Test that a WebAssembly code returns a specific result (address1.wast:261)
+PASS #103 Test that a WebAssembly code returns a specific result (address1.wast:262)
+PASS #104 Test that a WebAssembly code returns a specific result (address1.wast:263)
+PASS #105 Test that a WebAssembly code returns a specific result (address1.wast:264)
+PASS #106 Test that a WebAssembly code returns a specific result (address1.wast:266)
+PASS #107 Test that a WebAssembly code returns a specific result (address1.wast:267)
+PASS #108 Test that a WebAssembly code returns a specific result (address1.wast:268)
+PASS #109 Test that a WebAssembly code returns a specific result (address1.wast:269)
+PASS #110 Test that a WebAssembly code traps (address1.wast:270)
+PASS #111 Test that a WebAssembly code traps (address1.wast:272)
+PASS #112 Test that a WebAssembly code traps (address1.wast:273)
+PASS #113 Test that a WebAssembly code traps (address1.wast:274)
+PASS #114 Test that a WebAssembly code traps (address1.wast:275)
+PASS #115 Test that a WebAssembly code traps (address1.wast:276)
+PASS #116 Test that a WebAssembly code traps (address1.wast:277)
+PASS #117 Test that a WebAssembly code traps (address1.wast:278)
+PASS #118 Test that a WebAssembly code traps (address1.wast:280)
+PASS #119 Test that a WebAssembly code traps (address1.wast:281)
+PASS #120 Test that a WebAssembly code traps (address1.wast:282)
+PASS #121 Test that a WebAssembly code traps (address1.wast:283)
+PASS #122 Test that a WebAssembly code traps (address1.wast:284)
+PASS #123 Test that a WebAssembly code traps (address1.wast:285)
+PASS #124 Test that a WebAssembly code traps (address1.wast:286)
+PASS #125 Test that a WebAssembly code traps (address1.wast:288)
+PASS #126 Test that a WebAssembly code traps (address1.wast:289)
+PASS #127 Test that a WebAssembly code traps (address1.wast:290)
+PASS #128 Test that a WebAssembly code traps (address1.wast:291)
+PASS #129 Test that a WebAssembly code traps (address1.wast:292)
+PASS #130 Test that a WebAssembly code traps (address1.wast:293)
+PASS #131 Test that a WebAssembly code traps (address1.wast:294)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/align0.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/align0.wast.js-expected.txt
@@ -1,49 +1,23 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (align0.wast:3) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (align0.wast:3)
 PASS #3 Test that WebAssembly compilation succeeds (wrapper)
 PASS #4 Test that WebAssembly compilation succeeds (wrapper)
 PASS #5 Test that WebAssembly compilation succeeds (wrapper)
 PASS #6 Test that WebAssembly compilation succeeds (wrapper)
 PASS #7 Reinitialize the default imports
-FAIL #8 Test that WebAssembly compilation succeeds (align0.wast:3) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 35: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-FAIL #9 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-align0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/align0.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/align0.wast.js:21:3 expected true got false
+PASS #8 Test that WebAssembly compilation succeeds (align0.wast:3)
+PASS #9 Test that WebAssembly instantiation succeeds (align0.wast:3)
 PASS #10 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #11 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32_align_switch must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/align0.wast.js:10:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-align0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/align0.wast.js:10:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/align0.wast.js:21:3 expected true got false
-FAIL #12 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-align0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/align0.wast.js:10:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/align0.wast.js:21:3 expected true got false
+PASS #11 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #12 Run a WebAssembly test without special assertions (align0.wast:39)
 PASS #13 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #14 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32_align_switch must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/align0.wast.js:13:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-align0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/align0.wast.js:13:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/align0.wast.js:21:3 expected true got false
-FAIL #15 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-align0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/align0.wast.js:13:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/align0.wast.js:21:3 expected true got false
+PASS #14 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #15 Run a WebAssembly test without special assertions (align0.wast:40)
 PASS #16 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #17 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32_align_switch must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/align0.wast.js:16:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-align0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/align0.wast.js:16:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/align0.wast.js:21:3 expected true got false
-FAIL #18 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-align0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/align0.wast.js:16:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/align0.wast.js:21:3 expected true got false
+PASS #17 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #18 Run a WebAssembly test without special assertions (align0.wast:41)
 PASS #19 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #20 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32_align_switch must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/align0.wast.js:19:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-align0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/align0.wast.js:19:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/align0.wast.js:21:3 expected true got false
-FAIL #21 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-align0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/align0.wast.js:19:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/align0.wast.js:21:3 expected true got false
+PASS #20 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #21 Run a WebAssembly test without special assertions (align0.wast:42)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/binary0.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/binary0.wast.js-expected.txt
@@ -1,33 +1,23 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (binary0.wast:2) assert_equals: expected false but got true
-FAIL #3 Test that WebAssembly compilation succeeds (binary0.wast:8) assert_equals: expected false but got true
-FAIL #4 Test that WebAssembly compilation succeeds (binary0.wast:16) assert_equals: expected false but got true
-FAIL #5 Test that WebAssembly compilation succeeds (binary0.wast:26) assert_equals: expected false but got true
-FAIL #6 Test that WebAssembly compilation succeeds (binary0.wast:36) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (binary0.wast:2)
+PASS #3 Test that WebAssembly compilation succeeds (binary0.wast:8)
+PASS #4 Test that WebAssembly compilation succeeds (binary0.wast:16)
+PASS #5 Test that WebAssembly compilation succeeds (binary0.wast:26)
+PASS #6 Test that WebAssembly compilation succeeds (binary0.wast:36)
 PASS #7 Test that WebAssembly compilation fails (binary0.wast:47)
 PASS #8 Test that WebAssembly compilation fails (binary0.wast:58)
 PASS #9 Reinitialize the default imports
-FAIL #10 Test that WebAssembly compilation succeeds (binary0.wast:2) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 11: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-FAIL #11 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-binary0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/binary0.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/binary0.wast.js:39:3 expected true got false
-FAIL #12 Test that WebAssembly compilation succeeds (binary0.wast:8) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 11: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-FAIL #13 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-binary0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/binary0.wast.js:13:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/binary0.wast.js:39:3 expected true got false
-FAIL #14 Test that WebAssembly compilation succeeds (binary0.wast:16) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 11: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-FAIL #15 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-binary0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/binary0.wast.js:19:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/binary0.wast.js:39:3 expected true got false
-FAIL #16 Test that WebAssembly compilation succeeds (binary0.wast:26) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 11: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-FAIL #17 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-binary0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/binary0.wast.js:25:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/binary0.wast.js:39:3 expected true got false
-FAIL #18 Test that WebAssembly compilation succeeds (binary0.wast:36) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 11: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-FAIL #19 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-binary0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/binary0.wast.js:31:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/binary0.wast.js:39:3 expected true got false
+PASS #10 Test that WebAssembly compilation succeeds (binary0.wast:2)
+PASS #11 Test that WebAssembly instantiation succeeds (binary0.wast:2)
+PASS #12 Test that WebAssembly compilation succeeds (binary0.wast:8)
+PASS #13 Test that WebAssembly instantiation succeeds (binary0.wast:8)
+PASS #14 Test that WebAssembly compilation succeeds (binary0.wast:16)
+PASS #15 Test that WebAssembly instantiation succeeds (binary0.wast:16)
+PASS #16 Test that WebAssembly compilation succeeds (binary0.wast:26)
+PASS #17 Test that WebAssembly instantiation succeeds (binary0.wast:26)
+PASS #18 Test that WebAssembly compilation succeeds (binary0.wast:36)
+PASS #19 Test that WebAssembly instantiation succeeds (binary0.wast:36)
 PASS #20 Test that WebAssembly compilation fails (binary0.wast:47)
 PASS #21 Test that WebAssembly compilation fails (binary0.wast:58)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/data0.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/data0.wast.js-expected.txt
@@ -1,23 +1,19 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (data0.wast:5) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (data0.wast:5)
 PASS #3 Test that WebAssembly compilation succeeds (data0.wast:39)
-FAIL #4 Test that WebAssembly compilation succeeds (data0.wast:43) assert_equals: expected false but got true
+PASS #4 Test that WebAssembly compilation succeeds (data0.wast:43)
 PASS #5 Test that WebAssembly compilation succeeds (data0.wast:52)
 PASS #6 Test that WebAssembly compilation succeeds (data0.wast:57)
 PASS #7 Test that WebAssembly compilation succeeds (data0.wast:63)
 PASS #8 Test that WebAssembly compilation succeeds (data0.wast:68)
 PASS #9 Reinitialize the default imports
-FAIL #10 Test that WebAssembly compilation succeeds (data0.wast:5) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 15: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-FAIL #11 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-data0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/data0.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/data0.wast.js:45:3 expected true got false
+PASS #10 Test that WebAssembly compilation succeeds (data0.wast:5)
+PASS #11 Test that WebAssembly instantiation succeeds (data0.wast:5)
 PASS #12 Test that WebAssembly compilation succeeds (data0.wast:39)
 PASS #13 Test that WebAssembly instantiation succeeds (data0.wast:39)
-FAIL #14 Test that WebAssembly compilation succeeds (data0.wast:43) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 51: there can at most be one Memory section for now at {loc} expected true got false
-FAIL #15 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-data0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/data0.wast.js:19:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/data0.wast.js:45:3 expected true got false
+PASS #14 Test that WebAssembly compilation succeeds (data0.wast:43)
+PASS #15 Test that WebAssembly instantiation succeeds (data0.wast:43)
 PASS #16 Test that WebAssembly compilation succeeds (data0.wast:52)
 PASS #17 Test that WebAssembly instantiation succeeds (data0.wast:52)
 PASS #18 Test that WebAssembly compilation succeeds (data0.wast:57)

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/data1.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/data1.wast.js-expected.txt
@@ -1,86 +1,60 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (data1.wast:4) assert_equals: expected false but got true
-FAIL #3 Test that WebAssembly compilation succeeds (data1.wast:14) assert_equals: expected false but got true
-FAIL #4 Test that WebAssembly compilation succeeds (data1.wast:24) assert_equals: expected false but got true
-FAIL #5 Test that WebAssembly compilation succeeds (data1.wast:33) assert_equals: expected false but got true
-FAIL #6 Test that WebAssembly compilation succeeds (data1.wast:42) assert_equals: expected false but got true
-FAIL #7 Test that WebAssembly compilation succeeds (data1.wast:61) assert_equals: expected false but got true
-FAIL #8 Test that WebAssembly compilation succeeds (data1.wast:72) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (data1.wast:4)
+PASS #3 Test that WebAssembly compilation succeeds (data1.wast:14)
+PASS #4 Test that WebAssembly compilation succeeds (data1.wast:24)
+PASS #5 Test that WebAssembly compilation succeeds (data1.wast:33)
+PASS #6 Test that WebAssembly compilation succeeds (data1.wast:42)
+PASS #7 Test that WebAssembly compilation succeeds (data1.wast:61)
+PASS #8 Test that WebAssembly compilation succeeds (data1.wast:72)
 PASS #9 Test that WebAssembly compilation succeeds (data1.wast:81)
-FAIL #10 Test that WebAssembly compilation succeeds (data1.wast:89) assert_equals: expected false but got true
-FAIL #11 Test that WebAssembly compilation succeeds (data1.wast:99) assert_equals: expected false but got true
-FAIL #12 Test that WebAssembly compilation succeeds (data1.wast:109) assert_equals: expected false but got true
-FAIL #13 Test that WebAssembly compilation succeeds (data1.wast:118) assert_equals: expected false but got true
-FAIL #14 Test that WebAssembly compilation succeeds (data1.wast:128) assert_equals: expected false but got true
-FAIL #15 Test that WebAssembly compilation succeeds (data1.wast:137) assert_equals: expected false but got true
+PASS #10 Test that WebAssembly compilation succeeds (data1.wast:89)
+PASS #11 Test that WebAssembly compilation succeeds (data1.wast:99)
+PASS #12 Test that WebAssembly compilation succeeds (data1.wast:109)
+PASS #13 Test that WebAssembly compilation succeeds (data1.wast:118)
+PASS #14 Test that WebAssembly compilation succeeds (data1.wast:128)
+PASS #15 Test that WebAssembly compilation succeeds (data1.wast:137)
 PASS #16 Reinitialize the default imports
-FAIL #17 Test that WebAssembly compilation succeeds (data1.wast:4) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 15: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-PASS #18 Test that WebAssembly instantiation fails
-FAIL #19 Test that a WebAssembly module is uninstantiable assert_true: expected link error, observed TypeError: undefined is not an object (evaluating 'values[0].source') assert_uninstantiable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:433:24
-data1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/data1.wast.js:7:22
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/data1.wast.js:87:3 expected true got false
-FAIL #20 Test that WebAssembly compilation succeeds (data1.wast:14) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 15: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-PASS #21 Test that WebAssembly instantiation fails
-FAIL #22 Test that a WebAssembly module is uninstantiable assert_true: expected link error, observed TypeError: undefined is not an object (evaluating 'values[0].source') assert_uninstantiable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:433:24
-data1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/data1.wast.js:13:22
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/data1.wast.js:87:3 expected true got false
-FAIL #23 Test that WebAssembly compilation succeeds (data1.wast:24) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 15: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-PASS #24 Test that WebAssembly instantiation fails
-FAIL #25 Test that a WebAssembly module is uninstantiable assert_true: expected link error, observed TypeError: undefined is not an object (evaluating 'values[0].source') assert_uninstantiable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:433:24
-data1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/data1.wast.js:19:22
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/data1.wast.js:87:3 expected true got false
-FAIL #26 Test that WebAssembly compilation succeeds (data1.wast:33) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 15: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-PASS #27 Test that WebAssembly instantiation fails
-FAIL #28 Test that a WebAssembly module is uninstantiable assert_true: expected link error, observed TypeError: undefined is not an object (evaluating 'values[0].source') assert_uninstantiable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:433:24
-data1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/data1.wast.js:25:22
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/data1.wast.js:87:3 expected true got false
-FAIL #29 Test that WebAssembly compilation succeeds (data1.wast:42) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 15: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-PASS #30 Test that WebAssembly instantiation fails
-FAIL #31 Test that a WebAssembly module is uninstantiable assert_true: expected link error, observed TypeError: undefined is not an object (evaluating 'values[0].source') assert_uninstantiable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:433:24
-data1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/data1.wast.js:31:22
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/data1.wast.js:87:3 expected true got false
-FAIL #32 Test that WebAssembly compilation succeeds (data1.wast:61) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 45: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-PASS #33 Test that WebAssembly instantiation fails
-FAIL #34 Test that a WebAssembly module is uninstantiable assert_true: expected link error, observed TypeError: undefined is not an object (evaluating 'values[0].source') assert_uninstantiable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:433:24
-data1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/data1.wast.js:37:22
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/data1.wast.js:87:3 expected true got false
-FAIL #35 Test that WebAssembly compilation succeeds (data1.wast:72) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 15: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-PASS #36 Test that WebAssembly instantiation fails
-FAIL #37 Test that a WebAssembly module is uninstantiable assert_true: expected link error, observed TypeError: undefined is not an object (evaluating 'values[0].source') assert_uninstantiable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:433:24
-data1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/data1.wast.js:43:22
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/data1.wast.js:87:3 expected true got false
+PASS #17 Test that WebAssembly compilation succeeds (data1.wast:4)
+PASS #18 Test that WebAssembly instantiation fails (data1.wast:4)
+PASS #19 Test that a WebAssembly module is uninstantiable
+PASS #20 Test that WebAssembly compilation succeeds (data1.wast:14)
+PASS #21 Test that WebAssembly instantiation fails (data1.wast:14)
+PASS #22 Test that a WebAssembly module is uninstantiable
+PASS #23 Test that WebAssembly compilation succeeds (data1.wast:24)
+PASS #24 Test that WebAssembly instantiation fails (data1.wast:24)
+PASS #25 Test that a WebAssembly module is uninstantiable
+PASS #26 Test that WebAssembly compilation succeeds (data1.wast:33)
+PASS #27 Test that WebAssembly instantiation fails (data1.wast:33)
+PASS #28 Test that a WebAssembly module is uninstantiable
+PASS #29 Test that WebAssembly compilation succeeds (data1.wast:42)
+PASS #30 Test that WebAssembly instantiation fails (data1.wast:42)
+PASS #31 Test that a WebAssembly module is uninstantiable
+PASS #32 Test that WebAssembly compilation succeeds (data1.wast:61)
+PASS #33 Test that WebAssembly instantiation fails (data1.wast:61)
+PASS #34 Test that a WebAssembly module is uninstantiable
+PASS #35 Test that WebAssembly compilation succeeds (data1.wast:72)
+PASS #36 Test that WebAssembly instantiation fails (data1.wast:72)
+PASS #37 Test that a WebAssembly module is uninstantiable
 PASS #38 Test that WebAssembly compilation succeeds (data1.wast:81)
 PASS #39 Test that WebAssembly instantiation fails (data1.wast:81)
 PASS #40 Test that a WebAssembly module is uninstantiable
-FAIL #41 Test that WebAssembly compilation succeeds (data1.wast:89) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 15: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-PASS #42 Test that WebAssembly instantiation fails
-FAIL #43 Test that a WebAssembly module is uninstantiable assert_true: expected link error, observed TypeError: undefined is not an object (evaluating 'values[0].source') assert_uninstantiable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:433:24
-data1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/data1.wast.js:55:22
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/data1.wast.js:87:3 expected true got false
-FAIL #44 Test that WebAssembly compilation succeeds (data1.wast:99) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 15: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-PASS #45 Test that WebAssembly instantiation fails
-FAIL #46 Test that a WebAssembly module is uninstantiable assert_true: expected link error, observed TypeError: undefined is not an object (evaluating 'values[0].source') assert_uninstantiable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:433:24
-data1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/data1.wast.js:61:22
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/data1.wast.js:87:3 expected true got false
-FAIL #47 Test that WebAssembly compilation succeeds (data1.wast:109) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 15: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-PASS #48 Test that WebAssembly instantiation fails
-FAIL #49 Test that a WebAssembly module is uninstantiable assert_true: expected link error, observed TypeError: undefined is not an object (evaluating 'values[0].source') assert_uninstantiable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:433:24
-data1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/data1.wast.js:67:22
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/data1.wast.js:87:3 expected true got false
-FAIL #50 Test that WebAssembly compilation succeeds (data1.wast:118) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 51: there can at most be one Memory section for now at {loc} expected true got false
-PASS #51 Test that WebAssembly instantiation fails
-FAIL #52 Test that a WebAssembly module is uninstantiable assert_true: expected link error, observed TypeError: undefined is not an object (evaluating 'values[0].source') assert_uninstantiable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:433:24
-data1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/data1.wast.js:73:22
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/data1.wast.js:87:3 expected true got false
-FAIL #53 Test that WebAssembly compilation succeeds (data1.wast:128) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 15: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-PASS #54 Test that WebAssembly instantiation fails
-FAIL #55 Test that a WebAssembly module is uninstantiable assert_true: expected link error, observed TypeError: undefined is not an object (evaluating 'values[0].source') assert_uninstantiable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:433:24
-data1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/data1.wast.js:79:22
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/data1.wast.js:87:3 expected true got false
-FAIL #56 Test that WebAssembly compilation succeeds (data1.wast:137) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 51: there can at most be one Memory section for now at {loc} expected true got false
-PASS #57 Test that WebAssembly instantiation fails
-FAIL #58 Test that a WebAssembly module is uninstantiable assert_true: expected link error, observed TypeError: undefined is not an object (evaluating 'values[0].source') assert_uninstantiable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:433:24
-data1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/data1.wast.js:85:22
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/data1.wast.js:87:3 expected true got false
+PASS #41 Test that WebAssembly compilation succeeds (data1.wast:89)
+PASS #42 Test that WebAssembly instantiation fails (data1.wast:89)
+PASS #43 Test that a WebAssembly module is uninstantiable
+PASS #44 Test that WebAssembly compilation succeeds (data1.wast:99)
+PASS #45 Test that WebAssembly instantiation fails (data1.wast:99)
+PASS #46 Test that a WebAssembly module is uninstantiable
+PASS #47 Test that WebAssembly compilation succeeds (data1.wast:109)
+PASS #48 Test that WebAssembly instantiation fails (data1.wast:109)
+PASS #49 Test that a WebAssembly module is uninstantiable
+PASS #50 Test that WebAssembly compilation succeeds (data1.wast:118)
+PASS #51 Test that WebAssembly instantiation fails (data1.wast:118)
+PASS #52 Test that a WebAssembly module is uninstantiable
+PASS #53 Test that WebAssembly compilation succeeds (data1.wast:128)
+PASS #54 Test that WebAssembly instantiation fails (data1.wast:128)
+PASS #55 Test that a WebAssembly module is uninstantiable
+PASS #56 Test that WebAssembly compilation succeeds (data1.wast:137)
+PASS #57 Test that WebAssembly instantiation fails (data1.wast:137)
+PASS #58 Test that a WebAssembly module is uninstantiable
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/data_drop0.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/data_drop0.wast.js-expected.txt
@@ -1,39 +1,17 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (data_drop0.wast:2) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (data_drop0.wast:2)
 PASS #3 Reinitialize the default imports
-FAIL #4 Test that WebAssembly compilation succeeds (data_drop0.wast:2) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 40: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-FAIL #5 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-data_drop0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/data_drop0.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/data_drop0.wast.js:39:3 expected true got false
-FAIL #6 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-data_drop0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/data_drop0.wast.js:10:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/data_drop0.wast.js:39:3 expected true got false
-FAIL #7 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-data_drop0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/data_drop0.wast.js:13:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/data_drop0.wast.js:39:3 expected true got false
-FAIL #8 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-data_drop0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/data_drop0.wast.js:16:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/data_drop0.wast.js:39:3 expected true got false
-FAIL #9 Test that a WebAssembly code returns a specific result (data_drop0.wast:21) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-data_drop0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/data_drop0.wast.js:19:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/data_drop0.wast.js:39:3 expected true got false
-FAIL #10 Test that a WebAssembly code traps (data_drop0.wast:22) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-data_drop0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/data_drop0.wast.js:22:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/data_drop0.wast.js:39:3 expected true got false
-FAIL #11 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-data_drop0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/data_drop0.wast.js:25:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/data_drop0.wast.js:39:3 expected true got false
-FAIL #12 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-data_drop0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/data_drop0.wast.js:28:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/data_drop0.wast.js:39:3 expected true got false
-FAIL #13 Test that a WebAssembly code returns a specific result (data_drop0.wast:25) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-data_drop0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/data_drop0.wast.js:31:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/data_drop0.wast.js:39:3 expected true got false
-FAIL #14 Test that a WebAssembly code traps (data_drop0.wast:26) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-data_drop0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/data_drop0.wast.js:34:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/data_drop0.wast.js:39:3 expected true got false
-FAIL #15 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-data_drop0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/data_drop0.wast.js:37:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/data_drop0.wast.js:39:3 expected true got false
+PASS #4 Test that WebAssembly compilation succeeds (data_drop0.wast:2)
+PASS #5 Test that WebAssembly instantiation succeeds (data_drop0.wast:2)
+PASS #6 Run a WebAssembly test without special assertions (data_drop0.wast:18)
+PASS #7 Run a WebAssembly test without special assertions (data_drop0.wast:19)
+PASS #8 Run a WebAssembly test without special assertions (data_drop0.wast:20)
+PASS #9 Test that a WebAssembly code returns a specific result (data_drop0.wast:21)
+PASS #10 Test that a WebAssembly code traps (data_drop0.wast:22)
+PASS #11 Run a WebAssembly test without special assertions (data_drop0.wast:23)
+PASS #12 Run a WebAssembly test without special assertions (data_drop0.wast:24)
+PASS #13 Test that a WebAssembly code returns a specific result (data_drop0.wast:25)
+PASS #14 Test that a WebAssembly code traps (data_drop0.wast:26)
+PASS #15 Run a WebAssembly test without special assertions (data_drop0.wast:27)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/exports0.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/exports0.wast.js-expected.txt
@@ -2,10 +2,10 @@
 PASS #1 Reinitialize the default imports
 PASS #2 Test that WebAssembly compilation succeeds (exports0.wast:3)
 PASS #3 Test that WebAssembly compilation succeeds (exports0.wast:4)
-FAIL #4 Test that WebAssembly compilation succeeds (exports0.wast:5) assert_equals: expected false but got true
-FAIL #5 Test that WebAssembly compilation succeeds (exports0.wast:6) assert_equals: expected false but got true
-FAIL #6 Test that WebAssembly compilation succeeds (exports0.wast:32) assert_equals: expected false but got true
-FAIL #7 Test that WebAssembly compilation succeeds (exports0.wast:40) assert_equals: expected false but got true
+PASS #4 Test that WebAssembly compilation succeeds (exports0.wast:5)
+PASS #5 Test that WebAssembly compilation succeeds (exports0.wast:6)
+PASS #6 Test that WebAssembly compilation succeeds (exports0.wast:32)
+PASS #7 Test that WebAssembly compilation succeeds (exports0.wast:40)
 PASS #8 Test that WebAssembly compilation succeeds (exports0.wast:49)
 PASS #9 Test that WebAssembly compilation succeeds (exports0.wast:50)
 PASS #10 Reinitialize the default imports
@@ -13,22 +13,14 @@ PASS #11 Test that WebAssembly compilation succeeds (exports0.wast:3)
 PASS #12 Test that WebAssembly instantiation succeeds (exports0.wast:3)
 PASS #13 Test that WebAssembly compilation succeeds (exports0.wast:4)
 PASS #14 Test that WebAssembly instantiation succeeds (exports0.wast:4)
-FAIL #15 Test that WebAssembly compilation succeeds (exports0.wast:5) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 15: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-FAIL #16 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-exports0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/exports0.wast.js:19:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/exports0.wast.js:51:3 expected true got false
-FAIL #17 Test that WebAssembly compilation succeeds (exports0.wast:6) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 15: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-FAIL #18 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-exports0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/exports0.wast.js:25:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/exports0.wast.js:51:3 expected true got false
-FAIL #19 Test that WebAssembly compilation succeeds (exports0.wast:32) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 15: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-FAIL #20 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-exports0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/exports0.wast.js:31:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/exports0.wast.js:51:3 expected true got false
-FAIL #21 Test that WebAssembly compilation succeeds (exports0.wast:40) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 15: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-FAIL #22 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-exports0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/exports0.wast.js:37:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/exports0.wast.js:51:3 expected true got false
+PASS #15 Test that WebAssembly compilation succeeds (exports0.wast:5)
+PASS #16 Test that WebAssembly instantiation succeeds (exports0.wast:5)
+PASS #17 Test that WebAssembly compilation succeeds (exports0.wast:6)
+PASS #18 Test that WebAssembly instantiation succeeds (exports0.wast:6)
+PASS #19 Test that WebAssembly compilation succeeds (exports0.wast:32)
+PASS #20 Test that WebAssembly instantiation succeeds (exports0.wast:32)
+PASS #21 Test that WebAssembly compilation succeeds (exports0.wast:40)
+PASS #22 Test that WebAssembly instantiation succeeds (exports0.wast:40)
 PASS #23 Test that WebAssembly compilation succeeds (exports0.wast:49)
 PASS #24 Test that WebAssembly instantiation succeeds (exports0.wast:49)
 PASS #25 Test that WebAssembly compilation succeeds (exports0.wast:50)

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/float_exprs0.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/float_exprs0.wast.js-expected.txt
@@ -1,6 +1,6 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (float_exprs0.wast:1) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (float_exprs0.wast:1)
 PASS #3 Test that WebAssembly compilation succeeds (wrapper)
 PASS #4 Test that WebAssembly compilation succeeds (wrapper)
 PASS #5 Test that WebAssembly compilation succeeds (wrapper)
@@ -15,125 +15,45 @@ PASS #13 Test that WebAssembly compilation succeeds (wrapper)
 PASS #14 Test that WebAssembly compilation succeeds (wrapper)
 PASS #15 Test that WebAssembly compilation succeeds (wrapper)
 PASS #16 Reinitialize the default imports
-FAIL #17 Test that WebAssembly compilation succeeds (float_exprs0.wast:1) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 42: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-FAIL #18 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-float_exprs0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:48:3 expected true got false
+PASS #17 Test that WebAssembly compilation succeeds (float_exprs0.wast:1)
+PASS #18 Test that WebAssembly instantiation succeeds (float_exprs0.wast:1)
 PASS #19 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #20 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:init must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:10:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-float_exprs0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:10:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:48:3 expected true got false
-FAIL #21 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_exprs0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:10:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:48:3 expected true got false
+PASS #20 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #21 Run a WebAssembly test without special assertions (float_exprs0.wast:25)
 PASS #22 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #23 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:init must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:13:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-float_exprs0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:13:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:48:3 expected true got false
-FAIL #24 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_exprs0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:13:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:48:3 expected true got false
+PASS #23 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #24 Run a WebAssembly test without special assertions (float_exprs0.wast:26)
 PASS #25 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #26 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:init must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:16:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-float_exprs0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:16:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:48:3 expected true got false
-FAIL #27 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_exprs0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:16:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:48:3 expected true got false
+PASS #26 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #27 Run a WebAssembly test without special assertions (float_exprs0.wast:27)
 PASS #28 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #29 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:init must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:19:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-float_exprs0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:19:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:48:3 expected true got false
-FAIL #30 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_exprs0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:19:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:48:3 expected true got false
+PASS #29 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #30 Run a WebAssembly test without special assertions (float_exprs0.wast:28)
 PASS #31 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #32 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:check must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:22:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-float_exprs0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:22:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:48:3 expected true got false
-FAIL #33 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_exprs0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:22:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:48:3 expected true got false
+PASS #32 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #33 Run a WebAssembly test without special assertions (float_exprs0.wast:29)
 PASS #34 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #35 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:check must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:25:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-float_exprs0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:25:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:48:3 expected true got false
-FAIL #36 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_exprs0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:25:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:48:3 expected true got false
+PASS #35 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #36 Run a WebAssembly test without special assertions (float_exprs0.wast:30)
 PASS #37 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #38 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:check must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:28:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-float_exprs0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:28:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:48:3 expected true got false
-FAIL #39 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_exprs0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:28:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:48:3 expected true got false
+PASS #38 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #39 Run a WebAssembly test without special assertions (float_exprs0.wast:31)
 PASS #40 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #41 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:check must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:31:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-float_exprs0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:31:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:48:3 expected true got false
-FAIL #42 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_exprs0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:31:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:48:3 expected true got false
+PASS #41 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #42 Run a WebAssembly test without special assertions (float_exprs0.wast:32)
 PASS #43 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #44 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:run must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:34:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-float_exprs0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:34:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:48:3 expected true got false
-FAIL #45 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_exprs0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:34:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:48:3 expected true got false
+PASS #44 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #45 Run a WebAssembly test without special assertions (float_exprs0.wast:33)
 PASS #46 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #47 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:check must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:37:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-float_exprs0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:37:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:48:3 expected true got false
-FAIL #48 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_exprs0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:37:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:48:3 expected true got false
+PASS #47 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #48 Run a WebAssembly test without special assertions (float_exprs0.wast:34)
 PASS #49 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #50 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:check must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:40:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-float_exprs0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:40:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:48:3 expected true got false
-FAIL #51 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_exprs0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:40:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:48:3 expected true got false
+PASS #50 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #51 Run a WebAssembly test without special assertions (float_exprs0.wast:35)
 PASS #52 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #53 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:check must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:43:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-float_exprs0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:43:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:48:3 expected true got false
-FAIL #54 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_exprs0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:43:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:48:3 expected true got false
+PASS #53 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #54 Run a WebAssembly test without special assertions (float_exprs0.wast:36)
 PASS #55 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #56 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:check must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:46:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-float_exprs0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:46:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:48:3 expected true got false
-FAIL #57 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_exprs0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:46:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs0.wast.js:48:3 expected true got false
+PASS #56 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #57 Run a WebAssembly test without special assertions (float_exprs0.wast:37)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/float_exprs1.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/float_exprs1.wast.js-expected.txt
@@ -1,29 +1,15 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (float_exprs1.wast:4) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (float_exprs1.wast:4)
 PASS #3 Test that WebAssembly compilation succeeds (wrapper)
 PASS #4 Test that WebAssembly compilation succeeds (wrapper)
 PASS #5 Reinitialize the default imports
-FAIL #6 Test that WebAssembly compilation succeeds (float_exprs1.wast:4) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 37: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-FAIL #7 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-float_exprs1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs1.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs1.wast.js:15:3 expected true got false
+PASS #6 Test that WebAssembly compilation succeeds (float_exprs1.wast:4)
+PASS #7 Test that WebAssembly instantiation succeeds (float_exprs1.wast:4)
 PASS #8 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #9 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.kahan_sum must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs1.wast.js:10:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-float_exprs1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs1.wast.js:10:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs1.wast.js:15:3 expected true got false
-FAIL #10 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_exprs1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs1.wast.js:10:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs1.wast.js:15:3 expected true got false
+PASS #9 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #10 Run a WebAssembly test without special assertions (float_exprs1.wast:103)
 PASS #11 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #12 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.plain_sum must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs1.wast.js:13:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-float_exprs1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs1.wast.js:13:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs1.wast.js:15:3 expected true got false
-FAIL #13 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_exprs1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs1.wast.js:13:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_exprs1.wast.js:15:3 expected true got false
+PASS #12 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #13 Run a WebAssembly test without special assertions (float_exprs1.wast:104)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/float_memory0.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/float_memory0.wast.js-expected.txt
@@ -1,168 +1,68 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (float_memory0.wast:5) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (float_memory0.wast:5)
 PASS #3 Test that WebAssembly compilation succeeds (wrapper)
 PASS #4 Test that WebAssembly compilation succeeds (wrapper)
 PASS #5 Test that WebAssembly compilation succeeds (wrapper)
 PASS #6 Test that WebAssembly compilation succeeds (wrapper)
 PASS #7 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #8 Test that WebAssembly compilation succeeds (float_memory0.wast:35) assert_equals: expected false but got true
+PASS #8 Test that WebAssembly compilation succeeds (float_memory0.wast:35)
 PASS #9 Test that WebAssembly compilation succeeds (wrapper)
 PASS #10 Test that WebAssembly compilation succeeds (wrapper)
 PASS #11 Test that WebAssembly compilation succeeds (wrapper)
 PASS #12 Test that WebAssembly compilation succeeds (wrapper)
 PASS #13 Test that WebAssembly compilation succeeds (wrapper)
 PASS #14 Reinitialize the default imports
-FAIL #15 Test that WebAssembly compilation succeeds (float_memory0.wast:5) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 45: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-FAIL #16 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-float_memory0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:99:3 expected true got false
-FAIL #17 Test that a WebAssembly code returns a specific result (float_memory0.wast:20) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-float_memory0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:10:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:99:3 expected true got false
+PASS #15 Test that WebAssembly compilation succeeds (float_memory0.wast:5)
+PASS #16 Test that WebAssembly instantiation succeeds (float_memory0.wast:5)
+PASS #17 Test that a WebAssembly code returns a specific result (float_memory0.wast:20)
 PASS #18 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #19 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:13:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-float_memory0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:13:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:99:3 expected true got false
-FAIL #20 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:13:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:99:3 expected true got false
-FAIL #21 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:16:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:99:3 expected true got false
-FAIL #22 Test that a WebAssembly code returns a specific result (float_memory0.wast:23) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-float_memory0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:19:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:99:3 expected true got false
+PASS #19 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #20 Run a WebAssembly test without special assertions (float_memory0.wast:21)
+PASS #21 Run a WebAssembly test without special assertions (float_memory0.wast:22)
+PASS #22 Test that a WebAssembly code returns a specific result (float_memory0.wast:23)
 PASS #23 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #24 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:22:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-float_memory0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:22:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:99:3 expected true got false
-FAIL #25 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:22:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:99:3 expected true got false
-FAIL #26 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:25:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:99:3 expected true got false
-FAIL #27 Test that a WebAssembly code returns a specific result (float_memory0.wast:26) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-float_memory0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:28:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:99:3 expected true got false
+PASS #24 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #25 Run a WebAssembly test without special assertions (float_memory0.wast:24)
+PASS #26 Run a WebAssembly test without special assertions (float_memory0.wast:25)
+PASS #27 Test that a WebAssembly code returns a specific result (float_memory0.wast:26)
 PASS #28 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #29 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:31:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-float_memory0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:31:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:99:3 expected true got false
-FAIL #30 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:31:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:99:3 expected true got false
-FAIL #31 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:34:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:99:3 expected true got false
-FAIL #32 Test that a WebAssembly code returns a specific result (float_memory0.wast:29) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-float_memory0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:37:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:99:3 expected true got false
+PASS #29 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #30 Run a WebAssembly test without special assertions (float_memory0.wast:27)
+PASS #31 Run a WebAssembly test without special assertions (float_memory0.wast:28)
+PASS #32 Test that a WebAssembly code returns a specific result (float_memory0.wast:29)
 PASS #33 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #34 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:40:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-float_memory0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:40:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:99:3 expected true got false
-FAIL #35 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:40:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:99:3 expected true got false
-FAIL #36 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:43:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:99:3 expected true got false
-FAIL #37 Test that a WebAssembly code returns a specific result (float_memory0.wast:32) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-float_memory0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:46:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:99:3 expected true got false
+PASS #34 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #35 Run a WebAssembly test without special assertions (float_memory0.wast:30)
+PASS #36 Run a WebAssembly test without special assertions (float_memory0.wast:31)
+PASS #37 Test that a WebAssembly code returns a specific result (float_memory0.wast:32)
 PASS #38 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #39 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:49:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-float_memory0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:49:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:99:3 expected true got false
-FAIL #40 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:49:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:99:3 expected true got false
-FAIL #41 Test that WebAssembly compilation succeeds (float_memory0.wast:35) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 45: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-FAIL #42 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-float_memory0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:55:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:99:3 expected true got false
-FAIL #43 Test that a WebAssembly code returns a specific result (float_memory0.wast:46) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-float_memory0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:58:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:99:3 expected true got false
+PASS #39 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #40 Run a WebAssembly test without special assertions (float_memory0.wast:33)
+PASS #41 Test that WebAssembly compilation succeeds (float_memory0.wast:35)
+PASS #42 Test that WebAssembly instantiation succeeds (float_memory0.wast:35)
+PASS #43 Test that a WebAssembly code returns a specific result (float_memory0.wast:46)
 PASS #44 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #45 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:61:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-float_memory0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:61:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:99:3 expected true got false
-FAIL #46 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:61:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:99:3 expected true got false
-FAIL #47 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:64:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:99:3 expected true got false
-FAIL #48 Test that a WebAssembly code returns a specific result (float_memory0.wast:49) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-float_memory0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:67:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:99:3 expected true got false
+PASS #45 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #46 Run a WebAssembly test without special assertions (float_memory0.wast:47)
+PASS #47 Run a WebAssembly test without special assertions (float_memory0.wast:48)
+PASS #48 Test that a WebAssembly code returns a specific result (float_memory0.wast:49)
 PASS #49 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #50 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:70:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-float_memory0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:70:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:99:3 expected true got false
-FAIL #51 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:70:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:99:3 expected true got false
-FAIL #52 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:73:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:99:3 expected true got false
-FAIL #53 Test that a WebAssembly code returns a specific result (float_memory0.wast:52) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-float_memory0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:76:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:99:3 expected true got false
+PASS #50 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #51 Run a WebAssembly test without special assertions (float_memory0.wast:50)
+PASS #52 Run a WebAssembly test without special assertions (float_memory0.wast:51)
+PASS #53 Test that a WebAssembly code returns a specific result (float_memory0.wast:52)
 PASS #54 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #55 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:79:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-float_memory0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:79:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:99:3 expected true got false
-FAIL #56 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:79:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:99:3 expected true got false
-FAIL #57 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:82:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:99:3 expected true got false
-FAIL #58 Test that a WebAssembly code returns a specific result (float_memory0.wast:55) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-float_memory0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:85:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:99:3 expected true got false
+PASS #55 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #56 Run a WebAssembly test without special assertions (float_memory0.wast:53)
+PASS #57 Run a WebAssembly test without special assertions (float_memory0.wast:54)
+PASS #58 Test that a WebAssembly code returns a specific result (float_memory0.wast:55)
 PASS #59 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #60 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:88:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-float_memory0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:88:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:99:3 expected true got false
-FAIL #61 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:88:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:99:3 expected true got false
-FAIL #62 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:91:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:99:3 expected true got false
-FAIL #63 Test that a WebAssembly code returns a specific result (float_memory0.wast:58) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-float_memory0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:94:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:99:3 expected true got false
+PASS #60 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #61 Run a WebAssembly test without special assertions (float_memory0.wast:56)
+PASS #62 Run a WebAssembly test without special assertions (float_memory0.wast:57)
+PASS #63 Test that a WebAssembly code returns a specific result (float_memory0.wast:58)
 PASS #64 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #65 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:97:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-float_memory0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:97:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:99:3 expected true got false
-FAIL #66 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-float_memory0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:97:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/float_memory0.wast.js:99:3 expected true got false
+PASS #65 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #66 Run a WebAssembly test without special assertions (float_memory0.wast:59)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/imports0.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/imports0.wast.js-expected.txt
@@ -1,6 +1,6 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (imports0.wast:1) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (imports0.wast:1)
 PASS #3 Test that WebAssembly compilation succeeds (imports0.wast:21)
 PASS #4 Test that WebAssembly compilation succeeds (imports0.wast:25)
 PASS #5 Test that WebAssembly compilation succeeds (imports0.wast:30)
@@ -8,38 +8,24 @@ PASS #6 Test that WebAssembly compilation succeeds (imports0.wast:34)
 PASS #7 Test that WebAssembly compilation succeeds (imports0.wast:39)
 PASS #8 Test that WebAssembly compilation succeeds (imports0.wast:43)
 PASS #9 Reinitialize the default imports
-FAIL #10 Test that WebAssembly compilation succeeds (imports0.wast:1) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 79: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-FAIL #11 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-imports0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/imports0.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/imports0.wast.js:48:3 expected true got false
+PASS #10 Test that WebAssembly compilation succeeds (imports0.wast:1)
+PASS #11 Test that WebAssembly instantiation succeeds (imports0.wast:1)
 PASS #12 Test that WebAssembly compilation succeeds (imports0.wast:21)
 PASS #13 Test that WebAssembly instantiation fails (imports0.wast:21)
-FAIL #14 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed TypeError: import test:memory-2-inf must be an object assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
-imports0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/imports0.wast.js:16:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/imports0.wast.js:48:3 expected true got false
+PASS #14 Test that a WebAssembly module is unlinkable
 PASS #15 Test that WebAssembly compilation succeeds (imports0.wast:25)
 PASS #16 Test that WebAssembly instantiation fails (imports0.wast:25)
-FAIL #17 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed TypeError: import test:memory-2-4 must be an object assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
-imports0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/imports0.wast.js:22:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/imports0.wast.js:48:3 expected true got false
+PASS #17 Test that a WebAssembly module is unlinkable
 PASS #18 Test that WebAssembly compilation succeeds (imports0.wast:30)
 PASS #19 Test that WebAssembly instantiation fails (imports0.wast:30)
-FAIL #20 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed TypeError: import test:memory-2-inf must be an object assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
-imports0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/imports0.wast.js:28:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/imports0.wast.js:48:3 expected true got false
+PASS #20 Test that a WebAssembly module is unlinkable
 PASS #21 Test that WebAssembly compilation succeeds (imports0.wast:34)
 PASS #22 Test that WebAssembly instantiation fails (imports0.wast:34)
-FAIL #23 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed TypeError: import test:memory-2-4 must be an object assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
-imports0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/imports0.wast.js:34:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/imports0.wast.js:48:3 expected true got false
+PASS #23 Test that a WebAssembly module is unlinkable
 PASS #24 Test that WebAssembly compilation succeeds (imports0.wast:39)
 PASS #25 Test that WebAssembly instantiation fails (imports0.wast:39)
-FAIL #26 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed TypeError: import test:memory-2-inf must be an object assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
-imports0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/imports0.wast.js:40:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/imports0.wast.js:48:3 expected true got false
+PASS #26 Test that a WebAssembly module is unlinkable
 PASS #27 Test that WebAssembly compilation succeeds (imports0.wast:43)
 PASS #28 Test that WebAssembly instantiation fails (imports0.wast:43)
-FAIL #29 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed TypeError: import test:memory-2-4 must be an object assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
-imports0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/imports0.wast.js:46:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/imports0.wast.js:48:3 expected true got false
+PASS #29 Test that a WebAssembly module is unlinkable
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/imports1.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/imports1.wast.js-expected.txt
@@ -1,21 +1,11 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (imports1.wast:1) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (imports1.wast:1)
 PASS #3 Reinitialize the default imports
-FAIL #4 Test that WebAssembly compilation succeeds (imports1.wast:1) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 64: there can at most be one Memory section for now at {loc} expected true got false
-FAIL #5 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-imports1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/imports1.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/imports1.wast.js:21:3 expected true got false
-FAIL #6 Test that a WebAssembly code returns a specific result (imports1.wast:12) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-imports1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/imports1.wast.js:10:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/imports1.wast.js:21:3 expected true got false
-FAIL #7 Test that a WebAssembly code returns a specific result (imports1.wast:13) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-imports1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/imports1.wast.js:13:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/imports1.wast.js:21:3 expected true got false
-FAIL #8 Test that a WebAssembly code returns a specific result (imports1.wast:14) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-imports1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/imports1.wast.js:16:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/imports1.wast.js:21:3 expected true got false
-FAIL #9 Test that a WebAssembly code traps (imports1.wast:15) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-imports1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/imports1.wast.js:19:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/imports1.wast.js:21:3 expected true got false
+PASS #4 Test that WebAssembly compilation succeeds (imports1.wast:1)
+PASS #5 Test that WebAssembly instantiation succeeds (imports1.wast:1)
+PASS #6 Test that a WebAssembly code returns a specific result (imports1.wast:12)
+PASS #7 Test that a WebAssembly code returns a specific result (imports1.wast:13)
+PASS #8 Test that a WebAssembly code returns a specific result (imports1.wast:14)
+PASS #9 Test that a WebAssembly code traps (imports1.wast:15)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/imports2.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/imports2.wast.js-expected.txt
@@ -1,10 +1,10 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (imports2.wast:1) assert_equals: expected false but got true
-FAIL #3 Test that WebAssembly compilation succeeds (imports2.wast:9) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (imports2.wast:1)
+PASS #3 Test that WebAssembly compilation succeeds (imports2.wast:9)
 PASS #4 Test that WebAssembly compilation succeeds (imports2.wast:22)
-FAIL #5 Test that WebAssembly compilation succeeds (imports2.wast:33) assert_equals: expected false but got true
-FAIL #6 Test that WebAssembly compilation succeeds (imports2.wast:39) assert_equals: expected false but got true
+PASS #5 Test that WebAssembly compilation succeeds (imports2.wast:33)
+PASS #6 Test that WebAssembly compilation succeeds (imports2.wast:39)
 PASS #7 Test that WebAssembly compilation succeeds (imports2.wast:49)
 PASS #8 Test that WebAssembly compilation succeeds (imports2.wast:53)
 PASS #9 Test that WebAssembly compilation succeeds (imports2.wast:58)
@@ -12,58 +12,36 @@ PASS #10 Test that WebAssembly compilation succeeds (imports2.wast:62)
 PASS #11 Test that WebAssembly compilation succeeds (imports2.wast:66)
 PASS #12 Test that WebAssembly compilation succeeds (imports2.wast:70)
 PASS #13 Reinitialize the default imports
-FAIL #14 Test that WebAssembly compilation succeeds (imports2.wast:1) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 15: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-FAIL #15 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-imports2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/imports2.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/imports2.wast.js:96:3 expected true got false
-FAIL #16 Test that WebAssembly compilation succeeds (imports2.wast:9) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 54: there can at most be one Memory section for now at {loc} expected true got false
-FAIL #17 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-imports2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/imports2.wast.js:16:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/imports2.wast.js:96:3 expected true got false
-FAIL #18 Test that a WebAssembly code returns a specific result (imports2.wast:17) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-imports2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/imports2.wast.js:19:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/imports2.wast.js:96:3 expected true got false
-FAIL #19 Test that a WebAssembly code returns a specific result (imports2.wast:18) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-imports2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/imports2.wast.js:22:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/imports2.wast.js:96:3 expected true got false
-FAIL #20 Test that a WebAssembly code returns a specific result (imports2.wast:19) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-imports2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/imports2.wast.js:25:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/imports2.wast.js:96:3 expected true got false
-FAIL #21 Test that a WebAssembly code traps (imports2.wast:20) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-imports2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/imports2.wast.js:28:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/imports2.wast.js:96:3 expected true got false
+PASS #14 Test that WebAssembly compilation succeeds (imports2.wast:1)
+PASS #15 Test that WebAssembly instantiation succeeds (imports2.wast:1)
+PASS #16 Test that WebAssembly compilation succeeds (imports2.wast:9)
+PASS #17 Test that WebAssembly instantiation succeeds (imports2.wast:9)
+PASS #18 Test that a WebAssembly code returns a specific result (imports2.wast:17)
+PASS #19 Test that a WebAssembly code returns a specific result (imports2.wast:18)
+PASS #20 Test that a WebAssembly code returns a specific result (imports2.wast:19)
+PASS #21 Test that a WebAssembly code traps (imports2.wast:20)
 PASS #22 Test that WebAssembly compilation succeeds (imports2.wast:22)
 PASS #23 Test that WebAssembly instantiation succeeds (imports2.wast:22)
 PASS #24 Test that a WebAssembly code returns a specific result (imports2.wast:28)
 PASS #25 Test that a WebAssembly code returns a specific result (imports2.wast:29)
 PASS #26 Test that a WebAssembly code returns a specific result (imports2.wast:30)
 PASS #27 Test that a WebAssembly code traps (imports2.wast:31)
-FAIL #28 Test that WebAssembly compilation succeeds (imports2.wast:33) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 55: there can at most be one Memory section for now at {loc} expected true got false
-FAIL #29 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-imports2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/imports2.wast.js:52:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/imports2.wast.js:96:3 expected true got false
-FAIL #30 Test that WebAssembly compilation succeeds (imports2.wast:39) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 51: there can at most be one Memory section for now at {loc} expected true got false
-FAIL #31 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-imports2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/imports2.wast.js:58:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/imports2.wast.js:96:3 expected true got false
+PASS #28 Test that WebAssembly compilation succeeds (imports2.wast:33)
+PASS #29 Test that WebAssembly instantiation succeeds (imports2.wast:33)
+PASS #30 Test that WebAssembly compilation succeeds (imports2.wast:39)
+PASS #31 Test that WebAssembly instantiation succeeds (imports2.wast:39)
 PASS #32 Test that WebAssembly compilation succeeds (imports2.wast:49)
 PASS #33 Test that WebAssembly instantiation fails (imports2.wast:49)
-FAIL #34 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed TypeError: import test:unknown must be an object assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
-imports2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/imports2.wast.js:64:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/imports2.wast.js:96:3 expected true got false
+PASS #34 Test that a WebAssembly module is unlinkable
 PASS #35 Test that WebAssembly compilation succeeds (imports2.wast:53)
 PASS #36 Test that WebAssembly instantiation fails (imports2.wast:53)
 PASS #37 Test that a WebAssembly module is unlinkable
 PASS #38 Test that WebAssembly compilation succeeds (imports2.wast:58)
 PASS #39 Test that WebAssembly instantiation fails (imports2.wast:58)
-FAIL #40 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed TypeError: import test:memory-2-inf must be an object assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
-imports2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/imports2.wast.js:76:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/imports2.wast.js:96:3 expected true got false
+PASS #40 Test that a WebAssembly module is unlinkable
 PASS #41 Test that WebAssembly compilation succeeds (imports2.wast:62)
 PASS #42 Test that WebAssembly instantiation fails (imports2.wast:62)
-FAIL #43 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed TypeError: import test:memory-2-inf must be an object assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
-imports2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/imports2.wast.js:82:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/imports2.wast.js:96:3 expected true got false
+PASS #43 Test that a WebAssembly module is unlinkable
 PASS #44 Test that WebAssembly compilation succeeds (imports2.wast:66)
 PASS #45 Test that WebAssembly instantiation fails (imports2.wast:66)
 PASS #46 Test that a WebAssembly module is unlinkable

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/imports3.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/imports3.wast.js-expected.txt
@@ -1,57 +1,39 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (imports3.wast:1) assert_equals: expected false but got true
-FAIL #3 Test that WebAssembly compilation succeeds (imports3.wast:20) assert_equals: expected false but got true
-FAIL #4 Test that WebAssembly compilation succeeds (imports3.wast:27) assert_equals: expected false but got true
-FAIL #5 Test that WebAssembly compilation succeeds (imports3.wast:34) assert_equals: expected false but got true
-FAIL #6 Test that WebAssembly compilation succeeds (imports3.wast:41) assert_equals: expected false but got true
-FAIL #7 Test that WebAssembly compilation succeeds (imports3.wast:48) assert_equals: expected false but got true
-FAIL #8 Test that WebAssembly compilation succeeds (imports3.wast:55) assert_equals: expected false but got true
-FAIL #9 Test that WebAssembly compilation succeeds (imports3.wast:63) assert_equals: expected false but got true
-FAIL #10 Test that WebAssembly compilation succeeds (imports3.wast:70) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (imports3.wast:1)
+PASS #3 Test that WebAssembly compilation succeeds (imports3.wast:20)
+PASS #4 Test that WebAssembly compilation succeeds (imports3.wast:27)
+PASS #5 Test that WebAssembly compilation succeeds (imports3.wast:34)
+PASS #6 Test that WebAssembly compilation succeeds (imports3.wast:41)
+PASS #7 Test that WebAssembly compilation succeeds (imports3.wast:48)
+PASS #8 Test that WebAssembly compilation succeeds (imports3.wast:55)
+PASS #9 Test that WebAssembly compilation succeeds (imports3.wast:63)
+PASS #10 Test that WebAssembly compilation succeeds (imports3.wast:70)
 PASS #11 Reinitialize the default imports
-FAIL #12 Test that WebAssembly compilation succeeds (imports3.wast:1) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 79: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-FAIL #13 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-imports3_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/imports3.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/imports3.wast.js:60:3 expected true got false
-FAIL #14 Test that WebAssembly compilation succeeds (imports3.wast:20) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 49: there can at most be one Memory section for now at {loc} expected true got false
-PASS #15 Test that WebAssembly instantiation fails
-FAIL #16 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed TypeError: undefined is not an object (evaluating 'values[0].source') assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
-imports3_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/imports3.wast.js:16:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/imports3.wast.js:60:3 expected true got false
-FAIL #17 Test that WebAssembly compilation succeeds (imports3.wast:27) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 51: there can at most be one Memory section for now at {loc} expected true got false
-PASS #18 Test that WebAssembly instantiation fails
-FAIL #19 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed TypeError: undefined is not an object (evaluating 'values[0].source') assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
-imports3_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/imports3.wast.js:22:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/imports3.wast.js:60:3 expected true got false
-FAIL #20 Test that WebAssembly compilation succeeds (imports3.wast:34) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 53: there can at most be one Memory section for now at {loc} expected true got false
-PASS #21 Test that WebAssembly instantiation fails
-FAIL #22 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed TypeError: undefined is not an object (evaluating 'values[0].source') assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
-imports3_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/imports3.wast.js:28:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/imports3.wast.js:60:3 expected true got false
-FAIL #23 Test that WebAssembly compilation succeeds (imports3.wast:41) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 54: there can at most be one Memory section for now at {loc} expected true got false
-PASS #24 Test that WebAssembly instantiation fails
-FAIL #25 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed TypeError: undefined is not an object (evaluating 'values[0].source') assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
-imports3_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/imports3.wast.js:34:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/imports3.wast.js:60:3 expected true got false
-FAIL #26 Test that WebAssembly compilation succeeds (imports3.wast:48) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 55: there can at most be one Memory section for now at {loc} expected true got false
-PASS #27 Test that WebAssembly instantiation fails
-FAIL #28 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed TypeError: undefined is not an object (evaluating 'values[0].source') assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
-imports3_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/imports3.wast.js:40:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/imports3.wast.js:60:3 expected true got false
-FAIL #29 Test that WebAssembly compilation succeeds (imports3.wast:55) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 50: there can at most be one Memory section for now at {loc} expected true got false
-PASS #30 Test that WebAssembly instantiation fails
-FAIL #31 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed TypeError: undefined is not an object (evaluating 'values[0].source') assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
-imports3_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/imports3.wast.js:46:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/imports3.wast.js:60:3 expected true got false
-FAIL #32 Test that WebAssembly compilation succeeds (imports3.wast:63) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 51: there can at most be one Memory section for now at {loc} expected true got false
-PASS #33 Test that WebAssembly instantiation fails
-FAIL #34 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed TypeError: undefined is not an object (evaluating 'values[0].source') assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
-imports3_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/imports3.wast.js:52:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/imports3.wast.js:60:3 expected true got false
-FAIL #35 Test that WebAssembly compilation succeeds (imports3.wast:70) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 51: there can at most be one Memory section for now at {loc} expected true got false
-PASS #36 Test that WebAssembly instantiation fails
-FAIL #37 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed TypeError: undefined is not an object (evaluating 'values[0].source') assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
-imports3_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/imports3.wast.js:58:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/imports3.wast.js:60:3 expected true got false
+PASS #12 Test that WebAssembly compilation succeeds (imports3.wast:1)
+PASS #13 Test that WebAssembly instantiation succeeds (imports3.wast:1)
+PASS #14 Test that WebAssembly compilation succeeds (imports3.wast:20)
+PASS #15 Test that WebAssembly instantiation fails (imports3.wast:20)
+PASS #16 Test that a WebAssembly module is unlinkable
+PASS #17 Test that WebAssembly compilation succeeds (imports3.wast:27)
+PASS #18 Test that WebAssembly instantiation fails (imports3.wast:27)
+PASS #19 Test that a WebAssembly module is unlinkable
+PASS #20 Test that WebAssembly compilation succeeds (imports3.wast:34)
+PASS #21 Test that WebAssembly instantiation fails (imports3.wast:34)
+PASS #22 Test that a WebAssembly module is unlinkable
+PASS #23 Test that WebAssembly compilation succeeds (imports3.wast:41)
+PASS #24 Test that WebAssembly instantiation fails (imports3.wast:41)
+PASS #25 Test that a WebAssembly module is unlinkable
+PASS #26 Test that WebAssembly compilation succeeds (imports3.wast:48)
+PASS #27 Test that WebAssembly instantiation fails (imports3.wast:48)
+PASS #28 Test that a WebAssembly module is unlinkable
+PASS #29 Test that WebAssembly compilation succeeds (imports3.wast:55)
+PASS #30 Test that WebAssembly instantiation fails (imports3.wast:55)
+PASS #31 Test that a WebAssembly module is unlinkable
+PASS #32 Test that WebAssembly compilation succeeds (imports3.wast:63)
+PASS #33 Test that WebAssembly instantiation fails (imports3.wast:63)
+PASS #34 Test that a WebAssembly module is unlinkable
+PASS #35 Test that WebAssembly compilation succeeds (imports3.wast:70)
+PASS #36 Test that WebAssembly instantiation fails (imports3.wast:70)
+PASS #37 Test that a WebAssembly module is unlinkable
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/imports4.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/imports4.wast.js-expected.txt
@@ -1,53 +1,27 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (imports4.wast:1) assert_equals: expected false but got true
-FAIL #3 Test that WebAssembly compilation succeeds (imports4.wast:8) assert_equals: expected false but got true
-FAIL #4 Test that WebAssembly compilation succeeds (imports4.wast:19) assert_equals: expected false but got true
-FAIL #5 Test that WebAssembly compilation succeeds (imports4.wast:28) assert_equals: expected false but got true
-FAIL #6 Test that WebAssembly compilation succeeds (imports4.wast:39) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (imports4.wast:1)
+PASS #3 Test that WebAssembly compilation succeeds (imports4.wast:8)
+PASS #4 Test that WebAssembly compilation succeeds (imports4.wast:19)
+PASS #5 Test that WebAssembly compilation succeeds (imports4.wast:28)
+PASS #6 Test that WebAssembly compilation succeeds (imports4.wast:39)
 PASS #7 Reinitialize the default imports
-FAIL #8 Test that WebAssembly compilation succeeds (imports4.wast:1) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 15: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-FAIL #9 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-imports4_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/imports4.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/imports4.wast.js:72:3 expected true got false
-FAIL #10 Test that WebAssembly compilation succeeds (imports4.wast:8) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 63: there can at most be one Memory section for now at {loc} expected true got false
-FAIL #11 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-imports4_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/imports4.wast.js:16:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/imports4.wast.js:72:3 expected true got false
-FAIL #12 Test that a WebAssembly code returns a specific result (imports4.wast:13) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-imports4_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/imports4.wast.js:19:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/imports4.wast.js:72:3 expected true got false
-FAIL #13 Test that a WebAssembly code returns a specific result (imports4.wast:14) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-imports4_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/imports4.wast.js:22:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/imports4.wast.js:72:3 expected true got false
-FAIL #14 Test that a WebAssembly code returns a specific result (imports4.wast:15) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-imports4_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/imports4.wast.js:25:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/imports4.wast.js:72:3 expected true got false
-FAIL #15 Test that a WebAssembly code returns a specific result (imports4.wast:16) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-imports4_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/imports4.wast.js:28:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/imports4.wast.js:72:3 expected true got false
-FAIL #16 Test that a WebAssembly code returns a specific result (imports4.wast:17) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-imports4_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/imports4.wast.js:31:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/imports4.wast.js:72:3 expected true got false
-FAIL #17 Test that WebAssembly compilation succeeds (imports4.wast:19) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 34: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-FAIL #18 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-imports4_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/imports4.wast.js:38:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/imports4.wast.js:72:3 expected true got false
-FAIL #19 Test that a WebAssembly code returns a specific result (imports4.wast:26) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-imports4_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/imports4.wast.js:45:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/imports4.wast.js:72:3 expected true got false
-FAIL #20 Test that WebAssembly compilation succeeds (imports4.wast:28) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 66: there can at most be one Memory section for now at {loc} expected true got false
-FAIL #21 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-imports4_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/imports4.wast.js:52:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/imports4.wast.js:72:3 expected true got false
-FAIL #22 Test that a WebAssembly code returns a specific result (imports4.wast:37) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-imports4_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/imports4.wast.js:59:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/imports4.wast.js:72:3 expected true got false
-FAIL #23 Test that WebAssembly compilation succeeds (imports4.wast:39) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 75: there can at most be one Memory section for now at {loc} expected true got false
-FAIL #24 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-imports4_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/imports4.wast.js:66:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/imports4.wast.js:72:3 expected true got false
-FAIL #25 Test that a WebAssembly code returns a specific result (imports4.wast:47) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-imports4_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/imports4.wast.js:70:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/imports4.wast.js:72:3 expected true got false
+PASS #8 Test that WebAssembly compilation succeeds (imports4.wast:1)
+PASS #9 Test that WebAssembly instantiation succeeds (imports4.wast:1)
+PASS #10 Test that WebAssembly compilation succeeds (imports4.wast:8)
+PASS #11 Test that WebAssembly instantiation succeeds (imports4.wast:8)
+PASS #12 Test that a WebAssembly code returns a specific result (imports4.wast:13)
+PASS #13 Test that a WebAssembly code returns a specific result (imports4.wast:14)
+PASS #14 Test that a WebAssembly code returns a specific result (imports4.wast:15)
+PASS #15 Test that a WebAssembly code returns a specific result (imports4.wast:16)
+PASS #16 Test that a WebAssembly code returns a specific result (imports4.wast:17)
+PASS #17 Test that WebAssembly compilation succeeds (imports4.wast:19)
+PASS #18 Test that WebAssembly instantiation succeeds (imports4.wast:19)
+PASS #19 Test that a WebAssembly code returns a specific result (imports4.wast:26)
+PASS #20 Test that WebAssembly compilation succeeds (imports4.wast:28)
+PASS #21 Test that WebAssembly instantiation succeeds (imports4.wast:28)
+PASS #22 Test that a WebAssembly code returns a specific result (imports4.wast:37)
+PASS #23 Test that WebAssembly compilation succeeds (imports4.wast:39)
+PASS #24 Test that WebAssembly instantiation succeeds (imports4.wast:39)
+PASS #25 Test that a WebAssembly code returns a specific result (imports4.wast:47)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/linking0.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/linking0.wast.js-expected.txt
@@ -1,23 +1,17 @@
 
 PASS #1 Reinitialize the default imports
 PASS #2 Test that WebAssembly compilation succeeds (linking0.wast:1)
-FAIL #3 Test that WebAssembly compilation succeeds (linking0.wast:17) assert_equals: expected false but got true
-FAIL #4 Test that WebAssembly compilation succeeds (linking0.wast:31) assert_equals: expected false but got true
+PASS #3 Test that WebAssembly compilation succeeds (linking0.wast:17)
+PASS #4 Test that WebAssembly compilation succeeds (linking0.wast:31)
 PASS #5 Reinitialize the default imports
 PASS #6 Test that WebAssembly compilation succeeds (linking0.wast:1)
 PASS #7 Test that WebAssembly instantiation succeeds (linking0.wast:1)
-FAIL #8 Test that WebAssembly compilation succeeds (linking0.wast:17) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 64: there can at most be one Memory section for now at {loc} expected true got false
-PASS #9 Test that WebAssembly instantiation fails
-FAIL #10 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed TypeError: undefined is not an object (evaluating 'values[0].source') assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
-linking0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/linking0.wast.js:18:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/linking0.wast.js:32:3 expected true got false
+PASS #8 Test that WebAssembly compilation succeeds (linking0.wast:17)
+PASS #9 Test that WebAssembly instantiation fails (linking0.wast:17)
+PASS #10 Test that a WebAssembly module is unlinkable
 PASS #11 Test that a WebAssembly code traps (linking0.wast:27)
-FAIL #12 Test that WebAssembly compilation succeeds (linking0.wast:31) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 52: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-PASS #13 Test that WebAssembly instantiation fails
-FAIL #14 Test that a WebAssembly module is uninstantiable assert_true: expected link error, observed TypeError: undefined is not an object (evaluating 'values[0].source') assert_uninstantiable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:433:24
-linking0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/linking0.wast.js:27:22
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/linking0.wast.js:32:3 expected true got false
-FAIL #15 Test that a WebAssembly code returns a specific result (linking0.wast:42) assert_true: unexpected runtime error, observed RuntimeError: call_indirect to a signature that does not match assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-linking0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/linking0.wast.js:30:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/linking0.wast.js:32:3 expected true got false
+PASS #12 Test that WebAssembly compilation succeeds (linking0.wast:31)
+PASS #13 Test that WebAssembly instantiation fails (linking0.wast:31)
+PASS #14 Test that a WebAssembly module is uninstantiable
+PASS #15 Test that a WebAssembly code returns a specific result (linking0.wast:42)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/linking1.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/linking1.wast.js-expected.txt
@@ -1,57 +1,31 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (linking1.wast:1) assert_equals: expected false but got true
-FAIL #3 Test that WebAssembly compilation succeeds (linking1.wast:14) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (linking1.wast:1)
+PASS #3 Test that WebAssembly compilation succeeds (linking1.wast:14)
 PASS #4 Test that WebAssembly compilation succeeds (linking1.wast:31)
 PASS #5 Test that WebAssembly compilation succeeds (linking1.wast:45)
 PASS #6 Test that WebAssembly compilation succeeds (linking1.wast:51)
 PASS #7 Test that WebAssembly compilation succeeds (linking1.wast:59)
 PASS #8 Reinitialize the default imports
-FAIL #9 Test that WebAssembly compilation succeeds (linking1.wast:1) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 35: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-FAIL #10 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-linking1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/linking1.wast.js:8:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/linking1.wast.js:69:3 expected true got false
-FAIL #11 Test that WebAssembly compilation succeeds (linking1.wast:14) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 63: there can at most be one Memory section for now at {loc} expected true got false
-FAIL #12 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-linking1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/linking1.wast.js:19:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/linking1.wast.js:69:3 expected true got false
-FAIL #13 Test that a WebAssembly code returns a specific result (linking1.wast:27) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-linking1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/linking1.wast.js:23:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/linking1.wast.js:69:3 expected true got false
-FAIL #14 Test that a WebAssembly code returns a specific result (linking1.wast:28) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-linking1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/linking1.wast.js:26:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/linking1.wast.js:69:3 expected true got false
-FAIL #15 Test that a WebAssembly code returns a specific result (linking1.wast:29) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-linking1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/linking1.wast.js:29:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/linking1.wast.js:69:3 expected true got false
+PASS #9 Test that WebAssembly compilation succeeds (linking1.wast:1)
+PASS #10 Test that WebAssembly instantiation succeeds (linking1.wast:1)
+PASS #11 Test that WebAssembly compilation succeeds (linking1.wast:14)
+PASS #12 Test that WebAssembly instantiation succeeds (linking1.wast:14)
+PASS #13 Test that a WebAssembly code returns a specific result (linking1.wast:27)
+PASS #14 Test that a WebAssembly code returns a specific result (linking1.wast:28)
+PASS #15 Test that a WebAssembly code returns a specific result (linking1.wast:29)
 PASS #16 Test that WebAssembly compilation succeeds (linking1.wast:31)
-FAIL #17 Test that WebAssembly instantiation succeeds (linking1.wast:31) assert_true: unexpected instantiation error, observed TypeError: import Mm:mem1 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-linking1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/linking1.wast.js:36:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/linking1.wast.js:69:3 expected true got false
-FAIL #18 Test that a WebAssembly code returns a specific result (linking1.wast:40) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-linking1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/linking1.wast.js:40:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/linking1.wast.js:69:3 expected true got false
-FAIL #19 Test that a WebAssembly code returns a specific result (linking1.wast:41) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-linking1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/linking1.wast.js:43:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/linking1.wast.js:69:3 expected true got false
-FAIL #20 Test that a WebAssembly code returns a specific result (linking1.wast:42) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-linking1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/linking1.wast.js:46:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/linking1.wast.js:69:3 expected true got false
-FAIL #21 Test that a WebAssembly code returns a specific result (linking1.wast:43) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-linking1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/linking1.wast.js:49:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/linking1.wast.js:69:3 expected true got false
+PASS #17 Test that WebAssembly instantiation succeeds (linking1.wast:31)
+PASS #18 Test that a WebAssembly code returns a specific result (linking1.wast:40)
+PASS #19 Test that a WebAssembly code returns a specific result (linking1.wast:41)
+PASS #20 Test that a WebAssembly code returns a specific result (linking1.wast:42)
+PASS #21 Test that a WebAssembly code returns a specific result (linking1.wast:43)
 PASS #22 Test that WebAssembly compilation succeeds (linking1.wast:45)
-FAIL #23 Test that WebAssembly instantiation succeeds (linking1.wast:45) assert_true: unexpected instantiation error, observed TypeError: import Mm:mem1 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-linking1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/linking1.wast.js:55:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/linking1.wast.js:69:3 expected true got false
+PASS #23 Test that WebAssembly instantiation succeeds (linking1.wast:45)
 PASS #24 Test that WebAssembly compilation succeeds (linking1.wast:51)
 PASS #25 Test that WebAssembly instantiation fails (linking1.wast:51)
-FAIL #26 Test that a WebAssembly module is uninstantiable assert_true: expected link error, observed TypeError: import Mm:mem0 must be an object assert_uninstantiable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:433:24
-linking1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/linking1.wast.js:61:22
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/linking1.wast.js:69:3 expected true got false
+PASS #26 Test that a WebAssembly module is uninstantiable
 PASS #27 Test that WebAssembly compilation succeeds (linking1.wast:59)
 PASS #28 Test that WebAssembly instantiation fails (linking1.wast:59)
-FAIL #29 Test that a WebAssembly module is uninstantiable assert_true: expected link error, observed TypeError: import Mm:mem1 must be an object assert_uninstantiable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:433:24
-linking1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/linking1.wast.js:67:22
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/linking1.wast.js:69:3 expected true got false
+PASS #29 Test that a WebAssembly module is uninstantiable
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/linking2.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/linking2.wast.js-expected.txt
@@ -1,38 +1,18 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (linking2.wast:1) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (linking2.wast:1)
 PASS #3 Test that WebAssembly compilation succeeds (linking2.wast:14)
 PASS #4 Reinitialize the default imports
-FAIL #5 Test that WebAssembly compilation succeeds (linking2.wast:1) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 35: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-FAIL #6 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-linking2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/linking2.wast.js:8:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/linking2.wast.js:46:3 expected true got false
+PASS #5 Test that WebAssembly compilation succeeds (linking2.wast:1)
+PASS #6 Test that WebAssembly instantiation succeeds (linking2.wast:1)
 PASS #7 Test that WebAssembly compilation succeeds (linking2.wast:14)
-FAIL #8 Test that WebAssembly instantiation succeeds (linking2.wast:14) assert_true: unexpected instantiation error, observed TypeError: import Mm:mem1 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-linking2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/linking2.wast.js:19:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/linking2.wast.js:46:3 expected true got false
-FAIL #9 Test that a WebAssembly code returns a specific result (linking2.wast:22) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-linking2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/linking2.wast.js:23:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/linking2.wast.js:46:3 expected true got false
-FAIL #10 Test that a WebAssembly code returns a specific result (linking2.wast:23) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-linking2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/linking2.wast.js:26:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/linking2.wast.js:46:3 expected true got false
-FAIL #11 Test that a WebAssembly code returns a specific result (linking2.wast:24) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-linking2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/linking2.wast.js:29:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/linking2.wast.js:46:3 expected true got false
-FAIL #12 Test that a WebAssembly code returns a specific result (linking2.wast:25) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-linking2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/linking2.wast.js:32:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/linking2.wast.js:46:3 expected true got false
-FAIL #13 Test that a WebAssembly code returns a specific result (linking2.wast:26) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-linking2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/linking2.wast.js:35:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/linking2.wast.js:46:3 expected true got false
-FAIL #14 Test that a WebAssembly code returns a specific result (linking2.wast:27) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-linking2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/linking2.wast.js:38:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/linking2.wast.js:46:3 expected true got false
-FAIL #15 Test that a WebAssembly code returns a specific result (linking2.wast:28) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-linking2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/linking2.wast.js:41:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/linking2.wast.js:46:3 expected true got false
-FAIL #16 Test that a WebAssembly code returns a specific result (linking2.wast:29) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-linking2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/linking2.wast.js:44:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/linking2.wast.js:46:3 expected true got false
+PASS #8 Test that WebAssembly instantiation succeeds (linking2.wast:14)
+PASS #9 Test that a WebAssembly code returns a specific result (linking2.wast:22)
+PASS #10 Test that a WebAssembly code returns a specific result (linking2.wast:23)
+PASS #11 Test that a WebAssembly code returns a specific result (linking2.wast:24)
+PASS #12 Test that a WebAssembly code returns a specific result (linking2.wast:25)
+PASS #13 Test that a WebAssembly code returns a specific result (linking2.wast:26)
+PASS #14 Test that a WebAssembly code returns a specific result (linking2.wast:27)
+PASS #15 Test that a WebAssembly code returns a specific result (linking2.wast:28)
+PASS #16 Test that a WebAssembly code returns a specific result (linking2.wast:29)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/linking3.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/linking3.wast.js-expected.txt
@@ -1,43 +1,27 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (linking3.wast:1) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (linking3.wast:1)
 PASS #3 Test that WebAssembly compilation succeeds (linking3.wast:15)
 PASS #4 Test that WebAssembly compilation succeeds (linking3.wast:28)
 PASS #5 Test that WebAssembly compilation succeeds (linking3.wast:40)
 PASS #6 Test that WebAssembly compilation succeeds (linking3.wast:52)
 PASS #7 Test that WebAssembly compilation succeeds (linking3.wast:66)
 PASS #8 Reinitialize the default imports
-FAIL #9 Test that WebAssembly compilation succeeds (linking3.wast:1) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 35: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-FAIL #10 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-linking3_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/linking3.wast.js:8:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/linking3.wast.js:67:3 expected true got false
+PASS #9 Test that WebAssembly compilation succeeds (linking3.wast:1)
+PASS #10 Test that WebAssembly instantiation succeeds (linking3.wast:1)
 PASS #11 Test that WebAssembly compilation succeeds (linking3.wast:15)
 PASS #12 Test that WebAssembly instantiation fails (linking3.wast:15)
-FAIL #13 Test that a WebAssembly module is unlinkable assert_true: expected link error, observed TypeError: import Mm:mem1 must be an object assert_unlinkable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:410:24
-linking3_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/linking3.wast.js:18:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/linking3.wast.js:67:3 expected true got false
-FAIL #14 Test that a WebAssembly code returns a specific result (linking3.wast:23) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-linking3_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/linking3.wast.js:21:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/linking3.wast.js:67:3 expected true got false
+PASS #13 Test that a WebAssembly module is unlinkable
+PASS #14 Test that a WebAssembly code returns a specific result (linking3.wast:23)
 PASS #15 Test that WebAssembly compilation succeeds (linking3.wast:28)
 PASS #16 Test that WebAssembly instantiation fails (linking3.wast:28)
-FAIL #17 Test that a WebAssembly module is uninstantiable assert_true: expected link error, observed TypeError: import Mm:mem1 must be an object assert_uninstantiable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:433:24
-linking3_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/linking3.wast.js:27:22
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/linking3.wast.js:67:3 expected true got false
-FAIL #18 Test that a WebAssembly code returns a specific result (linking3.wast:36) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-linking3_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/linking3.wast.js:30:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/linking3.wast.js:67:3 expected true got false
-FAIL #19 Test that a WebAssembly code returns a specific result (linking3.wast:37) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-linking3_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/linking3.wast.js:33:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/linking3.wast.js:67:3 expected true got false
+PASS #17 Test that a WebAssembly module is uninstantiable
+PASS #18 Test that a WebAssembly code returns a specific result (linking3.wast:36)
+PASS #19 Test that a WebAssembly code returns a specific result (linking3.wast:37)
 PASS #20 Test that WebAssembly compilation succeeds (linking3.wast:40)
 PASS #21 Test that WebAssembly instantiation fails (linking3.wast:40)
-FAIL #22 Test that a WebAssembly module is uninstantiable assert_true: expected link error, observed TypeError: import Mm:mem1 must be an object assert_uninstantiable@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:433:24
-linking3_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/linking3.wast.js:39:22
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/linking3.wast.js:67:3 expected true got false
-FAIL #23 Test that a WebAssembly code returns a specific result (linking3.wast:49) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-linking3_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/linking3.wast.js:42:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/linking3.wast.js:67:3 expected true got false
+PASS #22 Test that a WebAssembly module is uninstantiable
+PASS #23 Test that a WebAssembly code returns a specific result (linking3.wast:49)
 PASS #24 Test that WebAssembly compilation succeeds (linking3.wast:52)
 PASS #25 Test that WebAssembly instantiation succeeds (linking3.wast:52)
 PASS #26 Test that WebAssembly compilation succeeds (linking3.wast:66)

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/load0.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/load0.wast.js-expected.txt
@@ -1,15 +1,9 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (load0.wast:3) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (load0.wast:3)
 PASS #3 Reinitialize the default imports
-FAIL #4 Test that WebAssembly compilation succeeds (load0.wast:3) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 36: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-FAIL #5 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-load0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load0.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load0.wast.js:15:3 expected true got false
-FAIL #6 Test that a WebAssembly code returns a specific result (load0.wast:18) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load0.wast.js:10:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load0.wast.js:15:3 expected true got false
-FAIL #7 Test that a WebAssembly code returns a specific result (load0.wast:19) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load0.wast.js:13:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load0.wast.js:15:3 expected true got false
+PASS #4 Test that WebAssembly compilation succeeds (load0.wast:3)
+PASS #5 Test that WebAssembly instantiation succeeds (load0.wast:3)
+PASS #6 Test that a WebAssembly code returns a specific result (load0.wast:18)
+PASS #7 Test that a WebAssembly code returns a specific result (load0.wast:19)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/load1.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/load1.wast.js-expected.txt
@@ -1,57 +1,25 @@
 
 PASS #1 Reinitialize the default imports
 PASS #2 Test that WebAssembly compilation succeeds (load1.wast:1)
-FAIL #3 Test that WebAssembly compilation succeeds (load1.wast:10) assert_equals: expected false but got true
+PASS #3 Test that WebAssembly compilation succeeds (load1.wast:10)
 PASS #4 Reinitialize the default imports
 PASS #5 Test that WebAssembly compilation succeeds (load1.wast:1)
 PASS #6 Test that WebAssembly instantiation succeeds (load1.wast:1)
-FAIL #7 Test that WebAssembly compilation succeeds (load1.wast:10) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 52: there can at most be one Memory section for now at {loc} expected true got false
-FAIL #8 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-load1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load1.wast.js:18:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load1.wast.js:65:3 expected true got false
-FAIL #9 Test that a WebAssembly code returns a specific result (load1.wast:25) assert_equals: assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load1.wast.js:21:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load1.wast.js:65:3 expected 1 but got 0
-FAIL #10 Test that a WebAssembly code returns a specific result (load1.wast:26) assert_equals: assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load1.wast.js:24:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load1.wast.js:65:3 expected 2 but got 0
-FAIL #11 Test that a WebAssembly code returns a specific result (load1.wast:27) assert_equals: assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load1.wast.js:27:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load1.wast.js:65:3 expected 3 but got 0
-FAIL #12 Test that a WebAssembly code returns a specific result (load1.wast:28) assert_equals: assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load1.wast.js:30:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load1.wast.js:65:3 expected 4 but got 0
-FAIL #13 Test that a WebAssembly code returns a specific result (load1.wast:29) assert_equals: assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load1.wast.js:33:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load1.wast.js:65:3 expected 5 but got 0
-FAIL #14 Test that a WebAssembly code returns a specific result (load1.wast:31) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load1.wast.js:36:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load1.wast.js:65:3 expected true got false
-FAIL #15 Test that a WebAssembly code returns a specific result (load1.wast:32) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load1.wast.js:39:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load1.wast.js:65:3 expected true got false
-FAIL #16 Test that a WebAssembly code returns a specific result (load1.wast:33) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load1.wast.js:42:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load1.wast.js:65:3 expected true got false
-FAIL #17 Test that a WebAssembly code returns a specific result (load1.wast:34) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load1.wast.js:45:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load1.wast.js:65:3 expected true got false
-FAIL #18 Test that a WebAssembly code returns a specific result (load1.wast:35) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load1.wast.js:48:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load1.wast.js:65:3 expected true got false
-FAIL #19 Test that a WebAssembly code returns a specific result (load1.wast:37) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load1.wast.js:51:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load1.wast.js:65:3 expected true got false
-FAIL #20 Test that a WebAssembly code returns a specific result (load1.wast:38) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load1.wast.js:54:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load1.wast.js:65:3 expected true got false
-FAIL #21 Test that a WebAssembly code returns a specific result (load1.wast:39) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load1.wast.js:57:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load1.wast.js:65:3 expected true got false
-FAIL #22 Test that a WebAssembly code returns a specific result (load1.wast:40) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load1.wast.js:60:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load1.wast.js:65:3 expected true got false
-FAIL #23 Test that a WebAssembly code returns a specific result (load1.wast:41) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load1.wast.js:63:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load1.wast.js:65:3 expected true got false
+PASS #7 Test that WebAssembly compilation succeeds (load1.wast:10)
+PASS #8 Test that WebAssembly instantiation succeeds (load1.wast:10)
+PASS #9 Test that a WebAssembly code returns a specific result (load1.wast:25)
+PASS #10 Test that a WebAssembly code returns a specific result (load1.wast:26)
+PASS #11 Test that a WebAssembly code returns a specific result (load1.wast:27)
+PASS #12 Test that a WebAssembly code returns a specific result (load1.wast:28)
+PASS #13 Test that a WebAssembly code returns a specific result (load1.wast:29)
+PASS #14 Test that a WebAssembly code returns a specific result (load1.wast:31)
+PASS #15 Test that a WebAssembly code returns a specific result (load1.wast:32)
+PASS #16 Test that a WebAssembly code returns a specific result (load1.wast:33)
+PASS #17 Test that a WebAssembly code returns a specific result (load1.wast:34)
+PASS #18 Test that a WebAssembly code returns a specific result (load1.wast:35)
+PASS #19 Test that a WebAssembly code returns a specific result (load1.wast:37)
+PASS #20 Test that a WebAssembly code returns a specific result (load1.wast:38)
+PASS #21 Test that a WebAssembly code returns a specific result (load1.wast:39)
+PASS #22 Test that a WebAssembly code returns a specific result (load1.wast:40)
+PASS #23 Test that a WebAssembly code returns a specific result (load1.wast:41)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/load2.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/load2.wast.js-expected.txt
@@ -1,120 +1,44 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (load2.wast:1) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (load2.wast:1)
 PASS #3 Reinitialize the default imports
-FAIL #4 Test that WebAssembly compilation succeeds (load2.wast:1) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 98: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-FAIL #5 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-load2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:120:3 expected true got false
-FAIL #6 Test that a WebAssembly code returns a specific result (load2.wast:162) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:10:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:120:3 expected true got false
-FAIL #7 Test that a WebAssembly code returns a specific result (load2.wast:164) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:13:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:120:3 expected true got false
-FAIL #8 Test that a WebAssembly code returns a specific result (load2.wast:165) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:16:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:120:3 expected true got false
-FAIL #9 Test that a WebAssembly code returns a specific result (load2.wast:166) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:19:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:120:3 expected true got false
-FAIL #10 Test that a WebAssembly code returns a specific result (load2.wast:168) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:22:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:120:3 expected true got false
-FAIL #11 Test that a WebAssembly code returns a specific result (load2.wast:169) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:25:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:120:3 expected true got false
-FAIL #12 Test that a WebAssembly code returns a specific result (load2.wast:170) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:28:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:120:3 expected true got false
-FAIL #13 Test that a WebAssembly code returns a specific result (load2.wast:172) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:31:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:120:3 expected true got false
-FAIL #14 Test that a WebAssembly code returns a specific result (load2.wast:174) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:34:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:120:3 expected true got false
-FAIL #15 Test that a WebAssembly code returns a specific result (load2.wast:175) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:37:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:120:3 expected true got false
-FAIL #16 Test that a WebAssembly code returns a specific result (load2.wast:176) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:40:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:120:3 expected true got false
-FAIL #17 Test that a WebAssembly code returns a specific result (load2.wast:178) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:43:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:120:3 expected true got false
-FAIL #18 Test that a WebAssembly code returns a specific result (load2.wast:179) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:46:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:120:3 expected true got false
-FAIL #19 Test that a WebAssembly code returns a specific result (load2.wast:180) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:49:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:120:3 expected true got false
-FAIL #20 Test that a WebAssembly code returns a specific result (load2.wast:182) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:52:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:120:3 expected true got false
-FAIL #21 Test that a WebAssembly code returns a specific result (load2.wast:183) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:55:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:120:3 expected true got false
-FAIL #22 Test that a WebAssembly code returns a specific result (load2.wast:184) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:58:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:120:3 expected true got false
-FAIL #23 Test that a WebAssembly code returns a specific result (load2.wast:186) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:61:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:120:3 expected true got false
-FAIL #24 Test that a WebAssembly code returns a specific result (load2.wast:187) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:64:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:120:3 expected true got false
-FAIL #25 Test that a WebAssembly code returns a specific result (load2.wast:188) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:67:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:120:3 expected true got false
-FAIL #26 Test that a WebAssembly code returns a specific result (load2.wast:189) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:70:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:120:3 expected true got false
-FAIL #27 Test that a WebAssembly code returns a specific result (load2.wast:191) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:73:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:120:3 expected true got false
-FAIL #28 Test that a WebAssembly code returns a specific result (load2.wast:192) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:76:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:120:3 expected true got false
-FAIL #29 Test that a WebAssembly code returns a specific result (load2.wast:193) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:79:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:120:3 expected true got false
-FAIL #30 Test that a WebAssembly code returns a specific result (load2.wast:195) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:82:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:120:3 expected true got false
-FAIL #31 Test that a WebAssembly code returns a specific result (load2.wast:196) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:85:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:120:3 expected true got false
-FAIL #32 Test that a WebAssembly code returns a specific result (load2.wast:197) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:88:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:120:3 expected true got false
-FAIL #33 Test that a WebAssembly code returns a specific result (load2.wast:198) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:91:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:120:3 expected true got false
-FAIL #34 Test that a WebAssembly code returns a specific result (load2.wast:199) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:94:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:120:3 expected true got false
-FAIL #35 Test that a WebAssembly code returns a specific result (load2.wast:200) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:97:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:120:3 expected true got false
-FAIL #36 Test that a WebAssembly code returns a specific result (load2.wast:202) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:100:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:120:3 expected true got false
-FAIL #37 Test that a WebAssembly code returns a specific result (load2.wast:204) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:103:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:120:3 expected true got false
-FAIL #38 Test that a WebAssembly code returns a specific result (load2.wast:205) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:106:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:120:3 expected true got false
-FAIL #39 Test that a WebAssembly code returns a specific result (load2.wast:207) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:109:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:120:3 expected true got false
-FAIL #40 Test that a WebAssembly code returns a specific result (load2.wast:209) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:112:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:120:3 expected true got false
-FAIL #41 Test that a WebAssembly code returns a specific result (load2.wast:210) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:115:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:120:3 expected true got false
-FAIL #42 Test that a WebAssembly code returns a specific result (load2.wast:212) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-load2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:118:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/load2.wast.js:120:3 expected true got false
+PASS #4 Test that WebAssembly compilation succeeds (load2.wast:1)
+PASS #5 Test that WebAssembly instantiation succeeds (load2.wast:1)
+PASS #6 Test that a WebAssembly code returns a specific result (load2.wast:162)
+PASS #7 Test that a WebAssembly code returns a specific result (load2.wast:164)
+PASS #8 Test that a WebAssembly code returns a specific result (load2.wast:165)
+PASS #9 Test that a WebAssembly code returns a specific result (load2.wast:166)
+PASS #10 Test that a WebAssembly code returns a specific result (load2.wast:168)
+PASS #11 Test that a WebAssembly code returns a specific result (load2.wast:169)
+PASS #12 Test that a WebAssembly code returns a specific result (load2.wast:170)
+PASS #13 Test that a WebAssembly code returns a specific result (load2.wast:172)
+PASS #14 Test that a WebAssembly code returns a specific result (load2.wast:174)
+PASS #15 Test that a WebAssembly code returns a specific result (load2.wast:175)
+PASS #16 Test that a WebAssembly code returns a specific result (load2.wast:176)
+PASS #17 Test that a WebAssembly code returns a specific result (load2.wast:178)
+PASS #18 Test that a WebAssembly code returns a specific result (load2.wast:179)
+PASS #19 Test that a WebAssembly code returns a specific result (load2.wast:180)
+PASS #20 Test that a WebAssembly code returns a specific result (load2.wast:182)
+PASS #21 Test that a WebAssembly code returns a specific result (load2.wast:183)
+PASS #22 Test that a WebAssembly code returns a specific result (load2.wast:184)
+PASS #23 Test that a WebAssembly code returns a specific result (load2.wast:186)
+PASS #24 Test that a WebAssembly code returns a specific result (load2.wast:187)
+PASS #25 Test that a WebAssembly code returns a specific result (load2.wast:188)
+PASS #26 Test that a WebAssembly code returns a specific result (load2.wast:189)
+PASS #27 Test that a WebAssembly code returns a specific result (load2.wast:191)
+PASS #28 Test that a WebAssembly code returns a specific result (load2.wast:192)
+PASS #29 Test that a WebAssembly code returns a specific result (load2.wast:193)
+PASS #30 Test that a WebAssembly code returns a specific result (load2.wast:195)
+PASS #31 Test that a WebAssembly code returns a specific result (load2.wast:196)
+PASS #32 Test that a WebAssembly code returns a specific result (load2.wast:197)
+PASS #33 Test that a WebAssembly code returns a specific result (load2.wast:198)
+PASS #34 Test that a WebAssembly code returns a specific result (load2.wast:199)
+PASS #35 Test that a WebAssembly code returns a specific result (load2.wast:200)
+PASS #36 Test that a WebAssembly code returns a specific result (load2.wast:202)
+PASS #37 Test that a WebAssembly code returns a specific result (load2.wast:204)
+PASS #38 Test that a WebAssembly code returns a specific result (load2.wast:205)
+PASS #39 Test that a WebAssembly code returns a specific result (load2.wast:207)
+PASS #40 Test that a WebAssembly code returns a specific result (load2.wast:209)
+PASS #41 Test that a WebAssembly code returns a specific result (load2.wast:210)
+PASS #42 Test that a WebAssembly code returns a specific result (load2.wast:212)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/memory-multi.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/memory-multi.wast.js-expected.txt
@@ -1,26 +1,14 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (memory-multi.wast:5) assert_equals: expected false but got true
-FAIL #3 Test that WebAssembly compilation succeeds (memory-multi.wast:26) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (memory-multi.wast:5)
+PASS #3 Test that WebAssembly compilation succeeds (memory-multi.wast:26)
 PASS #4 Reinitialize the default imports
-FAIL #5 Test that WebAssembly compilation succeeds (memory-multi.wast:5) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 35: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-FAIL #6 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_multi_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory-multi.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory-multi.wast.js:27:3 expected true got false
-FAIL #7 Test that a WebAssembly code returns a specific result (memory-multi.wast:22) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_multi_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory-multi.wast.js:10:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory-multi.wast.js:27:3 expected true got false
-FAIL #8 Test that a WebAssembly code returns a specific result (memory-multi.wast:23) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_multi_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory-multi.wast.js:13:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory-multi.wast.js:27:3 expected true got false
-FAIL #9 Test that WebAssembly compilation succeeds (memory-multi.wast:26) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 35: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-FAIL #10 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_multi_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory-multi.wast.js:19:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory-multi.wast.js:27:3 expected true got false
-FAIL #11 Test that a WebAssembly code returns a specific result (memory-multi.wast:41) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_multi_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory-multi.wast.js:22:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory-multi.wast.js:27:3 expected true got false
-FAIL #12 Test that a WebAssembly code returns a specific result (memory-multi.wast:42) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_multi_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory-multi.wast.js:25:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory-multi.wast.js:27:3 expected true got false
+PASS #5 Test that WebAssembly compilation succeeds (memory-multi.wast:5)
+PASS #6 Test that WebAssembly instantiation succeeds (memory-multi.wast:5)
+PASS #7 Test that a WebAssembly code returns a specific result (memory-multi.wast:22)
+PASS #8 Test that a WebAssembly code returns a specific result (memory-multi.wast:23)
+PASS #9 Test that WebAssembly compilation succeeds (memory-multi.wast:26)
+PASS #10 Test that WebAssembly instantiation succeeds (memory-multi.wast:26)
+PASS #11 Test that a WebAssembly code returns a specific result (memory-multi.wast:41)
+PASS #12 Test that a WebAssembly code returns a specific result (memory-multi.wast:42)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/memory_copy0.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/memory_copy0.wast.js-expected.txt
@@ -1,93 +1,35 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (memory_copy0.wast:2) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (memory_copy0.wast:2)
 PASS #3 Reinitialize the default imports
-FAIL #4 Test that WebAssembly compilation succeeds (memory_copy0.wast:2) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 42: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-FAIL #5 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_copy0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:93:3 expected true got false
-FAIL #6 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_copy0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:10:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:93:3 expected true got false
-FAIL #7 Test that a WebAssembly code returns a specific result (memory_copy0.wast:21) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:13:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:93:3 expected true got false
-FAIL #8 Test that a WebAssembly code returns a specific result (memory_copy0.wast:22) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:16:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:93:3 expected true got false
-FAIL #9 Test that a WebAssembly code returns a specific result (memory_copy0.wast:23) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:19:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:93:3 expected true got false
-FAIL #10 Test that a WebAssembly code returns a specific result (memory_copy0.wast:24) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:22:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:93:3 expected true got false
-FAIL #11 Test that a WebAssembly code returns a specific result (memory_copy0.wast:25) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:25:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:93:3 expected true got false
-FAIL #12 Test that a WebAssembly code returns a specific result (memory_copy0.wast:26) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:28:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:93:3 expected true got false
-FAIL #13 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_copy0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:31:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:93:3 expected true got false
-FAIL #14 Test that a WebAssembly code returns a specific result (memory_copy0.wast:30) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:34:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:93:3 expected true got false
-FAIL #15 Test that a WebAssembly code returns a specific result (memory_copy0.wast:31) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:37:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:93:3 expected true got false
-FAIL #16 Test that a WebAssembly code returns a specific result (memory_copy0.wast:32) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:40:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:93:3 expected true got false
-FAIL #17 Test that a WebAssembly code returns a specific result (memory_copy0.wast:33) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:43:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:93:3 expected true got false
-FAIL #18 Test that a WebAssembly code returns a specific result (memory_copy0.wast:34) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:46:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:93:3 expected true got false
-FAIL #19 Test that a WebAssembly code returns a specific result (memory_copy0.wast:35) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:49:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:93:3 expected true got false
-FAIL #20 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_copy0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:52:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:93:3 expected true got false
-FAIL #21 Test that a WebAssembly code returns a specific result (memory_copy0.wast:39) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:55:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:93:3 expected true got false
-FAIL #22 Test that a WebAssembly code returns a specific result (memory_copy0.wast:40) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:58:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:93:3 expected true got false
-FAIL #23 Test that a WebAssembly code returns a specific result (memory_copy0.wast:41) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:61:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:93:3 expected true got false
-FAIL #24 Test that a WebAssembly code returns a specific result (memory_copy0.wast:42) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:64:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:93:3 expected true got false
-FAIL #25 Test that a WebAssembly code returns a specific result (memory_copy0.wast:43) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:67:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:93:3 expected true got false
-FAIL #26 Test that a WebAssembly code returns a specific result (memory_copy0.wast:44) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:70:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:93:3 expected true got false
-FAIL #27 Test that a WebAssembly code returns a specific result (memory_copy0.wast:45) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:73:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:93:3 expected true got false
-FAIL #28 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_copy0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:76:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:93:3 expected true got false
-FAIL #29 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_copy0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:79:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:93:3 expected true got false
-FAIL #30 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_copy0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:82:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:93:3 expected true got false
-FAIL #31 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_copy0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:85:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:93:3 expected true got false
-FAIL #32 Test that a WebAssembly code traps (memory_copy0.wast:56) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_copy0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:88:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:93:3 expected true got false
-FAIL #33 Test that a WebAssembly code traps (memory_copy0.wast:58) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_copy0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:91:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy0.wast.js:93:3 expected true got false
+PASS #4 Test that WebAssembly compilation succeeds (memory_copy0.wast:2)
+PASS #5 Test that WebAssembly instantiation succeeds (memory_copy0.wast:2)
+PASS #6 Run a WebAssembly test without special assertions (memory_copy0.wast:19)
+PASS #7 Test that a WebAssembly code returns a specific result (memory_copy0.wast:21)
+PASS #8 Test that a WebAssembly code returns a specific result (memory_copy0.wast:22)
+PASS #9 Test that a WebAssembly code returns a specific result (memory_copy0.wast:23)
+PASS #10 Test that a WebAssembly code returns a specific result (memory_copy0.wast:24)
+PASS #11 Test that a WebAssembly code returns a specific result (memory_copy0.wast:25)
+PASS #12 Test that a WebAssembly code returns a specific result (memory_copy0.wast:26)
+PASS #13 Run a WebAssembly test without special assertions (memory_copy0.wast:29)
+PASS #14 Test that a WebAssembly code returns a specific result (memory_copy0.wast:30)
+PASS #15 Test that a WebAssembly code returns a specific result (memory_copy0.wast:31)
+PASS #16 Test that a WebAssembly code returns a specific result (memory_copy0.wast:32)
+PASS #17 Test that a WebAssembly code returns a specific result (memory_copy0.wast:33)
+PASS #18 Test that a WebAssembly code returns a specific result (memory_copy0.wast:34)
+PASS #19 Test that a WebAssembly code returns a specific result (memory_copy0.wast:35)
+PASS #20 Run a WebAssembly test without special assertions (memory_copy0.wast:38)
+PASS #21 Test that a WebAssembly code returns a specific result (memory_copy0.wast:39)
+PASS #22 Test that a WebAssembly code returns a specific result (memory_copy0.wast:40)
+PASS #23 Test that a WebAssembly code returns a specific result (memory_copy0.wast:41)
+PASS #24 Test that a WebAssembly code returns a specific result (memory_copy0.wast:42)
+PASS #25 Test that a WebAssembly code returns a specific result (memory_copy0.wast:43)
+PASS #26 Test that a WebAssembly code returns a specific result (memory_copy0.wast:44)
+PASS #27 Test that a WebAssembly code returns a specific result (memory_copy0.wast:45)
+PASS #28 Run a WebAssembly test without special assertions (memory_copy0.wast:48)
+PASS #29 Run a WebAssembly test without special assertions (memory_copy0.wast:49)
+PASS #30 Run a WebAssembly test without special assertions (memory_copy0.wast:52)
+PASS #31 Run a WebAssembly test without special assertions (memory_copy0.wast:53)
+PASS #32 Test that a WebAssembly code traps (memory_copy0.wast:56)
+PASS #33 Test that a WebAssembly code traps (memory_copy0.wast:58)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/memory_copy1.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/memory_copy1.wast.js-expected.txt
@@ -1,48 +1,20 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (memory_copy1.wast:2) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (memory_copy1.wast:2)
 PASS #3 Reinitialize the default imports
-FAIL #4 Test that WebAssembly compilation succeeds (memory_copy1.wast:2) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 42: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-FAIL #5 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_copy1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy1.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy1.wast.js:48:3 expected true got false
-FAIL #6 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_copy1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy1.wast.js:10:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy1.wast.js:48:3 expected true got false
-FAIL #7 Test that a WebAssembly code returns a specific result (memory_copy1.wast:21) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy1.wast.js:13:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy1.wast.js:48:3 expected true got false
-FAIL #8 Test that a WebAssembly code returns a specific result (memory_copy1.wast:22) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy1.wast.js:16:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy1.wast.js:48:3 expected true got false
-FAIL #9 Test that a WebAssembly code returns a specific result (memory_copy1.wast:23) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy1.wast.js:19:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy1.wast.js:48:3 expected true got false
-FAIL #10 Test that a WebAssembly code returns a specific result (memory_copy1.wast:24) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy1.wast.js:22:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy1.wast.js:48:3 expected true got false
-FAIL #11 Test that a WebAssembly code returns a specific result (memory_copy1.wast:25) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy1.wast.js:25:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy1.wast.js:48:3 expected true got false
-FAIL #12 Test that a WebAssembly code returns a specific result (memory_copy1.wast:26) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_copy1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy1.wast.js:28:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy1.wast.js:48:3 expected true got false
-FAIL #13 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_copy1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy1.wast.js:31:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy1.wast.js:48:3 expected true got false
-FAIL #14 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_copy1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy1.wast.js:34:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy1.wast.js:48:3 expected true got false
-FAIL #15 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_copy1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy1.wast.js:37:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy1.wast.js:48:3 expected true got false
-FAIL #16 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_copy1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy1.wast.js:40:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy1.wast.js:48:3 expected true got false
-FAIL #17 Test that a WebAssembly code traps (memory_copy1.wast:37) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_copy1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy1.wast.js:43:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy1.wast.js:48:3 expected true got false
-FAIL #18 Test that a WebAssembly code traps (memory_copy1.wast:39) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_copy1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy1.wast.js:46:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_copy1.wast.js:48:3 expected true got false
+PASS #4 Test that WebAssembly compilation succeeds (memory_copy1.wast:2)
+PASS #5 Test that WebAssembly instantiation succeeds (memory_copy1.wast:2)
+PASS #6 Run a WebAssembly test without special assertions (memory_copy1.wast:19)
+PASS #7 Test that a WebAssembly code returns a specific result (memory_copy1.wast:21)
+PASS #8 Test that a WebAssembly code returns a specific result (memory_copy1.wast:22)
+PASS #9 Test that a WebAssembly code returns a specific result (memory_copy1.wast:23)
+PASS #10 Test that a WebAssembly code returns a specific result (memory_copy1.wast:24)
+PASS #11 Test that a WebAssembly code returns a specific result (memory_copy1.wast:25)
+PASS #12 Test that a WebAssembly code returns a specific result (memory_copy1.wast:26)
+PASS #13 Run a WebAssembly test without special assertions (memory_copy1.wast:29)
+PASS #14 Run a WebAssembly test without special assertions (memory_copy1.wast:30)
+PASS #15 Run a WebAssembly test without special assertions (memory_copy1.wast:33)
+PASS #16 Run a WebAssembly test without special assertions (memory_copy1.wast:34)
+PASS #17 Test that a WebAssembly code traps (memory_copy1.wast:37)
+PASS #18 Test that a WebAssembly code traps (memory_copy1.wast:39)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/memory_fill0.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/memory_fill0.wast.js-expected.txt
@@ -1,54 +1,22 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (memory_fill0.wast:2) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (memory_fill0.wast:2)
 PASS #3 Reinitialize the default imports
-FAIL #4 Test that WebAssembly compilation succeeds (memory_fill0.wast:2) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 42: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-FAIL #5 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_fill0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_fill0.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_fill0.wast.js:54:3 expected true got false
-FAIL #6 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_fill0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_fill0.wast.js:10:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_fill0.wast.js:54:3 expected true got false
-FAIL #7 Test that a WebAssembly code returns a specific result (memory_fill0.wast:19) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_fill0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_fill0.wast.js:13:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_fill0.wast.js:54:3 expected true got false
-FAIL #8 Test that a WebAssembly code returns a specific result (memory_fill0.wast:20) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_fill0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_fill0.wast.js:16:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_fill0.wast.js:54:3 expected true got false
-FAIL #9 Test that a WebAssembly code returns a specific result (memory_fill0.wast:21) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_fill0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_fill0.wast.js:19:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_fill0.wast.js:54:3 expected true got false
-FAIL #10 Test that a WebAssembly code returns a specific result (memory_fill0.wast:22) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_fill0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_fill0.wast.js:22:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_fill0.wast.js:54:3 expected true got false
-FAIL #11 Test that a WebAssembly code returns a specific result (memory_fill0.wast:23) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_fill0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_fill0.wast.js:25:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_fill0.wast.js:54:3 expected true got false
-FAIL #12 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_fill0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_fill0.wast.js:28:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_fill0.wast.js:54:3 expected true got false
-FAIL #13 Test that a WebAssembly code returns a specific result (memory_fill0.wast:27) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_fill0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_fill0.wast.js:31:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_fill0.wast.js:54:3 expected true got false
-FAIL #14 Test that a WebAssembly code returns a specific result (memory_fill0.wast:28) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_fill0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_fill0.wast.js:34:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_fill0.wast.js:54:3 expected true got false
-FAIL #15 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_fill0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_fill0.wast.js:37:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_fill0.wast.js:54:3 expected true got false
-FAIL #16 Test that a WebAssembly code traps (memory_fill0.wast:34) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_fill0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_fill0.wast.js:40:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_fill0.wast.js:54:3 expected true got false
-FAIL #17 Test that a WebAssembly code returns a specific result (memory_fill0.wast:36) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_fill0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_fill0.wast.js:43:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_fill0.wast.js:54:3 expected true got false
-FAIL #18 Test that a WebAssembly code returns a specific result (memory_fill0.wast:37) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_fill0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_fill0.wast.js:46:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_fill0.wast.js:54:3 expected true got false
-FAIL #19 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_fill0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_fill0.wast.js:49:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_fill0.wast.js:54:3 expected true got false
-FAIL #20 Test that a WebAssembly code traps (memory_fill0.wast:43) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_fill0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_fill0.wast.js:52:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_fill0.wast.js:54:3 expected true got false
+PASS #4 Test that WebAssembly compilation succeeds (memory_fill0.wast:2)
+PASS #5 Test that WebAssembly instantiation succeeds (memory_fill0.wast:2)
+PASS #6 Run a WebAssembly test without special assertions (memory_fill0.wast:18)
+PASS #7 Test that a WebAssembly code returns a specific result (memory_fill0.wast:19)
+PASS #8 Test that a WebAssembly code returns a specific result (memory_fill0.wast:20)
+PASS #9 Test that a WebAssembly code returns a specific result (memory_fill0.wast:21)
+PASS #10 Test that a WebAssembly code returns a specific result (memory_fill0.wast:22)
+PASS #11 Test that a WebAssembly code returns a specific result (memory_fill0.wast:23)
+PASS #12 Run a WebAssembly test without special assertions (memory_fill0.wast:26)
+PASS #13 Test that a WebAssembly code returns a specific result (memory_fill0.wast:27)
+PASS #14 Test that a WebAssembly code returns a specific result (memory_fill0.wast:28)
+PASS #15 Run a WebAssembly test without special assertions (memory_fill0.wast:31)
+PASS #16 Test that a WebAssembly code traps (memory_fill0.wast:34)
+PASS #17 Test that a WebAssembly code returns a specific result (memory_fill0.wast:36)
+PASS #18 Test that a WebAssembly code returns a specific result (memory_fill0.wast:37)
+PASS #19 Run a WebAssembly test without special assertions (memory_fill0.wast:40)
+PASS #20 Test that a WebAssembly code traps (memory_fill0.wast:43)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/memory_grow.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/memory_grow.wast.js-expected.txt
@@ -1,160 +1,60 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (memory_grow.wast:1) assert_equals: expected false but got true
-FAIL #3 Test that WebAssembly compilation succeeds (memory_grow.wast:7) assert_equals: expected false but got true
-FAIL #4 Test that WebAssembly compilation succeeds (memory_grow.wast:81) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (memory_grow.wast:1)
+PASS #3 Test that WebAssembly compilation succeeds (memory_grow.wast:7)
+PASS #4 Test that WebAssembly compilation succeeds (memory_grow.wast:81)
 PASS #5 Reinitialize the default imports
-FAIL #6 Test that WebAssembly compilation succeeds (memory_grow.wast:1) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 15: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-FAIL #7 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_grow_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:165:3 expected true got false
-FAIL #8 Test that WebAssembly compilation succeeds (memory_grow.wast:7) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 50: there can at most be one Memory section for now at {loc} expected true got false
-FAIL #9 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_grow_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:16:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:165:3 expected true got false
-FAIL #10 Test that a WebAssembly code returns a specific result (memory_grow.wast:32) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:19:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:165:3 expected true got false
-FAIL #11 Test that a WebAssembly code returns a specific result (memory_grow.wast:33) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:22:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:165:3 expected true got false
-FAIL #12 Test that a WebAssembly code returns a specific result (memory_grow.wast:34) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:25:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:165:3 expected true got false
-FAIL #13 Test that a WebAssembly code returns a specific result (memory_grow.wast:35) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:28:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:165:3 expected true got false
-FAIL #14 Test that a WebAssembly code returns a specific result (memory_grow.wast:37) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:31:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:165:3 expected true got false
-FAIL #15 Test that a WebAssembly code returns a specific result (memory_grow.wast:38) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:34:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:165:3 expected true got false
-FAIL #16 Test that a WebAssembly code returns a specific result (memory_grow.wast:39) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:37:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:165:3 expected true got false
-FAIL #17 Test that a WebAssembly code returns a specific result (memory_grow.wast:40) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:40:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:165:3 expected true got false
-FAIL #18 Test that a WebAssembly code returns a specific result (memory_grow.wast:41) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:43:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:165:3 expected true got false
-FAIL #19 Test that a WebAssembly code returns a specific result (memory_grow.wast:43) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:46:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:165:3 expected true got false
-FAIL #20 Test that a WebAssembly code returns a specific result (memory_grow.wast:44) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:49:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:165:3 expected true got false
-FAIL #21 Test that a WebAssembly code returns a specific result (memory_grow.wast:45) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:52:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:165:3 expected true got false
-FAIL #22 Test that a WebAssembly code returns a specific result (memory_grow.wast:46) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:55:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:165:3 expected true got false
-FAIL #23 Test that a WebAssembly code returns a specific result (memory_grow.wast:47) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:58:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:165:3 expected true got false
-FAIL #24 Test that a WebAssembly code returns a specific result (memory_grow.wast:49) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:61:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:165:3 expected true got false
-FAIL #25 Test that a WebAssembly code returns a specific result (memory_grow.wast:50) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:64:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:165:3 expected true got false
-FAIL #26 Test that a WebAssembly code returns a specific result (memory_grow.wast:51) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:67:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:165:3 expected true got false
-FAIL #27 Test that a WebAssembly code returns a specific result (memory_grow.wast:52) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:70:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:165:3 expected true got false
-FAIL #28 Test that a WebAssembly code returns a specific result (memory_grow.wast:53) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:73:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:165:3 expected true got false
-FAIL #29 Test that a WebAssembly code returns a specific result (memory_grow.wast:55) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:76:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:165:3 expected true got false
-FAIL #30 Test that a WebAssembly code returns a specific result (memory_grow.wast:56) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:79:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:165:3 expected true got false
-FAIL #31 Test that a WebAssembly code returns a specific result (memory_grow.wast:57) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:82:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:165:3 expected true got false
-FAIL #32 Test that a WebAssembly code returns a specific result (memory_grow.wast:58) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:85:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:165:3 expected true got false
-FAIL #33 Test that a WebAssembly code returns a specific result (memory_grow.wast:59) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:88:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:165:3 expected true got false
-FAIL #34 Test that a WebAssembly code returns a specific result (memory_grow.wast:61) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:91:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:165:3 expected true got false
-FAIL #35 Test that a WebAssembly code returns a specific result (memory_grow.wast:62) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:94:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:165:3 expected true got false
-FAIL #36 Test that a WebAssembly code returns a specific result (memory_grow.wast:63) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:97:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:165:3 expected true got false
-FAIL #37 Test that a WebAssembly code returns a specific result (memory_grow.wast:64) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:100:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:165:3 expected true got false
-FAIL #38 Test that a WebAssembly code returns a specific result (memory_grow.wast:65) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:103:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:165:3 expected true got false
-FAIL #39 Test that a WebAssembly code returns a specific result (memory_grow.wast:67) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:106:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:165:3 expected true got false
-FAIL #40 Test that a WebAssembly code returns a specific result (memory_grow.wast:68) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:109:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:165:3 expected true got false
-FAIL #41 Test that a WebAssembly code returns a specific result (memory_grow.wast:69) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:112:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:165:3 expected true got false
-FAIL #42 Test that a WebAssembly code returns a specific result (memory_grow.wast:70) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:115:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:165:3 expected true got false
-FAIL #43 Test that a WebAssembly code returns a specific result (memory_grow.wast:71) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:118:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:165:3 expected true got false
-FAIL #44 Test that a WebAssembly code returns a specific result (memory_grow.wast:73) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:121:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:165:3 expected true got false
-FAIL #45 Test that a WebAssembly code returns a specific result (memory_grow.wast:74) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:124:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:165:3 expected true got false
-FAIL #46 Test that a WebAssembly code returns a specific result (memory_grow.wast:75) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:127:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:165:3 expected true got false
-FAIL #47 Test that a WebAssembly code returns a specific result (memory_grow.wast:76) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:130:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:165:3 expected true got false
-FAIL #48 Test that a WebAssembly code returns a specific result (memory_grow.wast:77) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:133:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:165:3 expected true got false
-FAIL #49 Test that a WebAssembly code returns a specific result (memory_grow.wast:78) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:136:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:165:3 expected true got false
-FAIL #50 Test that WebAssembly compilation succeeds (memory_grow.wast:81) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 42: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-FAIL #51 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_grow_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:142:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:165:3 expected true got false
-FAIL #52 Test that a WebAssembly code returns a specific result (memory_grow.wast:96) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:145:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:165:3 expected true got false
-FAIL #53 Test that a WebAssembly code returns a specific result (memory_grow.wast:97) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:148:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:165:3 expected true got false
-FAIL #54 Test that a WebAssembly code returns a specific result (memory_grow.wast:98) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:151:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:165:3 expected true got false
-FAIL #55 Test that a WebAssembly code returns a specific result (memory_grow.wast:99) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:154:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:165:3 expected true got false
-FAIL #56 Test that a WebAssembly code returns a specific result (memory_grow.wast:100) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:157:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:165:3 expected true got false
-FAIL #57 Test that a WebAssembly code returns a specific result (memory_grow.wast:101) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:160:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:165:3 expected true got false
-FAIL #58 Test that a WebAssembly code returns a specific result (memory_grow.wast:102) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_grow_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:163:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_grow.wast.js:165:3 expected true got false
+PASS #6 Test that WebAssembly compilation succeeds (memory_grow.wast:1)
+PASS #7 Test that WebAssembly instantiation succeeds (memory_grow.wast:1)
+PASS #8 Test that WebAssembly compilation succeeds (memory_grow.wast:7)
+PASS #9 Test that WebAssembly instantiation succeeds (memory_grow.wast:7)
+PASS #10 Test that a WebAssembly code returns a specific result (memory_grow.wast:32)
+PASS #11 Test that a WebAssembly code returns a specific result (memory_grow.wast:33)
+PASS #12 Test that a WebAssembly code returns a specific result (memory_grow.wast:34)
+PASS #13 Test that a WebAssembly code returns a specific result (memory_grow.wast:35)
+PASS #14 Test that a WebAssembly code returns a specific result (memory_grow.wast:37)
+PASS #15 Test that a WebAssembly code returns a specific result (memory_grow.wast:38)
+PASS #16 Test that a WebAssembly code returns a specific result (memory_grow.wast:39)
+PASS #17 Test that a WebAssembly code returns a specific result (memory_grow.wast:40)
+PASS #18 Test that a WebAssembly code returns a specific result (memory_grow.wast:41)
+PASS #19 Test that a WebAssembly code returns a specific result (memory_grow.wast:43)
+PASS #20 Test that a WebAssembly code returns a specific result (memory_grow.wast:44)
+PASS #21 Test that a WebAssembly code returns a specific result (memory_grow.wast:45)
+PASS #22 Test that a WebAssembly code returns a specific result (memory_grow.wast:46)
+PASS #23 Test that a WebAssembly code returns a specific result (memory_grow.wast:47)
+PASS #24 Test that a WebAssembly code returns a specific result (memory_grow.wast:49)
+PASS #25 Test that a WebAssembly code returns a specific result (memory_grow.wast:50)
+PASS #26 Test that a WebAssembly code returns a specific result (memory_grow.wast:51)
+PASS #27 Test that a WebAssembly code returns a specific result (memory_grow.wast:52)
+PASS #28 Test that a WebAssembly code returns a specific result (memory_grow.wast:53)
+PASS #29 Test that a WebAssembly code returns a specific result (memory_grow.wast:55)
+PASS #30 Test that a WebAssembly code returns a specific result (memory_grow.wast:56)
+PASS #31 Test that a WebAssembly code returns a specific result (memory_grow.wast:57)
+PASS #32 Test that a WebAssembly code returns a specific result (memory_grow.wast:58)
+PASS #33 Test that a WebAssembly code returns a specific result (memory_grow.wast:59)
+PASS #34 Test that a WebAssembly code returns a specific result (memory_grow.wast:61)
+PASS #35 Test that a WebAssembly code returns a specific result (memory_grow.wast:62)
+PASS #36 Test that a WebAssembly code returns a specific result (memory_grow.wast:63)
+PASS #37 Test that a WebAssembly code returns a specific result (memory_grow.wast:64)
+PASS #38 Test that a WebAssembly code returns a specific result (memory_grow.wast:65)
+PASS #39 Test that a WebAssembly code returns a specific result (memory_grow.wast:67)
+PASS #40 Test that a WebAssembly code returns a specific result (memory_grow.wast:68)
+PASS #41 Test that a WebAssembly code returns a specific result (memory_grow.wast:69)
+PASS #42 Test that a WebAssembly code returns a specific result (memory_grow.wast:70)
+PASS #43 Test that a WebAssembly code returns a specific result (memory_grow.wast:71)
+PASS #44 Test that a WebAssembly code returns a specific result (memory_grow.wast:73)
+PASS #45 Test that a WebAssembly code returns a specific result (memory_grow.wast:74)
+PASS #46 Test that a WebAssembly code returns a specific result (memory_grow.wast:75)
+PASS #47 Test that a WebAssembly code returns a specific result (memory_grow.wast:76)
+PASS #48 Test that a WebAssembly code returns a specific result (memory_grow.wast:77)
+PASS #49 Test that a WebAssembly code returns a specific result (memory_grow.wast:78)
+PASS #50 Test that WebAssembly compilation succeeds (memory_grow.wast:81)
+PASS #51 Test that WebAssembly instantiation succeeds (memory_grow.wast:81)
+PASS #52 Test that a WebAssembly code returns a specific result (memory_grow.wast:96)
+PASS #53 Test that a WebAssembly code returns a specific result (memory_grow.wast:97)
+PASS #54 Test that a WebAssembly code returns a specific result (memory_grow.wast:98)
+PASS #55 Test that a WebAssembly code returns a specific result (memory_grow.wast:99)
+PASS #56 Test that a WebAssembly code returns a specific result (memory_grow.wast:100)
+PASS #57 Test that a WebAssembly code returns a specific result (memory_grow.wast:101)
+PASS #58 Test that a WebAssembly code returns a specific result (memory_grow.wast:102)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/memory_init0.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/memory_init0.wast.js-expected.txt
@@ -1,45 +1,19 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (memory_init0.wast:2) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (memory_init0.wast:2)
 PASS #3 Reinitialize the default imports
-FAIL #4 Test that WebAssembly compilation succeeds (memory_init0.wast:2) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 42: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-FAIL #5 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_init0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_init0.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_init0.wast.js:45:3 expected true got false
-FAIL #6 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_init0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_init0.wast.js:10:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_init0.wast.js:45:3 expected true got false
-FAIL #7 Test that a WebAssembly code returns a specific result (memory_init0.wast:20) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_init0.wast.js:13:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_init0.wast.js:45:3 expected true got false
-FAIL #8 Test that a WebAssembly code returns a specific result (memory_init0.wast:21) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_init0.wast.js:16:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_init0.wast.js:45:3 expected true got false
-FAIL #9 Test that a WebAssembly code returns a specific result (memory_init0.wast:22) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_init0.wast.js:19:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_init0.wast.js:45:3 expected true got false
-FAIL #10 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_init0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_init0.wast.js:22:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_init0.wast.js:45:3 expected true got false
-FAIL #11 Test that a WebAssembly code traps (memory_init0.wast:28) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_init0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_init0.wast.js:25:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_init0.wast.js:45:3 expected true got false
-FAIL #12 Test that a WebAssembly code returns a specific result (memory_init0.wast:30) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_init0.wast.js:28:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_init0.wast.js:45:3 expected true got false
-FAIL #13 Test that a WebAssembly code returns a specific result (memory_init0.wast:31) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_init0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_init0.wast.js:31:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_init0.wast.js:45:3 expected true got false
-FAIL #14 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_init0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_init0.wast.js:34:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_init0.wast.js:45:3 expected true got false
-FAIL #15 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_init0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_init0.wast.js:37:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_init0.wast.js:45:3 expected true got false
-FAIL #16 Test that a WebAssembly code traps (memory_init0.wast:38) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_init0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_init0.wast.js:40:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_init0.wast.js:45:3 expected true got false
-FAIL #17 Test that a WebAssembly code traps (memory_init0.wast:40) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_init0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_init0.wast.js:43:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_init0.wast.js:45:3 expected true got false
+PASS #4 Test that WebAssembly compilation succeeds (memory_init0.wast:2)
+PASS #5 Test that WebAssembly instantiation succeeds (memory_init0.wast:2)
+PASS #6 Run a WebAssembly test without special assertions (memory_init0.wast:19)
+PASS #7 Test that a WebAssembly code returns a specific result (memory_init0.wast:20)
+PASS #8 Test that a WebAssembly code returns a specific result (memory_init0.wast:21)
+PASS #9 Test that a WebAssembly code returns a specific result (memory_init0.wast:22)
+PASS #10 Run a WebAssembly test without special assertions (memory_init0.wast:25)
+PASS #11 Test that a WebAssembly code traps (memory_init0.wast:28)
+PASS #12 Test that a WebAssembly code returns a specific result (memory_init0.wast:30)
+PASS #13 Test that a WebAssembly code returns a specific result (memory_init0.wast:31)
+PASS #14 Run a WebAssembly test without special assertions (memory_init0.wast:34)
+PASS #15 Run a WebAssembly test without special assertions (memory_init0.wast:35)
+PASS #16 Test that a WebAssembly code traps (memory_init0.wast:38)
+PASS #17 Test that a WebAssembly code traps (memory_init0.wast:40)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/memory_size0.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/memory_size0.wast.js-expected.txt
@@ -1,30 +1,14 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (memory_size0.wast:1) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (memory_size0.wast:1)
 PASS #3 Reinitialize the default imports
-FAIL #4 Test that WebAssembly compilation succeeds (memory_size0.wast:1) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 39: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-FAIL #5 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_size0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size0.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size0.wast.js:30:3 expected true got false
-FAIL #6 Test that a WebAssembly code returns a specific result (memory_size0.wast:12) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_size0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size0.wast.js:10:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size0.wast.js:30:3 expected true got false
-FAIL #7 Test that a WebAssembly code returns a specific result (memory_size0.wast:13) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_size0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size0.wast.js:13:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size0.wast.js:30:3 expected true got false
-FAIL #8 Test that a WebAssembly code returns a specific result (memory_size0.wast:14) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_size0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size0.wast.js:16:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size0.wast.js:30:3 expected true got false
-FAIL #9 Test that a WebAssembly code returns a specific result (memory_size0.wast:15) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_size0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size0.wast.js:19:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size0.wast.js:30:3 expected true got false
-FAIL #10 Test that a WebAssembly code returns a specific result (memory_size0.wast:16) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_size0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size0.wast.js:22:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size0.wast.js:30:3 expected true got false
-FAIL #11 Test that a WebAssembly code returns a specific result (memory_size0.wast:17) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_size0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size0.wast.js:25:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size0.wast.js:30:3 expected true got false
-FAIL #12 Test that a WebAssembly code returns a specific result (memory_size0.wast:18) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_size0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size0.wast.js:28:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size0.wast.js:30:3 expected true got false
+PASS #4 Test that WebAssembly compilation succeeds (memory_size0.wast:1)
+PASS #5 Test that WebAssembly instantiation succeeds (memory_size0.wast:1)
+PASS #6 Test that a WebAssembly code returns a specific result (memory_size0.wast:12)
+PASS #7 Test that a WebAssembly code returns a specific result (memory_size0.wast:13)
+PASS #8 Test that a WebAssembly code returns a specific result (memory_size0.wast:14)
+PASS #9 Test that a WebAssembly code returns a specific result (memory_size0.wast:15)
+PASS #10 Test that a WebAssembly code returns a specific result (memory_size0.wast:16)
+PASS #11 Test that a WebAssembly code returns a specific result (memory_size0.wast:17)
+PASS #12 Test that a WebAssembly code returns a specific result (memory_size0.wast:18)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/memory_size1.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/memory_size1.wast.js-expected.txt
@@ -1,51 +1,21 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (memory_size1.wast:1) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (memory_size1.wast:1)
 PASS #3 Reinitialize the default imports
-FAIL #4 Test that WebAssembly compilation succeeds (memory_size1.wast:1) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 41: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-FAIL #5 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_size1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size1.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size1.wast.js:51:3 expected true got false
-FAIL #6 Test that a WebAssembly code returns a specific result (memory_size1.wast:15) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_size1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size1.wast.js:10:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size1.wast.js:51:3 expected true got false
-FAIL #7 Test that a WebAssembly code returns a specific result (memory_size1.wast:16) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_size1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size1.wast.js:13:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size1.wast.js:51:3 expected true got false
-FAIL #8 Test that a WebAssembly code returns a specific result (memory_size1.wast:17) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_size1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size1.wast.js:16:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size1.wast.js:51:3 expected true got false
-FAIL #9 Test that a WebAssembly code returns a specific result (memory_size1.wast:18) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_size1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size1.wast.js:19:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size1.wast.js:51:3 expected true got false
-FAIL #10 Test that a WebAssembly code returns a specific result (memory_size1.wast:19) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_size1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size1.wast.js:22:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size1.wast.js:51:3 expected true got false
-FAIL #11 Test that a WebAssembly code returns a specific result (memory_size1.wast:20) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_size1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size1.wast.js:25:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size1.wast.js:51:3 expected true got false
-FAIL #12 Test that a WebAssembly code returns a specific result (memory_size1.wast:21) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_size1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size1.wast.js:28:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size1.wast.js:51:3 expected true got false
-FAIL #13 Test that a WebAssembly code returns a specific result (memory_size1.wast:22) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_size1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size1.wast.js:31:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size1.wast.js:51:3 expected true got false
-FAIL #14 Test that a WebAssembly code returns a specific result (memory_size1.wast:23) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_size1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size1.wast.js:34:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size1.wast.js:51:3 expected true got false
-FAIL #15 Test that a WebAssembly code returns a specific result (memory_size1.wast:24) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_size1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size1.wast.js:37:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size1.wast.js:51:3 expected true got false
-FAIL #16 Test that a WebAssembly code returns a specific result (memory_size1.wast:25) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_size1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size1.wast.js:40:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size1.wast.js:51:3 expected true got false
-FAIL #17 Test that a WebAssembly code returns a specific result (memory_size1.wast:27) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_size1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size1.wast.js:43:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size1.wast.js:51:3 expected true got false
-FAIL #18 Test that a WebAssembly code returns a specific result (memory_size1.wast:28) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_size1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size1.wast.js:46:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size1.wast.js:51:3 expected true got false
-FAIL #19 Test that a WebAssembly code returns a specific result (memory_size1.wast:29) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_size1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size1.wast.js:49:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size1.wast.js:51:3 expected true got false
+PASS #4 Test that WebAssembly compilation succeeds (memory_size1.wast:1)
+PASS #5 Test that WebAssembly instantiation succeeds (memory_size1.wast:1)
+PASS #6 Test that a WebAssembly code returns a specific result (memory_size1.wast:15)
+PASS #7 Test that a WebAssembly code returns a specific result (memory_size1.wast:16)
+PASS #8 Test that a WebAssembly code returns a specific result (memory_size1.wast:17)
+PASS #9 Test that a WebAssembly code returns a specific result (memory_size1.wast:18)
+PASS #10 Test that a WebAssembly code returns a specific result (memory_size1.wast:19)
+PASS #11 Test that a WebAssembly code returns a specific result (memory_size1.wast:20)
+PASS #12 Test that a WebAssembly code returns a specific result (memory_size1.wast:21)
+PASS #13 Test that a WebAssembly code returns a specific result (memory_size1.wast:22)
+PASS #14 Test that a WebAssembly code returns a specific result (memory_size1.wast:23)
+PASS #15 Test that a WebAssembly code returns a specific result (memory_size1.wast:24)
+PASS #16 Test that a WebAssembly code returns a specific result (memory_size1.wast:25)
+PASS #17 Test that a WebAssembly code returns a specific result (memory_size1.wast:27)
+PASS #18 Test that a WebAssembly code returns a specific result (memory_size1.wast:28)
+PASS #19 Test that a WebAssembly code returns a specific result (memory_size1.wast:29)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/memory_size2.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/memory_size2.wast.js-expected.txt
@@ -1,69 +1,27 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (memory_size2.wast:1) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (memory_size2.wast:1)
 PASS #3 Reinitialize the default imports
-FAIL #4 Test that WebAssembly compilation succeeds (memory_size2.wast:1) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 41: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-FAIL #5 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_size2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size2.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size2.wast.js:69:3 expected true got false
-FAIL #6 Test that a WebAssembly code returns a specific result (memory_size2.wast:14) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_size2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size2.wast.js:10:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size2.wast.js:69:3 expected true got false
-FAIL #7 Test that a WebAssembly code returns a specific result (memory_size2.wast:15) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_size2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size2.wast.js:13:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size2.wast.js:69:3 expected true got false
-FAIL #8 Test that a WebAssembly code returns a specific result (memory_size2.wast:16) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_size2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size2.wast.js:16:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size2.wast.js:69:3 expected true got false
-FAIL #9 Test that a WebAssembly code returns a specific result (memory_size2.wast:17) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_size2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size2.wast.js:19:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size2.wast.js:69:3 expected true got false
-FAIL #10 Test that a WebAssembly code returns a specific result (memory_size2.wast:18) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_size2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size2.wast.js:22:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size2.wast.js:69:3 expected true got false
-FAIL #11 Test that a WebAssembly code returns a specific result (memory_size2.wast:19) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_size2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size2.wast.js:25:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size2.wast.js:69:3 expected true got false
-FAIL #12 Test that a WebAssembly code returns a specific result (memory_size2.wast:20) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_size2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size2.wast.js:28:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size2.wast.js:69:3 expected true got false
-FAIL #13 Test that a WebAssembly code returns a specific result (memory_size2.wast:21) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_size2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size2.wast.js:31:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size2.wast.js:69:3 expected true got false
-FAIL #14 Test that a WebAssembly code returns a specific result (memory_size2.wast:22) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_size2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size2.wast.js:34:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size2.wast.js:69:3 expected true got false
-FAIL #15 Test that a WebAssembly code returns a specific result (memory_size2.wast:23) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_size2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size2.wast.js:37:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size2.wast.js:69:3 expected true got false
-FAIL #16 Test that a WebAssembly code returns a specific result (memory_size2.wast:24) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_size2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size2.wast.js:40:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size2.wast.js:69:3 expected true got false
-FAIL #17 Test that a WebAssembly code returns a specific result (memory_size2.wast:25) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_size2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size2.wast.js:43:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size2.wast.js:69:3 expected true got false
-FAIL #18 Test that a WebAssembly code returns a specific result (memory_size2.wast:26) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_size2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size2.wast.js:46:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size2.wast.js:69:3 expected true got false
-FAIL #19 Test that a WebAssembly code returns a specific result (memory_size2.wast:27) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_size2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size2.wast.js:49:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size2.wast.js:69:3 expected true got false
-FAIL #20 Test that a WebAssembly code returns a specific result (memory_size2.wast:28) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_size2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size2.wast.js:52:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size2.wast.js:69:3 expected true got false
-FAIL #21 Test that a WebAssembly code returns a specific result (memory_size2.wast:29) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_size2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size2.wast.js:55:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size2.wast.js:69:3 expected true got false
-FAIL #22 Test that a WebAssembly code returns a specific result (memory_size2.wast:30) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_size2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size2.wast.js:58:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size2.wast.js:69:3 expected true got false
-FAIL #23 Test that a WebAssembly code returns a specific result (memory_size2.wast:32) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_size2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size2.wast.js:61:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size2.wast.js:69:3 expected true got false
-FAIL #24 Test that a WebAssembly code returns a specific result (memory_size2.wast:33) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_size2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size2.wast.js:64:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size2.wast.js:69:3 expected true got false
-FAIL #25 Test that a WebAssembly code returns a specific result (memory_size2.wast:34) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_size2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size2.wast.js:67:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size2.wast.js:69:3 expected true got false
+PASS #4 Test that WebAssembly compilation succeeds (memory_size2.wast:1)
+PASS #5 Test that WebAssembly instantiation succeeds (memory_size2.wast:1)
+PASS #6 Test that a WebAssembly code returns a specific result (memory_size2.wast:14)
+PASS #7 Test that a WebAssembly code returns a specific result (memory_size2.wast:15)
+PASS #8 Test that a WebAssembly code returns a specific result (memory_size2.wast:16)
+PASS #9 Test that a WebAssembly code returns a specific result (memory_size2.wast:17)
+PASS #10 Test that a WebAssembly code returns a specific result (memory_size2.wast:18)
+PASS #11 Test that a WebAssembly code returns a specific result (memory_size2.wast:19)
+PASS #12 Test that a WebAssembly code returns a specific result (memory_size2.wast:20)
+PASS #13 Test that a WebAssembly code returns a specific result (memory_size2.wast:21)
+PASS #14 Test that a WebAssembly code returns a specific result (memory_size2.wast:22)
+PASS #15 Test that a WebAssembly code returns a specific result (memory_size2.wast:23)
+PASS #16 Test that a WebAssembly code returns a specific result (memory_size2.wast:24)
+PASS #17 Test that a WebAssembly code returns a specific result (memory_size2.wast:25)
+PASS #18 Test that a WebAssembly code returns a specific result (memory_size2.wast:26)
+PASS #19 Test that a WebAssembly code returns a specific result (memory_size2.wast:27)
+PASS #20 Test that a WebAssembly code returns a specific result (memory_size2.wast:28)
+PASS #21 Test that a WebAssembly code returns a specific result (memory_size2.wast:29)
+PASS #22 Test that a WebAssembly code returns a specific result (memory_size2.wast:30)
+PASS #23 Test that a WebAssembly code returns a specific result (memory_size2.wast:32)
+PASS #24 Test that a WebAssembly code returns a specific result (memory_size2.wast:33)
+PASS #25 Test that a WebAssembly code returns a specific result (memory_size2.wast:34)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/memory_size_import.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/memory_size_import.wast.js-expected.txt
@@ -1,26 +1,14 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (memory_size_import.wast:1) assert_equals: expected false but got true
-FAIL #3 Test that WebAssembly compilation succeeds (memory_size_import.wast:7) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (memory_size_import.wast:1)
+PASS #3 Test that WebAssembly compilation succeeds (memory_size_import.wast:7)
 PASS #4 Reinitialize the default imports
-FAIL #5 Test that WebAssembly compilation succeeds (memory_size_import.wast:1) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 15: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-FAIL #6 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_size_import_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size_import.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size_import.wast.js:30:3 expected true got false
-FAIL #7 Test that WebAssembly compilation succeeds (memory_size_import.wast:7) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 45: there can at most be one Memory section for now at {loc} expected true got false
-FAIL #8 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_size_import_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size_import.wast.js:16:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size_import.wast.js:30:3 expected true got false
-FAIL #9 Test that a WebAssembly code returns a specific result (memory_size_import.wast:19) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_size_import_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size_import.wast.js:19:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size_import.wast.js:30:3 expected true got false
-FAIL #10 Test that a WebAssembly code returns a specific result (memory_size_import.wast:20) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_size_import_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size_import.wast.js:22:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size_import.wast.js:30:3 expected true got false
-FAIL #11 Test that a WebAssembly code returns a specific result (memory_size_import.wast:21) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_size_import_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size_import.wast.js:25:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size_import.wast.js:30:3 expected true got false
-FAIL #12 Test that a WebAssembly code returns a specific result (memory_size_import.wast:22) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_size_import_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size_import.wast.js:28:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_size_import.wast.js:30:3 expected true got false
+PASS #5 Test that WebAssembly compilation succeeds (memory_size_import.wast:1)
+PASS #6 Test that WebAssembly instantiation succeeds (memory_size_import.wast:1)
+PASS #7 Test that WebAssembly compilation succeeds (memory_size_import.wast:7)
+PASS #8 Test that WebAssembly instantiation succeeds (memory_size_import.wast:7)
+PASS #9 Test that a WebAssembly code returns a specific result (memory_size_import.wast:19)
+PASS #10 Test that a WebAssembly code returns a specific result (memory_size_import.wast:20)
+PASS #11 Test that a WebAssembly code returns a specific result (memory_size_import.wast:21)
+PASS #12 Test that a WebAssembly code returns a specific result (memory_size_import.wast:22)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/memory_trap0.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/memory_trap0.wast.js-expected.txt
@@ -1,48 +1,20 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (memory_trap0.wast:1) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (memory_trap0.wast:1)
 PASS #3 Reinitialize the default imports
-FAIL #4 Test that WebAssembly compilation succeeds (memory_trap0.wast:1) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 47: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-FAIL #5 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_trap0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap0.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap0.wast.js:48:3 expected true got false
-FAIL #6 Test that a WebAssembly code returns a specific result (memory_trap0.wast:23) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_trap0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap0.wast.js:10:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap0.wast.js:48:3 expected true got false
-FAIL #7 Test that a WebAssembly code returns a specific result (memory_trap0.wast:24) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_trap0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap0.wast.js:13:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap0.wast.js:48:3 expected true got false
-FAIL #8 Test that a WebAssembly code traps (memory_trap0.wast:25) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap0.wast.js:16:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap0.wast.js:48:3 expected true got false
-FAIL #9 Test that a WebAssembly code traps (memory_trap0.wast:26) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap0.wast.js:19:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap0.wast.js:48:3 expected true got false
-FAIL #10 Test that a WebAssembly code traps (memory_trap0.wast:27) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap0.wast.js:22:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap0.wast.js:48:3 expected true got false
-FAIL #11 Test that a WebAssembly code traps (memory_trap0.wast:28) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap0.wast.js:25:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap0.wast.js:48:3 expected true got false
-FAIL #12 Test that a WebAssembly code traps (memory_trap0.wast:29) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap0.wast.js:28:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap0.wast.js:48:3 expected true got false
-FAIL #13 Test that a WebAssembly code traps (memory_trap0.wast:30) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap0.wast.js:31:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap0.wast.js:48:3 expected true got false
-FAIL #14 Test that a WebAssembly code traps (memory_trap0.wast:31) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap0.wast.js:34:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap0.wast.js:48:3 expected true got false
-FAIL #15 Test that a WebAssembly code traps (memory_trap0.wast:32) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap0.wast.js:37:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap0.wast.js:48:3 expected true got false
-FAIL #16 Test that a WebAssembly code traps (memory_trap0.wast:33) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap0.wast.js:40:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap0.wast.js:48:3 expected true got false
-FAIL #17 Test that a WebAssembly code traps (memory_trap0.wast:34) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap0.wast.js:43:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap0.wast.js:48:3 expected true got false
-FAIL #18 Test that a WebAssembly code returns a specific result (memory_trap0.wast:35) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_trap0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap0.wast.js:46:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap0.wast.js:48:3 expected true got false
+PASS #4 Test that WebAssembly compilation succeeds (memory_trap0.wast:1)
+PASS #5 Test that WebAssembly instantiation succeeds (memory_trap0.wast:1)
+PASS #6 Test that a WebAssembly code returns a specific result (memory_trap0.wast:23)
+PASS #7 Test that a WebAssembly code returns a specific result (memory_trap0.wast:24)
+PASS #8 Test that a WebAssembly code traps (memory_trap0.wast:25)
+PASS #9 Test that a WebAssembly code traps (memory_trap0.wast:26)
+PASS #10 Test that a WebAssembly code traps (memory_trap0.wast:27)
+PASS #11 Test that a WebAssembly code traps (memory_trap0.wast:28)
+PASS #12 Test that a WebAssembly code traps (memory_trap0.wast:29)
+PASS #13 Test that a WebAssembly code traps (memory_trap0.wast:30)
+PASS #14 Test that a WebAssembly code traps (memory_trap0.wast:31)
+PASS #15 Test that a WebAssembly code traps (memory_trap0.wast:32)
+PASS #16 Test that a WebAssembly code traps (memory_trap0.wast:33)
+PASS #17 Test that a WebAssembly code traps (memory_trap0.wast:34)
+PASS #18 Test that a WebAssembly code returns a specific result (memory_trap0.wast:35)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/memory_trap1.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/memory_trap1.wast.js-expected.txt
@@ -1,6 +1,6 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (memory_trap1.wast:1) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (memory_trap1.wast:1)
 PASS #3 Test that WebAssembly compilation succeeds (wrapper)
 PASS #4 Test that WebAssembly compilation succeeds (wrapper)
 PASS #5 Test that WebAssembly compilation succeeds (wrapper)
@@ -54,821 +54,277 @@ PASS #52 Test that WebAssembly compilation succeeds (wrapper)
 PASS #53 Test that WebAssembly compilation succeeds (wrapper)
 PASS #54 Test that WebAssembly compilation succeeds (wrapper)
 PASS #55 Reinitialize the default imports
-FAIL #56 Test that WebAssembly compilation succeeds (memory_trap1.wast:1) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 92: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-FAIL #57 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #58 Test that a WebAssembly code traps (memory_trap1.wast:79) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:10:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #59 Test that a WebAssembly code traps (memory_trap1.wast:80) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:13:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #60 Test that a WebAssembly code traps (memory_trap1.wast:81) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:16:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #61 Test that a WebAssembly code traps (memory_trap1.wast:82) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:19:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #62 Test that a WebAssembly code traps (memory_trap1.wast:83) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:22:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #63 Test that a WebAssembly code traps (memory_trap1.wast:84) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:25:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #64 Test that a WebAssembly code traps (memory_trap1.wast:85) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:28:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #65 Test that a WebAssembly code traps (memory_trap1.wast:86) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:31:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #66 Test that a WebAssembly code traps (memory_trap1.wast:87) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:34:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #67 Test that a WebAssembly code traps (memory_trap1.wast:88) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:37:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #68 Test that a WebAssembly code traps (memory_trap1.wast:89) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:40:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #69 Test that a WebAssembly code traps (memory_trap1.wast:90) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:43:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #70 Test that a WebAssembly code traps (memory_trap1.wast:91) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:46:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #71 Test that a WebAssembly code traps (memory_trap1.wast:92) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:49:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #72 Test that a WebAssembly code traps (memory_trap1.wast:93) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:52:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #73 Test that a WebAssembly code traps (memory_trap1.wast:94) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:55:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #74 Test that a WebAssembly code traps (memory_trap1.wast:95) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:58:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #75 Test that a WebAssembly code traps (memory_trap1.wast:96) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:61:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #76 Test that a WebAssembly code traps (memory_trap1.wast:97) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:64:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #77 Test that a WebAssembly code traps (memory_trap1.wast:98) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:67:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #78 Test that a WebAssembly code traps (memory_trap1.wast:99) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:70:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #79 Test that a WebAssembly code traps (memory_trap1.wast:100) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:73:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #80 Test that a WebAssembly code traps (memory_trap1.wast:101) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:76:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #81 Test that a WebAssembly code traps (memory_trap1.wast:102) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:79:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
+PASS #56 Test that WebAssembly compilation succeeds (memory_trap1.wast:1)
+PASS #57 Test that WebAssembly instantiation succeeds (memory_trap1.wast:1)
+PASS #58 Test that a WebAssembly code traps (memory_trap1.wast:79)
+PASS #59 Test that a WebAssembly code traps (memory_trap1.wast:80)
+PASS #60 Test that a WebAssembly code traps (memory_trap1.wast:81)
+PASS #61 Test that a WebAssembly code traps (memory_trap1.wast:82)
+PASS #62 Test that a WebAssembly code traps (memory_trap1.wast:83)
+PASS #63 Test that a WebAssembly code traps (memory_trap1.wast:84)
+PASS #64 Test that a WebAssembly code traps (memory_trap1.wast:85)
+PASS #65 Test that a WebAssembly code traps (memory_trap1.wast:86)
+PASS #66 Test that a WebAssembly code traps (memory_trap1.wast:87)
+PASS #67 Test that a WebAssembly code traps (memory_trap1.wast:88)
+PASS #68 Test that a WebAssembly code traps (memory_trap1.wast:89)
+PASS #69 Test that a WebAssembly code traps (memory_trap1.wast:90)
+PASS #70 Test that a WebAssembly code traps (memory_trap1.wast:91)
+PASS #71 Test that a WebAssembly code traps (memory_trap1.wast:92)
+PASS #72 Test that a WebAssembly code traps (memory_trap1.wast:93)
+PASS #73 Test that a WebAssembly code traps (memory_trap1.wast:94)
+PASS #74 Test that a WebAssembly code traps (memory_trap1.wast:95)
+PASS #75 Test that a WebAssembly code traps (memory_trap1.wast:96)
+PASS #76 Test that a WebAssembly code traps (memory_trap1.wast:97)
+PASS #77 Test that a WebAssembly code traps (memory_trap1.wast:98)
+PASS #78 Test that a WebAssembly code traps (memory_trap1.wast:99)
+PASS #79 Test that a WebAssembly code traps (memory_trap1.wast:100)
+PASS #80 Test that a WebAssembly code traps (memory_trap1.wast:101)
+PASS #81 Test that a WebAssembly code traps (memory_trap1.wast:102)
 PASS #82 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #83 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:82:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:82:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #84 Test that a WebAssembly code traps (memory_trap1.wast:103) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:82:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
+PASS #83 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #84 Test that a WebAssembly code traps (memory_trap1.wast:103)
 PASS #85 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #86 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:85:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:85:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #87 Test that a WebAssembly code traps (memory_trap1.wast:104) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:85:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
+PASS #86 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #87 Test that a WebAssembly code traps (memory_trap1.wast:104)
 PASS #88 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #89 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:88:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:88:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #90 Test that a WebAssembly code traps (memory_trap1.wast:105) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:88:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
+PASS #89 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #90 Test that a WebAssembly code traps (memory_trap1.wast:105)
 PASS #91 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #92 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:91:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:91:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #93 Test that a WebAssembly code traps (memory_trap1.wast:106) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:91:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
+PASS #92 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #93 Test that a WebAssembly code traps (memory_trap1.wast:106)
 PASS #94 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #95 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:94:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:94:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #96 Test that a WebAssembly code traps (memory_trap1.wast:107) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:94:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
+PASS #95 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #96 Test that a WebAssembly code traps (memory_trap1.wast:107)
 PASS #97 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #98 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:97:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:97:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #99 Test that a WebAssembly code traps (memory_trap1.wast:108) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:97:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
+PASS #98 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #99 Test that a WebAssembly code traps (memory_trap1.wast:108)
 PASS #100 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #101 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:100:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:100:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #102 Test that a WebAssembly code traps (memory_trap1.wast:109) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:100:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
+PASS #101 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #102 Test that a WebAssembly code traps (memory_trap1.wast:109)
 PASS #103 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #104 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:103:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:103:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #105 Test that a WebAssembly code traps (memory_trap1.wast:110) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:103:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
+PASS #104 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #105 Test that a WebAssembly code traps (memory_trap1.wast:110)
 PASS #106 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #107 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:106:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:106:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #108 Test that a WebAssembly code traps (memory_trap1.wast:111) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:106:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
+PASS #107 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #108 Test that a WebAssembly code traps (memory_trap1.wast:111)
 PASS #109 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #110 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:109:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:109:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #111 Test that a WebAssembly code traps (memory_trap1.wast:112) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:109:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
+PASS #110 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #111 Test that a WebAssembly code traps (memory_trap1.wast:112)
 PASS #112 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #113 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:112:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:112:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #114 Test that a WebAssembly code traps (memory_trap1.wast:113) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:112:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
+PASS #113 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #114 Test that a WebAssembly code traps (memory_trap1.wast:113)
 PASS #115 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #116 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:115:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:115:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #117 Test that a WebAssembly code traps (memory_trap1.wast:114) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:115:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
+PASS #116 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #117 Test that a WebAssembly code traps (memory_trap1.wast:114)
 PASS #118 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #119 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:118:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:118:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #120 Test that a WebAssembly code traps (memory_trap1.wast:115) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:118:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
+PASS #119 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #120 Test that a WebAssembly code traps (memory_trap1.wast:115)
 PASS #121 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #122 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:121:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:121:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #123 Test that a WebAssembly code traps (memory_trap1.wast:116) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:121:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
+PASS #122 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #123 Test that a WebAssembly code traps (memory_trap1.wast:116)
 PASS #124 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #125 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:124:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:124:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #126 Test that a WebAssembly code traps (memory_trap1.wast:117) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:124:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
+PASS #125 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #126 Test that a WebAssembly code traps (memory_trap1.wast:117)
 PASS #127 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #128 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:127:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:127:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #129 Test that a WebAssembly code traps (memory_trap1.wast:118) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:127:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
+PASS #128 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #129 Test that a WebAssembly code traps (memory_trap1.wast:118)
 PASS #130 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #131 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:130:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:130:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #132 Test that a WebAssembly code traps (memory_trap1.wast:119) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:130:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
+PASS #131 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #132 Test that a WebAssembly code traps (memory_trap1.wast:119)
 PASS #133 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #134 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:133:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:133:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #135 Test that a WebAssembly code traps (memory_trap1.wast:120) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:133:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
+PASS #134 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #135 Test that a WebAssembly code traps (memory_trap1.wast:120)
 PASS #136 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #137 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:136:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:136:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #138 Test that a WebAssembly code traps (memory_trap1.wast:121) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:136:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
+PASS #137 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #138 Test that a WebAssembly code traps (memory_trap1.wast:121)
 PASS #139 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #140 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:139:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:139:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #141 Test that a WebAssembly code traps (memory_trap1.wast:122) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:139:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
+PASS #140 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #141 Test that a WebAssembly code traps (memory_trap1.wast:122)
 PASS #142 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #143 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:142:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:142:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #144 Test that a WebAssembly code traps (memory_trap1.wast:123) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:142:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
+PASS #143 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #144 Test that a WebAssembly code traps (memory_trap1.wast:123)
 PASS #145 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #146 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:145:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:145:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #147 Test that a WebAssembly code traps (memory_trap1.wast:124) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:145:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
+PASS #146 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #147 Test that a WebAssembly code traps (memory_trap1.wast:124)
 PASS #148 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #149 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:148:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:148:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #150 Test that a WebAssembly code traps (memory_trap1.wast:125) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:148:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
+PASS #149 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #150 Test that a WebAssembly code traps (memory_trap1.wast:125)
 PASS #151 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #152 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:151:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:151:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #153 Test that a WebAssembly code traps (memory_trap1.wast:126) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:151:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #154 Test that a WebAssembly code traps (memory_trap1.wast:127) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:154:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #155 Test that a WebAssembly code traps (memory_trap1.wast:128) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:157:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #156 Test that a WebAssembly code traps (memory_trap1.wast:129) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:160:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #157 Test that a WebAssembly code traps (memory_trap1.wast:130) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:163:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #158 Test that a WebAssembly code traps (memory_trap1.wast:131) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:166:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #159 Test that a WebAssembly code traps (memory_trap1.wast:132) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:169:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #160 Test that a WebAssembly code traps (memory_trap1.wast:133) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:172:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #161 Test that a WebAssembly code traps (memory_trap1.wast:134) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:175:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #162 Test that a WebAssembly code traps (memory_trap1.wast:135) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:178:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #163 Test that a WebAssembly code traps (memory_trap1.wast:136) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:181:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #164 Test that a WebAssembly code traps (memory_trap1.wast:137) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:184:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #165 Test that a WebAssembly code traps (memory_trap1.wast:138) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:187:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #166 Test that a WebAssembly code traps (memory_trap1.wast:139) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:190:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #167 Test that a WebAssembly code traps (memory_trap1.wast:140) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:193:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #168 Test that a WebAssembly code traps (memory_trap1.wast:141) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:196:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #169 Test that a WebAssembly code traps (memory_trap1.wast:142) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:199:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #170 Test that a WebAssembly code traps (memory_trap1.wast:143) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:202:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #171 Test that a WebAssembly code traps (memory_trap1.wast:144) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:205:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #172 Test that a WebAssembly code traps (memory_trap1.wast:145) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:208:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #173 Test that a WebAssembly code traps (memory_trap1.wast:146) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:211:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #174 Test that a WebAssembly code traps (memory_trap1.wast:147) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:214:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #175 Test that a WebAssembly code traps (memory_trap1.wast:148) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:217:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #176 Test that a WebAssembly code traps (memory_trap1.wast:149) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:220:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #177 Test that a WebAssembly code traps (memory_trap1.wast:150) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:223:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #178 Test that a WebAssembly code traps (memory_trap1.wast:151) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:226:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #179 Test that a WebAssembly code traps (memory_trap1.wast:152) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:229:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #180 Test that a WebAssembly code traps (memory_trap1.wast:153) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:232:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #181 Test that a WebAssembly code traps (memory_trap1.wast:154) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:235:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #182 Test that a WebAssembly code traps (memory_trap1.wast:155) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:238:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #183 Test that a WebAssembly code traps (memory_trap1.wast:156) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:241:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #184 Test that a WebAssembly code traps (memory_trap1.wast:157) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:244:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #185 Test that a WebAssembly code traps (memory_trap1.wast:158) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:247:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #186 Test that a WebAssembly code traps (memory_trap1.wast:159) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:250:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #187 Test that a WebAssembly code traps (memory_trap1.wast:160) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:253:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #188 Test that a WebAssembly code traps (memory_trap1.wast:161) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:256:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #189 Test that a WebAssembly code traps (memory_trap1.wast:162) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:259:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #190 Test that a WebAssembly code traps (memory_trap1.wast:163) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:262:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #191 Test that a WebAssembly code traps (memory_trap1.wast:164) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:265:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #192 Test that a WebAssembly code traps (memory_trap1.wast:165) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:268:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #193 Test that a WebAssembly code traps (memory_trap1.wast:166) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:271:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #194 Test that a WebAssembly code traps (memory_trap1.wast:167) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:274:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #195 Test that a WebAssembly code traps (memory_trap1.wast:168) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:277:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #196 Test that a WebAssembly code traps (memory_trap1.wast:169) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:280:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #197 Test that a WebAssembly code traps (memory_trap1.wast:170) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:283:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
+PASS #152 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #153 Test that a WebAssembly code traps (memory_trap1.wast:126)
+PASS #154 Test that a WebAssembly code traps (memory_trap1.wast:127)
+PASS #155 Test that a WebAssembly code traps (memory_trap1.wast:128)
+PASS #156 Test that a WebAssembly code traps (memory_trap1.wast:129)
+PASS #157 Test that a WebAssembly code traps (memory_trap1.wast:130)
+PASS #158 Test that a WebAssembly code traps (memory_trap1.wast:131)
+PASS #159 Test that a WebAssembly code traps (memory_trap1.wast:132)
+PASS #160 Test that a WebAssembly code traps (memory_trap1.wast:133)
+PASS #161 Test that a WebAssembly code traps (memory_trap1.wast:134)
+PASS #162 Test that a WebAssembly code traps (memory_trap1.wast:135)
+PASS #163 Test that a WebAssembly code traps (memory_trap1.wast:136)
+PASS #164 Test that a WebAssembly code traps (memory_trap1.wast:137)
+PASS #165 Test that a WebAssembly code traps (memory_trap1.wast:138)
+PASS #166 Test that a WebAssembly code traps (memory_trap1.wast:139)
+PASS #167 Test that a WebAssembly code traps (memory_trap1.wast:140)
+PASS #168 Test that a WebAssembly code traps (memory_trap1.wast:141)
+PASS #169 Test that a WebAssembly code traps (memory_trap1.wast:142)
+PASS #170 Test that a WebAssembly code traps (memory_trap1.wast:143)
+PASS #171 Test that a WebAssembly code traps (memory_trap1.wast:144)
+PASS #172 Test that a WebAssembly code traps (memory_trap1.wast:145)
+PASS #173 Test that a WebAssembly code traps (memory_trap1.wast:146)
+PASS #174 Test that a WebAssembly code traps (memory_trap1.wast:147)
+PASS #175 Test that a WebAssembly code traps (memory_trap1.wast:148)
+PASS #176 Test that a WebAssembly code traps (memory_trap1.wast:149)
+PASS #177 Test that a WebAssembly code traps (memory_trap1.wast:150)
+PASS #178 Test that a WebAssembly code traps (memory_trap1.wast:151)
+PASS #179 Test that a WebAssembly code traps (memory_trap1.wast:152)
+PASS #180 Test that a WebAssembly code traps (memory_trap1.wast:153)
+PASS #181 Test that a WebAssembly code traps (memory_trap1.wast:154)
+PASS #182 Test that a WebAssembly code traps (memory_trap1.wast:155)
+PASS #183 Test that a WebAssembly code traps (memory_trap1.wast:156)
+PASS #184 Test that a WebAssembly code traps (memory_trap1.wast:157)
+PASS #185 Test that a WebAssembly code traps (memory_trap1.wast:158)
+PASS #186 Test that a WebAssembly code traps (memory_trap1.wast:159)
+PASS #187 Test that a WebAssembly code traps (memory_trap1.wast:160)
+PASS #188 Test that a WebAssembly code traps (memory_trap1.wast:161)
+PASS #189 Test that a WebAssembly code traps (memory_trap1.wast:162)
+PASS #190 Test that a WebAssembly code traps (memory_trap1.wast:163)
+PASS #191 Test that a WebAssembly code traps (memory_trap1.wast:164)
+PASS #192 Test that a WebAssembly code traps (memory_trap1.wast:165)
+PASS #193 Test that a WebAssembly code traps (memory_trap1.wast:166)
+PASS #194 Test that a WebAssembly code traps (memory_trap1.wast:167)
+PASS #195 Test that a WebAssembly code traps (memory_trap1.wast:168)
+PASS #196 Test that a WebAssembly code traps (memory_trap1.wast:169)
+PASS #197 Test that a WebAssembly code traps (memory_trap1.wast:170)
 PASS #198 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #199 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:286:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:286:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #200 Test that a WebAssembly code traps (memory_trap1.wast:171) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:286:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
+PASS #199 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #200 Test that a WebAssembly code traps (memory_trap1.wast:171)
 PASS #201 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #202 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:289:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:289:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #203 Test that a WebAssembly code traps (memory_trap1.wast:172) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:289:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
+PASS #202 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #203 Test that a WebAssembly code traps (memory_trap1.wast:172)
 PASS #204 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #205 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:292:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:292:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #206 Test that a WebAssembly code traps (memory_trap1.wast:173) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:292:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
+PASS #205 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #206 Test that a WebAssembly code traps (memory_trap1.wast:173)
 PASS #207 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #208 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:295:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:295:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #209 Test that a WebAssembly code traps (memory_trap1.wast:174) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:295:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
+PASS #208 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #209 Test that a WebAssembly code traps (memory_trap1.wast:174)
 PASS #210 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #211 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:298:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:298:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #212 Test that a WebAssembly code traps (memory_trap1.wast:175) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:298:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
+PASS #211 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #212 Test that a WebAssembly code traps (memory_trap1.wast:175)
 PASS #213 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #214 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:301:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:301:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #215 Test that a WebAssembly code traps (memory_trap1.wast:176) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:301:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
+PASS #214 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #215 Test that a WebAssembly code traps (memory_trap1.wast:176)
 PASS #216 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #217 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:304:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:304:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #218 Test that a WebAssembly code traps (memory_trap1.wast:177) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:304:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
+PASS #217 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #218 Test that a WebAssembly code traps (memory_trap1.wast:177)
 PASS #219 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #220 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:307:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:307:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #221 Test that a WebAssembly code traps (memory_trap1.wast:178) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:307:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
+PASS #220 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #221 Test that a WebAssembly code traps (memory_trap1.wast:178)
 PASS #222 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #223 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:310:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:310:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #224 Test that a WebAssembly code traps (memory_trap1.wast:179) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:310:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
+PASS #223 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #224 Test that a WebAssembly code traps (memory_trap1.wast:179)
 PASS #225 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #226 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:313:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:313:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #227 Test that a WebAssembly code traps (memory_trap1.wast:180) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:313:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
+PASS #226 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #227 Test that a WebAssembly code traps (memory_trap1.wast:180)
 PASS #228 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #229 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:316:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:316:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #230 Test that a WebAssembly code traps (memory_trap1.wast:181) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:316:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
+PASS #229 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #230 Test that a WebAssembly code traps (memory_trap1.wast:181)
 PASS #231 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #232 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:319:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:319:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #233 Test that a WebAssembly code traps (memory_trap1.wast:182) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:319:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
+PASS #232 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #233 Test that a WebAssembly code traps (memory_trap1.wast:182)
 PASS #234 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #235 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:322:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:322:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #236 Test that a WebAssembly code traps (memory_trap1.wast:183) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:322:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
+PASS #235 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #236 Test that a WebAssembly code traps (memory_trap1.wast:183)
 PASS #237 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #238 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:325:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:325:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #239 Test that a WebAssembly code traps (memory_trap1.wast:184) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:325:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
+PASS #238 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #239 Test that a WebAssembly code traps (memory_trap1.wast:184)
 PASS #240 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #241 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:328:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:328:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #242 Test that a WebAssembly code traps (memory_trap1.wast:185) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:328:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
+PASS #241 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #242 Test that a WebAssembly code traps (memory_trap1.wast:185)
 PASS #243 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #244 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:331:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:331:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #245 Test that a WebAssembly code traps (memory_trap1.wast:186) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:331:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
+PASS #244 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #245 Test that a WebAssembly code traps (memory_trap1.wast:186)
 PASS #246 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #247 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:334:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:334:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #248 Test that a WebAssembly code traps (memory_trap1.wast:187) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:334:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
+PASS #247 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #248 Test that a WebAssembly code traps (memory_trap1.wast:187)
 PASS #249 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #250 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:337:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:337:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #251 Test that a WebAssembly code traps (memory_trap1.wast:188) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:337:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
+PASS #250 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #251 Test that a WebAssembly code traps (memory_trap1.wast:188)
 PASS #252 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #253 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:340:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:340:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #254 Test that a WebAssembly code traps (memory_trap1.wast:189) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:340:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
+PASS #253 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #254 Test that a WebAssembly code traps (memory_trap1.wast:189)
 PASS #255 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #256 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:343:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:343:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #257 Test that a WebAssembly code traps (memory_trap1.wast:190) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:343:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
+PASS #256 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #257 Test that a WebAssembly code traps (memory_trap1.wast:190)
 PASS #258 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #259 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:346:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:346:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #260 Test that a WebAssembly code traps (memory_trap1.wast:191) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:346:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
+PASS #259 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #260 Test that a WebAssembly code traps (memory_trap1.wast:191)
 PASS #261 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #262 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:349:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:349:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #263 Test that a WebAssembly code traps (memory_trap1.wast:192) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:349:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
+PASS #262 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #263 Test that a WebAssembly code traps (memory_trap1.wast:192)
 PASS #264 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #265 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:352:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:352:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #266 Test that a WebAssembly code traps (memory_trap1.wast:193) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:352:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
+PASS #265 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #266 Test that a WebAssembly code traps (memory_trap1.wast:193)
 PASS #267 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #268 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:355:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:355:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #269 Test that a WebAssembly code traps (memory_trap1.wast:194) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:355:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #270 Test that a WebAssembly code traps (memory_trap1.wast:195) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:358:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #271 Test that a WebAssembly code traps (memory_trap1.wast:196) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:361:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #272 Test that a WebAssembly code traps (memory_trap1.wast:197) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:364:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #273 Test that a WebAssembly code traps (memory_trap1.wast:198) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:367:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #274 Test that a WebAssembly code traps (memory_trap1.wast:199) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:370:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #275 Test that a WebAssembly code traps (memory_trap1.wast:200) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:373:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #276 Test that a WebAssembly code traps (memory_trap1.wast:201) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:376:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #277 Test that a WebAssembly code traps (memory_trap1.wast:202) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:379:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #278 Test that a WebAssembly code traps (memory_trap1.wast:203) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:382:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #279 Test that a WebAssembly code traps (memory_trap1.wast:204) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:385:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #280 Test that a WebAssembly code traps (memory_trap1.wast:205) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:388:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #281 Test that a WebAssembly code traps (memory_trap1.wast:206) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:391:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #282 Test that a WebAssembly code traps (memory_trap1.wast:207) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:394:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #283 Test that a WebAssembly code traps (memory_trap1.wast:208) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:397:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #284 Test that a WebAssembly code traps (memory_trap1.wast:209) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:400:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #285 Test that a WebAssembly code traps (memory_trap1.wast:210) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:403:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #286 Test that a WebAssembly code traps (memory_trap1.wast:211) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:406:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #287 Test that a WebAssembly code traps (memory_trap1.wast:212) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:409:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #288 Test that a WebAssembly code traps (memory_trap1.wast:213) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:412:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #289 Test that a WebAssembly code traps (memory_trap1.wast:214) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:415:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #290 Test that a WebAssembly code traps (memory_trap1.wast:215) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:418:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #291 Test that a WebAssembly code traps (memory_trap1.wast:216) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:421:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #292 Test that a WebAssembly code traps (memory_trap1.wast:217) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:424:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #293 Test that a WebAssembly code traps (memory_trap1.wast:218) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:427:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #294 Test that a WebAssembly code traps (memory_trap1.wast:219) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:430:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #295 Test that a WebAssembly code traps (memory_trap1.wast:220) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:433:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #296 Test that a WebAssembly code traps (memory_trap1.wast:221) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:436:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #297 Test that a WebAssembly code traps (memory_trap1.wast:222) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:439:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #298 Test that a WebAssembly code traps (memory_trap1.wast:223) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:442:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #299 Test that a WebAssembly code traps (memory_trap1.wast:224) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:445:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #300 Test that a WebAssembly code traps (memory_trap1.wast:225) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:448:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #301 Test that a WebAssembly code traps (memory_trap1.wast:226) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:451:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #302 Test that a WebAssembly code traps (memory_trap1.wast:227) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:454:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #303 Test that a WebAssembly code traps (memory_trap1.wast:228) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:457:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #304 Test that a WebAssembly code traps (memory_trap1.wast:229) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:460:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #305 Test that a WebAssembly code traps (memory_trap1.wast:230) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:463:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #306 Test that a WebAssembly code traps (memory_trap1.wast:231) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:466:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #307 Test that a WebAssembly code traps (memory_trap1.wast:232) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:469:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #308 Test that a WebAssembly code traps (memory_trap1.wast:233) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:472:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #309 Test that a WebAssembly code traps (memory_trap1.wast:234) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:475:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #310 Test that a WebAssembly code returns a specific result (memory_trap1.wast:237) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:478:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #311 Test that a WebAssembly code returns a specific result (memory_trap1.wast:238) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:481:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #312 Test that a WebAssembly code returns a specific result (memory_trap1.wast:242) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:484:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #313 Test that a WebAssembly code traps (memory_trap1.wast:243) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:487:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #314 Test that a WebAssembly code returns a specific result (memory_trap1.wast:244) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:490:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #315 Test that a WebAssembly code traps (memory_trap1.wast:245) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:493:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #316 Test that a WebAssembly code returns a specific result (memory_trap1.wast:246) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:496:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
+PASS #268 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #269 Test that a WebAssembly code traps (memory_trap1.wast:194)
+PASS #270 Test that a WebAssembly code traps (memory_trap1.wast:195)
+PASS #271 Test that a WebAssembly code traps (memory_trap1.wast:196)
+PASS #272 Test that a WebAssembly code traps (memory_trap1.wast:197)
+PASS #273 Test that a WebAssembly code traps (memory_trap1.wast:198)
+PASS #274 Test that a WebAssembly code traps (memory_trap1.wast:199)
+PASS #275 Test that a WebAssembly code traps (memory_trap1.wast:200)
+PASS #276 Test that a WebAssembly code traps (memory_trap1.wast:201)
+PASS #277 Test that a WebAssembly code traps (memory_trap1.wast:202)
+PASS #278 Test that a WebAssembly code traps (memory_trap1.wast:203)
+PASS #279 Test that a WebAssembly code traps (memory_trap1.wast:204)
+PASS #280 Test that a WebAssembly code traps (memory_trap1.wast:205)
+PASS #281 Test that a WebAssembly code traps (memory_trap1.wast:206)
+PASS #282 Test that a WebAssembly code traps (memory_trap1.wast:207)
+PASS #283 Test that a WebAssembly code traps (memory_trap1.wast:208)
+PASS #284 Test that a WebAssembly code traps (memory_trap1.wast:209)
+PASS #285 Test that a WebAssembly code traps (memory_trap1.wast:210)
+PASS #286 Test that a WebAssembly code traps (memory_trap1.wast:211)
+PASS #287 Test that a WebAssembly code traps (memory_trap1.wast:212)
+PASS #288 Test that a WebAssembly code traps (memory_trap1.wast:213)
+PASS #289 Test that a WebAssembly code traps (memory_trap1.wast:214)
+PASS #290 Test that a WebAssembly code traps (memory_trap1.wast:215)
+PASS #291 Test that a WebAssembly code traps (memory_trap1.wast:216)
+PASS #292 Test that a WebAssembly code traps (memory_trap1.wast:217)
+PASS #293 Test that a WebAssembly code traps (memory_trap1.wast:218)
+PASS #294 Test that a WebAssembly code traps (memory_trap1.wast:219)
+PASS #295 Test that a WebAssembly code traps (memory_trap1.wast:220)
+PASS #296 Test that a WebAssembly code traps (memory_trap1.wast:221)
+PASS #297 Test that a WebAssembly code traps (memory_trap1.wast:222)
+PASS #298 Test that a WebAssembly code traps (memory_trap1.wast:223)
+PASS #299 Test that a WebAssembly code traps (memory_trap1.wast:224)
+PASS #300 Test that a WebAssembly code traps (memory_trap1.wast:225)
+PASS #301 Test that a WebAssembly code traps (memory_trap1.wast:226)
+PASS #302 Test that a WebAssembly code traps (memory_trap1.wast:227)
+PASS #303 Test that a WebAssembly code traps (memory_trap1.wast:228)
+PASS #304 Test that a WebAssembly code traps (memory_trap1.wast:229)
+PASS #305 Test that a WebAssembly code traps (memory_trap1.wast:230)
+PASS #306 Test that a WebAssembly code traps (memory_trap1.wast:231)
+PASS #307 Test that a WebAssembly code traps (memory_trap1.wast:232)
+PASS #308 Test that a WebAssembly code traps (memory_trap1.wast:233)
+PASS #309 Test that a WebAssembly code traps (memory_trap1.wast:234)
+PASS #310 Test that a WebAssembly code returns a specific result (memory_trap1.wast:237)
+PASS #311 Test that a WebAssembly code returns a specific result (memory_trap1.wast:238)
+PASS #312 Test that a WebAssembly code returns a specific result (memory_trap1.wast:242)
+PASS #313 Test that a WebAssembly code traps (memory_trap1.wast:243)
+PASS #314 Test that a WebAssembly code returns a specific result (memory_trap1.wast:244)
+PASS #315 Test that a WebAssembly code traps (memory_trap1.wast:245)
+PASS #316 Test that a WebAssembly code returns a specific result (memory_trap1.wast:246)
 PASS #317 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #318 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:499:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:499:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #319 Test that a WebAssembly code traps (memory_trap1.wast:247) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:499:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
+PASS #318 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #319 Test that a WebAssembly code traps (memory_trap1.wast:247)
 PASS #320 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #321 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:502:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:502:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #322 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:502:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
+PASS #321 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #322 Run a WebAssembly test without special assertions (memory_trap1.wast:248)
 PASS #323 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #324 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:505:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:270:37
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:505:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #325 Test that a WebAssembly code traps (memory_trap1.wast:249) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:505:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
+PASS #324 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #325 Test that a WebAssembly code traps (memory_trap1.wast:249)
 PASS #326 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #327 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:508:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:508:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
-FAIL #328 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-memory_trap1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:508:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/memory_trap1.wast.js:510:3 expected true got false
+PASS #327 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #328 Run a WebAssembly test without special assertions (memory_trap1.wast:250)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/start0.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/start0.wast.js-expected.txt
@@ -1,33 +1,15 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (start0.wast:1) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (start0.wast:1)
 PASS #3 Reinitialize the default imports
-FAIL #4 Test that WebAssembly compilation succeeds (start0.wast:1) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 40: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-FAIL #5 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-start0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/start0.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/start0.wast.js:33:3 expected true got false
-FAIL #6 Test that a WebAssembly code returns a specific result (start0.wast:32) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-start0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/start0.wast.js:10:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/start0.wast.js:33:3 expected true got false
-FAIL #7 Test that a WebAssembly code returns a specific result (start0.wast:33) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-start0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/start0.wast.js:13:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/start0.wast.js:33:3 expected true got false
-FAIL #8 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-start0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/start0.wast.js:16:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/start0.wast.js:33:3 expected true got false
-FAIL #9 Test that a WebAssembly code returns a specific result (start0.wast:36) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-start0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/start0.wast.js:19:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/start0.wast.js:33:3 expected true got false
-FAIL #10 Test that a WebAssembly code returns a specific result (start0.wast:37) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-start0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/start0.wast.js:22:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/start0.wast.js:33:3 expected true got false
-FAIL #11 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-start0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/start0.wast.js:25:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/start0.wast.js:33:3 expected true got false
-FAIL #12 Test that a WebAssembly code returns a specific result (start0.wast:40) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-start0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/start0.wast.js:28:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/start0.wast.js:33:3 expected true got false
-FAIL #13 Test that a WebAssembly code returns a specific result (start0.wast:41) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-start0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/start0.wast.js:31:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/start0.wast.js:33:3 expected true got false
+PASS #4 Test that WebAssembly compilation succeeds (start0.wast:1)
+PASS #5 Test that WebAssembly instantiation succeeds (start0.wast:1)
+PASS #6 Test that a WebAssembly code returns a specific result (start0.wast:32)
+PASS #7 Test that a WebAssembly code returns a specific result (start0.wast:33)
+PASS #8 Run a WebAssembly test without special assertions (start0.wast:35)
+PASS #9 Test that a WebAssembly code returns a specific result (start0.wast:36)
+PASS #10 Test that a WebAssembly code returns a specific result (start0.wast:37)
+PASS #11 Run a WebAssembly test without special assertions (start0.wast:39)
+PASS #12 Test that a WebAssembly code returns a specific result (start0.wast:40)
+PASS #13 Test that a WebAssembly code returns a specific result (start0.wast:41)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/store0.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/store0.wast.js-expected.txt
@@ -1,21 +1,11 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (store0.wast:3) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (store0.wast:3)
 PASS #3 Reinitialize the default imports
-FAIL #4 Test that WebAssembly compilation succeeds (store0.wast:3) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 43: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-FAIL #5 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-store0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/store0.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/store0.wast.js:21:3 expected true got false
-FAIL #6 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-store0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/store0.wast.js:10:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/store0.wast.js:21:3 expected true got false
-FAIL #7 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-store0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/store0.wast.js:13:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/store0.wast.js:21:3 expected true got false
-FAIL #8 Test that a WebAssembly code returns a specific result (store0.wast:24) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-store0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/store0.wast.js:16:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/store0.wast.js:21:3 expected true got false
-FAIL #9 Test that a WebAssembly code returns a specific result (store0.wast:25) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-store0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/store0.wast.js:19:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/store0.wast.js:21:3 expected true got false
+PASS #4 Test that WebAssembly compilation succeeds (store0.wast:3)
+PASS #5 Test that WebAssembly instantiation succeeds (store0.wast:3)
+PASS #6 Run a WebAssembly test without special assertions (store0.wast:22)
+PASS #7 Run a WebAssembly test without special assertions (store0.wast:23)
+PASS #8 Test that a WebAssembly code returns a specific result (store0.wast:24)
+PASS #9 Test that a WebAssembly code returns a specific result (store0.wast:25)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/store1.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/store1.wast.js-expected.txt
@@ -2,7 +2,7 @@
 PASS #1 Reinitialize the default imports
 PASS #2 Test that WebAssembly compilation succeeds (store1.wast:1)
 PASS #3 Test that WebAssembly compilation succeeds (store1.wast:13)
-FAIL #4 Test that WebAssembly compilation succeeds (store1.wast:30) assert_equals: expected false but got true
+PASS #4 Test that WebAssembly compilation succeeds (store1.wast:30)
 PASS #5 Reinitialize the default imports
 PASS #6 Test that WebAssembly compilation succeeds (store1.wast:1)
 PASS #7 Test that WebAssembly instantiation succeeds (store1.wast:1)
@@ -12,20 +12,10 @@ PASS #10 Run a WebAssembly test without special assertions (store1.wast:25)
 PASS #11 Run a WebAssembly test without special assertions (store1.wast:26)
 PASS #12 Test that a WebAssembly code returns a specific result (store1.wast:27)
 PASS #13 Test that a WebAssembly code returns a specific result (store1.wast:28)
-FAIL #14 Test that WebAssembly compilation succeeds (store1.wast:30) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 50: there can at most be one Memory section for now at {loc} expected true got false
-FAIL #15 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-store1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/store1.wast.js:41:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/store1.wast.js:55:3 expected true got false
-FAIL #16 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-store1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/store1.wast.js:44:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/store1.wast.js:55:3 expected true got false
-FAIL #17 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-store1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/store1.wast.js:47:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/store1.wast.js:55:3 expected true got false
-FAIL #18 Test that a WebAssembly code returns a specific result (store1.wast:51) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-store1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/store1.wast.js:50:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/store1.wast.js:55:3 expected true got false
-FAIL #19 Test that a WebAssembly code returns a specific result (store1.wast:52) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-store1_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/store1.wast.js:53:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/store1.wast.js:55:3 expected true got false
+PASS #14 Test that WebAssembly compilation succeeds (store1.wast:30)
+PASS #15 Test that WebAssembly instantiation succeeds (store1.wast:30)
+PASS #16 Run a WebAssembly test without special assertions (store1.wast:49)
+PASS #17 Run a WebAssembly test without special assertions (store1.wast:50)
+PASS #18 Test that a WebAssembly code returns a specific result (store1.wast:51)
+PASS #19 Test that a WebAssembly code returns a specific result (store1.wast:52)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/store2.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/store2.wast.js-expected.txt
@@ -1,78 +1,32 @@
 
 PASS #1 Reinitialize the default imports
 PASS #2 Test that WebAssembly compilation succeeds (store2.wast:1)
-FAIL #3 Test that WebAssembly compilation succeeds (store2.wast:6) assert_equals: expected false but got true
+PASS #3 Test that WebAssembly compilation succeeds (store2.wast:6)
 PASS #4 Reinitialize the default imports
 PASS #5 Test that WebAssembly compilation succeeds (store2.wast:1)
 PASS #6 Test that WebAssembly instantiation succeeds (store2.wast:1)
-FAIL #7 Test that WebAssembly compilation succeeds (store2.wast:6) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 57: there can at most be one Memory section for now at {loc} expected true got false
-FAIL #8 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-store2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/store2.wast.js:16:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/store2.wast.js:84:3 expected true got false
-FAIL #9 Test that a WebAssembly code returns a specific result (store2.wast:43) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-store2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/store2.wast.js:19:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/store2.wast.js:84:3 expected true got false
-FAIL #10 Test that a WebAssembly code returns a specific result (store2.wast:44) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-store2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/store2.wast.js:22:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/store2.wast.js:84:3 expected true got false
-FAIL #11 Test that a WebAssembly code returns a specific result (store2.wast:45) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-store2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/store2.wast.js:25:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/store2.wast.js:84:3 expected true got false
-FAIL #12 Test that a WebAssembly code returns a specific result (store2.wast:46) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-store2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/store2.wast.js:28:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/store2.wast.js:84:3 expected true got false
-FAIL #13 Test that a WebAssembly code returns a specific result (store2.wast:47) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-store2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/store2.wast.js:31:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/store2.wast.js:84:3 expected true got false
-FAIL #14 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-store2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/store2.wast.js:34:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/store2.wast.js:84:3 expected true got false
-FAIL #15 Test that a WebAssembly code returns a specific result (store2.wast:49) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-store2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/store2.wast.js:37:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/store2.wast.js:84:3 expected true got false
-FAIL #16 Test that a WebAssembly code returns a specific result (store2.wast:50) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-store2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/store2.wast.js:40:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/store2.wast.js:84:3 expected true got false
-FAIL #17 Test that a WebAssembly code returns a specific result (store2.wast:51) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-store2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/store2.wast.js:43:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/store2.wast.js:84:3 expected true got false
-FAIL #18 Test that a WebAssembly code returns a specific result (store2.wast:52) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-store2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/store2.wast.js:46:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/store2.wast.js:84:3 expected true got false
-FAIL #19 Test that a WebAssembly code returns a specific result (store2.wast:53) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-store2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/store2.wast.js:49:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/store2.wast.js:84:3 expected true got false
-FAIL #20 Test that a WebAssembly code returns a specific result (store2.wast:55) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-store2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/store2.wast.js:52:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/store2.wast.js:84:3 expected true got false
-FAIL #21 Test that a WebAssembly code returns a specific result (store2.wast:56) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-store2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/store2.wast.js:55:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/store2.wast.js:84:3 expected true got false
-FAIL #22 Test that a WebAssembly code returns a specific result (store2.wast:57) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-store2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/store2.wast.js:58:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/store2.wast.js:84:3 expected true got false
-FAIL #23 Test that a WebAssembly code returns a specific result (store2.wast:58) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-store2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/store2.wast.js:61:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/store2.wast.js:84:3 expected true got false
-FAIL #24 Test that a WebAssembly code returns a specific result (store2.wast:59) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-store2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/store2.wast.js:64:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/store2.wast.js:84:3 expected true got false
-FAIL #25 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-store2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/store2.wast.js:67:4
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/store2.wast.js:84:3 expected true got false
-FAIL #26 Test that a WebAssembly code returns a specific result (store2.wast:61) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-store2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/store2.wast.js:70:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/store2.wast.js:84:3 expected true got false
-FAIL #27 Test that a WebAssembly code returns a specific result (store2.wast:62) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-store2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/store2.wast.js:73:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/store2.wast.js:84:3 expected true got false
-FAIL #28 Test that a WebAssembly code returns a specific result (store2.wast:63) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-store2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/store2.wast.js:76:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/store2.wast.js:84:3 expected true got false
-FAIL #29 Test that a WebAssembly code returns a specific result (store2.wast:64) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-store2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/store2.wast.js:79:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/store2.wast.js:84:3 expected true got false
-FAIL #30 Test that a WebAssembly code returns a specific result (store2.wast:65) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:312:24
-store2_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/store2.wast.js:82:14
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/store2.wast.js:84:3 expected true got false
+PASS #7 Test that WebAssembly compilation succeeds (store2.wast:6)
+PASS #8 Test that WebAssembly instantiation succeeds (store2.wast:6)
+PASS #9 Test that a WebAssembly code returns a specific result (store2.wast:43)
+PASS #10 Test that a WebAssembly code returns a specific result (store2.wast:44)
+PASS #11 Test that a WebAssembly code returns a specific result (store2.wast:45)
+PASS #12 Test that a WebAssembly code returns a specific result (store2.wast:46)
+PASS #13 Test that a WebAssembly code returns a specific result (store2.wast:47)
+PASS #14 Run a WebAssembly test without special assertions (store2.wast:48)
+PASS #15 Test that a WebAssembly code returns a specific result (store2.wast:49)
+PASS #16 Test that a WebAssembly code returns a specific result (store2.wast:50)
+PASS #17 Test that a WebAssembly code returns a specific result (store2.wast:51)
+PASS #18 Test that a WebAssembly code returns a specific result (store2.wast:52)
+PASS #19 Test that a WebAssembly code returns a specific result (store2.wast:53)
+PASS #20 Test that a WebAssembly code returns a specific result (store2.wast:55)
+PASS #21 Test that a WebAssembly code returns a specific result (store2.wast:56)
+PASS #22 Test that a WebAssembly code returns a specific result (store2.wast:57)
+PASS #23 Test that a WebAssembly code returns a specific result (store2.wast:58)
+PASS #24 Test that a WebAssembly code returns a specific result (store2.wast:59)
+PASS #25 Run a WebAssembly test without special assertions (store2.wast:60)
+PASS #26 Test that a WebAssembly code returns a specific result (store2.wast:61)
+PASS #27 Test that a WebAssembly code returns a specific result (store2.wast:62)
+PASS #28 Test that a WebAssembly code returns a specific result (store2.wast:63)
+PASS #29 Test that a WebAssembly code returns a specific result (store2.wast:64)
+PASS #30 Test that a WebAssembly code returns a specific result (store2.wast:65)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/traps0.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/multi-memory/traps0.wast.js-expected.txt
@@ -1,51 +1,21 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (traps0.wast:1) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (traps0.wast:1)
 PASS #3 Reinitialize the default imports
-FAIL #4 Test that WebAssembly compilation succeeds (traps0.wast:1) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 47: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-FAIL #5 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-traps0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/traps0.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/traps0.wast.js:51:3 expected true got false
-FAIL #6 Test that a WebAssembly code traps (traps0.wast:22) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-traps0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/traps0.wast.js:10:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/traps0.wast.js:51:3 expected true got false
-FAIL #7 Test that a WebAssembly code traps (traps0.wast:23) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-traps0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/traps0.wast.js:13:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/traps0.wast.js:51:3 expected true got false
-FAIL #8 Test that a WebAssembly code traps (traps0.wast:24) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-traps0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/traps0.wast.js:16:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/traps0.wast.js:51:3 expected true got false
-FAIL #9 Test that a WebAssembly code traps (traps0.wast:25) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-traps0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/traps0.wast.js:19:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/traps0.wast.js:51:3 expected true got false
-FAIL #10 Test that a WebAssembly code traps (traps0.wast:26) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-traps0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/traps0.wast.js:22:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/traps0.wast.js:51:3 expected true got false
-FAIL #11 Test that a WebAssembly code traps (traps0.wast:27) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-traps0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/traps0.wast.js:25:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/traps0.wast.js:51:3 expected true got false
-FAIL #12 Test that a WebAssembly code traps (traps0.wast:28) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-traps0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/traps0.wast.js:28:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/traps0.wast.js:51:3 expected true got false
-FAIL #13 Test that a WebAssembly code traps (traps0.wast:29) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-traps0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/traps0.wast.js:31:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/traps0.wast.js:51:3 expected true got false
-FAIL #14 Test that a WebAssembly code traps (traps0.wast:30) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-traps0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/traps0.wast.js:34:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/traps0.wast.js:51:3 expected true got false
-FAIL #15 Test that a WebAssembly code traps (traps0.wast:31) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-traps0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/traps0.wast.js:37:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/traps0.wast.js:51:3 expected true got false
-FAIL #16 Test that a WebAssembly code traps (traps0.wast:32) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-traps0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/traps0.wast.js:40:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/traps0.wast.js:51:3 expected true got false
-FAIL #17 Test that a WebAssembly code traps (traps0.wast:33) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-traps0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/traps0.wast.js:43:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/traps0.wast.js:51:3 expected true got false
-FAIL #18 Test that a WebAssembly code traps (traps0.wast:34) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-traps0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/traps0.wast.js:46:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/traps0.wast.js:51:3 expected true got false
-FAIL #19 Test that a WebAssembly code traps (traps0.wast:35) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:269:24
-traps0_wast_js@http://web-platform.test:8800/wasm/core/js/multi-memory/traps0.wast.js:49:12
-global code@http://web-platform.test:8800/wasm/core/js/multi-memory/traps0.wast.js:51:3 expected true got false
+PASS #4 Test that WebAssembly compilation succeeds (traps0.wast:1)
+PASS #5 Test that WebAssembly instantiation succeeds (traps0.wast:1)
+PASS #6 Test that a WebAssembly code traps (traps0.wast:22)
+PASS #7 Test that a WebAssembly code traps (traps0.wast:23)
+PASS #8 Test that a WebAssembly code traps (traps0.wast:24)
+PASS #9 Test that a WebAssembly code traps (traps0.wast:25)
+PASS #10 Test that a WebAssembly code traps (traps0.wast:26)
+PASS #11 Test that a WebAssembly code traps (traps0.wast:27)
+PASS #12 Test that a WebAssembly code traps (traps0.wast:28)
+PASS #13 Test that a WebAssembly code traps (traps0.wast:29)
+PASS #14 Test that a WebAssembly code traps (traps0.wast:30)
+PASS #15 Test that a WebAssembly code traps (traps0.wast:31)
+PASS #16 Test that a WebAssembly code traps (traps0.wast:32)
+PASS #17 Test that a WebAssembly code traps (traps0.wast:33)
+PASS #18 Test that a WebAssembly code traps (traps0.wast:34)
+PASS #19 Test that a WebAssembly code traps (traps0.wast:35)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/relaxed-simd/i16x8_relaxed_q15mulr_s.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/relaxed-simd/i16x8_relaxed_q15mulr_s.wast.js-expected.txt
@@ -1,29 +1,15 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (i16x8_relaxed_q15mulr_s.wast:3) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (i16x8_relaxed_q15mulr_s.wast:3)
 PASS #3 Test that WebAssembly compilation succeeds (wrapper)
 PASS #4 Test that WebAssembly compilation succeeds (wrapper)
 PASS #5 Reinitialize the default imports
-FAIL #6 Test that WebAssembly compilation succeeds (i16x8_relaxed_q15mulr_s.wast:3) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 8: relaxed simd instructions not supported, in function at index 0 at {loc} expected true got false
-FAIL #7 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-i16x8_relaxed_q15mulr_s_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/i16x8_relaxed_q15mulr_s.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/i16x8_relaxed_q15mulr_s.wast.js:15:3 expected true got false
+PASS #6 Test that WebAssembly compilation succeeds (i16x8_relaxed_q15mulr_s.wast:3)
+PASS #7 Test that WebAssembly instantiation succeeds (i16x8_relaxed_q15mulr_s.wast:3)
 PASS #8 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #9 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:i16x8.relaxed_q15mulr_s must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/i16x8_relaxed_q15mulr_s.wast.js:10:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-i16x8_relaxed_q15mulr_s_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/i16x8_relaxed_q15mulr_s.wast.js:10:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/i16x8_relaxed_q15mulr_s.wast.js:15:3 expected true got false
-FAIL #10 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-i16x8_relaxed_q15mulr_s_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/i16x8_relaxed_q15mulr_s.wast.js:10:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/i16x8_relaxed_q15mulr_s.wast.js:15:3 expected true got false
+PASS #9 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #10 Run a WebAssembly test without special assertions (i16x8_relaxed_q15mulr_s.wast:13)
 PASS #11 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #12 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:i16x8.relaxed_q15mulr_s_cmp must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/i16x8_relaxed_q15mulr_s.wast.js:13:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-i16x8_relaxed_q15mulr_s_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/i16x8_relaxed_q15mulr_s.wast.js:13:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/i16x8_relaxed_q15mulr_s.wast.js:15:3 expected true got false
-FAIL #13 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-i16x8_relaxed_q15mulr_s_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/i16x8_relaxed_q15mulr_s.wast.js:13:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/i16x8_relaxed_q15mulr_s.wast.js:15:3 expected true got false
+PASS #12 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #13 Run a WebAssembly test without special assertions (i16x8_relaxed_q15mulr_s.wast:22)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/relaxed-simd/i32x4_relaxed_trunc.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/relaxed-simd/i32x4_relaxed_trunc.wast.js-expected.txt
@@ -1,9 +1,7 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (i32x4_relaxed_trunc.wast:3) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (i32x4_relaxed_trunc.wast:3)
 PASS #3 Reinitialize the default imports
-FAIL #4 Test that WebAssembly compilation succeeds (i32x4_relaxed_trunc.wast:3) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 6: relaxed simd instructions not supported, in function at index 0 at {loc} expected true got false
-FAIL #5 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-i32x4_relaxed_trunc_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/i32x4_relaxed_trunc.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/i32x4_relaxed_trunc.wast.js:9:3 expected true got false
+PASS #4 Test that WebAssembly compilation succeeds (i32x4_relaxed_trunc.wast:3)
+PASS #5 Test that WebAssembly instantiation succeeds (i32x4_relaxed_trunc.wast:3)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/relaxed-simd/i8x16_relaxed_swizzle.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/relaxed-simd/i8x16_relaxed_swizzle.wast.js-expected.txt
@@ -1,59 +1,27 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (i8x16_relaxed_swizzle.wast:3) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (i8x16_relaxed_swizzle.wast:3)
 PASS #3 Test that WebAssembly compilation succeeds (wrapper)
 PASS #4 Test that WebAssembly compilation succeeds (wrapper)
 PASS #5 Test that WebAssembly compilation succeeds (wrapper)
 PASS #6 Test that WebAssembly compilation succeeds (wrapper)
 PASS #7 Test that WebAssembly compilation succeeds (wrapper)
 PASS #8 Reinitialize the default imports
-FAIL #9 Test that WebAssembly compilation succeeds (i8x16_relaxed_swizzle.wast:3) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 8: relaxed simd instructions not supported, in function at index 0 at {loc} expected true got false
-FAIL #10 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-i8x16_relaxed_swizzle_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/i8x16_relaxed_swizzle.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/i8x16_relaxed_swizzle.wast.js:24:3 expected true got false
+PASS #9 Test that WebAssembly compilation succeeds (i8x16_relaxed_swizzle.wast:3)
+PASS #10 Test that WebAssembly instantiation succeeds (i8x16_relaxed_swizzle.wast:3)
 PASS #11 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #12 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:i8x16.relaxed_swizzle must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/i8x16_relaxed_swizzle.wast.js:10:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-i8x16_relaxed_swizzle_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/i8x16_relaxed_swizzle.wast.js:10:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/i8x16_relaxed_swizzle.wast.js:24:3 expected true got false
-FAIL #13 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-i8x16_relaxed_swizzle_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/i8x16_relaxed_swizzle.wast.js:10:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/i8x16_relaxed_swizzle.wast.js:24:3 expected true got false
+PASS #12 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #13 Run a WebAssembly test without special assertions (i8x16_relaxed_swizzle.wast:12)
 PASS #14 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #15 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:i8x16.relaxed_swizzle must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/i8x16_relaxed_swizzle.wast.js:13:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-i8x16_relaxed_swizzle_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/i8x16_relaxed_swizzle.wast.js:13:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/i8x16_relaxed_swizzle.wast.js:24:3 expected true got false
-FAIL #16 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-i8x16_relaxed_swizzle_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/i8x16_relaxed_swizzle.wast.js:13:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/i8x16_relaxed_swizzle.wast.js:24:3 expected true got false
+PASS #15 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #16 Run a WebAssembly test without special assertions (i8x16_relaxed_swizzle.wast:19)
 PASS #17 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #18 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:i8x16.relaxed_swizzle must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/i8x16_relaxed_swizzle.wast.js:16:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-i8x16_relaxed_swizzle_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/i8x16_relaxed_swizzle.wast.js:16:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/i8x16_relaxed_swizzle.wast.js:24:3 expected true got false
-FAIL #19 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-i8x16_relaxed_swizzle_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/i8x16_relaxed_swizzle.wast.js:16:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/i8x16_relaxed_swizzle.wast.js:24:3 expected true got false
+PASS #18 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #19 Run a WebAssembly test without special assertions (i8x16_relaxed_swizzle.wast:26)
 PASS #20 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #21 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:i8x16.relaxed_swizzle_cmp must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/i8x16_relaxed_swizzle.wast.js:19:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-i8x16_relaxed_swizzle_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/i8x16_relaxed_swizzle.wast.js:19:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/i8x16_relaxed_swizzle.wast.js:24:3 expected true got false
-FAIL #22 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-i8x16_relaxed_swizzle_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/i8x16_relaxed_swizzle.wast.js:19:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/i8x16_relaxed_swizzle.wast.js:24:3 expected true got false
+PASS #21 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #22 Run a WebAssembly test without special assertions (i8x16_relaxed_swizzle.wast:35)
 PASS #23 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #24 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:i8x16.relaxed_swizzle_cmp must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/i8x16_relaxed_swizzle.wast.js:22:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-i8x16_relaxed_swizzle_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/i8x16_relaxed_swizzle.wast.js:22:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/i8x16_relaxed_swizzle.wast.js:24:3 expected true got false
-FAIL #25 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-i8x16_relaxed_swizzle_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/i8x16_relaxed_swizzle.wast.js:22:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/i8x16_relaxed_swizzle.wast.js:24:3 expected true got false
+PASS #24 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #25 Run a WebAssembly test without special assertions (i8x16_relaxed_swizzle.wast:41)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/relaxed-simd/relaxed_dot_product.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/relaxed-simd/relaxed_dot_product.wast.js-expected.txt
@@ -1,6 +1,6 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (relaxed_dot_product.wast:3) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (relaxed_dot_product.wast:3)
 PASS #3 Test that WebAssembly compilation succeeds (wrapper)
 PASS #4 Test that WebAssembly compilation succeeds (wrapper)
 PASS #5 Test that WebAssembly compilation succeeds (wrapper)
@@ -12,98 +12,36 @@ PASS #10 Test that WebAssembly compilation succeeds (wrapper)
 PASS #11 Test that WebAssembly compilation succeeds (wrapper)
 PASS #12 Test that WebAssembly compilation succeeds (wrapper)
 PASS #13 Reinitialize the default imports
-FAIL #14 Test that WebAssembly compilation succeeds (relaxed_dot_product.wast:3) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 8: relaxed simd instructions not supported, in function at index 0 at {loc} expected true got false
-FAIL #15 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-relaxed_dot_product_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_dot_product.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_dot_product.wast.js:39:3 expected true got false
+PASS #14 Test that WebAssembly compilation succeeds (relaxed_dot_product.wast:3)
+PASS #15 Test that WebAssembly instantiation succeeds (relaxed_dot_product.wast:3)
 PASS #16 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #17 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:i16x8.relaxed_dot_i8x16_i7x16_s must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_dot_product.wast.js:10:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_dot_product_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_dot_product.wast.js:10:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_dot_product.wast.js:39:3 expected true got false
-FAIL #18 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_dot_product_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_dot_product.wast.js:10:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_dot_product.wast.js:39:3 expected true got false
+PASS #17 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #18 Run a WebAssembly test without special assertions (relaxed_dot_product.wast:18)
 PASS #19 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #20 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:i16x8.relaxed_dot_i8x16_i7x16_s must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_dot_product.wast.js:13:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_dot_product_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_dot_product.wast.js:13:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_dot_product.wast.js:39:3 expected true got false
-FAIL #21 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_dot_product_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_dot_product.wast.js:13:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_dot_product.wast.js:39:3 expected true got false
+PASS #20 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #21 Run a WebAssembly test without special assertions (relaxed_dot_product.wast:24)
 PASS #22 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #23 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:i16x8.relaxed_dot_i8x16_i7x16_s must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_dot_product.wast.js:16:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_dot_product_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_dot_product.wast.js:16:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_dot_product.wast.js:39:3 expected true got false
-FAIL #24 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_dot_product_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_dot_product.wast.js:16:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_dot_product.wast.js:39:3 expected true got false
+PASS #23 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #24 Run a WebAssembly test without special assertions (relaxed_dot_product.wast:32)
 PASS #25 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #26 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:i32x4.relaxed_dot_i8x16_i7x16_add_s must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_dot_product.wast.js:19:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_dot_product_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_dot_product.wast.js:19:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_dot_product.wast.js:39:3 expected true got false
-FAIL #27 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_dot_product_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_dot_product.wast.js:19:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_dot_product.wast.js:39:3 expected true got false
+PASS #26 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #27 Run a WebAssembly test without special assertions (relaxed_dot_product.wast:41)
 PASS #28 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #29 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:i32x4.relaxed_dot_i8x16_i7x16_add_s must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_dot_product.wast.js:22:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_dot_product_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_dot_product.wast.js:22:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_dot_product.wast.js:39:3 expected true got false
-FAIL #30 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_dot_product_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_dot_product.wast.js:22:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_dot_product.wast.js:39:3 expected true got false
+PASS #29 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #30 Run a WebAssembly test without special assertions (relaxed_dot_product.wast:49)
 PASS #31 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #32 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:i32x4.relaxed_dot_i8x16_i7x16_add_s must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_dot_product.wast.js:25:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_dot_product_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_dot_product.wast.js:25:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_dot_product.wast.js:39:3 expected true got false
-FAIL #33 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_dot_product_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_dot_product.wast.js:25:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_dot_product.wast.js:39:3 expected true got false
+PASS #32 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #33 Run a WebAssembly test without special assertions (relaxed_dot_product.wast:62)
 PASS #34 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #35 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:i16x8.relaxed_dot_i8x16_i7x16_s_cmp must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_dot_product.wast.js:28:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_dot_product_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_dot_product.wast.js:28:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_dot_product.wast.js:39:3 expected true got false
-FAIL #36 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_dot_product_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_dot_product.wast.js:28:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_dot_product.wast.js:39:3 expected true got false
+PASS #35 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #36 Run a WebAssembly test without special assertions (relaxed_dot_product.wast:75)
 PASS #37 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #38 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:i32x4.relaxed_dot_i8x16_i7x16_add_s_cmp must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_dot_product.wast.js:31:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_dot_product_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_dot_product.wast.js:31:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_dot_product.wast.js:39:3 expected true got false
-FAIL #39 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_dot_product_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_dot_product.wast.js:31:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_dot_product.wast.js:39:3 expected true got false
+PASS #38 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #39 Run a WebAssembly test without special assertions (relaxed_dot_product.wast:81)
 PASS #40 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #41 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:i16x8.relaxed_dot_i8x16_i7x16_s_cmp must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_dot_product.wast.js:34:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_dot_product_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_dot_product.wast.js:34:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_dot_product.wast.js:39:3 expected true got false
-FAIL #42 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_dot_product_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_dot_product.wast.js:34:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_dot_product.wast.js:39:3 expected true got false
+PASS #41 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #42 Run a WebAssembly test without special assertions (relaxed_dot_product.wast:91)
 PASS #43 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #44 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:i32x4.relaxed_dot_i8x16_i7x16_add_s_cmp must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_dot_product.wast.js:37:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_dot_product_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_dot_product.wast.js:37:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_dot_product.wast.js:39:3 expected true got false
-FAIL #45 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_dot_product_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_dot_product.wast.js:37:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_dot_product.wast.js:39:3 expected true got false
+PASS #44 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #45 Run a WebAssembly test without special assertions (relaxed_dot_product.wast:102)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/relaxed-simd/relaxed_laneselect.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/relaxed-simd/relaxed_laneselect.wast.js-expected.txt
@@ -1,6 +1,6 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (relaxed_laneselect.wast:3) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (relaxed_laneselect.wast:3)
 PASS #3 Test that WebAssembly compilation succeeds (wrapper)
 PASS #4 Test that WebAssembly compilation succeeds (wrapper)
 PASS #5 Test that WebAssembly compilation succeeds (wrapper)
@@ -13,107 +13,39 @@ PASS #11 Test that WebAssembly compilation succeeds (wrapper)
 PASS #12 Test that WebAssembly compilation succeeds (wrapper)
 PASS #13 Test that WebAssembly compilation succeeds (wrapper)
 PASS #14 Reinitialize the default imports
-FAIL #15 Test that WebAssembly compilation succeeds (relaxed_laneselect.wast:3) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 10: relaxed simd instructions not supported, in function at index 0 at {loc} expected true got false
-FAIL #16 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-relaxed_laneselect_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:42:3 expected true got false
+PASS #15 Test that WebAssembly compilation succeeds (relaxed_laneselect.wast:3)
+PASS #16 Test that WebAssembly instantiation succeeds (relaxed_laneselect.wast:3)
 PASS #17 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #18 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:i8x16.relaxed_laneselect must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:10:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_laneselect_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:10:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:42:3 expected true got false
-FAIL #19 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_laneselect_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:10:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:42:3 expected true got false
+PASS #18 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #19 Run a WebAssembly test without special assertions (relaxed_laneselect.wast:27)
 PASS #20 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #21 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:i16x8.relaxed_laneselect must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:13:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_laneselect_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:13:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:42:3 expected true got false
-FAIL #22 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_laneselect_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:13:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:42:3 expected true got false
+PASS #21 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #22 Run a WebAssembly test without special assertions (relaxed_laneselect.wast:34)
 PASS #23 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #24 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:i16x8.relaxed_laneselect must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:16:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_laneselect_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:16:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:42:3 expected true got false
-FAIL #25 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_laneselect_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:16:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:42:3 expected true got false
+PASS #24 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #25 Run a WebAssembly test without special assertions (relaxed_laneselect.wast:42)
 PASS #26 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #27 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:i32x4.relaxed_laneselect must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:19:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_laneselect_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:19:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:42:3 expected true got false
-FAIL #28 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_laneselect_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:19:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:42:3 expected true got false
+PASS #27 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #28 Run a WebAssembly test without special assertions (relaxed_laneselect.wast:51)
 PASS #29 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #30 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:i64x2.relaxed_laneselect must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:22:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_laneselect_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:22:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:42:3 expected true got false
-FAIL #31 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_laneselect_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:22:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:42:3 expected true got false
+PASS #30 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #31 Run a WebAssembly test without special assertions (relaxed_laneselect.wast:58)
 PASS #32 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #33 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:i64x2.relaxed_laneselect must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:25:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_laneselect_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:25:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:42:3 expected true got false
-FAIL #34 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_laneselect_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:25:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:42:3 expected true got false
+PASS #33 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #34 Run a WebAssembly test without special assertions (relaxed_laneselect.wast:65)
 PASS #35 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #36 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:i8x16.relaxed_laneselect_cmp must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:28:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_laneselect_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:28:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:42:3 expected true got false
-FAIL #37 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_laneselect_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:28:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:42:3 expected true got false
+PASS #36 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #37 Run a WebAssembly test without special assertions (relaxed_laneselect.wast:74)
 PASS #38 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #39 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:i16x8.relaxed_laneselect_cmp must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:31:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_laneselect_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:31:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:42:3 expected true got false
-FAIL #40 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_laneselect_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:31:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:42:3 expected true got false
+PASS #39 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #40 Run a WebAssembly test without special assertions (relaxed_laneselect.wast:80)
 PASS #41 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #42 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:i32x4.relaxed_laneselect_cmp must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:34:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_laneselect_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:34:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:42:3 expected true got false
-FAIL #43 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_laneselect_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:34:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:42:3 expected true got false
+PASS #42 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #43 Run a WebAssembly test without special assertions (relaxed_laneselect.wast:86)
 PASS #44 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #45 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:i64x2.relaxed_laneselect_cmp must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:37:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_laneselect_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:37:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:42:3 expected true got false
-FAIL #46 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_laneselect_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:37:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:42:3 expected true got false
+PASS #45 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #46 Run a WebAssembly test without special assertions (relaxed_laneselect.wast:92)
 PASS #47 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #48 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:i64x2.relaxed_laneselect_cmp must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:40:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_laneselect_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:40:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:42:3 expected true got false
-FAIL #49 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_laneselect_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:40:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_laneselect.wast.js:42:3 expected true got false
+PASS #48 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #49 Run a WebAssembly test without special assertions (relaxed_laneselect.wast:98)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/relaxed-simd/relaxed_madd_nmadd.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/relaxed-simd/relaxed_madd_nmadd.wast.js-expected.txt
@@ -1,6 +1,6 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (relaxed_madd_nmadd.wast:3) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (relaxed_madd_nmadd.wast:3)
 PASS #3 Test that WebAssembly compilation succeeds (wrapper)
 PASS #4 Test that WebAssembly compilation succeeds (wrapper)
 PASS #5 Test that WebAssembly compilation succeeds (wrapper)
@@ -17,168 +17,62 @@ PASS #15 Test that WebAssembly compilation succeeds (wrapper)
 PASS #16 Test that WebAssembly compilation succeeds (wrapper)
 PASS #17 Test that WebAssembly compilation succeeds (wrapper)
 PASS #18 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #19 Test that WebAssembly compilation succeeds (relaxed_madd_nmadd.wast:205) assert_equals: expected false but got true
+PASS #19 Test that WebAssembly compilation succeeds (relaxed_madd_nmadd.wast:205)
 PASS #20 Test that WebAssembly compilation succeeds (wrapper)
 PASS #21 Reinitialize the default imports
-FAIL #22 Test that WebAssembly compilation succeeds (relaxed_madd_nmadd.wast:3) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 10: relaxed simd instructions not supported, in function at index 0 at {loc} expected true got false
-FAIL #23 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-relaxed_madd_nmadd_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:66:3 expected true got false
+PASS #22 Test that WebAssembly compilation succeeds (relaxed_madd_nmadd.wast:3)
+PASS #23 Test that WebAssembly instantiation succeeds (relaxed_madd_nmadd.wast:3)
 PASS #24 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #25 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32x4.relaxed_madd must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:10:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_madd_nmadd_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:10:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:66:3 expected true got false
-FAIL #26 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_madd_nmadd_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:10:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:66:3 expected true got false
+PASS #25 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #26 Run a WebAssembly test without special assertions (relaxed_madd_nmadd.wast:33)
 PASS #27 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #28 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32x4.relaxed_madd must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:13:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_madd_nmadd_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:13:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:66:3 expected true got false
-FAIL #29 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_madd_nmadd_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:13:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:66:3 expected true got false
+PASS #28 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #29 Run a WebAssembly test without special assertions (relaxed_madd_nmadd.wast:49)
 PASS #30 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #31 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32x4.relaxed_nmadd must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:16:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_madd_nmadd_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:16:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:66:3 expected true got false
-FAIL #32 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_madd_nmadd_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:16:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:66:3 expected true got false
+PASS #31 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #32 Run a WebAssembly test without special assertions (relaxed_madd_nmadd.wast:56)
 PASS #33 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #34 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32x4.relaxed_nmadd must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:19:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_madd_nmadd_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:19:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:66:3 expected true got false
-FAIL #35 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_madd_nmadd_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:19:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:66:3 expected true got false
+PASS #34 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #35 Run a WebAssembly test without special assertions (relaxed_madd_nmadd.wast:63)
 PASS #36 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #37 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64x2.relaxed_madd must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:22:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_madd_nmadd_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:22:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:66:3 expected true got false
-FAIL #38 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_madd_nmadd_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:22:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:66:3 expected true got false
+PASS #37 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #38 Run a WebAssembly test without special assertions (relaxed_madd_nmadd.wast:75)
 PASS #39 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #40 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64x2.relaxed_madd must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:25:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_madd_nmadd_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:25:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:66:3 expected true got false
-FAIL #41 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_madd_nmadd_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:25:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:66:3 expected true got false
+PASS #40 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #41 Run a WebAssembly test without special assertions (relaxed_madd_nmadd.wast:91)
 PASS #42 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #43 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64x2.relaxed_nmadd must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:28:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_madd_nmadd_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:28:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:66:3 expected true got false
-FAIL #44 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_madd_nmadd_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:28:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:66:3 expected true got false
+PASS #43 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #44 Run a WebAssembly test without special assertions (relaxed_madd_nmadd.wast:98)
 PASS #45 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #46 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64x2.relaxed_nmadd must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:31:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_madd_nmadd_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:31:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:66:3 expected true got false
-FAIL #47 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_madd_nmadd_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:31:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:66:3 expected true got false
+PASS #46 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #47 Run a WebAssembly test without special assertions (relaxed_madd_nmadd.wast:105)
 PASS #48 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #49 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32x4.relaxed_madd_cmp must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:34:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_madd_nmadd_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:34:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:66:3 expected true got false
-FAIL #50 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_madd_nmadd_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:34:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:66:3 expected true got false
+PASS #49 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #50 Run a WebAssembly test without special assertions (relaxed_madd_nmadd.wast:119)
 PASS #51 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #52 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32x4.relaxed_madd_cmp must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:37:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_madd_nmadd_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:37:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:66:3 expected true got false
-FAIL #53 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_madd_nmadd_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:37:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:66:3 expected true got false
+PASS #52 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #53 Run a WebAssembly test without special assertions (relaxed_madd_nmadd.wast:134)
 PASS #54 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #55 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32x4.relaxed_nmadd_cmp must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:40:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_madd_nmadd_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:40:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:66:3 expected true got false
-FAIL #56 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_madd_nmadd_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:40:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:66:3 expected true got false
+PASS #55 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #56 Run a WebAssembly test without special assertions (relaxed_madd_nmadd.wast:140)
 PASS #57 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #58 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32x4.relaxed_nmadd_cmp must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:43:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_madd_nmadd_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:43:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:66:3 expected true got false
-FAIL #59 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_madd_nmadd_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:43:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:66:3 expected true got false
+PASS #58 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #59 Run a WebAssembly test without special assertions (relaxed_madd_nmadd.wast:146)
 PASS #60 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #61 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64x2.relaxed_madd_cmp must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:46:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_madd_nmadd_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:46:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:66:3 expected true got false
-FAIL #62 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_madd_nmadd_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:46:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:66:3 expected true got false
+PASS #61 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #62 Run a WebAssembly test without special assertions (relaxed_madd_nmadd.wast:157)
 PASS #63 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #64 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64x2.relaxed_madd_cmp must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:49:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_madd_nmadd_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:49:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:66:3 expected true got false
-FAIL #65 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_madd_nmadd_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:49:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:66:3 expected true got false
+PASS #64 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #65 Run a WebAssembly test without special assertions (relaxed_madd_nmadd.wast:172)
 PASS #66 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #67 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64x2.relaxed_nmadd_cmp must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:52:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_madd_nmadd_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:52:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:66:3 expected true got false
-FAIL #68 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_madd_nmadd_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:52:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:66:3 expected true got false
+PASS #67 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #68 Run a WebAssembly test without special assertions (relaxed_madd_nmadd.wast:178)
 PASS #69 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #70 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64x2.relaxed_nmadd_cmp must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:55:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_madd_nmadd_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:55:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:66:3 expected true got false
-FAIL #71 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_madd_nmadd_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:55:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:66:3 expected true got false
-FAIL #72 Test that WebAssembly compilation succeeds (relaxed_madd_nmadd.wast:205) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 58: relaxed simd instructions not supported, in function at index 0 at {loc} expected true got false
-FAIL #73 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-relaxed_madd_nmadd_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:61:18
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:66:3 expected true got false
+PASS #70 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #71 Run a WebAssembly test without special assertions (relaxed_madd_nmadd.wast:184)
+PASS #72 Test that WebAssembly compilation succeeds (relaxed_madd_nmadd.wast:205)
+PASS #73 Test that WebAssembly instantiation succeeds (relaxed_madd_nmadd.wast:205)
 PASS #74 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #75 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:test-consistent-nondeterminism must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:64:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_madd_nmadd_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:64:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:66:3 expected true got false
-FAIL #76 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_madd_nmadd_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:64:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_madd_nmadd.wast.js:66:3 expected true got false
+PASS #75 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #76 Run a WebAssembly test without special assertions (relaxed_madd_nmadd.wast:217)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/relaxed-simd/relaxed_min_max.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/relaxed-simd/relaxed_min_max.wast.js-expected.txt
@@ -1,6 +1,6 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (relaxed_min_max.wast:3) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (relaxed_min_max.wast:3)
 PASS #3 Test that WebAssembly compilation succeeds (wrapper)
 PASS #4 Test that WebAssembly compilation succeeds (wrapper)
 PASS #5 Test that WebAssembly compilation succeeds (wrapper)
@@ -26,224 +26,78 @@ PASS #24 Test that WebAssembly compilation succeeds (wrapper)
 PASS #25 Test that WebAssembly compilation succeeds (wrapper)
 PASS #26 Test that WebAssembly compilation succeeds (wrapper)
 PASS #27 Reinitialize the default imports
-FAIL #28 Test that WebAssembly compilation succeeds (relaxed_min_max.wast:3) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 8: relaxed simd instructions not supported, in function at index 0 at {loc} expected true got false
-FAIL #29 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-relaxed_min_max_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:81:3 expected true got false
+PASS #28 Test that WebAssembly compilation succeeds (relaxed_min_max.wast:3)
+PASS #29 Test that WebAssembly instantiation succeeds (relaxed_min_max.wast:3)
 PASS #30 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #31 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32x4.relaxed_min must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:10:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_min_max_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:10:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:81:3 expected true got false
-FAIL #32 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_min_max_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:10:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:81:3 expected true got false
+PASS #31 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #32 Run a WebAssembly test without special assertions (relaxed_min_max.wast:27)
 PASS #33 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #34 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32x4.relaxed_min must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:13:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_min_max_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:13:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:81:3 expected true got false
-FAIL #35 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_min_max_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:13:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:81:3 expected true got false
+PASS #34 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #35 Run a WebAssembly test without special assertions (relaxed_min_max.wast:35)
 PASS #36 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #37 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32x4.relaxed_max must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:16:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_min_max_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:16:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:81:3 expected true got false
-FAIL #38 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_min_max_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:16:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:81:3 expected true got false
+PASS #37 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #38 Run a WebAssembly test without special assertions (relaxed_min_max.wast:43)
 PASS #39 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #40 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32x4.relaxed_max must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:19:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_min_max_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:19:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:81:3 expected true got false
-FAIL #41 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_min_max_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:19:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:81:3 expected true got false
+PASS #40 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #41 Run a WebAssembly test without special assertions (relaxed_min_max.wast:51)
 PASS #42 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #43 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64x2.relaxed_min must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:22:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_min_max_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:22:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:81:3 expected true got false
-FAIL #44 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_min_max_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:22:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:81:3 expected true got false
+PASS #43 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #44 Run a WebAssembly test without special assertions (relaxed_min_max.wast:59)
 PASS #45 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #46 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64x2.relaxed_min must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:25:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_min_max_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:25:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:81:3 expected true got false
-FAIL #47 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_min_max_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:25:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:81:3 expected true got false
+PASS #46 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #47 Run a WebAssembly test without special assertions (relaxed_min_max.wast:67)
 PASS #48 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #49 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64x2.relaxed_min must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:28:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_min_max_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:28:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:81:3 expected true got false
-FAIL #50 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_min_max_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:28:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:81:3 expected true got false
+PASS #49 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #50 Run a WebAssembly test without special assertions (relaxed_min_max.wast:75)
 PASS #51 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #52 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64x2.relaxed_min must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:31:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_min_max_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:31:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:81:3 expected true got false
-FAIL #53 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_min_max_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:31:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:81:3 expected true got false
+PASS #52 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #53 Run a WebAssembly test without special assertions (relaxed_min_max.wast:83)
 PASS #54 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #55 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64x2.relaxed_max must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:34:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_min_max_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:34:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:81:3 expected true got false
-FAIL #56 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_min_max_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:34:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:81:3 expected true got false
+PASS #55 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #56 Run a WebAssembly test without special assertions (relaxed_min_max.wast:91)
 PASS #57 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #58 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64x2.relaxed_max must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:37:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_min_max_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:37:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:81:3 expected true got false
-FAIL #59 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_min_max_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:37:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:81:3 expected true got false
+PASS #58 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #59 Run a WebAssembly test without special assertions (relaxed_min_max.wast:99)
 PASS #60 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #61 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64x2.relaxed_max must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:40:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_min_max_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:40:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:81:3 expected true got false
-FAIL #62 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_min_max_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:40:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:81:3 expected true got false
+PASS #61 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #62 Run a WebAssembly test without special assertions (relaxed_min_max.wast:107)
 PASS #63 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #64 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64x2.relaxed_max must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:43:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_min_max_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:43:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:81:3 expected true got false
-FAIL #65 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_min_max_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:43:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:81:3 expected true got false
+PASS #64 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #65 Run a WebAssembly test without special assertions (relaxed_min_max.wast:115)
 PASS #66 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #67 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32x4.relaxed_min_cmp must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:46:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_min_max_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:46:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:81:3 expected true got false
-FAIL #68 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_min_max_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:46:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:81:3 expected true got false
+PASS #67 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #68 Run a WebAssembly test without special assertions (relaxed_min_max.wast:125)
 PASS #69 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #70 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32x4.relaxed_min_cmp must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:49:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_min_max_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:49:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:81:3 expected true got false
-FAIL #71 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_min_max_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:49:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:81:3 expected true got false
+PASS #70 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #71 Run a WebAssembly test without special assertions (relaxed_min_max.wast:130)
 PASS #72 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #73 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32x4.relaxed_max_cmp must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:52:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_min_max_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:52:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:81:3 expected true got false
-FAIL #74 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_min_max_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:52:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:81:3 expected true got false
+PASS #73 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #74 Run a WebAssembly test without special assertions (relaxed_min_max.wast:135)
 PASS #75 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #76 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32x4.relaxed_max_cmp must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:55:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_min_max_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:55:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:81:3 expected true got false
-FAIL #77 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_min_max_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:55:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:81:3 expected true got false
+PASS #76 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #77 Run a WebAssembly test without special assertions (relaxed_min_max.wast:140)
 PASS #78 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #79 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64x2.relaxed_min_cmp must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:58:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_min_max_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:58:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:81:3 expected true got false
-FAIL #80 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_min_max_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:58:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:81:3 expected true got false
+PASS #79 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #80 Run a WebAssembly test without special assertions (relaxed_min_max.wast:145)
 PASS #81 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #82 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64x2.relaxed_min_cmp must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:61:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_min_max_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:61:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:81:3 expected true got false
-FAIL #83 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_min_max_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:61:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:81:3 expected true got false
+PASS #82 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #83 Run a WebAssembly test without special assertions (relaxed_min_max.wast:150)
 PASS #84 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #85 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64x2.relaxed_min_cmp must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:64:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_min_max_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:64:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:81:3 expected true got false
-FAIL #86 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_min_max_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:64:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:81:3 expected true got false
+PASS #85 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #86 Run a WebAssembly test without special assertions (relaxed_min_max.wast:155)
 PASS #87 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #88 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64x2.relaxed_min_cmp must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:67:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_min_max_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:67:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:81:3 expected true got false
-FAIL #89 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_min_max_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:67:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:81:3 expected true got false
+PASS #88 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #89 Run a WebAssembly test without special assertions (relaxed_min_max.wast:160)
 PASS #90 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #91 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64x2.relaxed_max_cmp must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:70:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_min_max_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:70:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:81:3 expected true got false
-FAIL #92 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_min_max_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:70:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:81:3 expected true got false
+PASS #91 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #92 Run a WebAssembly test without special assertions (relaxed_min_max.wast:165)
 PASS #93 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #94 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64x2.relaxed_max_cmp must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:73:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_min_max_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:73:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:81:3 expected true got false
-FAIL #95 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_min_max_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:73:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:81:3 expected true got false
+PASS #94 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #95 Run a WebAssembly test without special assertions (relaxed_min_max.wast:170)
 PASS #96 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #97 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64x2.relaxed_max_cmp must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:76:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_min_max_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:76:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:81:3 expected true got false
-FAIL #98 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_min_max_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:76:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:81:3 expected true got false
+PASS #97 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #98 Run a WebAssembly test without special assertions (relaxed_min_max.wast:175)
 PASS #99 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #100 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64x2.relaxed_max_cmp must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:79:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:249:37
-relaxed_min_max_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:79:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:81:3 expected true got false
-FAIL #101 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:248:24
-relaxed_min_max_wast_js@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:79:4
-global code@http://web-platform.test:8800/wasm/core/js/relaxed-simd/relaxed_min_max.wast.js:81:3 expected true got false
+PASS #100 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #101 Run a WebAssembly test without special assertions (relaxed_min_max.wast:180)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/simd/simd_memory-multi.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/simd/simd_memory-multi.wast.js-expected.txt
@@ -1,9 +1,7 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (simd_memory-multi.wast:5) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (simd_memory-multi.wast:5)
 PASS #3 Reinitialize the default imports
-FAIL #4 Test that WebAssembly compilation succeeds (simd_memory-multi.wast:5) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 33: Memory section has more than one memory, WebAssembly currently only allows zero or one at {loc} expected true got false
-FAIL #5 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:207:24
-simd_memory_multi_wast_js@http://web-platform.test:8800/wasm/core/js/simd/simd_memory-multi.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/simd/simd_memory-multi.wast.js:9:3 expected true got false
+PASS #4 Test that WebAssembly compilation succeeds (simd_memory-multi.wast:5)
+PASS #5 Test that WebAssembly instantiation succeeds (simd_memory-multi.wast:5)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/esm-integration/source-phase-string-builtins.tentative.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/esm-integration/source-phase-string-builtins.tentative.any-expected.txt
@@ -1,4 +1,4 @@
 
-Harness Error (FAIL), message = SyntaxError: Unexpected identifier 'source'. "import." can only be followed with meta.
+Harness Error (FAIL), message = SyntaxError: Unexpected identifier 'source'. "import." can only be followed with meta or defer.
 
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/esm-integration/source-phase-string-builtins.tentative.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/esm-integration/source-phase-string-builtins.tentative.any.worker-expected.txt
@@ -1,4 +1,4 @@
 
-Harness Error (FAIL), message = SyntaxError: Unexpected identifier 'source'. "import." can only be followed with meta.
+Harness Error (FAIL), message = SyntaxError: Unexpected identifier 'source'. "import." can only be followed with meta or defer.
 
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/esm-integration/source-phase-string-constants.tentative.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/esm-integration/source-phase-string-constants.tentative.any-expected.txt
@@ -1,4 +1,4 @@
 
-Harness Error (FAIL), message = SyntaxError: Unexpected identifier 'source'. "import." can only be followed with meta.
+Harness Error (FAIL), message = SyntaxError: Unexpected identifier 'source'. "import." can only be followed with meta or defer.
 
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/esm-integration/source-phase-string-constants.tentative.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/esm-integration/source-phase-string-constants.tentative.any.worker-expected.txt
@@ -1,4 +1,4 @@
 
-Harness Error (FAIL), message = SyntaxError: Unexpected identifier 'source'. "import." can only be followed with meta.
+Harness Error (FAIL), message = SyntaxError: Unexpected identifier 'source'. "import." can only be followed with meta or defer.
 
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/esm-integration/source-phase.tentative.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/esm-integration/source-phase.tentative.any-expected.txt
@@ -1,4 +1,4 @@
 
-Harness Error (FAIL), message = SyntaxError: Unexpected identifier 'source'. "import." can only be followed with meta.
+Harness Error (FAIL), message = SyntaxError: Unexpected identifier 'source'. "import." can only be followed with meta or defer.
 
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/esm-integration/source-phase.tentative.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/esm-integration/source-phase.tentative.any.worker-expected.txt
@@ -1,4 +1,4 @@
 
-Harness Error (FAIL), message = SyntaxError: Unexpected identifier 'source'. "import." can only be followed with meta.
+Harness Error (FAIL), message = SyntaxError: Unexpected identifier 'source'. "import." can only be followed with meta or defer.
 
 

--- a/LayoutTests/js/Object-getOwnPropertyNames-expected.txt
+++ b/LayoutTests/js/Object-getOwnPropertyNames-expected.txt
@@ -62,7 +62,7 @@ PASS getSortedOwnPropertyNames(Error) is ['captureStackTrace', 'isError', 'lengt
 PASS getSortedOwnPropertyNames(Error.prototype) is ['constructor', 'message', 'name', 'toString']
 PASS getSortedOwnPropertyNames(Math) is ['E','LN10','LN2','LOG10E','LOG2E','PI','SQRT1_2','SQRT2','abs','acos','acosh','asin','asinh','atan','atan2','atanh','cbrt','ceil','clz32','cos','cosh','exp','expm1','f16round','floor','fround','hypot','imul','log','log10','log1p','log2','max','min','pow','random','round','sign','sin','sinh','sqrt','sumPrecise','tan','tanh','trunc']
 PASS getSortedOwnPropertyNames(JSON) is ['isRawJSON', 'parse', 'rawJSON', 'stringify']
-PASS getSortedOwnPropertyNames(Symbol) is ['asyncIterator','for', 'hasInstance', 'isConcatSpreadable', 'iterator', 'keyFor', 'length', 'match', 'matchAll', 'name', 'prototype', 'replace', 'search', 'species', 'split', 'toPrimitive', 'toStringTag', 'unscopables']
+PASS getSortedOwnPropertyNames(Symbol) is ['asyncDispose', 'asyncIterator', 'dispose', 'for', 'hasInstance', 'isConcatSpreadable', 'iterator', 'keyFor', 'length', 'match', 'matchAll', 'name', 'prototype', 'replace', 'search', 'species', 'split', 'toPrimitive', 'toStringTag', 'unscopables']
 PASS getSortedOwnPropertyNames(Symbol.prototype) is ['constructor', 'description', 'toString', 'valueOf']
 PASS getSortedOwnPropertyNames(Map) is ['groupBy', 'length', 'name', 'prototype']
 PASS getSortedOwnPropertyNames(Map.prototype) is ['clear', 'constructor', 'delete', 'entries', 'forEach', 'get', 'getOrInsert', 'getOrInsertComputed', 'has', 'keys', 'set', 'size', 'values']

--- a/LayoutTests/js/script-tests/Object-getOwnPropertyNames.js
+++ b/LayoutTests/js/script-tests/Object-getOwnPropertyNames.js
@@ -1,3 +1,6 @@
+//@ requireOptions("--useExplicitResourceManagement=1")
+// DumpRenderTree and WebKitTestRunner run with experimental features enabled, which changes the expectations for this test.
+
 description("Test to ensure correct behaviour of Object.getOwnPropertyNames");
 
 function argumentsObject() { return arguments; };
@@ -71,7 +74,7 @@ var expectedPropertyNamesSet = {
     "Error.prototype": "['constructor', 'message', 'name', 'toString']",
     "Math": "['E','LN10','LN2','LOG10E','LOG2E','PI','SQRT1_2','SQRT2','abs','acos','acosh','asin','asinh','atan','atan2','atanh','cbrt','ceil','clz32','cos','cosh','exp','expm1','f16round','floor','fround','hypot','imul','log','log10','log1p','log2','max','min','pow','random','round','sign','sin','sinh','sqrt','sumPrecise','tan','tanh','trunc']",
     "JSON": "['isRawJSON', 'parse', 'rawJSON', 'stringify']",
-    "Symbol": "['asyncIterator','for', 'hasInstance', 'isConcatSpreadable', 'iterator', 'keyFor', 'length', 'match', 'matchAll', 'name', 'prototype', 'replace', 'search', 'species', 'split', 'toPrimitive', 'toStringTag', 'unscopables']",
+    "Symbol": "['asyncDispose', 'asyncIterator', 'dispose', 'for', 'hasInstance', 'isConcatSpreadable', 'iterator', 'keyFor', 'length', 'match', 'matchAll', 'name', 'prototype', 'replace', 'search', 'species', 'split', 'toPrimitive', 'toStringTag', 'unscopables']",
     "Symbol.prototype": "['constructor', 'description', 'toString', 'valueOf']",
     "Map": "['groupBy', 'length', 'name', 'prototype']",
     "Map.prototype": "['clear', 'constructor', 'delete', 'entries', 'forEach', 'get', 'getOrInsert', 'getOrInsertComputed', 'has', 'keys', 'set', 'size', 'values']",

--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -287,11 +287,20 @@ add_custom_command(
     VERBATIM)
 add_custom_target(Bytecodes DEPENDS "${JavaScriptCore_DERIVED_SOURCES_DIR}/Bytecodes.h")
 
+add_custom_command(
+    OUTPUT ${JavaScriptCore_DERIVED_SOURCES_DIR}/JSCWebPreferenceOptions.h
+    MAIN_DEPENDENCY ${JAVASCRIPTCORE_DIR}/Scripts/PreferencesTemplates/JSCWebPreferenceOptions.h.erb
+    DEPENDS ${WTF_SCRIPTS_DIR}/GeneratePreferences.rb ${WTF_SCRIPTS_DIR}/Preferences/UnifiedWebPreferences.yaml WTF_CopyPreferences
+    COMMAND ${Ruby_EXECUTABLE} ${WTF_SCRIPTS_DIR}/GeneratePreferences.rb --frontend JavaScriptCore --outputDir "${JavaScriptCore_DERIVED_SOURCES_DIR}" --template ${JAVASCRIPTCORE_DIR}/Scripts/PreferencesTemplates/JSCWebPreferenceOptions.h.erb ${WTF_SCRIPTS_DIR}/Preferences/UnifiedWebPreferences.yaml
+    VERBATIM)
+add_custom_target(JSCWebPreferenceOptions DEPENDS "${JavaScriptCore_DERIVED_SOURCES_DIR}/JSCWebPreferenceOptions.h")
+
 string(TIMESTAMP BUILD_TIME "%s")
 
 list(APPEND JavaScriptCore_HEADERS
     ${JavaScriptCore_DERIVED_SOURCES_DIR}/BytecodeStructs.h
     ${JavaScriptCore_DERIVED_SOURCES_DIR}/Bytecodes.h
+    ${JavaScriptCore_DERIVED_SOURCES_DIR}/JSCWebPreferenceOptions.h
 )
 
 if (WTF_CPU_X86_64)
@@ -536,6 +545,7 @@ set(JavaScriptCore_PUBLIC_FRAMEWORK_HEADERS
 set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     ${JavaScriptCore_DERIVED_SOURCES_DIR}/Bytecodes.h
     ${JavaScriptCore_DERIVED_SOURCES_DIR}/JSCBuiltins.h
+    ${JavaScriptCore_DERIVED_SOURCES_DIR}/JSCWebPreferenceOptions.h
     ${JavaScriptCore_DERIVED_SOURCES_DIR}/WasmOps.h
 
     ${JavaScriptCore_DERIVED_SOURCES_DIR}/inspector/InspectorAlternateBackendDispatchers.h
@@ -1784,11 +1794,11 @@ WEBKIT_SYMLINK_FILES(JavaScriptCore_CopyPrivateHeaders
     FLATTENED
 )
 
-add_dependencies(JavaScriptCore_CopyPrivateHeaders Bytecodes JSCBuiltins)
+add_dependencies(JavaScriptCore_CopyPrivateHeaders Bytecodes JSCBuiltins JSCWebPreferenceOptions)
 
 target_include_directories(LowLevelInterpreterLib
     PRIVATE "$<TARGET_PROPERTY:JavaScriptCore,INCLUDE_DIRECTORIES>" "${JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS_DIR}/JavaScriptCore")
-add_dependencies(LowLevelInterpreterLib Bytecodes JSCBuiltins)
+add_dependencies(LowLevelInterpreterLib Bytecodes JSCBuiltins JSCWebPreferenceOptions)
 if (TARGET WTF_CopyHeaders)
     add_dependencies(LowLevelInterpreterLib WTF_CopyHeaders)
 endif ()

--- a/Source/JavaScriptCore/DerivedSources-input.xcfilelist
+++ b/Source/JavaScriptCore/DerivedSources-input.xcfilelist
@@ -18,8 +18,11 @@ $(BUILT_PRODUCTS_DIR)/usr/local/include/wtf/PlatformHave.h
 $(BUILT_PRODUCTS_DIR)/usr/local/include/wtf/PlatformLegacy.h
 $(BUILT_PRODUCTS_DIR)/usr/local/include/wtf/PlatformOS.h
 $(BUILT_PRODUCTS_DIR)/usr/local/include/wtf/PlatformUse.h
+$(BUILT_PRODUCTS_DIR)/usr/local/include/wtf/Scripts/GeneratePreferences.rb
+$(BUILT_PRODUCTS_DIR)/usr/local/include/wtf/Scripts/Preferences/UnifiedWebPreferences.yaml
 $(PROJECT_DIR)/DerivedSources.make
 $(PROJECT_DIR)/KeywordLookupGenerator.py
+$(PROJECT_DIR)/Scripts/PreferencesTemplates/JSCWebPreferenceOptions.h.erb
 $(PROJECT_DIR)/Scripts/UpdateContents.py
 $(PROJECT_DIR)/Scripts/generate-combined-inspector-json.py
 $(PROJECT_DIR)/Scripts/generate-js-builtins.py

--- a/Source/JavaScriptCore/DerivedSources-output.xcfilelist
+++ b/Source/JavaScriptCore/DerivedSources-output.xcfilelist
@@ -44,6 +44,7 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/JavaScriptCore/IntlSegmenterPrototype.lut.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/JavaScriptCore/IntlSegmentsPrototype.lut.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/JavaScriptCore/JSCBuiltins.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/JavaScriptCore/JSCBuiltins.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/JavaScriptCore/JSCWebPreferenceOptions.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/JavaScriptCore/JSDataViewPrototype.lut.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/JavaScriptCore/JSGlobalObject.lut.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/JavaScriptCore/JSIteratorHelperPrototype.lut.h

--- a/Source/JavaScriptCore/DerivedSources.make
+++ b/Source/JavaScriptCore/DerivedSources.make
@@ -75,7 +75,11 @@ all : \
     yarr/YarrCanonicalizeUnicode.cpp \
     WasmOps.h \
     WasmOMGIRGeneratorInlines.h \
+    JSCWebPreferenceOptions.h \
 #
+
+JSCWebPreferenceOptions.h : $(JavaScriptCore)/Scripts/PreferencesTemplates/JSCWebPreferenceOptions.h.erb $(WTF_BUILD_SCRIPTS_DIR)/Preferences/UnifiedWebPreferences.yaml $(WTF_BUILD_SCRIPTS_DIR)/GeneratePreferences.rb
+	$(RUBY) $(WTF_BUILD_SCRIPTS_DIR)/GeneratePreferences.rb --frontend JavaScriptCore --outputDir . --template $(JavaScriptCore)/Scripts/PreferencesTemplates/JSCWebPreferenceOptions.h.erb $(WTF_BUILD_SCRIPTS_DIR)/Preferences/UnifiedWebPreferences.yaml
 
 # JavaScript builtins.
 

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -1258,6 +1258,7 @@
 		53ADF4792F0D7A8000A05CDD /* LOLRegisterAllocator.h in Headers */ = {isa = PBXBuildFile; fileRef = 53ADF4732F0D7A2000A05CDD /* LOLRegisterAllocator.h */; };
 		53B0D0C42E2E834300FC209B /* SimpleRegisterAllocator.h in Headers */ = {isa = PBXBuildFile; fileRef = 53B0D0C32E2E834300FC209B /* SimpleRegisterAllocator.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		53B4BD121F68B32500D2BEA3 /* WasmOps.h in Headers */ = {isa = PBXBuildFile; fileRef = 533B15DE1DC7F463004D500A /* WasmOps.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		AA01FEED0000000000000002 /* JSCWebPreferenceOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = AA01FEED0000000000000001 /* JSCWebPreferenceOptions.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		53B601EC2034B8C5006BE667 /* JSCast.h in Headers */ = {isa = PBXBuildFile; fileRef = 53B601EB2034B8C5006BE667 /* JSCast.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		53C2CE9C22FCC3D6008B2853 /* AirHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 53C2CE9B22FCC3D6008B2853 /* AirHelpers.h */; };
 		53C4F66B21B1A409002FD009 /* JSAPIGlobalObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 53C4F66A21B1A409002FD009 /* JSAPIGlobalObject.h */; };
@@ -4454,6 +4455,7 @@
 		5338E2A62396EFEC00C61BAD /* CheckpointOSRExitSideState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CheckpointOSRExitSideState.h; sourceTree = "<group>"; };
 		5338EBA223AB04A300382662 /* FTLSelectPredictability.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FTLSelectPredictability.h; path = ftl/FTLSelectPredictability.h; sourceTree = "<group>"; };
 		533B15DE1DC7F463004D500A /* WasmOps.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WasmOps.h; sourceTree = "<group>"; };
+		AA01FEED0000000000000001 /* JSCWebPreferenceOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSCWebPreferenceOptions.h; sourceTree = "<group>"; };
 		533D074322C2D797004D2FE2 /* FinalizationRegistryConstructor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FinalizationRegistryConstructor.h; sourceTree = "<group>"; };
 		533D074522C2D87F004D2FE2 /* FinalizationRegistryConstructor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = FinalizationRegistryConstructor.cpp; sourceTree = "<group>"; };
 		533D074622C2D9D1004D2FE2 /* JSFinalizationRegistry.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSFinalizationRegistry.h; sourceTree = "<group>"; };
@@ -8303,6 +8305,7 @@
 				A125846D1B45A36000CC7F6C /* IntlNumberFormatPrototype.lut.h */,
 				A7D801A61880D6A80026C39B /* JSCBuiltins.cpp */,
 				A7D801A71880D6A80026C39B /* JSCBuiltins.h */,
+				AA01FEED0000000000000001 /* JSCWebPreferenceOptions.h */,
 				996B730A1BD9FA2C00331B84 /* JSDataViewPrototype.lut.h */,
 				996B730B1BD9FA2C00331B84 /* JSGlobalObject.lut.h */,
 				BC87CDB810712ACA000614CF /* JSONObject.lut.h */,
@@ -12147,6 +12150,7 @@
 				276B39182A71D2B600252F4E /* JSCustomGetterFunctionInlines.h in Headers */,
 				84323E7F25D5EC6A00F97776 /* JSCustomSetterFunction.h in Headers */,
 				276B38DD2A71D26400252F4E /* JSCustomSetterFunctionInlines.h in Headers */,
+				AA01FEED0000000000000002 /* JSCWebPreferenceOptions.h in Headers */,
 				0F2B66EC17B6B5AB00A7AE3F /* JSDataView.h in Headers */,
 				0F2B66EE17B6B5AB00A7AE3F /* JSDataViewPrototype.h in Headers */,
 				978801411471AD920041B016 /* JSDateMath.h in Headers */,

--- a/Source/JavaScriptCore/Scripts/PreferencesTemplates/JSCWebPreferenceOptions.h.erb
+++ b/Source/JavaScriptCore/Scripts/PreferencesTemplates/JSCWebPreferenceOptions.h.erb
@@ -1,0 +1,47 @@
+/*
+ * <%= @warning %>
+ *
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+// JSC feature-flag options whose source of truth is
+// Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml. This macro is
+// spliced into FOR_EACH_JSC_OPTION() in runtime/OptionsList.h so these options
+// are declared exactly as if written there directly. Feature flags are always
+// Normal availability.
+
+#define FOR_EACH_JSC_WEB_PREFERENCE_OPTION(v) \
+<% @jscOptions.each do |pref| -%>
+<%-
+    jscDefault = case pref.defaultValues["default"]
+        when true then "true"
+        when false then "false"
+        else pref.defaultValues["default"].to_s
+    end
+    jscDescription = (pref.humanReadableDescription.empty? || pref.humanReadableDescription == '""') ? "nullptr" : pref.humanReadableDescription + "_s"
+-%>
+    v(Bool, <%= pref.jscOptionName %>, <%= jscDefault %>, Normal, <%= jscDescription %>) \
+<% end %>

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <JavaScriptCore/GCLogging.h>
+#include <JavaScriptCore/JSCWebPreferenceOptions.h>
 #include <JavaScriptCore/JSExportMacros.h>
 
 #if OS(DARWIN)
@@ -663,33 +664,14 @@ bool hasCapacityToUseLargeGigacage();
     \
     /* Feature Flags */\
     \
+    /* Feature-flag options whose source of truth is UnifiedWebPreferences.yaml. */ \
+    FOR_EACH_JSC_WEB_PREFERENCE_OPTION(v) \
     /* Restricted so some app doesn't set this environment variable and start using it. */ \
-    v(Bool, useAsyncStackTrace, true, Normal, "Enable async stack traces") \
     v(Bool, disallowMixedWasmExceptions, true, Restricted, "Disallow using both legacy and modern (try_table) wasm exception specs in the same module."_s) \
-    v(Bool, useBigIntMathMethods, false, Normal, "Enable BigInt math helper methods."_s) \
-    v(Bool, useExplicitResourceManagement, false, Normal, "Enable explicit resource management builtins and syntax."_s) \
-    v(Bool, useImportDefer, false, Normal, "Enable deferred module import."_s) \
-    v(Bool, useIteratorChunking, false, Normal, "Expose the Iterator.prototype.chunks and Iterator.prototype.windows methods."_s) \
-    v(Bool, useIteratorSequencing, true, Normal, "Expose the Iterator.concat method."_s) \
-    v(Bool, useIteratorIncludes, false, Normal, "Expose the Iterator.includes method."_s) \
-    v(Bool, useIteratorJoin, false, Normal, "Expose the Iterator.prototype.join method."_s) \
-    v(Bool, useJSONSourceTextAccess, true, Normal, "Expose JSON source text access feature."_s) \
-    v(Bool, useJSPI, true, Normal, "Enable the implementation of JavaScript Promise Integration."_s) \
-    v(Bool, useMoreCurrencyDisplayChoices, false, Normal, "Enable more currencyDisplay choices for Intl.NumberFormat"_s) \
-    v(Bool, usePromiseIsPromise, false, Normal, nullptr) \
+    /* Not sourced from UnifiedWebPreferences.yaml: force-enabled via the cross-origin-isolation path and consumed in WebCore. */ \
     v(Bool, useSharedArrayBuffer, false, Normal, nullptr) \
-    v(Bool, useShadowRealm, false, Normal, "Expose the ShadowRealm object."_s) \
-    v(Bool, useTemporal, true, Normal, "Expose the Temporal object."_s) \
-    v(Bool, useIntlEraMonthcode, false, Normal, "Enable Intl.Era-monthcode Stage 4 proposal."_s) \
+    /* Not sourced from UnifiedWebPreferences.yaml: shares its semantics with the WebCore-bound TrustedTypes feature. */ \
     v(Bool, useTrustedTypes, true, Normal, "Enable trusted types eval protection feature."_s) \
-    v(Bool, useWasmJSStringBuiltins, true, Normal, "Enable the implementation of the JS String Builtins proposal."_s) \
-    v(Bool, useWasmMemory64, false, Normal, "Allow the Memory64 proposal for WebAssembly. This feature is currently only supported in the IPInt tier."_s) \
-    v(Bool, useWasmMemoryToBufferAPIs, true, Normal, "Enable the toFixedLengthBuffer() and toResizableBuffer() Wasm Memory.prototype functions."_s) \
-    v(Bool, useWasmMultiMemory, false, Normal, "Allow wasm code to access multiple linear memories") \
-    v(Bool, useWasmRelaxedSIMD, false, Normal, "Allow the relaxed simd instructions and types from the wasm relaxed simd spec."_s) \
-    v(Bool, useWasmSIMD, true, Normal, "Allow the new simd instructions and types from the wasm simd spec."_s) \
-    v(Bool, useWasmTailCalls, true, Normal, "Allow the new instructions from the wasm tail calls spec."_s) \
-    v(Bool, useWasmWideArithmetic, false, Normal, "Allow the wide arithmetic instructions from the wasm wide-arithmetic spec."_s) \
 
 
 

--- a/Source/WTF/Scripts/GeneratePreferences.rb
+++ b/Source/WTF/Scripts/GeneratePreferences.rb
@@ -39,7 +39,7 @@ optparse = OptionParser.new do |opts|
 
   opts.separator ""
 
-  opts.on("--frontend input", "frontend to generate preferences for (WebKit, WebKitLegacy)") { |frontend| options[:frontend] = frontend }
+  opts.on("--frontend input", "frontend to generate preferences for (WebKit, WebKitLegacy, WebCore, JavaScriptCore)") { |frontend| options[:frontend] = frontend }
   opts.on("--template input", "template to use for generation (may be specified multiple times)") { |template| options[:templates] << template }
   opts.on("--outputDir output", "directory to generate file in (default: cwd)") { |outputDir| options[:outputDirectory] = outputDir }
   opts.on("-h", "--help", "show this help message") { puts opts; exit 1 }
@@ -94,6 +94,7 @@ class Preference
   attr_accessor :richJavaScript
   attr_accessor :mediaPlaybackRelated
   attr_accessor :inspectorOverride
+  attr_accessor :jscOptionName
 
   def initialize(name, opts, frontend)
     @name = name
@@ -117,11 +118,14 @@ class Preference
     @condition = opts["condition"]
     @hidden = opts["hidden"] || false
     @defaultValues = opts["defaultValue"][frontend]
+    # JSC feature-flag options carry no JavaScriptCore default group; their default is the WebKit default.
+    @defaultValues ||= opts["defaultValue"]["WebKit"] if opts["jscOptionName"]
     @exposed = !opts["exposed"] || opts["exposed"].include?(frontend)
     @sharedPreferenceForWebProcess = opts["sharedPreferenceForWebProcess"] || false
     @richJavaScript = opts["richJavaScript"] || false
     @mediaPlaybackRelated = opts["mediaPlaybackRelated"] || false
     @inspectorOverride = opts["inspectorOverride"]
+    @jscOptionName = opts["jscOptionName"]
   end
 
   def nameLower
@@ -267,6 +271,8 @@ class Preferences
     @preferencesBoundToSetting = @preferences.select { |p| !p.webcoreBinding }
     @preferencesBoundToDeprecatedGlobalSettings = @preferences.select { |p| p.webcoreBinding == "DeprecatedGlobalSettings" }
 
+    @jscOptions = @preferences.select { |p| p.jscOptionName }.sort_by { |p| p.jscOptionName }
+
     @warning = "THIS FILE WAS AUTOMATICALLY GENERATED, DO NOT EDIT."
   end
 
@@ -286,6 +292,12 @@ class Preferences
         webcoreSettingOnly = !options["webcoreBinding"] && options["defaultValue"].keys == ["WebCore"]
         status = options["status"]
 
+        if options["jscOptionName"]
+          reject.call "Preference #{name} has jscOptionName, so it must set sharedPreferenceForWebProcess: true." if !options["sharedPreferenceForWebProcess"]
+          reject.call "Preference #{name} has jscOptionName, so it must specify a WebKit default value." if !options["defaultValue"]["WebKit"]
+          next if failed
+        end
+
         if %w{ unstable internal developer testable preview stable }.include?(status)
           reject.call "Preference #{name} has no humanReadableName, which is required." if !options["humanReadableName"]
           reject.call "Preference #{name} is visible in client UI and has a default value bound to WebCore::Settings, so it must have default values for all frontends" if webcoreSettingOnly
@@ -304,7 +316,11 @@ class Preferences
             end
         end
 
-        if options["defaultValue"].include?(@frontend)
+        # The JavaScriptCore "frontend" is the set of preferences that back a
+        # JSC::Options feature flag, identified by jscOptionName; every other frontend
+        # selects on the presence of its own default group.
+        includedInFrontend = @frontend == "JavaScriptCore" ? !options["jscOptionName"].nil? : options["defaultValue"].include?(@frontend)
+        if includedInFrontend
           preference = Preference.new(name, options, @frontend)
           @preferences << preference
           result << preference

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -701,6 +701,19 @@ AsyncOverflowScrollingEnabled:
     WebCore:
       default: false
 
+AsyncStackTraceEnabled:
+  type: bool
+  status: stable
+  category: javascript
+  humanReadableName: "Async Stack Traces"
+  humanReadableDescription: "Enable async stack traces"
+  webcoreBinding: none
+  jscOptionName: useAsyncStackTrace
+  sharedPreferenceForWebProcess: true
+  defaultValue:
+    WebKit:
+      default: true
+
 AsynchronousSpellCheckingEnabled:
   type: bool
   status: embedder
@@ -923,6 +936,19 @@ BidiContentAwarePasteEnabled:
     WebKitLegacy:
       default: false
     WebCore:
+      default: false
+
+BigIntMathMethodsEnabled:
+  type: bool
+  status: testable
+  category: javascript
+  humanReadableName: "BigInt Math Methods"
+  humanReadableDescription: "Enable BigInt math helper methods."
+  webcoreBinding: none
+  jscOptionName: useBigIntMathMethods
+  sharedPreferenceForWebProcess: true
+  defaultValue:
+    WebKit:
       default: false
 
 BlobFileAccessEnforcementEnabled:
@@ -3017,6 +3043,19 @@ ExperimentalSandboxEnabled:
     WebKit:
       default: false
 
+ExplicitResourceManagementEnabled:
+  type: bool
+  status: testable
+  category: javascript
+  humanReadableName: "Explicit Resource Management"
+  humanReadableDescription: "Enable explicit resource management builtins and syntax."
+  webcoreBinding: none
+  jscOptionName: useExplicitResourceManagement
+  sharedPreferenceForWebProcess: true
+  defaultValue:
+    WebKit:
+      default: false
+
 ExposeCaptureDevicesAfterCaptureEnabled:
   type: bool
   status: internal
@@ -4063,6 +4102,19 @@ ImageControlsEnabled:
     WebCore:
       default: false
 
+ImportDeferEnabled:
+  type: bool
+  status: testable
+  category: javascript
+  humanReadableName: "Import Defer"
+  humanReadableDescription: "Enable deferred module import."
+  webcoreBinding: none
+  jscOptionName: useImportDefer
+  sharedPreferenceForWebProcess: true
+  defaultValue:
+    WebKit:
+      default: false
+
 InactiveMediaCaptureStreamRepromptIntervalInMinutes:
   type: double
   status: embedder
@@ -4472,6 +4524,19 @@ InterruptVideoOnPageVisibilityChangeEnabled:
     WebCore:
       default: false
 
+IntlEraMonthcodeEnabled:
+  type: bool
+  status: testable
+  category: javascript
+  humanReadableName: "Intl Era and Month Code"
+  humanReadableDescription: "Enable Intl.Era-monthcode proposal."
+  webcoreBinding: none
+  jscOptionName: useIntlEraMonthcode
+  sharedPreferenceForWebProcess: true
+  defaultValue:
+    WebKit:
+      default: false
+
 InvisibleAutoplayNotPermitted:
   type: bool
   status: embedder
@@ -4608,6 +4673,58 @@ IsThirdPartyCookieBlockingDisabled:
     WebCore:
       default: false
 
+IteratorChunkingEnabled:
+  type: bool
+  status: testable
+  category: javascript
+  humanReadableName: "Iterator Chunking"
+  humanReadableDescription: "Expose the Iterator.prototype.chunks and Iterator.prototype.windows methods."
+  webcoreBinding: none
+  jscOptionName: useIteratorChunking
+  sharedPreferenceForWebProcess: true
+  defaultValue:
+    WebKit:
+      default: false
+
+IteratorIncludesEnabled:
+  type: bool
+  status: testable
+  category: javascript
+  humanReadableName: "Iterator Includes"
+  humanReadableDescription: "Expose the Iterator.includes method."
+  webcoreBinding: none
+  jscOptionName: useIteratorIncludes
+  sharedPreferenceForWebProcess: true
+  defaultValue:
+    WebKit:
+      default: false
+
+IteratorJoinEnabled:
+  type: bool
+  status: testable
+  category: javascript
+  humanReadableName: "Iterator Join"
+  humanReadableDescription: "Expose the Iterator.prototype.join method."
+  webcoreBinding: none
+  jscOptionName: useIteratorJoin
+  sharedPreferenceForWebProcess: true
+  defaultValue:
+    WebKit:
+      default: false
+
+IteratorSequencingEnabled:
+  type: bool
+  status: stable
+  category: javascript
+  humanReadableName: "Iterator Sequencing"
+  humanReadableDescription: "Expose the Iterator.concat method."
+  webcoreBinding: none
+  jscOptionName: useIteratorSequencing
+  sharedPreferenceForWebProcess: true
+  defaultValue:
+    WebKit:
+      default: true
+
 # FIXME: This is not relevent for WebKitLegacy, so should be excluded from WebKitLegacy entirely (though we should still set the default value to false when initializing settings).
 ItpDebugModeEnabled:
   type: bool
@@ -4622,6 +4739,32 @@ ItpDebugModeEnabled:
       default: false
     WebCore:
       default: false
+
+JSONSourceTextAccessEnabled:
+  type: bool
+  status: stable
+  category: javascript
+  humanReadableName: "JSON Source Text Access"
+  humanReadableDescription: "Expose JSON source text access feature."
+  webcoreBinding: none
+  jscOptionName: useJSONSourceTextAccess
+  sharedPreferenceForWebProcess: true
+  defaultValue:
+    WebKit:
+      default: true
+
+JSPIEnabled:
+  type: bool
+  status: stable
+  category: javascript
+  humanReadableName: "JavaScript Promise Integration"
+  humanReadableDescription: "Enable the implementation of JavaScript Promise Integration."
+  webcoreBinding: none
+  jscOptionName: useJSPI
+  sharedPreferenceForWebProcess: true
+  defaultValue:
+    WebKit:
+      default: true
 
 JavaScriptCanAccessClipboard:
   type: bool
@@ -5931,6 +6074,19 @@ MomentumScrollingAnimatorEnabled:
     WebCore:
       default: false
 
+MoreCurrencyDisplayChoicesEnabled:
+  type: bool
+  status: testable
+  category: javascript
+  humanReadableName: "More Currency Display Choices"
+  humanReadableDescription: "Enable more currencyDisplay choices for Intl.NumberFormat"
+  webcoreBinding: none
+  jscOptionName: useMoreCurrencyDisplayChoices
+  sharedPreferenceForWebProcess: true
+  defaultValue:
+    WebKit:
+      default: false
+
 MouseEventsSimulationEnabled:
   type: bool
   status: internal
@@ -6742,6 +6898,19 @@ ProcessSwapOnCrossSiteNavigationEnabled:
     WebKit:
       "PLATFORM(PLAYSTATION)": false
       default: true
+
+PromiseIsPromiseEnabled:
+  type: bool
+  status: testable
+  category: javascript
+  humanReadableName: "Promise.isPromise"
+  humanReadableDescription: "Expose the Promise.isPromise method."
+  webcoreBinding: none
+  jscOptionName: usePromiseIsPromise
+  sharedPreferenceForWebProcess: true
+  defaultValue:
+    WebKit:
+      default: false
 
 PropagateDamagingInformation:
    type: bool
@@ -7671,6 +7840,19 @@ SessionStorageEnabled:
       default: false
   sharedPreferenceForWebProcess: true
 
+ShadowRealmEnabled:
+  type: bool
+  status: testable
+  category: javascript
+  humanReadableName: "ShadowRealm"
+  humanReadableDescription: "Expose the ShadowRealm object."
+  webcoreBinding: none
+  jscOptionName: useShadowRealm
+  sharedPreferenceForWebProcess: true
+  defaultValue:
+    WebKit:
+      default: false
+
 ShadowRootReferenceTargetEnabled:
   type: bool
   status: testable
@@ -8448,6 +8630,19 @@ TelephoneNumberParsingEnabled:
       default: false
     WebCore:
       default: false
+
+TemporalEnabled:
+  type: bool
+  status: stable
+  category: javascript
+  humanReadableName: "Temporal"
+  humanReadableDescription: "Expose the Temporal object."
+  webcoreBinding: none
+  jscOptionName: useTemporal
+  sharedPreferenceForWebProcess: true
+  defaultValue:
+    WebKit:
+      default: true
 
 TemporaryTileCohortRetentionEnabled:
   type: bool
@@ -9467,6 +9662,110 @@ WantsBalancedSetDefersLoadingBehavior:
     WebKit:
       default: false
     WebCore:
+      default: false
+
+WasmJSStringBuiltinsEnabled:
+  type: bool
+  status: stable
+  category: javascript
+  humanReadableName: "WebAssembly JS String Builtins"
+  humanReadableDescription: "Enable the implementation of the JS String Builtins proposal."
+  webcoreBinding: none
+  jscOptionName: useWasmJSStringBuiltins
+  sharedPreferenceForWebProcess: true
+  defaultValue:
+    WebKit:
+      default: true
+
+WasmMemory64Enabled:
+  type: bool
+  status: testable
+  category: javascript
+  humanReadableName: "WebAssembly Memory64"
+  humanReadableDescription: "Allow the Memory64 proposal for WebAssembly. This feature is currently only supported in the IPInt tier."
+  webcoreBinding: none
+  jscOptionName: useWasmMemory64
+  sharedPreferenceForWebProcess: true
+  defaultValue:
+    WebKit:
+      default: false
+
+WasmMemoryToBufferAPIsEnabled:
+  type: bool
+  status: stable
+  category: javascript
+  humanReadableName: "WebAssembly Memory to Buffer APIs"
+  humanReadableDescription: "Enable the toFixedLengthBuffer() and toResizableBuffer() Wasm Memory.prototype functions."
+  webcoreBinding: none
+  jscOptionName: useWasmMemoryToBufferAPIs
+  sharedPreferenceForWebProcess: true
+  defaultValue:
+    WebKit:
+      default: true
+
+WasmMultiMemoryEnabled:
+  type: bool
+  status: testable
+  category: javascript
+  humanReadableName: "WebAssembly Multi-Memory"
+  humanReadableDescription: "Allow wasm code to access multiple linear memories"
+  webcoreBinding: none
+  jscOptionName: useWasmMultiMemory
+  sharedPreferenceForWebProcess: true
+  defaultValue:
+    WebKit:
+      default: false
+
+WasmRelaxedSIMDEnabled:
+  type: bool
+  status: testable
+  category: javascript
+  humanReadableName: "WebAssembly Relaxed SIMD"
+  humanReadableDescription: "Allow the relaxed simd instructions and types from the wasm relaxed simd spec."
+  webcoreBinding: none
+  jscOptionName: useWasmRelaxedSIMD
+  sharedPreferenceForWebProcess: true
+  defaultValue:
+    WebKit:
+      default: false
+
+WasmSIMDEnabled:
+  type: bool
+  status: stable
+  category: javascript
+  humanReadableName: "WebAssembly SIMD"
+  humanReadableDescription: "Allow the new simd instructions and types from the wasm simd spec."
+  webcoreBinding: none
+  jscOptionName: useWasmSIMD
+  sharedPreferenceForWebProcess: true
+  defaultValue:
+    WebKit:
+      default: true
+
+WasmTailCallsEnabled:
+  type: bool
+  status: stable
+  category: javascript
+  humanReadableName: "WebAssembly Tail Calls"
+  humanReadableDescription: "Allow the new instructions from the wasm tail calls spec."
+  webcoreBinding: none
+  jscOptionName: useWasmTailCalls
+  sharedPreferenceForWebProcess: true
+  defaultValue:
+    WebKit:
+      default: true
+
+WasmWideArithmeticEnabled:
+  type: bool
+  status: testable
+  category: javascript
+  humanReadableName: "WebAssembly Wide Arithmetic"
+  humanReadableDescription: "Allow the wide arithmetic instructions from the wasm wide-arithmetic spec."
+  webcoreBinding: none
+  jscOptionName: useWasmWideArithmetic
+  sharedPreferenceForWebProcess: true
+  defaultValue:
+    WebKit:
       default: false
 
 WebAPIStatisticsEnabled:

--- a/Source/WebKit/Scripts/PreferencesTemplates/SharedPreferencesForWebProcess.cpp.erb
+++ b/Source/WebKit/Scripts/PreferencesTemplates/SharedPreferencesForWebProcess.cpp.erb
@@ -91,4 +91,16 @@ bool updateSharedPreferencesForWebProcess(SharedPreferencesForWebProcess& shared
     return didChange;
 }
 
+JSCOptionsForWebProcess jscOptionsForWebProcess(const WebPreferencesStore& preferencesStore, bool isLockdownModeEnabled)
+{
+    // Project the JSC-option subset out of the full shared preferences so the values
+    // always match what SharedPreferencesForWebProcess would carry for the same store.
+    auto sharedPreferences = sharedPreferencesForWebProcess(preferencesStore, isLockdownModeEnabled);
+    JSCOptionsForWebProcess jscOptions;
+#define WEBKIT_COPY_JSC_OPTION_PREFERENCE(jscOption, preferenceField) jscOptions.preferenceField = sharedPreferences.preferenceField;
+    FOR_EACH_JSC_OPTION_SHARED_PREFERENCE(WEBKIT_COPY_JSC_OPTION_PREFERENCE)
+#undef WEBKIT_COPY_JSC_OPTION_PREFERENCE
+    return jscOptions;
+}
+
 } // namespace WebKit

--- a/Source/WebKit/Scripts/PreferencesTemplates/SharedPreferencesForWebProcess.h.erb
+++ b/Source/WebKit/Scripts/PreferencesTemplates/SharedPreferencesForWebProcess.h.erb
@@ -53,4 +53,25 @@ struct SharedPreferencesForWebProcess {
 SharedPreferencesForWebProcess sharedPreferencesForWebProcess(const WebPreferencesStore&, bool isLockdownModeEnabled);
 bool updateSharedPreferencesForWebProcess(SharedPreferencesForWebProcess&, const WebPreferencesStore&, bool isLockdownModeEnabled);
 
+// The subset of SharedPreferencesForWebProcess that backs JSC::Options feature flags.
+// It is delivered in WebProcessCreationParameters and applied to the process-global
+// JSC::Options before the first VM freezes them.
+struct JSCOptionsForWebProcess {
+<% @jscOptions.each do |pref| -%>
+    bool <%= pref.nameLower %> { <%= pref.defaultValues["default"] %> };
+<% end -%>
+
+    bool operator==(const JSCOptionsForWebProcess&) const = default;
+};
+
+JSCOptionsForWebProcess jscOptionsForWebProcess(const WebPreferencesStore&, bool isLockdownModeEnabled);
+
 } // namespace WebKit
+
+// Pairs each JSC::Options feature-flag option with the SharedPreferencesForWebProcess
+// field that carries its value: v(jscOption, sharedPreferenceField).
+#define FOR_EACH_JSC_OPTION_SHARED_PREFERENCE(v) \
+<% @jscOptions.each do |pref| -%>
+    v(<%= pref.jscOptionName %>, <%= pref.nameLower %>) \
+<% end -%>
+

--- a/Source/WebKit/Scripts/PreferencesTemplates/SharedPreferencesForWebProcess.serialization.in.erb
+++ b/Source/WebKit/Scripts/PreferencesTemplates/SharedPreferencesForWebProcess.serialization.in.erb
@@ -39,3 +39,10 @@ struct WebKit::SharedPreferencesForWebProcess {
 <%- end -%>
 <%- end -%>
 };
+
+header: "SharedPreferencesForWebProcess.h"
+[CustomHeader] struct WebKit::JSCOptionsForWebProcess {
+<% @jscOptions.each do |pref| -%>
+    bool <%= pref.nameLower %>;
+<% end -%>
+};

--- a/Source/WebKit/Shared/WebProcessCreationParameters.h
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.h
@@ -31,6 +31,7 @@
 #include "CacheModel.h"
 #include "SandboxExtension.h"
 #include "ScriptTrackingPrivacyFilter.h"
+#include "SharedPreferencesForWebProcess.h"
 #include "TextCheckerState.h"
 #include "UserData.h"
 
@@ -139,6 +140,11 @@ struct WebProcessCreationParameters {
     bool attrStyleEnabled { false };
     bool shouldThrowExceptionForGlobalConstantRedeclaration { true };
     WebCore::CrossOriginMode crossOriginMode { WebCore::CrossOriginMode::Shared }; // Cross-origin isolation via COOP+COEP headers.
+
+    // JSC feature-flag options delivered from the launching page's preferences and
+    // applied to the process-global JSC::Options before the first VM freezes them.
+    // See WebProcess::initializeWebProcess.
+    JSCOptionsForWebProcess jscOptions;
 
 #if ENABLE(SERVICE_CONTROLS)
     bool hasImageServices { false };

--- a/Source/WebKit/Shared/WebProcessCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.serialization.in
@@ -81,6 +81,7 @@ using WebCore::SystemSettings::State = WebCore::SystemSettingsState;
     bool attrStyleEnabled;
     bool shouldThrowExceptionForGlobalConstantRedeclaration;
     WebCore::CrossOriginMode crossOriginMode;
+    WebKit::JSCOptionsForWebProcess jscOptions;
 
 #if ENABLE(SERVICE_CONTROLS)
     bool hasImageServices;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -10347,7 +10347,7 @@ void WebPageProxy::triggerBrowsingContextGroupSwitchForNavigation(WebCore::Navig
     Ref processForNavigation = [&]() -> Ref<WebProcessProxy> {
         if (browsingContextGroupSwitchDecision == BrowsingContextGroupSwitchDecision::NewIsolatedGroup) {
             auto enableWebAssemblyDebugger = protect(m_configuration->preferences())->webAssemblyDebuggerEnabled() ? WebProcessProxy::EnableWebAssemblyDebugger::Yes : WebProcessProxy::EnableWebAssemblyDebugger::No;
-            return protect(m_configuration->processPool())->createNewWebProcess(protect(websiteDataStore()).ptr(), lockdownMode, enhancedSecurity, enableWebAssemblyDebugger, WebProcessProxy::IsPrewarmed::No, CrossOriginMode::Isolated);
+            return protect(m_configuration->processPool())->createNewWebProcess(protect(websiteDataStore()).ptr(), lockdownMode, enhancedSecurity, enableWebAssemblyDebugger, WebProcessProxy::IsPrewarmed::No, CrossOriginMode::Isolated, WebKit::jscOptionsForWebProcess(protect(m_configuration->preferences())->store(), lockdownMode == WebProcessProxy::LockdownMode::Enabled));
         }
         return protect(m_configuration->processPool())->processForSite(protect(websiteDataStore()), WebProcessProxy::IsolatedProcessType::MainFrame, responseSite, responseSite, { }, lockdownMode, enhancedSecurity, m_configuration, WebCore::ProcessSwapDisposition::COOP);
     }();

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -760,7 +760,7 @@ void WebProcessPool::establishRemoteWorkerContextConnectionToNetworkProcess(Remo
 
         WEBPROCESSPOOL_RELEASE_LOG_STATIC(ServiceWorker, "establishRemoteWorkerContextConnectionToNetworkProcess creating a new service worker process (process=%p, workerType=%" PUBLIC_LOG_STRING ", PID=%d)", remoteWorkerProcessProxy.get(), workerType == RemoteWorkerType::ServiceWorker ? "service" : "shared", remoteWorkerProcessProxy->processID());
 
-        processPool->initializeNewWebProcess(newProcessProxy, websiteDataStore.get());
+        processPool->initializeNewWebProcess(newProcessProxy, websiteDataStore.get(), WebProcessProxy::IsPrewarmed::No, WebProcessProxy::EnableWebAssemblyDebugger::No, WebKit::jscOptionsForWebProcess(preferencesStore.store, lockdownMode == WebProcessProxy::LockdownMode::Enabled));
         processPool->m_processes.append(WTF::move(newProcessProxy));
     }
 
@@ -826,10 +826,10 @@ void WebProcessPool::resolvePathsForSandboxExtensions()
     platformResolvePathsForSandboxExtensions();
 }
 
-Ref<WebProcessProxy> WebProcessPool::createNewWebProcess(WebsiteDataStore* websiteDataStore, WebProcessProxy::LockdownMode lockdownMode, EnhancedSecurity enhancedSecurity, WebProcessProxy::EnableWebAssemblyDebugger enableWebAssemblyDebugger, WebProcessProxy::IsPrewarmed isPrewarmed, CrossOriginMode crossOriginMode)
+Ref<WebProcessProxy> WebProcessPool::createNewWebProcess(WebsiteDataStore* websiteDataStore, WebProcessProxy::LockdownMode lockdownMode, EnhancedSecurity enhancedSecurity, WebProcessProxy::EnableWebAssemblyDebugger enableWebAssemblyDebugger, WebProcessProxy::IsPrewarmed isPrewarmed, CrossOriginMode crossOriginMode, JSCOptionsForWebProcess jscOptions)
 {
     auto processProxy = WebProcessProxy::create(*this, websiteDataStore, lockdownMode, enhancedSecurity, isPrewarmed, crossOriginMode, WebProcessProxy::ShouldLaunchProcess::Yes);
-    initializeNewWebProcess(processProxy, websiteDataStore, isPrewarmed, enableWebAssemblyDebugger);
+    initializeNewWebProcess(processProxy, websiteDataStore, isPrewarmed, enableWebAssemblyDebugger, jscOptions);
     m_processes.append(processProxy.copyRef());
 
     return processProxy;
@@ -843,6 +843,16 @@ RefPtr<WebProcessProxy> WebProcessPool::tryTakePrewarmedProcess(WebsiteDataStore
     if (protect(pageConfiguration.preferences())->webAssemblyDebuggerEnabled()) [[unlikely]]
         return nullptr;
 #endif
+
+    // A prewarmed process created its VM with the default JSC::Options (a pageless launch
+    // applies the default JSCOptionsForWebProcess), and those options are frozen once the VM
+    // exists. It can only serve a page whose feature-flag values all match those defaults; a
+    // page that needs different values must get a process launched with them. Other shared
+    // preferences are applied at runtime and so do not gate reuse here. See WebProcess::initializeWebProcess.
+    if (WebKit::jscOptionsForWebProcess(pageConfiguration.preferences().store(), lockdownMode == WebProcessProxy::LockdownMode::Enabled) != JSCOptionsForWebProcess { }) {
+        WEBPROCESSPOOL_RELEASE_LOG(Process, "tryTakePrewarmedProcess: Not using prewarmed process because the page requires non-default JavaScript feature flags");
+        return nullptr;
+    }
 
     RefPtr<WebProcessProxy> prewarmedProcess;
 
@@ -965,7 +975,7 @@ WebProcessDataStoreParameters WebProcessPool::webProcessDataStoreParameters(WebP
     };
 }
 
-void WebProcessPool::initializeNewWebProcess(WebProcessProxy& process, WebsiteDataStore* websiteDataStore, WebProcessProxy::IsPrewarmed isPrewarmed, WebProcessProxy::EnableWebAssemblyDebugger enableWebAssemblyDebugger)
+void WebProcessPool::initializeNewWebProcess(WebProcessProxy& process, WebsiteDataStore* websiteDataStore, WebProcessProxy::IsPrewarmed isPrewarmed, WebProcessProxy::EnableWebAssemblyDebugger enableWebAssemblyDebugger, JSCOptionsForWebProcess jscOptions)
 {
     WebProcessCreationParameters parameters;
     parameters.auxiliaryProcessParameters = AuxiliaryProcessProxy::auxiliaryProcessParameters();
@@ -1033,6 +1043,7 @@ void WebProcessPool::initializeNewWebProcess(WebProcessProxy& process, WebsiteDa
     parameters.attrStyleEnabled = m_configuration->attrStyleEnabled();
     parameters.shouldThrowExceptionForGlobalConstantRedeclaration = m_configuration->shouldThrowExceptionForGlobalConstantRedeclaration();
     parameters.crossOriginMode = process.crossOriginMode();
+    parameters.jscOptions = jscOptions;
 
 #if ENABLE(SERVICE_CONTROLS)
     auto& serviceController = ServicesController::singleton();
@@ -1313,7 +1324,7 @@ Ref<WebProcessProxy> WebProcessPool::processForSite(WebsiteDataStore& websiteDat
         }
     }
     auto enableWebAssemblyDebugger = protect(pageConfiguration.preferences())->webAssemblyDebuggerEnabled() ? WebProcessProxy::EnableWebAssemblyDebugger::Yes : WebProcessProxy::EnableWebAssemblyDebugger::No;
-    Ref process = createNewWebProcess(&websiteDataStore, lockdownMode, enhancedSecurity, enableWebAssemblyDebugger);
+    Ref process = createNewWebProcess(&websiteDataStore, lockdownMode, enhancedSecurity, enableWebAssemblyDebugger, WebProcessProxy::IsPrewarmed::No, CrossOriginMode::Shared, WebKit::jscOptionsForWebProcess(pageConfiguration.preferences().store(), lockdownMode == WebProcessProxy::LockdownMode::Enabled));
     process->setIsolatedProcessType(isolatedProcessType, mainFrameSite);
     if (processSwapDisposition == ProcessSwapDisposition::COOP)
         process->setIneligbleForWebProcessCache();

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -554,7 +554,7 @@ public:
     static void platformInitializeNetworkProcess(NetworkProcessCreationParameters&);
     static Vector<String> urlSchemesWithCustomProtocolHandlers();
 
-    Ref<WebProcessProxy> createNewWebProcess(WebsiteDataStore*, WebProcessProxy::LockdownMode, EnhancedSecurity, WebProcessProxy::EnableWebAssemblyDebugger = WebProcessProxy::EnableWebAssemblyDebugger::No, WebProcessProxy::IsPrewarmed = WebProcessProxy::IsPrewarmed::No, WebCore::CrossOriginMode = WebCore::CrossOriginMode::Shared);
+    Ref<WebProcessProxy> createNewWebProcess(WebsiteDataStore*, WebProcessProxy::LockdownMode, EnhancedSecurity, WebProcessProxy::EnableWebAssemblyDebugger = WebProcessProxy::EnableWebAssemblyDebugger::No, WebProcessProxy::IsPrewarmed = WebProcessProxy::IsPrewarmed::No, WebCore::CrossOriginMode = WebCore::CrossOriginMode::Shared, JSCOptionsForWebProcess = { });
 
     bool hasAudibleMediaActivity() const { return !!m_audibleMediaActivity; }
 #if PLATFORM(IOS_FAMILY)
@@ -644,7 +644,7 @@ private:
 
     RefPtr<WebProcessProxy> tryTakePrewarmedProcess(WebsiteDataStore&, WebProcessProxy::LockdownMode, EnhancedSecurity, const API::PageConfiguration&);
 
-    void initializeNewWebProcess(WebProcessProxy&, WebsiteDataStore*, WebProcessProxy::IsPrewarmed = WebProcessProxy::IsPrewarmed::No, WebProcessProxy::EnableWebAssemblyDebugger = WebProcessProxy::EnableWebAssemblyDebugger::No);
+    void initializeNewWebProcess(WebProcessProxy&, WebsiteDataStore*, WebProcessProxy::IsPrewarmed = WebProcessProxy::IsPrewarmed::No, WebProcessProxy::EnableWebAssemblyDebugger = WebProcessProxy::EnableWebAssemblyDebugger::No, JSCOptionsForWebProcess = { });
 
     void handleMessage(IPC::Connection&, const String& messageName, const UserData& messageBody);
     void handleSynchronousMessage(IPC::Connection&, const String& messageName, const UserData& messageBody, CompletionHandler<void(UserData&&)>&&);

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -694,7 +694,24 @@ void WebProcess::initializeWebProcess(WebProcessCreationParameters&& parameters,
     setMemoryCacheDisabled(parameters.memoryCacheDisabled);
 
     WebCore::DeprecatedGlobalSettings::setAttrStyleEnabled(parameters.attrStyleEnabled);
-    
+
+    // Push the launching page's feature-flag options into the process-global JSC::Options
+    // before the first VM is created. On first VM creation JSC::Options freeze and, in
+    // production, the config page is made read-only, so this is the only point at which
+    // these options can be set for this process; there is no safe later write. A page that
+    // needs different values is given a different web process by the UI process's process
+    // matching, so a single apply here is correct for the life of the process. For a
+    // pageless launch (prewarm/dummy) jscOptions is default-constructed to the option
+    // defaults, so this apply is a no-op. See commonVM() below, which creates the VM.
+    if (!WebCore::commonVMOrNull()) {
+        const auto& jscOptions = parameters.jscOptions;
+        JSC::Options::AllowUnfinalizedAccessScope scope;
+#define WEBKIT_APPLY_JSC_OPTION_FROM_SHARED_PREFERENCE(jscOption, preferenceField) JSC::Options::jscOption() = jscOptions.preferenceField;
+        FOR_EACH_JSC_OPTION_SHARED_PREFERENCE(WEBKIT_APPLY_JSC_OPTION_FROM_SHARED_PREFERENCE)
+#undef WEBKIT_APPLY_JSC_OPTION_FROM_SHARED_PREFERENCE
+        JSC::Options::notifyOptionsChanged();
+    }
+
     commonVM().setGlobalConstRedeclarationShouldThrow(parameters.shouldThrowExceptionForGlobalConstantRedeclaration);
 
     ScriptExecutionContext::setCrossOriginMode(parameters.crossOriginMode);

--- a/Tools/DumpRenderTree/mac/DumpRenderTree.mm
+++ b/Tools/DumpRenderTree/mac/DumpRenderTree.mm
@@ -1727,9 +1727,18 @@ static void setJSCOptions(const WTR::TestOptions& options)
         savedOptions.clear();
     }
 
-    if (options.jscOptions().length()) {
+    bool hasTestJSCOptions = options.jscOptions().length();
+    if (enableAllExperimentalFeatures || hasTestJSCOptions) {
         JSC::Options::dumpAllOptionsInALine(savedOptions);
-        JSC::Options::setOptions(options.jscOptions().c_str());
+        if (enableAllExperimentalFeatures) {
+            JSC::Options::AllowUnfinalizedAccessScope scope;
+#define WEBKIT_ENABLE_JSC_EXPERIMENTAL_OPTION(type, jscOption, defaultValue, status, description) JSC::Options::jscOption() = true;
+            FOR_EACH_JSC_WEB_PREFERENCE_OPTION(WEBKIT_ENABLE_JSC_EXPERIMENTAL_OPTION)
+#undef WEBKIT_ENABLE_JSC_EXPERIMENTAL_OPTION
+            JSC::Options::notifyOptionsChanged();
+        }
+        if (hasTestJSCOptions)
+            JSC::Options::setOptions(options.jscOptions().c_str());
     }
 }
 


### PR DESCRIPTION
#### 3af9d4073d75a9b44668cebc03a41223dbef5745
<pre>
JSC feature flags should be driven by UnifiedWebPreferences.yaml
<a href="https://bugs.webkit.org/show_bug.cgi?id=319384">https://bugs.webkit.org/show_bug.cgi?id=319384</a>
<a href="https://rdar.apple.com/182210113">rdar://182210113</a>

Reviewed by Ben Nham.

JSC&apos;s feature-flag options (e.g. useTemporal, useJSPI, and the wasm feature
flags) were declared standalone in OptionsList.h, separate from the web
preferences tracking other features. Move them into UnifiedWebPreferences.yaml.
Each is declared as a web preference with a jscOptionName tying it to its
JSC::Options option. GeneratePreferences.rb emits
FOR_EACH_JSC_WEB_PREFERENCE_OPTION, which is spliced into FOR_EACH_JSC_OPTION
in OptionsList.h, so the options are still declared there but are now sourced
from the yaml. It also generates, in SharedPreferencesForWebProcess.h, a
compact JSCOptionsForWebProcess struct with only the JSC options and a
FOR_EACH_JSC_OPTION_SHARED_PREFERENCE pairing macro.

JSC::Options freeze on first VM creation (and are made read-only in production),
so the launching page&apos;s values must reach the web process beforehand. They are
carried in WebProcessCreationParameters and applied in
WebProcess::initializeWebProcess ahead of commonVM(). A prewarmed process freezes
at the option defaults, so it is only reused for a page whose options match those
defaults. WebKitLegacy has no web process, so DumpRenderTree applies the options
in-process.

Also, re-baseline wasm WPT tests now that the JSC experimental options are
visible to the tests.

Canonical link: <a href="https://commits.webkit.org/317306@main">https://commits.webkit.org/317306@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/625064a73537e7a5e9c87917d7406d1911804716

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174858 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48791 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42572 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184438 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132766 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dd22cb73-5bc9-44e6-9862-7b4f4dc47d77) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176723 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50083 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48474 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136076 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/17a96cae-7d80-4bef-b5ee-050e45a723fe) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177816 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39513 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156871 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116555 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3366158f-9790-4237-ba05-fcffbcc38ea4) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/174180 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38154 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36534 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32916 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5380 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148577 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36363 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186863 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/36120 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/40284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40734 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145008 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48458 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144867 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49138 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32984 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114949 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26572 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39740 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121237 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/211950 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47644 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11333 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55283 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47046 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47277 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47104 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->