### PR TITLE
[WPE] Add a documentation section about compiling against the WPE platform

### DIFF
--- a/Source/WebKit/WPEPlatform/docs/compiling.md
+++ b/Source/WebKit/WPEPlatform/docs/compiling.md
@@ -1,0 +1,92 @@
+Title: Compiling against WPEPlatform
+Slug: compiling
+
+# Compiling against WPEPlatform
+
+This page lists the `pkg-config` modules and headers an application or
+browser needs to build against WPEPlatform, plus minimal
+[CMake](https://cmake.org) and [Meson](https://mesonbuild.com/)
+snippets. For a higher-level introduction to the API see
+[overview](overview.html).
+
+## pkg-config modules
+
+All of WPEPlatform's code is compiled into a single shared library,
+`libWPEWebKit-2.0`; there is no separate per-backend library. What
+varies is the set of installed `pkg-config` modules: the core
+`wpe-platform-2.0` module is always present and carries the compiler
+and linker flags (it links `libWPEWebKit-2.0`), while each per-backend
+module is installed only when its built-in implementation was enabled
+at build time (see [Build-time availability](#build-time-availability)
+below) and simply depends on the core module.
+
+| Module | Header | What it provides |
+|---|---|---|
+| `wpe-platform-2.0` | `<wpe/wpe-platform.h>` | The core API: [class@Display], [class@View], [class@Toplevel], [class@Buffer], events, settings, keymap, clipboard, gamepad, input-method, screens. |
+| `wpe-platform-wayland-2.0` | `<wpe/wayland/wpe-wayland.h>` | The built-in Wayland implementation (`wpe_display_wayland_new()`, `WPEScreenWayland`, `WPEToplevelWayland`, `WPEViewWayland`, `WPEClipboardWayland`). |
+| `wpe-platform-drm-2.0` | `<wpe/drm/wpe-drm.h>` | The built-in DRM/KMS implementation (`wpe_display_drm_new()`, related screen/toplevel/view classes). |
+| `wpe-platform-headless-2.0` | `<wpe/headless/wpe-headless.h>` | The built-in headless implementation (`wpe_display_headless_new()`, headless toplevel/view). |
+| `wpe-webkit-2.0` | `<wpe/webkit.h>` | The higher-level WebKit API. Almost every application needs this in addition to `wpe-platform-2.0`. |
+
+## Build-time availability
+
+WPEPlatform is gated behind WPE WebKit's `ENABLE_WPE_PLATFORM` CMake
+option. As of writing this option defaults to
+`ENABLE_DEVELOPER_MODE`, which means **release builds and distribution
+packages may ship without it**. Before assuming any of the modules
+above exist on a target, confirm that WPE WebKit was built with
+`-DENABLE_WPE_PLATFORM=ON`, or probe for the module from your build
+system:
+
+```sh
+pkg-config --exists wpe-platform-2.0 && echo present
+```
+
+The per-backend implementations are independently optional via
+`ENABLE_WPE_PLATFORM_WAYLAND`, `ENABLE_WPE_PLATFORM_DRM`, and
+`ENABLE_WPE_PLATFORM_HEADLESS` (all default `ON` when WPEPlatform
+itself is enabled). The DRM built-in additionally requires GBM
+(`USE_GBM`), so `wpe-platform-drm-2.0` is absent when GBM is
+unavailable even with the option left on. If your application pins to
+a specific built-in implementation, probe for that module too:
+
+```sh
+pkg-config --exists wpe-platform-wayland-2.0 || \
+    echo "Wayland built-in not available; fall back to the default display"
+```
+
+In most cases applications should prefer [func@Display.get_default]
+and let WPEPlatform pick whichever implementation is installed, rather
+than hard-linking against a specific backend.
+
+## CMake
+
+```cmake
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(WPEPlatform REQUIRED IMPORTED_TARGET wpe-platform-2.0)
+pkg_check_modules(WPEWebKit   REQUIRED IMPORTED_TARGET wpe-webkit-2.0)
+
+# Optional: only link the Wayland built-in if you need its symbols.
+pkg_check_modules(WPEPlatformWayland IMPORTED_TARGET wpe-platform-wayland-2.0)
+
+add_executable(my-browser main.c)
+target_link_libraries(my-browser PRIVATE
+    PkgConfig::WPEPlatform
+    PkgConfig::WPEWebKit
+)
+```
+
+## Meson
+
+```meson
+wpe_platform_dep = dependency('wpe-platform-2.0')
+wpe_webkit_dep   = dependency('wpe-webkit-2.0')
+
+# Optional Wayland built-in.
+wpe_platform_wayland_dep = dependency('wpe-platform-wayland-2.0',
+                                      required: false)
+
+executable('my-browser', 'main.c',
+    dependencies: [wpe_platform_dep, wpe_webkit_dep],
+)
+```

--- a/Source/WebKit/WPEPlatform/docs/wpeplatform.toml.in
+++ b/Source/WebKit/WPEPlatform/docs/wpeplatform.toml.in
@@ -36,6 +36,7 @@ base_url = "https://github.com/WebKit/WebKit/tree/main"
 [extra]
 content_files = [
     "overview.md",
+    "compiling.md",
     "tutorial-browser.md",
     "tutorial-platform.md"
 ]


### PR DESCRIPTION
#### 0a59594c2eb08f97ed562c60e559b53060f2580d
<pre>
[WPE] Add a documentation section about compiling against the WPE platform
<a href="https://bugs.webkit.org/show_bug.cgi?id=319385">https://bugs.webkit.org/show_bug.cgi?id=319385</a>

Reviewed by Adrian Perez de Castro.

This will be referenced from the tutorial section.

* Source/WebKit/WPEPlatform/docs/compiling.md: Added.
* Source/WebKit/WPEPlatform/docs/wpeplatform.toml.in:

Canonical link: <a href="https://commits.webkit.org/317185@main">https://commits.webkit.org/317185@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/680ebb4cc193e138b297b64bca01db4e2995b321

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174525 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48458 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42239 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184102 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132393 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49750 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48141 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135782 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177483 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39220 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156580 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116260 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37861 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32583 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148284 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36072 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186528 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/39791 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144698 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48125 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144558 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48804 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26527 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39455 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120784 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47311 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11037 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46713 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46944 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46771 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->