### PR TITLE
[JSC] Make releaseBBQCallee tolerate missing BBQ

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp
@@ -218,20 +218,20 @@ void CalleeGroup::releaseBBQCallee(const AbstractLocker& locker, FunctionCodeInd
     // tier it up soon.
     m_ipintCallees->at(functionIndex)->tierUpCounter().resetAndOptimizeSoon(m_mode);
 
-    // We could have triggered a tier up from a BBQCallee has MemoryMode::BoundsChecking
-    // but is currently running a MemoryMode::Signaling memory. In that case there may
-    // be nothing to release.
-    if (auto* tuple = optimizedCalleesTuple(locker, functionIndex)) [[likely]] {
-        RefPtr<BBQCallee> bbqCallee;
-        {
-            Locker bbqLocker { tuple->m_bbqCalleeLock };
-            bbqCallee = tuple->m_bbqCallee.convertToWeak();
-        }
-        bbqCallee->reportToVMsForDestruction();
+    // OMG may install without a same-mode BBQCallee (e.g. BoundsChecking BBQ while
+    // running Signaling memory). In that case there may be nothing to release.
+    auto* tuple = optimizedCalleesTuple(locker, functionIndex);
+    if (!tuple) [[unlikely]]
         return;
-    }
 
-    ASSERT(mode() == MemoryMode::Signaling);
+    RefPtr<BBQCallee> bbqCallee;
+    {
+        Locker bbqLocker { tuple->m_bbqCalleeLock };
+        if (!tuple->m_bbqCallee.isStrong() || !tuple->m_bbqCallee.get())
+            return;
+        bbqCallee = tuple->m_bbqCallee.convertToWeak();
+    }
+    bbqCallee->reportToVMsForDestruction();
 }
 #endif
 


### PR DESCRIPTION
#### fb935fc3e266c357c09b4f0e65b4d7c8c03f263a
<pre>
[JSC] Make releaseBBQCallee tolerate missing BBQ
<a href="https://bugs.webkit.org/show_bug.cgi?id=290296">https://bugs.webkit.org/show_bug.cgi?id=290296</a>

Reviewed by Yusuke Suzuki.

When freeRetiredWasmCode retires BBQ after OMG installs, there is not
always a same-mode BBQCallee to release. releaseBBQCallee assumed a
BBQ was present whenever an optimized-callee tuple existed, so
convertToWeak() followed by reportToVMsForDestruction() could null-deref
on a strong nullptr, and the fallback ASSERT required Signaling memory
— which is wrong for BoundsChecking and flaked on
workers/wasm-hashset.html in debug.

Only convert and report when the BBQ slot is still strong and non-null;
return early when there is no tuple or no BBQ. Drop the Signaling-only
assert.

* Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp:
(JSC::Wasm::CalleeGroup::releaseBBQCallee): Guard missing BBQ;
drop Signaling-only assert.

Canonical link: <a href="https://commits.webkit.org/317822@main">https://commits.webkit.org/317822@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa1743ff2ae4c7df9267de2a309fc1762739a49b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176329 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50264 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44054 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185925 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51556 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49948 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137344 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179285 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40825 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158119 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117819 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39474 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37837 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/6628 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149890 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37617 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34394 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/37597 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41991 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42048 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188349 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49929 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146380 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50613 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34234 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146198 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26788 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40967 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122817 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/116836 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49117 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12592 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48519 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48753 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48578 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->