### PR TITLE
[WPT] Various test cases in custom-elements/registries/element-mutation.html fail

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/ShadowRoot-init-declarative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/ShadowRoot-init-declarative-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Custom element inside 'shadowrootcustomelementregistry' declarative shadow root should use document's registry as attachShadow default registry assert_equals: expected object "[object CustomElementRegistry]" but got null
+PASS Custom element inside 'shadowrootcustomelementregistry' declarative shadow root should use document's registry as attachShadow default registry
 PASS Built-in element inside 'shadowrootcustomelementregistry' declarative shadow root should use document's registry as attachShadow default registry
 PASS Built-in element inside 'shadowrootcustomelementregistry' shadow root parsed via setHTMLUnsafe should use null registry
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/element-mutation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/element-mutation-expected.txt
@@ -1,17 +1,17 @@
 
 PASS An element with global registry should not change its registry when run append into a shadow tree with scoped registry.
-FAIL An element with scoped registry should not change its registry when run append out of the shadow tree. assert_equals: expected object "[object CustomElementRegistry]" but got object "[object CustomElementRegistry]"
-FAIL An element with scoped registry should not change its registry when run append into another shadow tree with different scoped registry. assert_equals: expected object "[object CustomElementRegistry]" but got object "[object CustomElementRegistry]"
+PASS An element with scoped registry should not change its registry when run append out of the shadow tree.
+PASS An element with scoped registry should not change its registry when run append into another shadow tree with different scoped registry.
 PASS A freshly created element should preserve global registry after append into and removal from a scoped shadow root.
 PASS A freshly created element should preserve global registry when run append between scoped shadow roots.
 PASS An element with global registry should not change its registry when run appendChild into a shadow tree with scoped registry.
-FAIL An element with scoped registry should not change its registry when run appendChild out of the shadow tree. assert_equals: expected object "[object CustomElementRegistry]" but got object "[object CustomElementRegistry]"
-FAIL An element with scoped registry should not change its registry when run appendChild into another shadow tree with different scoped registry. assert_equals: expected object "[object CustomElementRegistry]" but got object "[object CustomElementRegistry]"
+PASS An element with scoped registry should not change its registry when run appendChild out of the shadow tree.
+PASS An element with scoped registry should not change its registry when run appendChild into another shadow tree with different scoped registry.
 PASS A freshly created element should preserve global registry after appendChild into and removal from a scoped shadow root.
 PASS A freshly created element should preserve global registry when run appendChild between scoped shadow roots.
 PASS An element with global registry should not change its registry when run prepend into a shadow tree with scoped registry.
-FAIL An element with scoped registry should not change its registry when run prepend out of the shadow tree. assert_equals: expected object "[object CustomElementRegistry]" but got object "[object CustomElementRegistry]"
-FAIL An element with scoped registry should not change its registry when run prepend into another shadow tree with different scoped registry. assert_equals: expected object "[object CustomElementRegistry]" but got object "[object CustomElementRegistry]"
+PASS An element with scoped registry should not change its registry when run prepend out of the shadow tree.
+PASS An element with scoped registry should not change its registry when run prepend into another shadow tree with different scoped registry.
 PASS A freshly created element should preserve global registry after prepend into and removal from a scoped shadow root.
 PASS A freshly created element should preserve global registry when run prepend between scoped shadow roots.
 

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -3476,7 +3476,7 @@ ExceptionOr<ShadowRoot&> Element::attachShadow(const ShadowRootInit& init, std::
     }
     auto scopedRegistry = ShadowRootScopedCustomElementRegistry::No;
     if (!registryKind)
-        registryKind = !registry && usesNullCustomElementRegistry() ? CustomElementRegistryKind::Null : CustomElementRegistryKind::Window;
+        registryKind = CustomElementRegistryKind::Window;
     if (registryKind == CustomElementRegistryKind::Null) {
         ASSERT(!registry);
         scopedRegistry = ShadowRootScopedCustomElementRegistry::Yes;

--- a/Source/WebCore/html/parser/HTMLConstructionSite.cpp
+++ b/Source/WebCore/html/parser/HTMLConstructionSite.cpp
@@ -861,12 +861,12 @@ std::tuple<RefPtr<HTMLElement>, RefPtr<JSCustomElementInterface>, RefPtr<CustomE
             } else
                 element = HTMLUnknownElement::create(qualifiedName, ownerDocument);
         }
-        if (!registry && treeScope->rootNode().usesNullCustomElementRegistry())
-            element->setUsesNullCustomElementRegistry();
     }
     ASSERT(element);
-    if (m_isParsingFragment && !registry && containerForCurrentNode().usesNullCustomElementRegistry())
-        element->setUsesNullCustomElementRegistry();
+    if (!registry) {
+        if (m_isParsingFragment ? containerForCurrentNode().usesNullCustomElementRegistry() : treeScope->rootNode().usesNullCustomElementRegistry())
+            element->setUsesNullCustomElementRegistry();
+    }
     if (registry && registry->isScoped() && registry != treeScope->customElementRegistry()) [[unlikely]]
         CustomElementRegistry::addToScopedCustomElementRegistryMap(*element, *registry);
 


### PR DESCRIPTION
#### ae158f8fc58313a4daffc8fe8f6307086d08c0f9
<pre>
[WPT] Various test cases in custom-elements/registries/element-mutation.html fail
<a href="https://bugs.webkit.org/show_bug.cgi?id=319388">https://bugs.webkit.org/show_bug.cgi?id=319388</a>

Reviewed by NOBODY (OOPS!).

The failure was caused by a built-in element (e.g. div) parsed inside a shadowrootcustomelementregistry
(null-registry) declarative shadow root not getting the usesNullCustomElementRegistry flag - only custom
elements and unknown elements did (in HTMLConstructionSite::createHTMLElementOrFindCustomElementInterface
inside the if (!element) block). The built-in element merely resolved to null via its tree scope.

That worked for the original (parsed before any global registry was ensured), but broke on cloning: once
the global registry exists, cloning the subtree runs the clone through Element::insertionSteps, where
treeScope().customElementRegistry() (null), which differs from document().customElementRegistry() (global)
pins it to the global registry in the scoped map. Once pinned, registry.initialize(shadowRoot) could no
longer hand it the scoped registry - hence the failures.

This PR applies two fixes to address the failures.

1. HTMLConstructionSite.cpp - set usesNullCustomElementRegistry on all elements (built-in included) parsed
   inside a null-registry tree scope, so an element behaves identically to its clones and keeps resolving
   to null across mutations. This unifies the previously separate custom-element and fragment-parsing branches.
2. Element::attachShadow - an imperative attachShadow() with no explicit registry now always defaults to
   the document&apos;s registry, instead of null when the host carries the null-registry flag. The host stays null;
   only the new shadow root uses the global registry.

(2) is required because (1) gives built-in elements the flag, and without it their attachShadow default would
flip to null. As a bonus, it also fixes the pre-existing ShadowRoot-init-declarative.html custom-element FAIL
(which failed for exactly this reason).

Test: imported/w3c/web-platform-tests/custom-elements/registries/element-mutation.html

* LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/ShadowRoot-init-declarative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/element-mutation-expected.txt:
* Source/WebCore/dom/Element.cpp:
* Source/WebCore/html/parser/HTMLConstructionSite.cpp:
(WebCore::HTMLConstructionSite::createHTMLElementOrFindCustomElementInterface):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ae158f8fc58313a4daffc8fe8f6307086d08c0f9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174517 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48450 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42231 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184094 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132385 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7b467e29-7489-4097-afde-7cfa8907aa24) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176382 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49742 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48133 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135772 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d448eb12-3159-4584-bf9d-8d44b6404dc6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177475 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39212 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156570 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116250 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dff2b321-1869-4e7c-9819-9ccd7393d5da) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37853 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36222 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32575 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148276 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36062 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186520 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39765 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40419 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144690 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48117 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144549 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48796 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32682 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/held.https.any.sharedworker.html (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39449 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120774 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47303 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11026 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46705 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46936 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46763 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->