### PR TITLE
Picture-in-Picture stops updating MediaStream video frames

### DIFF
--- a/LayoutTests/media/picture-in-picture/picture-in-picture-media-stream-frames-expected.txt
+++ b/LayoutTests/media/picture-in-picture/picture-in-picture-media-stream-frames-expected.txt
@@ -1,0 +1,24 @@
+
+RUN(internals.settings.setAllowsPictureInPictureMediaPlayback(true))
+RUN(internals.setMockVideoPresentationModeEnabled(true))
+RUN(video.srcObject = canvas.captureStream())
+EVENT(playing)
+
+Test that frames keep arriving while the video is inline:
+RUN(inlineFrameCount = video.getVideoPlaybackQuality().totalVideoFrames)
+EXPECTED (video.getVideoPlaybackQuality().totalVideoFrames > inlineFrameCount == 'true') OK
+
+Test that frames keep arriving after entering Picture-in-Picture:
+RUN(video.requestPictureInPicture())
+EVENT(enterpictureinpicture)
+EXPECTED (internals.mediaElementViewportVisibility(video) == 'VisibleInPictureInPicture') OK
+RUN(pipFrameCount = video.getVideoPlaybackQuality().totalVideoFrames)
+EXPECTED (video.getVideoPlaybackQuality().totalVideoFrames > pipFrameCount == 'true') OK
+
+Test that frames keep arriving after leaving Picture-in-Picture:
+RUN(document.exitPictureInPicture())
+EVENT(leavepictureinpicture)
+RUN(inlineAgainFrameCount = video.getVideoPlaybackQuality().totalVideoFrames)
+EXPECTED (video.getVideoPlaybackQuality().totalVideoFrames > inlineAgainFrameCount == 'true') OK
+END OF TEST
+

--- a/LayoutTests/media/picture-in-picture/picture-in-picture-media-stream-frames.html
+++ b/LayoutTests/media/picture-in-picture/picture-in-picture-media-stream-frames.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<script src="../video-test.js"></script>
+	<script>
+	window.addEventListener('load', event => {
+		runTest().then(endTest).catch(failTest);
+	})
+
+	var canvas;
+	var drawTimer;
+
+	function drawFrame()
+	{
+		var context = canvas.getContext('2d');
+		context.fillStyle = context.fillStyle == 'red' ? 'green' : 'red';
+		context.fillRect(0, 0, canvas.width, canvas.height);
+		drawTimer = setTimeout(drawFrame, 50);
+	}
+
+	async function runTest() {
+		if (!window.internals)
+			throw('Requires window.internals');
+
+		run('internals.settings.setAllowsPictureInPictureMediaPlayback(true)');
+		run('internals.setMockVideoPresentationModeEnabled(true)');
+
+		canvas = document.getElementById('canvas');
+		findMediaElement();
+
+		drawFrame();
+		run('video.srcObject = canvas.captureStream()');
+		await waitFor(video, 'playing');
+
+		consoleWrite('');
+		consoleWrite('Test that frames keep arriving while the video is inline:');
+		run('inlineFrameCount = video.getVideoPlaybackQuality().totalVideoFrames');
+		await testExpectedEventually('video.getVideoPlaybackQuality().totalVideoFrames > inlineFrameCount', true, '==', 3000);
+
+		consoleWrite('');
+		consoleWrite('Test that frames keep arriving after entering Picture-in-Picture:');
+		internals.withUserGesture(() => {
+			return run('video.requestPictureInPicture()');
+		});
+		await waitFor(video, 'enterpictureinpicture');
+		await testExpectedEventually('internals.mediaElementViewportVisibility(video)', 'VisibleInPictureInPicture', '==', 1000);
+
+		run('pipFrameCount = video.getVideoPlaybackQuality().totalVideoFrames');
+		await testExpectedEventually('video.getVideoPlaybackQuality().totalVideoFrames > pipFrameCount', true, '==', 3000);
+
+		consoleWrite('');
+		consoleWrite('Test that frames keep arriving after leaving Picture-in-Picture:');
+		internals.withUserGesture(() => {
+			return run('document.exitPictureInPicture()');
+		});
+		await waitFor(video, 'leavepictureinpicture');
+
+		run('inlineAgainFrameCount = video.getVideoPlaybackQuality().totalVideoFrames');
+		await testExpectedEventually('video.getVideoPlaybackQuality().totalVideoFrames > inlineAgainFrameCount', true, '==', 3000);
+
+		clearTimeout(drawTimer);
+	}
+	</script>
+</head>
+<body>
+	<canvas id='canvas' width='160' height='120'></canvas>
+	<video controls autoplay></video>
+</body>
+</html>

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -9920,6 +9920,9 @@ void HTMLMediaElement::setFullscreenMode(VideoFullscreenMode mode)
     schedulePlaybackControlsManagerUpdate();
     scheduleUpdateAcceleratedRenderingState();
 
+    if (RefPtr player = this->player())
+        player->setViewportVisibility(viewportVisibility());
+
     updatePlayerDynamicRangeLimit();
 }
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
@@ -717,7 +717,10 @@ void MediaPlayerPrivateMediaStreamAVFObjC::setVisibleForCanvas(bool)
 
 void MediaPlayerPrivateMediaStreamAVFObjC::setViewportVisibility(ViewportVisibility visibility)
 {
-    m_isVisibleInViewPort = visibility == ViewportVisibility::VisibleInViewport;
+    if (visibility == ViewportVisibility::NotVisible || visibility == ViewportVisibility::IntersectingViewport)
+        m_isVisibleInViewPort = false;
+    else
+        m_isVisibleInViewPort = true;
 }
 
 MediaTime MediaPlayerPrivateMediaStreamAVFObjC::duration() const


### PR DESCRIPTION
#### f2396869a1715c1e06b0b3a9bb9644cd5271c20a
<pre>
Picture-in-Picture stops updating MediaStream video frames
<a href="https://bugs.webkit.org/show_bug.cgi?id=319387">https://bugs.webkit.org/show_bug.cgi?id=319387</a>
<a href="https://rdar.apple.com/180740366">rdar://180740366</a>

Reviewed by Jer Noble.

314324@main added &quot;VisibleInFullscreen&quot; and
&quot;VisibleInPictureInPicture&quot; to enum MediaPlayerViewportVisibility but
didn&apos;t update MediaPlayerPrivateMediaStreamAVFObjC::setViewportVisibility
to know that these values indicate that m_isVisibleInViewPort should
be set to true.

Also, now that viewport visibility can change when the fullscreen mode changes,
we should call setViewportVisibility when the fullscreen mode changes to keep
m_isVisibleInViewPort up to date.

New test: LayoutTests/media/picture-in-picture/picture-in-picture-media-stream-frames.html

* LayoutTests/media/picture-in-picture/picture-in-picture-media-stream-frames-expected.txt: Added.
* LayoutTests/media/picture-in-picture/picture-in-picture-media-stream-frames.html: Added.
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::setFullscreenMode):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::setViewportVisibility):

Canonical link: <a href="https://commits.webkit.org/317345@main">https://commits.webkit.org/317345@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b502621868f9a094938b3f46f6d45f71baf73c13

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175013 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48946 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42727 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184594 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/132921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/efd6743e-e826-44bf-a734-a814ca990d71) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176878 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50238 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48629 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136210 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/132921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dbdbf26f-f35b-4b60-9eca-9b3cbeb2d777) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177971 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39647 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157000 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116689 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38288 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33071 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148711 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36492 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187018 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/40526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145151 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48613 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156556 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145008 "Passed tests") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49293 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115111 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26593 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39870 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/121432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47799 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11465 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47202 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47432 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47259 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->