### PR TITLE
[JSC] Use JSSlimPromiseReaction for JSAsyncGenerator queue

### DIFF
--- a/Source/JavaScriptCore/runtime/JSAsyncGenerator.cpp
+++ b/Source/JavaScriptCore/runtime/JSAsyncGenerator.cpp
@@ -90,30 +90,26 @@ void JSAsyncGenerator::enqueue(VM& vm, JSValue value, int32_t mode, JSObject* se
     } else {
         JSValue last = queue();
         if (last.isNull()) {
-            auto* item = JSFullPromiseReaction::create(
+            auto* item = JSSlimPromiseReaction::createAsyncGeneratorRequest(
                 vm,
                 settlementTarget,
                 value,
-                jsNumber(mode),
-                jsUndefined(), // Will be set to self (prev)
+                static_cast<uint8_t>(mode),
                 nullptr // Will be set to self (next)
             );
             item->setNext(vm, item);
-            item->setContext(vm, item);
             setQueue(vm, item);
         } else {
-            auto* tail = uncheckedDowncast<JSFullPromiseReaction>(last);
-            auto* head = uncheckedDowncast<JSFullPromiseReaction>(tail->next());
-            auto* item = JSFullPromiseReaction::create(
+            auto* tail = uncheckedDowncast<JSSlimPromiseReaction>(last);
+            auto* head = uncheckedDowncast<JSSlimPromiseReaction>(tail->next());
+            auto* item = JSSlimPromiseReaction::createAsyncGeneratorRequest(
                 vm,
                 settlementTarget,
                 value,
-                jsNumber(mode),
-                tail, // prev = old tail
+                static_cast<uint8_t>(mode),
                 head // next = head (to maintain circular)
             );
             tail->setNext(vm, item);
-            head->setContext(vm, item);
             setQueue(vm, item);
         }
     }
@@ -131,18 +127,17 @@ JSObject* JSAsyncGenerator::dequeue(VM& vm)
         setResumeValue(vm, jsUndefined());
         setResumePromise(vm, jsUndefined());
     } else {
-        auto* tail = uncheckedDowncast<JSFullPromiseReaction>(last);
-        auto* head = uncheckedDowncast<JSFullPromiseReaction>(tail->next());
+        auto* tail = uncheckedDowncast<JSSlimPromiseReaction>(last);
+        auto* head = uncheckedDowncast<JSSlimPromiseReaction>(tail->next());
 
         setResumePromise(vm, head->promise());
-        setResumeValue(vm, head->onFulfilled());
-        setResumeMode(head->onRejected().asInt32());
+        setResumeValue(vm, head->handlerOrContext());
+        setResumeMode(head->asyncGeneratorResumeMode());
 
         if (head == tail)
             setQueue(vm, jsNull());
         else {
-            auto* newHead = uncheckedDowncast<JSFullPromiseReaction>(head->next());
-            newHead->setContext(vm, tail); // newHead.prev = tail
+            auto* newHead = uncheckedDowncast<JSSlimPromiseReaction>(head->next());
             tail->setNext(vm, newHead);
         }
     }

--- a/Source/JavaScriptCore/runtime/JSPromiseReaction.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromiseReaction.cpp
@@ -67,7 +67,7 @@ const ClassInfo JSSlimPromiseReaction::s_info = { "SlimPromiseReaction"_s, &JSPr
 
 JSSlimPromiseReaction* JSSlimPromiseReaction::create(VM& vm, JSValue promise, JSValue handler, bool isFulfill, JSPromiseReaction* next)
 {
-    JSSlimPromiseReaction* result = new (NotNull, allocateCell<JSSlimPromiseReaction>(vm)) JSSlimPromiseReaction(vm, vm.slimPromiseReactionStructure.get(), promise, handler, next, InternalMicrotask::None, isFulfill);
+    JSSlimPromiseReaction* result = new (NotNull, allocateCell<JSSlimPromiseReaction>(vm)) JSSlimPromiseReaction(vm, vm.slimPromiseReactionStructure.get(), promise, handler, next, static_cast<uint8_t>(InternalMicrotask::None), isFulfill);
     result->finishCreation(vm);
     return result;
 }
@@ -75,7 +75,14 @@ JSSlimPromiseReaction* JSSlimPromiseReaction::create(VM& vm, JSValue promise, JS
 JSSlimPromiseReaction* JSSlimPromiseReaction::create(VM& vm, JSValue promise, InternalMicrotask task, JSValue context, JSPromiseReaction* next)
 {
     ASSERT(task != InternalMicrotask::None);
-    JSSlimPromiseReaction* result = new (NotNull, allocateCell<JSSlimPromiseReaction>(vm)) JSSlimPromiseReaction(vm, vm.slimPromiseReactionStructure.get(), promise, context, next, task, false);
+    JSSlimPromiseReaction* result = new (NotNull, allocateCell<JSSlimPromiseReaction>(vm)) JSSlimPromiseReaction(vm, vm.slimPromiseReactionStructure.get(), promise, context, next, static_cast<uint8_t>(task), false);
+    result->finishCreation(vm);
+    return result;
+}
+
+JSSlimPromiseReaction* JSSlimPromiseReaction::createAsyncGeneratorRequest(VM& vm, JSValue settlementTarget, JSValue value, uint8_t resumeMode, JSPromiseReaction* next)
+{
+    JSSlimPromiseReaction* result = new (NotNull, allocateCell<JSSlimPromiseReaction>(vm)) JSSlimPromiseReaction(vm, vm.slimPromiseReactionStructure.get(), settlementTarget, value, next, resumeMode, false);
     result->finishCreation(vm);
     return result;
 }

--- a/Source/JavaScriptCore/runtime/JSPromiseReaction.h
+++ b/Source/JavaScriptCore/runtime/JSPromiseReaction.h
@@ -57,10 +57,10 @@ public:
     static JSValue tryGetContext(JSValue reactionsValue);
 
 protected:
-    JSPromiseReaction(VM& vm, Structure* structure, JSValue promise, JSPromiseReaction* next, InternalMicrotask task = InternalMicrotask::None)
+    JSPromiseReaction(VM& vm, Structure* structure, JSValue promise, JSPromiseReaction* next, uint8_t payload)
         : Base(vm, structure)
         , m_promise(promise, WriteBarrierEarlyInit)
-        , m_next(next, static_cast<uint8_t>(task))
+        , m_next(next, payload)
     {
     }
 
@@ -86,14 +86,17 @@ public:
     static JSSlimPromiseReaction* create(VM&, JSValue promise, JSValue handler, bool isFulfill, JSPromiseReaction* next);
     static JSSlimPromiseReaction* create(VM&, JSValue promise, InternalMicrotask, JSValue context, JSPromiseReaction* next);
 
+    static JSSlimPromiseReaction* createAsyncGeneratorRequest(VM&, JSValue settlementTarget, JSValue value, uint8_t resumeMode, JSPromiseReaction* next);
+    uint8_t asyncGeneratorResumeMode() const { return m_next.type(); }
+
     bool isFulfillHandler() const { return perCellBit(); }
 
     JSValue handlerOrContext() const { return m_handlerOrContext.get(); }
     void setHandlerOrContext(VM& vm, JSValue value) { m_handlerOrContext.set(vm, this, value); }
 
 private:
-    JSSlimPromiseReaction(VM& vm, Structure* structure, JSValue promise, JSValue handlerOrContext, JSPromiseReaction* next, InternalMicrotask task, bool isFulfill)
-        : Base(vm, structure, promise, next, task)
+    JSSlimPromiseReaction(VM& vm, Structure* structure, JSValue promise, JSValue handlerOrContext, JSPromiseReaction* next, uint8_t payload, bool isFulfill)
+        : Base(vm, structure, promise, next, payload)
         , m_handlerOrContext(handlerOrContext, WriteBarrierEarlyInit)
     {
         if (isFulfill)
@@ -128,9 +131,10 @@ public:
     void setOnRejected(VM& vm, JSValue value) { m_onRejected.set(vm, this, value); }
     void setContext(VM& vm, JSValue value) { m_context.set(vm, this, value); }
 
+
 private:
     JSFullPromiseReaction(VM& vm, Structure* structure, JSValue promise, JSValue onFulfilled, JSValue onRejected, JSValue context, JSPromiseReaction* next)
-        : Base(vm, structure, promise, next)
+        : Base(vm, structure, promise, next, static_cast<uint8_t>(InternalMicrotask::None))
         , m_onFulfilled(onFulfilled, WriteBarrierEarlyInit)
         , m_onRejected(onRejected, WriteBarrierEarlyInit)
         , m_context(context, WriteBarrierEarlyInit)


### PR DESCRIPTION
#### 74cc52330394d1cad391692a951228eb6db5e8d4
<pre>
[JSC] Use JSSlimPromiseReaction for JSAsyncGenerator queue
<a href="https://bugs.webkit.org/show_bug.cgi?id=319393">https://bugs.webkit.org/show_bug.cgi?id=319393</a>
<a href="https://rdar.apple.com/182224083">rdar://182224083</a>

Reviewed by Keith Miller.

We can stop using JSFullPromiseReaction and use JSSlimPromiseReaction if
we apply the following changes in JSAsyncGenerator.

1. We can just use circular singly-linked-list for queueing. Since
   queueing is always just enqueue and dequeue, we do not need to have
   doubly-linked-list.
2. Pack resumeMode into JSSlimPromiseReaction&apos;s payload.

* Source/JavaScriptCore/runtime/JSAsyncGenerator.cpp:
(JSC::JSAsyncGenerator::enqueue):
(JSC::JSAsyncGenerator::dequeue):
* Source/JavaScriptCore/runtime/JSPromiseReaction.cpp:
(JSC::JSSlimPromiseReaction::create):
(JSC::JSSlimPromiseReaction::createAsyncGeneratorRequest):
* Source/JavaScriptCore/runtime/JSPromiseReaction.h:
(JSC::JSPromiseReaction::JSPromiseReaction):

Canonical link: <a href="https://commits.webkit.org/317181@main">https://commits.webkit.org/317181@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b269cbd66dc2c07bbed55ad8e15050f0a81f7b8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174530 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48463 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42244 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184107 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132398 "Failed to checkout and rebase branch from PR 69389") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b092c27a-e820-43e1-91c1-0f466560aecf) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49755 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48146 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135785 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/132398 "Failed to checkout and rebase branch from PR 69389") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4c336e22-0e89-4a4a-a753-67222a5eb23d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177488 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39228 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/156586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116263 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e9a5ccbd-2ccb-44e4-9ed9-69239da8d417) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37869 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32588 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5095 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/148292 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36078 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186533 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/35792 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/39800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144702 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48130 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144562 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48809 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26526 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39458 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120791 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/211583 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47316 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11043 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55204 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46718 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46949 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46776 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->