### PR TITLE
AX: Make replacement of the placeholder empty-content tree more robust, and add more diagnostic information when tree building fails

### DIFF
--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -402,6 +402,16 @@ bool AXObjectCache::shouldServeInitialCachedFrame()
 }
 
 static constexpr Seconds updateTreeSnapshotTimerInterval { 100_ms };
+
+// The isolated tree is initially served as a temporary empty-content placeholder (AXIsolatedTree::createEmpty)
+// while the full tree is built off the client-request critical path in buildIsolatedTree(). If that build
+// transiently fails (e.g. a detached document during navigation), the build timer repeats at this interval
+// until it succeeds, so we don't get stuck serving the empty placeholder.
+static constexpr Seconds buildIsolatedTreeRetryInterval { 200_ms };
+// Give up after this long so a cache that can never build a tree (e.g. its document is gone for good) doesn't
+// wake up forever.
+static constexpr Seconds buildIsolatedTreeMaxRetryDuration { 60_s };
+static constexpr unsigned buildIsolatedTreeMaxRetries = static_cast<unsigned>(buildIsolatedTreeMaxRetryDuration / buildIsolatedTreeRetryInterval);
 #endif
 
 AXObjectCache::AXObjectCache(LocalFrame& localFrame, Document* document)
@@ -1258,8 +1268,12 @@ RefPtr<AXIsolatedTree> AXObjectCache::getOrCreateIsolatedTree()
         // build a temporary "empty" isolated tree consisting only of the ScrollView and the
         // WebArea objects. Then we schedule building the entire isolated tree on a Timer.
         tree = AXIsolatedTree::createEmpty(*this);
-        if (!m_buildIsolatedTreeTimer.isActive())
-            m_buildIsolatedTreeTimer.startOneShot(0_s);
+        // Repeat the build until it succeeds (buildIsolatedTree() stops the timer on success), so a single
+        // failed build attempt can't leave us permanently serving the empty-content placeholder.
+        if (!m_buildIsolatedTreeTimer.isActive()) {
+            m_buildIsolatedTreeRetryCount = 0;
+            m_buildIsolatedTreeTimer.start(0_s, buildIsolatedTreeRetryInterval);
+        }
     }
 
     return tree;
@@ -1267,14 +1281,32 @@ RefPtr<AXIsolatedTree> AXObjectCache::getOrCreateIsolatedTree()
 
 void AXObjectCache::buildIsolatedTree()
 {
-    m_buildIsolatedTreeTimer.stop();
-
-    RefPtr tree = AXIsolatedTree::create(*this);
-
-    if (RefPtr webArea = rootWebArea()) {
-        postPlatformNotification(*webArea, AXNotification::LoadComplete);
-        postPlatformNotification(*webArea, AXNotification::FocusedUIElementChanged);
+    if (m_isBuildingIsolatedTree) {
+        // Building the tree for a large document can take a while. If we're still working on it when the
+        // timer fires again, early-exit.
+        return;
     }
+    SetForScope buildingIsolatedTree(m_isBuildingIsolatedTree, true);
+
+    if (RefPtr tree = AXIsolatedTree::create(*this)) {
+        // The temporary empty-content placeholder has been replaced with the full tree, so stop retrying.
+        m_buildIsolatedTreeTimer.stop();
+        m_buildIsolatedTreeRetryCount = 0;
+        m_lastIsolatedTreeBuildFailed = false;
+
+        if (RefPtr webArea = rootWebArea()) {
+            postPlatformNotification(*webArea, AXNotification::LoadComplete);
+            postPlatformNotification(*webArea, AXNotification::FocusedUIElementChanged);
+        }
+        return;
+    }
+
+    // create() returned null, so the build failed.
+    m_lastIsolatedTreeBuildFailed = true;
+    m_documentPresentAtLastIsolatedTreeBuildFailure = !!document();
+
+    if (++m_buildIsolatedTreeRetryCount >= buildIsolatedTreeMaxRetries)
+        m_buildIsolatedTreeTimer.stop();
 }
 
 void AXObjectCache::setIsolatedTree(Ref<AXIsolatedTree> tree)
@@ -6230,6 +6262,7 @@ AXTreeData AXObjectCache::treeData(std::optional<OptionSet<AXStreamOptions>> add
     TextStream stream(TextStream::LineMode::MultipleLine);
 
     stream << "\nAXObjectTree:\n";
+    stream << "Tree ID: " << treeID().loggingString() << "\n";
     stream << "Loading progress: " << m_loadingProgress << "\n";
 
     RefPtr document = this->document();
@@ -6271,9 +6304,21 @@ AXTreeData AXObjectCache::treeData(std::optional<OptionSet<AXStreamOptions>> add
 
         stream << "\nAXIsolatedTree:\n";
 
+        // Build-timer diagnostics (state on the AXObjectCache). Useful when the tree is stuck as an
+        // empty-content placeholder because the full-tree build never succeeded. gaveUp=yes means we
+        // exhausted buildIsolatedTreeMaxRetries and will no longer retry for this cache.
+        stream << "Build status: inProgress=" << (m_isBuildingIsolatedTree ? "yes" : "no")
+            << ", retries=" << m_buildIsolatedTreeRetryCount << "/" << buildIsolatedTreeMaxRetries
+            << ", gaveUp=" << (m_buildIsolatedTreeRetryCount >= buildIsolatedTreeMaxRetries ? "yes" : "no")
+            << ", lastBuildFailed=" << (m_lastIsolatedTreeBuildFailed ? "yes" : "no")
+            << ", documentPresentAtLastFailure=" << (m_documentPresentAtLastIsolatedTreeBuildFailure ? "yes" : "no")
+            << ", buildTimerActive=" << (m_buildIsolatedTreeTimer.isActive() ? "yes" : "no") << "\n";
+
         RefPtr tree = getOrCreateIsolatedTree();
         if (tree) {
+            stream << "Tree ID: " << tree->treeID().loggingString() << "\n";
             stream << "Loading progress: " << tree->loadingProgress() << ", isEmptyContentTree: " << (tree->isEmptyContentTree() ? "yes" : "no") << ", nodeMapSize: " << tree->nodeMapSize() << "\n";
+            stream << "Creation anomalies: emptyContentMissingRoot=" << (tree->emptyContentCreatedWithoutRoot() ? "yes" : "no") << ", fullTreeMissingRoot=" << (tree->fullTreeCreatedWithoutRoot() ? "yes" : "no") << ", webAreaMissing=" << (tree->webAreaMissingAtCreation() ? "yes" : "no") << "\n";
             if (auto focusID = tree->unsafeFocusedNodeID())
                 stream << "Focused object: ID=" << focusID->loggingString() << "\n";
             else

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -1115,6 +1115,15 @@ private:
     const Ref<AXGeometryManager> m_geometryManager;
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     Timer m_buildIsolatedTreeTimer;
+    // True while buildIsolatedTree() is running, to guard against re-entrant builds.
+    bool m_isBuildingIsolatedTree { false };
+    // Consecutive failed isolated-tree build attempts. The build timer gives up once this reaches
+    // buildIsolatedTreeMaxRetries.
+    unsigned m_buildIsolatedTreeRetryCount { 0 };
+    // Diagnostics for the most recent buildIsolatedTree() attempt where AXIsolatedTree::create()
+    // returned null.
+    bool m_lastIsolatedTreeBuildFailed { false };
+    bool m_documentPresentAtLastIsolatedTreeBuildFailure { false };
     bool m_deferredRegenerateIsolatedTree { false };
     DeferrableOneShotTimer m_selectedTextRangeTimer;
     Markable<AXID> m_lastDebouncedTextRangeObject;

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -125,7 +125,8 @@ Ref<AXIsolatedTree> AXIsolatedTree::createEmpty(AXObjectCache& axObjectCache)
     if (RefPtr axRoot = axObjectCache.document() ? axObjectCache.getOrCreate(axObjectCache.document()->view()) : nullptr) {
         tree->updatingSubtree(axRoot.get());
         tree->createEmptyContent(*axRoot);
-    }
+    } else
+        tree->m_emptyContentCreatedWithoutRoot = true;
 
     tree->updateLoadingProgress(axObjectCache.loadingProgress());
     tree->m_processingProgress = 0;
@@ -163,6 +164,7 @@ void AXIsolatedTree::createEmptyContent(AccessibilityObject& axRoot)
     });
     if (!axWebArea) {
         // FIXME: Can hit this almost 100% of the time on google.com with ENABLE(ACCESSIBILITY_LOCAL_FRAME).
+        m_webAreaMissingAtCreation = true;
         AX_BROKEN_ASSERT_NOT_REACHED();
         return;
     }
@@ -209,6 +211,8 @@ RefPtr<AXIsolatedTree> AXIsolatedTree::create(AXObjectCache& axObjectCache)
     RefPtr axRoot = axObjectCache.getOrCreate(document->view());
     if (axRoot)
         tree->generateSubtree(*axRoot);
+    else
+        tree->m_fullTreeCreatedWithoutRoot = true;
 
     if (RefPtr axFocus = axObjectCache.focusedObjectForPage(document->page()))
         tree->setFocusedNodeID(axFocus->objectID());

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -437,6 +437,16 @@ public:
     static Ref<AXIsolatedTree> createEmpty(AXObjectCache&);
     constexpr bool isEmptyContentTree() const { return m_isEmptyContentTree; }
     unsigned nodeMapSize() const { return m_nodeMap.size(); }
+
+    // Diagnostics for a broken tree. See AXObjectCache::treeData().
+    // True if createEmpty() couldn't obtain the root ScrollView, so the empty-content placeholder was
+    // created without a root (createEmptyContent() was never reached).
+    bool emptyContentCreatedWithoutRoot() const { return m_emptyContentCreatedWithoutRoot; }
+    // True if create() couldn't obtain the root ScrollView, so the full tree was built with no content.
+    bool fullTreeCreatedWithoutRoot() const { return m_fullTreeCreatedWithoutRoot; }
+    // True if createEmptyContent() couldn't find the WebArea child and bailed (see the FIXME there).
+    bool webAreaMissingAtCreation() const { return m_webAreaMissingAtCreation; }
+
     virtual ~AXIsolatedTree();
 
     static void removeTreeForFrameID(FrameIdentifier);
@@ -762,6 +772,11 @@ private:
     // These are placed here to fit in padding that would otherwise be between m_pendingSortedLiveRegionIDs and m_pendingSortedNonRootWebAreaIDs.
     OptionSet<ActivityState> m_pageActivityState;
     bool m_isEmptyContentTree { false };
+    // Diagnostics for a degenerate tree; surfaced in AXObjectCache::treeData(). Only written on the main
+    // thread at creation time.
+    bool m_emptyContentCreatedWithoutRoot { false };
+    bool m_fullTreeCreatedWithoutRoot { false };
+    bool m_webAreaMissingAtCreation { false };
     bool m_queuedForDestruction WTF_GUARDED_BY_LOCK(m_changeLogLock) { false };
     bool m_isMainFrame { false };
     bool m_siteIsolationEnabled { false };


### PR DESCRIPTION
#### bfb2fbfbd35510eff4911869dcd2ba517a7f5b7b
<pre>
AX: Make replacement of the placeholder empty-content tree more robust, and add more diagnostic information when tree building fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=319398">https://bugs.webkit.org/show_bug.cgi?id=319398</a>
<a href="https://rdar.apple.com/182225753">rdar://182225753</a>

Reviewed by NOBODY (OOPS!).

Today, AXObjectCache::getOrCreateIsolatedTree() serves a temporary empty-content isolated tree
(AXIsolatedTree::createEmpty() — just the ScrollView and WebArea) and schedules AXObjectCache::buildIsolatedTree()
on a one-shot timer to replace it with the full tree via AXIsolatedTree::create() -&gt; storeTree().

This swap was a single-shot with no retry. If that one build didn&apos;t store a full
tree — e.g. AXIsolatedTree::create() returned null because the document was
transiently detached — nothing ever retried.  Every subsequent getOrCreateIsolatedTree()
returned the already-stored empty placeholder. The tree was then permanently stuck as the
empty placeholder, so VoiceOver read &quot;empty web content&quot;.

This commit makes the build self-healing by repeating the build timer until it succeeds:

  - getOrCreateIsolatedTree() now starts m_buildIsolatedTreeTimer as a repeating
    timer (immediate first fire, then every buildIsolatedTreeRetryInterval) instead
    of a single 0s one-shot.

  - buildIsolatedTree() stops the timer only once AXIsolatedTree::create() returns a
    full tree, and gives up after buildIsolatedTreeMaxRetries (~60s) so a cache that
    can never build a tree doesn&apos;t wake up forever. It also guards against re-entrant
    builds while a long build is in progress.

Also add diagnostics to the tree dump (AXObjectCache::treeData()) to make this
class of failure obvious next time:

  - The AXObjectCache and AXIsolatedTree tree IDs, potentially helpful in
    determining whether we are calling applyPendingChanges() on the wrong
    tree in response to client requests.

  - Build status: in-progress, retry count / cap, gave-up, whether the last build
    failed, whether a document was present at that failure, and whether the build
    timer is active.

  - Creation anomalies: the empty-content placeholder was created without a root, the
    full tree was created without a root, or createEmptyContent() couldn&apos;t find the
    WebArea child.

* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::getOrCreateIsolatedTree):
(WebCore::AXObjectCache::buildIsolatedTree):
(WebCore::AXObjectCache::treeData):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::createEmpty):
(WebCore::AXIsolatedTree::createEmptyContent):
(WebCore::AXIsolatedTree::create):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
(WebCore::AXIsolatedTree::emptyContentCreatedWithoutRoot const):
(WebCore::AXIsolatedTree::fullTreeCreatedWithoutRoot const):
(WebCore::AXIsolatedTree::webAreaMissingAtCreation const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bfb2fbfbd35510eff4911869dcd2ba517a7f5b7b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174535 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48468 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42249 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184112 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132403 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/795f5213-e895-42bc-91c6-0a062267d3e3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176400 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49760 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48151 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135790 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95829 "5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2c8a8e48-157c-4913-b4aa-a03762d2a480) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177493 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39224 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156583 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116268 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d2af743c-8c59-4796-ae77-1c0209e86ace) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37865 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36237 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32593 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148288 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36075 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186538 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39788 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40434 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144706 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48135 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144567 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48814 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32695 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/bfcache/abort.tentative.https.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114626 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39462 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120797 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47321 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11040 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46723 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46954 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46781 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->