### PR TITLE
[JSC][Temporal][Intl.Era] Add useIntlEraMonthcode option and narrow AvailableCalendars

### DIFF
--- a/JSTests/stress/temporal-calendar-canonical-set.js
+++ b/JSTests/stress/temporal-calendar-canonical-set.js
@@ -1,0 +1,58 @@
+//@ requireOptions("--useTemporal=1", "--useIntlEraMonthcode=1")
+
+// Regression for proposal-intl-era-monthcode Phase 0.
+
+function shouldBe(actual, expected, label) {
+    if (actual !== expected)
+        throw new Error(`${label}: expected ${expected}, got ${actual}`);
+}
+
+const canonical = ["buddhist", "chinese", "coptic", "dangi", "ethioaa", "ethiopic",
+    "gregory", "hebrew", "indian", "islamic-civil", "islamic-tbla",
+    "islamic-umalqura", "iso8601", "japanese", "persian", "roc"];
+const nonCanonical = ["islamic", "islamic-rgsa", "bangla", "gujarati", "kannada",
+    "marathi", "odia", "tamil", "telugu", "vikram"];
+
+// Intl.supportedValuesOf contains the canonical set. Under the flag, JSC also
+// excludes non-canonical entries (V8 currently still lists them).
+{
+    const ids = Intl.supportedValuesOf("calendar");
+    for (const c of canonical)
+        shouldBe(ids.includes(c), true, `supportedValuesOf contains ${c}`);
+    if (typeof $vm !== "undefined") {
+        for (const nc of nonCanonical)
+            shouldBe(ids.includes(nc), false, `supportedValuesOf must not contain ${nc}`);
+    }
+}
+
+// Temporal accepts canonical.
+for (const id of canonical) {
+    const pd = Temporal.PlainDate.from({ year: 2024, month: 1, day: 1, calendar: id });
+    shouldBe(pd.calendarId, id, `Temporal accepts ${id}`);
+}
+
+// Legacy CLDR aliases canonicalize.
+shouldBe(Temporal.PlainDate.from({ year: 1445, month: 1, day: 1, calendar: "islamicc" }).calendarId, "islamic-civil", "islamicc -> islamic-civil");
+shouldBe(Temporal.PlainDate.from({ year: 2016, month: 1, day: 1, calendar: "ethiopic-amete-alem" }).calendarId, "ethioaa", "ethiopic-amete-alem -> ethioaa");
+
+// Temporal rejects non-canonical.
+for (const id of [...nonCanonical, "nonexistent"]) {
+    let threw = false;
+    try { Temporal.PlainDate.from({ year: 2024, month: 1, day: 1, calendar: id }); }
+    catch (e) { threw = e instanceof RangeError; }
+    shouldBe(threw, true, `Temporal rejects ${id}`);
+}
+
+// Intl.DateTimeFormat: bare islamic -> islamic-tbla (JSC-only; V8 hasn't caught up).
+if (typeof $vm !== "undefined") {
+    shouldBe(new Intl.DateTimeFormat("en", { calendar: "islamic" }).resolvedOptions().calendar, "islamic-tbla", "islamic -> islamic-tbla");
+}
+
+// Indic variants fall back to a member of AvailableCalendars.
+{
+    const available = Intl.supportedValuesOf("calendar");
+    for (const id of ["bangla", "gujarati", "kannada", "marathi", "odia", "tamil", "telugu", "vikram"]) {
+        const resolved = new Intl.DateTimeFormat("en", { calendar: id }).resolvedOptions().calendar;
+        shouldBe(available.includes(resolved), true, `${id} falls back into AvailableCalendars: got ${resolved}`);
+    }
+}

--- a/JSTests/test262/config.yaml
+++ b/JSTests/test262/config.yaml
@@ -4,6 +4,7 @@ flags:
   SharedArrayBuffer: useSharedArrayBuffer
   Atomics: useSharedArrayBuffer
   Temporal: useTemporal
+  Intl.Era-monthcode: useIntlEraMonthcode
   ShadowRealm: useShadowRealm
   json-parse-with-source: useJSONSourceTextAccess
   iterator-sequencing: useIteratorSequencing

--- a/Source/JavaScriptCore/API/tests/TemporalCoreTest.cpp
+++ b/Source/JavaScriptCore/API/tests/TemporalCoreTest.cpp
@@ -36,12 +36,14 @@
 #include "JSCTimeZone.h"
 #include "PlainDateTimeCore.h"
 #include "Rounding.h"
+#include "TemporalCalendar.h"
 #include "TemporalCoreTypes.h"
 #include "TemporalEnums.h"
 #include "TimeZoneICUBridge.h"
 #include "ZonedDateTimeCore.h"
 #include <stdio.h>
 #include <wtf/Int128.h>
+#include <wtf/text/MakeString.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
@@ -2789,6 +2791,29 @@ static void testCalendarDateFromFields()
     TCHECK_TRUE(rEth.has_value() && rEth->year() == 2023, "ethiopic: am 2016 -> ISO 2023");
 }
 
+static void testIsBuiltinCalendar()
+{
+    // Canonical (16 entries) — accepted regardless of flag.
+    auto calenders = { "buddhist"_s, "chinese"_s, "coptic"_s, "dangi"_s, "ethioaa"_s,
+        "ethiopic"_s, "gregory"_s, "hebrew"_s, "indian"_s,
+        "islamic-civil"_s, "islamic-tbla"_s, "islamic-umalqura"_s,
+        "iso8601"_s, "japanese"_s, "persian"_s, "roc"_s };
+    for (auto id : calenders)
+        TCHECK_TRUE(JSC::isBuiltinCalendar(id).has_value(), makeString(id, ": canonical accepted"_s).utf8().data());
+
+    // Legacy CLDR aliases resolve to their canonical CalendarID (both flag states).
+    TCHECK_TRUE(JSC::isBuiltinCalendar("islamicc"_s).has_value(), "islamicc alias -> islamic-civil");
+    TCHECK_TRUE(JSC::isBuiltinCalendar("ethiopic-amete-alem"_s).has_value(), "ethiopic-amete-alem alias -> ethioaa");
+    TCHECK_TRUE(*JSC::isBuiltinCalendar("islamicc"_s) == *JSC::isBuiltinCalendar("islamic-civil"_s), "islamicc same CalendarID as islamic-civil");
+    TCHECK_TRUE(*JSC::isBuiltinCalendar("ethiopic-amete-alem"_s) == *JSC::isBuiltinCalendar("ethioaa"_s), "ethiopic-amete-alem same CalendarID as ethioaa");
+
+    // Unknown identifier: rejected in either mode.
+    TCHECK_TRUE(!JSC::isBuiltinCalendar("nonexistent-calendar-name"_s).has_value(), "unknown -> nullopt");
+
+    // Case-insensitive canonical: ISO8601 accepted regardless of case.
+    TCHECK_TRUE(JSC::isBuiltinCalendar("ISO8601"_s).has_value(), "ISO8601 case-insensitive accepted");
+}
+
 static void testCalendarICUNonISO()
 {
     // Gregory calendar: same as ISO for modern dates
@@ -3810,6 +3835,7 @@ static void runStressTests()
     testCalendarISO8601Fields(); // ISO field accessors
     testCalendarICUNonISO(); // Non-ISO calendars (hebrew, chinese, japanese, persian)
     testCalendarDateFromFields(); // calendarDateFromFields: era, monthCode, overflow, ROC, Japanese, Buddhist, Coptic, Ethiopic
+    testIsBuiltinCalendar(); // Canonical Temporal calendar set + legacy aliases
     testCalendarFieldsFunctions(); // yearMonthFromFields, monthDayFromFields, differenceYearMonth, plainYearMonthAdd, etc.
 
     // parseISODateTime

--- a/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
@@ -802,6 +802,13 @@ void IntlDateTimeFormat::initializeDateTimeFormat(JSGlobalObject* globalObject, 
             // Handling "islamicc" candidate for backward compatibility.
             if (calendar == "islamicc"_s)
                 calendar = "islamic-civil"_s;
+            if (Options::useIntlEraMonthcode()) {
+                // https://tc39.es/proposal-intl-era-monthcode/#sec-createdatetimeformat step 9
+                if (calendar == "islamic"_s)
+                    calendar = "islamic-tbla"_s;
+                if (!intlAvailableCalendarIndex().contains(calendar))
+                    calendar = defaultCalendarForLocale(resolved.dataLocale);
+            }
         }
         impl->m_calendar = WTF::move(calendar);
     }

--- a/Source/JavaScriptCore/runtime/IntlObject.cpp
+++ b/Source/JavaScriptCore/runtime/IntlObject.cpp
@@ -1713,33 +1713,49 @@ const Vector<String>& intlAvailableCalendars()
     static LazyNeverDestroyed<Vector<String>> availableCalendars;
     static std::once_flag initializeOnce;
     std::call_once(initializeOnce, [&] {
-        UErrorCode status = U_ZERO_ERROR;
-        auto enumeration = std::unique_ptr<UEnumeration, ICUDeleter<uenum_close>>(ucal_getKeywordValuesForLocale("calendars", "und", false, &status));
-        ASSERT(U_SUCCESS(status));
-
-        int32_t count = uenum_count(enumeration.get(), &status);
-        ASSERT(U_SUCCESS(status));
-
         auto createImmortalThreadSafeString = [&](String&& string) {
             if (string.is8Bit())
                 return StringImpl::createStaticStringImpl(string.span8());
             return StringImpl::createStaticStringImpl(string.span16());
         };
-
         availableCalendars.construct();
-        for (int32_t i = 0; i < count; ++i) {
-            int32_t length = 0;
-            const char* pointer = uenum_next(enumeration.get(), &length, &status);
-            ASSERT(U_SUCCESS(status));
-            String calendar(unsafeMakeSpan(pointer, static_cast<size_t>(length)));
-            if (auto mapped = mapICUCalendarKeywordToBCP47(calendar))
-                calendar = WTF::move(mapped.value());
 
-            // Skip if the obtained calendar code is not meeting Unicode Locale Identifier's `type` definition
-            // as whole ECMAScript's i18n is relying on Unicode Local Identifiers.
-            if (!isUnicodeLocaleIdentifierType(calendar))
-                continue;
-            availableCalendars->append(createImmortalThreadSafeString(WTF::move(calendar)));
+        if (Options::useIntlEraMonthcode()) {
+            // https://tc39.es/proposal-intl-era-monthcode/#sup-availablecalendars
+            // proposal-intl-era-monthcode "Calendar Type" table.
+            static constexpr ASCIILiteral canonicalCalendars[] {
+                "buddhist"_s, "chinese"_s, "coptic"_s, "dangi"_s, "ethioaa"_s,
+                "ethiopic"_s, "gregory"_s, "hebrew"_s, "indian"_s,
+                "islamic-civil"_s, "islamic-tbla"_s, "islamic-umalqura"_s,
+                "iso8601"_s, "japanese"_s, "persian"_s, "roc"_s,
+            };
+            for (auto id : canonicalCalendars) {
+                String s(id);
+                availableCalendars->append(createImmortalThreadSafeString(WTF::move(s)));
+            }
+        } else {
+            // Pre-proposal (default): use ICU4C's keyword-set enumeration.
+            UErrorCode status = U_ZERO_ERROR;
+            auto enumeration = std::unique_ptr<UEnumeration, ICUDeleter<uenum_close>>(ucal_getKeywordValuesForLocale("calendars", "und", false, &status));
+            ASSERT(U_SUCCESS(status));
+
+            int32_t count = uenum_count(enumeration.get(), &status);
+            ASSERT(U_SUCCESS(status));
+
+            for (int32_t i = 0; i < count; ++i) {
+                int32_t length = 0;
+                const char* pointer = uenum_next(enumeration.get(), &length, &status);
+                ASSERT(U_SUCCESS(status));
+                String calendar(unsafeMakeSpan(pointer, static_cast<size_t>(length)));
+                if (auto mapped = mapICUCalendarKeywordToBCP47(calendar))
+                    calendar = WTF::move(mapped.value());
+
+                // Skip if the obtained calendar code is not meeting Unicode Locale Identifier's `type` definition
+                // as whole ECMAScript's i18n is relying on Unicode Local Identifiers.
+                if (!isUnicodeLocaleIdentifierType(calendar))
+                    continue;
+                availableCalendars->append(createImmortalThreadSafeString(WTF::move(calendar)));
+            }
         }
 
         // The AvailableCalendars abstract operation returns a List, ordered as if an Array of the same
@@ -1750,6 +1766,30 @@ const Vector<String>& intlAvailableCalendars()
             });
     });
     return availableCalendars;
+}
+
+const UncheckedKeyHashMap<String, CalendarID, ASCIICaseInsensitiveHash>& intlAvailableCalendarIndex()
+{
+    static LazyNeverDestroyed<UncheckedKeyHashMap<String, CalendarID, ASCIICaseInsensitiveHash>> index;
+    static std::once_flag onceKey;
+    std::call_once(onceKey, [&] {
+        const auto& calendars = intlAvailableCalendars();
+        UncheckedKeyHashMap<String, CalendarID, ASCIICaseInsensitiveHash> table;
+        for (CalendarID i = 0; i < calendars.size(); ++i)
+            table.add(calendars[i], i);
+
+        // Legacy CLDR aliases map to the same CalendarID as their canonical form.
+        auto addAlias = [&](ASCIILiteral alias, ASCIILiteral canonical) {
+            auto it = table.find(canonical);
+            if (it != table.end())
+                table.add(String(alias), it->value);
+        };
+        addAlias("islamicc"_s, "islamic-civil"_s);
+        addAlias("ethiopic-amete-alem"_s, "ethioaa"_s);
+
+        index.construct(WTF::move(table));
+    });
+    return index.get();
 }
 
 CalendarID iso8601CalendarIDStorage { std::numeric_limits<CalendarID>::max() };
@@ -1782,7 +1822,8 @@ CalendarID iso8601CalendarIDSlow()
                     return; \
                 } \
             } \
-            RELEASE_ASSERT_NOT_REACHED(); \
+            if (!Options::useIntlEraMonthcode()) \
+                RELEASE_ASSERT_NOT_REACHED(); \
         }); \
         return name##CalendarIDStorage; \
     }

--- a/Source/JavaScriptCore/runtime/IntlObject.h
+++ b/Source/JavaScriptCore/runtime/IntlObject.h
@@ -105,6 +105,8 @@ inline const LocaleSet& intlDurationFormatAvailableLocales() { return intlAvaila
 using CalendarID = unsigned;
 JS_EXPORT_PRIVATE const Vector<String>& intlAvailableCalendars();
 
+JS_EXPORT_PRIVATE const UncheckedKeyHashMap<String, CalendarID, ASCIICaseInsensitiveHash>& intlAvailableCalendarIndex();
+
 extern CalendarID JS_EXPORT_PRIVATE iso8601CalendarIDStorage;
 CalendarID JS_EXPORT_PRIVATE iso8601CalendarIDSlow();
 inline CalendarID iso8601CalendarID()

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -677,6 +677,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, useSharedArrayBuffer, false, Normal, nullptr) \
     v(Bool, useShadowRealm, false, Normal, "Expose the ShadowRealm object."_s) \
     v(Bool, useTemporal, true, Normal, "Expose the Temporal object."_s) \
+    v(Bool, useIntlEraMonthcode, false, Normal, "Enable Intl.Era-monthcode Stage 4 proposal."_s) \
     v(Bool, useTrustedTypes, true, Normal, "Enable trusted types eval protection feature."_s) \
     v(Bool, useWasmJSStringBuiltins, true, Normal, "Enable the implementation of the JS String Builtins proposal."_s) \
     v(Bool, useWasmMemory64, false, Normal, "Allow the Memory64 proposal for WebAssembly. This feature is currently only supported in the IPInt tier."_s) \

--- a/Source/JavaScriptCore/runtime/TemporalCalendar.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalCalendar.cpp
@@ -47,28 +47,11 @@ namespace JSC {
 
 std::optional<CalendarID> isBuiltinCalendar(StringView string)
 {
-    // FIXME: bare "islamic" is accepted via ICU's keyword set but V8/temporal_rs reject it;
-    // canonicalize to "islamic-civil" (CLDR alias) or filter out.
-    const auto& calendars = intlAvailableCalendars();
-    for (unsigned index = 0; index < calendars.size(); ++index) {
-        if (WTF::equalIgnoringASCIICase(calendars[index], string))
-            return index;
-    }
-    // Legacy alias: "islamicc" → "islamic-civil" (per CLDR/BCP 47).
-    if (WTF::equalIgnoringASCIICase(string, "islamicc"_s)) {
-        for (unsigned index = 0; index < calendars.size(); ++index) {
-            if (calendars[index] == "islamic-civil"_s)
-                return index;
-        }
-    }
-    // Legacy alias: "ethiopic-amete-alem" → "ethioaa".
-    if (WTF::equalIgnoringASCIICase(string, "ethiopic-amete-alem"_s)) {
-        for (unsigned index = 0; index < calendars.size(); ++index) {
-            if (calendars[index] == "ethioaa"_s)
-                return index;
-        }
-    }
-    return std::nullopt;
+    const auto& index = intlAvailableCalendarIndex();
+    auto entry = index.find<ASCIICaseInsensitiveStringViewHashTranslator>(string);
+    if (entry == index.end())
+        return std::nullopt;
+    return entry->value;
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal-calendarresolvefields


### PR DESCRIPTION
#### 6ea58a42a90953702692b60e2347b63075394968
<pre>
[JSC][Temporal][Intl.Era] Add useIntlEraMonthcode option and narrow AvailableCalendars
<a href="https://bugs.webkit.org/show_bug.cgi?id=319397">https://bugs.webkit.org/show_bug.cgi?id=319397</a>
<a href="https://rdar.apple.com/182225399">rdar://182225399</a>

Reviewed by Sosuke Suzuki.

Adds a new runtime option --useIntlEraMonthcode (default: off) implementing
part of Intl.Era-monthcode (Stage 4, advanced March 10, 2026).

Also introduces intlAvailableCalendarIndex() — an O(1) case-insensitive
name-to-CalendarID lookup (mirrors intlAvailableTimeZoneIndex) — and
rewrites isBuiltinCalendar to use it. Legacy CLDR aliases (islamicc,
ethiopic-amete-alem) are pre-populated in the index.

Tests: JSTests/stress/temporal-calendar-canonical-set.js
       Source/JavaScriptCore/API/tests/TemporalCoreTest.cpp

Canonical link: <a href="https://commits.webkit.org/317214@main">https://commits.webkit.org/317214@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/461e0a9596ff8495990c2383fe2f6f0c99da3ed4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174542 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48475 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42256 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184119 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132410 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0eb45652-1c67-4542-9800-2d342c358106) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49767 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48158 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135816 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6cca3189-d5d8-429e-9774-fadef9db3b8b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177500 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39235 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156608 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116294 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37876 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36248 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32600 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5117 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148299 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36100 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186545 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/35804 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39798 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40445 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144712 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48142 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144573 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48821 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32720 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26539 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39473 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120805 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/211595 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47328 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11065 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55207 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46730 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46961 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46788 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->