### PR TITLE
[interactive-widget] Implement logic to support overlays-content

### DIFF
--- a/LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-keyboard-scroll-expected.txt
+++ b/LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-keyboard-scroll-expected.txt
@@ -1,0 +1,18 @@
+Scrolled to 40, 1048
+PASS document.scrollingElement.scrollTop is 1048
+PASS document.scrollingElement.scrollLeft is 40
+PASS window.visualViewport.pageTop is not 0
+PASS window.visualViewport.scale is 1
+PASS window.visualViewport.width is 390
+PASS window.visualViewport.height is 797
+Scrolled to 0, 0
+PASS document.scrollingElement.scrollTop is 0
+PASS document.scrollingElement.scrollLeft is 0
+PASS window.visualViewport.pageTop is 0
+PASS window.visualViewport.scale is 1
+PASS window.visualViewport.width is 390
+PASS window.visualViewport.height is 797
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-keyboard-scroll.html
+++ b/LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-keyboard-scroll.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, interactive-widget=overlays-content"/>
+    <style>
+        body {
+            height: 2000px;
+            width: 2000px;
+        }
+        input {
+            width: 400px;
+            height: 50px;
+        }
+    </style>
+    <script src="../../../resources/js-test.js"></script>
+    <script src="../../../resources/ui-helper.js"></script>
+</head>
+<body>
+    <input id="input" type="text">
+    <script>
+        jsTestIsAsync = true;
+        addEventListener("load", async () => {
+            let textField = document.querySelector("input");
+            await UIHelper.activateElement(textField);
+            await UIHelper.waitForKeyboardToShow();
+
+            window.scrollTo(40, 1048);
+            debug('Scrolled to ' + window.scrollX + ', ' + window.scrollY);
+
+            shouldBe('document.scrollingElement.scrollTop', '1048');
+            shouldBe('document.scrollingElement.scrollLeft', '40');
+            shouldNotBe('window.visualViewport.pageTop', '0');
+            shouldBe('window.visualViewport.scale', '1');
+            shouldBe('window.visualViewport.width', JSON.stringify(internals.layoutViewportRect().width));
+            shouldBe('window.visualViewport.height', JSON.stringify(internals.layoutViewportRect().height));
+
+            window.scrollTo(0, 0);
+            debug('Scrolled to ' + window.scrollX + ', ' + window.scrollY);
+
+            shouldBe('document.scrollingElement.scrollTop', '0');
+            shouldBe('document.scrollingElement.scrollLeft', '0');
+            shouldBe('window.visualViewport.pageTop', '0');
+            shouldBe('window.visualViewport.scale', '1');
+            shouldBe('window.visualViewport.width', JSON.stringify(internals.layoutViewportRect().width));
+            shouldBe('window.visualViewport.height', JSON.stringify(internals.layoutViewportRect().height));
+
+            finishJSTest();
+        });
+    </script>
+</body>
+
+</html>

--- a/LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-obscured-insets-expected.txt
+++ b/LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-obscured-insets-expected.txt
@@ -1,0 +1,22 @@
+layoutViewport: {"x":0,"y":0,"width":390,"height":747,"top":0,"right":390,"bottom":747,"left":0}
+visualViewportRect: {"x":0,"y":0,"width":390,"height":747,"top":0,"right":390,"bottom":747,"left":0}
+PASS window.visualViewport.pageTop is 0
+PASS window.visualViewport.scale is 1
+PASS window.visualViewport.width is 390
+PASS window.visualViewport.height is 747
+layoutViewport: {"x":0,"y":0,"width":390,"height":697,"top":0,"right":390,"bottom":697,"left":0}
+visualViewportRect: {"x":0,"y":0,"width":390,"height":697,"top":0,"right":390,"bottom":697,"left":0}
+PASS window.visualViewport.pageTop is 0
+PASS window.visualViewport.scale is 1
+PASS window.visualViewport.width is 390
+PASS window.visualViewport.height is 697
+layoutViewport: {"x":0,"y":0,"width":390,"height":729,"top":0,"right":390,"bottom":729,"left":0}
+visualViewportRect: {"x":0,"y":0,"width":390,"height":729,"top":0,"right":390,"bottom":729,"left":0}
+PASS window.visualViewport.pageTop is 0
+PASS window.visualViewport.scale is 1
+PASS window.visualViewport.width is 390
+PASS window.visualViewport.height is 729
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-obscured-insets.html
+++ b/LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-obscured-insets.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, interactive-widget=overlays-content"/>
+    <style>
+        input {
+            width: 400px;
+            height: 50px;
+        }
+        body {
+            background-color: pink;
+        }
+    </style>
+    <script src="../../../resources/js-test.js"></script>
+    <script src="../../../resources/ui-helper.js"></script>
+</head>
+<body>
+    <input id="input" type="text">
+    <script>
+        jsTestIsAsync = true;
+        addEventListener("load", async () => {
+            let textField = document.querySelector("input");
+
+            // Test the bottom inset being smaller than the input accessory view.
+            await UIHelper.setObscuredInsets(0, 0, 50, 0);
+            await UIHelper.renderingUpdate();
+            await UIHelper.activateElement(textField);
+            await UIHelper.waitForKeyboardToShow();
+
+            debug('layoutViewport: ' + JSON.stringify(internals.layoutViewportRect()));
+            debug('visualViewportRect: ' + JSON.stringify(internals.visualViewportRect()));
+
+            shouldBe('window.visualViewport.pageTop', '0');
+            shouldBe('window.visualViewport.scale', '1');
+            shouldBe('window.visualViewport.width', JSON.stringify(internals.layoutViewportRect().width));
+            shouldBe('window.visualViewport.height', JSON.stringify(internals.layoutViewportRect().height));
+
+            // Test the bottom inset being bigger than the input accessory view.
+            await UIHelper.setObscuredInsets(0, 0, 100, 0);
+            await UIHelper.renderingUpdate();
+            await UIHelper.activateElement(textField);
+            await UIHelper.waitForKeyboardToShow();
+
+            debug('layoutViewport: ' + JSON.stringify(internals.layoutViewportRect()));
+            debug('visualViewportRect: ' + JSON.stringify(internals.visualViewportRect()));
+
+            shouldBe('window.visualViewport.pageTop', '0');
+            shouldBe('window.visualViewport.scale', '1');
+            shouldBe('window.visualViewport.width', JSON.stringify(internals.layoutViewportRect().width));
+            shouldBe('window.visualViewport.height', JSON.stringify(internals.layoutViewportRect().height));
+
+            // Test the bottom inset being equal to the input accessory view.
+            await UIHelper.setObscuredInsets(0, 0, 68, 0);
+            await UIHelper.renderingUpdate();
+            await UIHelper.activateElement(textField);
+            await UIHelper.waitForKeyboardToShow();
+
+            debug('layoutViewport: ' + JSON.stringify(internals.layoutViewportRect()));
+            debug('visualViewportRect: ' + JSON.stringify(internals.visualViewportRect()));
+
+            shouldBe('window.visualViewport.pageTop', '0');
+            shouldBe('window.visualViewport.scale', '1');
+            shouldBe('window.visualViewport.width', JSON.stringify(internals.layoutViewportRect().width));
+            shouldBe('window.visualViewport.height', JSON.stringify(internals.layoutViewportRect().height));
+
+            finishJSTest();
+        });
+    </script>
+</body>
+</html>

--- a/LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-zoom-disabled-expected.txt
+++ b/LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-zoom-disabled-expected.txt
@@ -1,0 +1,10 @@
+layoutViewport: {"x":0,"y":0,"width":390,"height":797,"top":0,"right":390,"bottom":797,"left":0}
+visualViewportRect: {"x":0,"y":0,"width":390,"height":797,"top":0,"right":390,"bottom":797,"left":0}
+PASS window.visualViewport.pageTop is 0
+PASS window.visualViewport.scale is 1
+PASS window.visualViewport.width is 390
+PASS window.visualViewport.height is 797
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-zoom-disabled.html
+++ b/LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-zoom-disabled.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, interactive-widget=overlays-content"/>
+    <style>
+        input {
+            width: 400px;
+            height: 50px;
+        }
+    </style>
+    <script src="../../../resources/js-test.js"></script>
+    <script src="../../../resources/ui-helper.js"></script>
+</head>
+<body>
+    <input id="input" type="text">
+
+    <script>
+        jsTestIsAsync = true;
+        addEventListener("load", async () => {
+            let textField = document.querySelector("input");
+            await UIHelper.activateElement(textField);
+            await UIHelper.waitForKeyboardToShow();
+
+            debug('layoutViewport: ' + JSON.stringify(internals.layoutViewportRect()));
+            debug('visualViewportRect: ' + JSON.stringify(internals.visualViewportRect()));
+
+            shouldBe('window.visualViewport.pageTop', '0');
+            shouldBe('window.visualViewport.scale', '1');
+            shouldBe('window.visualViewport.width', JSON.stringify(internals.layoutViewportRect().width));
+            shouldBe('window.visualViewport.height', JSON.stringify(internals.layoutViewportRect().height));
+
+            finishJSTest();
+        });
+    </script>
+</body>
+
+</html>

--- a/LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-zoom-enabled-expected.txt
+++ b/LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-zoom-enabled-expected.txt
@@ -1,0 +1,11 @@
+layoutViewport: {"x":0,"y":0,"width":390,"height":797,"top":0,"right":390,"bottom":797,"left":0}
+visualViewportRect: {"x":0,"y":0,"width":268,"height":548,"top":0,"right":268,"bottom":548,"left":0}
+PASS window.visualViewport.pageTop is 0
+PASS window.visualViewport.scale is not 1
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Layout viewport: {"x":0,"y":0,"width":390,"height":797,"top":0,"right":390,"bottom":797,"left":0}
+Visual viewport: {"x":0,"y":0,"width":268,"height":548,"top":0,"right":268,"bottom":548,"left":0}
+
+

--- a/LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-zoom-enabled.html
+++ b/LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-zoom-enabled.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1, interactive-widget=overlays-content"/>
+    <style>
+        input {
+            width: 400px;
+            height: 50px;
+        }
+    </style>
+    <script src="../../../resources/js-test.js"></script>
+    <script src="../../../resources/ui-helper.js"></script>
+</head>
+<body>
+    <p id="results"></p>
+    <input id="input" type="text">
+
+    <script>
+        jsTestIsAsync = true;
+        addEventListener("load", async () => {
+            let textField = document.querySelector("input");
+            await UIHelper.activateElement(textField);
+            await UIHelper.waitForKeyboardToShow();
+
+            debug('layoutViewport: ' + JSON.stringify(internals.layoutViewportRect()));
+            debug('visualViewportRect: ' + JSON.stringify(internals.visualViewportRect()));
+
+            shouldBe('window.visualViewport.pageTop', '0');
+            shouldNotBe('window.visualViewport.scale', '1');
+            var output = 'Layout viewport: ' + JSON.stringify(internals.layoutViewportRect()) + '\nVisual viewport: ' + JSON.stringify(internals.visualViewportRect()) + '\n';
+            document.getElementById('results').innerText = output;
+
+            finishJSTest();
+        });
+    </script>
+</body>
+
+</html>

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -2907,6 +2907,13 @@ static CGFloat liveResizeMinimumWidthDifference()
 
 #endif // HAVE(UIKIT_RESIZABLE_WINDOWS)
 
+- (CGRect)_inputViewBoundsForViewportCalculations
+{
+    if (_perProcessState.viewportMetaTagInteractiveWidget == WebCore::InteractiveWidget::OverlaysContent)
+        return CGRectZero;
+    return _inputViewBoundsInWindow;
+}
+
 // Unobscured content rect where the user can interact. When the keyboard is up, this should be the area above or below the keyboard, wherever there is enough space.
 - (CGRect)_contentRectForUserInteraction
 {
@@ -3192,7 +3199,7 @@ static bool scrollViewCanScroll(UIScrollView *scrollView)
         velocityData = { 0, 0, 0, timestamp };
     }
 
-    CGRect unobscuredContentRectRespectingInputViewBounds = [_contentView _computeUnobscuredContentRectRespectingInputViewBounds:unobscuredRectInContentCoordinates inputViewBounds:_inputViewBoundsInWindow];
+    CGRect unobscuredContentRectRespectingInputViewBounds = [_contentView _computeUnobscuredContentRectRespectingInputViewBounds:unobscuredRectInContentCoordinates inputViewBounds:[self _inputViewBoundsForViewportCalculations]];
     WebCore::FloatRect fixedPositionRectForLayout = _page->computeLayoutViewportRect(unobscuredRectInContentCoordinates, unobscuredContentRectRespectingInputViewBounds, _page->layoutViewportRect(), scaleFactor, WebCore::LayoutViewportConstraint::ConstrainedToDocumentRect);
 
     return { {
@@ -3517,7 +3524,9 @@ static WebCore::IntDegrees activeOrientation(WKWebView *webView)
         return [self.window convertRect:keyboardFrameInScreen fromCoordinateSpace:self.window.screen.coordinateSpace];
     })();
 
-    if (adjustScrollView) {
+    BOOL keyboardShouldOverlayContent = _perProcessState.viewportMetaTagInteractiveWidget == WebCore::InteractiveWidget::OverlaysContent;
+
+    if (adjustScrollView && !keyboardShouldOverlayContent) {
         CGFloat bottomInsetBeforeAdjustment = [_scrollView contentInset].bottom;
         SetForScope insetAdjustmentGuard(_perProcessState.currentlyAdjustingScrollViewInsetsForKeyboard, YES);
         [_scrollView _adjustForAutomaticKeyboardInfo:keyboardInfo animated:YES lastAdjustment:&_lastAdjustmentForScroller];


### PR DESCRIPTION
#### 80c3a241b03b8d60167b12567351a2c9a8cd75b7
<pre>
[interactive-widget] Implement logic to support overlays-content
<a href="https://bugs.webkit.org/show_bug.cgi?id=297473">https://bugs.webkit.org/show_bug.cgi?id=297473</a>
<a href="https://rdar.apple.com/158431078">rdar://158431078</a>

Reviewed by Wenson Hsieh, Abrar Rahman Protyasha, Aditya Keerthi, and Richard Robinson.

Add support for the overlays-content value for interactive-widgets.
To do so, the virtual keyboard should not contribute to the visual
viewport calculations and simply overlay the page. So, create a new
helper `_inputViewBoundsForViewportCalculations` that returns CGRectZero
if the value is overlays-content and `_inputViewBoundsInWindow` otherwise.
The value of `_computeUnobscuredContentRectRespectingInputViewBounds` is
now in respect to `_inputViewBoundsForViewportCalculations`.

Additionally when the virtual keyboard is up, it is possible that the page
is adjusted via scrolling + clamping (`_adjustForAutomaticKeyboardInfo`). If
overlays-content, the keyboard should not contribute to scrollable extent which
will change the visual viewport, so gate this based on the interactive-widget
value.

Add layout tests that ensure the visual viewport does not change and test that
they fail without overlays-content mode.

Alternatives tried and considered before include directly altering `_inputViewBoundsInWindow`.
While it worked and prevented the visual viewport from resizing, it broke context menus and
other calculations that relied on `_inputViewBoundsInWindow`. In those cases, WebKit still
needs to know the size of and factor in the virtual keyboard being up.

* LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-keyboard-scroll-expected.txt: Added.
* LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-keyboard-scroll.html: Added.
* LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-obscured-insets-expected.txt: Added.
* LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-obscured-insets.html: Added.
* LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-zoom-disabled-expected.txt: Added.
* LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-zoom-disabled.html: Added.
* LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-zoom-enabled-expected.txt: Added.
* LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-zoom-enabled.html: Added.
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _inputViewBoundsForViewportCalculations]):
(-[WKWebView _createVisibleContentRectUpdate]):
(-[WKWebView _keyboardChangedWithInfo:adjustScrollView:]):

Canonical link: <a href="https://commits.webkit.org/317200@main">https://commits.webkit.org/317200@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5df50be27bbda2a01f78731e1391fbd94c90b9a5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174557 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48490 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42271 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184134 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132425 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cae0e417-d865-4b61-9779-605366e10a81) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49782 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48173 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135809 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3102961e-1ffe-4081-a4c4-f396be630e82) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177515 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39238 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156604 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116287 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/827f1618-0971-4b04-a2ce-67b41546091f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37879 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32615 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148302 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36096 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186561 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39816 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144725 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48157 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156159 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144586 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48836 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26535 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39477 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120823 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47343 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11061 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46745 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46976 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46803 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->