### PR TITLE
Adopt USDKit change to avoid large memory allocations

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/Model/ModelBridge.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelBridge.swift
@@ -57,15 +57,21 @@ extension WKBridgeVertexLayout {
     let bufferIndex: Int
     let bufferOffset: Int
     let bufferStride: Int
+    let stepFunction: MTLVertexStepFunction
+    let stepRate: Int
 
     init(
         bufferIndex: Int,
         bufferOffset: Int,
-        bufferStride: Int
+        bufferStride: Int,
+        stepFunction: MTLVertexStepFunction,
+        stepRate: Int
     ) {
         self.bufferIndex = bufferIndex
         self.bufferOffset = bufferOffset
         self.bufferStride = bufferStride
+        self.stepFunction = stepFunction
+        self.stepRate = stepRate
     }
 }
 
@@ -664,7 +670,13 @@ private func webAttributesFromAttributes(_ attributes: [LowLevelMesh.Attribute])
 
 private func webLayoutsFromLayouts(_ attributes: [LowLevelMesh.Layout]) -> [WKBridgeVertexLayout] {
     attributes.map({ a in
-        WKBridgeVertexLayout(bufferIndex: a.bufferIndex, bufferOffset: a.bufferOffset, bufferStride: a.bufferStride)
+        WKBridgeVertexLayout(
+            bufferIndex: a.bufferIndex,
+            bufferOffset: a.bufferOffset,
+            bufferStride: a.bufferStride,
+            stepFunction: a.stepFunction,
+            stepRate: a.stepRate
+        )
     })
 }
 

--- a/Source/WebKit/GPUProcess/graphics/Model/ModelTypes.h
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelTypes.h
@@ -95,10 +95,12 @@ typedef NS_ENUM(uint8_t, WKBridgeVertexSemantic) {
 @property (nonatomic, readonly) long bufferIndex;
 @property (nonatomic, readonly) long bufferOffset;
 @property (nonatomic, readonly) long bufferStride;
+@property (nonatomic, readonly) MTLVertexStepFunction stepFunction;
+@property (nonatomic, readonly) long stepRate;
 
 - (instancetype)init NS_UNAVAILABLE;
 
-- (instancetype)initWithBufferIndex:(long)bufferIndex bufferOffset:(long)bufferOffset bufferStride:(long)bufferStride NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithBufferIndex:(long)bufferIndex bufferOffset:(long)bufferOffset bufferStride:(long)bufferStride stepFunction:(MTLVertexStepFunction)stepFunction stepRate:(long)stepRate NS_DESIGNATED_INITIALIZER;
 
 @end
 
@@ -565,10 +567,20 @@ struct ImageAsset {
     ImageAssetSwizzle swizzle { };
 };
 
+enum class VertexStepFunction : uint8_t {
+    Constant,
+    PerVertex,
+    PerInstance,
+    PerPatch,
+    PerPatchControlPoint,
+};
+
 struct VertexLayout {
     long bufferIndex;
     long bufferOffset;
     long bufferStride;
+    VertexStepFunction stepFunction;
+    long stepRate;
 };
 
 struct MeshPart {

--- a/Source/WebKit/GPUProcess/graphics/Model/ModelUtils.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelUtils.swift
@@ -84,28 +84,6 @@ extension simd_float4x4 {
     }
 }
 
-extension LowLevelMeshResource.Descriptor {
-    static func fromLlmDescriptor(_ llmDescriptor: LowLevelMesh.Descriptor) -> Self {
-        var descriptor = Self.init()
-        descriptor.vertexCapacity = llmDescriptor.vertexCapacity
-        descriptor.vertexAttributes = llmDescriptor.vertexAttributes.map { attribute in
-            .init(
-                semantic: mapSemantic(attribute.semantic),
-                format: attribute.format,
-                layoutIndex: attribute.layoutIndex,
-                offset: attribute.offset
-            )
-        }
-        descriptor.vertexLayouts = llmDescriptor.vertexLayouts.map { layout in
-            .init(bufferIndex: layout.bufferIndex, bufferOffset: layout.bufferOffset, bufferStride: layout.bufferStride)
-        }
-        descriptor.indexCapacity = llmDescriptor.indexCapacity
-        descriptor.indexType = llmDescriptor.indexType
-
-        return descriptor
-    }
-}
-
 @_lifetime(buffer: copy buffer)
 private func copyDataIntoBuffer(_ buffer: inout MutableRawSpan, from data: Data) {
     precondition(
@@ -238,7 +216,13 @@ extension LowLevelMeshResource.Descriptor {
             )
         }
         descriptor.vertexLayouts = llmDescriptor.vertexLayouts.map { layout in
-            .init(bufferIndex: layout.bufferIndex, bufferOffset: layout.bufferOffset, bufferStride: layout.bufferStride)
+            .init(
+                bufferIndex: layout.bufferIndex,
+                bufferOffset: layout.bufferOffset,
+                bufferStride: layout.bufferStride,
+                stepFunction: layout.stepFunction,
+                stepRate: layout.stepRate
+            )
         }
         descriptor.indexCapacity = llmDescriptor.indexCapacity
         descriptor.indexType = llmDescriptor.indexType

--- a/Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.mm
+++ b/Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.mm
@@ -234,6 +234,22 @@ static MTLIndexType toMetal(WebModel::IndexType indexType)
     }
 }
 
+static MTLVertexStepFunction toMetal(WebModel::VertexStepFunction stepFunction)
+{
+    switch (stepFunction) {
+    case WebModel::VertexStepFunction::Constant:
+        return MTLVertexStepFunctionConstant;
+    case WebModel::VertexStepFunction::PerVertex:
+        return MTLVertexStepFunctionPerVertex;
+    case WebModel::VertexStepFunction::PerInstance:
+        return MTLVertexStepFunctionPerInstance;
+    case WebModel::VertexStepFunction::PerPatch:
+        return MTLVertexStepFunctionPerPatch;
+    case WebModel::VertexStepFunction::PerPatchControlPoint:
+        return MTLVertexStepFunctionPerPatchControlPoint;
+    }
+}
+
 static MTLPixelFormat toMetal(WebCore::WebGPU::TextureFormat textureFormat)
 {
     switch (textureFormat) {
@@ -605,7 +621,7 @@ static NSArray<WKBridgeVertexLayout *> *convert(const Vector<VertexLayout>& layo
 
     NSMutableArray<WKBridgeVertexLayout *> *result = [NSMutableArray array];
     for (const auto& layout : layouts)
-        [result addObject:[WebKit::allocWKBridgeVertexLayoutInstance() initWithBufferIndex:layout.bufferIndex bufferOffset:layout.bufferOffset bufferStride:layout.bufferStride]];
+        [result addObject:[WebKit::allocWKBridgeVertexLayoutInstance() initWithBufferIndex:layout.bufferIndex bufferOffset:layout.bufferOffset bufferStride:layout.bufferStride stepFunction:toMetal(layout.stepFunction) stepRate:layout.stepRate]];
 
     return result;
 }

--- a/Source/WebKit/Shared/Model.serialization.in
+++ b/Source/WebKit/Shared/Model.serialization.in
@@ -169,10 +169,21 @@ header: <WebKit/ModelTypes.h>
 };
 
 header: <WebKit/ModelTypes.h>
+[CustomHeader] enum class WebModel::VertexStepFunction : uint8_t {
+    Constant,
+    PerVertex,
+    PerInstance,
+    PerPatch,
+    PerPatchControlPoint,
+};
+
+header: <WebKit/ModelTypes.h>
 [AdditionalEncoder=StreamConnectionEncoder, CustomHeader] struct WebModel::VertexLayout {
     long bufferIndex;
     long bufferOffset;
     long bufferStride;
+    WebModel::VertexStepFunction stepFunction;
+    long stepRate;
 };
 
 header: <WebKit/ModelTypes.h>

--- a/Source/WebKit/WebProcess/Model/ModelInlineConverters.h
+++ b/Source/WebKit/WebProcess/Model/ModelInlineConverters.h
@@ -191,6 +191,24 @@ static WebModel::IndexType toIndexType(MTLIndexType indexType)
     }
 }
 
+static WebModel::VertexStepFunction toStepFunction(MTLVertexStepFunction stepFunction)
+{
+    switch (stepFunction) {
+    case MTLVertexStepFunctionConstant:
+        return WebModel::VertexStepFunction::Constant;
+    case MTLVertexStepFunctionPerVertex:
+        return WebModel::VertexStepFunction::PerVertex;
+    case MTLVertexStepFunctionPerInstance:
+        return WebModel::VertexStepFunction::PerInstance;
+    case MTLVertexStepFunctionPerPatch:
+        return WebModel::VertexStepFunction::PerPatch;
+    case MTLVertexStepFunctionPerPatchControlPoint:
+        return WebModel::VertexStepFunction::PerPatchControlPoint;
+    default:
+        RELEASE_ASSERT_NOT_REACHED("%s - USD file is corrupt", __PRETTY_FUNCTION__);
+    }
+}
+
 static WebCore::WebGPU::TextureViewDimension toTextureViewDimension(MTLTextureType textureType)
 {
     switch (textureType) {
@@ -454,6 +472,8 @@ static WebModel::VertexLayout convert(WKBridgeVertexLayout *layout)
         .bufferIndex = layout.bufferIndex,
         .bufferOffset = layout.bufferOffset,
         .bufferStride = layout.bufferStride,
+        .stepFunction = toStepFunction(layout.stepFunction),
+        .stepRate = layout.stepRate,
     };
 }
 static Vector<WebModel::VertexLayout> convert(NSArray<WKBridgeVertexLayout *> *layouts)


### PR DESCRIPTION
#### dc654cc764a152af178c0d685087afc3f26d8c76
<pre>
Adopt USDKit change to avoid large memory allocations
<a href="https://bugs.webkit.org/show_bug.cgi?id=319392">https://bugs.webkit.org/show_bug.cgi?id=319392</a>
<a href="https://rdar.apple.com/182222544">rdar://182222544</a>

Reviewed by Ruthvik Konda.

Pass along missing step-rate and step function.

* Source/WebKit/GPUProcess/graphics/Model/ModelBridge.swift:
(webLayoutsFromLayouts(_:)):
* Source/WebKit/GPUProcess/graphics/Model/ModelTypes.h:
* Source/WebKit/GPUProcess/graphics/Model/ModelUtils.swift:
(LowLevelMeshResource.fromLlmDescriptor(_:)):
* Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.mm:
(WebModel::toMetal):
* Source/WebKit/Shared/Model.serialization.in:
* Source/WebKit/WebProcess/Model/ModelInlineConverters.h:
(WebKit::toStepFunction):
(WebKit::convert):

Canonical link: <a href="https://commits.webkit.org/317198@main">https://commits.webkit.org/317198@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80143fd973681b0bc9cbf2aba3db776370b7a3b6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174594 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48527 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/42308 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184171 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/132462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49819 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48210 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/135846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/132462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a604d60a-27fd-4802-a9bd-87df1e82f6cf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177552 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/39275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/156635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116324 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/37916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32652 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/148339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/36127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186599 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/39879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/144764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48194 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/156190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144623 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38977 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/48873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32747 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/48873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/120873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47380 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/11094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/46782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/47013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/46840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->