### PR TITLE
[libpas] Test zero_mode edge cases in LargeFreeHeapTests

### DIFF
--- a/Source/bmalloc/libpas/src/test/LargeFreeHeapTests.cpp
+++ b/Source/bmalloc/libpas/src/test/LargeFreeHeapTests.cpp
@@ -587,6 +587,81 @@ void testFragmentationSplitRecoalesceContaminatedByNonZero(bool useFastHeap)
         testSimpleLargeFreeHeap(actions, frees, 1);
 }
 
+void testFreshChunkCoalesceZeroMode(pas_zero_mode existingMode, pas_zero_mode freshMode,
+                                    pas_zero_mode expectedMergedMode, bool useFastHeap)
+{
+    // The existing free [4096, 4300) is too small to satisfy a 512-aligned 300-byte request on its
+    // own, so the allocator is invoked. The mock source returns a fresh chunk whose left padding
+    // [4300, 4608) abuts the existing free's end (4300); find_by_end merges the two
+    // (pas_large_free_create_merged), and since the merge exposes a lower aligned address (4096)
+    // than the fresh chunk's own result (4608), the allocation is served from the merged range. The
+    // result and the leftover [4396, 5120) must carry pas_zero_mode_merge(existing, fresh).
+    vector<Action> actions = {
+        Action::deallocate(4096, 204, trappingAllocator, trappingDeallocator, existingMode),
+        Action::allocate(300, alignSimple(512), 4096,
+                         allocateOnce(300, alignSimple(512), 4300, 4608, 4908, 5120, freshMode),
+                         { }, expectedMergedMode),
+    };
+    set<Free> frees = { Free(4396, 5120, expectedMergedMode) };
+    if (useFastHeap)
+        testFastLargeFreeHeap(actions, frees, 1);
+    else
+        testSimpleLargeFreeHeap(actions, frees, 1);
+}
+
+void testBestFitCandidateZeroMode(bool winnerIsZero, bool useFastHeap)
+{
+    // Two free regions of differing modes: a small [1000, 1100) and a larger [2000, 2400). A
+    // 350-byte request fits only the larger one, so best-fit must pick it; the result and its
+    // leftover [2350, 2400) carry the larger (winning) region's mode, while the small region is
+    // left untouched with its own mode.
+    pas_zero_mode largeMode = winnerIsZero ? pas_zero_mode_is_all_zero : pas_zero_mode_may_have_non_zero;
+    pas_zero_mode smallMode = winnerIsZero ? pas_zero_mode_may_have_non_zero : pas_zero_mode_is_all_zero;
+    vector<Action> actions = {
+        Action::deallocate(1000, 100, trappingAllocator, trappingDeallocator, smallMode),
+        Action::deallocate(2000, 400, trappingAllocator, trappingDeallocator, largeMode),
+        Action::allocate(350, alignSimple(1), 2000, trappingAllocator, trappingDeallocator, largeMode),
+    };
+    set<Free> frees = { Free(1000, 1100, smallMode), Free(2350, 2400, largeMode) };
+    if (useFastHeap)
+        testFastLargeFreeHeap(actions, frees, 1);
+    else
+        testSimpleLargeFreeHeap(actions, frees, 1);
+}
+
+void testThreeWayCoalesceZeroMode(pas_zero_mode leftMode, pas_zero_mode middleMode,
+                                  pas_zero_mode rightMode, pas_zero_mode expectedMode,
+                                  bool useFastHeap)
+{
+    // Seed two non-adjacent frees [1000, 1100) and [1200, 1300); freeing the middle [1100, 1200)
+    // coalesces with BOTH neighbors at once. The resulting [1000, 1300) must carry
+    // pas_zero_mode_merge folded over all three ranges (is_all_zero only if all three are).
+    vector<Action> actions = {
+        Action::deallocate(1000, 100, trappingAllocator, trappingDeallocator, leftMode),
+        Action::deallocate(1200, 100, trappingAllocator, trappingDeallocator, rightMode),
+        Action::deallocate(1100, 100, trappingAllocator, trappingDeallocator, middleMode),
+    };
+    set<Free> frees = { Free(1000, 1300, expectedMode) };
+    if (useFastHeap)
+        testFastLargeFreeHeap(actions, frees, 1);
+    else
+        testSimpleLargeFreeHeap(actions, frees, 1);
+}
+
+void testZeroSizeAllocationIsAllZero(bool useFastHeap)
+{
+    // A zero-size allocation succeeds with begin 0 and zero_mode is_all_zero, touching nothing.
+    vector<Action> actions = {
+        Action::allocate(0, alignSimple(1), 0, trappingAllocator, trappingDeallocator,
+                         pas_zero_mode_is_all_zero),
+    };
+    set<Free> frees = { };
+    if (useFastHeap)
+        testFastLargeFreeHeap(actions, frees, 1);
+    else
+        testSimpleLargeFreeHeap(actions, frees, 1);
+}
+
 } // anonymous namespace
 
 void addLargeFreeHeapTests()
@@ -1422,5 +1497,48 @@ void addLargeFreeHeapTests()
         ADD_TEST(testFragmentationSplitRecoalescePreservesZero(useFastHeap));
         ADD_TEST(testFragmentationSplitRecoalesceContaminatedByNonZero(useFastHeap));
     }
+
+    // Coalescing a fresh source chunk with an adjacent existing free must merge their zero_modes:
+    // is_all_zero only when both the existing free and the fresh chunk are is_all_zero.
+    for (bool useFastHeap : { false, true }) {
+        ADD_TEST(testFreshChunkCoalesceZeroMode(pas_zero_mode_is_all_zero, pas_zero_mode_is_all_zero,
+                                                pas_zero_mode_is_all_zero, useFastHeap));
+        ADD_TEST(testFreshChunkCoalesceZeroMode(pas_zero_mode_is_all_zero, pas_zero_mode_may_have_non_zero,
+                                                pas_zero_mode_may_have_non_zero, useFastHeap));
+        ADD_TEST(testFreshChunkCoalesceZeroMode(pas_zero_mode_may_have_non_zero, pas_zero_mode_is_all_zero,
+                                                pas_zero_mode_may_have_non_zero, useFastHeap));
+        ADD_TEST(testFreshChunkCoalesceZeroMode(pas_zero_mode_may_have_non_zero, pas_zero_mode_may_have_non_zero,
+                                                pas_zero_mode_may_have_non_zero, useFastHeap));
+    }
+
+    // When best-fit selects among free ranges of differing modes, the chosen range's mode flows to
+    // the allocation result and its leftover, while the unchosen range keeps its own mode.
+    for (bool useFastHeap : { false, true }) {
+        ADD_TEST(testBestFitCandidateZeroMode(true, useFastHeap));
+        ADD_TEST(testBestFitCandidateZeroMode(false, useFastHeap));
+    }
+
+    // A free coalescing with two neighbors at once (three-way merge) folds all three zero_modes:
+    // is_all_zero only when all three are. Exercise every (left, middle, right) combination.
+    for (bool useFastHeap : { false, true }) {
+        for (pas_zero_mode leftMode : { pas_zero_mode_may_have_non_zero, pas_zero_mode_is_all_zero }) {
+            for (pas_zero_mode middleMode : { pas_zero_mode_may_have_non_zero, pas_zero_mode_is_all_zero }) {
+                for (pas_zero_mode rightMode : { pas_zero_mode_may_have_non_zero, pas_zero_mode_is_all_zero }) {
+                    pas_zero_mode expectedMode =
+                        (leftMode == pas_zero_mode_is_all_zero
+                         && middleMode == pas_zero_mode_is_all_zero
+                         && rightMode == pas_zero_mode_is_all_zero)
+                        ? pas_zero_mode_is_all_zero
+                        : pas_zero_mode_may_have_non_zero;
+                    ADD_TEST(testThreeWayCoalesceZeroMode(leftMode, middleMode, rightMode,
+                                                          expectedMode, useFastHeap));
+                }
+            }
+        }
+    }
+
+    // A zero-size allocation returns is_all_zero.
+    for (bool useFastHeap : { false, true })
+        ADD_TEST(testZeroSizeAllocationIsAllZero(useFastHeap));
 }
 


### PR DESCRIPTION
#### 1ebad5b591a41ffa838ca3b6a63aea19e8587799
<pre>
[libpas] Test zero_mode edge cases in LargeFreeHeapTests
<a href="https://bugs.webkit.org/show_bug.cgi?id=319401">https://bugs.webkit.org/show_bug.cgi?id=319401</a>
<a href="https://rdar.apple.com/182229562">rdar://182229562</a>

Reviewed by Marcus Plutowski and Yusuke Suzuki.

Extend the zero_mode coverage to branches that were only ever exercised with
a single zero_mode (so they would pass even if the field were mishandled),
on both the simple and fast heaps:

- a fresh source chunk coalescing (find_by_end -&gt; pas_large_free_create_merged)
  with an adjacent existing free of a differing mode, feeding the result and
  the leftover;
- best-fit selecting among candidate frees of differing modes (the winner&apos;s
  mode flows to the result and its leftover; the unchosen free is untouched);
- a free coalescing with two neighbors at once (all eight three-way mode
  combinations, across both heaps&apos; differing fold orders);
- a zero-size allocation returning is_all_zero.

Tests: Source/bmalloc/libpas/src/test/LargeFreeHeapTests.cpp:

* Source/bmalloc/libpas/src/test/LargeFreeHeapTests.cpp:
(std::testFreshChunkCoalesceZeroMode):
(std::testBestFitCandidateZeroMode):
(std::testThreeWayCoalesceZeroMode):
(std::testZeroSizeAllocationIsAllZero):
(addLargeFreeHeapTests):

Canonical link: <a href="https://commits.webkit.org/317188@main">https://commits.webkit.org/317188@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2109b0444370c4d9239749b7468a795aa9969f3c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174545 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48478 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42259 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184122 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/132413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fc01d66b-35ef-42af-ad68-050f16c2fb89) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49770 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48161 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135799 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/132413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c160135e-6172-4de6-8b8b-b3cfff46700e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177503 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39234 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156590 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116277 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/58f76cde-4a7a-4318-8585-e4a08e9d94a6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37875 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32603 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5099 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/148298 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36082 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186548 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/35807 "Built successfully and passed tests") | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144713 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48145 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144574 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48824 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26529 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39468 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/120809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/211598 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47331 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11047 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55208 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46733 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46964 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46791 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->