### PR TITLE
[EWS] Don't blame PR author for pre-existing flaky API test failures

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -6233,13 +6233,21 @@ class AnalyzeAPITestsResults(buildstep.BuildStep, AddToLogMixin):
         flaky_failures = list(flaky_failures)[:self.NUM_FAILURES_TO_DISPLAY]
         flaky_failures_string = ', '.join(flaky_failures)
         new_failures = failures_with_patch - clean_tree_failures
-        new_failures_to_display = list(new_failures)[:self.NUM_FAILURES_TO_DISPLAY]
-        new_failures_string = ', '.join(new_failures_to_display)
 
         yield self._addToLog('stderr', '\nFailures in API Test first run: {}'.format(list(first_run_failures)[:self.NUM_FAILURES_TO_DISPLAY]))
         yield self._addToLog('stderr', '\nFailures in API Test second run: {}'.format(list(second_run_failures)[:self.NUM_FAILURES_TO_DISPLAY]))
         yield self._addToLog('stderr', '\nFlaky Tests: {}'.format(flaky_failures_string))
         yield self._addToLog('stderr', '\nFailures in API Test on clean tree: {}'.format(clean_tree_failures_string))
+
+        # A flaky test can fail on both runs with the change and still pass on the single clean-tree
+        # run, which would otherwise be misattributed to the change. Consult the Results Database and
+        # drop failures that are already flaky/pre-existing at tip-of-tree.
+        results_db_pre_existing = set()
+        if new_failures:
+            new_failures, results_db_pre_existing = yield self.filter_pre_existing_failures(new_failures)
+
+        new_failures_to_display = list(new_failures)[:self.NUM_FAILURES_TO_DISPLAY]
+        new_failures_string = ', '.join(new_failures_to_display)
 
         if new_failures:
             yield self._addToLog('stderr', '\nNew failures: {}\n'.format(new_failures_string))
@@ -6255,13 +6263,16 @@ class AnalyzeAPITestsResults(buildstep.BuildStep, AddToLogMixin):
             yield self._addToLog('stderr', '\nNo new failures\n')
             self.build.results = SUCCESS
             self.descriptionDone = 'Passed API tests'
-            pluralSuffix = 's' if len(clean_tree_failures) > 1 else ''
+            pre_existing_failures = clean_tree_failures.union(results_db_pre_existing)
+            pre_existing_failures_to_display = list(pre_existing_failures)[:self.NUM_FAILURES_TO_DISPLAY]
+            pre_existing_failures_string = ', '.join(pre_existing_failures_to_display)
+            pluralSuffix = 's' if len(pre_existing_failures) > 1 else ''
             message = ''
-            if clean_tree_failures:
-                message = 'Found {} pre-existing API test failure{}: {}'.format(len(clean_tree_failures), pluralSuffix, clean_tree_failures_string)
-                for clean_tree_failure in clean_tree_failures_to_display:
-                    self.send_email_for_pre_existing_failure(clean_tree_failure)
-            if len(clean_tree_failures) > self.NUM_FAILURES_TO_DISPLAY:
+            if pre_existing_failures:
+                message = 'Found {} pre-existing API test failure{}: {}'.format(len(pre_existing_failures), pluralSuffix, pre_existing_failures_string)
+                for pre_existing_failure in pre_existing_failures_to_display:
+                    self.send_email_for_pre_existing_failure(pre_existing_failure)
+            if len(pre_existing_failures) > self.NUM_FAILURES_TO_DISPLAY:
                 message += ' ...'
             if flaky_failures:
                 message += ' Found flaky tests: {}'.format(flaky_failures_string)
@@ -6269,6 +6280,41 @@ class AnalyzeAPITestsResults(buildstep.BuildStep, AddToLogMixin):
                     self.send_email_for_flaky_failure(flaky_failure)
             self.build.buildFinished([message], SUCCESS)
             defer.returnValue(SUCCESS)
+
+    @defer.inlineCallbacks
+    def filter_pre_existing_failures(self, tests):
+        still_new = set()
+        pre_existing = set()
+
+        identifier = self.getProperty('identifier', None)
+        platform = self.getProperty('platform', None)
+        configuration = {}
+        if platform:
+            configuration['platform'] = platform
+        style = self.getProperty('configuration', None)
+        if style and style in ['debug', 'release']:
+            configuration['style'] = style
+
+        yield self._addToLog('results-db', f'Checking Results database for new failures. Identifier: {identifier}, configuration: {configuration}')
+        has_commit = False
+        if identifier:
+            has_commit = yield ResultsDatabase.has_commit(commit=identifier)
+            if not has_commit:
+                yield self._addToLog('results-db', f"'{identifier}' could not be found on the results database, falling back to tip-of-tree\n")
+
+        for test in sorted(tests):
+            data = yield ResultsDatabase.is_test_pre_existing_failure(
+                test, configuration=configuration,
+                commit=identifier if has_commit else None,
+                suite='api-tests',
+            )
+            yield self._addToLog('results-db', f"\n{test}: pass_rate: {data['pass_rate']}, pre-existing-failure={data['is_existing_failure']}\nResponse from results-db: {data['raw_data']}\n{data['logs']}")
+            if data['is_existing_failure'] and not data['request_failed']:
+                pre_existing.add(test)
+            else:
+                still_new.add(test)
+
+        defer.returnValue((still_new, pre_existing))
 
     def getBuildStepByName(self, name):
         for step in self.build.executedSteps:

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -6040,6 +6040,77 @@ Ran 1296 tests of 1298 with 1293 successful
         return self.run_step()
 
 
+class TestAnalyzeAPITestsResults(BuildStepMixinAdditions, unittest.TestCase):
+    def setUp(self):
+        self.longMessage = True
+        return self.setup_test_build_step()
+
+    def tearDown(self):
+        return self.tear_down_test_build_step()
+
+    def configureStep(self, first_run, second_run, clean_tree):
+        self.setup_step(AnalyzeAPITestsResults())
+        self.setProperty('platform', 'ios')
+        self.setProperty('configuration', 'release')
+        self.setProperty('identifier', '316168@main')
+
+        results_by_step = {
+            RunAPITests.name: {'Failed': [{'name': test} for test in first_run]},
+            ReRunAPITests.name: {'Failed': [{'name': test} for test in second_run]},
+            RunAPITestsWithoutChange.name: {'Failed': [{'name': test} for test in clean_tree]},
+        }
+
+        def fake_get_tests_results(step, name):
+            step.results[name] = results_by_step.get(name)
+            return defer.succeed(step.results[name])
+
+        self.patch(AnalyzeAPITestsResults, 'getTestsResults', fake_get_tests_results)
+
+    def mock_results_db(self, pass_rates=None, request_failed=None):
+        pass_rates = pass_rates or {}
+        request_failed = request_failed or set()
+
+        def is_test_pre_existing_failure(test, configuration=None, commit=None, suite=None):
+            pass_rate = pass_rates.get(test, 100)
+            return defer.succeed({
+                'is_existing_failure': pass_rate <= ResultsDatabase.PERCENT_SUCCESS_RATE_FOR_PRE_EXISTING_FAILURE,
+                'pass_rate': pass_rate,
+                'raw_data': {'pass': pass_rate},
+                'logs': '',
+                'request_failed': test in request_failed,
+            })
+
+        self.patch(ResultsDatabase, 'is_test_pre_existing_failure', is_test_pre_existing_failure)
+        self.patch(ResultsDatabase, 'has_commit', lambda commit, logger=None: defer.succeed(True))
+
+    def test_flaky_pre_existing_failure_not_blamed(self):
+        # Bug 318816: a flaky test fails both runs with the change, passes the single clean-tree run,
+        # but the Results DB knows it is pre-existing/flaky, so the change must not be blamed.
+        self.mock_results_db(pass_rates={'MultipleAccounts': 49})
+        self.configureStep(first_run=['MultipleAccounts'], second_run=['MultipleAccounts'], clean_tree=[])
+        self.expect_outcome(result=SUCCESS, state_string='Passed API tests')
+        return self.run_step()
+
+    def test_true_regression_still_blamed(self):
+        self.mock_results_db(pass_rates={'RegressedTest': 100})
+        self.configureStep(first_run=['RegressedTest'], second_run=['RegressedTest'], clean_tree=[])
+        self.expect_outcome(result=FAILURE, state_string='Found 1 new API test failure: RegressedTest (failure)')
+        return self.run_step()
+
+    def test_mixed_failures_blame_only_genuine(self):
+        self.mock_results_db(pass_rates={'FlakyTest': 49, 'RegressedTest': 100})
+        self.configureStep(first_run=['FlakyTest', 'RegressedTest'], second_run=['FlakyTest', 'RegressedTest'], clean_tree=[])
+        self.expect_outcome(result=FAILURE, state_string='Found 1 new API test failure: RegressedTest (failure)')
+        return self.run_step()
+
+    def test_results_db_request_failure_fails_closed(self):
+        # If the Results DB is unreachable we must keep blaming the change to avoid a false negative.
+        self.mock_results_db(pass_rates={'FlakyTest': 49}, request_failed={'FlakyTest'})
+        self.configureStep(first_run=['FlakyTest'], second_run=['FlakyTest'], clean_tree=[])
+        self.expect_outcome(result=FAILURE, state_string='Found 1 new API test failure: FlakyTest (failure)')
+        return self.run_step()
+
+
 class TestRunAPITestsParallelSafety(BuildStepMixinAdditions, unittest.TestCase):
     def setUp(self):
         self.longMessage = True


### PR DESCRIPTION
#### 0a666b7021a5fe07cde1929212c1f5afb40fe805
<pre>
[EWS] Don&apos;t blame PR author for pre-existing flaky API test failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=318816">https://bugs.webkit.org/show_bug.cgi?id=318816</a>
<a href="https://rdar.apple.com/181634454">rdar://181634454</a>

Reviewed by NOBODY (OOPS!).

A flaky test can fail both with-change runs by chance and then pass the one clean-tree run,
which could result in a false positive for the PR author, even though the results-db checks
in the first and second runs identified it as pre-existing on tip of tree. This manifested
when multiple failures were encountered in the test run, with one being pre-existing and another
appearing to be novel, which caused both tests to be flagged as failures to retry and monitor.

Before blaming the change, filter the candidate new failures through the results database
and drop any test it reports as flaky/pre-existing (pass rate at or below the existing
pre-existing failure threshold). A genuine regression breaks a test that historically passes,
so its pass rate stays high and it is still blamed; this only removes failures that are already
flaky independent of the change. If the results database request fails we keep blaming the change,
so uncertainty never suppresses what could be a real failure.

* Tools/CISupport/ews-build/steps.py:
(AnalyzeAPITestsResults.analyzeResults): Filter new failures through the results database
and fold the dropped ones into the pre-existing reporting.
(AnalyzeAPITestsResults.filter_pre_existing_failures): Added.
* Tools/CISupport/ews-build/steps_unittest.py:
(TestAnalyzeAPITestsResults): Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a666b7021a5fe07cde1929212c1f5afb40fe805

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174547 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48480 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42261 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184124 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132415 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/211d655f-6895-429c-801f-41b69aca129e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176412 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49772 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48163 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135801 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95834 "3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b8780920-f830-455c-8beb-4481365c5331) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177505 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39230 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156598 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116279 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/56e6800f-04d7-4101-a177-4ffd9bf9fbcc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37871 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36245 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32605 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148294 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36090 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186551 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40442 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144716 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/173947 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48147 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144577 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48826 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32710 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114613 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39469 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47333 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11055 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46735 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46966 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46793 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->