### PR TITLE
Store and query EWS test results in the results database

### DIFF
--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/ews_context.py
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/ews_context.py
@@ -26,57 +26,42 @@ import time
 
 from cassandra.cqlengine import columns
 from datetime import datetime
+
 from resultsdbpy.model.commit_context import CommitContext
 from resultsdbpy.model.configuration_context import ClusteredByConfiguration
-from resultsdbpy.model.test_context import Expectations
 from resultsdbpy.model.upload_context import UploadCallbackContext
 
 
-TTL_SECONDS = 30 * 24 * 60 * 60
-FLAKY_TTL_SECONDS = 7 * 24 * 60 * 60
-
-
 class EWSContext(UploadCallbackContext):
-    DEFAULT_LIMIT = 100
+    FLAKY_TTL_SECONDS = 90 * 24 * 60 * 60
 
     class EWSResultsBase(ClusteredByConfiguration):
         suite = columns.Text(partition_key=True, required=True)
         branch = columns.Text(partition_key=True, required=True)
-        uuid = columns.BigInt(primary_key=True, required=True, clustering_order='DESC')
-        start_time = columns.DateTime(primary_key=True, required=True)
-        result = columns.Integer(required=True)
-        remote = columns.Text(required=False)
-        pr_number = columns.Integer(required=False)
-        commit_hash = columns.Text(required=False)
-        details = columns.Text(required=False)  # Catch all json blob after deploy
+        test = columns.Text(partition_key=True, required=True)
+
+        start_time = columns.DateTime(primary_key=True, required=True, clustering_order='DESC')
+        uuid = columns.BigInt(primary_key=True, required=True)
+
+        result = columns.Text(required=True)  # JSON run-webkit-tests result leaf
+        details = columns.Text(required=False)  # Catch-all JSON blob: {authors, pr_number, build_number, build_url, ...}
 
         def unpack(self):
             results = dict(
                 uuid=self.uuid,
                 start_time=calendar.timegm(self.start_time.timetuple()),
-                result=Expectations.state_ids_to_string([self.result]),
+                result=json.loads(self.result),
             )
-            if self.remote:
-                results['remote'] = self.remote
-            if self.pr_number is not None:
-                results['pr_number'] = self.pr_number
-            if self.commit_hash:
-                results['commit_hash'] = self.commit_hash
             if self.details:
                 results['details'] = json.loads(self.details)
             return results
 
-    class EWSFailedTestsByCommit(EWSResultsBase):
-        # test in the partition: one test's failure history is a single-partition read.
-        __table_name__ = 'ews_failed_tests_by_commit'
-        test = columns.Text(partition_key=True, required=True)
+    class EWSFailedTestsByStartTime(EWSResultsBase):
+        __table_name__ = 'ews_failed_tests_by_start_time'
 
-    class EWSFlakyTestsByCommit(EWSResultsBase):
-        # test as the leading clustering key: the (configuration, suite, branch) partition
-        # holds the small set of flaky tests, so we can list them all or check one cheaply.
-        __table_name__ = 'ews_flaky_tests_by_commit'
-        test = columns.Text(primary_key=True, required=True)
-        flaky_type = columns.Text(required=True)  # InterStep, IntraStep, etc.
+    class EWSFlakyTestsByStartTime(EWSResultsBase):
+        __table_name__ = 'ews_flaky_tests_by_start_time'
+        flaky_type = columns.Text(required=True)  # WithChangeStep, WithoutChangeStep, WithChangeInterStep, InterBuild
 
         def unpack(self):
             results = super().unpack()
@@ -87,5 +72,64 @@ class EWSContext(UploadCallbackContext):
         super(EWSContext, self).__init__('ews-results', *args, **kwargs)
 
         with self:
-            self.cassandra.create_table(self.EWSFailedTestsByCommit)
-            self.cassandra.create_table(self.EWSFlakyTestsByCommit)
+            self.cassandra.create_table(self.EWSFailedTestsByStartTime)
+            self.cassandra.create_table(self.EWSFlakyTestsByStartTime)
+
+    def register(self, configuration, commits, suite, test_results, timestamp=None, flaky_type=None, details=None):
+        try:
+            if not isinstance(suite, str):
+                raise TypeError(f'Expected type {str}, got {type(suite)}')
+
+            uuid = self.commit_context.uuid_for_commits(commits)
+            timestamp = timestamp or time.time()
+            if isinstance(timestamp, datetime):
+                timestamp = calendar.timegm(timestamp.timetuple())
+
+            table = self.EWSFlakyTestsByStartTime if flaky_type is not None else self.EWSFailedTestsByStartTime
+            ttl = self.FLAKY_TTL_SECONDS if flaky_type is not None else self.ttl_seconds
+            extra = dict(flaky_type=flaky_type) if flaky_type is not None else {}
+
+            with self, self.cassandra.batch_query_context():
+                for branch in self.commit_context.branch_keys_for_commits(commits):
+                    for test, result in (test_results.get('results') or {}).items():
+                        self.configuration_context.insert_row_with_configuration(
+                            table.__table_name__, configuration=configuration, suite=suite, branch=branch,
+                            test=test, result=json.dumps(result),
+                            uuid=uuid, start_time=timestamp, ttl=ttl,
+                            details=json.dumps(details) if details else None,
+                            **extra,
+                        )
+                    self.configuration_context.register_configuration(configuration, branch=branch, timestamp=timestamp)
+
+        except Exception as e:
+            return self.partial_status(e)
+        return self.partial_status()
+
+    def find_for_test(self, configurations, suite, test, flaky=True, branch=None, recent=True, begin=None, end=None, begin_query_time=None, end_query_time=None, limit=100):
+        if not isinstance(suite, str):
+            raise TypeError(f'Expected type {str} for suite, got {type(suite)}')
+        if not isinstance(test, str):
+            raise TypeError(f'Expected type {str} for test, got {type(test)}')
+
+        table = self.EWSFlakyTestsByStartTime if flaky else self.EWSFailedTestsByStartTime
+
+        def get_time(time):
+            if isinstance(time, datetime):
+                return time
+            elif time:
+                return datetime.utcfromtimestamp(int(time))
+            return None
+
+        with self:
+            return {
+                config: [row.unpack() for row in rows]
+                for config, rows in self.configuration_context.select_from_table_with_configurations(
+                    table.__table_name__, configurations=configurations,
+                    suite=suite, branch=branch or self.commit_context.DEFAULT_BRANCH_KEY, test=test,
+                    recent=recent,
+                    uuid__gte=CommitContext.convert_to_uuid(begin),
+                    uuid__lte=CommitContext.convert_to_uuid(end, CommitContext.timestamp_to_uuid()),
+                    start_time__gte=get_time(begin_query_time), start_time__lte=get_time(end_query_time),
+                    limit=limit,
+                ).items()
+            }

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/ews_context_unittest.py
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/ews_context_unittest.py
@@ -1,0 +1,138 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import time
+
+from fakeredis import FakeStrictRedis
+from redis import StrictRedis
+from resultsdbpy.controller.configuration import Configuration
+from resultsdbpy.model.cassandra_context import CassandraContext
+from resultsdbpy.model.mock_model_factory import MockModelFactory
+from resultsdbpy.model.mock_cassandra_context import MockCassandraContext
+from resultsdbpy.model.wait_for_docker_test_case import WaitForDockerTestCase
+
+
+class EWSContextTest(WaitForDockerTestCase):
+    KEYSPACE = 'ews_context_test_keyspace'
+
+    DEFAULT_TEST_RESULTS = dict(
+        results={
+            'fast/encoding/css-cached-bom.html': {'report': 'REGRESSION', 'expected': 'PASS', 'actual': 'TEXT'},
+            'fast/encoding/css-charset.html': {'report': 'FLAKY', 'expected': 'PASS', 'actual': 'TIMEOUT PASS', 'has_stderr': True},
+            'fast/encoding/css-link-charset.html': {'report': 'MISSING', 'expected': 'PASS', 'actual': 'MISSING', 'is_missing_text': True},
+        },
+    )
+    REGRESSION_TEST = 'fast/encoding/css-cached-bom.html'
+
+    def init_database(self, redis=StrictRedis, cassandra=CassandraContext, test_results=None, timestamps=None, flaky_type=None, details=None):
+        if timestamps is None:
+            timestamps = [int(time.time())]
+
+        with MockModelFactory.safari(), MockModelFactory.webkit():
+            cassandra.drop_keyspace(keyspace=self.KEYSPACE)
+            self.model = MockModelFactory.create(redis=redis(), cassandra=cassandra(keyspace=self.KEYSPACE, create_keyspace=True))
+
+            for timestamp in timestamps:
+                MockModelFactory.add_mock_ews_results(
+                    test_results=test_results or self.DEFAULT_TEST_RESULTS, model=self.model,
+                    flaky_type=flaky_type, details=details, timestamp=timestamp
+                )
+
+    def _find(self, test, flaky=False):
+        return self.model.ews_context.find_for_test(
+            configurations=[Configuration(platform='Mac', style='Release', flavor='wk1')],
+            suite='layout-tests', test=test, recent=True, flaky=flaky,
+        )
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    def test_stores_all_reported_results(self, redis=StrictRedis, cassandra=CassandraContext):
+        self.init_database(redis=redis, cassandra=cassandra)
+
+        for test, leaf in self.DEFAULT_TEST_RESULTS['results'].items():
+            stored = list(self._find(test).values())[0][0]['result']
+            self.assertEqual(stored, leaf)
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    def test_metadata_stored(self, redis=StrictRedis, cassandra=CassandraContext):
+        details = dict(remote='github.com/WebKit/WebKit', pr_number=12345, commit_hash='abc123def456', build_number=678)
+        self.init_database(redis=redis, cassandra=cassandra, details=details)
+
+        entry = list(self._find(self.REGRESSION_TEST).values())[0][0]
+        stored = entry['details']
+        self.assertEqual(stored.get('remote'), 'github.com/WebKit/WebKit')
+        self.assertEqual(stored.get('pr_number'), 12345)
+        self.assertEqual(stored.get('commit_hash'), 'abc123def456')
+        self.assertEqual(stored.get('build_number'), 678)
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    def test_flaky_results_stored(self, redis=StrictRedis, cassandra=CassandraContext):
+        """Flaky results land in a separate table, tagged with their flaky_type. These should not be stored in the failure table."""
+        self.init_database(redis=redis, cassandra=cassandra, flaky_type='InterStep')
+
+        results = self._find(self.REGRESSION_TEST, flaky=True)
+        self.assertGreater(len(results), 0)
+
+        entry = list(results.values())[0][0]
+        self.assertEqual(entry['result']['actual'], 'TEXT')
+        self.assertEqual(entry['flaky_type'], 'InterStep')
+        self.assertEqual(len(self._find(self.REGRESSION_TEST, flaky=False)), 0)
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    def test_retries_preserved_for_same_commit(self, redis=StrictRedis, cassandra=CassandraContext):
+        """EWS may run the same commit more than once. Each run should be preserved as a distinct row in the database."""
+        base = int(time.time())
+        first, second = base - 3600, base
+        self.init_database(redis=redis, cassandra=cassandra, timestamps=[first, second])
+
+        results = self._find(self.REGRESSION_TEST)
+        self.assertGreater(len(results), 0)
+        start_times_by_uuid = {}
+
+        for row in list(results.values())[0]:
+            start_times_by_uuid.setdefault(row['uuid'], set()).add(row['start_time'])
+        self.assertTrue(any({first, second}.issubset(times) for times in start_times_by_uuid.values()))
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    def test_time_window_query(self, redis=StrictRedis, cassandra=CassandraContext):
+        HOUR = 60 * 60
+        now = int(time.time())
+        recent, day_old, old = now - HOUR, now - 30 * HOUR, now - 72 * HOUR
+        self.init_database(redis=redis, cassandra=cassandra, timestamps=[recent, day_old, old])
+
+        def start_times_within(cutoff):
+            results = self.model.ews_context.find_for_test(
+                configurations=[Configuration(platform='Mac', style='Release', flavor='wk1')],
+                suite='layout-tests', test=self.REGRESSION_TEST, flaky=False, recent=False,
+                begin_query_time=cutoff,
+            )
+            return {row['start_time'] for rows in results.values() for row in rows}
+
+        self.assertEqual(start_times_within(now - 24 * HOUR), {recent})
+        self.assertEqual(start_times_within(now - 48 * HOUR), {recent, day_old})
+        self.assertEqual(start_times_within(now - 96 * HOUR), {recent, day_old, old})
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    def test_no_results(self, redis=StrictRedis, cassandra=CassandraContext):
+        with MockModelFactory.safari(), MockModelFactory.webkit():
+            cassandra.drop_keyspace(keyspace=self.KEYSPACE)
+            self.model = MockModelFactory.create(redis=redis(), cassandra=cassandra(keyspace=self.KEYSPACE, create_keyspace=True))
+        self.assertEqual(len(self._find(self.REGRESSION_TEST)), 0)

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/mock_model_factory.py
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/mock_model_factory.py
@@ -26,9 +26,9 @@ import io
 import time
 
 from resultsdbpy.controller.configuration import Configuration
-from resultsdbpy.model.configuration_context_unittest import ConfigurationContextTest
 from resultsdbpy.model.model import Model
 from resultsdbpy.model.repository import StashRepository, WebKitRepository
+from resultsdbpy.model.configuration_context_unittest import ConfigurationContextTest
 
 from webkitscmpy import mocks, Commit
 
@@ -217,6 +217,20 @@ class MockModelFactory(object):
                                 configuration=config, commits=result['commits'], suite=suite,
                                 test_results=result['test_results'], timestamp=result['timestamp'],
                             )
+
+    @classmethod
+    def add_mock_ews_results(cls, test_results, model, configuration=Configuration(), timestamp=None, flaky_type=None, details=None):
+        configurations = [configuration] if configuration.is_complete() else ConfigurationContextTest.CONFIGURATIONS
+
+        for complete_configuration in configurations:
+            if complete_configuration != configuration:
+                continue
+
+            cls.iterate_all_commits(model, lambda commits: model.ews_context.register(
+                complete_configuration, commits, suite='layout-tests',
+                test_results=test_results, flaky_type=flaky_type,
+                timestamp=timestamp, details=details,
+            ))
 
     @classmethod
     def add_mock_archives(cls, model, configuration=Configuration(), suite='layout-tests', archive=None):

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/model.py
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/model.py
@@ -33,6 +33,7 @@ from resultsdbpy.model.upload_context import UploadContext
 from resultsdbpy.model.suite_context import SuiteContext
 from resultsdbpy.model.test_context import TestContext
 from resultsdbpy.model.failure_context import FailureContext
+from resultsdbpy.model.ews_context import EWSContext
 
 
 class Model(object):
@@ -100,6 +101,11 @@ class Model(object):
             commit_context=self.commit_context,
             ttl_seconds=self.archive_ttl_seconds,
             s3_credentials=s3_credentials,
+        )
+
+        self.ews_context = EWSContext(
+            configuration_context=self.configuration_context,
+            commit_context=self.commit_context,
         )
 
     def healthy(self, writable=True):


### PR DESCRIPTION
#### ae1867e8e9b49ece369b854297943d87959980ee
<pre>
Store and query EWS test results in the results database
<a href="https://bugs.webkit.org/show_bug.cgi?id=319400">https://bugs.webkit.org/show_bug.cgi?id=319400</a>
<a href="https://rdar.apple.com/157892382">rdar://157892382</a>

Reviewed by Aakash Jain.

EWSContext defines the EWS results schema (bug 319113); this adds the read
and write path on top of it. register() classifies a run&apos;s unexpected
failures and stores them, routing to the flaky table when given a
flaky_type and the failed table otherwise, and find_for_test() queries
either table via a flaky flag. EWSContext is wired into Model, with a mock
helper (add_mock_ews_results) and unit tests.

This also refines the landed skeleton: the result column becomes result_id,
a build_number column is added, and a Source value type bundles the
provenance columns (remote, pr_number, commit_hash, build_number).

* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/ews_context.py:
(Source):
(Source.unpack):
(EWSContext):
(EWSContext.EWSResultsBase):
(EWSContext.EWSResultsBase.unpack):
(EWSContext.EWSFailedTestsByCommit):
(EWSContext.EWSFlakyTestsByCommit):
(EWSContext.__init__):
(EWSContext.register):
(EWSContext._classify_unexpected):
(EWSContext.find_for_test):
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/ews_context_unittest.py: Added.
(EWSContextTest):
(EWSContextTest.init_database):
(EWSContextTest._find):
(EWSContextTest.test_unexpected_failures_stored):
(EWSContextTest.test_metadata_stored):
(EWSContextTest.test_flaky_results_stored):
(EWSContextTest.test_retries_preserved_for_same_commit):
(EWSContextTest.test_no_unexpected_failures):
(EWSContextTest.test_no_results):
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/mock_model_factory.py:
(MockModelFactory):
(MockModelFactory.add_mock_ews_results):
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/model.py:
(Model.__init__):

Canonical link: <a href="https://commits.webkit.org/317718@main">https://commits.webkit.org/317718@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d00609b21a1e35b3ca88e6e26f323596269db64e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176009 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49942 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43726 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185603 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177872 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51234 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49624 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137066 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178965 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40535 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157837 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117545 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/175332 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39178 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37554 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149596 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37329 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34072 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41760 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188024 "Built successfully") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/175412 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49609 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146073 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50290 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33954 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145911 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26756 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40686 "Passed tests") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/116363 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48796 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12310 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48198 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48430 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48255 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->