### PR TITLE
AX: Preserve the user's focus when invoking an aria-actions custom action

### DIFF
--- a/LayoutTests/accessibility/aria-actions-focus-author-override-expected.txt
+++ b/LayoutTests/accessibility/aria-actions-focus-author-override-expected.txt
@@ -1,0 +1,17 @@
+This test verifies that when an aria-actions custom action's handler moves focus to some other element, that focus change is respected (not bounced back to the origin) and is surfaced to assistive technology.
+
+Invoking the custom action runs the handler, which moves focus elsewhere:
+PASS: source.invokeCustomActionAtIndex(0) === true
+PASS: actionClicked === true
+
+Focus lands on the element the handler chose, not the origin or the action target:
+PASS: document.activeElement.id === 'elsewhere'
+PASS: accessibilityController.focusedElement.domIdentifier === 'elsewhere'
+
+That focus change is surfaced to assistive technology:
+PASS: focusNotificationCount > 0 === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Source Delete Elsewhere

--- a/LayoutTests/accessibility/aria-actions-focus-author-override.html
+++ b/LayoutTests/accessibility/aria-actions-focus-author-override.html
@@ -1,0 +1,61 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ ARIAActionsSupportEnabled=true ] -->
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<button id="source" aria-actions="action">Source</button>
+<button id="action">Delete</button>
+<button id="elsewhere">Elsewhere</button>
+
+<script>
+var output = "This test verifies that when an aria-actions custom action's handler moves focus to some other element, that focus change is respected (not bounced back to the origin) and is surfaced to assistive technology.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var actionClicked = false;
+    document.getElementById("action").addEventListener("click", () => {
+        actionClicked = true;
+        // The action handler deliberately moves focus somewhere of its own choosing.
+        document.getElementById("elsewhere").focus();
+    });
+
+    var focusNotificationCount = 0;
+    accessibilityController.addNotificationListener((axElement, notification) => {
+        if (notification == "AXFocusChanged")
+            ++focusNotificationCount;
+    });
+
+    var source = accessibilityController.accessibleElementById("source");
+
+    setTimeout(async () => {
+        document.getElementById("source").focus();
+        await waitFor(() => accessibilityController.focusedElement?.domIdentifier == "source");
+
+        // Ignore focus notifications from establishing the initial focus above.
+        focusNotificationCount = 0;
+
+        output += "Invoking the custom action runs the handler, which moves focus elsewhere:\n";
+        output += expect("source.invokeCustomActionAtIndex(0)", "true");
+        output += expect("actionClicked", "true");
+        output += "\n";
+
+        output += "Focus lands on the element the handler chose, not the origin or the action target:\n";
+        output += expect("document.activeElement.id", "'elsewhere'");
+        await waitFor(() => accessibilityController.focusedElement?.domIdentifier == "elsewhere");
+        output += expect("accessibilityController.focusedElement.domIdentifier", "'elsewhere'");
+        output += "\n";
+
+        output += "That focus change is surfaced to assistive technology:\n";
+        output += expect("focusNotificationCount > 0", "true");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/aria-actions-focus-in-other-frame-expected.txt
+++ b/LayoutTests/accessibility/aria-actions-focus-in-other-frame-expected.txt
@@ -1,0 +1,15 @@
+This test verifies that when page focus is in a different frame than an aria-actions host, invoking one of its actions falls back to a plain activation (focus may move to the target) rather than losing the focus that was in the other frame.
+
+Focus starts in a different frame:
+PASS: document.activeElement.id === 'frame'
+PASS: frame.contentDocument.activeElement.id === 'inner'
+
+Invoking the action falls back to a plain press, so focus is not lost from the other frame:
+PASS: source.invokeCustomActionAtIndex(0) === true
+PASS: actionClicked === true
+PASS: document.activeElement.id === 'action'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Source Delete

--- a/LayoutTests/accessibility/aria-actions-focus-in-other-frame.html
+++ b/LayoutTests/accessibility/aria-actions-focus-in-other-frame.html
@@ -1,0 +1,45 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ ARIAActionsSupportEnabled=true ] -->
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<button id="source" aria-actions="action">Source</button>
+<button id="action">Delete</button>
+<iframe id="frame" srcdoc="<button id='inner'>Inner</button>"></iframe>
+
+<script>
+var output = "This test verifies that when page focus is in a different frame than an aria-actions host, invoking one of its actions falls back to a plain activation (focus may move to the target) rather than losing the focus that was in the other frame.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var actionClicked = false;
+    document.getElementById("action").addEventListener("click", () => actionClicked = true);
+
+    var source = accessibilityController.accessibleElementById("source");
+    var frame = document.getElementById("frame");
+    frame.addEventListener("load", () => {
+        setTimeout(async () => {
+            // Move DOM focus into the (different) local frame.
+            frame.contentDocument.getElementById("inner").focus();
+            output += "Focus starts in a different frame:\n";
+            output += expect("document.activeElement.id", "'frame'");
+            output += expect("frame.contentDocument.activeElement.id", "'inner'");
+            output += "\n";
+
+            output += "Invoking the action falls back to a plain press, so focus is not lost from the other frame:\n";
+            output += expect("source.invokeCustomActionAtIndex(0)", "true");
+            output += expect("actionClicked", "true");
+            output += expect("document.activeElement.id", "'action'");
+
+            debug(output);
+            finishJSTest();
+        }, 0);
+    });
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/aria-actions-focus-no-origin-expected.txt
+++ b/LayoutTests/accessibility/aria-actions-focus-no-origin-expected.txt
@@ -1,0 +1,19 @@
+This test verifies that invoking an aria-actions custom action while nothing is focused leaves focus cleared, rather than moving it to the (focusable) action target, and that the transient focus movement is not surfaced to assistive technology.
+
+Nothing is focused before invoking the action:
+PASS: document.activeElement === document.body === true
+
+Invoking the custom action clicks the focusable action target:
+PASS: source.invokeCustomActionAtIndex(0) === true
+PASS: actionClicked === true
+
+Focus is left cleared, rather than moving to the action target:
+PASS: document.activeElement === document.body === true
+
+No accessibility focus notification was surfaced for the transient focus movement:
+PASS: focusNotificationCount === 0
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Source Delete

--- a/LayoutTests/accessibility/aria-actions-focus-no-origin.html
+++ b/LayoutTests/accessibility/aria-actions-focus-no-origin.html
@@ -1,0 +1,55 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ ARIAActionsSupportEnabled=true ] -->
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<button id="source" aria-actions="action">Source</button>
+<button id="action">Delete</button>
+
+<script>
+var output = "This test verifies that invoking an aria-actions custom action while nothing is focused leaves focus cleared, rather than moving it to the (focusable) action target, and that the transient focus movement is not surfaced to assistive technology.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var actionClicked = false;
+    document.getElementById("action").addEventListener("click", () => actionClicked = true);
+
+    var focusNotificationCount = 0;
+    accessibilityController.addNotificationListener((axElement, notification) => {
+        if (notification == "AXFocusChanged")
+            ++focusNotificationCount;
+    });
+
+    var source = accessibilityController.accessibleElementById("source");
+
+    setTimeout(async () => {
+        // Nothing is focused up front.
+        output += "Nothing is focused before invoking the action:\n";
+        output += expect("document.activeElement === document.body", "true");
+        output += "\n";
+
+        output += "Invoking the custom action clicks the focusable action target:\n";
+        output += expect("source.invokeCustomActionAtIndex(0)", "true");
+        output += expect("actionClicked", "true");
+        output += "\n";
+
+        output += "Focus is left cleared, rather than moving to the action target:\n";
+        output += expect("document.activeElement === document.body", "true");
+        output += "\n";
+
+        // Give any (unexpected) focus notification a chance to be delivered before asserting none fired.
+        await new Promise(resolve => setTimeout(resolve, 0));
+        output += "No accessibility focus notification was surfaced for the transient focus movement:\n";
+        output += expect("focusNotificationCount", "0");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/aria-actions-focus-restore-fallback-expected.txt
+++ b/LayoutTests/accessibility/aria-actions-focus-restore-fallback-expected.txt
@@ -1,0 +1,17 @@
+This test verifies that if an aria-actions custom action's handler removes the focused origin (so focus can't be restored to it), focus is left on the action target and surfaced to assistive technology, rather than assistive technology being left pointed at the removed origin.
+
+Invoking the custom action runs the handler, which removes the focused origin:
+PASS: source.invokeCustomActionAtIndex(0) === true
+PASS: actionClicked === true
+
+Focus is left on the action target, since the origin could no longer take it back:
+PASS: document.activeElement.id === 'action'
+
+Assistive technology converges on the action target rather than the removed origin:
+PASS: accessibilityController.focusedElement.domIdentifier === 'action'
+PASS: focusNotificationCount > 0 === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Delete

--- a/LayoutTests/accessibility/aria-actions-focus-restore-fallback.html
+++ b/LayoutTests/accessibility/aria-actions-focus-restore-fallback.html
@@ -1,0 +1,60 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ ARIAActionsSupportEnabled=true ] -->
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<button id="source" aria-actions="action">Source</button>
+<button id="action">Delete</button>
+
+<script>
+var output = "This test verifies that if an aria-actions custom action's handler removes the focused origin (so focus can't be restored to it), focus is left on the action target and surfaced to assistive technology, rather than assistive technology being left pointed at the removed origin.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var actionClicked = false;
+    document.getElementById("action").addEventListener("click", () => {
+        actionClicked = true;
+        // Remove the focused origin during the action, so restoring focus to it will fail.
+        document.getElementById("source").remove();
+    });
+
+    var focusNotificationCount = 0;
+    accessibilityController.addNotificationListener((axElement, notification) => {
+        if (notification == "AXFocusChanged")
+            ++focusNotificationCount;
+    });
+
+    var source = accessibilityController.accessibleElementById("source");
+
+    setTimeout(async () => {
+        document.getElementById("source").focus();
+        await waitFor(() => accessibilityController.focusedElement?.domIdentifier == "source");
+
+        // Ignore focus notifications from establishing the initial focus above.
+        focusNotificationCount = 0;
+
+        output += "Invoking the custom action runs the handler, which removes the focused origin:\n";
+        output += expect("source.invokeCustomActionAtIndex(0)", "true");
+        output += expect("actionClicked", "true");
+        output += "\n";
+
+        output += "Focus is left on the action target, since the origin could no longer take it back:\n";
+        output += expect("document.activeElement.id", "'action'");
+        output += "\n";
+
+        output += "Assistive technology converges on the action target rather than the removed origin:\n";
+        await waitFor(() => accessibilityController.focusedElement?.domIdentifier == "action");
+        output += expect("accessibilityController.focusedElement.domIdentifier", "'action'");
+        output += expect("focusNotificationCount > 0", "true");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/aria-actions-preserves-focus-expected.txt
+++ b/LayoutTests/accessibility/aria-actions-preserves-focus-expected.txt
@@ -1,0 +1,20 @@
+This test verifies that invoking an aria-actions custom action preserves focus wherever it was rather than moving it to the (focusable) action target, and that the transient focus movement is not surfaced to assistive technology.
+
+With the element hosting the actions focused, invoking the action preserves focus on it:
+PASS: source.invokeCustomActionAtIndex(0) === true
+PASS: actionClicked === true
+PASS: document.activeElement.id === 'source'
+PASS: accessibilityController.focusedElement.domIdentifier === 'source'
+PASS: focusNotificationCount === 0
+
+With an unrelated element focused, invoking the action preserves focus on that element:
+PASS: source.invokeCustomActionAtIndex(0) === true
+PASS: actionClicked === true
+PASS: document.activeElement.id === 'other'
+PASS: accessibilityController.focusedElement.domIdentifier === 'other'
+PASS: focusNotificationCount === 0
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Source Delete Other

--- a/LayoutTests/accessibility/aria-actions-preserves-focus.html
+++ b/LayoutTests/accessibility/aria-actions-preserves-focus.html
@@ -1,0 +1,64 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ ARIAActionsSupportEnabled=true ] -->
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<button id="source" aria-actions="action">Source</button>
+<button id="action">Delete</button>
+<button id="other">Other</button>
+
+<script>
+var output = "This test verifies that invoking an aria-actions custom action preserves focus wherever it was rather than moving it to the (focusable) action target, and that the transient focus movement is not surfaced to assistive technology.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var actionClicked = false;
+    document.getElementById("action").addEventListener("click", () => actionClicked = true);
+
+    var focusNotificationCount = 0;
+    accessibilityController.addNotificationListener((axElement, notification) => {
+        if (notification == "AXFocusChanged")
+            ++focusNotificationCount;
+    });
+
+    var source = accessibilityController.accessibleElementById("source");
+    var originId;
+
+    async function invokeActionAndVerifyFocusIsPreserved(id) {
+        originId = id;
+        document.getElementById(originId).focus();
+        await waitFor(() => accessibilityController.focusedElement?.domIdentifier == originId);
+
+        // Ignore focus notifications and clicks from establishing the initial focus above.
+        focusNotificationCount = 0;
+        actionClicked = false;
+
+        output += expect("source.invokeCustomActionAtIndex(0)", "true");
+        output += expect("actionClicked", "true");
+        output += expect("document.activeElement.id", `'${originId}'`);
+        output += expect("accessibilityController.focusedElement.domIdentifier", `'${originId}'`);
+
+        // Give any (unexpected) focus notification a chance to be delivered before asserting none fired.
+        await new Promise(resolve => setTimeout(resolve, 0));
+        output += expect("focusNotificationCount", "0");
+    }
+
+    setTimeout(async () => {
+        output += "With the element hosting the actions focused, invoking the action preserves focus on it:\n";
+        await invokeActionAndVerifyFocusIsPreserved("source");
+        output += "\n";
+
+        output += "With an unrelated element focused, invoking the action preserves focus on that element:\n";
+        await invokeActionAndVerifyFocusIsPreserved("other");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1017,6 +1017,11 @@ accessibility/dynamic-speak-as.html [ Failure ]
 # Missing AccessibilityUIElement::{ariaActionsElementAtIndex, invokeCustomActionAtIndex} implementations.
 accessibility/aria-actions.html [ Skip ]
 accessibility/aria-actions-ignored-target.html [ Skip ]
+accessibility/aria-actions-preserves-focus.html [ Skip ]
+accessibility/aria-actions-focus-author-override.html [ Skip ]
+accessibility/aria-actions-focus-restore-fallback.html [ Skip ]
+accessibility/aria-actions-focus-no-origin.html [ Skip ]
+accessibility/aria-actions-focus-in-other-frame.html [ Skip ]
 
 # Missing AccessibilityUIElement::showMenu implementation.
 accessibility/show-menu-fires-contextmenu-event.html [ Skip ]

--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -2335,7 +2335,7 @@ bool performCustomActionPress(AXTreeID treeID, AXID targetID)
     return retrieveValueFromMainThreadWithTimeoutAndDefault([treeID, targetID] () -> bool {
         if (WeakPtr<AXObjectCache> cache = AXTreeStore<AXObjectCache>::axObjectCacheForID(treeID)) {
             if (RefPtr object = cache->objectForID(targetID))
-                return object->press();
+                return object->pressPreservingFocus();
         }
         return false;
     }, InteractiveTimeout, false);

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -2395,6 +2395,20 @@ static bool shouldDeferFocusChange(Element* element)
 
 void AXObjectCache::onFocusChange(Element* oldElement, Element* newElement)
 {
+    if (m_suppressedFocusChange && m_suppressedFocusChange->get() == newElement) {
+        // We deliberately don't want to surface this focus change to assistive technology.
+        // One situation where this is relevant is downstream of invoking an aria-action.
+        // Inherently, the simulated click that results from invoking the action moves
+        // focus to the action target, but the user experience for aria-actions demands
+        // that focus "stay on" (or immediately bounce back to) the originating element.
+        // We explicitly do not want assistive technologies to actually bounce back and forth
+        // as that would cause confusing announcements, so we supress the focus change.
+        //
+        // A null suppressed element matches a clearing of focus, used when the focus we're
+        // restoring had no origin (nothing was focused before the action).
+        return;
+    }
+
     if (m_deferredRemoteFrameFocus) {
         if (newElement) {
             // Focus is going to a local element, not the remote frame.

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -683,6 +683,11 @@ public:
     void NODELETE setTextSelectionIntent(const AXTextStateChangeIntent&);
     void NODELETE setIsSynchronizingSelection(bool);
 
+    // While non-std::nullopt, a focus change onto the given element will not be surfaced to assistive
+    // technology. A null target suppresses a *clearing* of focus instead.
+    void beginSuppressingFocusChange(Element* target) { m_suppressedFocusChange = WeakPtr { target }; }
+    void endSuppressingFocusChange() { m_suppressedFocusChange = std::nullopt; }
+
     void postTextStateChangeNotification(Node*, AXTextEditType, const String&, const VisiblePosition&);
     void postTextReplacementNotification(Node*, AXTextEditType deletionType, const String& deletedText, AXTextEditType insertionType, const String& insertedText, const VisiblePosition&);
     void postTextReplacementNotificationForTextControl(HTMLTextFormControlElement&, const String& deletedText, const String& insertedText);
@@ -1108,6 +1113,13 @@ private:
     Vector<CanvasFocusPathBoundsChange> m_deferredCanvasFocusPathBoundsChanges;
     std::optional<std::pair<WeakPtr<Element, WeakPtrImplWithEventTargetData>, WeakPtr<Element, WeakPtrImplWithEventTargetData>>> m_deferredFocusedNodeChange;
     std::optional<DeferredRemoteFrameFocus> m_deferredRemoteFrameFocus;
+    // A std::nullopt means no focus change is set up for suppression.
+    // A non-std::nullopt value of nullptr means to suppress the next focus clear.
+    // A non-std::nullopt value of an element means to suppress the focus change to that element.
+    //
+    // In all three cases, the term "suppression" refers to the act of not surfacing a focus
+    // change notification to assistive technologies.
+    std::optional<WeakPtr<Element, WeakPtrImplWithEventTargetData>> m_suppressedFocusChange;
     WeakHashSet<AccessibilityObject> m_deferredUnconnectedObjects;
 #if PLATFORM(MAC)
     HashMap<PreSortedObjectType, Vector<Ref<AccessibilityObject>>, IntHash<PreSortedObjectType>, WTF::StrongEnumHashTraits<PreSortedObjectType>> m_deferredUnsortedObjects;

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -97,6 +97,7 @@
 #include "PositionInlines.h"
 #include "ProgressTracker.h"
 #include "Range.h"
+#include "RemoteFrame.h"
 #include "RenderElementInlines.h"
 #include "RenderImage.h"
 #include "RenderImageResource.h"
@@ -1613,6 +1614,73 @@ bool AccessibilityObject::press()
     }
 
     return pressElement->accessKeyAction(true) || pressElement->dispatchSimulatedClick(nullptr, SendMouseUpDownEvents);
+}
+
+bool AccessibilityObject::pressPreservingFocus()
+{
+    RefPtr document = this->document();
+    RefPtr page = document ? document->page() : nullptr;
+    WeakPtr cache = axObjectCache();
+    if (!cache || !document || !page) {
+        // Without a cache to suppress notifications through, or a document / page to reason about
+        // focus within, there's nothing to preserve, so just perform the press.
+        return press();
+    }
+
+    // The focus we want to preserve is the page's focused element, which need not live in the
+    // action target's document. If it's in a remote (out-of-process) frame we can't reach it as an
+    // Element at all. If it's in a different local frame, we can't cleanly suppress its notifications
+    // from here (a cross-document focus change fires onFocusChange on both documents' caches). In
+    // either case, fall back to a plain press, which may move focus to the target as it did before
+    // this change.
+    // FIXME: Preserve focus across frames (local *and* remote) too.
+    auto& focusController = page->focusController();
+    if (is<RemoteFrame>(focusController.focusedFrame()))
+        return press();
+    RefPtr focusedLocalFrame = focusController.localFocusedFrame();
+    RefPtr originalFocusedElement = focusedLocalFrame ? focusedLocalFrame->document()->focusedElement() : nullptr;
+    if (originalFocusedElement && &originalFocusedElement->document() != document.get())
+        return press();
+
+    RefPtr actionTarget = dynamicDowncast<Element>(node());
+    cache->beginSuppressingFocusChange(actionTarget.get());
+    bool result = press();
+
+    if (!cache) {
+        // press() can run author script that tears down the cache, in which case the WeakPtr is nulled
+        // and there's nothing left to clean up.
+        return result;
+    }
+    cache->endSuppressingFocusChange();
+
+    if (!actionTarget || document->focusedElement() != actionTarget) {
+        // Pressing didn't move focus, or author script moved it somewhere else (which we don't
+        // want to overwrite).
+        return result;
+    }
+
+    // Pressing the action target moved focus onto it. Restore focus to where it was (the original
+    // element, or nothing if nothing was focused). We suppress that notification too, since as far
+    // as assistive technology is concerned, focus never left where it was before the action.
+    cache->beginSuppressingFocusChange(originalFocusedElement.get());
+    if (originalFocusedElement)
+        originalFocusedElement->focus();
+    else
+        document->setFocusedElement(nullptr);
+
+    if (!cache) {
+        // focus() / setFocusedElement() can also run author script that tears down the cache.
+        return result;
+    }
+    cache->endSuppressingFocusChange();
+
+    // If focus didn't end up where we intended (e.g. author script disconnected the origin during
+    // the press so it couldn't take focus back), surface the real focus now so assistive technology
+    // moves to it, rather than being left pointed at the stale origin whose focus change we suppressed above.
+    if (RefPtr currentFocusedElement = document->focusedElement(); currentFocusedElement && currentFocusedElement != originalFocusedElement)
+        cache->onFocusChange(nullptr, currentFocusedElement.get());
+
+    return result;
 }
 
 bool AccessibilityObject::performShowMenuAction()

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -578,6 +578,11 @@ public:
     void performDismissActionIgnoringResult() final { performDismissAction(); }
     bool press() override;
     bool syncPress() override { return press(); }
+    // Presses this object as an aria-actions action target, then restores focus to wherever it was
+    // beforehand (not only when the action's host was focused) if pressing moved focus onto this
+    // object, e.g. because it's a focusable button. The intervening focus movement is not surfaced
+    // to assistive technology, so invoking an action never moves the user's focus.
+    bool pressPreservingFocus();
     bool performShowMenuAction();
 
     std::optional<AccessibilityOrientation> explicitOrientation() const override { return std::nullopt; }


### PR DESCRIPTION
#### 9d4fccacaa23d20fbc6870a3f1278b656bbd5acf
<pre>
AX: Preserve the user&apos;s focus when invoking an aria-actions custom action
<a href="https://bugs.webkit.org/show_bug.cgi?id=319391">https://bugs.webkit.org/show_bug.cgi?id=319391</a>
<a href="https://rdar.apple.com/182223716">rdar://182223716</a>

Reviewed by Dominic Mazzoni.

An element&apos;s aria-actions attribute exposes other elements as custom actions on
that element. When an assistive technology invokes one of those actions, the
following sequence happens:

  1. The platform&apos;s custom-action handler calls performCustomActionPress()
     which resolves the action target and presses it.

  2. This dispatches a simulated click (to pretend a &quot;real&quot; mouseclick
     happened for privacy reasons). This inherently causes focus to
     move to it.

The result is that invoking an action steals focus from wherever the AT user was,
and fires an accessibility focus notification for the target. This is not the
desired user experience for aria-actions -- focus should remain on the originating,
aria-actions-having element.

Fix this by giving the custom-action path its own press variant, pressPreservingFocus().
It records where focus currently is, presses the action target, and if the press moved
focus onto that target, restores focus to where it was. The accessibility focus notifications
for both the transient move onto the target and the restore are suppressed, so the momentary
focus movement is never surfaced to the assistive technology. The check-and-restore is done
synchronously, so no author script can run between observing that focus landed
on the target and restoring it. This only affects the aria-actions custom-action path.

If author script moved focus somewhere other than the action target, that is respected and left
in place. If the origin can no longer take focus back (e.g. it was disconnected during the press),
the real focus is surfaced so the assistive technology can move there instead of being left
pointed at the stale origin.

This heuristic aligns with other browsers.

* LayoutTests/accessibility/aria-actions-focus-author-override-expected.txt: Added.
* LayoutTests/accessibility/aria-actions-focus-author-override.html: Added.
* LayoutTests/accessibility/aria-actions-focus-in-other-frame-expected.txt: Added.
* LayoutTests/accessibility/aria-actions-focus-in-other-frame.html: Added.
* LayoutTests/accessibility/aria-actions-focus-no-origin-expected.txt: Added.
* LayoutTests/accessibility/aria-actions-focus-no-origin.html: Added.
* LayoutTests/accessibility/aria-actions-focus-restore-fallback-expected.txt: Added.
* LayoutTests/accessibility/aria-actions-focus-restore-fallback.html: Added.
* LayoutTests/accessibility/aria-actions-preserves-focus-expected.txt: Added.
* LayoutTests/accessibility/aria-actions-preserves-focus.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::Accessibility::performCustomActionPress):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::onFocusChange):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::pressPreservingFocus):
* Source/WebCore/accessibility/AccessibilityObject.h:

Canonical link: <a href="https://commits.webkit.org/317542@main">https://commits.webkit.org/317542@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ba0d3fdb73096764d041627477b1446977f2337

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175118 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49051 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42832 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184704 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/133026 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1a6a6ee8-46ad-436d-8528-ecc3cd403bc2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176983 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50343 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48734 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136306 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96147 "4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/78e9c907-f9e7-442b-b65b-12bd4b619c7f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178076 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39741 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157094 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116785 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/543c0bca-d62a-4016-8edb-565a2de46107) 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/174440 "webkitpy-tests (failure)") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38382 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36766 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33177 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5603 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148805 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36587 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187124 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/36380 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/40780 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40969 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145251 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/174518 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48718 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156650 "") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145107 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39198 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49398 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33207 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115232 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39965 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121695 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/212210 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47904 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11560 "") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55367 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47307 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47537 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47364 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->