### PR TITLE
AX: VoiceOver is silent during character navigation inside a local iframe

### DIFF
--- a/LayoutTests/accessibility/mac/local-frame-input-selection-notification-expected.txt
+++ b/LayoutTests/accessibility/mac/local-frame-input-selection-notification-expected.txt
@@ -1,0 +1,7 @@
+Ensures a caret/selection move inside a text input in an in-process (local) iframe posts AXSelectedTextChanged on the main-frame web area. Regression test for VoiceOver character navigation being silent inside a local iframe: the child frame's selection change was posted only on the child frame's own web area, never on the main web area (the document text-selection context VoiceOver tracks), so nothing was announced.
+PASS: receivedSelectionChangedOnMainWebArea === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/local-frame-input-selection-notification.html
+++ b/LayoutTests/accessibility/mac/local-frame-input-selection-notification.html
@@ -1,0 +1,65 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+<style>
+iframe {
+    width: 200px;
+    height: 100px;
+    border: none;
+}
+</style>
+</head>
+<body>
+
+<div id="container">
+    <iframe id="iframe" title="CVV Input" onload="runTest()" src="../resources/local-frame-text-input.html"></iframe>
+</div>
+
+<script>
+var output = "Ensures a caret/selection move inside a text input in an in-process (local) iframe posts AXSelectedTextChanged on the main-frame web area. Regression test for VoiceOver character navigation being silent inside a local iframe: the child frame's selection change was posted only on the child frame's own web area, never on the main web area (the document text-selection context VoiceOver tracks), so nothing was announced.\n";
+
+window.jsTestIsAsync = true;
+
+var mainWebArea;
+var receivedSelectionChangedOnMainWebArea = false;
+
+function notificationCallback(element, notificationName) {
+    if (notificationName !== "AXSelectedTextChanged")
+        return;
+
+    // With the fix, a selection change inside the local child frame is also posted on this (main) frame's
+    // web area. Without it, the notification is posted only on the child frame's own web area and never
+    // reaches the main web area here, so the test times out.
+    if (!receivedSelectionChangedOnMainWebArea && element && mainWebArea && element.isEqual(mainWebArea)) {
+        receivedSelectionChangedOnMainWebArea = true;
+        output += expect("receivedSelectionChangedOnMainWebArea", "true");
+        accessibilityController.removeNotificationListener();
+        debug(output);
+        finishJSTest();
+    }
+}
+
+function runTest() {
+    if (!window.accessibilityController)
+        return;
+
+    setTimeout(async function() {
+        await waitForIframeAccessibilityReady("container", "cvv");
+
+        mainWebArea = accessibilityController.rootElement.childAtIndex(0);
+        accessibilityController.addNotificationListener(notificationCallback);
+
+        // Put content in the iframe's input, focus it, then move the caret. The selection change happens
+        // inside the child frame; the fix relays AXSelectedTextChanged up to the main web area. Deferred
+        // so we don't dirty the selection in the middle of AX notification dispatch.
+        var input = document.getElementById("iframe").contentDocument.getElementById("cvv");
+        input.value = "123";
+        input.focus();
+        setTimeout(() => { input.setSelectionRange(1, 3); }, 0);
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
+++ b/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
@@ -40,6 +40,7 @@
 #import "CocoaAccessibilityConstants.h"
 #import "DeprecatedGlobalSettings.h"
 #import "DocumentView.h"
+#import "FrameTree.h"
 #import "LocalFrameInlines.h"
 #import "LocalFrameView.h"
 #import "RenderObject.h"
@@ -572,6 +573,28 @@ void AXObjectCache::postTextSelectionChangePlatformNotification(AccessibilityObj
         if (root->wrapper() != axObject->wrapper())
             AXPostNotificationWithUserInfo(axObject->wrapper(), NSAccessibilitySelectedTextChangedNotification, userInfo.get());
     }
+
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+    // A selection change inside an in-process (local) child frame is posted above only on that child
+    // frame's own web area and text control. VoiceOver tracks the document's text-selection context on
+    // the MAIN frame's web area, and a child frame's root web area does not connect to it through the
+    // ordinary parentObject() chain (AccessibilityScrollView::parentObject() returns nullptr for a root
+    // web area; the link exists only via crossFrameParentObject()). So VoiceOver never associates the
+    // child-frame selection change with the document and announces nothing when arrowing through a text
+    // field inside an iframe. Also post the notification on each ancestor frame's web area (up to the
+    // main frame's), reusing the same userInfo — its marker range and TextChangeElement carry their own
+    // (child) tree identifiers, so the announced selection resolves correctly cross-frame.
+    RefPtr document = this->document();
+    RefPtr frame = document ? document->frame() : nullptr;
+    for (RefPtr<Frame> ancestor = frame ? frame->tree().parent() : nullptr; ancestor; ancestor = ancestor->tree().parent()) {
+        if (RefPtr localAncestorFrame = dynamicDowncast<LocalFrame>(ancestor.get())) {
+            RefPtr ancestorDocument = localAncestorFrame->document();
+            CheckedPtr ancestorCache = ancestorDocument ? ancestorDocument->existingAXObjectCache() : nullptr;
+            if (RefPtr ancestorRoot = ancestorCache ? ancestorCache->rootWebArea() : nullptr)
+                AXPostNotificationWithUserInfo(ancestorRoot->wrapper(), NSAccessibilitySelectedTextChangedNotification, userInfo.get());
+        }
+    }
+#endif // ENABLE(ACCESSIBILITY_LOCAL_FRAME)
 }
 
 static void addTextMarkerForVisiblePosition(NSMutableDictionary *change, AXObjectCache& cache, const VisiblePosition& position)


### PR DESCRIPTION
#### 20461c7e4d144c9c1f4e229034df982eac5fea44
<pre>
AX: VoiceOver is silent during character navigation inside a local iframe
<a href="https://bugs.webkit.org/show_bug.cgi?id=319402">https://bugs.webkit.org/show_bug.cgi?id=319402</a>
<a href="https://rdar.apple.com/182229891">rdar://182229891</a>

Reviewed by Tyler Wilcock.

A selection/caret change inside an in-process (local) iframe was
posted only on the child frame&apos;s own web area, never on an ancestor&apos;s,
so VoiceOver never associated it with the document and stayed
silent. After posting on the child frame, walk up the ancestor local
frames and repost AXSelectedTextChanged on each one&apos;s web area
(reusing the same userInfo), so the change reaches the main web area
VoiceOver tracks.

Test: accessibility/mac/local-frame-input-selection-notification.html

* LayoutTests/accessibility/mac/local-frame-input-selection-notification-expected.txt: Added.
* LayoutTests/accessibility/mac/local-frame-input-selection-notification.html: Added.
* Source/WebCore/accessibility/mac/AXObjectCacheMac.mm:
(WebCore::AXObjectCache::postTextSelectionChangePlatformNotification):

Canonical link: <a href="https://commits.webkit.org/317264@main">https://commits.webkit.org/317264@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/951f15421b7db57d45e2b9ffa7be7013583baf71

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174552 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48485 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42266 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184129 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132420 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3119d7f2-294d-4076-9057-0f5af3662208) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176417 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49777 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48168 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135804 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95838 "1 flakes 3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/987c79d0-91dc-42c9-8809-679d0c33046d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177510 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39237 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156596 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116282 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/945e73df-040e-4818-bcbe-badc700f638b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37878 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36251 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32610 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148301 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36088 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186556 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39811 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40448 "Found 1 new test failure: imported/w3c/web-platform-tests/html/cross-origin-opener-policy/resource-popup.https.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144719 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48152 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156151 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144580 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39017 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48831 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32708 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114614 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39474 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120817 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47338 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11053 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46740 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46971 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46798 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->