### PR TITLE
Web Inspector: Timeline recording import reports "unsupported version" as a HAR Import Error

### DIFF
--- a/LayoutTests/inspector/timeline/import-errors-expected.txt
+++ b/LayoutTests/inspector/timeline/import-errors-expected.txt
@@ -1,0 +1,27 @@
+Tests that WI.TimelineManager.processJSON reports import errors through the Timeline importer.
+
+
+== Running test suite: TimelineManager.processJSON.errors
+-- Running test case: ExplicitError
+PASS: Should have synthesized an import error.
+PASS: Import error should be synthesized by WI.TimelineManager.
+Error Message: could not read file
+
+-- Running test case: NotAnObject
+PASS: Should have synthesized an import error.
+PASS: Import error should be synthesized by WI.TimelineManager.
+Error Message: invalid JSON
+
+-- Running test case: MissingRequiredKeys
+PASS: Should have synthesized an import error.
+PASS: Import error should be synthesized by WI.TimelineManager.
+Error Message: invalid JSON
+
+-- Running test case: UnsupportedVersion
+PASS: Should have synthesized an import error.
+PASS: Import error should be synthesized by WI.TimelineManager.
+Error Message: unsupported version
+
+-- Running test case: Cleanup
+Restored.
+

--- a/LayoutTests/inspector/timeline/import-errors.html
+++ b/LayoutTests/inspector/timeline/import-errors.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("TimelineManager.processJSON.errors");
+
+    // The synthesizeImportError variants differ only by their message prefix, so stub both and
+    // record which manager handled each error path. This lets us assert that every import error --
+    // including the unsupported-version path (webkit.org/b/319407) -- is synthesized by
+    // WI.TimelineManager and not another manager such as WI.NetworkManager.
+    let lastError = null;
+    let originalTimelineSynthesize = WI.TimelineManager.synthesizeImportError;
+    let originalNetworkSynthesize = WI.NetworkManager.synthesizeImportError;
+    WI.TimelineManager.synthesizeImportError = (message) => { lastError = {manager: "TimelineManager", message}; };
+    WI.NetworkManager.synthesizeImportError = (message) => { lastError = {manager: "NetworkManager", message}; };
+
+    function addErrorTestCase({name, description, data}) {
+        suite.addTestCase({
+            name,
+            description,
+            async test() {
+                lastError = null;
+                await WI.timelineManager.processJSON(data);
+                InspectorTest.expectThat(lastError, "Should have synthesized an import error.");
+                InspectorTest.expectEqual(lastError.manager, "TimelineManager", "Import error should be synthesized by WI.TimelineManager.");
+                InspectorTest.log(`Error Message: ${lastError.message}`);
+            }
+        });
+    }
+
+    addErrorTestCase({
+        name: "ExplicitError",
+        description: "An error surfaced while loading the file should be reported.",
+        data: {filename: "test.json", json: null, error: "could not read file"},
+    });
+
+    addErrorTestCase({
+        name: "NotAnObject",
+        description: "JSON that is not an object should be rejected.",
+        data: {filename: "test.json", json: 42},
+    });
+
+    addErrorTestCase({
+        name: "MissingRequiredKeys",
+        description: "JSON missing the recording/overview/version keys should be rejected.",
+        data: {filename: "test.json", json: {}},
+    });
+
+    addErrorTestCase({
+        name: "UnsupportedVersion",
+        description: "A recording with an unsupported serialization version should be rejected by the Timeline importer.",
+        data: {filename: "test.json", json: {recording: {}, overview: {}, version: WI.TimelineRecording.SerializationVersion + 1000}},
+    });
+
+    suite.addTestCase({
+        name: "Cleanup",
+        description: "Restore the stubbed synthesizeImportError methods.",
+        async test() {
+            WI.TimelineManager.synthesizeImportError = originalTimelineSynthesize;
+            WI.NetworkManager.synthesizeImportError = originalNetworkSynthesize;
+            InspectorTest.log("Restored.");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Tests that WI.TimelineManager.processJSON reports import errors through the Timeline importer.</p>
+</body>
+</html>

--- a/Source/WebInspectorUI/UserInterface/Controllers/TimelineManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/TimelineManager.js
@@ -332,7 +332,7 @@ WI.TimelineManager = class TimelineManager extends WI.Object
         }
 
         if (json.version !== WI.TimelineRecording.SerializationVersion) {
-            WI.NetworkManager.synthesizeImportError(WI.UIString("unsupported version"));
+            WI.TimelineManager.synthesizeImportError(WI.UIString("unsupported version"));
             return;
         }
 


### PR DESCRIPTION
#### b709f9a52609ca525c10eaeda0cc0ff9c8c9f52b
<pre>
Web Inspector: Timeline recording import reports &quot;unsupported version&quot; as a HAR Import Error
<a href="https://bugs.webkit.org/show_bug.cgi?id=319403">https://bugs.webkit.org/show_bug.cgi?id=319403</a>
<a href="https://rdar.apple.com/182231038">rdar://182231038</a>

Reviewed by Devin Rousso.

TimelineManager.processJSON() reports every import failure through
WI.TimelineManager.synthesizeImportError(), which prefixes the message
with &quot;Timeline Recording Import Error:&quot;. The unsupported-version path
mistakenly called WI.NetworkManager.synthesizeImportError() instead,
which prefixes with &quot;HAR Import Error:&quot;. As a result, importing a
timeline recording with an unsupported serialization version surfaced a
misleading &quot;HAR Import Error: unsupported version&quot; message.

Route the version-mismatch error through WI.TimelineManager like the
other error paths in processJSON().

* Source/WebInspectorUI/UserInterface/Controllers/TimelineManager.js:
(WI.TimelineManager.prototype.async processJSON):
* LayoutTests/inspector/timeline/import-errors-expected.txt: Added.
* LayoutTests/inspector/timeline/import-errors.html: Added.

Canonical link: <a href="https://commits.webkit.org/317217@main">https://commits.webkit.org/317217@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e4b8ecf14e5834fecd6bfb9c57a87398ac9c7b0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174558 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48491 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42272 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184135 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132426 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b55ea3d4-9bd8-4e18-8275-c048e59b12a8) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49783 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48174 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135810 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fdd0c020-8eb2-40db-9c1c-89cb867c9fd2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177516 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39240 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156601 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116288 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/34fa78bf-d2b0-4790-8229-8d1572aabb48) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37881 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36254 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32616 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148304 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36093 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186562 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39817 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40451 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144726 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48158 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156156 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144587 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38989 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48837 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32713 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39480 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120824 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47344 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11058 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46746 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46977 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46804 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->