### PR TITLE
[GFC] Grid item's overflowing content may not get painted

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-overflowing-item-content-is-painted-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-overflowing-item-content-is-painted-expected.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<link rel="author" title="Morten Stenshorne" href="mstensho@chromium.org">
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height:100px; background:green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-overflowing-item-content-is-painted.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-overflowing-item-content-is-painted.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-grid/">
+<link rel="help" href="https://drafts.csswg.org/css-overflow/#scrollable">
+<link rel="match" href="../reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="An off screen grid item's overflowing context is still painted in the overflow hidden container.">
+<p>Test passes if there is a filled green square.</p>
+<div style="width: 100px; height: 100px; overflow: hidden;">
+  <div style="display: grid; grid-template-columns: 100px; grid-template-rows: 50px; margin-left: -150px; margin-top: -100px;">
+    <div style="grid-column: 1 / 2; grid-row: 1 / 2;">
+      <div style="width: 250px; height: 200px; background: green;"></div>
+    </div>
+  </div>
+</div>

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.cpp
@@ -236,6 +236,13 @@ void GridLayout::updateOverflow(RenderGrid& renderGrid)
         LayoutRect gridItemBorderBoxRect = Layout::BoxGeometry::borderBoxRect(layoutState->geometryForBox(layoutBox));
         gridItemBorderBoxRect.move(contentBoxOffset);
         gridItemsOverflowRect.unite(gridItemBorderBoxRect);
+
+        CheckedRef gridItemRenderer = downcast<RenderBox>(*layoutBox->rendererForIntegration());
+        if (gridItemRenderer->hasVisualOverflow()) {
+            auto gridItemVisualOverflowRect = gridItemRenderer->visualOverflowRectForPropagation(renderGrid.writingMode());
+            gridItemVisualOverflowRect.move(gridItemRenderer->locationOffset());
+            gridItemsOverflowRect.unite(gridItemVisualOverflowRect);
+        }
     }
 
     if (!renderGrid.borderBoxRect().contains(gridItemsOverflowRect))


### PR DESCRIPTION
#### 965adbc7f1f4db86a27a2e14de308abd2da61fdc
<pre>
[GFC] Grid item&apos;s overflowing content may not get painted
<a href="https://bugs.webkit.org/show_bug.cgi?id=319406">https://bugs.webkit.org/show_bug.cgi?id=319406</a>
<a href="https://rdar.apple.com/182233113">rdar://182233113</a>

Reviewed by Alan Baradlay.

In the attached testcase we have a grid with a grid item that is
positioned offscreen via a negative margin on the grid. The container
that the grid is in has overflow: hidden and is positioned inside the
body. The following diagram shows what this content is like:

    (-150,-100)          (-50,-100)
        +--------------------+
        |  grid container    |   border box 100x50, pushed off the
        |  + grid item       |   top-left with negative margins so it
        +--------------------+   lies entirely outside the clip region
    (-150,-50)           (-50,-50)
        :                              (0,0)             (100,0)
        :  green item content            +-----------------+
        :  (250x200) overflows           |                 |
        :  down/right into the           |  visible green  |
        :  clip region .................|.  (fills box)    |
        :                                |                 |
        +--------------------------------+-----------------+
    (-150,100)                        (0,100)           (100,100)
                                     overflow:hidden container (100x100)

Currently the overflowing content does not get painted because in
RenderBlock:paint we bail since the grid, which is the visual content,
is clipped out. This is similar to the bug that we fixed in 316668@main
but in this case the overflowing content comes from the grid item&apos;s
content and not the grid item itself.

So, to fix it we expand upon the fix we applied in the previous patch
and also take into consideration any visual overflow that comes from
within the grid item.

Canonical link: <a href="https://commits.webkit.org/317250@main">https://commits.webkit.org/317250@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f239ddb8a7509a17118a54979c179682563db4f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174577 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48510 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42291 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184154 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132445 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/04113bf2-b6bc-45af-879d-48982cf158eb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176442 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49802 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48193 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135830 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/580542a8-21a7-48b6-83ad-9f66484bf71c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177535 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39262 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156618 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116308 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cfae3894-bd37-4316-ae56-489e9272b56d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37903 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36275 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32635 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148326 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36110 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186581 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39899 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40472 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144747 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48177 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156173 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144607 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39010 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48856 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32730 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39493 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120848 "Found 121 new failures in b3/B3Value.h, b3/testb3_7.cpp, WebProcess/Network/WebResourceLoader.cpp, UIProcess/WebProcessPool.cpp, Shared/Cocoa/WKNSArray.mm, Shared/SessionState.cpp, NetworkProcess/NetworkResourceLoadParameters.cpp, WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm, WebProcess/WebPage/WebPage.cpp, WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm ...") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47363 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11076 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46765 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46996 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46823 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->