### PR TITLE
Web Inspector: [SI] coordinate Cmd+Z across per-frame undo stacks

### DIFF
--- a/LayoutTests/http/tests/site-isolation/inspector/dom/cross-frame-undo-coordinator-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/dom/cross-frame-undo-coordinator-expected.txt
@@ -1,0 +1,33 @@
+Tests cross-frame Cmd+Z ordering through WI.DOMUndoCoordinator's LIFO of edited targets.
+
+
+
+== Running test suite: SiteIsolation.DOM.UndoCoordinator.CrossFrame
+-- Running test case: Setup
+PASS: Should find #parent-target in the main page.
+PASS: Should find a cross-origin frame target.
+PASS: Should find #container in the iframe.
+
+-- Running test case: EditFrameThenMain.UndoUndoesMainFirst
+PASS: Frame edit applied.
+PASS: Main edit applied.
+PASS: First undo reversed the main edit.
+PASS: First undo did NOT touch the iframe edit.
+PASS: Second undo reversed the iframe edit.
+
+-- Running test case: RedoFollowsLIFOInReverse
+PASS: First redo restored the iframe edit.
+PASS: First redo did NOT restore the main edit.
+PASS: Second redo restored the main edit.
+
+-- Running test case: MultipleEditsPerTargetReversedInOrder
+PASS: Both iframe edits reversed.
+PASS: Main edit reversed.
+
+-- Running test case: ExtraUndoIsHarmless
+PASS: Empty-stack undo() did not push to undoStack.
+PASS: Empty-stack undo() did not push to redoStack.
+PASS: Empty-stack redo() falls back to main exactly once.
+PASS: Empty-stack redo() did not push to undoStack.
+PASS: Empty-stack redo() did not push to redoStack.
+

--- a/LayoutTests/http/tests/site-isolation/inspector/dom/cross-frame-undo-coordinator.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/dom/cross-frame-undo-coordinator.html
@@ -1,0 +1,193 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script src="../debugger/resources/site-isolation-debugger-test-utilities.js"></script>
+<script>
+function test() {
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.DOM.UndoCoordinator.CrossFrame");
+
+    let mainTarget = null;
+    let frameTarget = null;
+    let parentNode = null;
+    let frameContainerNode = null;
+
+    function bid(node) { return node.backendNodeId; }
+
+    async function getOuterHTMLViaTarget(target, node) {
+        let {outerHTML} = await target.DOMAgent.getOuterHTML(bid(node));
+        return outerHTML;
+    }
+
+    async function findChildElement(parent, predicate) {
+        await new Promise((resolve) => parent.getChildNodes(resolve));
+        return parent.children.find(predicate);
+    }
+
+    function clearCoordinatorStacks() {
+        WI.domUndoCoordinator._undoTargetStack = [];
+        WI.domUndoCoordinator._redoTargetStack = [];
+    }
+
+    suite.addTestCase({
+        name: "Setup",
+        description: "Locate edit targets in both the main page and the cross-origin iframe.",
+        async test() {
+            mainTarget = WI.assumingMainTarget();
+
+            // Resolve a node in the main page (#parent-target).
+            let mainDoc = await new Promise((resolve) => WI.domManager.requestDocument(resolve));
+            parentNode = await new Promise((resolve) => {
+                mainDoc.querySelector("#parent-target", (nodeId) => resolve(WI.domManager.nodeForId(nodeId)));
+            });
+            InspectorTest.expectNotNull(parentNode, "Should find #parent-target in the main page.");
+
+            // Resolve the cross-origin frame target and walk to its #container.
+            let frameTargets = WI.targets.filter((t) => t.type === WI.TargetType.Frame);
+            let urlTargetMap = await fetchDocumentURLsForTargets(frameTargets);
+            let mainFrameTarget = urlTargetMap.get(WI.networkManager.mainFrame.url);
+            frameTarget = frameTargets.find((t) => t !== mainFrameTarget);
+            InspectorTest.expectNotNull(frameTarget, "Should find a cross-origin frame target.");
+
+            if (frameTarget.isProvisional) {
+                let committedEvent = await WI.targetManager.awaitEvent(WI.TargetManager.Event.DidCommitProvisionalTarget);
+                frameTarget = committedEvent.data.target;
+            }
+            await frameTarget.ensureTargetExecutionContext();
+
+            let frameDoc = WI.domManager.frameTargetDocumentForTarget(frameTarget);
+            if (!frameDoc) {
+                let docEvent = await WI.domManager.awaitEvent(WI.DOMManager.Event.FrameDocumentAvailable);
+                frameDoc = docEvent.data.document;
+            }
+            let htmlNode = await findChildElement(frameDoc, (n) => n.nodeName() === "HTML");
+            let bodyNode = await findChildElement(htmlNode, (n) => n.nodeName() === "BODY");
+            frameContainerNode = await findChildElement(bodyNode, (n) => n.getAttribute && n.getAttribute("id") === "container");
+            InspectorTest.expectNotNull(frameContainerNode, "Should find #container in the iframe.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "EditFrameThenMain.UndoUndoesMainFirst",
+        description: "Edit iframe, then main, then Cmd+Z twice. Main edit reverses first (LIFO).",
+        async test() {
+            clearCoordinatorStacks();
+
+            // Edit 1: attribute on iframe node.
+            await frameTarget.DOMAgent.setAttributeValue(bid(frameContainerNode), "data-edit-frame", "1");
+            WI.domUndoCoordinator.didEdit(frameTarget);
+            let frameAfter = await getOuterHTMLViaTarget(frameTarget, frameContainerNode);
+            InspectorTest.expectThat(frameAfter.includes(`data-edit-frame="1"`), "Frame edit applied.");
+
+            // Edit 2: attribute on main-page node.
+            await mainTarget.DOMAgent.setAttributeValue(bid(parentNode), "data-edit-main", "1");
+            WI.domUndoCoordinator.didEdit(mainTarget);
+            let mainAfter = await getOuterHTMLViaTarget(mainTarget, parentNode);
+            InspectorTest.expectThat(mainAfter.includes(`data-edit-main="1"`), "Main edit applied.");
+
+            // Cmd+Z #1 — should undo the most recent edit (main).
+            await WI.domUndoCoordinator.undo();
+            let mainAfterUndo1 = await getOuterHTMLViaTarget(mainTarget, parentNode);
+            let frameAfterUndo1 = await getOuterHTMLViaTarget(frameTarget, frameContainerNode);
+            InspectorTest.expectThat(!mainAfterUndo1.includes(`data-edit-main`), "First undo reversed the main edit.");
+            InspectorTest.expectThat(frameAfterUndo1.includes(`data-edit-frame="1"`), "First undo did NOT touch the iframe edit.");
+
+            // Cmd+Z #2 — should undo the next-most-recent edit (frame).
+            await WI.domUndoCoordinator.undo();
+            let frameAfterUndo2 = await getOuterHTMLViaTarget(frameTarget, frameContainerNode);
+            InspectorTest.expectThat(!frameAfterUndo2.includes(`data-edit-frame`), "Second undo reversed the iframe edit.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "RedoFollowsLIFOInReverse",
+        description: "After two undos, two redos restore frame edit then main edit.",
+        async test() {
+            clearCoordinatorStacks();
+
+            // Re-apply the same two edits.
+            await frameTarget.DOMAgent.setAttributeValue(bid(frameContainerNode), "data-edit-frame", "1");
+            WI.domUndoCoordinator.didEdit(frameTarget);
+            await mainTarget.DOMAgent.setAttributeValue(bid(parentNode), "data-edit-main", "1");
+            WI.domUndoCoordinator.didEdit(mainTarget);
+
+            await WI.domUndoCoordinator.undo();
+            await WI.domUndoCoordinator.undo();
+
+            // First redo — bring back the frame edit (oldest undone, deepest in redo stack pops first).
+            await WI.domUndoCoordinator.redo();
+            let frameAfterRedo1 = await getOuterHTMLViaTarget(frameTarget, frameContainerNode);
+            let mainAfterRedo1 = await getOuterHTMLViaTarget(mainTarget, parentNode);
+            InspectorTest.expectThat(frameAfterRedo1.includes(`data-edit-frame="1"`), "First redo restored the iframe edit.");
+            InspectorTest.expectThat(!mainAfterRedo1.includes(`data-edit-main`), "First redo did NOT restore the main edit.");
+
+            // Second redo — bring back the main edit.
+            await WI.domUndoCoordinator.redo();
+            let mainAfterRedo2 = await getOuterHTMLViaTarget(mainTarget, parentNode);
+            InspectorTest.expectThat(mainAfterRedo2.includes(`data-edit-main="1"`), "Second redo restored the main edit.");
+
+            // Drain through the coordinator so frontend and backend stacks both end empty.
+            await WI.domUndoCoordinator.undo();
+            await WI.domUndoCoordinator.undo();
+        }
+    });
+
+    suite.addTestCase({
+        name: "MultipleEditsPerTargetReversedInOrder",
+        description: "Two edits to the same target then one to another reverse in strict reverse order.",
+        async test() {
+            clearCoordinatorStacks();
+
+            // Edit iframe twice in a row, then main once.
+            await frameTarget.DOMAgent.setAttributeValue(bid(frameContainerNode), "data-edit-a", "1");
+            WI.domUndoCoordinator.didEdit(frameTarget);
+            await frameTarget.DOMAgent.setAttributeValue(bid(frameContainerNode), "data-edit-b", "1");
+            WI.domUndoCoordinator.didEdit(frameTarget);
+            await mainTarget.DOMAgent.setAttributeValue(bid(parentNode), "data-edit-main", "1");
+            WI.domUndoCoordinator.didEdit(mainTarget);
+
+            // Three undos should reverse all three edits, in reverse order: main, then iframe-b, then iframe-a.
+            await WI.domUndoCoordinator.undo();
+            await WI.domUndoCoordinator.undo();
+            await WI.domUndoCoordinator.undo();
+
+            let frameAfter = await getOuterHTMLViaTarget(frameTarget, frameContainerNode);
+            let mainAfter = await getOuterHTMLViaTarget(mainTarget, parentNode);
+            InspectorTest.expectThat(!frameAfter.includes(`data-edit-a`) && !frameAfter.includes(`data-edit-b`), "Both iframe edits reversed.");
+            InspectorTest.expectThat(!mainAfter.includes(`data-edit-main`), "Main edit reversed.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "ExtraUndoIsHarmless",
+        description: "Calling undo on empty stacks falls back to main without polluting either coordinator stack.",
+        async test() {
+            clearCoordinatorStacks();
+
+            // Spy on main's redo before calling. We're verifying both that the fallback
+            // dispatches to main AND that the coordinator stays in a known-empty state.
+            let mainRedoCalls = 0;
+            let originalRedo = mainTarget.DOMAgent.redo.bind(mainTarget.DOMAgent);
+            mainTarget.DOMAgent.redo = (...args) => { mainRedoCalls++; return originalRedo(...args); };
+
+            await WI.domUndoCoordinator.undo();
+            await WI.domUndoCoordinator.undo();
+
+            InspectorTest.expectEqual(WI.domUndoCoordinator._undoTargetStack.length, 0, "Empty-stack undo() did not push to undoStack.");
+            InspectorTest.expectEqual(WI.domUndoCoordinator._redoTargetStack.length, 0, "Empty-stack undo() did not push to redoStack.");
+
+            await WI.domUndoCoordinator.redo();
+            mainTarget.DOMAgent.redo = originalRedo;
+
+            InspectorTest.expectEqual(mainRedoCalls, 1, "Empty-stack redo() falls back to main exactly once.");
+            InspectorTest.expectEqual(WI.domUndoCoordinator._undoTargetStack.length, 0, "Empty-stack redo() did not push to undoStack.");
+            InspectorTest.expectEqual(WI.domUndoCoordinator._redoTargetStack.length, 0, "Empty-stack redo() did not push to redoStack.");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+
+<body onload="runTest()">
+<p id="parent-target" data-role="parent-root">Tests cross-frame Cmd+Z ordering through WI.DOMUndoCoordinator's LIFO of edited targets.</p>
+<iframe src="http://localhost:8000/site-isolation/inspector/dom/resources/dom-frame.html"></iframe>
+</body>

--- a/LayoutTests/http/tests/site-isolation/inspector/dom/undo-coordinator-frame-target-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/dom/undo-coordinator-frame-target-expected.txt
@@ -21,12 +21,24 @@ PASS: main frame markUndoableState NOT called.
 PASS: Subsequent undo routes to child frame.
 PASS: Subsequent undo did NOT hit main frame.
 
--- Running test case: DidEditSwitchesRouting
-PASS: undo routes to child frame after didEdit(childFrameTarget).
-PASS: redo routes to main frame after didEdit(mainFrameTarget).
-PASS: redo did NOT hit child frame after switching to main frame.
+-- Running test case: DidEditOrdersStackAcrossFrames
+PASS: First undo routes to main frame (most recent edit).
+PASS: First undo did NOT hit child frame yet.
+PASS: Second undo routes to child frame (earlier edit).
+PASS: First redo routes back to child frame.
+PASS: Second redo routes back to main frame.
+
+-- Running test case: DidEditAfterUndoClearsRedoStack
+PASS: Undo reverses the child frame edit.
+PASS: Redo is a no-op: new edit cleared the redo stack.
+PASS: Redo did NOT reach back to the child frame either.
 
 -- Running test case: NullTargetIsNoop
 PASS: undo still routes to child frame after didEdit(null).
-PASS: didEdit(null) did NOT reset routing to main frame.
+PASS: didEdit(null) did NOT push a main frame entry.
+PASS: Stack now empty: subsequent undo falls back to main as a no-op dispatch.
+
+-- Running test case: TargetRemovedFiltersBothStacks
+PASS: Removed main frame target is skipped, not dispatched to.
+PASS: undo falls through to the next entry, the child frame.
 

--- a/LayoutTests/http/tests/site-isolation/inspector/dom/undo-coordinator-frame-target.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/dom/undo-coordinator-frame-target.html
@@ -58,8 +58,8 @@ function test() {
             let mainFrameCalls = spyAgent(mainFrameTarget);
             let childCalls = spyAgent(childFrameTarget);
 
-            WI.domUndoCoordinator.undo();
-            WI.domUndoCoordinator.redo();
+            await WI.domUndoCoordinator.undo();
+            await WI.domUndoCoordinator.redo();
 
             InspectorTest.expectEqual(pageCalls.undo, 1, "page target undo called once.");
             InspectorTest.expectEqual(pageCalls.redo, 1, "page target redo called once.");
@@ -75,7 +75,7 @@ function test() {
 
     suite.addTestCase({
         name: "MarkUndoableStateRoutesToFrameTarget",
-        description: "markUndoableState(childFrameTarget) dispatches to the child frame agent and sets it as last-edit target.",
+        description: "markUndoableState(childFrameTarget) dispatches to the child frame agent and pushes it onto the undo stack.",
         async test() {
             let mainCalls = spyAgent(mainFrameTarget);
             let childCalls = spyAgent(childFrameTarget);
@@ -84,7 +84,7 @@ function test() {
             InspectorTest.expectEqual(childCalls.markUndoableState, 1, "child frame markUndoableState called.");
             InspectorTest.expectEqual(mainCalls.markUndoableState, 0, "main frame markUndoableState NOT called.");
 
-            WI.domUndoCoordinator.undo();
+            await WI.domUndoCoordinator.undo();
             InspectorTest.expectEqual(childCalls.undo, 1, "Subsequent undo routes to child frame.");
             InspectorTest.expectEqual(mainCalls.undo, 0, "Subsequent undo did NOT hit main frame.");
 
@@ -94,20 +94,48 @@ function test() {
     });
 
     suite.addTestCase({
-        name: "DidEditSwitchesRouting",
-        description: "didEdit(childFrameTarget) then didEdit(mainFrameTarget) — undo follows the latest target.",
+        name: "DidEditOrdersStackAcrossFrames",
+        description: "didEdit(childFrameTarget) then didEdit(mainFrameTarget) — undo reverses in LIFO order: main first, then child.",
         async test() {
             let mainCalls = spyAgent(mainFrameTarget);
             let childCalls = spyAgent(childFrameTarget);
 
             WI.domUndoCoordinator.didEdit(childFrameTarget);
-            WI.domUndoCoordinator.undo();
-            InspectorTest.expectEqual(childCalls.undo, 1, "undo routes to child frame after didEdit(childFrameTarget).");
+            WI.domUndoCoordinator.didEdit(mainFrameTarget);
+
+            await WI.domUndoCoordinator.undo();
+            InspectorTest.expectEqual(mainCalls.undo, 1, "First undo routes to main frame (most recent edit).");
+            InspectorTest.expectEqual(childCalls.undo, 0, "First undo did NOT hit child frame yet.");
+
+            await WI.domUndoCoordinator.undo();
+            InspectorTest.expectEqual(childCalls.undo, 1, "Second undo routes to child frame (earlier edit).");
+
+            await WI.domUndoCoordinator.redo();
+            InspectorTest.expectEqual(childCalls.redo, 1, "First redo routes back to child frame.");
+
+            await WI.domUndoCoordinator.redo();
+            InspectorTest.expectEqual(mainCalls.redo, 1, "Second redo routes back to main frame.");
+
+            mainCalls.restore();
+            childCalls.restore();
+        }
+    });
+
+    suite.addTestCase({
+        name: "DidEditAfterUndoClearsRedoStack",
+        description: "A new edit after undo() invalidates the redo stack, standard undo/redo semantics.",
+        async test() {
+            let mainCalls = spyAgent(mainFrameTarget);
+            let childCalls = spyAgent(childFrameTarget);
+
+            WI.domUndoCoordinator.didEdit(childFrameTarget);
+            await WI.domUndoCoordinator.undo();
+            InspectorTest.expectEqual(childCalls.undo, 1, "Undo reverses the child frame edit.");
 
             WI.domUndoCoordinator.didEdit(mainFrameTarget);
-            WI.domUndoCoordinator.redo();
-            InspectorTest.expectEqual(mainCalls.redo, 1, "redo routes to main frame after didEdit(mainFrameTarget).");
-            InspectorTest.expectEqual(childCalls.redo, 0, "redo did NOT hit child frame after switching to main frame.");
+            await WI.domUndoCoordinator.redo();
+            InspectorTest.expectEqual(mainCalls.redo, 0, "Redo is a no-op: new edit cleared the redo stack.");
+            InspectorTest.expectEqual(childCalls.redo, 0, "Redo did NOT reach back to the child frame either.");
 
             mainCalls.restore();
             childCalls.restore();
@@ -116,7 +144,7 @@ function test() {
 
     suite.addTestCase({
         name: "NullTargetIsNoop",
-        description: "didEdit(null) preserves the prior last-edit target.",
+        description: "didEdit(null) does not push onto the undo stack.",
         async test() {
             WI.domUndoCoordinator.didEdit(childFrameTarget);
             WI.domUndoCoordinator.didEdit(null);
@@ -124,9 +152,36 @@ function test() {
             let mainCalls = spyAgent(mainFrameTarget);
             let childCalls = spyAgent(childFrameTarget);
 
-            WI.domUndoCoordinator.undo();
+            await WI.domUndoCoordinator.undo();
             InspectorTest.expectEqual(childCalls.undo, 1, "undo still routes to child frame after didEdit(null).");
-            InspectorTest.expectEqual(mainCalls.undo, 0, "didEdit(null) did NOT reset routing to main frame.");
+            InspectorTest.expectEqual(mainCalls.undo, 0, "didEdit(null) did NOT push a main frame entry.");
+
+            await WI.domUndoCoordinator.undo();
+            InspectorTest.expectEqual(mainCalls.undo, 1, "Stack now empty: subsequent undo falls back to main as a no-op dispatch.");
+
+            mainCalls.restore();
+            childCalls.restore();
+        }
+    });
+
+    suite.addTestCase({
+        name: "TargetRemovedFiltersBothStacks",
+        description: "A torn-down frame's target is filtered out of the undo/redo stacks and cannot be popped later.",
+        async test() {
+            WI.domUndoCoordinator.didEdit(childFrameTarget);
+            WI.domUndoCoordinator.didEdit(mainFrameTarget);
+
+            // Simulate main frame target teardown via the same public event the coordinator listens
+            // on, without actually calling TargetManager.removeTarget() (which would destroy the
+            // target and break later test cases that still need it).
+            WI.targetManager.dispatchEventToListeners(WI.TargetManager.Event.TargetRemoved, {target: mainFrameTarget});
+
+            let mainCalls = spyAgent(mainFrameTarget);
+            let childCalls = spyAgent(childFrameTarget);
+
+            await WI.domUndoCoordinator.undo();
+            InspectorTest.expectEqual(mainCalls.undo, 0, "Removed main frame target is skipped, not dispatched to.");
+            InspectorTest.expectEqual(childCalls.undo, 1, "undo falls through to the next entry, the child frame.");
 
             mainCalls.restore();
             childCalls.restore();

--- a/Source/WebInspectorUI/UserInterface/Controllers/DOMUndoCoordinator.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/DOMUndoCoordinator.js
@@ -27,14 +27,28 @@ WI.DOMUndoCoordinator = class DOMUndoCoordinator
 {
     constructor()
     {
-        // Most recently edited target. Cmd+Z dispatches here. Stays valid until that target is removed.
-        this._lastEditTarget = null;
+        // Per-edit LIFOs of targets. Each successful didEdit pushes one entry; undo/redo
+        // move entries between the two stacks. No deduplication: the stacks mirror each
+        // backend agent's per-process InspectorHistory so that Cmd+Z reverses edits in
+        // the order they were made across frames.
+        this._undoTargetStack = [];
+        this._redoTargetStack = [];
+
+        // Chained promise that serializes undo/redo dispatch. Without this, back-to-back
+        // Cmd+Z presses could send overlapping DOM.undo/DOM.redo commands whose responses
+        // resolve out of order (especially across frame targets in different processes),
+        // corrupting the order entries land back on the opposite stack.
+        this._chainedOperationsPromise = Promise.resolve();
 
         WI.targetManager.addEventListener(WI.TargetManager.Event.TargetRemoved, this._handleTargetRemoved, this);
     }
 
     // Public
 
+    // didEdit()/markUndoableState() only push a target and fire a command; they don't need to
+    // wait on anything, so they stay synchronous. undo()/redo() are async because they must wait
+    // for their turn in _chainedOperationsPromise and then for the backend response before it's
+    // safe to move the target to the opposite stack — see _performOperationSoon() below.
     didEdit(target)
     {
         // A null target means "the edit's target is unknown," not "the edit belongs to main." Defaulting to
@@ -42,7 +56,8 @@ WI.DOMUndoCoordinator = class DOMUndoCoordinator
         // and keep the existing routing. markUndoableState() is what supplies the concrete target.
         if (!target)
             return;
-        this._lastEditTarget = target;
+        this._undoTargetStack.push(target);
+        this._redoTargetStack = [];
     }
 
     markUndoableState(target)
@@ -50,6 +65,11 @@ WI.DOMUndoCoordinator = class DOMUndoCoordinator
         // Unlike didEdit(), a missing target here is a real page-level edit (e.g. a DOMNode with no owning
         // frame target, or a CSS edit while FrameCSSAgent does not yet exist), which genuinely belongs to
         // main. Resolve it so the edit is both recorded and dispatched against a concrete target.
+        //
+        // Assumes each call here corresponds to a nonempty backend undo group: InspectorHistory::undo()/redo()
+        // collapse over consecutive UndoableStateMark entries, so calling this without a preceding real edit
+        // action produces an empty backend group while still pushing a stack entry here, breaking the 1:1
+        // correspondence the multi-target undo/redo stacks rely on.
         target ||= WI.assumingMainTarget();
         this.didEdit(target);
         if (target.hasCommand("DOM.markUndoableState"))
@@ -58,23 +78,70 @@ WI.DOMUndoCoordinator = class DOMUndoCoordinator
 
     undo()
     {
-        let target = this._lastEditTarget || WI.assumingMainTarget();
-        if (target.hasCommand("DOM.undo"))
-            target.DOMAgent.undo();
+        return this._performOperationSoon(() => this._undo());
     }
 
     redo()
     {
-        let target = this._lastEditTarget || WI.assumingMainTarget();
-        if (target.hasCommand("DOM.redo"))
-            target.DOMAgent.redo();
+        return this._performOperationSoon(() => this._redo());
     }
 
     // Private
 
+    // undo()/redo() are invoked as fire-and-forget from keyboard shortcut handlers, so
+    // no caller is positioned to catch a rejection. Log and swallow failures here instead
+    // of leaving an unhandled rejection for something downstream to trip over; the chain
+    // itself is kept alive by catching separately so one failed operation can't wedge
+    // every operation queued after it.
+    _performOperationSoon(operation)
+    {
+        let result = this._chainedOperationsPromise.then(operation);
+        this._chainedOperationsPromise = result.catch(() => {});
+        return result.catch((error) => { console.error(error); });
+    }
+
+    async _undo()
+    {
+        let target = this._undoTargetStack.lastValue;
+        if (!target) {
+            // Older Page-only backend without the per-frame DOM.undo introduced for Site Isolation:
+            // nothing was ever pushed, so dispatch against main. The main target definitely supports
+            // DOM.undo (assuming ITML has been deprecated), so no hasCommand() guard is needed.
+            await WI.assumingMainTarget().DOMAgent.undo();
+            return;
+        }
+
+        if (!target.hasCommand("DOM.undo")) {
+            console.assert(false, "Edited target should support DOM.undo", target);
+            return;
+        }
+        this._undoTargetStack.pop();
+        await target.DOMAgent.undo();
+        this._redoTargetStack.push(target);
+    }
+
+    async _redo()
+    {
+        let target = this._redoTargetStack.lastValue;
+        if (!target) {
+            // Same older-backend fallback as _undo() above.
+            await WI.assumingMainTarget().DOMAgent.redo();
+            return;
+        }
+
+        if (!target.hasCommand("DOM.redo")) {
+            console.assert(false, "Edited target should support DOM.redo", target);
+            return;
+        }
+        this._redoTargetStack.pop();
+        await target.DOMAgent.redo();
+        this._undoTargetStack.push(target);
+    }
+
     _handleTargetRemoved(event)
     {
-        if (this._lastEditTarget === event.data.target)
-            this._lastEditTarget = null;
+        let removed = event.data.target;
+        this._undoTargetStack = this._undoTargetStack.filter((t) => t !== removed);
+        this._redoTargetStack = this._redoTargetStack.filter((t) => t !== removed);
     }
 };


### PR DESCRIPTION
#### de24f73abd975bc8500b7efcba2290a244143c9e
<pre>
Web Inspector: [SI] coordinate Cmd+Z across per-frame undo stacks
<a href="https://bugs.webkit.org/show_bug.cgi?id=315597">https://bugs.webkit.org/show_bug.cgi?id=315597</a>
<a href="https://rdar.apple.com/177978474">rdar://177978474</a>

Reviewed by Qianlang Chen.

Replace WI.DOMUndoCoordinator&apos;s single _lastEditTarget slot with a pair
of LIFO target stacks that record one entry per edit, in order. Each
edit&apos;s target — the main page or a cross-origin iframe — is pushed when
didEdit is called. undo pops the top, dispatches to that target&apos;s
DOMAgent, and pushes to the redo stack on completion; redo is the
symmetric inverse. Empty-stack undo and redo fall back to the main
target as a no-op without pushing onto either stack. TargetRemoved
filters both stacks so a torn-down frame can&apos;t be popped later.

End-user effect: edit a node in a cross-origin iframe, edit a node on
the main page, press Cmd+Z — the main edit reverses; press Cmd+Z again,
the iframe edit reverses.

The existing single-target dispatch test is updated to await the now-
async undo/redo entry points.

Test: http/tests/site-isolation/inspector/dom/cross-frame-undo-coordinator.html

* LayoutTests/http/tests/site-isolation/inspector/dom/cross-frame-undo-coordinator-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/dom/cross-frame-undo-coordinator.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/dom/undo-coordinator-frame-target-expected.txt:
* LayoutTests/http/tests/site-isolation/inspector/dom/undo-coordinator-frame-target.html:
* Source/WebInspectorUI/UserInterface/Controllers/DOMUndoCoordinator.js:
(WI.DOMUndoCoordinator):
(WI.DOMUndoCoordinator.prototype.didEdit):
(WI.DOMUndoCoordinator.prototype.markUndoableState):
(WI.DOMUndoCoordinator.prototype.undo):
(WI.DOMUndoCoordinator.prototype.redo):
(WI.DOMUndoCoordinator.prototype._performOperationSoon):
(WI.DOMUndoCoordinator.prototype.async _undo):
(WI.DOMUndoCoordinator.prototype.async _redo):
(WI.DOMUndoCoordinator.prototype._handleTargetRemoved):

Canonical link: <a href="https://commits.webkit.org/317698@main">https://commits.webkit.org/317698@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/82349898b55407d653a1a18d4e100238f4c4fcad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176039 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49972 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/43756 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185633 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/51264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49654 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/137094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178995 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/51264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/157867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/117573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/51264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/37582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/51264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/37361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34102 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41680 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188055 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49639 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/157418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/146104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50320 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/145939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26751 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/40717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122515 "Built successfully") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116426 "Failed to checkout and rebase branch from PR 69404") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48826 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/12340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48228 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48460 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48285 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->