### PR TITLE
[GFC] Initial implementation of logic to disbribute extra space.

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
@@ -307,6 +307,88 @@ static void sizeTracksToFitNonSpanningItems(const ResolveIntrinsicTrackSizesCont
     }
 }
 
+// Used for space distribution.
+static Vector<size_t> indexesForUnfrozenAffectedTracks(const TrackIndexes& affectedTracks, const WTF::Range<size_t>& itemSpan,
+    const UnsizedTracks& unsizedTracks, const Vector<LayoutUnit>& itemIncurredIncreases)
+{
+    Vector<size_t> indexes;
+    for (auto [affectedIndex, trackIndex] : WTF::indexedRange(affectedTracks)) {
+        if (itemSpan.contains(trackIndex) && unsizedTracks[trackIndex].baseSize + itemIncurredIncreases[affectedIndex] < unsizedTracks[trackIndex].growthLimit)
+            indexes.append(affectedIndex);
+    }
+    return indexes;
+}
+
+// https://drafts.csswg.org/css-grid-1/#extra-space
+[[maybe_unused]] static void distributeExtraSpaceToBaseSizes(UnsizedTracks& unsizedTracks, const GridItemIndexes& accommodatedItemsIndexes,
+    const PlacedGridItemSpanList& gridItemSpanList, const Vector<LayoutUnit>& sizeContributions, const TrackIndexes& affectedTracksIndexes)
+{
+    ASSERT(accommodatedItemsIndexes.size() == sizeContributions.size());
+
+    // 1. Maintain separately for each affected track a planned increase, initially set to 0.
+    Vector<LayoutUnit> plannedIncreases(affectedTracksIndexes.size());
+
+    // 2. For each accommodated item...
+    for (auto [contributionIndex, gridItemIndex] : WTF::indexedRange(accommodatedItemsIndexes)) {
+        // ...considering only tracks the item spans:
+        auto itemSpan = gridItemSpanList[gridItemIndex];
+
+        ASSERT(itemSpan.distance() == 1);
+
+        // 2.1. Find the space to distribute: the item's size contribution minus the base sizes of
+        //      every track it spans, floored at zero.
+        LayoutUnit spannedBaseSizes;
+        for (size_t trackIndex = itemSpan.begin(); trackIndex < itemSpan.end(); ++trackIndex)
+            spannedBaseSizes += unsizedTracks[trackIndex].baseSize;
+        auto spaceToDistribute = std::max(0_lu, sizeContributions[contributionIndex] - spannedBaseSizes);
+        if (!spaceToDistribute)
+            continue;
+
+        // 2.2. Distribute space up to limits: find the item-incurred increase for each affected
+        //      track...
+        Vector<LayoutUnit> itemIncurredIncreases(affectedTracksIndexes.size());
+        auto unfrozenIndexes = indexesForUnfrozenAffectedTracks(affectedTracksIndexes, itemSpan, unsizedTracks, itemIncurredIncreases);
+        while (!unfrozenIndexes.isEmpty() && spaceToDistribute) {
+
+            // ...by distributing the space equally among the affected tracks the item spans,
+            //  freezing a track once its base size plus that increase reaches its growth limit.
+            auto tracksRemainingForDistributionCount = unfrozenIndexes.size();
+            for (auto affectedIndex : unfrozenIndexes) {
+                auto& track = unsizedTracks[affectedTracksIndexes[affectedIndex]];
+                auto spaceRemainingUntilGrowthLimit = track.growthLimit - (track.baseSize + itemIncurredIncreases[affectedIndex]);
+                auto spaceDistributed = std::min(spaceToDistribute / tracksRemainingForDistributionCount, spaceRemainingUntilGrowthLimit);
+                itemIncurredIncreases[affectedIndex] += spaceDistributed;
+                spaceToDistribute -= spaceDistributed;
+                --tracksRemainingForDistributionCount;
+            }
+            unfrozenIndexes = indexesForUnfrozenAffectedTracks(affectedTracksIndexes, itemSpan, unsizedTracks, itemIncurredIncreases);
+        }
+
+        // 2.3. Distribute space to non-affected tracks: if extra space remains and the item spans
+        //      both affected and non-affected tracks, distribute it into the non-affected tracks.
+        auto distributeSpaceToNonAffectedTracks = [] {
+            notImplemented();
+        };
+        UNUSED_VARIABLE(distributeSpaceToNonAffectedTracks);
+
+        // 2.4. Distribute space beyond limits: if extra space still remains, unfreeze and continue
+        //      distributing it to the item-incurred increases.
+        auto distributeSpaceBeyondLimits = [] {
+            notImplemented();
+        };
+        UNUSED_VARIABLE(distributeSpaceBeyondLimits);
+
+        // 2.5. For each affected track, if its item-incurred increase is larger than its planned
+        //      increase, set the planned increase to that value.
+        for (auto [affectedIndex, trackIndex] : WTF::indexedRange(affectedTracksIndexes))
+            plannedIncreases[affectedIndex] = std::max(plannedIncreases[affectedIndex], itemIncurredIncreases[affectedIndex]);
+    }
+
+    // 3. Update the affected tracks' base sizes by adding in the planned increase.
+    for (auto [affectedTrackIndex, trackIndex] : WTF::indexedRange(affectedTracksIndexes))
+        unsizedTracks[trackIndex].baseSize += plannedIncreases[affectedTrackIndex];
+}
+
 // https://drafts.csswg.org/css-grid-1/#algo-content
 static void resolveIntrinsicTrackSizes(const ResolveIntrinsicTrackSizesContext& resolveIntrinsicTrackSizesContext,
     UnsizedTracks& unsizedTracks)


### PR DESCRIPTION
#### 51ce0edf7d809f538fcd20dbf03b58c89bd473aa
<pre>
[GFC] Initial implementation of logic to disbribute extra space.
<a href="https://bugs.webkit.org/show_bug.cgi?id=319626">https://bugs.webkit.org/show_bug.cgi?id=319626</a>
<a href="https://rdar.apple.com/problem/182450492">rdar://problem/182450492</a>

Reviewed by Alan Baradlay.

<a href="https://drafts.csswg.org/css-grid-1/#extra-space">https://drafts.csswg.org/css-grid-1/#extra-space</a>

This is the very first implementation and focuses the new function on
specifically distributing space to the base sizes of the tracks. The
basic idea is that we just through each item and the track is spans,
then add extra space to the tracks so that the total size of the area is
enough to fit its contribution.

Steps 2.3 and 2.4 (distribute to non-affected tracks / distribute beyond limits) are left as
notImplemented() lambdas since neither can fire for the reachable cases today: only items spanning
a single track are supported, and the affected flexible tracks that reach this step still have
infinite growth limits, so step 2.2 absorbs the entire space.

Canonical link: <a href="https://commits.webkit.org/317388@main">https://commits.webkit.org/317388@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de6a5b36471997f8201ba788a114c0100e996594

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175135 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49067 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42848 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184720 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/133042 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7ec4da68-4b74-464e-ab78-51bab9d78246) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176999 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50359 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48750 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136319 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1398a366-8fe2-427b-9e9c-ff2cd3d12b52) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178092 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39751 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157100 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116798 "Found 1 new API test failure: TestWTF:WTF_ParkingLot.UnparkOneFiftyThenFiftyAllFast (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/39492b8b-37aa-4d0a-9fd6-e5b347fc074a) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/174456 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38392 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36777 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33193 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5609 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148815 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36593 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187140 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/36396 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/40738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145262 "Passed tests") | | 
| [❌ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/174535 "Failed resultsdbpy unit tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48734 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156656 "") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145118 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39105 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49414 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115249 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39975 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/121586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/212226 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47920 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11566 "") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55379 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47323 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47553 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47380 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->