### PR TITLE
[Web Inspector] NetworkResourcesData::removeCachedResource scans the entire resource map on every CachedResource teardown

### DIFF
--- a/Source/WebCore/inspector/NetworkResourcesData.cpp
+++ b/Source/WebCore/inspector/NetworkResourcesData.cpp
@@ -141,6 +141,9 @@ void NetworkResourcesData::resourceCreated(const String& requestId, const String
 
     auto resourceData = makeUnique<ResourceData>(requestId, loaderId);
     resourceData->setCachedResource(&cachedResource);
+    m_cachedResourceToRequestIds.ensure(cachedResource, [] {
+        return HashSet<String>();
+    }).iterator->value.add(requestId);
     m_requestIdToResourceDataMap.set(requestId, WTF::move(resourceData));
 }
 
@@ -276,6 +279,11 @@ void NetworkResourcesData::addCachedResource(const String& requestId, CachedReso
     if (!resourceData)
         return;
     resourceData->setCachedResource(cachedResource);
+    if (cachedResource) {
+        m_cachedResourceToRequestIds.ensure(*cachedResource, [] {
+            return HashSet<String>();
+        }).iterator->value.add(requestId);
+    }
 }
 
 void NetworkResourcesData::addResourceSharedBuffer(const String& requestId, RefPtr<FragmentedSharedBuffer>&& buffer, const String& textEncodingName)
@@ -311,14 +319,13 @@ NetworkResourcesData::ResourceData const* NetworkResourcesData::dataForURL(const
 Vector<String> NetworkResourcesData::removeCachedResource(CachedResource* cachedResource)
 {
     Vector<String> result;
-    for (auto& entry : m_requestIdToResourceDataMap) {
-        ResourceData* resourceData = entry.value.get();
-        if (resourceData->cachedResource() == cachedResource) {
+    for (auto& requestId : m_cachedResourceToRequestIds.take(*cachedResource)) {
+        if (auto* resourceData = resourceDataForRequestId(requestId)) {
+            ASSERT(resourceData->cachedResource() == cachedResource);
             resourceData->setCachedResource(nullptr);
-            result.append(entry.key);
+            result.append(requestId);
         }
     }
-
     return result;
 }
 
@@ -327,6 +334,7 @@ void NetworkResourcesData::clear(std::optional<String> preservedLoaderId)
     if (!preservedLoaderId) {
         m_requestIdToResourceDataMap.clear();
         m_requestIdsDeque.clear();
+        m_cachedResourceToRequestIds.clear();
         m_contentSize = 0;
         return;
     }
@@ -338,6 +346,7 @@ void NetworkResourcesData::clear(std::optional<String> preservedLoaderId)
         if (resourceData->loaderId() == *preservedLoaderId)
             m_requestIdsDeque.add(requestId);
         else {
+            removeRequestIdFromCachedResourceIndex(*resourceData, requestId);
             m_contentSize -= resourceData->evictContent();
             m_requestIdToResourceDataMap.remove(requestId);
         }
@@ -363,8 +372,24 @@ void NetworkResourcesData::ensureNoDataForRequestId(const String& requestId)
         return;
 
     ResourceData* resourceData = result.get();
+    removeRequestIdFromCachedResourceIndex(*resourceData, requestId);
     if (resourceData->hasContent() || resourceData->hasData())
         m_contentSize -= resourceData->evictContent();
+}
+
+void NetworkResourcesData::removeRequestIdFromCachedResourceIndex(const ResourceData& resourceData, const String& requestId)
+{
+    RefPtr cachedResource = resourceData.cachedResource();
+    if (!cachedResource)
+        return;
+
+    auto it = m_cachedResourceToRequestIds.find(*cachedResource);
+    if (it == m_cachedResourceToRequestIds.end())
+        return;
+
+    it->value.remove(requestId);
+    if (it->value.isEmpty())
+        m_cachedResourceToRequestIds.remove(it);
 }
 
 bool NetworkResourcesData::ensureFreeSpace(size_t size)

--- a/Source/WebCore/inspector/NetworkResourcesData.h
+++ b/Source/WebCore/inspector/NetworkResourcesData.h
@@ -33,10 +33,12 @@
 #include "InspectorResourceType.h"
 #include "SharedBuffer.h"
 #include "TextResourceDecoder.h"
+#include <wtf/HashSet.h>
 #include <wtf/ListHashSet.h>
 #include <wtf/RobinHoodHashMap.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WallTime.h>
+#include <wtf/WeakHashMap.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
@@ -166,10 +168,12 @@ public:
 private:
     ResourceData* resourceDataForRequestId(const String& requestId);
     void ensureNoDataForRequestId(const String& requestId);
+    void removeRequestIdFromCachedResourceIndex(const ResourceData&, const String& requestId);
     bool ensureFreeSpace(size_t);
 
     ListHashSet<String> m_requestIdsDeque;
     MemoryCompactRobinHoodHashMap<String, std::unique_ptr<ResourceData>> m_requestIdToResourceDataMap;
+    WeakHashMap<CachedResource, HashSet<String>> m_cachedResourceToRequestIds;
     size_t m_contentSize { 0 };
     Settings m_settings;
 };


### PR DESCRIPTION
#### 4180ee3718172362b532edb2249da0f96f895c77
<pre>
[Web Inspector] NetworkResourcesData::removeCachedResource scans the entire resource map on every CachedResource teardown
<a href="https://bugs.webkit.org/show_bug.cgi?id=319412">https://bugs.webkit.org/show_bug.cgi?id=319412</a>
<a href="https://rdar.apple.com/182240672">rdar://182240672</a>

Reviewed by NOBODY (OOPS!).

removeCachedResource() walked the whole m_requestIdToResourceDataMap
comparing each entry&apos;s cachedResource() pointer to find the request IDs
associated with a resource. It is called from
InspectorNetworkAgent::willDestroyCachedResource(), which fires from
CachedResource::deref() for every cached resource that goes away while a
Web Inspector Network agent is enabled, making resource teardown O(N) in
the number of recorded resources (O(N*M) across a session).

Add a reverse index so the lookup is O(1). It is a
WeakHashMap&lt;CachedResource, HashSet&lt;String&gt;&gt; rather than a raw-pointer
keyed map: keys can never dangle and dead entries auto-purge. The lookup
at teardown is valid because willDestroyCachedResource() runs from
deref() while the resource is still fully intact, before it is
destroyed.

A CachedResource can back more than one request ID (memory-cache reuse
across loads), so the value stays a set. Both removal paths that drop a
forward-map entry (partial clear() and ensureNoDataForRequestId()) prune
the reverse index too via removeRequestIdFromCachedResourceIndex(), so
it never retains stale request IDs.

No change in behavior; covered by existing inspector/network tests.

* Source/WebCore/inspector/NetworkResourcesData.cpp:
(WebCore::NetworkResourcesData::resourceCreated):
(WebCore::NetworkResourcesData::addCachedResource):
(WebCore::NetworkResourcesData::removeCachedResource):
(WebCore::NetworkResourcesData::clear):
(WebCore::NetworkResourcesData::ensureNoDataForRequestId):
(WebCore::NetworkResourcesData::removeRequestIdFromCachedResourceIndex):
* Source/WebCore/inspector/NetworkResourcesData.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4180ee3718172362b532edb2249da0f96f895c77

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174585 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48518 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42299 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184162 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132453 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176450 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49810 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48201 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135835 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95857 "5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/366eed61-0229-4423-a955-f7494839097e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177543 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39266 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156622 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116313 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/098047e3-59c1-40b5-92c5-34a5734c083b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37907 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36282 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32643 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148330 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36114 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186590 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39861 "Found 121 new failures in b3/testb3_7.cpp, b3/B3Value.h, WebProcess/Network/WebResourceLoader.cpp, UIProcess/WebProcessPool.cpp, Shared/Cocoa/WKNSArray.mm, Shared/SessionState.cpp, NetworkProcess/NetworkResourceLoadParameters.cpp, WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm, WebProcess/WebPage/WebPage.cpp, WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm ...") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40479 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144754 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48185 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144614 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48864 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32734 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114644 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39500 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120858 "Found 121 new failures in b3/B3Value.h, b3/testb3_7.cpp, WebProcess/Network/WebResourceLoader.cpp, UIProcess/WebProcessPool.cpp, Shared/Cocoa/WKNSArray.mm, Shared/SessionState.cpp, NetworkProcess/NetworkResourceLoadParameters.cpp, WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm, WebProcess/WebPage/WebPage.cpp, WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm ...") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47371 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11080 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46773 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47004 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46831 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->