### PR TITLE
Make Font ThreadSafeRefCounted

### DIFF
--- a/Source/WebCore/platform/graphics/Font.h
+++ b/Source/WebCore/platform/graphics/Font.h
@@ -30,6 +30,7 @@
 #include <WebCore/TrustedFonts.h>
 #include <wtf/BitVector.h>
 #include <wtf/Platform.h>
+#include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/WeakPtr.h>
 
 #if PLATFORM(COCOA)
@@ -95,7 +96,7 @@ struct FontInternalAttributes {
 };
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(Font);
-class Font : public RefCounted<Font>, public CanMakeSingleThreadWeakPtr<Font> {
+class Font : public ThreadSafeRefCounted<Font>, public CanMakeSingleThreadWeakPtr<Font> {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Font, Font);
 public:
     using Origin = FontOrigin;

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.cpp
@@ -411,6 +411,7 @@ void RemoteGraphicsContext::drawGlyphs(RenderingResourceIdentifier fontIdentifie
 {
     RefPtr font = resourceCache().cachedFont(fontIdentifier);
     MESSAGE_CHECK(font);
+    ASSERT(!font->weakCount());
     Vector<GlyphBufferGlyph, 128> glyphs { glyphsAdvances.span<0>() };
     Vector<GlyphBufferAdvance, 128> advances { glyphsAdvances.span<1>() };
     context().drawGlyphs(*font, glyphs.span(), advances.span(), localAnchor, fontSmoothingMode);


### PR DESCRIPTION
#### 65fab76fe0e94ccb163d5a19d4748ae7c4a6e394
<pre>
Make Font ThreadSafeRefCounted
<a href="https://bugs.webkit.org/show_bug.cgi?id=309793">https://bugs.webkit.org/show_bug.cgi?id=309793</a>
<a href="https://rdar.apple.com/169616107">rdar://169616107</a>

Reviewed by NOBODY (OOPS!).

A Font can be reached from two RemoteRenderingBackend work-queue threads when a
DisplayList-backed ImageBuffer is transferred between backends: DrawGlyphs holds a
Ref&lt;const Font&gt;, so after the transfer both threads run ref and deref on the same
Font. Font used RefCounted, whose counter is not atomic, so concurrent updates lose
a reference and free the Font while it is still referenced. Therefore make Font
ThreadSafeRefCounted so ref and deref are atomic. Weak pointers to Font are only
created by web-process layout code (main thread and workers) and never in the GPU
process, so the single-thread weak-pointer base stays correct. Assert in the GPU
process that a drawn Font has no weak pointers to keep that invariant enforced.

* Source/WebCore/platform/graphics/Font.h:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.cpp:
(WebKit::RemoteGraphicsContext::drawGlyphs):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/65fab76fe0e94ccb163d5a19d4748ae7c4a6e394

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174588 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48521 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42302 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184165 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132456 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e85ed6ad-d9fb-401c-b0e7-ef6431cf57cf) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176453 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49813 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48204 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135841 "Failure limit exceed. At least found 500 new test failures: accessibility/ARIA-reflection.html accessibility/accessibility-crash-focused-element-change.html accessibility/accessibility-crash-setattribute.html accessibility/accessibility-crash-with-dynamic-inline-content.html accessibility/accessibility-node-memory-management.html accessibility/accessibility-node-reparent.html accessibility/accessibility-object-detached.html accessibility/accessibility-object-update-during-style-resolution-crash.html accessibility/activation-of-input-field-inside-other-element.html accessibility/active-descendant-changes-result-in-focus-changes.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95859 "3 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7037661a-60f3-48ff-8148-e43fbc80ca74) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177546 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39271 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156630 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116319 "Found 159 new API test failures: WPE/TestInputMethodContext:/webkit/WebKitInputMethodContext/invalid-sequence, WPE/TestWebProcessExtensions:/webkit/WebKitWebProcessExtension/form-submission-steps, WPE/TestInputMethodContext:/webkit/WebKitInputMethodContext/cancel-sequence, WPE/TestCookieManager:/webkit/WebKitCookieManager/delete-cookies, WPE/TestCookieManager:/webkit/WebKitCookieManager/cookies-changed, TestWebCore:CachedMatchFinder.FindMatchFromWithBackwardsOptionFindsPrecedingMatch, TestWebKit:WebKit.PendingAPIRequestURL, WPE/TestLoaderClient:/webkit/WebKitWebView/user-agent, TestWebCore:CachedMatchFinder.SearchResultCacheDistinguishesDifferentTargets, TestWebKit:WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidBeginAndEndEditingEvents ... (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c9123531-cb76-402a-8268-378213b4b13c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37912 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36286 "") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32646 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148335 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36122 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186593 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39869 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40483 "Found 61 new test failures: accessibility/ARIA-reflection.html accessibility/accessibility-crash-focused-element-change.html accessibility/accessibility-crash-setattribute.html accessibility/combobox/aria-combobox-control-owns-elements.html accessibility/combobox/aria-combobox-hierarchy.html accessibility/combobox/aria-combobox-no-owns.html accessibility/combobox/mac/aria-combobox-activedescendant.html accessibility/combobox/mac/combobox-activedescendant-notifications.html accessibility/custom-elements/autocomplete.html accessibility/custom-elements/controls-shadow.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144759 "Failure limit exceed. At least found 493 new test failures: accessibility/accessibility-node-reparent.html accessibility/accessibility-object-detached.html accessibility/accessibility-object-update-during-style-resolution-crash.html accessibility/activation-of-input-field-inside-other-element.html accessibility/active-descendant-changes-result-in-focus-changes.html accessibility/add-children-pseudo-element.html accessibility/adjacent-continuations-cause-assertion-failure.html accessibility/alt-tag-on-image-with-nonimage-role.html accessibility/anchor-linked-anonymous-block-crash.html accessibility/anchor-with-click-handler-is-link.html ... (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48188 "Built successfully") | | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144619 "Found 263 new API test failures: WebKitGTK/TestSSL:/webkit/WebKitWebView/tls-errors-policy, WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/disable-web-security, WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/run-javascript, TestWebKit:WebKit.GeolocationBasicWithHighAccuracy, WebKitGTK/TestUIClient:/webkit/WebKitWebView/color-chooser-request, WebKitGTK/TestInspector:/webkit/WebKitWebInspector/default, WebKitGTK/TestLoaderClient:/webkit/WebKitWebView/unfinished-subresource-load, WebKitGTK/TestOpenXRInstanceLifecycle:/webkit/OpenXR/instance-released-on-teardown, WebKitGTK/TestLoaderClient:/webkit/WebKitWebView/stop-loading, WebKitGTK/TestWebKitWebXR:/webkit/WebKitWebXR/hit-test ... (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48867 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32742 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114647 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39503 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120864 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47374 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11088 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46776 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47007 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46834 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->