### PR TITLE
Web Inspector: DOMStorageManager looks up storage objects with an O(n) Object.shallowEqual scan on every storage event

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Controllers/DOMStorageManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/DOMStorageManager.js
@@ -63,7 +63,10 @@ WI.DOMStorageManager = class DOMStorageManager extends WI.Object
 
     // Public
 
-    get domStorageObjects() { return this._domStorageObjects; }
+    get domStorageObjects()
+    {
+        return [...this._localStorageObjects.values(), ...this._sessionStorageObjects.values()];
+    }
 
     get cookieStorageObjects()
     {
@@ -160,7 +163,8 @@ WI.DOMStorageManager = class DOMStorageManager extends WI.Object
 
     _reset()
     {
-        this._domStorageObjects = [];
+        this._localStorageObjects = new Map;
+        this._sessionStorageObjects = new Map;
         this._cookieStorageObjects = {};
 
         this.dispatchEventToListeners(DOMStorageManager.Event.Cleared);
@@ -174,13 +178,8 @@ WI.DOMStorageManager = class DOMStorageManager extends WI.Object
 
     _domStorageForIdentifier(id)
     {
-        for (var storageObject of this._domStorageObjects) {
-            // The id is an object, so we need to compare the properties using Object.shallowEqual.
-            if (Object.shallowEqual(storageObject.id, id))
-                return storageObject;
-        }
-
-        return null;
+        let domStorageObjects = id.isLocalStorage ? this._localStorageObjects : this._sessionStorageObjects;
+        return domStorageObjects.get(id.securityOrigin) || null;
     }
 
     _addDOMStorageIfNeeded(frame)
@@ -203,7 +202,8 @@ WI.DOMStorageManager = class DOMStorageManager extends WI.Object
                 return;
 
             let domStorage = new WI.DOMStorageObject(identifier, frame.mainResource.urlComponents.host, identifier.isLocalStorage);
-            this._domStorageObjects.push(domStorage);
+            let domStorageObjects = identifier.isLocalStorage ? this._localStorageObjects : this._sessionStorageObjects;
+            domStorageObjects.set(identifier.securityOrigin, domStorage);
             this.dispatchEventToListeners(DOMStorageManager.Event.DOMStorageObjectWasAdded, {domStorage});
         };
         addDOMStorage(true);


### PR DESCRIPTION
#### bd758aa007dd580c7b3a547ce485d52afc5343fb
<pre>
Web Inspector: DOMStorageManager looks up storage objects with an O(n) Object.shallowEqual scan on every storage event
<a href="https://bugs.webkit.org/show_bug.cgi?id=319415">https://bugs.webkit.org/show_bug.cgi?id=319415</a>
<a href="https://rdar.apple.com/182241938">rdar://182241938</a>

Reviewed by Devin Rousso.

DOMStorageManager stored its DOMStorageObjects in an array and resolved
the object for an incoming storage event by walking the whole array and
calling Object.shallowEqual on each entry&apos;s identifier. This ran for every
DOMStorage observer event (itemAdded/itemUpdated/itemRemoved/itemsCleared),
as well as on every add-if-needed and inspect.

Back the collection with two Maps, one for localStorage and one for
sessionStorage, each keyed directly by securityOrigin. This turns the
lookup into an O(1) Map.get and drops the per-element Object.shallowEqual
comparison. The public domStorageObjects getter continues to return an
array, so existing consumers are unchanged.

Covered by the existing inspector/storage/domStorage-events.html test,
which drives set/remove/clear on both sessionStorage and localStorage and
asserts the events reach the correct DOMStorageObject.

* Source/WebInspectorUI/UserInterface/Controllers/DOMStorageManager.js:
(WI.DOMStorageManager.prototype.get domStorageObjects):
(WI.DOMStorageManager.prototype._reset):
(WI.DOMStorageManager.prototype._domStorageForIdentifier):
(WI.DOMStorageManager.prototype._addDOMStorageIfNeeded):

Canonical link: <a href="https://commits.webkit.org/317561@main">https://commits.webkit.org/317561@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/10e698306801a85d39328b870cbe75d5d78bd584

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175654 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49587 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/43370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185246 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1909e5aa-1b9d-4909-b8ca-002e640f89dd) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50879 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49269 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/136771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178610 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/40219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/43370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117249 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fa332223-36ed-40d3-9bb6-071c86d5b629) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/38861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/37237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/43370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/149280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/43370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33716 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41278 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187667 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49254 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/43370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/145755 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39215 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/49934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/43370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/145593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/49934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122129 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115955 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48441 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/43370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/47843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/48075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/47900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->