### PR TITLE
[list-marker] Add regression tests

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-in-multicol-relpos-content-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-in-multicol-relpos-content-expected.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.list {
+    display: list-item;
+    columns: 2;
+    column-fill: auto;
+    height: 100px;
+    padding-inline-start: 20px;
+    width: 100px;
+    margin-left: 20px;
+}
+
+.list::marker {
+    color: magenta;
+}
+
+.columnFiller {
+    height: 100px;
+    width: 20px;
+    background: green;
+}
+</style>
+</head>
+<body>
+<div class="list">
+    <div class="columnFiller"></div>
+    <div class="itemContent">item</div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-in-multicol-relpos-content-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-in-multicol-relpos-content-ref.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.list {
+    display: list-item;
+    columns: 2;
+    column-fill: auto;
+    height: 100px;
+    padding-inline-start: 20px;
+    width: 100px;
+    margin-left: 20px;
+}
+
+.list::marker {
+    color: magenta;
+}
+
+.columnFiller {
+    height: 100px;
+    width: 20px;
+    background: green;
+}
+</style>
+</head>
+<body>
+<div class="list">
+    <div class="columnFiller"></div>
+    <div class="itemContent">item</div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-in-multicol-relpos-content.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-in-multicol-relpos-content.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Lists: outside marker position for content flowing into a later multicol column</title>
+<link rel="help" href="https://drafts.csswg.org/css-lists-3/#list-style-position-property">
+<link rel="author" title="Yulun Wu" href="mailto:yulun_wu@apple.com">
+<link rel="match" href="outside-marker-in-multicol-relpos-content-ref.html">
+<meta name="assert" content="An outside list marker for content that flows into a later column of a multi-column list item must paint adjacent to that column; relative positioning of the item content must not shift it.">
+<style>
+.container {
+    margin-left: 20px;
+}
+.list {
+    display: list-item;
+    columns: 2;
+    column-fill: auto;
+    height: 100px;
+    padding-inline-start: 20px;
+    width: 100px;
+}
+
+.list::marker {
+    color: magenta;
+}
+
+.columnFiller {
+    height: 100px;
+    width: 20px;
+    background: green;
+}
+
+.itemContent {
+    position: relative;
+}
+</style>
+</head>
+<body>
+<div class="container">
+    <div class="list">
+        <div class="columnFiller"></div>
+        <div class="itemContent">item</div>
+    </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-relpos-block-content-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-relpos-block-content-expected.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.list {
+    margin: 0;
+    padding-inline-start: 20px;
+    font: 16px/1.4 monospace;
+}
+
+.itemContent {
+    margin: 0;
+}
+</style>
+</head>
+<body>
+<ol class="list">
+    <li class="item"><p class="itemContent">Item A</p></li>
+    <li class="item"><p class="itemContent">Item B</p></li>
+    <li class="item"><p class="itemContent">Item C</p></li>
+</ol>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-relpos-block-content-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-relpos-block-content-ref.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.list {
+    margin: 0;
+    padding-inline-start: 20px;
+    font: 16px/1.4 monospace;
+}
+
+.itemContent {
+    margin: 0;
+}
+</style>
+</head>
+<body>
+<ol class="list">
+    <li class="item"><p class="itemContent">Item A</p></li>
+    <li class="item"><p class="itemContent">Item B</p></li>
+    <li class="item"><p class="itemContent">Item C</p></li>
+</ol>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-relpos-block-content.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-relpos-block-content.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Lists: outside marker position with relatively positioned list and block content</title>
+<link rel="help" href="https://drafts.csswg.org/css-lists-3/#list-style-position-property">
+<link rel="author" title="Yulun Wu" href="mailto:yulun_wu@apple.com">
+<link rel="match" href="outside-marker-with-relpos-block-content-ref.html">
+<meta name="assert" content="Outside list markers must not overlap when the list and its block-level item content are relatively positioned.">
+<style>
+.list {
+    position: relative;
+    margin: 0;
+    padding-inline-start: 20px;
+    font: 16px/1.4 monospace;
+}
+
+.itemContent {
+    position: relative;
+    margin: 0;
+}
+</style>
+</head>
+<body>
+<ol class="list">
+    <li class="item"><p class="itemContent">Item A</p></li>
+    <li class="item"><p class="itemContent">Item B</p></li>
+    <li class="item"><p class="itemContent">Item C</p></li>
+</ol>
+</body>
+</html>


### PR DESCRIPTION
#### dc0b697b5b7d323c573873e5bdfdc48ea753460a
<pre>
[list-marker] Add regression tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=318844">https://bugs.webkit.org/show_bug.cgi?id=318844</a>
<a href="https://rdar.apple.com/181615895">rdar://181615895</a>

Reviewed by Alan Baradlay.

309188@main (reverted) introduced two regressions when it broke
list marker parenting for multi-column and position: relative.

<a href="https://bugs.webkit.org/show_bug.cgi?id=318928">https://bugs.webkit.org/show_bug.cgi?id=318928</a>

<a href="https://bugs.webkit.org/show_bug.cgi?id=318844">https://bugs.webkit.org/show_bug.cgi?id=318844</a>

This PR adds regression tests to prevent these regressions from coming back.

* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-in-multicol-relpos-content-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-in-multicol-relpos-content-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-in-multicol-relpos-content.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-relpos-block-content-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-relpos-block-content-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-relpos-block-content.html: Added.

Canonical link: <a href="https://commits.webkit.org/317216@main">https://commits.webkit.org/317216@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68484b84496cc8c04a10fa3ebd353ca5a552b0f4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174678 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48611 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/42392 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184257 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/132546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49903 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48294 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/135916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/132546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177636 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/39349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/156708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/116394 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/37990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32736 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/148413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/36200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186683 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/144841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48278 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/156264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/144700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48958 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26541 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/39573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47464 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/11168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46866 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47097 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46924 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->