### PR TITLE
[animation-triggers] add parsing support for the `timeline-trigger-active-range` shorthand

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/parsing/timeline-trigger-active-range-shorthand.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/parsing/timeline-trigger-active-range-shorthand.tentative-expected.txt
@@ -1,83 +1,83 @@
 
 FAIL e.style['timeline-trigger-active-range'] = "auto" should set the property value assert_not_equals: property should be set got disallowed value ""
 FAIL e.style['timeline-trigger-active-range'] = "auto auto" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-active-range'] = "normal" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-active-range'] = "normal normal" should set the property value assert_not_equals: property should be set got disallowed value ""
+PASS e.style['timeline-trigger-active-range'] = "normal" should set the property value
+FAIL e.style['timeline-trigger-active-range'] = "normal normal" should set the property value assert_equals: serialization should be canonical expected "normal normal" but got "normal"
 FAIL e.style['timeline-trigger-active-range'] = "normal auto" should set the property value assert_not_equals: property should be set got disallowed value ""
 FAIL e.style['timeline-trigger-active-range'] = "auto normal" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-active-range'] = "cover 0% normal" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-active-range'] = "cover 50% normal" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-active-range'] = "normal cover 100%" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-active-range'] = "normal cover 50%" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-active-range'] = "cover" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-active-range'] = "contain" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-active-range'] = "entry" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-active-range'] = "entry-crossing" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-active-range'] = "exit" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-active-range'] = "exit-crossing" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-active-range'] = "entry, exit" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-active-range'] = "entry 0% entry 100%" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-active-range'] = "entry-crossing 0% entry-crossing 100%" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-active-range'] = "exit 0% exit 100%" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-active-range'] = "exit-crossing 0% exit-crossing 100%" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-active-range'] = "cover 0% cover 100%" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-active-range'] = "contain 0% contain 100%" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-active-range'] = "entry calc(10% - 10%) entry calc(50% + 50%)" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-active-range'] = "cover 50%" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-active-range'] = "contain 50%" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-active-range'] = "entry 50%" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-active-range'] = "entry-crossing 50%" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-active-range'] = "exit 50%" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-active-range'] = "exit-crossing 50%" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-active-range'] = "entry 50px exit 100px" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-active-range'] = "exit calc(10% + 50px)" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-active-range'] = "entry 50% exit 50%" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-active-range'] = "cover 50% entry 50%, contain 50% exit 50%" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-active-range'] = "50% exit 50%" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-active-range'] = "normal 100px" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-active-range'] = "100px" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-active-range'] = "10%" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-active-range'] = "100px normal" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['timeline-trigger-active-range'] = "100% normal" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['timeline-trigger-active-range'] = "cover 0% normal" should set the property value assert_equals: serialization should be canonical expected "cover normal" but got "cover"
+FAIL e.style['timeline-trigger-active-range'] = "cover 50% normal" should set the property value assert_equals: serialization should be canonical expected "cover 50% normal" but got "cover 50%"
+PASS e.style['timeline-trigger-active-range'] = "normal cover 100%" should set the property value
+PASS e.style['timeline-trigger-active-range'] = "normal cover 50%" should set the property value
+PASS e.style['timeline-trigger-active-range'] = "cover" should set the property value
+PASS e.style['timeline-trigger-active-range'] = "contain" should set the property value
+PASS e.style['timeline-trigger-active-range'] = "entry" should set the property value
+PASS e.style['timeline-trigger-active-range'] = "entry-crossing" should set the property value
+PASS e.style['timeline-trigger-active-range'] = "exit" should set the property value
+PASS e.style['timeline-trigger-active-range'] = "exit-crossing" should set the property value
+PASS e.style['timeline-trigger-active-range'] = "entry, exit" should set the property value
+PASS e.style['timeline-trigger-active-range'] = "entry 0% entry 100%" should set the property value
+PASS e.style['timeline-trigger-active-range'] = "entry-crossing 0% entry-crossing 100%" should set the property value
+PASS e.style['timeline-trigger-active-range'] = "exit 0% exit 100%" should set the property value
+PASS e.style['timeline-trigger-active-range'] = "exit-crossing 0% exit-crossing 100%" should set the property value
+PASS e.style['timeline-trigger-active-range'] = "cover 0% cover 100%" should set the property value
+PASS e.style['timeline-trigger-active-range'] = "contain 0% contain 100%" should set the property value
+FAIL e.style['timeline-trigger-active-range'] = "entry calc(10% - 10%) entry calc(50% + 50%)" should set the property value assert_equals: serialization should be canonical expected "entry" but got "entry calc(0%) entry calc(100%)"
+PASS e.style['timeline-trigger-active-range'] = "cover 50%" should set the property value
+PASS e.style['timeline-trigger-active-range'] = "contain 50%" should set the property value
+PASS e.style['timeline-trigger-active-range'] = "entry 50%" should set the property value
+PASS e.style['timeline-trigger-active-range'] = "entry-crossing 50%" should set the property value
+PASS e.style['timeline-trigger-active-range'] = "exit 50%" should set the property value
+PASS e.style['timeline-trigger-active-range'] = "exit-crossing 50%" should set the property value
+PASS e.style['timeline-trigger-active-range'] = "entry 50px exit 100px" should set the property value
+PASS e.style['timeline-trigger-active-range'] = "exit calc(10% + 50px)" should set the property value
+PASS e.style['timeline-trigger-active-range'] = "entry 50% exit 50%" should set the property value
+PASS e.style['timeline-trigger-active-range'] = "cover 50% entry 50%, contain 50% exit 50%" should set the property value
+PASS e.style['timeline-trigger-active-range'] = "50% exit 50%" should set the property value
+PASS e.style['timeline-trigger-active-range'] = "normal 100px" should set the property value
+PASS e.style['timeline-trigger-active-range'] = "100px" should set the property value
+PASS e.style['timeline-trigger-active-range'] = "10%" should set the property value
+FAIL e.style['timeline-trigger-active-range'] = "100px normal" should set the property value assert_equals: serialization should be canonical expected "100px normal" but got "100px"
+FAIL e.style['timeline-trigger-active-range'] = "100% normal" should set the property value assert_equals: serialization should be canonical expected "100% normal" but got "100%"
 FAIL e.style['timeline-trigger-active-range'] = "100px auto" should set the property value assert_not_equals: property should be set got disallowed value ""
 FAIL e.style['timeline-trigger-active-range'] = "100% auto" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL Property timeline-trigger-active-range value 'auto' assert_true: timeline-trigger-active-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-active-range value 'auto auto' assert_true: timeline-trigger-active-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-active-range value 'normal' assert_true: timeline-trigger-active-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-active-range value 'auto normal' assert_true: timeline-trigger-active-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-active-range value 'normal auto' assert_true: timeline-trigger-active-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-active-range value 'normal normal' assert_true: timeline-trigger-active-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-active-range value 'cover' assert_true: timeline-trigger-active-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-active-range value 'contain' assert_true: timeline-trigger-active-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-active-range value 'entry' assert_true: timeline-trigger-active-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-active-range value 'entry-crossing' assert_true: timeline-trigger-active-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-active-range value 'exit' assert_true: timeline-trigger-active-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-active-range value 'exit-crossing' assert_true: timeline-trigger-active-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-active-range value 'entry, exit' assert_true: timeline-trigger-active-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-active-range value 'entry 0% entry 100%' assert_true: timeline-trigger-active-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-active-range value 'entry-crossing 0% entry-crossing 100%' assert_true: timeline-trigger-active-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-active-range value 'exit 0% exit 100%' assert_true: timeline-trigger-active-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-active-range value 'exit-crossing 0% exit-crossing 100%' assert_true: timeline-trigger-active-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-active-range value 'cover 0% cover 100%' assert_true: timeline-trigger-active-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-active-range value 'contain 0% contain 100%' assert_true: timeline-trigger-active-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-active-range value 'entry calc(10% - 10%) entry calc(50% + 50%)' assert_true: timeline-trigger-active-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-active-range value 'cover 50%' assert_true: timeline-trigger-active-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-active-range value 'contain 50%' assert_true: timeline-trigger-active-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-active-range value 'entry 50%' assert_true: timeline-trigger-active-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-active-range value 'entry-crossing 50%' assert_true: timeline-trigger-active-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-active-range value 'exit 50%' assert_true: timeline-trigger-active-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-active-range value 'exit-crossing 50%' assert_true: timeline-trigger-active-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-active-range value 'entry 50px exit 100px' assert_true: timeline-trigger-active-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-active-range value 'exit calc(10% + 50px)' assert_true: timeline-trigger-active-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-active-range value 'entry 50% exit 50%' assert_true: timeline-trigger-active-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-active-range value 'cover 50% entry 50%, contain 50% exit 50%' assert_true: timeline-trigger-active-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-active-range value 'entry 10em exit 20em' assert_true: timeline-trigger-active-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-active-range value '10em exit 20em' assert_true: timeline-trigger-active-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-active-range value 'normal 100px' assert_true: timeline-trigger-active-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-active-range value '100px' assert_true: timeline-trigger-active-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-active-range value '100px normal' assert_true: timeline-trigger-active-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-active-range value '10% normal' assert_true: timeline-trigger-active-range doesn't seem to be supported in the computed style expected true got false
-FAIL Property timeline-trigger-active-range value '10% calc(70% + 10% * sign(100em - 1px))' assert_true: timeline-trigger-active-range doesn't seem to be supported in the computed style expected true got false
+FAIL Property timeline-trigger-active-range value 'auto' assert_true: 'auto' is a supported value for timeline-trigger-active-range. expected true got false
+FAIL Property timeline-trigger-active-range value 'auto auto' assert_true: 'auto auto' is a supported value for timeline-trigger-active-range. expected true got false
+PASS Property timeline-trigger-active-range value 'normal'
+FAIL Property timeline-trigger-active-range value 'auto normal' assert_true: 'auto normal' is a supported value for timeline-trigger-active-range. expected true got false
+FAIL Property timeline-trigger-active-range value 'normal auto' assert_true: 'normal auto' is a supported value for timeline-trigger-active-range. expected true got false
+FAIL Property timeline-trigger-active-range value 'normal normal' assert_equals: expected "normal normal" but got "normal"
+PASS Property timeline-trigger-active-range value 'cover'
+PASS Property timeline-trigger-active-range value 'contain'
+PASS Property timeline-trigger-active-range value 'entry'
+PASS Property timeline-trigger-active-range value 'entry-crossing'
+PASS Property timeline-trigger-active-range value 'exit'
+PASS Property timeline-trigger-active-range value 'exit-crossing'
+PASS Property timeline-trigger-active-range value 'entry, exit'
+PASS Property timeline-trigger-active-range value 'entry 0% entry 100%'
+PASS Property timeline-trigger-active-range value 'entry-crossing 0% entry-crossing 100%'
+PASS Property timeline-trigger-active-range value 'exit 0% exit 100%'
+PASS Property timeline-trigger-active-range value 'exit-crossing 0% exit-crossing 100%'
+PASS Property timeline-trigger-active-range value 'cover 0% cover 100%'
+PASS Property timeline-trigger-active-range value 'contain 0% contain 100%'
+PASS Property timeline-trigger-active-range value 'entry calc(10% - 10%) entry calc(50% + 50%)'
+PASS Property timeline-trigger-active-range value 'cover 50%'
+PASS Property timeline-trigger-active-range value 'contain 50%'
+PASS Property timeline-trigger-active-range value 'entry 50%'
+PASS Property timeline-trigger-active-range value 'entry-crossing 50%'
+PASS Property timeline-trigger-active-range value 'exit 50%'
+PASS Property timeline-trigger-active-range value 'exit-crossing 50%'
+PASS Property timeline-trigger-active-range value 'entry 50px exit 100px'
+PASS Property timeline-trigger-active-range value 'exit calc(10% + 50px)'
+PASS Property timeline-trigger-active-range value 'entry 50% exit 50%'
+PASS Property timeline-trigger-active-range value 'cover 50% entry 50%, contain 50% exit 50%'
+PASS Property timeline-trigger-active-range value 'entry 10em exit 20em'
+PASS Property timeline-trigger-active-range value '10em exit 20em'
+PASS Property timeline-trigger-active-range value 'normal 100px'
+PASS Property timeline-trigger-active-range value '100px'
+FAIL Property timeline-trigger-active-range value '100px normal' assert_equals: expected "100px normal" but got "100px"
+FAIL Property timeline-trigger-active-range value '10% normal' assert_equals: expected "10% normal" but got "10%"
+PASS Property timeline-trigger-active-range value '10% calc(70% + 10% * sign(100em - 1px))'
 PASS e.style['timeline-trigger-active-range'] = "entry 50% 0s" should not set the property value
 PASS e.style['timeline-trigger-active-range'] = "0s entry 50%" should not set the property value
 PASS e.style['timeline-trigger-active-range'] = "1s" should not set the property value
@@ -101,46 +101,46 @@ PASS e.style['timeline-trigger-active-range'] = "thing 100px" should not set the
 PASS e.style['timeline-trigger-active-range'] = "100% thing" should not set the property value
 PASS e.style['timeline-trigger-active-range'] = "normal foo normal 100%" should not set the property value
 PASS e.style['timeline-trigger-active-range'] = "normal normal 100%" should not set the property value
-FAIL e.style['timeline-trigger-active-range'] = "normal" should set timeline-trigger-active-range-end assert_equals: timeline-trigger-active-range-end should be canonical expected "auto" but got ""
-FAIL e.style['timeline-trigger-active-range'] = "normal" should set timeline-trigger-active-range-start assert_equals: timeline-trigger-active-range-start should be canonical expected "normal" but got ""
-FAIL e.style['timeline-trigger-active-range'] = "normal" should not set unrelated longhands assert_true: expected true got false
-FAIL e.style['timeline-trigger-active-range'] = "normal normal" should set timeline-trigger-active-range-end assert_equals: timeline-trigger-active-range-end should be canonical expected "normal" but got ""
-FAIL e.style['timeline-trigger-active-range'] = "normal normal" should set timeline-trigger-active-range-start assert_equals: timeline-trigger-active-range-start should be canonical expected "normal" but got ""
-FAIL e.style['timeline-trigger-active-range'] = "normal normal" should not set unrelated longhands assert_true: expected true got false
-FAIL e.style['timeline-trigger-active-range'] = "normal entry 100%" should set timeline-trigger-active-range-end assert_equals: timeline-trigger-active-range-end should be canonical expected "entry" but got ""
-FAIL e.style['timeline-trigger-active-range'] = "normal entry 100%" should set timeline-trigger-active-range-start assert_equals: timeline-trigger-active-range-start should be canonical expected "normal" but got ""
-FAIL e.style['timeline-trigger-active-range'] = "normal entry 100%" should not set unrelated longhands assert_true: expected true got false
-FAIL e.style['timeline-trigger-active-range'] = "normal entry 10%" should set timeline-trigger-active-range-end assert_equals: timeline-trigger-active-range-end should be canonical expected "entry 10%" but got ""
-FAIL e.style['timeline-trigger-active-range'] = "normal entry 10%" should set timeline-trigger-active-range-start assert_equals: timeline-trigger-active-range-start should be canonical expected "normal" but got ""
-FAIL e.style['timeline-trigger-active-range'] = "normal entry 10%" should not set unrelated longhands assert_true: expected true got false
-FAIL e.style['timeline-trigger-active-range'] = "cover" should set timeline-trigger-active-range-end assert_equals: timeline-trigger-active-range-end should be canonical expected "cover" but got ""
-FAIL e.style['timeline-trigger-active-range'] = "cover" should set timeline-trigger-active-range-start assert_equals: timeline-trigger-active-range-start should be canonical expected "cover" but got ""
-FAIL e.style['timeline-trigger-active-range'] = "cover" should not set unrelated longhands assert_true: expected true got false
-FAIL e.style['timeline-trigger-active-range'] = "contain" should set timeline-trigger-active-range-end assert_equals: timeline-trigger-active-range-end should be canonical expected "contain" but got ""
-FAIL e.style['timeline-trigger-active-range'] = "contain" should set timeline-trigger-active-range-start assert_equals: timeline-trigger-active-range-start should be canonical expected "contain" but got ""
-FAIL e.style['timeline-trigger-active-range'] = "contain" should not set unrelated longhands assert_true: expected true got false
-FAIL e.style['timeline-trigger-active-range'] = "contain 100% contain 0%" should set timeline-trigger-active-range-end assert_equals: timeline-trigger-active-range-end should be canonical expected "contain 0%" but got ""
-FAIL e.style['timeline-trigger-active-range'] = "contain 100% contain 0%" should set timeline-trigger-active-range-start assert_equals: timeline-trigger-active-range-start should be canonical expected "contain 100%" but got ""
-FAIL e.style['timeline-trigger-active-range'] = "contain 100% contain 0%" should not set unrelated longhands assert_true: expected true got false
-FAIL e.style['timeline-trigger-active-range'] = "entry 10% exit 20%" should set timeline-trigger-active-range-end assert_equals: timeline-trigger-active-range-end should be canonical expected "exit 20%" but got ""
-FAIL e.style['timeline-trigger-active-range'] = "entry 10% exit 20%" should set timeline-trigger-active-range-start assert_equals: timeline-trigger-active-range-start should be canonical expected "entry 10%" but got ""
-FAIL e.style['timeline-trigger-active-range'] = "entry 10% exit 20%" should not set unrelated longhands assert_true: expected true got false
-FAIL e.style['timeline-trigger-active-range'] = "entry calc(10% + 10px) exit 20px" should set timeline-trigger-active-range-end assert_equals: timeline-trigger-active-range-end should be canonical expected "exit 20px" but got ""
-FAIL e.style['timeline-trigger-active-range'] = "entry calc(10% + 10px) exit 20px" should set timeline-trigger-active-range-start assert_equals: timeline-trigger-active-range-start should be canonical expected "entry calc(10% + 10px)" but got ""
-FAIL e.style['timeline-trigger-active-range'] = "entry calc(10% + 10px) exit 20px" should not set unrelated longhands assert_true: expected true got false
-FAIL e.style['timeline-trigger-active-range'] = "entry, exit" should set timeline-trigger-active-range-end assert_equals: timeline-trigger-active-range-end should be canonical expected "entry, exit" but got ""
-FAIL e.style['timeline-trigger-active-range'] = "entry, exit" should set timeline-trigger-active-range-start assert_equals: timeline-trigger-active-range-start should be canonical expected "entry, exit" but got ""
-FAIL e.style['timeline-trigger-active-range'] = "entry, exit" should not set unrelated longhands assert_true: expected true got false
-FAIL e.style['timeline-trigger-active-range'] = "entry 0%, exit" should set timeline-trigger-active-range-end assert_equals: timeline-trigger-active-range-end should be canonical expected "entry, exit" but got ""
-FAIL e.style['timeline-trigger-active-range'] = "entry 0%, exit" should set timeline-trigger-active-range-start assert_equals: timeline-trigger-active-range-start should be canonical expected "entry, exit" but got ""
-FAIL e.style['timeline-trigger-active-range'] = "entry 0%, exit" should not set unrelated longhands assert_true: expected true got false
-FAIL e.style['timeline-trigger-active-range'] = "exit calc(10% + 50px)" should set timeline-trigger-active-range-end assert_equals: timeline-trigger-active-range-end should be canonical expected "exit" but got ""
-FAIL e.style['timeline-trigger-active-range'] = "exit calc(10% + 50px)" should set timeline-trigger-active-range-start assert_equals: timeline-trigger-active-range-start should be canonical expected "exit calc(10% + 50px)" but got ""
-FAIL e.style['timeline-trigger-active-range'] = "exit calc(10% + 50px)" should not set unrelated longhands assert_true: expected true got false
-FAIL e.style['timeline-trigger-active-range'] = "100px" should set timeline-trigger-active-range-end assert_equals: timeline-trigger-active-range-end should be canonical expected "auto" but got ""
-FAIL e.style['timeline-trigger-active-range'] = "100px" should set timeline-trigger-active-range-start assert_equals: timeline-trigger-active-range-start should be canonical expected "100px" but got ""
-FAIL e.style['timeline-trigger-active-range'] = "100px" should not set unrelated longhands assert_true: expected true got false
-FAIL e.style['timeline-trigger-active-range'] = "10%" should set timeline-trigger-active-range-end assert_equals: timeline-trigger-active-range-end should be canonical expected "auto" but got ""
-FAIL e.style['timeline-trigger-active-range'] = "10%" should set timeline-trigger-active-range-start assert_equals: timeline-trigger-active-range-start should be canonical expected "10%" but got ""
-FAIL e.style['timeline-trigger-active-range'] = "10%" should not set unrelated longhands assert_true: expected true got false
+FAIL e.style['timeline-trigger-active-range'] = "normal" should set timeline-trigger-active-range-end assert_equals: timeline-trigger-active-range-end should be canonical expected "auto" but got "normal"
+PASS e.style['timeline-trigger-active-range'] = "normal" should set timeline-trigger-active-range-start
+PASS e.style['timeline-trigger-active-range'] = "normal" should not set unrelated longhands
+PASS e.style['timeline-trigger-active-range'] = "normal normal" should set timeline-trigger-active-range-end
+PASS e.style['timeline-trigger-active-range'] = "normal normal" should set timeline-trigger-active-range-start
+PASS e.style['timeline-trigger-active-range'] = "normal normal" should not set unrelated longhands
+PASS e.style['timeline-trigger-active-range'] = "normal entry 100%" should set timeline-trigger-active-range-end
+PASS e.style['timeline-trigger-active-range'] = "normal entry 100%" should set timeline-trigger-active-range-start
+PASS e.style['timeline-trigger-active-range'] = "normal entry 100%" should not set unrelated longhands
+PASS e.style['timeline-trigger-active-range'] = "normal entry 10%" should set timeline-trigger-active-range-end
+PASS e.style['timeline-trigger-active-range'] = "normal entry 10%" should set timeline-trigger-active-range-start
+PASS e.style['timeline-trigger-active-range'] = "normal entry 10%" should not set unrelated longhands
+PASS e.style['timeline-trigger-active-range'] = "cover" should set timeline-trigger-active-range-end
+PASS e.style['timeline-trigger-active-range'] = "cover" should set timeline-trigger-active-range-start
+PASS e.style['timeline-trigger-active-range'] = "cover" should not set unrelated longhands
+PASS e.style['timeline-trigger-active-range'] = "contain" should set timeline-trigger-active-range-end
+PASS e.style['timeline-trigger-active-range'] = "contain" should set timeline-trigger-active-range-start
+PASS e.style['timeline-trigger-active-range'] = "contain" should not set unrelated longhands
+PASS e.style['timeline-trigger-active-range'] = "contain 100% contain 0%" should set timeline-trigger-active-range-end
+PASS e.style['timeline-trigger-active-range'] = "contain 100% contain 0%" should set timeline-trigger-active-range-start
+PASS e.style['timeline-trigger-active-range'] = "contain 100% contain 0%" should not set unrelated longhands
+PASS e.style['timeline-trigger-active-range'] = "entry 10% exit 20%" should set timeline-trigger-active-range-end
+PASS e.style['timeline-trigger-active-range'] = "entry 10% exit 20%" should set timeline-trigger-active-range-start
+PASS e.style['timeline-trigger-active-range'] = "entry 10% exit 20%" should not set unrelated longhands
+PASS e.style['timeline-trigger-active-range'] = "entry calc(10% + 10px) exit 20px" should set timeline-trigger-active-range-end
+PASS e.style['timeline-trigger-active-range'] = "entry calc(10% + 10px) exit 20px" should set timeline-trigger-active-range-start
+PASS e.style['timeline-trigger-active-range'] = "entry calc(10% + 10px) exit 20px" should not set unrelated longhands
+PASS e.style['timeline-trigger-active-range'] = "entry, exit" should set timeline-trigger-active-range-end
+PASS e.style['timeline-trigger-active-range'] = "entry, exit" should set timeline-trigger-active-range-start
+PASS e.style['timeline-trigger-active-range'] = "entry, exit" should not set unrelated longhands
+PASS e.style['timeline-trigger-active-range'] = "entry 0%, exit" should set timeline-trigger-active-range-end
+PASS e.style['timeline-trigger-active-range'] = "entry 0%, exit" should set timeline-trigger-active-range-start
+PASS e.style['timeline-trigger-active-range'] = "entry 0%, exit" should not set unrelated longhands
+PASS e.style['timeline-trigger-active-range'] = "exit calc(10% + 50px)" should set timeline-trigger-active-range-end
+PASS e.style['timeline-trigger-active-range'] = "exit calc(10% + 50px)" should set timeline-trigger-active-range-start
+PASS e.style['timeline-trigger-active-range'] = "exit calc(10% + 50px)" should not set unrelated longhands
+FAIL e.style['timeline-trigger-active-range'] = "100px" should set timeline-trigger-active-range-end assert_equals: timeline-trigger-active-range-end should be canonical expected "auto" but got "normal"
+PASS e.style['timeline-trigger-active-range'] = "100px" should set timeline-trigger-active-range-start
+PASS e.style['timeline-trigger-active-range'] = "100px" should not set unrelated longhands
+FAIL e.style['timeline-trigger-active-range'] = "10%" should set timeline-trigger-active-range-end assert_equals: timeline-trigger-active-range-end should be canonical expected "auto" but got "normal"
+PASS e.style['timeline-trigger-active-range'] = "10%" should set timeline-trigger-active-range-start
+PASS e.style['timeline-trigger-active-range'] = "10%" should not set unrelated longhands
 

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -13364,6 +13364,24 @@
                 "url": "https://drafts.csswg.org/animation-triggers-1/#propdef-timeline-trigger-active-range-start"
             }
         },
+        "timeline-trigger-active-range": {
+            "codegen-properties": {
+                "longhands": [
+                    "timeline-trigger-active-range-start",
+                    "timeline-trigger-active-range-end"
+                ],
+                "coordinated-value-list-property": true,
+                "separator": ",",
+                "parser-function": "consumeTimelineTriggerActiveRangeShorthand",
+                "parser-grammar-unused": "[ <'timeline-trigger-active-range-start'> <'timeline-trigger-active-range-end'>? ]#",
+                "parser-grammar-unused-reason": "Needs support for shorthand grammars.",
+                "settings-flag": "animationTriggersEnabled"
+            },
+            "specification": {
+                "category": "animation-triggers",
+                "url": "https://drafts.csswg.org/animation-triggers-1/#propdef-timeline-trigger-active-range"
+            }
+        },
         "timeline-trigger-active-range-end": {
             "animation-type": "not animatable",
             "initial": "normal",

--- a/Source/WebCore/css/ShorthandSerializer.cpp
+++ b/Source/WebCore/css/ShorthandSerializer.cpp
@@ -451,6 +451,7 @@ String ShorthandSerializer::serialize()
         return serializeCoordinatingListPropertyGroup();
     case CSSPropertyAnimationRange:
     case CSSPropertyTimelineTriggerActivationRange:
+    case CSSPropertyTimelineTriggerActiveRange:
         return serializeAnimationRange();
     default:
         ASSERT_NOT_REACHED();

--- a/Source/WebCore/css/parser/CSSPropertyParserCustom.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserCustom.h
@@ -173,6 +173,7 @@ public:
     static bool consumeContainIntrinsicSizeShorthand(CSSParserTokenRange&, PropertyParserState&, const StylePropertyShorthand&, PropertyParserResult&);
     static bool consumeAnimationRangeShorthand(CSSParserTokenRange&, PropertyParserState&, const StylePropertyShorthand&, PropertyParserResult&);
     static bool consumeTimelineTriggerActivationRangeShorthand(CSSParserTokenRange&, PropertyParserState&, const StylePropertyShorthand&, PropertyParserResult&);
+    static bool consumeTimelineTriggerActiveRangeShorthand(CSSParserTokenRange&, PropertyParserState&, const StylePropertyShorthand&, PropertyParserResult&);
     static bool consumeScrollTimelineShorthand(CSSParserTokenRange&, PropertyParserState&, const StylePropertyShorthand&, PropertyParserResult&);
     static bool consumeViewTimelineShorthand(CSSParserTokenRange&, PropertyParserState&, const StylePropertyShorthand&, PropertyParserResult&);
     static bool consumeLineClampShorthand(CSSParserTokenRange&, PropertyParserState&, const StylePropertyShorthand&, PropertyParserResult&);
@@ -2127,6 +2128,11 @@ inline bool PropertyParserCustom::consumeAnimationRangeShorthand(CSSParserTokenR
 }
 
 inline bool PropertyParserCustom::consumeTimelineTriggerActivationRangeShorthand(CSSParserTokenRange& range, PropertyParserState& state, const StylePropertyShorthand& shorthand, PropertyParserResult& result)
+{
+    return consumeAnimationRangeShorthand(range, state, shorthand, result);
+}
+
+inline bool PropertyParserCustom::consumeTimelineTriggerActiveRangeShorthand(CSSParserTokenRange& range, PropertyParserState& state, const StylePropertyShorthand& shorthand, PropertyParserResult& result)
 {
     return consumeAnimationRangeShorthand(range, state, shorthand, result);
 }

--- a/Source/WebCore/style/StyleExtractorCustom.h
+++ b/Source/WebCore/style/StyleExtractorCustom.h
@@ -170,6 +170,7 @@ public:
     static RefPtr<CSSValue> extractTextDecorationShorthand(ExtractorState&);
     static RefPtr<CSSValue> extractTextWrapShorthand(ExtractorState&);
     static RefPtr<CSSValue> extractTimelineTriggerActivationRangeShorthand(ExtractorState&);
+    static RefPtr<CSSValue> extractTimelineTriggerActiveRangeShorthand(ExtractorState&);
     static RefPtr<CSSValue> extractTransformOriginShorthand(ExtractorState&);
     static RefPtr<CSSValue> extractTransitionShorthand(ExtractorState&);
     static RefPtr<CSSValue> extractViewTimelineShorthand(ExtractorState&);
@@ -268,6 +269,7 @@ public:
     static void extractTextDecorationShorthandSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
     static void extractTextWrapShorthandSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
     static void extractTimelineTriggerActivationRangeShorthandSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
+    static void extractTimelineTriggerActiveRangeShorthandSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
     static void extractTransformOriginShorthandSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
     static void extractTransitionShorthandSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
     static void extractViewTimelineShorthandSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
@@ -2729,6 +2731,23 @@ inline void ExtractorCustom::extractTimelineTriggerActivationRangeShorthandSeria
         builder.append(convertAnimationRange(state, value)->cssText(context));
     };
     return extractCoordinatedValueListSerialization<CSSPropertyTimelineTriggerActivationRange>(state, builder, context, state.style.timelineTriggers(), mapper);
+}
+
+inline RefPtr<CSSValue> ExtractorCustom::extractTimelineTriggerActiveRangeShorthand(ExtractorState& state)
+{
+    auto mapper = [](auto& state, const auto& value, const std::optional<TimelineTrigger>&, const auto&) -> Ref<CSSValue> {
+        return convertAnimationRange(state, value);
+    };
+    return extractCoordinatedValueListValue<CSSPropertyTimelineTriggerActiveRange>(state, state.style.timelineTriggers(), mapper);
+}
+
+inline void ExtractorCustom::extractTimelineTriggerActiveRangeShorthandSerialization(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context)
+{
+    auto mapper = [&](auto& state, auto& builder, const auto& context, const auto& value, const std::optional<TimelineTrigger>&, const auto&) {
+        // FIXME: Do this more efficiently without creating and destroying a CSSValue object.
+        builder.append(convertAnimationRange(state, value)->cssText(context));
+    };
+    return extractCoordinatedValueListSerialization<CSSPropertyTimelineTriggerActiveRange>(state, builder, context, state.style.timelineTriggers(), mapper);
 }
 
 inline RefPtr<CSSValue> ExtractorCustom::extractBackgroundShorthand(ExtractorState& state)

--- a/Source/WebCore/style/values/animation-triggers/StyleTimelineTrigger.h
+++ b/Source/WebCore/style/values/animation-triggers/StyleTimelineTrigger.h
@@ -48,6 +48,7 @@ namespace Style {
 
 #define FOR_EACH_TIMELINE_TRIGGER_SHORTHAND(macro) \
     macro(TimelineTrigger, TimelineTriggerActivationRange, SingleAnimationRange, activationRange, ActivationRange) \
+    macro(TimelineTrigger, TimelineTriggerActiveRange, SingleAnimationRange, activeRange, ActiveRange) \
 \
 
 #define FOR_EACH_TIMELINE_TRIGGER_PROPERTY(macro) \
@@ -83,6 +84,16 @@ struct TimelineTrigger {
     bool isActivationRangeUnset() const { return isActivationRangeStartUnset() && isActivationRangeEndUnset(); }
     bool isActivationRangeSet() const { return isActivationRangeStartSet() || isActivationRangeEndSet(); }
     bool isActivationRangeFilled() const { return isActivationRangeStartFilled() || isActivationRangeEndFilled(); }
+
+    // Support for the `timeline-trigger-activation-range` shorthand.
+    static SingleAnimationRange initialActiveRange() { return { initialActiveRangeStart(), initialActiveRangeEnd() }; }
+    SingleAnimationRange activeRange() const { return { activeRangeStart(), activeRangeEnd() }; }
+    void setActiveRange(SingleAnimationRange&& activeRange) { setActiveRangeStart(WTF::move(activeRange.start)); setActiveRangeEnd(WTF::move(activeRange.end)); }
+    void fillActiveRange(SingleAnimationRange&& activeRange) { fillActiveRangeStart(WTF::move(activeRange.start)); fillActiveRangeEnd(WTF::move(activeRange.end)); }
+    void clearActiveRange() { clearActiveRangeStart(); clearActiveRangeEnd(); }
+    bool isActiveRangeUnset() const { return isActiveRangeStartUnset() && isActiveRangeEndUnset(); }
+    bool isActiveRangeSet() const { return isActiveRangeStartSet() || isActiveRangeEndSet(); }
+    bool isActiveRangeFilled() const { return isActiveRangeStartFilled() || isActiveRangeEndFilled(); }
 
     bool operator==(const TimelineTrigger&) const = default;
 


### PR DESCRIPTION
#### c7c7bc6765f51e6b0fcac564efbd0e42688d491f
<pre>
[animation-triggers] add parsing support for the `timeline-trigger-active-range` shorthand
<a href="https://bugs.webkit.org/show_bug.cgi?id=319418">https://bugs.webkit.org/show_bug.cgi?id=319418</a>
<a href="https://rdar.apple.com/182243126">rdar://182243126</a>

Reviewed by Brent Fulgham.

The animation-triggers spec adds a new shorthand property: `timeline-trigger-active-range`.

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/animation-trigger/parsing/timeline-trigger-active-range-shorthand.tentative-expected.txt:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/ShorthandSerializer.cpp:
(WebCore::ShorthandSerializer::serialize):
* Source/WebCore/css/parser/CSSPropertyParserCustom.h:
(WebCore::CSS::PropertyParserCustom::consumeTimelineTriggerActiveRangeShorthand):
* Source/WebCore/style/StyleExtractorCustom.h:
(WebCore::Style::ExtractorCustom::extractTimelineTriggerActiveRangeShorthand):
(WebCore::Style::ExtractorCustom::extractTimelineTriggerActiveRangeShorthandSerialization):
* Source/WebCore/style/values/animation-triggers/StyleTimelineTrigger.h:
(WebCore::Style::TimelineTrigger::initialActiveRange):
(WebCore::Style::TimelineTrigger::activeRange const):
(WebCore::Style::TimelineTrigger::setActiveRange):
(WebCore::Style::TimelineTrigger::fillActiveRange):
(WebCore::Style::TimelineTrigger::clearActiveRange):
(WebCore::Style::TimelineTrigger::isActiveRangeUnset const):
(WebCore::Style::TimelineTrigger::isActiveRangeSet const):
(WebCore::Style::TimelineTrigger::isActiveRangeFilled const):

Canonical link: <a href="https://commits.webkit.org/317291@main">https://commits.webkit.org/317291@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/78f823211dd89726e646e799ae668823958d5b00

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174596 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48529 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42310 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184252 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132464 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/db9e1615-69f6-4ee6-a1fe-0f6eb5ec5e11) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176461 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49821 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48212 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135917 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95870 "1 flakes 3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/737bdd93-c3e6-4f82-aab6-43af0beb4475) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177554 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39280 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156634 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116395 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4048190e-007f-4e75-9de5-29ae06a8ebeb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37921 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36293 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32654 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148344 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36126 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186601 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39882 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40490 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144770 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48196 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144629 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48875 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32746 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114655 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26569 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39508 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120875 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47382 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11093 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46784 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47015 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46842 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->