### PR TITLE
corner-shape: Clean up buildBevelCorners to match spec terminology

### DIFF
--- a/Source/WebCore/platform/graphics/CornerShapeUtilities.cpp
+++ b/Source/WebCore/platform/graphics/CornerShapeUtilities.cpp
@@ -123,13 +123,13 @@ static Corner makeCorner(const CornerInput& input)
 
 static std::pair<FloatPoint, FloatPoint> buildBevelCorners(const Corner& original, double startInset, double endInset)
 {
-    auto inwardNormal = (original.end - original.start).perpendicular().normalized();
+    auto strokeDirection = (original.end - original.start).perpendicular().normalized();
     auto outerToCenter = original.center - original.outer;
-    // Ensure the inward normal points toward the center of the corner
-    if (dotProduct(inwardNormal, outerToCenter) < 0)
-        inwardNormal = inwardNormal.scaled(-1);
-    auto innerStart = original.start + inwardNormal * float(startInset);
-    auto innerEnd = original.end + inwardNormal * float(endInset);
+    // Ensure the stroke direction points inward, toward the center of the corner.
+    if (dotProduct(strokeDirection, outerToCenter) < 0)
+        strokeDirection = strokeDirection.scaled(-1);
+    auto adjustedCornerStart = original.start + strokeDirection * float(startInset);
+    auto adjustedCornerEnd = original.end + strokeDirection * float(endInset);
 
     auto extendStart = (original.center - original.start).directionScaledBy(float(startInset));
     auto extendEnd = (original.center - original.end).directionScaledBy(float(endInset));
@@ -137,8 +137,9 @@ static std::pair<FloatPoint, FloatPoint> buildBevelCorners(const Corner& origina
     auto clipEnd = original.end + extendEnd;
     auto clipOuter = original.outer + extendStart + extendEnd;
 
-    auto axisAlignedCornerStart = findIntersection(innerStart, innerEnd, clipStart, clipOuter).value_or(innerStart);
-    auto axisAlignedCornerEnd = findIntersection(innerEnd, innerStart, clipEnd, clipOuter).value_or(innerEnd);
+    auto controlPoint = midPoint(adjustedCornerStart, adjustedCornerEnd);
+    auto axisAlignedCornerStart = findIntersection(adjustedCornerStart, controlPoint, clipStart, clipOuter).value_or(adjustedCornerStart);
+    auto axisAlignedCornerEnd = findIntersection(adjustedCornerEnd, controlPoint, clipEnd, clipOuter).value_or(adjustedCornerEnd);
 
     return { axisAlignedCornerStart, axisAlignedCornerEnd };
 }


### PR DESCRIPTION
#### 92f6bcd1fd07c46ffc7bdfef2342768926615145
<pre>
corner-shape: Clean up buildBevelCorners to match spec terminology
<a href="https://bugs.webkit.org/show_bug.cgi?id=319419">https://bugs.webkit.org/show_bug.cgi?id=319419</a>
<a href="https://rdar.apple.com/182243334">rdar://182243334</a>

Reviewed by Simon Fraser.

buildBevelCorners() uses local names that don&apos;t line up with the CSS Borders
and Box Decorations Level 4 &quot;border-aligned corner clip-out path&quot; algorithm,
making it hard to check the code against the spec. Also considering some variables
represent the same thing in adjustCornerforInset so this change syncs them

Rename and restructure for clarity, with no behavior change:
- inwardNormal -&gt; strokeDirection
- innerStart / innerEnd -&gt; adjustedCornerStart / adjustedCornerEnd
- Compute the intersection lines through an explicit midpoint controlPoint
(midPoint(adjustedCornerStart, adjustedCornerEnd)) rather than the raw
start/end pair. The midpoint lies on the start-&gt;end line, so the intersection
is identical; this just names the construct the way the spec does.

No functional change; this is a readability / spec-alignment cleanup. New tests
are not necessary here

* Source/WebCore/platform/graphics/CornerShapeUtilities.cpp:

Canonical link: <a href="https://commits.webkit.org/317243@main">https://commits.webkit.org/317243@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a3375c50db46e245eae141a56ddfad0e57d6105

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174599 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48532 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42313 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184177 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132467 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176464 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49824 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48215 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135849 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177557 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39278 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156638 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116327 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37919 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36295 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32657 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148342 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36130 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186604 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39885 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40492 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144766 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48199 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144625 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39008 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48878 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32750 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 unsafe-merge~~](https://ews-build.webkit.org/#/builders/22/builds/26548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39509 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120878 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47385 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11097 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46787 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47018 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46845 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->