### PR TITLE
[Site Isolation] Fix TestWebKitAPI.WKWebsiteDataStore.* tests

### DIFF
--- a/Source/WebCore/platform/audio/AudioSession.cpp
+++ b/Source/WebCore/platform/audio/AudioSession.cpp
@@ -120,6 +120,12 @@ void AudioSession::setSharedSession(Ref<AudioSession>&& session)
     });
 }
 
+void AudioSession::clearSharedSession(AudioSession& session)
+{
+    if (sharedAudioSession() == &session)
+        sharedAudioSession() = nullptr;
+}
+
 void AudioSession::addAudioSessionChangedObserver(const ChangedObserver& observer)
 {
     ASSERT(!audioSessionChangedObservers().contains(observer));

--- a/Source/WebCore/platform/audio/AudioSession.h
+++ b/Source/WebCore/platform/audio/AudioSession.h
@@ -100,6 +100,7 @@ class WEBCORE_EXPORT AudioSession : public AbstractThreadSafeRefCountedAndCanMak
 public:
     static Ref<AudioSession> create();
     static void setSharedSession(Ref<AudioSession>&&);
+    static void clearSharedSession(AudioSession&);
     static AudioSession& singleton();
 
     static bool NODELETE enableMediaPlayback();

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.cpp
@@ -38,6 +38,7 @@
 #include "WebProcessProxy.h"
 #include <WebCore/PlatformMediaSessionInterface.h>
 #include <WebCore/PlatformMediaSessionManager.h>
+#include <wtf/NeverDestroyed.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
@@ -86,6 +87,14 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteMediaSessionManagerAudioHardwareListener);
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteMediaSessionManagerProxy);
 
+#if PLATFORM(COCOA)
+static WeakPtr<RemoteMediaSessionManagerProxy>& currentAudioHardwareListenerCreator()
+{
+    static NeverDestroyed<WeakPtr<RemoteMediaSessionManagerProxy>> instance;
+    return instance;
+}
+#endif
+
 RefPtr<RemoteMediaSessionManagerProxy> RemoteMediaSessionManagerProxy::create(WebPageProxy& page)
 {
     return adoptRef(new RemoteMediaSessionManagerProxy(page));
@@ -95,7 +104,6 @@ RemoteMediaSessionManagerProxy::RemoteMediaSessionManagerProxy(WebPageProxy& pag
     : REMOTE_MEDIA_SESSION_MANAGER_BASE_CLASS(page.webPageIDInMainFrameProcess())
     , m_page(page)
     , m_pageID(page.webPageIDInMainFrameProcess())
-    , m_process(page.legacyMainFrameProcess())
 {
 #if USE(AUDIO_SESSION)
     AudioSession::setSharedSession(*this);
@@ -105,14 +113,29 @@ RemoteMediaSessionManagerProxy::RemoteMediaSessionManagerProxy(WebPageProxy& pag
     WebCore::AudioHardwareListener::setCreationFunction([protectedThis = Ref { *this }] (WebCore::AudioHardwareListener::Client& client) {
         return protectedThis->ensureAudioHardwareListenerProxy(client);
     });
+    currentAudioHardwareListenerCreator() = *this;
 #endif
 
-    m_process->addMessageReceiver(Messages::RemoteMediaSessionManagerProxy::messageReceiverName(), m_pageID, *this);
+    page.legacyMainFrameProcess().addMessageReceiver(Messages::RemoteMediaSessionManagerProxy::messageReceiverName(), m_pageID, *this);
 }
 
 RemoteMediaSessionManagerProxy::~RemoteMediaSessionManagerProxy()
 {
-    m_process->removeMessageReceiver(Messages::RemoteMediaSessionManagerProxy::messageReceiverName(), m_pageID);
+    if (RefPtr process = this->process())
+        process->removeMessageReceiver(Messages::RemoteMediaSessionManagerProxy::messageReceiverName(), m_pageID);
+    invalidate();
+}
+
+void RemoteMediaSessionManagerProxy::invalidate()
+{
+#if USE(AUDIO_SESSION)
+    AudioSession::clearSharedSession(*this);
+#endif
+
+#if PLATFORM(COCOA)
+    if (currentAudioHardwareListenerCreator() == this)
+        WebCore::AudioHardwareListener::resetCreationFunction();
+#endif
 }
 
 void RemoteMediaSessionManagerProxy::addMediaSession(RemoteMediaSessionState&& state)
@@ -293,9 +316,16 @@ RefPtr<WebCore::PlatformMediaSessionInterface> RemoteMediaSessionManagerProxy::f
     return session;
 }
 
+RefPtr<WebProcessProxy> RemoteMediaSessionManagerProxy::process() const
+{
+    RefPtr page = m_page.get();
+    return page ? &page->legacyMainFrameProcess() : nullptr;
+}
+
 IPC::Connection* RemoteMediaSessionManagerProxy::messageSenderConnection() const
 {
-    return m_process->hasConnection() ? &m_process->connection() : nullptr;
+    RefPtr process = this->process();
+    return process && process->hasConnection() ? &process->connection() : nullptr;
 }
 
 uint64_t RemoteMediaSessionManagerProxy::messageSenderDestinationID() const
@@ -305,7 +335,8 @@ uint64_t RemoteMediaSessionManagerProxy::messageSenderDestinationID() const
 
 std::optional<SharedPreferencesForWebProcess> RemoteMediaSessionManagerProxy::sharedPreferencesForWebProcess() const
 {
-    return m_process->sharedPreferencesForWebProcess();
+    RefPtr process = this->process();
+    return process ? process->sharedPreferencesForWebProcess() : std::nullopt;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.h
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.h
@@ -80,6 +80,8 @@ public:
 
     virtual ~RemoteMediaSessionManagerProxy();
 
+    void invalidate();
+
     // IPC::MessageReceiver, WebCore::AudioSession.
     void ref() const final { WebCore::REMOTE_MEDIA_SESSION_MANAGER_BASE_CLASS::ref(); }
     void deref() const final { WebCore::REMOTE_MEDIA_SESSION_MANAGER_BASE_CLASS::deref(); }
@@ -90,7 +92,7 @@ public:
     uint32_t weakRefCount() const final { return REMOTE_MEDIA_SESSION_MANAGER_BASE_CLASS::weakRefCount(); }
 #endif
 
-    const Ref<WebProcessProxy> process() const { return m_process; }
+    RefPtr<WebProcessProxy> process() const;
 
 private:
     friend class RemotePageMediaSessionManagerProxy;
@@ -159,7 +161,6 @@ private:
 
     WeakPtr<WebPageProxy> m_page;
     WebCore::PageIdentifier m_pageID;
-    const Ref<WebProcessProxy> m_process;
     HashMap<WebCore::MediaSessionIdentifier, Ref<RemoteMediaSessionProxy>> m_sessionProxies;
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -13653,7 +13653,8 @@ void WebPageProxy::resetState(ResetStateReason resetStateReason)
 #endif
 
 #if ENABLE(VIDEO) || ENABLE(WEB_AUDIO)
-    m_mediaSessionManagerProxy = nullptr;
+    if (RefPtr mediaSessionManagerProxy = std::exchange(m_mediaSessionManagerProxy, nullptr))
+        mediaSessionManagerProxy->invalidate();
 #endif
 
     for (Ref editCommand : std::exchange(m_editCommandSet, { }))


### PR DESCRIPTION
#### b8ecb320d4dd01e6588ceb75d32f7a0eaa483e04
<pre>
[Site Isolation] Fix TestWebKitAPI.WKWebsiteDataStore.* tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=319420">https://bugs.webkit.org/show_bug.cgi?id=319420</a>
<a href="https://rdar.apple.com/182245093">rdar://182245093</a>

Reviewed by NOBODY (OOPS!).

Tests like WKWebsiteDataStore.ListIdentifiers is failing under Site Isolation because WebProcessProxy is still alive
after WebPageProxy is closed, holding WebsiteDataStore and thus NetworkProcessProxy alive. This is a leak because
web process or network process should exit when clients close all WKWebViews.

Investigation indicates the reference chain is:
AudioHardwareListener / AudioSession =&gt; RemoteMediaSessionManagerProxy =&gt; WebProcessProxy.
So the bug is RemoteMediaSessionManagerProxy registers itself as global singleton AudioSession::sharedAudioSession()
(which is a strong ref) when is is being created by WebPageProxy, but it does not clear the reference when WebPageProxy
is closed. This causes leakage of WebProcessProxy (and other objects) as RemoteMediaSessionManagerProxy holds strong
ref to WebProcessProxy.

To fix this leak, add AudioSession::clearSharedSession() and call it from a new
RemoteMediaSessionManagerProxy::invalidate(), which runs both from the destructor and from WebPageProxy::resetState()
when the manager is torn down ahead of a process swap, breaking the cycle before the swap can strand a live process
reference.

Also, stop caching a strong Ref&lt;WebProcessProxy&gt; in RemoteMediaSessionManagerProxy and instead derive the process on
demand from the page&apos;s WeakPtr, matching how the sibling proxies (WebFullScreenManagerProxy,
VideoPresentationManagerProxy, PlaybackSessionManagerProxy) already do it. This removes the last strong ref to
WebProcessProxy the manager was holding.

* Source/WebCore/platform/audio/AudioSession.cpp:
(WebCore::AudioSession::clearSharedSession):
* Source/WebCore/platform/audio/AudioSession.h:
* Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.cpp:
(WebKit::currentAudioHardwareListenerCreator):
(WebKit::RemoteMediaSessionManagerProxy::RemoteMediaSessionManagerProxy):
(WebKit::RemoteMediaSessionManagerProxy::~RemoteMediaSessionManagerProxy):
(WebKit::RemoteMediaSessionManagerProxy::invalidate):
(WebKit::RemoteMediaSessionManagerProxy::process const):
(WebKit::RemoteMediaSessionManagerProxy::messageSenderConnection const):
(WebKit::RemoteMediaSessionManagerProxy::sharedPreferencesForWebProcess const):
* Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.h:
(WebKit::RemoteMediaSessionManagerProxy::process const): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::resetState):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8ecb320d4dd01e6588ceb75d32f7a0eaa483e04

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174609 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48542 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42323 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184187 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132477 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/97e9e262-661a-42d4-93d0-e5113f7edcf8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176474 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49834 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48225 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135853 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95871 "1 flakes 5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/447284b2-dd0e-44f2-9e7c-8bb6257562ca) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177567 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39287 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156645 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116331 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ca037bee-24e7-45e9-8e3e-10dec7e57fea) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37928 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36303 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32667 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148351 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36137 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186614 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/40622 "Found 799 new failures in UIProcess/Media/RemoteMediaSessionManagerProxy.cpp, WebProcess/WebPage/WebFrame.cpp, Platform/IPC/cocoa/MachMessage.cpp, WebProcess/Network/webrtc/WebRTCResolver.cpp, UIProcess/WebFullScreenManagerProxy.cpp, WebProcess/Network/WebResourceLoader.cpp, testing/LegacyMockCDM.cpp, WebProcess/WebPage/WebPage.cpp, Shared/Cocoa/CoreIPCNSURLRequest.mm, WebProcess/GPU/graphics/ImageBufferRemotePDFDocumentBackend.cpp ...") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40500 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144776 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48209 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144635 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48888 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32757 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114668 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39518 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120889 "Found 3 new failures in UIProcess/Media/RemoteMediaSessionManagerProxy.cpp") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47395 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11105 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46797 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47028 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46855 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->