### PR TITLE
[GFC] Support fixed-length padding on grid items

### DIFF
--- a/LayoutTests/fast/css-grid-layout/grid-item-with-em-padding-track-sizing-expected.html
+++ b/LayoutTests/fast/css-grid-layout/grid-item-with-em-padding-track-sizing-expected.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+/* Reference: draw each grid item as an absolutely positioned box so the layout
+   never touches grid track sizing. box-sizing: border-box keeps the padding
+   inside the 150px cell, matching a stretched grid item, and the content ends
+   up at (paddingLeft, paddingTop). The test uses em padding (0.1em .. 1.6em at
+   a 20px font-size); this reference uses the resolved pixel values. */
+.grid {
+    position: relative;
+    width: 300px;
+    height: 300px;
+    background-color: green;
+}
+.item {
+    position: absolute;
+    box-sizing: border-box;
+    width: 150px;
+    height: 150px;
+    background-color: blue;
+}
+.topLeft {
+    left: 0;
+    top: 0;
+    padding: 2px 4px 6px 8px;
+}
+.topRight {
+    left: 150px;
+    top: 0;
+    padding: 10px 12px 14px 16px;
+}
+.bottomLeft {
+    left: 0;
+    top: 150px;
+    padding: 18px 20px 22px 24px;
+}
+.bottomRight {
+    left: 150px;
+    top: 150px;
+    padding: 26px 28px 30px 32px;
+}
+.topLeftContent {
+    width: 20px;
+    height: 20px;
+    background-color: red;
+}
+.topRightContent {
+    width: 20px;
+    height: 40px;
+    background-color: red;
+}
+.bottomLeftContent {
+    width: 40px;
+    height: 20px;
+    background-color: red;
+}
+.bottomRightContent {
+    width: 40px;
+    height: 40px;
+    background-color: red;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+    <div class="item topLeft"><div class="topLeftContent"></div></div>
+    <div class="item topRight"><div class="topRightContent"></div></div>
+    <div class="item bottomLeft"><div class="bottomLeftContent"></div></div>
+    <div class="item bottomRight"><div class="bottomRightContent"></div></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/fast/css-grid-layout/grid-item-with-em-padding-track-sizing.html
+++ b/LayoutTests/fast/css-grid-layout/grid-item-with-em-padding-track-sizing.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.grid {
+    display: grid;
+    width: 300px;
+    height: 300px;
+    grid-template-columns: 150px 150px;
+    grid-template-rows: 150px 150px;
+    font-size: 20px;
+    background-color: green;
+}
+/* Verify fixed em padding resolves correctly. */
+.topLeft {
+    grid-row: 1 / 2;
+    grid-column: 1 / 2;
+    padding: 0.1em 0.2em 0.3em 0.4em;
+    background-color: blue;
+}
+.topRight {
+    grid-row: 1 / 2;
+    grid-column: 2 / 3;
+    padding: 0.5em 0.6em 0.7em 0.8em;
+    background-color: blue;
+}
+.bottomLeft {
+    grid-row: 2 / 3;
+    grid-column: 1 / 2;
+    padding: 0.9em 1em 1.1em 1.2em;
+    background-color: blue;
+}
+.bottomRight {
+    grid-row: 2 / 3;
+    grid-column: 2 / 3;
+    padding: 1.3em 1.4em 1.5em 1.6em;
+    background-color: blue;
+}
+.topLeftContent {
+    width: 20px;
+    height: 20px;
+    background-color: red;
+}
+.topRightContent {
+    width: 20px;
+    height: 40px;
+    background-color: red;
+}
+.bottomLeftContent {
+    width: 40px;
+    height: 20px;
+    background-color: red;
+}
+.bottomRightContent {
+    width: 40px;
+    height: 40px;
+    background-color: red;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+    <div class="topLeft"><div class="topLeftContent"></div></div>
+    <div class="topRight"><div class="topRightContent"></div></div>
+    <div class="bottomLeft"><div class="bottomLeftContent"></div></div>
+    <div class="bottomRight"><div class="bottomRightContent"></div></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/fast/css-grid-layout/grid-item-with-fixed-padding-and-percent-margin-expected.html
+++ b/LayoutTests/fast/css-grid-layout/grid-item-with-fixed-padding-and-percent-margin-expected.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+/* Reference: draw the single grid item as an absolutely positioned box so the
+   layout never touches grid. The 10% margin resolves against the 100px column
+   (10px on each side), placing the 80x80 border-box at (10,10). box-sizing:
+   border-box keeps the 5px padding inside, so the content lands at (5,5). The
+   grid is two 100px columns wide (200px) with only the first cell occupied. */
+.grid {
+    position: relative;
+    width: 200px;
+    height: 100px;
+    background-color: green;
+}
+.item {
+    position: absolute;
+    box-sizing: border-box;
+    left: 10px;
+    top: 10px;
+    width: 80px;
+    height: 80px;
+    padding: 5px;
+    background-color: blue;
+}
+.itemContent {
+    width: 20px;
+    height: 20px;
+    background-color: red;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+    <div class="item"><div class="itemContent"></div></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/fast/css-grid-layout/grid-item-with-fixed-padding-and-percent-margin.html
+++ b/LayoutTests/fast/css-grid-layout/grid-item-with-fixed-padding-and-percent-margin.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.grid {
+    display: grid;
+    width: 200px;
+    grid-template-columns: 100px 100px;
+    grid-template-rows: 100px;
+    background-color: green;
+}
+/* Verify a percentage-margin item stays on legacy RenderGrid even with fixed padding. */
+.item {
+    grid-row: 1 / 2;
+    grid-column: 1 / 2;
+    margin: 10%;
+    padding: 5px;
+    background-color: blue;
+}
+.itemContent {
+    width: 20px;
+    height: 20px;
+    background-color: red;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+    <div class="item"><div class="itemContent"></div></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/fast/css-grid-layout/grid-item-with-fixed-padding-intrinsic-track-sizing-expected.html
+++ b/LayoutTests/fast/css-grid-layout/grid-item-with-fixed-padding-intrinsic-track-sizing-expected.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+/* Reference: draw each grid item as an absolutely positioned box so the layout
+   never touches grid track sizing. Each cell's width is the item's content
+   width plus its fixed padding (20+8+4 = 32, 40+16+12 = 68), which is what
+   max-content track sizing must produce. box-sizing: border-box keeps the
+   padding inside the cell so content lands at (paddingLeft, 0). */
+.grid {
+    position: relative;
+    width: 100px;
+    height: 100px;
+    background-color: green;
+}
+.item {
+    position: absolute;
+    box-sizing: border-box;
+    top: 0;
+    height: 100px;
+    background-color: blue;
+}
+.left {
+    left: 0;
+    width: 32px;
+    padding: 0 4px 0 8px;
+}
+.right {
+    left: 32px;
+    width: 68px;
+    padding: 0 12px 0 16px;
+}
+.leftContent {
+    width: 20px;
+    height: 20px;
+    background-color: red;
+}
+.rightContent {
+    width: 40px;
+    height: 20px;
+    background-color: red;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+    <div class="item left"><div class="leftContent"></div></div>
+    <div class="item right"><div class="rightContent"></div></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/fast/css-grid-layout/grid-item-with-fixed-padding-intrinsic-track-sizing.html
+++ b/LayoutTests/fast/css-grid-layout/grid-item-with-fixed-padding-intrinsic-track-sizing.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.grid {
+    display: grid;
+    /* Sum of the two max-content tracks, so there is zero free space. */
+    width: 100px;
+    grid-template-columns: max-content max-content;
+    grid-template-rows: 100px;
+    background-color: green;
+}
+/* Verify fixed padding contributes to max-content track sizing. */
+.left {
+    grid-row: 1 / 2;
+    grid-column: 1 / 2;
+    width: 20px;
+    padding: 0 4px 0 8px;
+    background-color: blue;
+}
+.right {
+    grid-row: 1 / 2;
+    grid-column: 2 / 3;
+    width: 40px;
+    padding: 0 12px 0 16px;
+    background-color: blue;
+}
+.leftContent {
+    width: 20px;
+    height: 20px;
+    background-color: red;
+}
+.rightContent {
+    width: 40px;
+    height: 20px;
+    background-color: red;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+    <div class="left"><div class="leftContent"></div></div>
+    <div class="right"><div class="rightContent"></div></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/fast/css-grid-layout/grid-item-with-fixed-padding-track-sizing-expected.html
+++ b/LayoutTests/fast/css-grid-layout/grid-item-with-fixed-padding-track-sizing-expected.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+/* Reference: draw each grid item as an absolutely positioned box so the layout
+   never touches grid track sizing. box-sizing: border-box keeps the padding
+   inside the 150px cell, matching a stretched grid item, and the content ends
+   up at (paddingLeft, paddingTop). */
+.grid {
+    position: relative;
+    width: 300px;
+    height: 300px;
+    background-color: green;
+}
+.item {
+    position: absolute;
+    box-sizing: border-box;
+    width: 150px;
+    height: 150px;
+    background-color: blue;
+}
+.topLeft {
+    left: 0;
+    top: 0;
+    padding: 2px 4px 6px 8px;
+}
+.topRight {
+    left: 150px;
+    top: 0;
+    padding: 10px 12px 14px 16px;
+}
+.bottomLeft {
+    left: 0;
+    top: 150px;
+    padding: 18px 20px 22px 24px;
+}
+.bottomRight {
+    left: 150px;
+    top: 150px;
+    padding: 26px 28px 30px 32px;
+}
+.topLeftContent {
+    width: 20px;
+    height: 20px;
+    background-color: red;
+}
+.topRightContent {
+    width: 20px;
+    height: 40px;
+    background-color: red;
+}
+.bottomLeftContent {
+    width: 40px;
+    height: 20px;
+    background-color: red;
+}
+.bottomRightContent {
+    width: 40px;
+    height: 40px;
+    background-color: red;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+    <div class="item topLeft"><div class="topLeftContent"></div></div>
+    <div class="item topRight"><div class="topRightContent"></div></div>
+    <div class="item bottomLeft"><div class="bottomLeftContent"></div></div>
+    <div class="item bottomRight"><div class="bottomRightContent"></div></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/fast/css-grid-layout/grid-item-with-fixed-padding-track-sizing.html
+++ b/LayoutTests/fast/css-grid-layout/grid-item-with-fixed-padding-track-sizing.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.grid {
+    display: grid;
+    width: 300px;
+    height: 300px;
+    grid-template-columns: 150px 150px;
+    grid-template-rows: 150px 150px;
+    background-color: green;
+}
+/* Verify fixed padding positions item content at (paddingLeft, paddingTop). */
+.topLeft {
+    grid-row: 1 / 2;
+    grid-column: 1 / 2;
+    padding: 2px 4px 6px 8px;
+    background-color: blue;
+}
+.topRight {
+    grid-row: 1 / 2;
+    grid-column: 2 / 3;
+    padding: 10px 12px 14px 16px;
+    background-color: blue;
+}
+.bottomLeft {
+    grid-row: 2 / 3;
+    grid-column: 1 / 2;
+    padding: 18px 20px 22px 24px;
+    background-color: blue;
+}
+.bottomRight {
+    grid-row: 2 / 3;
+    grid-column: 2 / 3;
+    padding: 26px 28px 30px 32px;
+    background-color: blue;
+}
+.topLeftContent {
+    width: 20px;
+    height: 20px;
+    background-color: red;
+}
+.topRightContent {
+    width: 20px;
+    height: 40px;
+    background-color: red;
+}
+.bottomLeftContent {
+    width: 40px;
+    height: 20px;
+    background-color: red;
+}
+.bottomRightContent {
+    width: 40px;
+    height: 40px;
+    background-color: red;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+    <div class="topLeft"><div class="topLeftContent"></div></div>
+    <div class="topRight"><div class="topRightContent"></div></div>
+    <div class="bottomLeft"><div class="bottomLeftContent"></div></div>
+    <div class="bottomRight"><div class="bottomRightContent"></div></div>
+</div>
+</body>
+</html>

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
@@ -72,7 +72,7 @@ enum class GridAvoidanceReason : uint8_t {
     GridItemHasNonInitialMaxWidth,
     GridItemHasNonInitialMaxHeight,
     GridItemHasBorder,
-    GridItemHasPadding,
+    GridItemHasPercentOrCalcPadding,
     GridItemHasMargin,
     GridItemHasBorderBoxSizing,
     GridItemHasVerticalWritingMode,
@@ -511,13 +511,17 @@ static EnumSet<GridAvoidanceReason> gridLayoutAvoidanceReason(const RenderGrid& 
         if (gridItemStyle->border().hasBorder())
             ADD_REASON_AND_RETURN_IF_NEEDED(GridAvoidanceReason::GridItemHasBorder, reasons, reasonCollectionMode);
 
-        auto gridItemHasPadding = [&] {
+        // Fixed padding is threaded into item and track sizing as part of the border-box size and lays
+        // out identically to legacy RenderGrid. Percentage and calc() padding resolve against the grid
+        // item's grid area, which needs additional plumbing, so keep those items on the legacy path.
+        // FIXME: Support percentage and calc() padding on grid items and remove this restriction.
+        auto gridItemHasUnsupportedPadding = [&] {
             return gridItemStyle->paddingBox().anyOf([](const Style::PaddingEdge& paddingEdge) {
-                return !paddingEdge.isPossiblyZero();
+                return paddingEdge.isPercentOrCalculated();
             });
         };
-        if (gridItemHasPadding())
-            ADD_REASON_AND_RETURN_IF_NEEDED(GridAvoidanceReason::GridItemHasPadding, reasons, reasonCollectionMode);
+        if (gridItemHasUnsupportedPadding())
+            ADD_REASON_AND_RETURN_IF_NEEDED(GridAvoidanceReason::GridItemHasPercentOrCalcPadding, reasons, reasonCollectionMode);
 
         auto gridItemHasMargins = [&] {
             return gridItemStyle->marginBox().anyOf([](const Style::MarginEdge& marginEdge) {
@@ -774,8 +778,8 @@ static void printReason(GridAvoidanceReason reason, TextStream& stream)
     case GridAvoidanceReason::GridItemHasBorder:
         stream << "grid item has border";
         break;
-    case GridAvoidanceReason::GridItemHasPadding:
-        stream << "grid item has padding";
+    case GridAvoidanceReason::GridItemHasPercentOrCalcPadding:
+        stream << "grid item has percent or calc padding";
         break;
     case GridAvoidanceReason::GridItemHasMargin:
         stream << "grid item has margin";


### PR DESCRIPTION
#### d178f20c276b12ca56d653cf3bc3e27e78815ba2
<pre>
[GFC] Support fixed-length padding on grid items
<a href="https://bugs.webkit.org/show_bug.cgi?id=319430">https://bugs.webkit.org/show_bug.cgi?id=319430</a>
&lt;<a href="https://rdar.apple.com/182249991">rdar://182249991</a>&gt;

Reviewed by Sammy Gill.

Narrow and rename the padding avoidance reason (now GridItemHasPercentOrCalcPadding)
so grid items whose padding is a fixed length (px, em, etc) use GFC instead of the
legacy RenderGrid.

Fixed-length padding is threaded into item and track sizing as part of the
item&apos;s border-box size, so it lays out identically to legacy RenderGrid.

Percentage and calc() padding remain on the legacy path for now.

* LayoutTests/fast/css-grid-layout/grid-item-with-em-padding-track-sizing-expected.html: Added.
* LayoutTests/fast/css-grid-layout/grid-item-with-em-padding-track-sizing.html: Added.
* LayoutTests/fast/css-grid-layout/grid-item-with-fixed-padding-and-percent-margin-expected.html: Added.
* LayoutTests/fast/css-grid-layout/grid-item-with-fixed-padding-and-percent-margin.html: Added.
* LayoutTests/fast/css-grid-layout/grid-item-with-fixed-padding-intrinsic-track-sizing-expected.html: Added.
* LayoutTests/fast/css-grid-layout/grid-item-with-fixed-padding-intrinsic-track-sizing.html: Added.
* LayoutTests/fast/css-grid-layout/grid-item-with-fixed-padding-track-sizing-expected.html: Added.
* LayoutTests/fast/css-grid-layout/grid-item-with-fixed-padding-track-sizing.html: Added.
* Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp:
(WebCore::LayoutIntegration::gridLayoutAvoidanceReason):
(WebCore::LayoutIntegration::printReason):

Canonical link: <a href="https://commits.webkit.org/317597@main">https://commits.webkit.org/317597@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/54e31541a384a9098d929e2b3db63fa8a1038e02

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175749 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49682 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43465 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185342 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/55cc677a-4531-4f1b-ac3b-c3bcef45d650) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177612 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50974 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49364 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/136846 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a1006ecf-a724-4f34-8652-c6afc5effa94) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178705 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/40304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/157620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117324 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8c6d4bdb-824f-4977-be9f-e73af58ca859) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/38946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/37326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/149365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37112 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33811 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41375 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187763 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49349 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/157171 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/145838 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50029 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33736 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145680 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26706 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40473 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122225 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116050 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48536 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12090 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47938 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48170 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47995 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->