### PR TITLE
[Page Loading] Network process crashes when downloading a cross-origin target=_blank link

### DIFF
--- a/Source/WebCore/loader/PolicyChecker.cpp
+++ b/Source/WebCore/loader/PolicyChecker.cpp
@@ -379,9 +379,10 @@ void PolicyChecker::checkNewWindowPolicy(NavigationAction&& navigationAction, Re
 
         switch (policyAction) {
         case PolicyAction::Download:
-            if (!frame->effectiveSandboxFlags().contains(SandboxFlag::Downloads))
+            if (!frame->effectiveSandboxFlags().contains(SandboxFlag::Downloads)) {
+                frame->loader().setOriginalURLForDownloadRequest(request);
                 frame->loader().client().startDownload(request);
-            else if (RefPtr document = frame->document())
+            } else if (RefPtr document = frame->document())
                 document->addConsoleMessage(MessageSource::Security, MessageLevel::Error, "Not allowed to download due to sandboxing"_s);
             [[fallthrough]];
         case PolicyAction::Ignore:

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Download.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Download.mm
@@ -3501,4 +3501,70 @@ TEST(WKDownload, SuggestedFilenameCorrectedByContentType)
     EXPECT_WK_STREQ("video.mp4", receivedSuggestedFilename.get());
 }
 
+#if PLATFORM(MAC)
+TEST(WKDownload, CrossSiteTargetBlankDownloadDoesNotCrashNetworkProcess)
+{
+    HTTPServer server({
+        { "/opener"_s, { "<a id='dl' href='https://s3.amazonaws.com/file.txt' target='_blank' rel='noreferrer' style='display:block;width:100%;height:100%'>Full logs</a>"_s } },
+        { "/file.txt"_s, { { { "Content-Type"_s, "text/plain"_s } }, "download content"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    RetainPtr configuration = server.httpsProxyConfiguration();
+
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    [navigationDelegate allowAnyTLSCertificate];
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
+    webView.get().navigationDelegate = navigationDelegate.get();
+
+    RetainPtr downloadDelegate = adoptNS([TestDownloadDelegate new]);
+    __block bool done = false;
+    __block bool downloadStarted = false;
+    __block bool processCrashed = false;
+
+    downloadDelegate.get().decideDestinationUsingResponse = ^(WKDownload *, NSURLResponse *, NSString *, void (^completionHandler)(NSURL *)) {
+        downloadStarted = true;
+        done = true;
+        completionHandler(nil);
+    };
+    downloadDelegate.get().didFailWithError = ^(WKDownload *, NSError *, NSData *) {
+        // A clean download failure is not a network process crash.
+        downloadStarted = true;
+        done = true;
+    };
+
+    // Safari answers an option-click on a link with WKNavigationActionPolicyDownload.
+    navigationDelegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^completionHandler)(WKNavigationActionPolicy)) {
+        if ([action.request.URL.host isEqualToString:@"s3.amazonaws.com"])
+            completionHandler(WKNavigationActionPolicyDownload);
+        else
+            completionHandler(WKNavigationActionPolicyAllow);
+    };
+    navigationDelegate.get().navigationActionDidBecomeDownload = ^(WKNavigationAction *, WKDownload *download) {
+        download.delegate = downloadDelegate.get();
+    };
+    navigationDelegate.get().webContentProcessDidTerminate = ^(WKWebView *, _WKProcessTerminationReason) {
+        processCrashed = true;
+        done = true;
+    };
+
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
+    __block RetainPtr<TestWKWebView> openedWebView;
+    uiDelegate.get().createWebViewWithConfiguration = ^WKWebView *(WKWebViewConfiguration *configuration, WKNavigationAction *, WKWindowFeatures *) {
+        openedWebView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
+        openedWebView.get().navigationDelegate = navigationDelegate.get();
+        return openedWebView.get();
+    };
+    webView.get().UIDelegate = uiDelegate.get();
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://ews-build.webkit.org/opener"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    [webView clickOnElementID:@"dl"];
+
+    Util::run(&done);
+    EXPECT_TRUE(downloadStarted);
+    EXPECT_FALSE(processCrashed);
+}
+#endif // PLATFORM(MAC)
+
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -31,6 +31,7 @@
 #import "Helpers/cocoa/FindInPageUtilities.h"
 #import "Helpers/cocoa/HTTPServer.h"
 #import "Helpers/cocoa/TestCocoa.h"
+#import "Helpers/cocoa/TestDownloadDelegate.h"
 #import "Helpers/cocoa/TestNavigationDelegate.h"
 #import "Helpers/cocoa/TestScriptMessageHandler.h"
 #import "Helpers/cocoa/TestUIDelegate.h"
@@ -10521,6 +10522,65 @@ TEST(SiteIsolation, CrossProcessSameDocumentHistoryTraversalDoesNotStall)
     [webView evaluateJavaScript:@"history.back()" inFrame:childFrames[0].info completionHandler:nil];
     waitForURL(@"https://example.com/page");
     EXPECT_WK_STREQ(@"https://example.com/page", [[webView URL] absoluteString]);
+}
+
+TEST(SiteIsolation, CrossSiteTargetBlankDownloadDoesNotCrashNetworkProcess)
+{
+    HTTPServer server({
+        { "/opener"_s, { "<a id='dl' href='https://s3.amazonaws.com/file.txt' target='_blank' rel='noreferrer' style='display:block;width:100%;height:100%'>Full logs</a>"_s } },
+        { "/file.txt"_s, { { { "Content-Type"_s, "text/plain"_s } }, "download content"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(server, CGRectMake(0, 0, 400, 400));
+    RetainPtr navDelegate = navigationDelegate;
+
+    RetainPtr downloadDelegate = adoptNS([TestDownloadDelegate new]);
+    __block bool done = false;
+    __block bool downloadStarted = false;
+    __block bool processCrashed = false;
+
+    downloadDelegate.get().decideDestinationUsingResponse = ^(WKDownload *, NSURLResponse *, NSString *, void (^completionHandler)(NSURL *)) {
+        downloadStarted = true;
+        done = true;
+        completionHandler(nil);
+    };
+    downloadDelegate.get().didFailWithError = ^(WKDownload *, NSError *, NSData *) {
+        // A clean download failure is not a network process crash.
+        downloadStarted = true;
+        done = true;
+    };
+
+    navigationDelegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^completionHandler)(WKNavigationActionPolicy)) {
+        if ([action.request.URL.host isEqualToString:@"s3.amazonaws.com"])
+            completionHandler(WKNavigationActionPolicyDownload);
+        else
+            completionHandler(WKNavigationActionPolicyAllow);
+    };
+    navigationDelegate.get().navigationActionDidBecomeDownload = ^(WKNavigationAction *, WKDownload *download) {
+        download.delegate = downloadDelegate.get();
+    };
+    navigationDelegate.get().webContentProcessDidTerminate = ^(WKWebView *, _WKProcessTerminationReason) {
+        processCrashed = true;
+        done = true;
+    };
+
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
+    __block RetainPtr<TestWKWebView> openedWebView;
+    uiDelegate.get().createWebViewWithConfiguration = ^WKWebView *(WKWebViewConfiguration *configuration, WKNavigationAction *, WKWindowFeatures *) {
+        openedWebView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
+        openedWebView.get().navigationDelegate = navDelegate.get();
+        return openedWebView.get();
+    };
+    webView.get().UIDelegate = uiDelegate.get();
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://ews-build.webkit.org/opener"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    [webView clickOnElementID:@"dl"];
+
+    Util::run(&done);
+    EXPECT_TRUE(downloadStarted);
+    EXPECT_FALSE(processCrashed);
 }
 
 }


### PR DESCRIPTION
#### 7935a51ec31047310970afdf9c0a73765686058d
<pre>
[Page Loading] Network process crashes when downloading a cross-origin target=_blank link
<a href="https://bugs.webkit.org/show_bug.cgi?id=319427">https://bugs.webkit.org/show_bug.cgi?id=319427</a>
<a href="https://rdar.apple.com/182181803">rdar://182181803</a>

Reviewed by Chris Dumez.

Option-clicking a cross-origin link with target=&quot;_blank&quot; (for example the &quot;Full logs&quot;
link on an ews-build.webkit.org results page, which points to an S3 URL) reliably
terminates the Network process.

PolicyChecker::checkNewWindowPolicy() handles new-window (target=&quot;_blank&quot;) navigations. Its
PolicyAction::Download case called FrameLoaderClient::startDownload() without first calling
FrameLoader::setOriginalURLForDownloadRequest(), unlike the same-frame path in
checkNavigationPolicy(). As a result the download request kept the firstPartyForCookies that
FrameLoader sets for a willOpenInNewWindow main-resource load, which is the destination URL
itself (the cross-origin URL). The StartDownload IPC is then sent from the source page&apos;s web
process, whose allowed-first-parties set only contains the source site, so the CSRF
first-party-for-cookies MESSAGE_CHECK in NetworkConnectionToWebProcess::startDownload()
rejected the message and terminated the process.

Call setOriginalURLForDownloadRequest() in checkNewWindowPolicy()&apos;s download case, matching
checkNavigationPolicy(). Because m_frame is the source frame, firstPartyForCookies becomes the
originating page, which is in the process&apos;s allowed set.

* Source/WebCore/loader/PolicyChecker.cpp:
(WebCore::PolicyChecker::checkNewWindowPolicy):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Download.mm:
(TestWebKitAPI::TEST): Added CrossSiteTargetBlankDownloadDoesNotCrashNetworkProcess.
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::TEST): Added CrossSiteTargetBlankDownloadDoesNotCrashNetworkProcess.

Canonical link: <a href="https://commits.webkit.org/317338@main">https://commits.webkit.org/317338@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/163efaa9bc8334dbd1fdff994eceba7608f7cf8c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175016 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48949 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42730 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184597 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/132924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/402ac831-cd21-4714-a8cc-3ea8dcddd38b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176881 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50241 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48632 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/136211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/132924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0b568513-9d35-4d31-9808-5e8147178b70) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177974 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39653 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/157007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116690 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/66312482-e27d-458c-a8bf-7eddbcb946d3) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/38294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33074 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/148717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36499 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187021 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/40530 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/145156 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48616 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145012 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39069 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49296 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115114 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39873 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/121435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47802 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11472 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47205 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47435 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47262 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->