### PR TITLE
[Site Isolation] Content in cross-origin subframes is missing when copying and pasting

### DIFF
--- a/Source/WebCore/editing/cocoa/EditorCocoa.mm
+++ b/Source/WebCore/editing/cocoa/EditorCocoa.mm
@@ -65,6 +65,7 @@
 #import "PasteboardStrategy.h"
 #import "PlatformNSAdaptiveImageGlyph.h"
 #import "PlatformStrategies.h"
+#import "RemoteFrame.h"
 #import "RenderElement.h"
 #import "ReplaceSelectionCommand.h"
 #import "Settings.h"
@@ -149,22 +150,22 @@ static RetainPtr<NSAttributedString> selectionInImageOverlayAsAttributedString(c
 #endif
 }
 
-static RetainPtr<NSAttributedString> selectionAsAttributedString(const Document& document)
+static RetainPtr<NSAttributedString> selectionAsAttributedString(const Document& document, HashMap<FrameIdentifier, AttributedString>&& remoteFrameContent)
 {
     auto selection = document.selection().selection();
     if (ImageOverlay::isInsideOverlay(selection))
         return selectionInImageOverlayAsAttributedString(selection);
     auto range = selection.firstRange();
-    return range ? attributedString(*range, IgnoreUserSelectNone::Yes).nsAttributedString() : adoptNS([[NSAttributedString alloc] init]);
+    return range ? attributedString(*range, IgnoreUserSelectNone::Yes, WTF::move(remoteFrameContent)).nsAttributedString() : adoptNS([NSAttributedString new]);
 }
 
 template<typename PasteboardContent>
-void populateRichTextDataIfNeeded(PasteboardContent& content, const Document& document)
+void populateRichTextDataIfNeeded(PasteboardContent& content, const Document& document, HashMap<FrameIdentifier, AttributedString>&& remoteFrameContent = { })
 {
     if (!document.settings().writeRichTextDataWhenCopyingOrDragging())
         return;
 
-    auto string = selectionAsAttributedString(document);
+    auto string = selectionAsAttributedString(document, WTF::move(remoteFrameContent));
     content.dataInRTFDFormat = [string containsAttachments] ? Editor::dataInRTFDFormat(string.get()) : nullptr;
     content.dataInRTFFormat = Editor::dataInRTFFormat(string.get());
     content.dataInAttributedStringFormat = AttributedString::fromNSAttributedString(string.get());
@@ -183,9 +184,24 @@ void Editor::writeSelectionToPasteboard(Pasteboard& pasteboard)
                 LegacyWebArchive::ShouldSaveScriptsFromMemoryCache::Yes,
                 LegacyWebArchive::ShouldArchiveSubframes::No
             };
-            if (document->settings().siteIsolationEnabled())
+            HashMap<FrameIdentifier, AttributedString> remoteFrameContent;
+            if (document->settings().siteIsolationEnabled()) {
                 content.webArchive = LegacyWebArchive::createFromSelection(protect(document->frame()), WTF::move(options));
-            populateRichTextDataIfNeeded(content, document);
+                if (content.webArchive) {
+                    Vector<FrameIdentifier> remoteFrameIdentifiers;
+                    RefPtr localFrame = document->frame();
+                    if (localFrame) {
+                        auto subframeIdentifiers = protect(content.webArchive)->subframeIdentifiers();
+                        for (RefPtr frame = localFrame->tree().traverseNext(localFrame.get()); frame; frame = frame->tree().traverseNext(localFrame.get())) {
+                            if (is<RemoteFrame>(*frame) && subframeIdentifiers.contains(frame->frameID()))
+                                remoteFrameIdentifiers.append(frame->frameID());
+                        }
+                    }
+                    if (localFrame && !remoteFrameIdentifiers.isEmpty())
+                        remoteFrameContent = client()->collectAttributedStringsForRemoteFrames(localFrame->frameID(), remoteFrameIdentifiers);
+                }
+            }
+            populateRichTextDataIfNeeded(content, document, WTF::move(remoteFrameContent));
         }
         client()->getClientPasteboardData(selectedRange(), content.clientTypesAndData);
     }

--- a/Source/WebCore/editing/cocoa/NodeHTMLConverter.h
+++ b/Source/WebCore/editing/cocoa/NodeHTMLConverter.h
@@ -24,12 +24,14 @@
  */
 
 #import <WebCore/AttributedString.h>
+#import <WebCore/FrameIdentifier.h>
 #import <WebCore/SimpleRange.h>
+#import <wtf/HashMap.h>
 
 namespace WebCore {
 
 enum class IgnoreUserSelectNone : bool;
 
-WEBCORE_EXPORT AttributedString attributedString(const SimpleRange&, IgnoreUserSelectNone);
+WEBCORE_EXPORT AttributedString attributedString(const SimpleRange&, IgnoreUserSelectNone, HashMap<FrameIdentifier, AttributedString>&& remoteFrameContent = { });
 
 } // namespace WebCore

--- a/Source/WebCore/editing/cocoa/NodeHTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/NodeHTMLConverter.mm
@@ -71,6 +71,7 @@
 #import "LocalFrame.h"
 #import "LocalizedStrings.h"
 #import "NodeName.h"
+#import "RemoteFrame.h"
 #import "RenderImage.h"
 #import "RenderText.h"
 #import "StyleComputedStyle+GettersInlines.h"
@@ -175,7 +176,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLConverterCaches);
 
 class HTMLConverter {
 public:
-    explicit HTMLConverter(const SimpleRange&, IgnoreUserSelectNone);
+    explicit HTMLConverter(const SimpleRange&, IgnoreUserSelectNone, HashMap<FrameIdentifier, AttributedString>&& remoteFrameContent);
     ~HTMLConverter();
 
     AttributedString convert();
@@ -184,6 +185,7 @@ private:
     Position m_start;
     Position m_end;
     SingleThreadWeakPtr<DocumentLoader> m_dataSource;
+    const HashMap<FrameIdentifier, AttributedString> m_remoteFrameContent;
 
     HashMap<Ref<Element>, RetainPtr<NSDictionary>> m_attributesForElements;
     HashMap<RetainPtr<CFTypeRef>, Ref<Element>> m_textTableFooters;
@@ -262,9 +264,10 @@ private:
     void _adjustTrailingNewline();
 };
 
-HTMLConverter::HTMLConverter(const SimpleRange& range, IgnoreUserSelectNone treatment)
+HTMLConverter::HTMLConverter(const SimpleRange& range, IgnoreUserSelectNone treatment, HashMap<FrameIdentifier, AttributedString>&& remoteFrameContent)
     : m_start(makeContainerOffsetPosition(range.start))
     , m_end(makeContainerOffsetPosition(range.end))
+    , m_remoteFrameContent(WTF::move(remoteFrameContent))
     , m_userSelectNoneStateCache(ComposedTree)
     , m_ignoreUserSelectNoneContent(treatment == IgnoreUserSelectNone::Yes && !protect(range.start.document())->quirks().needsToCopyUserSelectNoneQuirk())
 {
@@ -1824,6 +1827,12 @@ BOOL HTMLConverter::_processElement(Element& element, NSInteger depth)
         if (RefPtr contentDocument = frameElement->contentDocument()) {
             _traverseNode(*contentDocument, depth + 1, true /* embedded */);
             retval = NO;
+        } else if (RefPtr remoteFrame = dynamicDowncast<RemoteFrame>(frameElement->contentFrame())) {
+            if (auto it = m_remoteFrameContent.find(remoteFrame->frameID()); it != m_remoteFrameContent.end()) {
+                if (RetainPtr subframeAttrString = it->value.nsAttributedString())
+                    [_attrStr appendAttributedString:subframeAttrString];
+            }
+            retval = NO;
         }
     } else if (element.hasTagName(brTag)) {
         RefPtr blockElement = _blockLevelElementForNode(protect(element.parentInComposedTree()));
@@ -2300,9 +2309,9 @@ Node* HTMLConverterCaches::cacheAncestorsOfStartToBeConverted(const Position& st
 namespace WebCore {
 
 // This function supports more HTML features than the editing variant below, such as tables.
-AttributedString attributedString(const SimpleRange& range, IgnoreUserSelectNone treatment)
+AttributedString attributedString(const SimpleRange& range, IgnoreUserSelectNone treatment, HashMap<FrameIdentifier, AttributedString>&& remoteFrameContent)
 {
-    return HTMLConverter { range, treatment }.convert();
+    return HTMLConverter { range, treatment, WTF::move(remoteFrameContent) }.convert();
 }
 
 }

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -319,6 +319,9 @@ private:
     void NODELETE clearUndoRedoOperations() final { }
 
     DOMPasteAccessResponse NODELETE requestDOMPasteAccess(DOMPasteAccessCategory, FrameIdentifier, const String&) final { return DOMPasteAccessResponse::DeniedForGesture; }
+#if PLATFORM(COCOA)
+    HashMap<FrameIdentifier, AttributedString> collectAttributedStringsForRemoteFrames(FrameIdentifier, const Vector<FrameIdentifier>&) final { return { }; }
+#endif
 
     bool NODELETE canCopyCut(LocalFrame*, bool defaultValue) const final { return defaultValue; }
     bool NODELETE canPaste(LocalFrame*, bool defaultValue) const final { return defaultValue; }

--- a/Source/WebCore/page/EditorClient.h
+++ b/Source/WebCore/page/EditorClient.h
@@ -45,6 +45,10 @@ enum class DOMPasteAccessCategory : uint8_t;
 enum class DOMPasteAccessResponse : uint8_t;
 enum class MouseEventInputSource : uint8_t;
 
+#if PLATFORM(COCOA)
+struct AttributedString;
+#endif
+
 #if ENABLE(ATTACHMENT_ELEMENT)
 enum class AttachmentAssociatedElementType : uint8_t;
 #endif
@@ -114,6 +118,9 @@ public:
     virtual void willWriteSelectionToPasteboard(const std::optional<SimpleRange>&) = 0;
     virtual void didWriteSelectionToPasteboard() = 0;
     virtual void getClientPasteboardData(const std::optional<SimpleRange>&, Vector<std::pair<String, RefPtr<WebCore::SharedBuffer>>>& pasteboardTypesAndData) = 0;
+#if PLATFORM(COCOA)
+    virtual HashMap<FrameIdentifier, AttributedString> collectAttributedStringsForRemoteFrames(FrameIdentifier rootFrameIdentifier, const Vector<FrameIdentifier>&) = 0;
+#endif
     virtual void requestCandidatesForSelection(const VisibleSelection&) { }
     virtual void handleAcceptedCandidateWithSoftSpaces(TextCheckingResult) { }
 

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -2028,6 +2028,92 @@ void WebPageProxy::getWebArchiveDataWithSelectedFrames(WebFrameProxy& rootFrame,
     }
 }
 
+static bool validateFrameIdentifiersForAttributedStringCollection(FrameIdentifier rootFrameIdentifier, const Vector<FrameIdentifier>& frameIdentifiers)
+{
+    auto isInSubtree = [&](WebFrameProxy& frame) {
+        for (RefPtr ancestor = &frame; ancestor; ancestor = ancestor->parentFrame()) {
+            if (ancestor->frameID() == rootFrameIdentifier)
+                return true;
+        }
+        return false;
+    };
+
+    for (auto identifier : frameIdentifiers) {
+        if (identifier == rootFrameIdentifier)
+            continue;
+
+        RefPtr frame = WebFrameProxy::webFrame(identifier);
+        if (frame && !isInSubtree(*frame))
+            return false;
+    }
+
+    return true;
+}
+
+void WebPageProxy::getAttributedStringsForRemoteFrames(IPC::Connection& connection, FrameIdentifier rootFrameIdentifier, const Vector<FrameIdentifier>& frameIdentifiers, CompletionHandler<void(HashMap<FrameIdentifier, AttributedString>&&)>&& completionHandler)
+{
+    if (!hasRunningProcess() || frameIdentifiers.isEmpty()) {
+        completionHandler({ });
+        return;
+    }
+
+    RefPtr rootFrame = WebFrameProxy::webFrame(rootFrameIdentifier);
+    MESSAGE_CHECK_COMPLETION(rootFrame && rootFrame->page() == this && &rootFrame->process() == WebProcessProxy::fromConnection(connection).ptr(), connection, completionHandler({ }));
+    MESSAGE_CHECK_COMPLETION(validateFrameIdentifiersForAttributedStringCollection(rootFrameIdentifier, frameIdentifiers), connection, completionHandler({ }));
+
+    HashMap<Ref<WebProcessProxy>, Vector<FrameIdentifier>> processFrames;
+    for (auto frameIdentifier : frameIdentifiers) {
+        RefPtr frame = WebFrameProxy::webFrame(frameIdentifier);
+        if (!frame)
+            continue;
+
+        processFrames.ensure(protect(frame->process()), [] {
+            return Vector<FrameIdentifier> { };
+        }).iterator->value.append(frameIdentifier);
+    }
+
+    if (processFrames.isEmpty()) {
+        completionHandler({ });
+        return;
+    }
+
+    class AttributedStringMapCallbackAggregator final : public RefCounted<AttributedStringMapCallbackAggregator> {
+    public:
+        static Ref<AttributedStringMapCallbackAggregator> create(CompletionHandler<void(HashMap<FrameIdentifier, AttributedString>&&)>&& completionHandler)
+        {
+            return adoptRef(*new AttributedStringMapCallbackAggregator(WTF::move(completionHandler)));
+        }
+
+        ~AttributedStringMapCallbackAggregator()
+        {
+            m_completionHandler(WTF::move(m_result));
+        }
+
+        void addResult(HashMap<FrameIdentifier, AttributedString>&& result)
+        {
+            for (auto&& [frameIdentifier, attributedString] : WTF::move(result))
+                m_result.set(frameIdentifier, WTF::move(attributedString));
+        }
+
+    private:
+        AttributedStringMapCallbackAggregator(CompletionHandler<void(HashMap<FrameIdentifier, AttributedString>&&)>&& completionHandler)
+            : m_completionHandler(WTF::move(completionHandler))
+        {
+        }
+
+        HashMap<FrameIdentifier, AttributedString> m_result;
+        CompletionHandler<void(HashMap<FrameIdentifier, AttributedString>&&)> m_completionHandler;
+    };
+
+    Ref aggregator = AttributedStringMapCallbackAggregator::create(WTF::move(completionHandler));
+    for (auto& [process, frameIDs] : processFrames) {
+        protect(process)->sendWithAsyncReply(Messages::WebPage::GetContentsAsAttributedStringForFrames(frameIDs), [frameIDs, aggregator](auto&& result) {
+            if (result.size() <= frameIDs.size())
+                aggregator->addResult(WTF::move(result));
+        }, webPageIDInProcess(process.get()));
+    }
+}
+
 String WebPageProxy::presentingApplicationBundleIdentifier() const
 {
     if (std::optional auditToken = presentingApplicationAuditToken()) {

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1742,6 +1742,7 @@ public:
     void getContentsAsString(ContentAsStringIncludesChildFrames, CompletionHandler<void(const String&)>&&);
 #if PLATFORM(COCOA)
     void getContentsAsAttributedString(CompletionHandler<void(const WebCore::AttributedString&)>&&);
+    void getAttributedStringsForRemoteFrames(IPC::Connection&, WebCore::FrameIdentifier rootFrameIdentifier, const Vector<WebCore::FrameIdentifier>&, CompletionHandler<void(HashMap<WebCore::FrameIdentifier, WebCore::AttributedString>&&)>&&);
 #endif
     void getBytecodeProfile(CompletionHandler<void(const String&)>&&);
     void getSamplingProfilerOutput(CompletionHandler<void(const String&)>&&);

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -201,6 +201,7 @@ messages -> WebPageProxy {
 
 #if PLATFORM(COCOA)
     DidReceivePositionInformation(struct WebKit::InteractionInformationAtPosition information) CanDispatchOutOfOrder
+    GetAttributedStringsForRemoteFrames(WebCore::FrameIdentifier rootFrameIdentifier, Vector<WebCore::FrameIdentifier> frameIdentifiers) -> (HashMap<WebCore::FrameIdentifier, WebCore::AttributedString> result) Synchronous
 #endif
 
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp
@@ -515,6 +515,13 @@ bool WebEditorClient::shouldAllowSingleClickToChangeSelection(WebCore::Node& tar
     return page && page->shouldAllowSingleClickToChangeSelection(targetNode, newSelection, inputSource);
 }
 
+HashMap<WebCore::FrameIdentifier, WebCore::AttributedString> WebEditorClient::collectAttributedStringsForRemoteFrames(WebCore::FrameIdentifier rootFrameIdentifier, const Vector<WebCore::FrameIdentifier>& frameIdentifiers)
+{
+    if (RefPtr page = m_page.get())
+        return page->attributedStringsForRemoteFrames(rootFrameIdentifier, frameIdentifiers);
+    return { };
+}
+
 #endif // PLATFORM(COCOA)
 
 static bool getActionTypeForKeyEvent(KeyboardEvent* event, WKInputFieldActionType& type)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h
@@ -125,6 +125,7 @@ private:
 
 #if PLATFORM(COCOA)
     void setInsertionPasteboard(const String& pasteboardName) final;
+    HashMap<WebCore::FrameIdentifier, WebCore::AttributedString> collectAttributedStringsForRemoteFrames(WebCore::FrameIdentifier rootFrameIdentifier, const Vector<WebCore::FrameIdentifier>&) final;
 #endif
 
 #if USE(APPKIT)

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -819,6 +819,16 @@ void WebPage::getContentsAsAttributedString(CompletionHandler<void(const WebCore
     completionHandler(localFrame ? attributedString(makeRangeSelectingNodeContents(*protect(localFrame->document())), IgnoreUserSelectNone::No) : AttributedString { });
 }
 
+HashMap<WebCore::FrameIdentifier, WebCore::AttributedString> WebPage::attributedStringsForRemoteFrames(WebCore::FrameIdentifier rootFrameIdentifier, const Vector<WebCore::FrameIdentifier>& frameIdentifiers)
+{
+    if (frameIdentifiers.isEmpty())
+        return { };
+
+    auto sendResult = sendSync(Messages::WebPageProxy::GetAttributedStringsForRemoteFrames(rootFrameIdentifier, frameIdentifiers));
+    auto [result] = sendResult.takeReplyOr(HashMap<WebCore::FrameIdentifier, WebCore::AttributedString> { });
+    return result;
+}
+
 void WebPage::setRemoteObjectRegistry(WebRemoteObjectRegistry* registry)
 {
     m_remoteObjectRegistry = registry;
@@ -1741,6 +1751,27 @@ void WebPage::getWebArchivesForFrames(const Vector<WebCore::FrameIdentifier>& fr
         };
         if (RefPtr archive = WebCore::LegacyWebArchive::create(*document, WTF::move(options)))
             result.add(localFrame->frameID(), archive.releaseNonNull());
+    }
+    completionHandler(WTF::move(result));
+}
+
+void WebPage::getContentsAsAttributedStringForFrames(const Vector<FrameIdentifier>& frameIdentifiers, CompletionHandler<void(HashMap<FrameIdentifier, AttributedString>&&)>&& completionHandler)
+{
+    HashMap<FrameIdentifier, AttributedString> result;
+    for (auto& frameIdentifier : frameIdentifiers) {
+        RefPtr frame = WebFrame::webFrame(frameIdentifier);
+        if (!frame)
+            continue;
+
+        RefPtr localFrame = frame->coreLocalFrame();
+        if (!localFrame)
+            continue;
+
+        RefPtr document = localFrame->document();
+        if (!document)
+            continue;
+
+        result.add(frameIdentifier, attributedString(makeRangeSelectingNodeContents(*document), IgnoreUserSelectNone::No));
     }
     completionHandler(WTF::move(result));
 }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1108,6 +1108,7 @@ public:
 
 #if PLATFORM(COCOA)
     bool shouldAllowSingleClickToChangeSelection(WebCore::Node& targetNode, const WebCore::VisibleSelection& newSelection, WebCore::MouseEventInputSource);
+    HashMap<WebCore::FrameIdentifier, WebCore::AttributedString> attributedStringsForRemoteFrames(WebCore::FrameIdentifier rootFrameIdentifier, const Vector<WebCore::FrameIdentifier>&);
     void selectWithGesture(const WebCore::IntPoint&, GestureType, GestureRecognizerState, bool isInteractingWithFocusedElement, CompletionHandler<void(const WebCore::IntPoint&, GestureType, GestureRecognizerState, OptionSet<SelectionFlags>)>&&);
     void updateFocusBeforeSelectingTextAtLocation(const WebCore::IntPoint&);
     WebCore::VisiblePosition visiblePositionInFocusedNodeForPoint(const WebCore::LocalFrame&, const WebCore::IntPoint&, bool isInteractingWithFocusedElement);
@@ -2436,6 +2437,7 @@ private:
 #if PLATFORM(COCOA)
     void getWebArchiveData(CompletionHandler<void(const std::optional<IPC::SharedBufferReference>&)>&&);
     void getWebArchivesForFrames(const Vector<WebCore::FrameIdentifier>& frameIdentifiers, CompletionHandler<void(HashMap<WebCore::FrameIdentifier, Ref<WebCore::LegacyWebArchive>>&&)>&&);
+    void getContentsAsAttributedStringForFrames(const Vector<WebCore::FrameIdentifier>& frameIdentifiers, CompletionHandler<void(HashMap<WebCore::FrameIdentifier, WebCore::AttributedString>&&)>&&);
 #endif
     void getWebArchiveOfFrameWithFileName(WebCore::FrameIdentifier, const Vector<WebCore::MarkupExclusionRule>&, const String& fileName, CompletionHandler<void(const std::optional<IPC::SharedBufferReference>&)>&&);
     void runJavaScript(WebFrame*, RunJavaScriptParameters&&, ContentWorldIdentifier, bool, CompletionHandler<void(Expected<JavaScriptEvaluationResult, std::optional<WebCore::ExceptionDetails>>)>&&);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -276,6 +276,7 @@ messages -> WebPage WantsAsyncDispatchMessage {
 #if PLATFORM(COCOA)
     GetWebArchiveData() -> (std::optional<IPC::SharedBufferReference> dataReference)
     GetWebArchivesForFrames(Vector<WebCore::FrameIdentifier> frameIdentifiers) -> (HashMap<WebCore::FrameIdentifier, Ref<WebCore::LegacyWebArchive>> frameArchives)
+    GetContentsAsAttributedStringForFrames(Vector<WebCore::FrameIdentifier> frameIdentifiers) -> (HashMap<WebCore::FrameIdentifier, WebCore::AttributedString> frameAttributedStrings)
 #endif
 
     RunJavaScriptInFrameInScriptWorld(struct WebKit::RunJavaScriptParameters parameters, std::optional<WebCore::FrameIdentifier> frameID, struct WebKit::ContentWorldData world, bool wantsResult) -> (Expected<WebKit::JavaScriptEvaluationResult, std::optional<WebCore::ExceptionDetails>> result)

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.h
@@ -84,6 +84,10 @@ private:
     void didWriteSelectionToPasteboard() final;
     void getClientPasteboardData(const std::optional<WebCore::SimpleRange>&, Vector<std::pair<String, RefPtr<WebCore::SharedBuffer>>>& pasteboardTypesAndData) final;
 
+#if PLATFORM(COCOA)
+    HashMap<WebCore::FrameIdentifier, WebCore::AttributedString> collectAttributedStringsForRemoteFrames(WebCore::FrameIdentifier, const Vector<WebCore::FrameIdentifier>&) final { return { }; }
+#endif
+
     void setInsertionPasteboard(const String&) final;
     WebCore::DOMPasteAccessResponse requestDOMPasteAccess(WebCore::DOMPasteAccessCategory, WebCore::FrameIdentifier, const String&) final { return WebCore::DOMPasteAccessResponse::DeniedForGesture; }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -6565,6 +6565,82 @@ TEST(SiteIsolation, CreateWebArchiveNestedFrameForCopy)
     validateWebArchiveMainResource([actualNestedFrameArchives.firstObject objectForKey:@"WebMainResource"], expectedNestedFrameResource);
 }
 
+TEST(SiteIsolation, ReadAttributedStringFromPasteboardAfterCopyWithCrossSiteIframe)
+{
+    static constexpr auto mainframeBytes = R"TESTRESOURCE(
+    <!DOCTYPE html>
+    mainframecontent
+    <iframe id='subframe' src='https://example2.com/subframe'></iframe>
+    <script>
+        function alertSubframe() { document.getElementById('subframe').contentWindow.postMessage('alert', '*'); }
+    </script>
+    )TESTRESOURCE"_s;
+
+    static constexpr auto subframeBytes = R"TESTRESOURCE(
+    <!DOCTYPE html>
+    subframecontent
+    <script>
+        window.addEventListener('message', function(event) {
+            alert('hi');
+        });
+    </script>
+    )TESTRESOURCE"_s;
+
+    HTTPServer server({
+        { "/mainframe"_s, { mainframeBytes } },
+        { "/subframe"_s, { subframeBytes } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto webViewAndDelegates = makeWebViewAndDelegates(server);
+    RetainPtr webView = webViewAndDelegates.webView;
+    RetainPtr navigationDelegate = webViewAndDelegates.navigationDelegate;
+    RetainPtr uiDelegate = webViewAndDelegates.uiDelegate;
+    WKPreferencesSetWriteRichTextDataWhenCopyingOrDragging((__bridge WKPreferencesRef)[[webView configuration] preferences], true);
+    static bool alerted = false;
+    [uiDelegate setRunJavaScriptAlertPanelWithMessage:^(WKWebView *, NSString *message, WKFrameInfo *, void (^completionHandler)()) {
+        alerted = true;
+        completionHandler();
+    }];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/mainframe"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    checkFrameTreesInProcesses(webView, {
+        { "https://example.com"_s,
+            { { RemoteFrame } }
+        }, { RemoteFrame,
+            { { "https://example2.com"_s } }
+        },
+    });
+
+    [webView stringByEvaluatingJavaScript:@"getSelection().selectAllChildren(document.body)"];
+    [webView waitForNextPresentationUpdate];
+
+    [webView copy:nil];
+    [webView waitForNextPresentationUpdate];
+
+    [webView evaluateJavaScript:@"alertSubframe()" completionHandler:nil];
+    Util::run(&alerted);
+
+#if PLATFORM(MAC)
+    RetainPtr objects = [NSPasteboard.generalPasteboard readObjectsForClasses:@[NSAttributedString.class] options:@{ }];
+    EXPECT_EQ([objects count], 1u);
+    RetainPtr result = [objects firstObject];
+#elif PLATFORM(IOS_FAMILY)
+    RetainPtr itemProvider = [[UIPasteboard.generalPasteboard itemProviders] firstObject];
+    __block bool doneLoading = false;
+    __block RetainPtr<NSAttributedString> result;
+    [itemProvider loadObjectOfClass:NSAttributedString.class completionHandler:^(NSAttributedString *string, NSError *) {
+        result = string;
+        doneLoading = true;
+    }];
+    Util::run(&doneLoading);
+#endif
+
+    EXPECT_TRUE([[result string] containsString:@"mainframecontent"]);
+    EXPECT_TRUE([[result string] containsString:@"subframecontent"]);
+}
+
 TEST(SiteIsolation, LoadWebArchive)
 {
     RetainPtr<NSURL> archiveURL = [NSBundle.test_resourcesBundle URLForResource:@"SiteIsolationLoadWebArchive" withExtension:@"webarchive"];


### PR DESCRIPTION
#### 2b157dbbd4053751d8fcf196f2056a7e66e71697
<pre>
[Site Isolation] Content in cross-origin subframes is missing when copying and pasting
<a href="https://bugs.webkit.org/show_bug.cgi?id=319423">https://bugs.webkit.org/show_bug.cgi?id=319423</a>
<a href="https://rdar.apple.com/176590191">rdar://176590191</a>

Reviewed by Abrar Rahman Protyasha.

When copying content that includes cross-origin subframes, content in those subframes is missing
upon pasting into native apps like TextEdit or Notes, which attempt to read `NSAttributedString`s
from the pasteboard.

While there&apos;s an existing solution added in <a href="https://commits.webkit.org/300189@main">https://commits.webkit.org/300189@main</a> to ensure that
web archives capture cross-origin content under site isolation, there&apos;s currently no similar
architecture in place for attributed strings, which means we currently just skip over content in
cross-origin subframes.

To fix this, we apply the same approach taken in 300189@main to attributed string conversion; see
comments below for more details.

Test: SiteIsolation.ReadAttributedStringFromPasteboardAfterCopyWithCrossSiteIframe

* Source/WebCore/editing/cocoa/EditorCocoa.mm:
(WebCore::selectionAsAttributedString):

Add a `remoteFrameContent` argument here, that represents `AttributedString`s collected from remote
frames.

(WebCore::populateRichTextDataIfNeeded):

When serializing attributed strings, collect all remote frame IDs that represent frames where we
need to recursively convert into attributed strings.

(WebCore::Editor::writeSelectionToPasteboard):
* Source/WebCore/editing/cocoa/NodeHTMLConverter.h:
(WebCore::attributedString):
* Source/WebCore/editing/cocoa/NodeHTMLConverter.mm:
(HTMLConverter::HTMLConverter):
(HTMLConverter::_processElement):

Slot in attributed strings collected from remote subframes.

(WebCore::attributedString):
* Source/WebCore/page/EditorClient.h:
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::getAttributedStringsForRemoteFrames):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp:
(WebKit::WebEditorClient::collectAttributedStringsForRemoteFrames):

Add a new client hook that takes a list of remote frame IDs, and calls into the UI process to fan
out to all remote frames and convert their content into attributed strings.

* Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::getAttributedStringsForRemoteFrames):
(WebKit::WebPage::getContentsAsAttributedStringForFrames):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::(SiteIsolation, ReadAttributedStringFromPasteboardAfterCopyWithCrossSiteIframe)):

Add an API test to exercise the fix.

Canonical link: <a href="https://commits.webkit.org/317283@main">https://commits.webkit.org/317283@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d149e2b5d144b2d79e69886ab3062cffb26ab995

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174766 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48699 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42480 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184346 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132674 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8c05498c-88c3-4c79-82b6-ccfc6f538688) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176631 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49991 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48382 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135995 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177724 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39432 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156789 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116473 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c5750c47-630a-4edb-8891-36ab1201d5f8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38073 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32824 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148496 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36281 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186771 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc-debug-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/40124 "Found 119 new failures in b3/B3Value.h, b3/testb3_7.cpp, WebProcess/Network/WebResourceLoader.cpp, UIProcess/WebProcessPool.cpp, Shared/Cocoa/WKNSArray.mm, Shared/SessionState.cpp, NetworkProcess/NetworkResourceLoadParameters.cpp, WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm, WebProcess/WebPage/WebPage.cpp, WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm ...") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40650 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/prefer-common-to-both-axes.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144924 "Passed tests") | | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48366 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144783 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39028 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49046 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32902 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114825 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39658 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121099 "Found 119 new failures in b3/testb3_7.cpp, b3/B3Value.h, WebProcess/Network/WebResourceLoader.cpp, UIProcess/WebProcessPool.cpp, Shared/Cocoa/WKNSArray.mm, Shared/SessionState.cpp, NetworkProcess/NetworkResourceLoadParameters.cpp, WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm, WebProcess/WebPage/WebPage.cpp, WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm ...") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47552 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11251 "Passed tests") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46954 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47185 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47012 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->