### PR TITLE
VTT cue positioning algorithm should use floats instead of ints

### DIFF
--- a/Source/WebCore/rendering/RenderVTTCue.cpp
+++ b/Source/WebCore/rendering/RenderVTTCue.cpp
@@ -35,6 +35,7 @@
 #include "RenderBoxModelObjectInlines.h"
 #include "RenderInline.h"
 #include "RenderLayoutState.h"
+#include "RenderObjectInlines.h"
 #include "RenderView.h"
 #include "TextTrackCueGeneric.h"
 #include "VTTCue.h"
@@ -174,19 +175,32 @@ void RenderVTTCue::placeBoxInDefaultPosition(LayoutUnit position, bool& switched
     switched = false;
 }
 
+FloatRect RenderVTTCue::unroundedAbsoluteBoundingBoxRect(const RenderBox& box)
+{
+    // Unlike RenderObject::absoluteBoundingBoxRect(), this does not round the
+    // result to an IntRect. Sibling cues are compared against each other and
+    // against their container to decide whether they overlap and to compute
+    // how far to move them; rounding each box's edges to the nearest pixel
+    // independently before doing that comparison can make boxes whose true
+    // (subpixel) edges already touch appear to have a gap between them, or
+    // vice-versa appear to overlap when they don't.
+    FloatRect localRect(0, 0, box.borderBoxWidth(), box.borderBoxHeight());
+    return box.localToAbsoluteQuad(localRect).boundingBox();
+}
+
 bool RenderVTTCue::isOutside() const
 {
     if (!firstChild())
         return false;
 
     if (auto* backdropBox = this->backdropBox())
-        return !rectIsWithinContainer(backdropBox->absoluteBoundingBoxRect());
+        return !rectIsWithinContainer(unroundedAbsoluteBoundingBoxRect(*backdropBox));
     return false;
 }
 
-bool RenderVTTCue::rectIsWithinContainer(const IntRect& rect) const
+bool RenderVTTCue::rectIsWithinContainer(const FloatRect& rect) const
 {
-    return containingBlock()->absoluteBoundingBoxRect().contains(rect);
+    return unroundedAbsoluteBoundingBoxRect(*containingBlock()).contains(rect);
 }
 
 
@@ -203,11 +217,11 @@ RenderVTTCue* RenderVTTCue::overlappingObject() const
     ASSERT(firstChild());
 
     if (auto* backdropBox = this->backdropBox())
-        return overlappingObjectForRect(backdropBox->absoluteBoundingBoxRect());
+        return overlappingObjectForRect(unroundedAbsoluteBoundingBoxRect(*backdropBox));
     return nullptr;
 }
 
-RenderVTTCue* RenderVTTCue::overlappingObjectForRect(const IntRect& rect) const
+RenderVTTCue* RenderVTTCue::overlappingObjectForRect(const FloatRect& rect) const
 {
     for (RenderObject* sibling = previousSibling(); sibling; sibling = sibling->previousSibling()) {
         auto* previousCue = downcast<RenderVTTCue>(sibling);
@@ -215,7 +229,7 @@ RenderVTTCue* RenderVTTCue::overlappingObjectForRect(const IntRect& rect) const
             continue;
 
         auto* previousCueBackdropBox = previousCue->backdropBox();
-        if (previousCueBackdropBox && rect.intersects(previousCueBackdropBox->absoluteBoundingBoxRect()))
+        if (previousCueBackdropBox && rect.intersects(unroundedAbsoluteBoundingBoxRect(*previousCueBackdropBox)))
             return previousCue;
     }
 
@@ -297,13 +311,13 @@ void RenderVTTCue::moveIfNecessaryToKeepWithinContainer()
     if (!backdropBox)
         return;
 
-    IntRect containerRect = containingBlock()->absoluteBoundingBoxRect();
-    IntRect cueRect = backdropBox->absoluteBoundingBoxRect();
+    FloatRect containerRect = unroundedAbsoluteBoundingBoxRect(*containingBlock());
+    FloatRect cueRect = unroundedAbsoluteBoundingBoxRect(*backdropBox);
 
-    int topOverflow = cueRect.y() - containerRect.y();
-    int bottomOverflow = containerRect.maxY() - cueRect.maxY();
+    float topOverflow = cueRect.y() - containerRect.y();
+    float bottomOverflow = containerRect.maxY() - cueRect.maxY();
 
-    int verticalAdjustment = 0;
+    float verticalAdjustment = 0;
     if (topOverflow < 0)
         verticalAdjustment = -topOverflow;
     else if (bottomOverflow < 0)
@@ -312,10 +326,10 @@ void RenderVTTCue::moveIfNecessaryToKeepWithinContainer()
     if (verticalAdjustment)
         setY(y() + verticalAdjustment);
 
-    int leftOverflow = cueRect.x() - containerRect.x();
-    int rightOverflow = containerRect.maxX() - cueRect.maxX();
+    float leftOverflow = cueRect.x() - containerRect.x();
+    float rightOverflow = containerRect.maxX() - cueRect.maxX();
 
-    int horizontalAdjustment = 0;
+    float horizontalAdjustment = 0;
     if (leftOverflow < 0)
         horizontalAdjustment = -leftOverflow;
     else if (rightOverflow < 0)
@@ -325,7 +339,7 @@ void RenderVTTCue::moveIfNecessaryToKeepWithinContainer()
         setX(x() + horizontalAdjustment);
 }
 
-bool RenderVTTCue::findNonOverlappingPosition(int& newX, int& newY) const
+bool RenderVTTCue::findNonOverlappingPosition(float& newX, float& newY) const
 {
     if (!firstChild())
         return false;
@@ -336,8 +350,8 @@ bool RenderVTTCue::findNonOverlappingPosition(int& newX, int& newY) const
 
     newX = x();
     newY = y();
-    IntRect srcRect = backdropBox->absoluteBoundingBoxRect();
-    IntRect destRect = srcRect;
+    FloatRect srcRect = unroundedAbsoluteBoundingBoxRect(*backdropBox);
+    FloatRect destRect = srcRect;
 
     // Move the box up, looking for a non-overlapping position:
     while (RenderVTTCue* cue = overlappingObjectForRect(destRect)) {
@@ -345,9 +359,9 @@ bool RenderVTTCue::findNonOverlappingPosition(int& newX, int& newY) const
         if (!cueBackdropBox)
             continue;
         if (m_cue->vertical() == VTTCue::DirectionSetting::Horizontal)
-            destRect.setY(cueBackdropBox->absoluteBoundingBoxRect().y() - destRect.height());
+            destRect.setY(unroundedAbsoluteBoundingBoxRect(*cueBackdropBox).y() - destRect.height());
         else
-            destRect.setX(cueBackdropBox->absoluteBoundingBoxRect().x() - destRect.width());
+            destRect.setX(unroundedAbsoluteBoundingBoxRect(*cueBackdropBox).x() - destRect.width());
     }
 
     if (rectIsWithinContainer(destRect)) {
@@ -364,9 +378,9 @@ bool RenderVTTCue::findNonOverlappingPosition(int& newX, int& newY) const
         if (!cueBackdropBox)
             continue;
         if (m_cue->vertical() == VTTCue::DirectionSetting::Horizontal)
-            destRect.setY(cueBackdropBox->absoluteBoundingBoxRect().maxY());
+            destRect.setY(unroundedAbsoluteBoundingBoxRect(*cueBackdropBox).maxY());
         else
-            destRect.setX(cueBackdropBox->absoluteBoundingBoxRect().maxX());
+            destRect.setX(unroundedAbsoluteBoundingBoxRect(*cueBackdropBox).maxX());
     }
 
     if (rectIsWithinContainer(destRect)) {
@@ -450,7 +464,7 @@ void RenderVTTCue::repositionCueSnapToLinesNotSet()
 
     // ↳ If cue’s WebVTT cue snap-to-lines flag is false
     // 1. Let bounding box be the bounding box of the boxes in boxes.
-    auto boundingBox = backdropBox->absoluteBoundingBoxRect();
+    auto boundingBox = unroundedAbsoluteBoundingBoxRect(*backdropBox);
 
     // 2. Run the appropriate steps from the following list:
     switch (m_cue->vertical()) {
@@ -497,8 +511,8 @@ void RenderVTTCue::repositionCueSnapToLinesNotSet()
     // from their current position, use the highest one amongst them; if there are several at that height,
     // then use the leftmost one amongst them.
     moveIfNecessaryToKeepWithinContainer();
-    int x = 0;
-    int y = 0;
+    float x = 0;
+    float y = 0;
     if (findNonOverlappingPosition(x, y)) {
         setX(x);
         setY(y);

--- a/Source/WebCore/rendering/RenderVTTCue.h
+++ b/Source/WebCore/rendering/RenderVTTCue.h
@@ -29,6 +29,7 @@
 #if ENABLE(VIDEO)
 
 #include "FloatPoint.h"
+#include "FloatRect.h"
 #include "InlineIteratorInlineBox.h"
 #include "RenderBlockFlow.h"
 
@@ -49,16 +50,16 @@ private:
     void layout() override;
 
     bool isOutside() const;
-    bool rectIsWithinContainer(const IntRect&) const;
+    bool rectIsWithinContainer(const FloatRect&) const;
     bool isOverlapping() const;
     RenderVTTCue* overlappingObject() const;
-    RenderVTTCue* overlappingObjectForRect(const IntRect&) const;
+    RenderVTTCue* overlappingObjectForRect(const FloatRect&) const;
     bool shouldSwitchDirection(const InlineIterator::InlineBox&, LayoutUnit) const;
 
     void NODELETE moveBoxesByStep(LayoutUnit);
     bool NODELETE switchDirection(bool&, LayoutUnit&);
     void moveIfNecessaryToKeepWithinContainer();
-    bool findNonOverlappingPosition(int& x, int& y) const;
+    bool findNonOverlappingPosition(float& x, float& y) const;
 
     bool initializeLayoutParameters(LayoutUnit&, LayoutUnit&);
     void NODELETE placeBoxInDefaultPosition(LayoutUnit, bool&);
@@ -68,6 +69,7 @@ private:
 
     RenderBlockFlow* backdropBox() const;
     RenderInline* cueBox() const;
+    static FloatRect unroundedAbsoluteBoundingBoxRect(const RenderBox&);
 
     WeakPtr<VTTCue, WeakPtrImplWithEventTargetData> m_cue;
     FloatPoint m_fallbackPosition;


### PR DESCRIPTION
#### 41e9a94793ef26fa41fd5eaee3da722803f4d3ed
<pre>
VTT cue positioning algorithm should use floats instead of ints
<a href="https://bugs.webkit.org/show_bug.cgi?id=319433">https://bugs.webkit.org/show_bug.cgi?id=319433</a>
<a href="https://rdar.apple.com/182250995">rdar://182250995</a>

Reviewed by Eric Carlson.

Currently, WebKit fails WebVTT WPT 2_cues_overlapping_partially_move_up.html
and 2_cues_overlapping_partially_move_down.html. These tests check that when
a VTT file uses the line setting to position cues such that they overlap,
the browser moves the second cue as minimally as possible so that they do not overlap.

The rendered cues&apos; top and bottom edges should be flush with each other, since the spec
expects the cue to be moved minimally and makes no indication that we should be
rounding to the nearest integer. However, WebKit&apos;s rendering of these vtt files
puts a gap between the two cues. This is caused by our use of integers in RenderVTTCue.
We should instead use floats.

No new test expectations due to bugs in the wpt tests that cause us to still fail them.
One a future patch fixes the tests the expectations will be updated.

* Source/WebCore/rendering/RenderVTTCue.cpp:
(WebCore::RenderVTTCue::unroundedAbsoluteBoundingBoxRect):
(WebCore::RenderVTTCue::isOutside const):
(WebCore::RenderVTTCue::rectIsWithinContainer const):
(WebCore::RenderVTTCue::overlappingObject const):
(WebCore::RenderVTTCue::overlappingObjectForRect const):
(WebCore::RenderVTTCue::moveIfNecessaryToKeepWithinContainer):
(WebCore::RenderVTTCue::findNonOverlappingPosition const):
(WebCore::RenderVTTCue::repositionCueSnapToLinesNotSet):
* Source/WebCore/rendering/RenderVTTCue.h:

Canonical link: <a href="https://commits.webkit.org/317391@main">https://commits.webkit.org/317391@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/39c2c06ded4aa0c398d0486d63e8976fb888917f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174633 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48566 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42347 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184211 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132501 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8b3f7e3c-f8da-416b-b4fd-d6d911dbd812) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176498 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49858 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48249 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135872 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95884 "5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c212582d-4db3-4cf3-af7c-7531d58be418) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177591 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39305 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156661 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116350 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5976e865-d91e-4c43-9a9f-b332d2e5895b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37946 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36325 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32691 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148369 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36153 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186638 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/40009 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40523 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144795 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48233 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144654 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48912 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32774 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114692 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26630 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39532 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120922 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47419 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11121 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46821 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47052 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46879 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->