### PR TITLE
[Coordinated Graphics] ScrollingTreeCoordinated: Consolidate findEventListenerRegionTypes and collectDescendantLayersAtPoint

### DIFF
--- a/Source/WebCore/page/scrolling/coordinated/ScrollingTreeCoordinated.cpp
+++ b/Source/WebCore/page/scrolling/coordinated/ScrollingTreeCoordinated.cpp
@@ -111,11 +111,9 @@ void ScrollingTreeCoordinated::didCompletePlatformRenderingUpdate()
     renderingUpdateComplete();
 }
 
-static bool collectDescendantLayersAtPoint(Vector<Ref<CoordinatedPlatformLayer>>& layersAtPoint, const Ref<CoordinatedPlatformLayer>& parent, const FloatPoint& point)
+static bool traverseDescendantLayersAtPoint(const Ref<CoordinatedPlatformLayer>& parent, const FloatPoint& point, const auto& iterator)
 {
-    bool existsOnDescendent = false;
-    bool existsOnLayer = !!parent->scrollingNodeID() && parent->bounds().contains(point) && parent->eventRegion().contains(roundedIntPoint(point));
-    for (auto& child : parent->children()) {
+    for (auto& child : parent->children() | std::views::reverse) {
         Locker childLocker { child->lock() };
         FloatPoint transformedPoint(point);
         if (child->transform().isInvertible()) {
@@ -128,13 +126,15 @@ static bool collectDescendantLayersAtPoint(Vector<Ref<CoordinatedPlatformLayer>>
             auto pointInChildSpace = transform.projectPoint(point);
             transformedPoint.set(pointInChildSpace.x(), pointInChildSpace.y());
         }
-        existsOnDescendent |= collectDescendantLayersAtPoint(layersAtPoint, child, transformedPoint);
+        if (traverseDescendantLayersAtPoint(child, transformedPoint, iterator))
+            return true;
     }
 
-    if (existsOnLayer && !existsOnDescendent)
-        layersAtPoint.append(parent);
-
-    return existsOnLayer || existsOnDescendent;
+    if (parent->bounds().contains(point) && parent->eventRegion().contains(roundedIntPoint(point))) {
+        if (iterator(parent, point))
+            return true;
+    }
+    return false;
 }
 
 RefPtr<ScrollingTreeNode> ScrollingTreeCoordinated::scrollingNodeForPoint(FloatPoint point)
@@ -146,19 +146,25 @@ RefPtr<ScrollingTreeNode> ScrollingTreeCoordinated::scrollingNodeForPoint(FloatP
     Locker layerLocker { m_layerHitTestMutex };
 
     auto rootContentsLayer = static_cast<ScrollingTreeFrameScrollingNodeCoordinated*>(rootScrollingNode)->rootContentsLayer();
-    Vector<Ref<CoordinatedPlatformLayer>> layersAtPoint;
+
+    RefPtr<ScrollingTreeNode> hitScrollingNode;
     {
         Locker rootContentsLayerLocker { rootContentsLayer->lock() };
-        collectDescendantLayersAtPoint(layersAtPoint, Ref { *rootContentsLayer }, point);
+        traverseDescendantLayersAtPoint(Ref { *rootContentsLayer }, point, [&](const Ref<CoordinatedPlatformLayer>& layer, const FloatPoint&) {
+            if (!layer->scrollingNodeID())
+                return false;
+            Locker locker { layer->lock() };
+            auto* scrollingNode = nodeForID(layer->scrollingNodeID());
+            if (is<ScrollingTreeScrollingNode>(scrollingNode)) {
+                hitScrollingNode = scrollingNode;
+                return true;
+            }
+            return false;
+        });
     }
 
-    for (auto& layer : layersAtPoint | std::views::reverse) {
-        Locker locker { layer->lock() };
-        auto* scrollingNode = nodeForID(layer->scrollingNodeID());
-        if (is<ScrollingTreeScrollingNode>(scrollingNode))
-            return scrollingNode;
-    }
-
+    if (hitScrollingNode)
+        return hitScrollingNode;
     return rootScrollingNode;
 }
 
@@ -178,32 +184,6 @@ void ScrollingTreeCoordinated::hasNodeWithAnimatedScrollChanged(bool hasNodeWith
 #endif
 
 #if ENABLE(WHEEL_EVENT_REGIONS)
-static OptionSet<EventListenerRegionType> findEventListenerRegionTypes(const Ref<CoordinatedPlatformLayer>& parent, const FloatPoint& point)
-{
-    bool existsOnLayer = parent->bounds().contains(point) && parent->eventRegion().contains(roundedIntPoint(point));
-    for (auto& child : parent->children() | std::views::reverse) {
-        Locker childLocker { child->lock() };
-        FloatPoint transformedPoint(point);
-        if (child->transform().isInvertible()) {
-            float originX = child->anchorPoint().x() * child->size().width();
-            float originY = child->anchorPoint().y() * child->size().height();
-            auto transform = *(TransformationMatrix()
-                .translate3d(originX + child->position().x() - parent->boundsOrigin().x(), originY + child->position().y() - parent->boundsOrigin().y(), child->anchorPoint().z())
-                .multiply(child->transform())
-                .translate3d(-originX, -originY, -child->anchorPoint().z()).inverse());
-            auto pointInChildSpace = transform.projectPoint(point);
-            transformedPoint.set(pointInChildSpace.x(), pointInChildSpace.y());
-        }
-        if (auto result = findEventListenerRegionTypes(child, transformedPoint))
-            return result;
-    }
-
-    if (existsOnLayer)
-        return parent->eventRegion().eventListenerRegionTypesForPoint(roundedIntPoint(point));
-
-    return { };
-}
-
 OptionSet<EventListenerRegionType> ScrollingTreeCoordinated::eventListenerRegionTypesForPoint(FloatPoint point) const
 {
     RefPtr rootScrollingNode = rootNode();
@@ -214,7 +194,13 @@ OptionSet<EventListenerRegionType> ScrollingTreeCoordinated::eventListenerRegion
 
     Ref rootContentsLayer = *static_cast<ScrollingTreeFrameScrollingNodeCoordinated*>(rootScrollingNode.get())->rootContentsLayer();
     Locker rootContentsLayerLocker { rootContentsLayer->lock() };
-    return findEventListenerRegionTypes(rootContentsLayer, point);
+
+    OptionSet<EventListenerRegionType> result;
+    traverseDescendantLayersAtPoint(rootContentsLayer, point, [&](const Ref<CoordinatedPlatformLayer>& layer, const FloatPoint& point) {
+        result = layer->eventRegion().eventListenerRegionTypesForPoint(roundedIntPoint(point));
+        return true;
+    });
+    return result;
 }
 #endif
 


### PR DESCRIPTION
#### 02d83f451467b19713c72eb4fb6d07dc7a0d6c4c
<pre>
[Coordinated Graphics] ScrollingTreeCoordinated: Consolidate findEventListenerRegionTypes and collectDescendantLayersAtPoint
<a href="https://bugs.webkit.org/show_bug.cgi?id=319437">https://bugs.webkit.org/show_bug.cgi?id=319437</a>

Reviewed by NOBODY (OOPS!).

<a href="https://commits.webkit.org/315799@main">315799@main</a> added findEventListenerRegionTypes() in ScrollingTreeCoordinated.cpp
by copying collectDescendantLayersAtPoint() in the file. They can be consolidated.
Removed them, and added traverseDescendantLayersAtPoint().

* Source/WebCore/page/scrolling/coordinated/ScrollingTreeCoordinated.cpp:
(WebCore::traverseDescendantLayersAtPoint):
(WebCore::ScrollingTreeCoordinated::scrollingNodeForPoint):
(WebCore::ScrollingTreeCoordinated::eventListenerRegionTypesForPoint const):
(WebCore::collectDescendantLayersAtPoint): Deleted.
(WebCore::findEventListenerRegionTypes): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/02d83f451467b19713c72eb4fb6d07dc7a0d6c4c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174640 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48573 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42354 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184218 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132508 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176505 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49865 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48256 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135878 "Found 5 new test failures: fast/events/remove-child-onscroll.html fast/scrolling/scrolling-inside-scrolled-overflowarea.html fast/scrolling/sync-scroll-overscroll-behavior-element.html fast/scrolling/sync-scroll-overscroll-behavior-unscrollable-element.html scrollbars/scroll-rtl-or-bt-layer.html (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177598 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39311 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156663 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116356 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37952 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32698 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148375 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36155 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186645 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/39944 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144803 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48240 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144662 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48919 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39546 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/120930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47426 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11123 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46828 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47059 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46886 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->