### PR TITLE
[WPT] Various test cases in custom-elements/registries/element-mutation.html fail

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/ShadowRoot-init-declarative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/ShadowRoot-init-declarative-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Custom element inside 'shadowrootcustomelementregistry' declarative shadow root should use document's registry as attachShadow default registry assert_equals: expected object "[object CustomElementRegistry]" but got null
+PASS Custom element inside 'shadowrootcustomelementregistry' declarative shadow root should use document's registry as attachShadow default registry
 PASS Built-in element inside 'shadowrootcustomelementregistry' declarative shadow root should use document's registry as attachShadow default registry
 PASS Built-in element inside 'shadowrootcustomelementregistry' shadow root parsed via setHTMLUnsafe should use null registry
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/element-mutation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/element-mutation-expected.txt
@@ -1,17 +1,17 @@
 
 PASS An element with global registry should not change its registry when run append into a shadow tree with scoped registry.
-FAIL An element with scoped registry should not change its registry when run append out of the shadow tree. assert_equals: expected object "[object CustomElementRegistry]" but got object "[object CustomElementRegistry]"
-FAIL An element with scoped registry should not change its registry when run append into another shadow tree with different scoped registry. assert_equals: expected object "[object CustomElementRegistry]" but got object "[object CustomElementRegistry]"
+PASS An element with scoped registry should not change its registry when run append out of the shadow tree.
+PASS An element with scoped registry should not change its registry when run append into another shadow tree with different scoped registry.
 PASS A freshly created element should preserve global registry after append into and removal from a scoped shadow root.
 PASS A freshly created element should preserve global registry when run append between scoped shadow roots.
 PASS An element with global registry should not change its registry when run appendChild into a shadow tree with scoped registry.
-FAIL An element with scoped registry should not change its registry when run appendChild out of the shadow tree. assert_equals: expected object "[object CustomElementRegistry]" but got object "[object CustomElementRegistry]"
-FAIL An element with scoped registry should not change its registry when run appendChild into another shadow tree with different scoped registry. assert_equals: expected object "[object CustomElementRegistry]" but got object "[object CustomElementRegistry]"
+PASS An element with scoped registry should not change its registry when run appendChild out of the shadow tree.
+PASS An element with scoped registry should not change its registry when run appendChild into another shadow tree with different scoped registry.
 PASS A freshly created element should preserve global registry after appendChild into and removal from a scoped shadow root.
 PASS A freshly created element should preserve global registry when run appendChild between scoped shadow roots.
 PASS An element with global registry should not change its registry when run prepend into a shadow tree with scoped registry.
-FAIL An element with scoped registry should not change its registry when run prepend out of the shadow tree. assert_equals: expected object "[object CustomElementRegistry]" but got object "[object CustomElementRegistry]"
-FAIL An element with scoped registry should not change its registry when run prepend into another shadow tree with different scoped registry. assert_equals: expected object "[object CustomElementRegistry]" but got object "[object CustomElementRegistry]"
+PASS An element with scoped registry should not change its registry when run prepend out of the shadow tree.
+PASS An element with scoped registry should not change its registry when run prepend into another shadow tree with different scoped registry.
 PASS A freshly created element should preserve global registry after prepend into and removal from a scoped shadow root.
 PASS A freshly created element should preserve global registry when run prepend between scoped shadow roots.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-custom-element-registry-customelementregistry-attribute-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-custom-element-registry-customelementregistry-attribute-expected.txt
@@ -10,16 +10,16 @@ PASS Setting customelementregistry content attribute after a custom element had 
 PASS Cloning a custom element with null regsitry should create an element with null registry
 PASS Descendants of an element with customelementregistry should use null registry
 PASS Setting customelementregistry content attribute during constructor should not make it use null registry
-FAIL Body with customelementregistry attribute during initial parse should have null registry and propagate to children assert_equals: div child of body with customelementregistry should have null registry expected null but got object "[object CustomElementRegistry]"
-FAIL Custom element candidate child of body with customelementregistry should have null registry during initial parse assert_equals: custom element candidate child of body with customelementregistry should have null registry expected null but got object "[object CustomElementRegistry]"
-FAIL Descendants of body with customelementregistry should all have null registry during initial parse assert_equals: div child should have null registry expected null but got object "[object CustomElementRegistry]"
-FAIL Body with customelementregistry in a complete document structure should have null registry assert_equals: div child should have null registry expected null but got object "[object CustomElementRegistry]"
+PASS Body with customelementregistry attribute during initial parse should have null registry and propagate to children
+PASS Custom element candidate child of body with customelementregistry should have null registry during initial parse
+PASS Descendants of body with customelementregistry should all have null registry during initial parse
+PASS Body with customelementregistry in a complete document structure should have null registry
 PASS Initial parse: built-in element with customelementregistry has null registry
 PASS Initial parse: custom element candidate with customelementregistry has null registry
 PASS Initial parse: built-in element without customelementregistry uses global registry
 PASS Initial parse: custom element candidate without customelementregistry uses global registry
-FAIL Initial parse: child of element with customelementregistry inherits null registry assert_equals: Child of element with customelementregistry should have null registry expected null but got object "[object CustomElementRegistry]"
-FAIL Initial parse: custom element candidate child inherits null registry from parent assert_equals: Custom element candidate child of element with customelementregistry should have null registry expected null but got object "[object CustomElementRegistry]"
-FAIL Initial parse: deeply nested descendant inherits null registry assert_equals: Deeply nested custom element candidate should have null registry expected null but got object "[object CustomElementRegistry]"
+PASS Initial parse: child of element with customelementregistry inherits null registry
+PASS Initial parse: custom element candidate child inherits null registry from parent
+PASS Initial parse: deeply nested descendant inherits null registry
 PASS Initial parse: global registry define only upgrades elements without customelementregistry
 

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -3476,7 +3476,7 @@ ExceptionOr<ShadowRoot&> Element::attachShadow(const ShadowRootInit& init, std::
     }
     auto scopedRegistry = ShadowRootScopedCustomElementRegistry::No;
     if (!registryKind)
-        registryKind = !registry && usesNullCustomElementRegistry() ? CustomElementRegistryKind::Null : CustomElementRegistryKind::Window;
+        registryKind = CustomElementRegistryKind::Window;
     if (registryKind == CustomElementRegistryKind::Null) {
         ASSERT(!registry);
         scopedRegistry = ShadowRootScopedCustomElementRegistry::Yes;

--- a/Source/WebCore/html/parser/HTMLConstructionSite.cpp
+++ b/Source/WebCore/html/parser/HTMLConstructionSite.cpp
@@ -861,11 +861,9 @@ std::tuple<RefPtr<HTMLElement>, RefPtr<JSCustomElementInterface>, RefPtr<CustomE
             } else
                 element = HTMLUnknownElement::create(qualifiedName, ownerDocument);
         }
-        if (!registry && treeScope->rootNode().usesNullCustomElementRegistry())
-            element->setUsesNullCustomElementRegistry();
     }
     ASSERT(element);
-    if (m_isParsingFragment && !registry && containerForCurrentNode().usesNullCustomElementRegistry())
+    if (!registry && containerForCurrentNode().usesNullCustomElementRegistry())
         element->setUsesNullCustomElementRegistry();
     if (registry && registry->isScoped() && registry != treeScope->customElementRegistry()) [[unlikely]]
         CustomElementRegistry::addToScopedCustomElementRegistryMap(*element, *registry);


### PR DESCRIPTION
#### 8b4bcb5752d08f72fca8ca9c4a44264b2faa6e4c
<pre>
[WPT] Various test cases in custom-elements/registries/element-mutation.html fail
<a href="https://bugs.webkit.org/show_bug.cgi?id=319388">https://bugs.webkit.org/show_bug.cgi?id=319388</a>

Reviewed by Chris Dumez.

The failure was caused by a built-in element (e.g. div) parsed inside an declarative
shadow root with null registry (e.g. declared with shadowrootcustomelementregistry
content attribute on template) not getting the usesNullCustomElementRegistry flag -
only custom elements and unknown elements did (in HTMLConstructionSite&apos;s
createHTMLElementOrFindCustomElementInterface inside the &quot;if (!element)&quot; block).
The built-in element merely resolved to null via its tree scope.

That worked for the original (parsed before any global registry was ensured), but
broke on cloning: once the global registry exists, cloning the subtree runs
Element::insertionSteps on the cloned nodes which pins the cloned element with
the global registry in the scoped map. Once pinned, registry.initialize(shadowRoot)
could no longer hand it the scoped registry - hence the failures.

This PR applies two fixes to address the failures.

1. HTMLConstructionSite.cpp - set usesNullCustomElementRegistry on all elements
   (built-in included) parsed inside a null-registry tree scope, so an element
   behaves identically to its clones and keeps resolving to null across mutations.
   This unifies the previously separate custom-element and fragment-parsing branches.
2. Element::attachShadow - an imperative attachShadow() with no explicit registry
   now always defaults to the document&apos;s registry, instead of null when the host
   carries the null-registry flag. The host stays null; only the new shadow root uses
   the global registry.

(2) is required because (1) gives built-in elements the flag, and without it their
attachShadow default would flip to null. As a bonus, it also fixes the pre-existing
ShadowRoot-init-declarative.html custom-element FAIL, which failed for this exact
reason.

Finally, this PR also addresses a bug that we weren&apos;t propagating the parent node&apos;s
null-registry-ness to a child node during non-fragment parsing by generalizing
the condition (no longer checks m_isParsingFragment).

Test: imported/w3c/web-platform-tests/custom-elements/registries/element-mutation.html

* LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/ShadowRoot-init-declarative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/element-mutation-expected.txt:
* Source/WebCore/dom/Element.cpp:
* Source/WebCore/html/parser/HTMLConstructionSite.cpp:
(WebCore::HTMLConstructionSite::createHTMLElementOrFindCustomElementInterface):

Canonical link: <a href="https://commits.webkit.org/317215@main">https://commits.webkit.org/317215@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/054822febac44d59ec862baa7f6041e5ad46f1a5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174641 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48574 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42355 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184219 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132509 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a9bc53a6-f89f-48d5-bbda-f41a69aa829f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176506 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49866 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48257 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135879 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ead59126-edeb-405a-9c22-3a74c8df4dc1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177599 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39310 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/156682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116357 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37951 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32699 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148374 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36174 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186646 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/39945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144804 "Found 1 new test failure: editing/selection/drag-in-iframe.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48241 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144663 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48920 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26540 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39537 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/120931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47427 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11142 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46829 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47060 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46887 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->