### PR TITLE
[Site Isolation] Fix TestWebKitAPI.ProcessSwap.NavigateToDataURLThenBack

### DIFF
--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -72,6 +72,7 @@
 #include "WKContextPrivate.h"
 #include "WebAutomationSession.h"
 #include "WebBackForwardCache.h"
+#include "WebBackForwardCacheEntry.h"
 #include "WebBackForwardList.h"
 #include "WebBackForwardListItem.h"
 #include "WebCompiledContentRuleList.h"
@@ -2194,6 +2195,16 @@ void WebProcessPool::processForNavigation(WebPageProxy& page, WebFrameProxy& fra
                     return;
                 }
             }
+            if (RefPtr entry = targetItem->backForwardCacheEntry()) {
+                if (RefPtr process = entry->process(); process && process->state() != AuxiliaryProcessProxy::State::Terminated) {
+                    ASSERT(isolatedProcessType != WebProcessProxy::IsolatedProcessType::Shared);
+                    prepareProcessForNavigation(process.releaseNonNull(), page, nullptr,
+                        "Using target back/forward item's process (in-process BFCache)"_s, isolatedProcessType,
+                        site, mainFrameSite, navigation, lockdownMode, enhancedSecurity, loadedWebArchive,
+                        WTF::move(dataStore), WTF::move(completionHandler));
+                    return;
+                }
+            }
         }
     }
 
@@ -2395,11 +2406,9 @@ std::tuple<Ref<WebProcessProxy>, RefPtr<SuspendedPageProxy>, ASCIILiteral> WebPr
         }
     }
 
-    const bool treatAsSameOriginNavigation = [&targetURL, &sourceURL, &frame, siteIsolationEnabled] {
+    const bool treatAsSameOriginNavigation = [&targetURL, &sourceURL, siteIsolationEnabled] {
         if (siteIsolationEnabled) {
             if (targetURL.protocolIsAbout() && !SecurityPolicy::shouldInheritSecurityOriginFromOwner(targetURL))
-                return false;
-            if (frame.isMainFrame() && targetURL.protocolIsData())
                 return false;
         }
 


### PR DESCRIPTION
#### 98a1df0a260dab874c97274992b92f2ef667d053
<pre>
[Site Isolation] Fix TestWebKitAPI.ProcessSwap.NavigateToDataURLThenBack
<a href="https://bugs.webkit.org/show_bug.cgi?id=319440">https://bugs.webkit.org/show_bug.cgi?id=319440</a>
<a href="https://rdar.apple.com/182254652">rdar://182254652</a>

Reviewed by Basuke Suzuki.

Commit 314948@main fixed BFCache restore for back-navigation through a data: URL under Site
Isolation by forcing a process swap on main-frame data: URL navigations. However, this broke the
existing behavior that data: URL navigations should stay in the same process, which is consistent
with other browsers.

The process swap is unnecessary because the in-process BFCache (WebCore::BackForwardCache) handles
this case correctly on its own: when navigating from a regular page to a data: URL without a process
swap, the source page is suspended into the in-process BFCache and is correctly restored on back
navigation.

Revert the data: URL carve-out from processForNavigationInternal, restoring data: URLs to
same-origin treatment (no process swap) under Site Isolation.

However, this exposed a separate gap: when navigating back to a page that was cached only via the
in-process BFCache (no SuspendedPageProxy, because no process swap occurred), processForNavigation
under Site Isolation had no way to find the correct process. It checked targetItem-&gt;suspendedPage()
but not targetItem-&gt;backForwardCacheEntry(). Since the WebContent process already notifies the
UIProcess via didCacheBackForwardItem (which calls WebBackForwardCache::addEntry with the process
identifier), a valid BackForwardCacheEntry exists on the item — it just wasn&apos;t being consulted.

Add a fallback in processForNavigation: after the suspendedPage check, also check
backForwardCacheEntry() and reuse its process when available. This ensures back navigation to pages
cached via in-process BFCache correctly reuses the original process instead of spawning a new one.

The !site.isEmpty() gate fix from 314948@main (which allows SuspendedPageProxy lookup for
back-navigations to file:// and other empty-site URLs) is intentionally kept as it is an independent
improvement.

* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::processForNavigation):
(WebKit::WebProcessPool::processForNavigationInternal):

Canonical link: <a href="https://commits.webkit.org/317435@main">https://commits.webkit.org/317435@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb2c28a7dcfeea533413b52574c4e109ba21793d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175072 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49005 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42786 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184657 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132980 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50297 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48688 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136263 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96122 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/45d97f0f-dbec-4f10-8c06-432d1e55f6c7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178030 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39697 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157053 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116741 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b1ac7a9c-e32c-4b9c-8345-a2e3475c8419) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38338 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36727 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33130 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148761 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36545 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187078 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/40641 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40930 "Found 1 new test failure: http/wpt/background-fetch/change-documents-in-progress-event.window.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145208 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48672 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145064 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39128 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49352 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33166 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115178 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39932 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121540 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47858 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11518 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47261 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47491 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47318 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->