### PR TITLE
Use the correct feature name when disabling Chrome frame throttling in the benchmark runner

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/osx_chrome_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/osx_chrome_driver.py
@@ -70,7 +70,7 @@ class OSXChromeCanaryDriver(OSXChromeDriverBase):
         set_binary_location_impl(options, browser_build_path, self.app_name, self.process_name)
 
     def launch_args_with_url(self, url):
-        return super(OSXChromeCanaryDriver, self).launch_args_with_url(url) + ['--enable-field-trial-config', '--disable-features=ThrottleConsecutiveNoDamageMainFrames']
+        return super(OSXChromeCanaryDriver, self).launch_args_with_url(url) + ['--enable-field-trial-config', '--disable-features=ThrottleRepeatedNoDamageFrames']
 
 
 class OSXChromeBetaDriver(OSXChromeDriverBase):
@@ -83,7 +83,7 @@ class OSXChromeBetaDriver(OSXChromeDriverBase):
         set_binary_location_impl(options, browser_build_path, self.app_name, self.process_name)
 
     def launch_args_with_url(self, url):
-        return super(OSXChromeBetaDriver, self).launch_args_with_url(url) + ['--enable-field-trial-config', '--disable-features=ThrottleConsecutiveNoDamageMainFrames']
+        return super(OSXChromeBetaDriver, self).launch_args_with_url(url) + ['--enable-field-trial-config', '--disable-features=ThrottleRepeatedNoDamageFrames']
 
 
 class OSXChromeDevDriver(OSXChromeDriverBase):
@@ -96,7 +96,7 @@ class OSXChromeDevDriver(OSXChromeDriverBase):
         set_binary_location_impl(options, browser_build_path, self.app_name, self.process_name)
 
     def launch_args_with_url(self, url):
-        return super(OSXChromeDevDriver, self).launch_args_with_url(url) + ['--enable-field-trial-config', '--disable-features=ThrottleConsecutiveNoDamageMainFrames']
+        return super(OSXChromeDevDriver, self).launch_args_with_url(url) + ['--enable-field-trial-config', '--disable-features=ThrottleRepeatedNoDamageFrames']
 
 
 class OSXChromeForTestingDriver(OSXChromeDriverBase):
@@ -109,7 +109,7 @@ class OSXChromeForTestingDriver(OSXChromeDriverBase):
         set_binary_location_impl(options, browser_build_path, self.app_name, self.process_name)
 
     def launch_args_with_url(self, url):
-        return super(OSXChromeForTestingDriver, self).launch_args_with_url(url) + ['--enable-field-trial-config', '--disable-features=ThrottleConsecutiveNoDamageMainFrames']
+        return super(OSXChromeForTestingDriver, self).launch_args_with_url(url) + ['--enable-field-trial-config', '--disable-features=ThrottleRepeatedNoDamageFrames']
 
 
 class OSXChromiumDriver(OSXChromeDriverBase):


### PR DESCRIPTION
#### 42be825315e2f127a763859c60e772b52b05d25b
<pre>
Use the correct feature name when disabling Chrome frame throttling in the benchmark runner
<a href="https://bugs.webkit.org/show_bug.cgi?id=319441">https://bugs.webkit.org/show_bug.cgi?id=319441</a>
<a href="https://rdar.apple.com/problem/182254455">rdar://problem/182254455</a>

Reviewed by Dewei Zhu.

The flag disabled for non-stable Chrome channels should be ThrottleRepeatedNoDamageFrames, not ThrottleConsecutiveNoDamageMainFrames. Follow-up to 316751@main.

* Tools/Scripts/webkitpy/benchmark_runner/browser_driver/osx_chrome_driver.py:
(OSXChromeCanaryDriver.launch_args_with_url):
(OSXChromeBetaDriver.launch_args_with_url):
(OSXChromeDevDriver.launch_args_with_url):
(OSXChromeForTestingDriver.launch_args_with_url):

Canonical link: <a href="https://commits.webkit.org/317206@main">https://commits.webkit.org/317206@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9a03ea0e0858cde96a31458f23f120ff817da76

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174646 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48579 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42360 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184224 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/132514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f4ba9ce7-2b6e-4041-a68b-753038d4dbd4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176511 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49871 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48262 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/135882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/132514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/008273d4-f649-4c2a-8f66-6fd4bad8aee6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177604 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/39318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/156668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116360 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6f5fd0db-05a8-4226-a5e0-7cf037d466f6) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/173967 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/37959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32704 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/148382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/36160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186651 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/144808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48246 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144667 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38984 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48925 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39540 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47432 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/11128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46834 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47065 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/46892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->