### PR TITLE
[Cleanup] Add logging to WebAVPlayerLayerView

### DIFF
--- a/Source/WebCore/Configurations/AllowedSPI-legacy.toml
+++ b/Source/WebCore/Configurations/AllowedSPI-legacy.toml
@@ -121,6 +121,7 @@ requires = ["!HAVE_WEBCONTENTRESTRICTIONS", "HAVE_WEBCONTENTANALYSIS_FRAMEWORK"]
 [[legacy]]
 selectors = [
     { name = "borderColorForEdge:", class = "?" },
+    { name = "webPlayerLayer", class = "?" },
     { name = "transferVideoViewTo:", class = "?" },
     { name = "widthForLayer:edge:", class = "?" },
 ]

--- a/Source/WebCore/platform/cocoa/WebAVPlayerLayer.h
+++ b/Source/WebCore/platform/cocoa/WebAVPlayerLayer.h
@@ -58,4 +58,12 @@ WEBCORE_EXPORT @interface WebAVPlayerLayer : CALayer
 - (void)stopShowingCaptionPreview;
 @end
 
+#if !RELEASE_LOG_DISABLED
+@interface WebAVPlayerLayer (Logging)
+@property (readonly, nonatomic) uint64_t logIdentifier;
+@property (readonly, nullable, nonatomic) const Logger* loggerPtr;
+@property (readonly, nullable, nonatomic) WTFLogChannel* logChannel;
+@end
+#endif
+
 #endif // HAVE(AVKIT)

--- a/Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm
+++ b/Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm
@@ -45,14 +45,6 @@
 #import <pal/cocoa/AVFoundationSoftLink.h>
 #import <pal/cocoa/AVKitSoftLink.h>
 
-#if !RELEASE_LOG_DISABLED
-@interface WebAVPlayerLayer (Logging)
-@property (readonly, nonatomic) uint64_t logIdentifier;
-@property (readonly, nonatomic) const Logger* loggerPtr;
-@property (readonly, nonatomic) WTFLogChannel* logChannel;
-@end
-#endif
-
 namespace WebCore {
 class WebAVPlayerLayerPresentationModelClient final : public VideoPresentationModelClient, public CanMakeCheckedPtr<WebAVPlayerLayerPresentationModelClient> {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(WebAVPlayerLayerPresentationModelClient);

--- a/Source/WebCore/platform/cocoa/WebAVPlayerLayerView.h
+++ b/Source/WebCore/platform/cocoa/WebAVPlayerLayerView.h
@@ -32,8 +32,11 @@
 
 #import <pal/spi/cocoa/AVKitSPI.h>
 
+@class WebAVPlayerLayer;
+
 WEBCORE_EXPORT @interface WebAVPlayerLayerView : __AVPlayerLayerView
 @property (retain) UIView* videoView;
+@property (readonly, nonatomic) WebAVPlayerLayer *webPlayerLayer;
 - (void)transferVideoViewTo:(WebAVPlayerLayerView *)playerLayerView;
 @end
 

--- a/Source/WebCore/platform/cocoa/WebAVPlayerLayerView.mm
+++ b/Source/WebCore/platform/cocoa/WebAVPlayerLayerView.mm
@@ -32,6 +32,7 @@
 #import <WebCore/VideoPresentationModel.h>
 #import <objc/message.h>
 #import <objc/runtime.h>
+#import <wtf/LoggerHelper.h>
 
 #import <pal/cf/CoreMediaSoftLink.h>
 #import <pal/cocoa/AVFoundationSoftLink.h>
@@ -42,6 +43,17 @@
 static NSString * const pictureInPicturePlayerLayerViewKey = @"_pictureInPicturePlayerLayerView";
 #endif
 
+#if !RELEASE_LOG_DISABLED
+@interface WebAVPlayerLayerView (Logging)
+@property (nonatomic) uint64_t logIdentifier;
+@property (nonatomic) const Logger* loggerPtr;
+@property (readonly, nonatomic) WTFLogChannel* logChannel;
+@end
+#endif
+
+// __PRETTY_FUNC__ does the wrong thing for C-style ObjC method implementations:
+#define C_OBJC_LOGIDENTIFIER WTF::Logger::LogSiteIdentifier(__func__, self.logIdentifier)
+
 namespace WebCore {
 
 static Class WebAVPlayerLayerView_layerClass(id, SEL)
@@ -49,53 +61,53 @@ static Class WebAVPlayerLayerView_layerClass(id, SEL)
     return [WebAVPlayerLayer class];
 }
 
-static void WebAVPlayerLayerView_transferVideoViewTo(id aSelf, SEL, WebAVPlayerLayerView *targetPlayerLayerView)
+static WebAVPlayerLayer *WebAVPlayerLayerView_webPlayerLayer(WebAVPlayerLayerView *self, SEL)
 {
-    WebAVPlayerLayerView *playerLayerView = aSelf;
-    RetainPtr videoView = [playerLayerView videoView];
-    if (!videoView)
-        return;
+    return (WebAVPlayerLayer *)[self playerLayer];
+}
 
+static void WebAVPlayerLayerView_transferVideoViewTo(WebAVPlayerLayerView *self, SEL, WebAVPlayerLayerView *targetPlayerLayerView)
+{
+    RetainPtr videoView = [self videoView];
+    if (!videoView) {
+        OBJC_ALWAYS_LOG(C_OBJC_LOGIDENTIFIER, "No videoView; bailing");
+        return;
+    }
+
+    OBJC_ALWAYS_LOG(C_OBJC_LOGIDENTIFIER, "Transferring videoView to (", targetPlayerLayerView.logIdentifier, ")");
     [CATransaction begin];
     [CATransaction setDisableActions:YES];
     [videoView removeFromSuperview];
-    [playerLayerView setVideoView:nil];
+    [self setVideoView:nil];
     [targetPlayerLayerView setVideoView:videoView.get()];
     [targetPlayerLayerView addSubview:videoView.get()];
     [CATransaction commit];
 }
 
-static AVPlayerController *WebAVPlayerLayerView_playerController(id aSelf, SEL)
+static AVPlayerController *WebAVPlayerLayerView_playerController(WebAVPlayerLayerView *self, SEL)
 {
-    __AVPlayerLayerView *playerLayer = aSelf;
-    WebAVPlayerLayer *webAVPlayerLayer = (WebAVPlayerLayer *)[playerLayer playerLayer];
-    return [webAVPlayerLayer playerController];
+    return self.webPlayerLayer.playerController;
 }
 
-static void WebAVPlayerLayerView_setPlayerController(id aSelf, SEL, AVPlayerController *playerController)
+static void WebAVPlayerLayerView_setPlayerController(WebAVPlayerLayerView *self, SEL, AVPlayerController *playerController)
 {
-    __AVPlayerLayerView *playerLayerView = aSelf;
-    WebAVPlayerLayer *webAVPlayerLayer = (WebAVPlayerLayer *)[playerLayerView playerLayer];
-    [webAVPlayerLayer setPlayerController:playerController];
+    [self.webPlayerLayer setPlayerController:playerController];
 }
 
-static AVPlayerLayer *WebAVPlayerLayerView_playerLayer(id aSelf, SEL)
+static AVPlayerLayer *WebAVPlayerLayerView_playerLayer(WebAVPlayerLayerView *self, SEL sel)
 {
-    __AVPlayerLayerView *playerLayerView = aSelf;
-
     if ([PAL::get__AVPlayerLayerViewClassSingleton() instancesRespondToSelector:@selector(playerLayer)]) {
-        objc_super superClass { playerLayerView, PAL::get__AVPlayerLayerViewClassSingleton() };
+        objc_super superClass { self, PAL::get__AVPlayerLayerViewClassSingleton() };
         auto superClassMethod = reinterpret_cast<AVPlayerLayer *(*)(objc_super *, SEL)>(objc_msgSendSuper);
-        return superClassMethod(&superClass, @selector(playerLayer));
+        return superClassMethod(&superClass, sel);
     }
 
-    return (AVPlayerLayer *)[playerLayerView layer];
+    return (AVPlayerLayer *)[self layer];
 }
 
-static UIView *WebAVPlayerLayerView_videoView(id aSelf, SEL)
+static UIView *WebAVPlayerLayerView_videoView(WebAVPlayerLayerView *self, SEL)
 {
-    __AVPlayerLayerView *playerLayerView = aSelf;
-    WebAVPlayerLayer *webAVPlayerLayer = (WebAVPlayerLayer *)[playerLayerView playerLayer];
+    WebAVPlayerLayer *webAVPlayerLayer = (WebAVPlayerLayer *)[self playerLayer];
     CALayer* videoLayer = [webAVPlayerLayer videoSublayer];
     if (!videoLayer || !videoLayer.delegate)
         return nil;
@@ -103,20 +115,20 @@ static UIView *WebAVPlayerLayerView_videoView(id aSelf, SEL)
     return (UIView *)[videoLayer delegate];
 }
 
-static void WebAVPlayerLayerView_setVideoView(id aSelf, SEL, UIView *videoView)
+static void WebAVPlayerLayerView_setVideoView(WebAVPlayerLayerView *self, SEL, UIView *videoView)
 {
-    __AVPlayerLayerView *playerLayerView = aSelf;
-    WebAVPlayerLayer *webAVPlayerLayer = (WebAVPlayerLayer *)[playerLayerView playerLayer];
+    OBJC_ALWAYS_LOG(C_OBJC_LOGIDENTIFIER, "view: ", (bool)videoView);
+    WebAVPlayerLayer *webAVPlayerLayer = (WebAVPlayerLayer *)[self playerLayer];
     [webAVPlayerLayer setVideoSublayer:[videoView layer]];
 }
 
 #if HAVE(PICTUREINPICTUREPLAYERLAYERVIEW)
-static void WebAVPlayerLayerView_startRoutingVideoToPictureInPicturePlayerLayerView(id aSelf, SEL)
+static void WebAVPlayerLayerView_startRoutingVideoToPictureInPicturePlayerLayerView(WebAVPlayerLayerView *self, SEL)
 {
-    WebAVPlayerLayerView *playerLayerView = aSelf;
-    auto *pipView = (WebAVPictureInPicturePlayerLayerView *)[playerLayerView pictureInPicturePlayerLayerView];
+    OBJC_ALWAYS_LOG(C_OBJC_LOGIDENTIFIER);
+    auto *pipView = (WebAVPictureInPicturePlayerLayerView *)[self pictureInPicturePlayerLayerView];
 
-    auto *playerLayer = (WebAVPlayerLayer *)[playerLayerView playerLayer];
+    auto *playerLayer = (WebAVPlayerLayer *)[self playerLayer];
     auto *pipPlayerLayer = (WebAVPlayerLayer *)[pipView layer];
     [playerLayer setVideoGravity:AVLayerVideoGravityResizeAspectFill];
     [pipPlayerLayer setPresentationModel:playerLayer.presentationModel];
@@ -124,51 +136,65 @@ static void WebAVPlayerLayerView_startRoutingVideoToPictureInPicturePlayerLayerV
     [pipPlayerLayer setVideoDimensions:playerLayer.videoDimensions];
     [pipPlayerLayer setVideoGravity:playerLayer.videoGravity];
     [pipPlayerLayer setPlayerController:playerLayer.playerController];
-    [pipView addSubview:playerLayerView.videoView];
+    [pipView addSubview:self.videoView];
     [pipPlayerLayer setCaptionsLayer:playerLayer.captionsLayer];
     [pipPlayerLayer layoutSublayers];
 }
 
-static void WebAVPlayerLayerView_stopRoutingVideoToPictureInPicturePlayerLayerView(id aSelf, SEL)
+static void WebAVPlayerLayerView_stopRoutingVideoToPictureInPicturePlayerLayerView(WebAVPlayerLayerView *self, SEL)
 {
-    WebAVPlayerLayerView *playerLayerView = aSelf;
-    auto *pipView = (WebAVPictureInPicturePlayerLayerView *)[playerLayerView pictureInPicturePlayerLayerView];
+    OBJC_ALWAYS_LOG(C_OBJC_LOGIDENTIFIER);
+    auto *pipView = (WebAVPictureInPicturePlayerLayerView *)[self pictureInPicturePlayerLayerView];
 
-    auto *playerLayer = (WebAVPlayerLayer *)[playerLayerView playerLayer];
+    auto *playerLayer = (WebAVPlayerLayer *)[self playerLayer];
     auto *pipPlayerLayer = (WebAVPlayerLayer *)[pipView layer];
-    [playerLayerView addSubview:playerLayerView.videoView];
+    [self addSubview:self.videoView];
     [playerLayer setCaptionsLayer:pipPlayerLayer.captionsLayer];
     [playerLayer layoutSublayers];
 }
 
-static WebAVPictureInPicturePlayerLayerView *WebAVPlayerLayerView_pictureInPicturePlayerLayerView(id aSelf, SEL)
+static WebAVPictureInPicturePlayerLayerView *WebAVPlayerLayerView_pictureInPicturePlayerLayerView(WebAVPlayerLayerView *self, SEL)
 {
-    WebAVPlayerLayerView *playerLayerView = aSelf;
-    if (WebAVPictureInPicturePlayerLayerView *pipView = [playerLayerView valueForKey:pictureInPicturePlayerLayerViewKey])
+    if (WebAVPictureInPicturePlayerLayerView *pipView = [self valueForKey:pictureInPicturePlayerLayerViewKey])
         return pipView;
 
     RetainPtr pipView = adoptNS([allocWebAVPictureInPicturePlayerLayerViewInstance() initWithFrame:CGRectZero]);
-    [playerLayerView setValue:pipView.get() forKey:pictureInPicturePlayerLayerViewKey];
+    [self setValue:pipView.get() forKey:pictureInPicturePlayerLayerViewKey];
     return pipView.autorelease();
 }
 #endif // HAVE(PICTUREINPICTUREPLAYERLAYERVIEW)
 
-static void WebAVPlayerLayerView_dealloc(id aSelf, SEL)
+static void WebAVPlayerLayerView_dealloc(WebAVPlayerLayerView *self, SEL)
 {
-    WebAVPlayerLayerView *playerLayerView = aSelf;
-
-    RetainPtr<UIView> videoView = playerLayerView.videoView;
-    [playerLayerView setVideoView:nil];
+    RetainPtr<UIView> videoView = self.videoView;
+    [self setVideoView:nil];
     [videoView removeFromSuperview];
     videoView = nil;
 
 #if HAVE(PICTUREINPICTUREPLAYERLAYERVIEW)
-    [playerLayerView setValue:nil forKey:pictureInPicturePlayerLayerViewKey];
+    [self setValue:nil forKey:pictureInPicturePlayerLayerViewKey];
 #endif
-    objc_super superClass { playerLayerView, PAL::get__AVPlayerLayerViewClassSingleton() };
+    objc_super superClass { self, PAL::get__AVPlayerLayerViewClassSingleton() };
     auto super_dealloc = reinterpret_cast<void(*)(objc_super*, SEL)>(objc_msgSendSuper);
     super_dealloc(&superClass, @selector(dealloc));
 }
+
+#if !RELEASE_LOG_DISABLED
+static uint64_t WebAVPlayerLayerView_logIdentifier(WebAVPlayerLayerView *self, SEL)
+{
+    return self.webPlayerLayer.logIdentifier;
+}
+
+static const Logger* WebAVPlayerLayerView_loggerPtr(WebAVPlayerLayerView *self, SEL)
+{
+    return self.webPlayerLayer.loggerPtr;
+}
+
+static WTFLogChannel* WebAVPlayerLayerView_logChannel(WebAVPlayerLayerView *self, SEL)
+{
+    return self.webPlayerLayer.logChannel;
+}
+#endif
 
 #pragma mark - Methods
 
@@ -179,6 +205,7 @@ WebAVPlayerLayerView *allocWebAVPlayerLayerViewInstance()
         auto theClass = objc_allocateClassPair(PAL::get__AVPlayerLayerViewClassSingleton(), "WebAVPlayerLayerView", 0);
         class_addMethod(theClass, @selector(dealloc), (IMP)WebAVPlayerLayerView_dealloc, "v@:");
         class_addMethod(theClass, @selector(transferVideoViewTo:), (IMP)WebAVPlayerLayerView_transferVideoViewTo, "v@:@");
+        class_addMethod(theClass, @selector(webPlayerLayer), (IMP)WebAVPlayerLayerView_webPlayerLayer, "@@:");
         class_addMethod(theClass, @selector(setPlayerController:), (IMP)WebAVPlayerLayerView_setPlayerController, "v@:@");
         class_addMethod(theClass, @selector(playerController), (IMP)WebAVPlayerLayerView_playerController, "@@:");
         class_addMethod(theClass, @selector(setVideoView:), (IMP)WebAVPlayerLayerView_setVideoView, "v@:@");
@@ -190,6 +217,11 @@ WebAVPlayerLayerView *allocWebAVPlayerLayerViewInstance()
         class_addMethod(theClass, @selector(pictureInPicturePlayerLayerView), (IMP)WebAVPlayerLayerView_pictureInPicturePlayerLayerView, "@@:");
         
         class_addIvar(theClass, "_pictureInPicturePlayerLayerView", sizeof(WebAVPictureInPicturePlayerLayerView *), log2(sizeof(WebAVPictureInPicturePlayerLayerView *)), "@");
+#endif
+#if !RELEASE_LOG_DISABLED
+        class_addMethod(theClass, @selector(logIdentifier), (IMP)WebAVPlayerLayerView_logIdentifier, "Q@:");
+        class_addMethod(theClass, @selector(loggerPtr), (IMP)WebAVPlayerLayerView_loggerPtr, "^v@:");
+        class_addMethod(theClass, @selector(logChannel), (IMP)WebAVPlayerLayerView_logChannel, "^v@:");
 #endif
 
         objc_registerClassPair(theClass);
@@ -206,17 +238,16 @@ static Class WebAVPictureInPicturePlayerLayerView_layerClass(id, SEL)
     return [WebAVPlayerLayer class];
 }
 
-static void WebAVPictureInPicturePlayerLayerView_dealloc(id aSelf, SEL)
+static void WebAVPictureInPicturePlayerLayerView_dealloc(WebAVPictureInPicturePlayerLayerView *self, SEL)
 {
-    WebAVPictureInPicturePlayerLayerView *pipView = aSelf;
-    WebAVPlayerLayer *pipPlayerLayer = dynamic_objc_cast<WebAVPlayerLayer>([pipView layer]);
+    WebAVPlayerLayer *pipPlayerLayer = dynamic_objc_cast<WebAVPlayerLayer>([self layer]);
 
     // Clear layer references before [super dealloc] to avoid crashes
     // during view hierarchy teardown.
     [pipPlayerLayer setVideoSublayer:nil];
     [pipPlayerLayer setCaptionsLayer:nil];
 
-    objc_super superClass { pipView, PAL::getUIViewClassSingleton() };
+    objc_super superClass { self, PAL::getUIViewClassSingleton() };
     auto super_dealloc = reinterpret_cast<void(*)(objc_super*, SEL)>(objc_msgSendSuper);
     super_dealloc(&superClass, @selector(dealloc));
 }


### PR DESCRIPTION
#### 081c4c12c5c5e20776b38bcd53856dfa9d248644
<pre>
[Cleanup] Add logging to WebAVPlayerLayerView
<a href="https://rdar.apple.com/182253584">rdar://182253584</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=319438">https://bugs.webkit.org/show_bug.cgi?id=319438</a>

Reviewed by Eric Carlson.

Add Logging to WebAVPlayerLayerView by using logger information from WebAVPlayerLayer.

But to do so with LoggerHelper, each C-style method implementation needs to have a `self`
variable which the LoggerHelper macros can use to construct the log statement. Update all
the methods signatures in WebAVPlayerLayerView.mm to declare a `self` parameter for the
first parameter, whose type is the type of the underlying class. This makes the code much
cleaner and easier to reason about, in addition to making LoggerHelper work.

* Source/WebCore/Configurations/AllowedSPI-legacy.toml:
* Source/WebCore/platform/cocoa/WebAVPlayerLayer.h:
* Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm:
* Source/WebCore/platform/cocoa/WebAVPlayerLayerView.h:
* Source/WebCore/platform/cocoa/WebAVPlayerLayerView.mm:
(WebCore::WebAVPlayerLayerView_webPlayerLayer):
(WebCore::WebAVPlayerLayerView_transferVideoViewTo):
(WebCore::WebAVPlayerLayerView_playerController):
(WebCore::WebAVPlayerLayerView_setPlayerController):
(WebCore::WebAVPlayerLayerView_playerLayer):
(WebCore::WebAVPlayerLayerView_videoView):
(WebCore::WebAVPlayerLayerView_setVideoView):
(WebCore::WebAVPlayerLayerView_startRoutingVideoToPictureInPicturePlayerLayerView):
(WebCore::WebAVPlayerLayerView_stopRoutingVideoToPictureInPicturePlayerLayerView):
(WebCore::WebAVPlayerLayerView_pictureInPicturePlayerLayerView):
(WebCore::WebAVPlayerLayerView_dealloc):
(WebCore::WebAVPlayerLayerView_logIdentifier):
(WebCore::WebAVPlayerLayerView_loggerPtr):
(WebCore::WebAVPlayerLayerView_logChannel):
(WebCore::allocWebAVPlayerLayerViewInstance):
(WebCore::WebAVPictureInPicturePlayerLayerView_dealloc):

Canonical link: <a href="https://commits.webkit.org/317289@main">https://commits.webkit.org/317289@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4e0bbff2409f8b70750f24868bd5f852952cf04

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174648 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48581 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42362 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184226 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132516 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ef3ffc07-5f70-46af-90b9-24df4ccf610e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176513 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49873 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48264 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135885 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177606 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39321 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156670 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116363 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7e1cca35-0e9c-40fd-bcfd-9f1de5964807) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37962 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36339 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32706 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148385 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36162 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186653 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39956 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40537 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144811 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48248 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144670 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39035 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48927 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32783 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114707 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39543 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120940 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47434 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11130 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46836 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47067 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46894 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->