### PR TITLE
macOS CMake: Build broken due to duplicate DOMProgressEvent interface in WebKit Swift module

### DIFF
--- a/Source/WebKit/Modules/OSX.modulemap
+++ b/Source/WebKit/Modules/OSX.modulemap
@@ -2,9 +2,4 @@ framework module WebKit [system] {
   umbrella header "WebKit.h"
   module * { export * }
   export *
-
-  explicit module DOMProgressEvent {
-    header "DOMProgressEvent.h"
-    export *
-  }
 }


### PR DESCRIPTION
#### e11b457c148021c0070d710f1ec328347fad4671
<pre>
macOS CMake: Build broken due to duplicate DOMProgressEvent interface in WebKit Swift module
<a href="https://bugs.webkit.org/show_bug.cgi?id=319446">https://bugs.webkit.org/show_bug.cgi?id=319446</a>

Reviewed by NOBODY (OOPS!).

The Swift module build for WebKit on Apple platforms now uses
-import-underlying-module, so clang compiles WebKit&apos;s own
Objective-C module from OSX.modulemap as part of the Swift step.

OSX.modulemap declared an explicit DOMProgressEvent submodule.
On macOS this is redundant: the umbrella already reaches
DOMProgressEvent.h through WebKit.h -&gt; WebKitLegacy.h -&gt; DOM.h -&gt;
DOMEvents.h.

In CMake, the forwarding-headers directory and the assembled framework
each hold a copy of DOMProgressEvent.h at a different path, so the
umbrella&apos;s include of that header and the explicit submodule&apos;s header
directive resolve to two different files. Clang then sees the same
@interface twice and fails with a duplicate interface definition.

The Xcode build does not hit this because both imports resolve to a
single file, so the explicit submodule was harmless there.

Remove the redundant submodule. DOMProgressEvent.h stays part of the
WebKit module through the umbrella, and no client imports the
WebKit.DOMProgressEvent submodule by name, so the module is unchanged
for both builds.

No new tests: build system changes only.

* Source/WebKit/Modules/OSX.modulemap:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e11b457c148021c0070d710f1ec328347fad4671

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174652 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48585 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42366 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184230 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132520 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8c65e3cb-509c-4836-be9a-f80629aa86ce) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49877 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48268 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135887 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95894 "4 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/315432e2-6b63-4b66-aa26-8aa333931c6d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177610 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39323 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156676 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116365 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b3d5c9b7-b9da-4688-8ba7-6232a4e2f472) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37964 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36341 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32710 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148387 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36168 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186657 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39960 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40539 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144815 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48252 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144674 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48931 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32789 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114711 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39547 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120944 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47438 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11136 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46840 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47071 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46898 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->