### PR TITLE
Remove stale assertion in NetworkProcess::destroySession

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -710,11 +710,6 @@ void NetworkProcess::setSession(PAL::SessionID sessionID, std::unique_ptr<Networ
 void NetworkProcess::destroySession(PAL::SessionID sessionID, CompletionHandler<void()>&& completionHandler)
 {
     ASSERT(RunLoop::isMain());
-#if !USE(SOUP) && !USE(CURL)
-    // cURL and Soup based ports destroy the default session right before the process exits to avoid leaking
-    // network resources like the cookies database.
-    ASSERT(sessionID != PAL::SessionID::defaultSessionID());
-#endif
 
     if (auto session = m_networkSessions.take(sessionID)) {
         auto dataStoreIdentifier = session->dataStoreIdentifier();


### PR DESCRIPTION
#### 7461d46a642d423be04d82011c5c548322024672
<pre>
Remove stale assertion in NetworkProcess::destroySession
<a href="https://bugs.webkit.org/show_bug.cgi?id=319448">https://bugs.webkit.org/show_bug.cgi?id=319448</a>
<a href="https://rdar.apple.com/182258579">rdar://182258579</a>

Reviewed by Alexey Proskuryakov.

TestWebKitAPI.NetworkProcess.TerminateWhenNoDefaultWebsiteDataStore hits this assertion on debug builds. The test calls
[WKWebsiteDataStore _deleteDefaultDataStoreForTesting] to release the last strong reference to the default
WebsiteDataStore, which runs WebsiteDataStore::~WebsiteDataStore() and unconditionally sends DestroySession for whatever
sessionID that WebsiteDataStore had, including the default one, to NetworkProcess.

This assertion was added in 205434@main, before _deleteDefaultDataStoreForTesting was repurposed by 251983@main to also
exercise NetworkProcess&apos;s session/process lifetime logic. At the time the assertion was introduced, the default
WebsiteDataStore held the last reference to NetworkProcessProxy for the whole lifetime of the process, so
destroySession() was never expected to run for the default session on Cocoa. That assumption no longer holds: it is
legitimate for the default session to be destroyed while NetworkProcessProxy stays alive, since all WebsiteDataStores
(default, ephemeral, custom persistent) share a single NetworkProcessProxy on Cocoa, so destroying the default session
does not necessarily mean the process is going away.

destroySession()&apos;s cleanup itself (removing the session from m_networkSessions and m_networkStorageSessions) has no
special dependency on the sessionID not being the default one, so removing the assertion does not change behavior for
any port; it only stops a stale invariant from firing on a legitimate code path.

* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::destroySession):

Canonical link: <a href="https://commits.webkit.org/317277@main">https://commits.webkit.org/317277@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6175be298562bc8ba3e9d38c68a5bf7a7e10a8ac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174655 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48588 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42369 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184233 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132523 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e560bf45-e53f-4c06-816e-b9edf7bc91cb) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49880 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48271 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135895 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95897 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9e8bb4b1-1301-48d5-9424-b97e3130132e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177613 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39328 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156679 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116373 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6005685f-e17e-45ad-ad98-e499792dad91) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37969 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36346 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32713 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148392 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36171 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186660 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39964 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40544 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144821 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48255 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144680 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39024 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48934 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32792 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114714 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39551 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120950 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47441 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11139 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46843 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47074 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46901 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->