### PR TITLE
Digital Credentials: Fix UncountedLambdaCapturesChecker failure in WebPageProxy

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -11276,25 +11276,25 @@ void WebPageProxy::showContactPicker(IPC::Connection& connection, ContactsReques
 }
 
 #if ENABLE(WEBDRIVER_BIDI) && ENABLE(WEB_AUTHN)
-template<typename StorePendingHandler>
-static bool applyVirtualWalletBehavior(const VirtualWalletBehavior& behavior, DigitalCredentialsPickerCompletionHandler&& completionHandler, NOESCAPE const StorePendingHandler& storePendingHandler)
+enum class VirtualWalletDisposition : uint8_t { NotHandled, Handled, StorePendingHandler };
+
+static VirtualWalletDisposition applyVirtualWalletBehavior(const VirtualWalletBehavior& behavior, DigitalCredentialsPickerCompletionHandler& completionHandler)
 {
     using VirtualWalletAction = Inspector::Protocol::BidiDigitalCredentials::VirtualWalletAction;
     switch (behavior.action) {
     case VirtualWalletAction::Wait:
-        storePendingHandler(WTF::move(completionHandler));
-        return true;
+        return VirtualWalletDisposition::StorePendingHandler;
     case VirtualWalletAction::Decline:
         completionHandler(makeUnexpected(WebCore::ExceptionData { WebCore::ExceptionCode::NotAllowedError, "Virtual wallet declined the request."_s }));
-        return true;
+        return VirtualWalletDisposition::Handled;
     case VirtualWalletAction::Respond:
         completionHandler(WebCore::DigitalCredentialsResponseData { behavior.protocol, behavior.responseJSON });
-        return true;
+        return VirtualWalletDisposition::Handled;
     case VirtualWalletAction::Clear:
         ASSERT_NOT_REACHED();
         break;
     }
-    return false;
+    return VirtualWalletDisposition::NotHandled;
 }
 #endif
 
@@ -11328,16 +11328,20 @@ void WebPageProxy::showDigitalCredentialsChooser(IPC::Connection& connection, st
                         contextID = automationSession->handleForWebPageProxy(*this);
                     const auto walletBehavior = agent.behaviorForContext(contextID);
                     if (walletBehavior) {
-                        bool handled = applyVirtualWalletBehavior(*walletBehavior, WTF::move(completionHandler), [&](DigitalCredentialsPickerCompletionHandler&& handler) {
+                        switch (applyVirtualWalletBehavior(*walletBehavior, completionHandler)) {
+                        case VirtualWalletDisposition::StorePendingHandler:
                             // FIXME: A concurrent request from a site-isolated cross-origin iframe (separate
                             // process) can clobber this single slot; only same-process concurrency is
                             // serialized by prepareCredentialRequests (webkit.org/b/318408).
                             ASSERT(!m_pendingDigitalCredentialsWaitContextID);
                             m_pendingDigitalCredentialsWaitContextID = contextID;
-                            agent.holdPendingHandler(contextID, WTF::move(handler));
-                        });
-                        if (handled)
+                            agent.holdPendingHandler(contextID, WTF::move(completionHandler));
                             return;
+                        case VirtualWalletDisposition::Handled:
+                            return;
+                        case VirtualWalletDisposition::NotHandled:
+                            break;
+                        }
                     }
                 }
             }
@@ -11345,12 +11349,16 @@ void WebPageProxy::showDigitalCredentialsChooser(IPC::Connection& connection, st
 
 #if ENABLE(WEBDRIVER_BIDI)
             if (const auto& testBehavior = internals().testingVirtualWalletBehavior) {
-                bool handled = applyVirtualWalletBehavior(*testBehavior, WTF::move(completionHandler), [&](DigitalCredentialsPickerCompletionHandler&& handler) {
+                switch (applyVirtualWalletBehavior(*testBehavior, completionHandler)) {
+                case VirtualWalletDisposition::StorePendingHandler:
                     settlePendingTestingDigitalCredentialHandler("Superseded by a new digital credential request."_s);
-                    internals().testingPendingDigitalCredentialHandler = WTF::move(handler);
-                });
-                if (handled)
+                    internals().testingPendingDigitalCredentialHandler = WTF::move(completionHandler);
                     return;
+                case VirtualWalletDisposition::Handled:
+                    return;
+                case VirtualWalletDisposition::NotHandled:
+                    break;
+                }
             }
 #endif
 


### PR DESCRIPTION
#### c2aac863a62f189a0ca1690a55315d81c1149075
<pre>
Digital Credentials: Fix UncountedLambdaCapturesChecker failure in WebPageProxy

<a href="https://bugs.webkit.org/show_bug.cgi?id=319450">https://bugs.webkit.org/show_bug.cgi?id=319450</a>
<a href="https://rdar.apple.com/182259354">rdar://182259354</a>

Reviewed by Ryosuke Niwa.

The virtual wallet behavior handling in showDigitalCredentialsChooser passed
this-capturing lambdas to applyVirtualWalletBehavior to store the pending
completion handler, which the UncountedLambdaCapturesChecker flagged. Replace
the callback with a VirtualWalletDisposition return value so each caller stores
the handler inline, removing the lambda capture entirely.

Canonical link: <a href="https://commits.webkit.org/317237@main">https://commits.webkit.org/317237@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/47a75b3a1c1e46538c9bf327d2d7d4e33cf1142f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174657 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48590 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42371 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184235 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132525 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bbd5f990-3dcc-4a94-bc03-89991ac97373) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49882 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48273 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135896 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177615 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39331 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156681 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116374 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2bc83308-986f-45e3-8564-0ab8eb8bb92b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37972 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36348 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32715 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148395 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36173 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186662 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39966 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40546 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144820 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48257 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144679 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39002 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48936 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32794 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39554 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120952 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47443 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11141 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46845 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47076 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46903 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->