### PR TITLE
[JSC] DFG strength reduction folds a compiler-thread RegExp execution failure into a definite no-match

### DIFF
--- a/JSTests/stress/dfg-strength-reduction-regexp-jit-code-failure-not-no-match.js
+++ b/JSTests/stress/dfg-strength-reduction-regexp-jit-code-failure-not-no-match.js
@@ -1,0 +1,25 @@
+// The Yarr JIT frame for this pattern is large enough to fail the JIT stack check on a DFG
+// compiler thread (which has a much smaller stack than the mutator), while the mutator keeps
+// matching successfully via the Yarr JIT so no bytecode ever gets compiled. DFG strength
+// reduction must treat that compiler-thread failure as "give up folding", not as a no-match.
+const termCount = 30000;
+const testRegExp = new RegExp("^" + "a?".repeat(termCount) + "$");
+const execRegExp = new RegExp("^" + "a?".repeat(termCount) + "(b)?$");
+const subject = "a";
+
+function foldableTest() {
+    return testRegExp.test(subject);
+}
+noInline(foldableTest);
+
+function foldableExec() {
+    return execRegExp.exec(subject);
+}
+noInline(foldableExec);
+
+for (let i = 0; i < testLoopCount; i++) {
+    if (!foldableTest())
+        throw new Error("test() folded to false at iteration " + i);
+    if (foldableExec() === null)
+        throw new Error("exec() folded to null at iteration " + i);
+}

--- a/Source/JavaScriptCore/runtime/RegExp.cpp
+++ b/Source/JavaScriptCore/runtime/RegExp.cpp
@@ -356,6 +356,8 @@ bool RegExp::matchConcurrently(
         return false;
 
     position = matchInline<Yarr::MatchFrom::CompilerThread>(nullptr, vm, s, startOffset, ovector);
+    if (position == static_cast<int>(Yarr::JSRegExpResult::JITCodeFailure))
+        return false;
     if (m_state == ParseError)
         return false;
     return true;
@@ -432,6 +434,8 @@ bool RegExp::matchConcurrently(VM& vm, StringView s, unsigned startOffset, Match
         return false;
 
     result = matchInline<Yarr::MatchFrom::CompilerThread>(nullptr, vm, s, startOffset);
+    if (result.start == static_cast<size_t>(Yarr::JSRegExpResult::JITCodeFailure))
+        return false;
     return true;
 }
 

--- a/Source/JavaScriptCore/runtime/RegExpInlines.h
+++ b/Source/JavaScriptCore/runtime/RegExpInlines.h
@@ -172,8 +172,10 @@ ALWAYS_INLINE int RegExp::matchInline(JSGlobalObject* nullOrGlobalObject, VM& vm
                 if (m_state == ParseError)
                     return throwError();
             }
-            if (!m_regExpBytecode)
-                return -1;
+            if (!m_regExpBytecode) {
+                ASSERT(matchFrom == Yarr::MatchFrom::CompilerThread);
+                return result;
+            }
             {
                 Yarr::MatchingContextHolder regExpContext(vm, this, matchFrom);
                 result = Yarr::interpret(m_regExpBytecode.get(), s, startOffset, reinterpret_cast<unsigned*>(offsetVector));
@@ -302,8 +304,10 @@ ALWAYS_INLINE MatchResult RegExp::matchInline(JSGlobalObject* nullOrGlobalObject
             if (m_state == ParseError)
                 return throwError();
         }
-        if (!m_regExpBytecode)
-            return MatchResult::failed();
+        if (!m_regExpBytecode) {
+            ASSERT(matchFrom == Yarr::MatchFrom::CompilerThread);
+            return result;
+        }
     }
 #endif
 


### PR DESCRIPTION
#### 338e02c8838aed9c72f9244a53c928a1e6a969e5
<pre>
[JSC] DFG strength reduction folds a compiler-thread RegExp execution failure into a definite no-match
<a href="https://bugs.webkit.org/show_bug.cgi?id=319452">https://bugs.webkit.org/show_bug.cgi?id=319452</a>

Reviewed by Yusuke Suzuki.

313689@main made RegExp bytecode compilation mutator-only: when Yarr JIT code returns
JITCodeFailure on a compiler thread and no bytecode exists, matchInline bails out with
-1 / MatchResult::failed().

That bail is indistinguishable from a real no-match. If a RegExp only ever runs via the
Yarr JIT (so bytecode is never compiled) and the JIT stack check fails against the small
compiler-thread stack, matchConcurrently reports an authoritative no-match and DFG
strength reduction permanently folds exec to null and test to false, even though the
mutator matches successfully.

This patch keeps the JITCodeFailure sentinel on the bail path and makes matchConcurrently
return false for it, so strength reduction gives up folding and defers to runtime.

    const re = new RegExp(&quot;^&quot; + &quot;a?&quot;.repeat(30000) + &quot;$&quot;);
    function f() { return re.test(&quot;a&quot;); }
    // After DFG tier-up, f() returns false forever; direct re.test(&quot;a&quot;) is true.

Test: JSTests/stress/dfg-strength-reduction-regexp-jit-code-failure-not-no-match.js

* JSTests/stress/dfg-strength-reduction-regexp-jit-code-failure-not-no-match.js: Added.
(foldableTest):
(foldableExec):
* Source/JavaScriptCore/runtime/RegExp.cpp:
(JSC::RegExp::matchConcurrently):
* Source/JavaScriptCore/runtime/RegExpInlines.h:
(JSC::RegExp::matchInline):

Canonical link: <a href="https://commits.webkit.org/317231@main">https://commits.webkit.org/317231@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a27da05647b7b5e2c14bcdfa03fa471b5bd7adcd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174659 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48592 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42373 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184237 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132527 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49884 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48275 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135898 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177617 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39333 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156686 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116376 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37974 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32717 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5195 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148397 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36178 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186664 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/35921 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39969 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40547 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144823 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48259 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144682 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38999 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48938 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39558 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120954 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/211712 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47445 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11146 "") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55229 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46847 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47078 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46905 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->