### PR TITLE
[WPT] [Linter] WEB_FEATURES.yml references WPT files that are not imported

### DIFF
--- a/Tools/Scripts/webkitpy/style/checker.py
+++ b/Tools/Scripts/webkitpy/style/checker.py
@@ -118,6 +118,12 @@ _BASE_FILTER_RULES = [
     '-runtime/threadsafe_fn',
     '-runtime/rtti',
     '-whitespace/blank_line',
+
+    # WebKit's importer drops some files (e.g. manual tests), causing these rules to trip
+    # when such missing files are the only match for entries in a WEB_FEATURES.yml file:
+    '-wpt/lint/missing_web_features_file',
+    '-wpt/lint/unnecessary_exclusion_in_web_features_file',
+
     # List Python pep8 categories last.
     #
     # Because much of WebKit's Python code base does not abide by the


### PR DESCRIPTION
#### dd7bc6ee2d58fa1c17ddb5a29f3ca584fba46e31
<pre>
[WPT] [Linter] WEB_FEATURES.yml references WPT files that are not imported
<a href="https://bugs.webkit.org/show_bug.cgi?id=319451">https://bugs.webkit.org/show_bug.cgi?id=319451</a>
<a href="https://rdar.apple.com/182259744">rdar://182259744</a>

Reviewed by Sam Sneddon.

Ignore WPT Linter rules that enforce at least one match for
WEB_FEATURES.yml entries:
 * -wpt/lint/missing_web_features_file&apos; : no match for file inclusion
 * -wpt/lint/unnecessary_exclusion_in_web_features_file&apos; : no match for exclusion

LayoutTests/imported/w3c/web-platform-tests/wpt lint --all flags 15
violations of these rules, all unhelpful. These only trip because our
tree does not have the same files as the one in the wpt repo. Run
`check-webkit-style LayoutTests/imported/w3c/web-platform-tests/gamepad/WEB_FEATURES.yml`
for an example of a violation.

* Tools/Scripts/webkitpy/style/checker.py:

Canonical link: <a href="https://commits.webkit.org/317617@main">https://commits.webkit.org/317617@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df666512fe45fc8123612dd81a770a5d34ded49f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174660 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48593 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42374 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184238 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132528 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/af13549d-278d-4b98-8a57-f02960bed991) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176525 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49885 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48276 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135899 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95902 "1 flakes 3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/14f8ff70-0da2-475b-9dc5-1594c0c578f1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177618 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39332 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156687 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116377 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/765cf0ce-4f4a-44c2-bbbd-4d931c7a7605) 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37973 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36351 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32718 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148396 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36179 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186665 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/35922 "Build is in progress. Recent messages:") | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40549 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144824 "Passed tests") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/174060 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48260 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144683 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39251 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48939 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32800 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114719 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39556 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47446 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11147 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46848 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47079 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46906 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->