### PR TITLE
[SaferCPP] analyze-safer-cpp reports "OK" for files that fail to compile

### DIFF
--- a/Tools/Scripts/analyze-safer-cpp
+++ b/Tools/Scripts/analyze-safer-cpp
@@ -598,17 +598,22 @@ def main():
         if args.verbose:
             sys.stderr.write(' '.join(shlex.quote(a) for a in argv) + '\n')
         proc = subprocess.run(argv, cwd=cwd, capture_output=True, text=True)
-        return tu, proc.stderr, header_only
+        return tu, proc.returncode, proc.stderr, header_only
 
     totalUnexpected = 0
     totalErrors = 0
     with concurrent.futures.ThreadPoolExecutor(max_workers=max(1, args.j)) as pool:
-        for tu, stderr, header_only in pool.map(runOne, workItems):
+        for tu, returncode, stderr, header_only in pool.map(runOne, workItems):
             blocks, unexpected, errors = filter_diagnostics(
                 stderr, requestedPaths, expectations, args.ignore_expectations)
             label = repo_relative(tu) + ' (header-only)' if header_only else repo_relative(tu)
             print('==> {}'.format(label))
-            if blocks:
+            if returncode != 0 and not errors:
+                print('  error: clang exited {}; file did not compile:'.format(returncode))
+                for line in stderr.splitlines():
+                    print('    ' + line)
+                errors += 1
+            elif blocks:
                 for b in blocks:
                     print(b)
             else:

--- a/Tools/Scripts/webkitpy/safer_cpp/analyze_safer_cpp_unittest.py
+++ b/Tools/Scripts/webkitpy/safer_cpp/analyze_safer_cpp_unittest.py
@@ -1,0 +1,69 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+ANALYZE_SAFER_CPP = os.path.realpath(
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..', 'analyze-safer-cpp'))
+
+
+@unittest.skipIf(sys.platform.startswith('win'), 'fake clang stub is a POSIX shell script')
+class AnalyzeSaferCppTest(unittest.TestCase):
+    def test_compile_failure_is_not_reported_as_a_clean_pass(self):
+        # A file that fails to compile (e.g. a fatal-error missing header) must not be
+        # reported as analyzed cleanly: clang's non-zero exit has to fail the run, even
+        # though a "fatal error:" line is not one of the checker diagnostics the tool parses.
+        with tempfile.TemporaryDirectory() as directory:
+            fakeClang = os.path.join(directory, 'fake-clang')
+            with open(fakeClang, 'w') as f:
+                f.write('#!/bin/sh\n'
+                        'echo "$0:1:10: fatal error: \'nope.h\' file not found" 1>&2\n'
+                        'exit 1\n')
+            os.chmod(fakeClang, 0o755)
+
+            source = os.path.join(directory, 'repro.cpp')
+            with open(source, 'w') as f:
+                f.write('#include "nope.h"\nint main() { return 0; }\n')
+
+            compileCommands = os.path.join(directory, 'compile_commands.json')
+            with open(compileCommands, 'w') as f:
+                json.dump([{'directory': directory, 'file': source,
+                            'command': 'clang++ -c {} -o {}.o'.format(source, source)}], f)
+
+            proc = subprocess.run(
+                [sys.executable, ANALYZE_SAFER_CPP, source,
+                 '--compile-commands', compileCommands, '--clang', fakeClang],
+                capture_output=True, text=True)
+
+            output = proc.stdout + proc.stderr
+            self.assertNotEqual(proc.returncode, 0,
+                                'a compile failure must not exit 0:\n' + output)
+            self.assertIn('did not compile', output)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
#### b008d85bb026f03ac31665a9f99536906c88bf77
<pre>
[SaferCPP] analyze-safer-cpp reports &quot;OK&quot; for files that fail to compile

<a href="https://bugs.webkit.org/show_bug.cgi?id=317931">https://bugs.webkit.org/show_bug.cgi?id=317931</a>
<a href="https://rdar.apple.com/181330433">rdar://181330433</a>

Reviewed by Ryosuke Niwa.

analyze-safer-cpp ignored clang&apos;s exit code, and its diagnostic regex matches
&quot;error:&quot; but not &quot;fatal error:&quot;, so a file that failed to compile was reported
as &quot;OK&quot; with a zero exit. On a configured-but-unbuilt compile_commands tree
(missing generated headers) every file &quot;passes&quot; without being analyzed.

Surface a non-zero clang exit with no parsed diagnostic as an error, printing
the file and clang&apos;s output, so a compile failure fails the run instead of
passing silently.

Canonical link: <a href="https://commits.webkit.org/317370@main">https://commits.webkit.org/317370@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/249e9056c1581e6480e192f6551c460c95c97d0c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174664 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48597 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42378 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184242 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132532 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8860eb58-16d1-44aa-8175-b78efd043b3e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176529 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49889 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48280 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135904 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95906 "4 flakes 4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7c033010-5aaa-4cc0-addd-3ef22960cf2b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177622 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39338 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156691 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116382 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bdc804d1-c13a-4857-9e58-de48f8565e27) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/173985 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37979 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36354 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32722 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148402 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36183 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186669 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40552 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144829 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48264 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144688 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39095 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48943 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32804 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114723 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39561 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47450 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11151 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46852 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47083 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46910 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->