### PR TITLE
Web Inspector: [SI] DOMManager rescans every DOM node for each pending frame document when splicing

### DIFF
--- a/LayoutTests/inspector/unit-tests/dom-frame-document-splice-expected.txt
+++ b/LayoutTests/inspector/unit-tests/dom-frame-document-splice-expected.txt
@@ -1,0 +1,57 @@
+Tests DOMManager frame-document splicing: URL matching, deferred/JS-inserted iframes, duplicate URLs, and destroyed-node handling.
+
+
+== Running test suite: DOMManager.FrameDocumentSplice
+-- Running test case: ImmediateExactURLMatch
+PASS: Should splice.
+PASS: iframe.contentDocument should be the frame document.
+PASS: Frame document's parentNode should be the iframe.
+PASS: iframe should have a single child.
+PASS: iframe's child should be the frame document.
+PASS: ChildNodeCountUpdated should fire once.
+PASS: NodeInserted should fire once for (frameDocument, iframe).
+
+-- Running test case: RelativeSrcResolvedAgainstOwnerDocument
+PASS: Relative src should resolve and match.
+PASS: iframe.contentDocument should be set.
+
+-- Running test case: NoMatchLeavesDocumentUnspliced
+PASS: Should not splice.
+PASS: iframe.contentDocument should remain unset.
+
+-- Running test case: DeferredSpliceOnLaterInsertedIframe
+PASS: With no iframe yet, the document stays unspliced.
+PASS: Frame document should not be parented yet.
+PASS: Unspliced list should drain after the iframe appears.
+PASS: The newly-inserted iframe should adopt the pending frame document.
+
+-- Running test case: DistinctURLsMatchDistinctIframes
+PASS: Both documents should splice.
+PASS: iframe A should adopt doc A.
+PASS: iframe B should adopt doc B.
+
+-- Running test case: TwoDocumentsSameURLOneIframeConsumesOnlyOne
+PASS: The single iframe should adopt the first matching document.
+PASS: The second same-URL document should remain unspliced.
+PASS: The leftover document should be the second one.
+
+-- Running test case: TwoDocumentsSameURLTwoIframesEachConsumesOne
+PASS: Both documents should splice.
+PASS: First iframe should adopt the first document.
+PASS: Second iframe should adopt the second document.
+
+-- Running test case: IframeWithExistingContentDocumentSkipped
+PASS: Should not re-match an already-populated iframe.
+PASS: Existing contentDocument should be untouched.
+
+-- Running test case: DestroyedIframeSkipped
+PASS: Should not splice into a destroyed iframe.
+
+-- Running test case: DestroyedPendingDocumentDropped
+PASS: Both entries should leave the unspliced list.
+PASS: The live document should splice.
+
+-- Running test case: LegacyFrameElementMatches
+PASS: Should splice into a <frame>.
+PASS: <frame>.contentDocument should be set.
+

--- a/LayoutTests/inspector/unit-tests/dom-frame-document-splice.html
+++ b/LayoutTests/inspector/unit-tests/dom-frame-document-splice.html
@@ -1,0 +1,256 @@
+<!DOCTYPE html>
+<html>
+<head>
+
+<!-- This test is symlinked and run from a different location to test site isolated behaviors. Attempt to find the test driver from two possible places. -->
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script src="../../../../../inspector/resources/inspector-test.js"></script>
+
+<script>
+function test()
+{
+    const DOCUMENT_NODE = 9;
+    const ELEMENT_NODE = 1;
+
+    let nextNodeId = 1;
+
+    // Build a standalone DOMManager per test case so _idToDOMNode / _unsplicedFrameDocuments
+    // are isolated. Constructing WI.DOMNode against a manager auto-registers it in that
+    // manager's _idToDOMNode, which is exactly what the splice logic scans.
+    function makeManager() {
+        return new WI.DOMManager;
+    }
+
+    function makeDocument(manager, url) {
+        return new WI.DOMNode(manager, null, false, {
+            nodeId: nextNodeId++,
+            nodeType: DOCUMENT_NODE,
+            nodeName: "#document",
+            documentURL: url,
+        });
+    }
+
+    function makeFrameElement(manager, ownerDocument, src, {nodeName = "IFRAME"} = {}) {
+        return new WI.DOMNode(manager, ownerDocument, false, {
+            nodeId: nextNodeId++,
+            nodeType: ELEMENT_NODE,
+            nodeName,
+            localName: nodeName.toLowerCase(),
+            attributes: src != null ? ["src", src] : [],
+        });
+    }
+
+    // A cross-origin frame document is modeled the same way as any document node.
+    let makeFrameDocument = makeDocument;
+
+    let suite = InspectorTest.createSyncSuite("DOMManager.FrameDocumentSplice");
+
+    suite.addTestCase({
+        name: "ImmediateExactURLMatch",
+        description: "A frame document splices into the iframe whose src exactly matches its documentURL.",
+        test() {
+            let manager = makeManager();
+            let pageDocument = makeDocument(manager, "https://example.com/");
+            let iframe = makeFrameElement(manager, pageDocument, "https://frames.test/a.html");
+            let frameDocument = makeFrameDocument(manager, "https://frames.test/a.html");
+
+            let childNodeCountEvents = 0;
+            let nodeInsertedEvents = 0;
+            manager.addEventListener(WI.DOMManager.Event.ChildNodeCountUpdated, () => { ++childNodeCountEvents; });
+            manager.addEventListener(WI.DOMManager.Event.NodeInserted, (event) => {
+                if (event.data.node === frameDocument && event.data.parent === iframe)
+                    ++nodeInsertedEvents;
+            });
+
+            InspectorTest.expectTrue(manager._trySpliceFrameDocumentIntoNode(frameDocument), "Should splice.");
+            InspectorTest.expectEqual(iframe._contentDocument, frameDocument, "iframe.contentDocument should be the frame document.");
+            InspectorTest.expectEqual(frameDocument.parentNode, iframe, "Frame document's parentNode should be the iframe.");
+            InspectorTest.expectEqual(iframe._children.length, 1, "iframe should have a single child.");
+            InspectorTest.expectEqual(iframe._children[0], frameDocument, "iframe's child should be the frame document.");
+            InspectorTest.expectEqual(childNodeCountEvents, 1, "ChildNodeCountUpdated should fire once.");
+            InspectorTest.expectEqual(nodeInsertedEvents, 1, "NodeInserted should fire once for (frameDocument, iframe).");
+        }
+    });
+
+    suite.addTestCase({
+        name: "RelativeSrcResolvedAgainstOwnerDocument",
+        description: "A relative iframe src is resolved against the parent document URL before matching.",
+        test() {
+            let manager = makeManager();
+            let pageDocument = makeDocument(manager, "https://example.com/dir/page.html");
+            let iframe = makeFrameElement(manager, pageDocument, "child.html");
+            let frameDocument = makeFrameDocument(manager, "https://example.com/dir/child.html");
+
+            InspectorTest.expectTrue(manager._trySpliceFrameDocumentIntoNode(frameDocument), "Relative src should resolve and match.");
+            InspectorTest.expectEqual(iframe._contentDocument, frameDocument, "iframe.contentDocument should be set.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "NoMatchLeavesDocumentUnspliced",
+        description: "A frame document with no matching iframe is not spliced.",
+        test() {
+            let manager = makeManager();
+            let pageDocument = makeDocument(manager, "https://example.com/");
+            let iframe = makeFrameElement(manager, pageDocument, "https://frames.test/a.html");
+            let frameDocument = makeFrameDocument(manager, "https://frames.test/b.html");
+
+            InspectorTest.expectFalse(manager._trySpliceFrameDocumentIntoNode(frameDocument), "Should not splice.");
+            InspectorTest.expectNull(iframe._contentDocument ?? null, "iframe.contentDocument should remain unset.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "DeferredSpliceOnLaterInsertedIframe",
+        description: "A frame document that arrives before its iframe splices once the iframe is later inserted (the JS-insertion retry path).",
+        test() {
+            let manager = makeManager();
+            let pageDocument = makeDocument(manager, "https://example.com/");
+            let frameDocument = makeFrameDocument(manager, "https://frames.test/a.html");
+
+            // Frame document arrived first: it sits in the unspliced list.
+            manager._unsplicedFrameDocuments.push(frameDocument);
+            manager._trySpliceUnsplicedFrameDocuments();
+            InspectorTest.expectEqual(manager._unsplicedFrameDocuments.length, 1, "With no iframe yet, the document stays unspliced.");
+            InspectorTest.expectNull(frameDocument.parentNode ?? null, "Frame document should not be parented yet.");
+
+            // A matching iframe is later inserted (e.g. via script). This is the pass that _childNodeInserted triggers.
+            let iframe = makeFrameElement(manager, pageDocument, "https://frames.test/a.html");
+            manager._trySpliceUnsplicedFrameDocuments();
+
+            InspectorTest.expectEqual(manager._unsplicedFrameDocuments.length, 0, "Unspliced list should drain after the iframe appears.");
+            InspectorTest.expectEqual(iframe._contentDocument, frameDocument, "The newly-inserted iframe should adopt the pending frame document.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "DistinctURLsMatchDistinctIframes",
+        description: "Multiple pending documents each splice into their own iframe by URL, regardless of ordering.",
+        test() {
+            let manager = makeManager();
+            let pageDocument = makeDocument(manager, "https://example.com/");
+            let iframeA = makeFrameElement(manager, pageDocument, "https://frames.test/a.html");
+            let iframeB = makeFrameElement(manager, pageDocument, "https://frames.test/b.html");
+            let docB = makeFrameDocument(manager, "https://frames.test/b.html");
+            let docA = makeFrameDocument(manager, "https://frames.test/a.html");
+
+            // Pending order (B, A) is intentionally the reverse of element order (A, B).
+            manager._unsplicedFrameDocuments.push(docB, docA);
+            manager._trySpliceUnsplicedFrameDocuments();
+
+            InspectorTest.expectEqual(manager._unsplicedFrameDocuments.length, 0, "Both documents should splice.");
+            InspectorTest.expectEqual(iframeA._contentDocument, docA, "iframe A should adopt doc A.");
+            InspectorTest.expectEqual(iframeB._contentDocument, docB, "iframe B should adopt doc B.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "TwoDocumentsSameURLOneIframeConsumesOnlyOne",
+        description: "Within one pass, a matched iframe is not reused; a duplicate-URL document stays unspliced.",
+        test() {
+            let manager = makeManager();
+            let pageDocument = makeDocument(manager, "https://example.com/");
+            let iframe = makeFrameElement(manager, pageDocument, "https://frames.test/a.html");
+            let doc1 = makeFrameDocument(manager, "https://frames.test/a.html");
+            let doc2 = makeFrameDocument(manager, "https://frames.test/a.html");
+
+            manager._unsplicedFrameDocuments.push(doc1, doc2);
+            manager._trySpliceUnsplicedFrameDocuments();
+
+            InspectorTest.expectEqual(iframe._contentDocument, doc1, "The single iframe should adopt the first matching document.");
+            InspectorTest.expectEqual(manager._unsplicedFrameDocuments.length, 1, "The second same-URL document should remain unspliced.");
+            InspectorTest.expectEqual(manager._unsplicedFrameDocuments[0], doc2, "The leftover document should be the second one.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "TwoDocumentsSameURLTwoIframesEachConsumesOne",
+        description: "A reused candidate snapshot still lets a second document match a second same-URL iframe.",
+        test() {
+            let manager = makeManager();
+            let pageDocument = makeDocument(manager, "https://example.com/");
+            let iframe1 = makeFrameElement(manager, pageDocument, "https://frames.test/a.html");
+            let iframe2 = makeFrameElement(manager, pageDocument, "https://frames.test/a.html");
+            let doc1 = makeFrameDocument(manager, "https://frames.test/a.html");
+            let doc2 = makeFrameDocument(manager, "https://frames.test/a.html");
+
+            manager._unsplicedFrameDocuments.push(doc1, doc2);
+            manager._trySpliceUnsplicedFrameDocuments();
+
+            InspectorTest.expectEqual(manager._unsplicedFrameDocuments.length, 0, "Both documents should splice.");
+            InspectorTest.expectEqual(iframe1._contentDocument, doc1, "First iframe should adopt the first document.");
+            InspectorTest.expectEqual(iframe2._contentDocument, doc2, "Second iframe should adopt the second document.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "IframeWithExistingContentDocumentSkipped",
+        description: "An iframe that already has a contentDocument is not re-matched.",
+        test() {
+            let manager = makeManager();
+            let pageDocument = makeDocument(manager, "https://example.com/");
+            let iframe = makeFrameElement(manager, pageDocument, "https://frames.test/a.html");
+            let existingDocument = makeFrameDocument(manager, "https://frames.test/a.html");
+            iframe._contentDocument = existingDocument;
+
+            let newDocument = makeFrameDocument(manager, "https://frames.test/a.html");
+            InspectorTest.expectFalse(manager._trySpliceFrameDocumentIntoNode(newDocument), "Should not re-match an already-populated iframe.");
+            InspectorTest.expectEqual(iframe._contentDocument, existingDocument, "Existing contentDocument should be untouched.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "DestroyedIframeSkipped",
+        description: "A destroyed iframe node is never a splice target.",
+        test() {
+            let manager = makeManager();
+            let pageDocument = makeDocument(manager, "https://example.com/");
+            let iframe = makeFrameElement(manager, pageDocument, "https://frames.test/a.html");
+            iframe.markDestroyed();
+            let frameDocument = makeFrameDocument(manager, "https://frames.test/a.html");
+
+            InspectorTest.expectFalse(manager._trySpliceFrameDocumentIntoNode(frameDocument), "Should not splice into a destroyed iframe.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "DestroyedPendingDocumentDropped",
+        description: "A destroyed pending document is dropped from the unspliced list without matching.",
+        test() {
+            let manager = makeManager();
+            let pageDocument = makeDocument(manager, "https://example.com/");
+            let iframe = makeFrameElement(manager, pageDocument, "https://frames.test/a.html");
+            let deadDocument = makeFrameDocument(manager, "https://frames.test/a.html");
+            deadDocument.markDestroyed();
+            let liveDocument = makeFrameDocument(manager, "https://frames.test/a.html");
+
+            manager._unsplicedFrameDocuments.push(deadDocument, liveDocument);
+            manager._trySpliceUnsplicedFrameDocuments();
+
+            InspectorTest.expectEqual(manager._unsplicedFrameDocuments.length, 0, "Both entries should leave the unspliced list.");
+            InspectorTest.expectEqual(iframe._contentDocument, liveDocument, "The live document should splice.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "LegacyFrameElementMatches",
+        description: "A <frame> element (not just <iframe>) is a valid splice target.",
+        test() {
+            let manager = makeManager();
+            let pageDocument = makeDocument(manager, "https://example.com/");
+            let frame = makeFrameElement(manager, pageDocument, "https://frames.test/a.html", {nodeName: "FRAME"});
+            let frameDocument = makeFrameDocument(manager, "https://frames.test/a.html");
+
+            InspectorTest.expectTrue(manager._trySpliceFrameDocumentIntoNode(frameDocument), "Should splice into a <frame>.");
+            InspectorTest.expectEqual(frame._contentDocument, frameDocument, "<frame>.contentDocument should be set.");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Tests DOMManager frame-document splicing: URL matching, deferred/JS-inserted iframes, duplicate URLs, and destroyed-node handling.</p>
+</body>
+</html>

--- a/Source/WebInspectorUI/UserInterface/Controllers/DOMManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/DOMManager.js
@@ -165,19 +165,29 @@ WI.DOMManager = class DOMManager extends WI.Object
     // FIXME: <https://webkit.org/b/298980> URL-based matching is fragile (breaks with redirects,
     // blob: URLs, about:srcdoc, query strings). Use frame identity information (frame ID or target ID)
     // threaded through Target.targetCreated to directly look up the parent iframe element.
-    _trySpliceFrameDocumentIntoNode(frameDocument)
+    _unmatchedFrameNodes()
     {
-        let frameDocURL = frameDocument.documentURL;
-
+        // Only iframe/frame elements without a contentDocument are splice candidates.
+        let frameNodes = [];
         for (let node of Object.values(this._idToDOMNode)) {
-            if (node._destroyed)
+            if (node._destroyed || node._contentDocument)
                 continue;
 
             let nodeName = node._nodeName;
-            if (nodeName !== "IFRAME" && nodeName !== "FRAME")
-                continue;
+            if (nodeName === "IFRAME" || nodeName === "FRAME")
+                frameNodes.push(node);
+        }
+        return frameNodes;
+    }
 
-            if (node._contentDocument)
+    _trySpliceFrameDocumentIntoNode(frameDocument, candidateNodes)
+    {
+        let frameDocURL = frameDocument.documentURL;
+        let frameDocHref = null;
+
+        for (let node of candidateNodes || this._unmatchedFrameNodes()) {
+            // A node may have been matched by an earlier document in this pass.
+            if (node._destroyed || node._contentDocument)
                 continue;
 
             let srcAttr = node.getAttribute("src");
@@ -185,14 +195,13 @@ WI.DOMManager = class DOMManager extends WI.Object
                 continue;
 
             // Match by URL: exact match, then resolve relative src against parent document.
-            let matched = false;
-            if (srcAttr === frameDocURL)
-                matched = true;
-            else {
+            let matched = srcAttr === frameDocURL;
+            if (!matched) {
                 try {
                     let srcURL = new URL(srcAttr, node.ownerDocument ? node.ownerDocument.documentURL : undefined);
-                    let docURL = new URL(frameDocURL);
-                    if (srcURL.href === docURL.href)
+                    if (frameDocHref === null)
+                        frameDocHref = new URL(frameDocURL).href;
+                    if (srcURL.href === frameDocHref)
                         matched = true;
                 } catch (e) {
                 }
@@ -217,10 +226,16 @@ WI.DOMManager = class DOMManager extends WI.Object
         if (!this._unsplicedFrameDocuments.length)
             return;
 
+        // Collect candidate frame nodes once and reuse across all pending documents,
+        // rather than rescanning every DOM node for each pending document.
+        let candidateNodes = this._unmatchedFrameNodes();
+        if (!candidateNodes.length)
+            return;
+
         this._unsplicedFrameDocuments = this._unsplicedFrameDocuments.filter((doc) => {
             if (doc._destroyed)
                 return false;
-            return !this._trySpliceFrameDocumentIntoNode(doc);
+            return !this._trySpliceFrameDocumentIntoNode(doc, candidateNodes);
         });
     }
 


### PR DESCRIPTION
#### c009a18f6225d1341f04ef7b30d9afd879ff3435
<pre>
Web Inspector: [SI] DOMManager rescans every DOM node for each pending frame document when splicing
<a href="https://bugs.webkit.org/show_bug.cgi?id=319454">https://bugs.webkit.org/show_bug.cgi?id=319454</a>
<a href="https://rdar.apple.com/182266167">rdar://182266167</a>

Reviewed by NOBODY (OOPS!).

When a cross-origin frame document arrives before its owning iframe element is known,
it is queued and re-tried later. _trySpliceUnsplicedFrameDocuments() ran that retry by
calling _trySpliceFrameDocumentIntoNode() once per pending document, and each call
allocated a fresh Object.values(this._idToDOMNode) and linearly scanned every known DOM
node to find a matching iframe/frame element. It also constructed a new URL for the
frame document&apos;s URL on every candidate node. The result was O(pendingDocuments *
totalNodes) work with a per-document array allocation and redundant per-node URL parsing.

Collect the candidate iframe/frame elements once per pass in _unmatchedFrameNodes() and
reuse that list across all pending documents, and resolve the frame document&apos;s URL lazily
at most once per document. This lowers the cost to O(totalNodes + pendingDocuments *
frameElements) with no behavior change: an element matched by an earlier document in the
same pass is still skipped via its now-set contentDocument, so duplicate-URL documents and
already-populated iframes behave exactly as before.

Test: inspector/unit-tests/dom-frame-document-splice.html

* LayoutTests/inspector/unit-tests/dom-frame-document-splice-expected.txt: Added.
* LayoutTests/inspector/unit-tests/dom-frame-document-splice.html: Added.
* Source/WebInspectorUI/UserInterface/Controllers/DOMManager.js:
(WI.DOMManager.prototype._unmatchedFrameNodes):
(WI.DOMManager.prototype._trySpliceFrameDocumentIntoNode):
(WI.DOMManager.prototype._trySpliceUnsplicedFrameDocuments):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c009a18f6225d1341f04ef7b30d9afd879ff3435

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174666 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48599 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42380 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184244 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132534 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a63b6e8c-d67d-45b7-95a6-0ede8b884e43) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49891 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48282 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135905 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95909 "3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d4a79c79-e62e-4ae4-a757-2be48e6b1281) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177624 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39339 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156693 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116383 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2df4cf00-ffc1-4c7e-9846-110a852261e3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37980 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36357 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32724 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148403 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36185 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186671 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39981 "Found 121 new failures in b3/testb3_7.cpp, b3/B3Value.h, WebProcess/Network/WebResourceLoader.cpp, UIProcess/WebProcessPool.cpp, Shared/Cocoa/WKNSArray.mm, Shared/SessionState.cpp, NetworkProcess/NetworkResourceLoadParameters.cpp, WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm, WebProcess/WebPage/WebPage.cpp, WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm ...") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40555 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144830 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48266 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156249 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144689 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48945 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32806 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114725 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39563 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120962 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47452 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11153 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46854 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47085 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46912 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->