### PR TITLE
Canvas drawTextUnchecked does't always draw when using maxWidth

### DIFF
--- a/LayoutTests/fast/canvas/fillText-maxWidth-edge-clip-expected.html
+++ b/LayoutTests/fast/canvas/fillText-maxWidth-edge-clip-expected.html
@@ -1,0 +1,31 @@
+<html>
+<body>
+<canvas width="200" height="200" style="border: solid 1px gray"></canvas>
+<script>
+const text = "Hi";
+const clip = 20;
+const iterations = 10;
+const increment = 4;
+
+const canvas = document.getElementsByTagName('canvas')[0];
+const width = canvas.width / 2 - clip;
+const height = canvas.height / 2;
+const ctx = canvas.getContext('2d');
+
+ctx.font = "10px monospace";
+ctx.fillStyle = "blue";
+
+const maxWidth = Math.floor(ctx.measureText(text).width) - 1;
+
+for (let i = 0; i < iterations; ++i) {
+  const x = width + (i - iterations / 2) * increment;
+  const y = i * 10;
+  ctx.fillText("Hi", x, y, maxWidth);
+}
+
+ctx.clearRect(width, 0, canvas.width, canvas.height);
+ctx.clearRect(0, height, canvas.width, canvas.height);
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/canvas/fillText-maxWidth-edge-clip.html
+++ b/LayoutTests/fast/canvas/fillText-maxWidth-edge-clip.html
@@ -1,0 +1,32 @@
+<html>
+<body>
+<canvas width="200" height="200" style="border: solid 1px gray"></canvas>
+<script>
+const text = "Hi";
+const clip = 20;
+const iterations = 10;
+const increment = 4;
+
+const canvas = document.getElementsByTagName('canvas')[0];
+const width = canvas.width / 2 - clip;
+const height = canvas.height / 2;
+const ctx = canvas.getContext('2d');
+
+let region = new Path2D();
+region.rect(0, 0, width, height);
+ctx.clip(region);
+
+ctx.font = "10px monospace";
+ctx.fillStyle = "blue";
+
+const maxWidth = Math.floor(ctx.measureText(text).width) - 1;
+
+for (let i = 0; i < iterations; ++i) {
+  const x = width + (i - iterations / 2) * increment;
+  const y = i * 10;
+  ctx.fillText(text, x, y, maxWidth);
+}
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -3046,7 +3046,7 @@ void CanvasRenderingContext2DBase::drawTextUnchecked(const TextRun& textRun, dou
         repaintEntireCanvas = true;
     } else {
         auto clipBounds = c->clipBounds();
-        if ((clipBounds.isEmpty() || (!textRect.isEmpty() && !clipBounds.intersects(enclosingIntRect(textRect)))) && !shouldDrawShadows())
+        if ((clipBounds.isEmpty() || (!useMaxWidth && !textRect.isEmpty() && !clipBounds.intersects(enclosingIntRect(textRect)))) && !shouldDrawShadows())
             return;
         drawText(*c, location);
     }


### PR DESCRIPTION
#### 4a04a6e57b9fec788b0b26fbfd601125906108c9
<pre>
Canvas drawTextUnchecked does&apos;t always draw when using maxWidth
<a href="https://bugs.webkit.org/show_bug.cgi?id=319455">https://bugs.webkit.org/show_bug.cgi?id=319455</a>
<a href="https://rdar.apple.com/179479689">rdar://179479689</a>

Reviewed by Mike Wyrzykowski.

When a `maxWidth` is provided, and is smaller than the actual text width,
the text is shrunk by translating and scaling the context.
However the computed `textRect` is not changed accordingly, so its
intersection with the updated context clip is now incorrect, leading to
some texts not being drawn at all.

The fix here is never to optimize out `maxWidth`-shortened texts.

* LayoutTests/fast/canvas/fillText-maxWidth-edge-clip-expected.html: Added.
* LayoutTests/fast/canvas/fillText-maxWidth-edge-clip.html: Added.
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::drawTextUnchecked):

Canonical link: <a href="https://commits.webkit.org/317260@main">https://commits.webkit.org/317260@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ab265d33504c860f564385ee6a48755384475fe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174685 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48618 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42399 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184264 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132553 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a2b80f59-b056-4d1c-8838-48b4f5a1d5f6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176550 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49910 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48301 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135922 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d812c2b0-55bb-4cea-8cea-8611752adbcd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177643 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39356 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156709 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116400 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/70f1c5c9-ca71-4a23-8d79-8cf79bf3683a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37997 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36375 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32743 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148420 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36201 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186690 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/40012 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40573 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144846 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48285 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156265 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144706 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39013 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48965 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32822 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39579 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120991 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47471 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11169 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46873 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47104 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46931 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->