### PR TITLE
[Web Inspector] Avoid redundant String copy of request URL in InspectorNetworkAgent::willSendRequest

### DIFF
--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
@@ -420,7 +420,7 @@ void InspectorNetworkAgent::willSendRequest(ResourceLoaderIdentifier identifier,
     RefPtr document = loader && loader->frame() ? loader->frame()->document() : nullptr;
     auto initiatorObject = buildInitiatorObject(document, &request);
 
-    String url = loader ? loader->url().string() : request.url().string();
+    auto& url = loader ? loader->url().string() : request.url().string();
     std::optional<Inspector::Protocol::Page::ResourceType> typePayload;
     if (type != ResourceType::Other)
         typePayload = protocolResourceType;


### PR DESCRIPTION
#### 836e1d17c4ea38f965511d9d13acf983d50760e5
<pre>
[Web Inspector] Avoid redundant String copy of request URL in InspectorNetworkAgent::willSendRequest
<a href="https://bugs.webkit.org/show_bug.cgi?id=319456">https://bugs.webkit.org/show_bug.cgi?id=319456</a>
<a href="https://rdar.apple.com/182268053">rdar://182268053</a>

Reviewed by Devin Rousso.

In willSendRequest(), the local `url` was declared as `String`, copying the
string returned by `DocumentLoader::url().string()` / `ResourceRequest::url().string()`.
Both accessors return a `const URL&amp;` (LIFETIME_BOUND) and `URL::string()` returns
a `const String&amp;`, so the value can be bound directly to a reference. Both the
loader and the request outlive the requestWillBeSent() dispatch, and the frontend
dispatcher takes `const String&amp; documentURL`, so no copy is required.

Bind `url` with `auto&amp;` (deduces to `const String&amp;`) to drop the gratuitous
ref-count churn.

* Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp:
(WebCore::InspectorNetworkAgent::willSendRequest):

Canonical link: <a href="https://commits.webkit.org/317223@main">https://commits.webkit.org/317223@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c3b33925384e88a84d4a5d9b3cd204ef81def3e9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174668 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48601 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42382 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184246 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132536 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ead48cb1-b869-4652-9c37-d9a24eed9ba5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176533 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49893 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48284 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135907 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95910 "Build is in progress. Recent messages:") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e34c620a-9d2e-4f3d-b0a2-f1779f89a0a9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177626 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39340 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/156695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116385 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2db87761-34b7-4c5d-b421-c65644affa81) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37981 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32726 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148404 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36187 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186673 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/39984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144831 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48268 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144690 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38994 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48954 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39569 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/120964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47454 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11155 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46856 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47087 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46914 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->