### PR TITLE
[GTK] Add Expiration Dates to WebKitWebExtensionMatchPattern

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitWebExtensionMatchPattern.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebExtensionMatchPattern.cpp
@@ -54,6 +54,7 @@ struct _WebKitWebExtensionMatchPattern {
     CString path { matchPattern->path().utf8() };
     bool matchesAllURLs { matchPattern->matchesAllURLs() };
     bool matchesAllHosts { matchPattern->matchesAllHosts() };
+    GRefPtr<GDateTime> expiration;
     int referenceCount { 1 };
 #else
     _WebKitWebExtensionMatchPattern()
@@ -362,6 +363,42 @@ static OptionSet<WebExtensionMatchPattern::Options> toImpl(WebKitWebExtensionMat
 }
 
 /**
+ * webkit_web_extension_match_pattern_get_expiration_date:
+ * @matchPattern: A #WebKitWebExtensionMatchPattern
+ *
+ * Get the expiration date of @matchPattern. If the match pattern does not expire, a distant future date will be returned instead.
+ *
+ * Since: 2.54
+ */
+GDateTime* webkit_web_extension_match_pattern_get_expiration_date(WebKitWebExtensionMatchPattern* matchPattern)
+{
+    g_return_val_if_fail(matchPattern, nullptr);
+
+    if (matchPattern->expiration)
+        return matchPattern->expiration.get();
+    return g_date_time_new_utc(9999, 12, 31, 23, 59, 00);
+}
+
+/**
+ * webkit_web_extension_match_pattern_set_expiration_date:
+ * @matchPattern: A #WebKitWebExtensionMatchPattern
+ * @expirationDate: The expiration date for this pattern
+ *
+ * Specify the expiration date for the provided match pattern.
+ *
+ * If no expiration date is provided, or the match pattern should not expire, a date in the distant future will be used.
+ *
+ * Since: 2.54
+ */
+void webkit_web_extension_match_pattern_set_expiration_date(WebKitWebExtensionMatchPattern* matchPattern, GDateTime* expirationDate)
+{
+    g_return_if_fail(matchPattern);
+    g_return_if_fail(expirationDate);
+
+    matchPattern->expiration = adoptGRef(expirationDate);
+}
+
+/**
  * webkit_web_extension_match_pattern_matches_url:
  * @matchPattern: A #WebKitWebExtensionMatchPattern
  * @url: The URL to match against the pattern.
@@ -380,7 +417,6 @@ gboolean webkit_web_extension_match_pattern_matches_url(WebKitWebExtensionMatchP
 
     if (options & WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_MATCH_BIDIRECTIONALLY)
         g_warning("Invalid parameter: WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_MATCH_BIDIRECTIONALLY is not valid when matching a URL");
-
 
     return matchPattern->matchPattern->matchesURL(URL(String::fromUTF8(url)), toImpl(options));
 }
@@ -470,6 +506,16 @@ gboolean webkit_web_extension_match_pattern_get_matches_all_urls(WebKitWebExtens
 gboolean webkit_web_extension_match_pattern_get_matches_all_hosts(WebKitWebExtensionMatchPattern* matchPattern)
 {
     return 0;
+}
+
+GDateTime* webkit_web_extension_match_pattern_get_expiration_date(WebKitWebExtensionMatchPattern* matchPattern)
+{
+    return 0;
+}
+
+void webkit_web_extension_match_pattern_set_expiration_date(WebKitWebExtensionMatchPattern* matchPattern, GDateTime* expirationDate)
+{
+    return;
 }
 
 gboolean webkit_web_extension_match_pattern_matches_url(WebKitWebExtensionMatchPattern* matchPattern, const gchar* url, WebKitWebExtensionMatchPatternOptions  options)

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebExtensionMatchPattern.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebExtensionMatchPattern.h.in
@@ -99,6 +99,13 @@ webkit_web_extension_match_pattern_get_matches_all_urls (WebKitWebExtensionMatch
 WEBKIT_API gboolean
 webkit_web_extension_match_pattern_get_matches_all_hosts (WebKitWebExtensionMatchPattern *matchPattern);
 
+WEBKIT_API GDateTime*
+webkit_web_extension_match_pattern_get_expiration_date (WebKitWebExtensionMatchPattern *matchPattern);
+
+WEBKIT_API void
+webkit_web_extension_match_pattern_set_expiration_date (WebKitWebExtensionMatchPattern *matchPattern,
+                                                        GDateTime                      *expirationDate);
+
 WEBKIT_API gboolean
 webkit_web_extension_match_pattern_matches_url (WebKitWebExtensionMatchPattern        *matchPattern,
                                                 const gchar                           *url,

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKPage/glib/TestWebKitWebExtensionMatchPattern.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKPage/glib/TestWebKitWebExtensionMatchPattern.cpp
@@ -978,6 +978,26 @@ static void testCustomURLScheme(Test*, gconstpointer)
     g_assert_no_error(error.get());
 }
 
+static void testExpirationDate(Test*, gconstpointer)
+{
+    GUniqueOutPtr<GError> error;
+
+    auto expirationDate = g_date_time_new_now_local();
+
+    WebKitWebExtensionMatchPattern* matchPattern = webkit_web_extension_match_pattern_new_all_urls();
+    webkit_web_extension_match_pattern_set_expiration_date(matchPattern, expirationDate);
+
+    g_assert_cmpint(g_date_time_equal(expirationDate, webkit_web_extension_match_pattern_get_expiration_date(matchPattern)), ==, TRUE);
+
+    // Ensure that a second match pattern doesn't also have the same expiration date
+    WebKitWebExtensionMatchPattern* secondMatchPattern = webkit_web_extension_match_pattern_new_all_urls();
+    g_assert_cmpint(g_date_time_equal(expirationDate, webkit_web_extension_match_pattern_get_expiration_date(secondMatchPattern)), ==, FALSE);
+
+    // Ensure a newly created match pattern is at least 100 years off
+    matchPattern = webkit_web_extension_match_pattern_new_all_urls();
+    g_assert_cmpint(g_date_time_difference(webkit_web_extension_match_pattern_get_expiration_date(matchPattern), expirationDate), >, G_TIME_SPAN_DAY * 365 * 100);
+}
+
 void beforeAll()
 {
     Test::add("WebKitWebExtensionMatchPattern", "pattern-validity", testPatternValidity);
@@ -986,6 +1006,7 @@ void beforeAll()
     Test::add("WebKitWebExtensionMatchPattern", "matches-all-hosts", testMatchesAllHosts);
     Test::add("WebKitWebExtensionMatchPattern", "matches-all-urls", testMatchesAllURLs);
     Test::add("WebKitWebExtensionMatchPattern", "custom-url-scheme", testCustomURLScheme);
+    Test::add("WebKitWebExtensionMatchPattern", "expiration-date", testExpirationDate);
 }
 
 void afterAll()


### PR DESCRIPTION
#### 88225d01e75bd4409a2dce8c4614bfb337c56e86
<pre>
[GTK] Add Expiration Dates to WebKitWebExtensionMatchPattern
<a href="https://bugs.webkit.org/show_bug.cgi?id=319457">https://bugs.webkit.org/show_bug.cgi?id=319457</a>

Reviewed by NOBODY (OOPS!).

Instead of creating a second (similar) wrapper struct for WebKitWebExtensionContext, add expirations
to the existing MatchPattern wrapper.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKPage/glib/TestWebKitWebExtensionMatchPattern.cpp

* Source/WebKit/UIProcess/API/glib/WebKitWebExtensionMatchPattern.cpp:
(webkit_web_extension_match_pattern_get_expiration_date):
(webkit_web_extension_match_pattern_set_expiration_date):
(webkit_web_extension_match_pattern_matches_url):
* Source/WebKit/UIProcess/API/glib/WebKitWebExtensionMatchPattern.h.in:
* Tools/TestWebKitAPI/Tests/WebKit/WKPage/glib/TestWebKitWebExtensionMatchPattern.cpp:
(testExpirationDate):
(beforeAll):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/88225d01e75bd4409a2dce8c4614bfb337c56e86

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174669 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48602 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42383 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184247 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132537 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176534 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49894 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48285 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135909 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95911 "3 flakes 4 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177627 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39345 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156696 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116387 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37986 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36361 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32727 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148409 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36188 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186674 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39995 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40559 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144834 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48269 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144693 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48948 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32809 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114728 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39565 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120965 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47455 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11156 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46857 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47088 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46915 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->