### PR TITLE
AX: iOS VoiceOver can't swipe past the last element inside iframes or render a cursor for iframe content

### DIFF
--- a/LayoutTests/accessibility/ios-simulator/iframe-exit-traversal-expected.txt
+++ b/LayoutTests/accessibility/ios-simulator/iframe-exit-traversal-expected.txt
@@ -1,0 +1,10 @@
+Tests that an element inside an iframe can traverse back out to the hosting document on iOS. Walking up the accessibilityContainer chain from an element inside the iframe must cross the local frame boundary so VoiceOver can advance past the last iframe element and render a cursor.
+
+Named ancestors of frame-link (crossing out of the iframe): ["iframe","content"]
+PASS: reachedIframeOwner === true
+PASS: reachedContent === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/ios-simulator/iframe-exit-traversal.html
+++ b/LayoutTests/accessibility/ios-simulator/iframe-exit-traversal.html
@@ -1,0 +1,56 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="content">
+<iframe id="iframe" onload="startTest();" src="data:text/html,<body><button id='frame-button'>Click me</button><a href='%23' id='frame-link'>a</a></body>"></iframe>
+</div>
+
+<script>
+var output = "Tests that an element inside an iframe can traverse back out to the hosting document on iOS. Walking up the accessibilityContainer chain from an element inside the iframe must cross the local frame boundary so VoiceOver can advance past the last iframe element and render a cursor.\n\n";
+
+var reachedIframeOwner = false;
+var reachedContent = false;
+
+if (window.accessibilityController)
+    window.jsTestIsAsync = true;
+
+function startTest() {
+    if (!window.accessibilityController)
+        return;
+
+    // frame-link is the last focusable element inside the iframe. accessibleElementById descends
+    // cross-frame (via accessibilityElementAtIndex) to find it.
+    var frameLink = accessibilityController.accessibleElementById("frame-link");
+
+    // Walk up the accessibilityContainer chain, recording each named ancestor. We should cross
+    // the iframe boundary, eventually reaching #content.
+    var namedAncestors = [];
+    var element = frameLink ? frameLink.parentElement() : null;
+    for (var i = 0; element && i < 25; i++) {
+        var domId = element.domIdentifier;
+        if (domId)
+            namedAncestors.push(domId);
+        if (domId == "iframe")
+            reachedIframeOwner = true;
+        if (domId == "content") {
+            reachedContent = true;
+            break;
+        }
+        element = element.parentElement();
+    }
+
+    output += `Named ancestors of frame-link (crossing out of the iframe): ${JSON.stringify(namedAncestors)}\n`;
+    output += expect("reachedIframeOwner", "true");
+    output += expect("reachedContent", "true");
+
+    debug(output);
+    finishJSTest();
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -1954,8 +1954,12 @@ static void appendStringToResult(NSMutableString *result, NSString *string)
     RefPtr<AccessibilityObject> object = self.axBackingObject;
     AXAttributeCacheScope enableCache(object->axObjectCache());
 
-    // As long as there's a parent wrapper, that's the correct chain to climb.
-    RefPtr parent = object->parentObjectUnignored();
+    // As long as there's a parent wrapper, that's the correct chain to climb. Use the cross-frame variant
+    // so that ascending out of a local iframe reaches the hosting frame in the parent document. Without this,
+    // parentObjectUnignored() returns null at the iframe's root scroll view, the container chain dead-ends, and
+    // VoiceOver can neither advance past the last iframe element nor resolve the view/window needed to draw its cursor.
+    // This mirrors the macOS wrapper (handleParentAttribute / scrollViewParent).
+    RefPtr parent = object->crossFrameParentObjectUnignored();
     if (parent)
         return parent->wrapper();
 


### PR DESCRIPTION
#### a90848164db6573df50ccfbb8e145f8e03c3c216
<pre>
AX: iOS VoiceOver can&apos;t swipe past the last element inside iframes or render a cursor for iframe content
<a href="https://bugs.webkit.org/show_bug.cgi?id=319459">https://bugs.webkit.org/show_bug.cgi?id=319459</a>
<a href="https://rdar.apple.com/179279930">rdar://179279930</a>

Reviewed by Chris Fleizach.

With ENABLE(ACCESSIBILITY_LOCAL_FRAME), each frame gets its own AXObjectCache and
an iframe&apos;s root AccessibilityScrollView reports isRoot() == true, so its
parentObject() returns null. On iOS, -[WebAccessibilityObjectWrapper
accessibilityContainer] climbed the tree with the non-cross-frame
parentObjectUnignored(), which therefore dead-ended at the iframe root

This broken link means it can neither advance past the last iframe element
nor resolve the view/window needed to draw its focus cursor.

Fix accessibilityContainer to ascend with crossFrameParentObjectUnignored(),
matching macOS. It crosses the local frame boundary at the iframe root and
behaves identically to parentObjectUnignored() elsewhere and when the flag is
off.

* LayoutTests/accessibility/ios-simulator/iframe-exit-traversal-expected.txt: Added.
* LayoutTests/accessibility/ios-simulator/iframe-exit-traversal.html: Added.
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
(-[WebAccessibilityObjectWrapper accessibilityContainer]):

Canonical link: <a href="https://commits.webkit.org/317285@main">https://commits.webkit.org/317285@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a96622441acc726d892f95142579888b29872a1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174673 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48606 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42387 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184251 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132541 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d256159c-a377-4cc6-ad85-7b38558c4a2e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176538 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49898 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48289 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135910 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/92e148d9-113c-4cce-a268-d8b784494848) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177631 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39342 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156703 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116388 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/50ad52a8-89fc-4649-8c1e-b3dc720c0bfe) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37983 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36363 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32731 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148406 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36195 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186678 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39993 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40561 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144835 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48273 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156259 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144694 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39031 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48952 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32816 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114732 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39574 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120972 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47459 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11163 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46861 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47092 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46919 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->