### PR TITLE
[GLIB] Strip port name from API test results before upload to resultsdb

### DIFF
--- a/Tools/glib/api_test_runner.py
+++ b/Tools/glib/api_test_runner.py
@@ -352,6 +352,18 @@ class TestRunner(object):
     def _get_test_short_name(self, test_path):
         return test_path.replace(self._test_programs_base_dir(), '', 1).lstrip('/').split(':', 1)[0]
 
+    def _get_test_name_for_upload(self, test_path):
+        # Test binaries are built into a port-specific subdirectory
+        # (TestWebKitAPI/WebKitGTK for GTK, TestWebKitAPI/WPE for WPE), so the
+        # short name carries that prefix. Strip it so the same test is reported
+        # to results.webkit.org under a single name regardless of the port that
+        # ran it.
+        short_name = self._get_test_short_name(test_path)
+        for prefix in ('WebKitGTK/', 'WPE/'):
+            if short_name.startswith(prefix):
+                return short_name[len(prefix):]
+        return short_name
+
     def _getsubtests_to_run_for_test(self, requested_test_name):
         subtests_to_run = []
         requested_test_name = self._get_test_short_name(requested_test_name)
@@ -518,7 +530,7 @@ class TestRunner(object):
             results = {}
             for test, test_cases in tests_to_upload.items():
                 for test_case in test_cases:
-                    name = "%s:%s" % (self._get_test_short_name(test), test_case[0])
+                    name = "%s:%s" % (self._get_test_name_for_upload(test), test_case[0])
                     results[name] = Upload.create_test_result(actual=test_case[1], expected=' '.join(test_case[2]) if test_case[2] else None)
 
             upload = Upload(


### PR DESCRIPTION
#### 9a5c798a823ee80752f2f3e2bb39710a3f537e9a
<pre>
[GLIB] Strip port name from API test results before upload to resultsdb
<a href="https://bugs.webkit.org/show_bug.cgi?id=319460">https://bugs.webkit.org/show_bug.cgi?id=319460</a>

Reviewed by Carlos Garcia Campos.

Currently the uploaded results include the port name in the full test
name, so

- WPE/TestWebKitWebView:/webkit/WebKitWebView/is-web-process-responsive
- WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/is-web-process-responsive

are reported as two different tests even though they are the same test
run on different ports, making analysis of cross-port failures harder.

Stripping out the port prefix normalizes the test name and simplifies
analysis.

* Tools/glib/api_test_runner.py:
(TestRunner._get_test_name_for_upload):
(TestRunner.run_tests):

Canonical link: <a href="https://commits.webkit.org/317226@main">https://commits.webkit.org/317226@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ae0232552ba25bcc2731466951f108c5396b418

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174677 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48610 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42391 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184256 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132545 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176542 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49902 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48293 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135915 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177635 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39347 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/156702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116393 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37988 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32735 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148411 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36194 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186682 "Built successfully") | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144840 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48277 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144699 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48957 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114736 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26543 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39572 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47463 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11162 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46865 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47096 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46923 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->