### PR TITLE
CustomElementRegistry.prototype.initialize does not upgrade custom element in a declarative shadow root

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-initialize-upgrades-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-initialize-upgrades-expected.txt
@@ -9,6 +9,6 @@ PASS XHTMLDocument: CustomElementRegistry.prototype.initialize should upgrade th
 PASS XHTMLDocument: CustomElementRegistry.prototype.initialize should upgrade elements in tree order
 PASS XHTMLDocument: CustomElementRegistry.prototype.initialize only upgrades elements beloning to the registry
 PASS CustomElementRegistry.prototype.initialize upgrades already initialized elements
-FAIL CustomElementRegistry.prototype.initialize upgrades custom elements in declarative shadow root when initialize() runs before define() assert_equals: expected "ABElement" but got "HTMLElement"
+PASS CustomElementRegistry.prototype.initialize upgrades custom elements in declarative shadow root when initialize() runs before define()
 PASS CustomElementRegistry.prototype.initialize upgrades custom elements in imperative shadow root when inserted before define()
 

--- a/Source/WebCore/dom/CustomElementRegistry.cpp
+++ b/Source/WebCore/dom/CustomElementRegistry.cpp
@@ -208,6 +208,8 @@ ExceptionOr<void> CustomElementRegistry::initialize(Node& root)
         ASSERT(shadowRoot->hasScopedCustomElementRegistry());
         shadowRoot->clearUsesNullCustomElementRegistry();
         shadowRoot->setCustomElementRegistry(*this);
+        if (shadowRoot->isConnected())
+            didAssociateWithDocument(protect(shadowRoot->document()).get());
     } else if (auto* documentFragment = dynamicDowncast<DocumentFragment>(*containerRoot); documentFragment && documentFragment->usesNullCustomElementRegistry())
         documentFragment->clearUsesNullCustomElementRegistry();
 


### PR DESCRIPTION
#### 4b5b7934b22c10c01a7e475e51162816476b3811
<pre>
CustomElementRegistry.prototype.initialize does not upgrade custom element in a declarative shadow root
<a href="https://bugs.webkit.org/show_bug.cgi?id=319462">https://bugs.webkit.org/show_bug.cgi?id=319462</a>

Reviewed by Chris Dumez.

The bug was caused by the missing call to didAssociateWithDocument in CustomElementRegistry::initialize.

Test: imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-initialize-upgrades.html

* LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-initialize-upgrades-expected.txt:
* Source/WebCore/dom/CustomElementRegistry.cpp:
(WebCore::CustomElementRegistry::initialize):

Canonical link: <a href="https://commits.webkit.org/317252@main">https://commits.webkit.org/317252@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/197749fd47d505146f84c0660e584ef897fc6c7f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174681 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48614 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42395 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184260 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132549 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1f521afb-170d-42d3-9263-eabb55ce7f2a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176546 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49906 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48297 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135919 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4c4e2e73-1e71-4807-a54e-3e9846e9c0b6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177639 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39352 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156705 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116397 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6c6fdc1c-8c72-4a85-a6a7-b07ea9a327e3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37993 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36371 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32739 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148416 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36197 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186686 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/40006 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40569 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144843 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48281 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144704 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48961 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32818 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26554 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39577 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121013 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47467 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11165 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46869 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47100 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46927 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->