### PR TITLE
Some tests in custom-elements/registries/adoption.window.html fail

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/adoption.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/adoption.window-expected.txt
@@ -23,11 +23,11 @@ PASS Adoption including shadow root with scoped registry (null registry target)
 PASS Adoption including shadow root with global registry into a scoped registry (null registry target)
 PASS Adoption including shadow root with explicit global registry into a scoped registry (null registry target)
 PASS Adoption including shadow root with scoped registry into a scoped registry (null registry target)
-FAIL Adoption with global registry (scoped registry target) assert_equals: expected null but got object "[object CustomElementRegistry]"
-FAIL Adoption with explicit global registry (scoped registry target) assert_equals: expected null but got object "[object CustomElementRegistry]"
+PASS Adoption with global registry (scoped registry target)
+PASS Adoption with explicit global registry (scoped registry target)
 PASS Adoption with scoped registry (scoped registry target)
-FAIL Adoption with global registry into a scoped registry (scoped registry target) assert_equals: expected null but got object "[object CustomElementRegistry]"
-FAIL Adoption with explicit global registry into a scoped registry (scoped registry target) assert_equals: expected null but got object "[object CustomElementRegistry]"
+PASS Adoption with global registry into a scoped registry (scoped registry target)
+PASS Adoption with explicit global registry into a scoped registry (scoped registry target)
 PASS Adoption with scoped registry into a scoped registry (scoped registry target)
 PASS Adoption including shadow root with global registry (scoped registry target)
 PASS Adoption including shadow root with explicit global registry (scoped registry target)

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -2279,6 +2279,16 @@ void Node::moveTreeToNewScope(Node& root, TreeScope& oldScope, TreeScope& newSco
     }
 }
 
+inline void Node::adoptCustomElementRegistryIntoScopedRegistryDocument()
+{
+    // Called during adoption only when the destination document's custom element registry is scoped.
+    // An element that inherits the global custom element registry (neither uses the null registry
+    // nor an explicit scoped registry) has no global registry to inherit in such a document, so it
+    // ends up with a null custom element registry.
+    if (is<Element>(*this) && !usesNullCustomElementRegistry() && !usesScopedCustomElementRegistryMap())
+        setUsesNullCustomElementRegistry();
+}
+
 void Node::moveNodeToNewDocumentFastCase(Document& oldDocument, Document& newDocument)
 {
     ASSERT(!oldDocument.shouldInvalidateNodeListAndCollectionCaches());
@@ -2295,6 +2305,9 @@ void Node::moveNodeToNewDocumentFastCase(Document& oldDocument, Document& newDoc
     if (usesNullCustomElementRegistry() && !newDocument.usesNullCustomElementRegistry()) [[unlikely]]
         clearUsesNullCustomElementRegistry();
 
+    if (RefPtr newRegistry = newDocument.customElementRegistry(); newRegistry && newRegistry->isScoped()) [[unlikely]]
+        adoptCustomElementRegistryIntoScopedRegistryDocument();
+
     if (!hasTypeFlag(TypeFlag::HasDidMoveToNewDocument) && !hasEventTargetFlag(EventTargetFlag::HasLangAttr) && !hasEventTargetFlag(EventTargetFlag::HasXMLLangAttr)
         && !isDefinedCustomElement())
         return;
@@ -2310,6 +2323,9 @@ void Node::moveNodeToNewDocumentSlowCase(Document& oldDocument, Document& newDoc
 
     if (usesNullCustomElementRegistry() && !newDocument.usesNullCustomElementRegistry()) [[unlikely]]
         clearUsesNullCustomElementRegistry();
+
+    if (RefPtr newRegistry = newDocument.customElementRegistry(); newRegistry && newRegistry->isScoped()) [[unlikely]]
+        adoptCustomElementRegistryIntoScopedRegistryDocument();
 
     if (hasRareData()) {
         if (auto* nodeLists = rareData()->nodeLists())

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -801,6 +801,7 @@ private:
     static void moveTreeToNewScope(Node&, TreeScope& oldScope, TreeScope& newScope);
     void moveNodeToNewDocumentFastCase(Document& oldDocument, Document& newDocument);
     void moveNodeToNewDocumentSlowCase(Document& oldDocument, Document& newDocument);
+    void adoptCustomElementRegistryIntoScopedRegistryDocument();
 
     WEBCORE_EXPORT void notifyInspectorOfRendererChange();
 


### PR DESCRIPTION
#### 3fa5dd557fcbe80731eea7cf7d65b23ff1e5c4f8
<pre>
Some tests in custom-elements/registries/adoption.window.html fail
<a href="https://bugs.webkit.org/show_bug.cgi?id=319463">https://bugs.webkit.org/show_bug.cgi?id=319463</a>

Reviewed by Chris Dumez.

When a node, which uses the global registry of a document, gets adopted to another document that
is associated with a scoped custom element registry (i.e. it didn&apos;t have a browsing context so
there was no global registry), it must use null registry after the adoption.

Test: imported/w3c/web-platform-tests/custom-elements/registries/adoption.window.html

* LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/adoption.window-expected.txt:
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::adoptCustomElementRegistryIntoScopedRegistryDocument): Added.
(WebCore::Node::moveNodeToNewDocumentFastCase):
(WebCore::Node::moveNodeToNewDocumentSlowCase):
* Source/WebCore/dom/Node.h:

Canonical link: <a href="https://commits.webkit.org/317251@main">https://commits.webkit.org/317251@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e9f9d49abb584b1254593e8e836bfa16811b9777

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174683 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48616 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42397 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184262 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132551 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/142cfc18-38cc-4eb5-bf9f-6c921a6c3c2e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176548 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49908 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48299 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135931 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/21bbcb15-15d6-433d-bd13-03b63fe00cb7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177641 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39361 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156713 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116409 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38002 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36373 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32741 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148425 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36205 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186688 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/40037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40571 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144849 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48283 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144709 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48963 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32826 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26553 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39582 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120988 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47469 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11173 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46871 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47102 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46929 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->