### PR TITLE
[JSC] `Temporal.Duration` rounding divides by zero when a time zone transition skips an entire day

### DIFF
--- a/JSTests/stress/temporal-duration-round-zero-length-nudge-window.js
+++ b/JSTests/stress/temporal-duration-round-zero-length-nudge-window.js
@@ -1,0 +1,63 @@
+//@ requireOptions("--useTemporal=1")
+
+// Rounding a Duration relative to a ZonedDateTime whose calendar day is entirely
+// skipped by a time zone transition (e.g. Pacific/Apia skipped 2011-12-30, jumping
+// from -10:00 to +14:00) produces a zero-length nudge window in NudgeToCalendarUnit:
+// startEpochNs equals endEpochNs, so computing the progress fraction divides by zero.
+// This must throw a RangeError instead of dividing by zero.
+// https://github.com/tc39/proposal-temporal/issues/3310
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`expected ${String(expected)} but got ${String(actual)}`);
+}
+function shouldThrowRangeError(fn) {
+    try { fn(); } catch (e) {
+        if (!(e instanceof RangeError))
+            throw new Error(`expected RangeError, got ${e}`);
+        return;
+    }
+    throw new Error("expected RangeError but no exception thrown");
+}
+
+// Pacific/Apia: 2011-12-30 does not exist. The one-day window ending on the skipped
+// day collapses: both bounds resolve to the same instant.
+{
+    const relativeTo = Temporal.ZonedDateTime.from('2012-01-01T12:00:00[Pacific/Apia]');
+    const oneDayAgo = Temporal.Duration.from({ days: -1 });
+    shouldThrowRangeError(() => oneDayAgo.round({ smallestUnit: 'days', relativeTo }));
+    shouldThrowRangeError(() => oneDayAgo.total({ unit: 'days', relativeTo }));
+    shouldThrowRangeError(() => relativeTo.until(relativeTo.add(oneDayAgo), { smallestUnit: 'days' }));
+}
+
+// Same, starting inside the day right after the gap with a sub-day remainder.
+{
+    const relativeTo = Temporal.ZonedDateTime.from('2011-12-31T00:30:00+14:00[Pacific/Apia]');
+    shouldThrowRangeError(() => Temporal.Duration.from('-PT30M').total({ unit: 'days', relativeTo }));
+}
+
+// Here the retry window (additionalShift=true) still does not contain the destination.
+{
+    const relativeTo = Temporal.ZonedDateTime.from('2011-12-31T12:00:00+14:00[Pacific/Apia]');
+    const duration = Temporal.Duration.from({ days: -1, hours: -12 });
+    shouldThrowRangeError(() => duration.round({ smallestUnit: 'day', relativeTo }));
+    shouldThrowRangeError(() => duration.total({ unit: 'day', relativeTo }));
+}
+
+// Pacific/Kiritimati: 1994-12-31 does not exist.
+{
+    const relativeTo = Temporal.ZonedDateTime.from('1995-01-02T12:00:00[Pacific/Kiritimati]');
+    const oneDayAgo = Temporal.Duration.from({ days: -1 });
+    shouldThrowRangeError(() => oneDayAgo.round({ smallestUnit: 'days', relativeTo }));
+    shouldThrowRangeError(() => oneDayAgo.total({ unit: 'days', relativeTo }));
+    shouldThrowRangeError(() => relativeTo.until(relativeTo.add(oneDayAgo), { smallestUnit: 'days' }));
+}
+
+// Ordinary DST transitions (1-hour shifts) can leave the destination outside the
+// nudge window even after the additionalShift retry, but the window is not
+// zero-length; this must keep computing the same result as before.
+{
+    const x = Temporal.ZonedDateTime.from('1997-09-21T23:00:02.000000002+03:30[Asia/Tehran]');
+    const y = Temporal.ZonedDateTime.from('1996-07-17T23:59:07.540000748+04:30[Asia/Tehran]');
+    shouldBe(y.since(x, { smallestUnit: 'day', roundingMode: 'floor', largestUnit: 'year' }).toString(), '-P1Y2M4D');
+}

--- a/Source/JavaScriptCore/runtime/temporal/core/DurationArithmetic.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/DurationArithmetic.cpp
@@ -683,17 +683,19 @@ TemporalResult<Nudged> nudgeToCalendarUnit(int32_t sign,
             return makeUnexpected(retried.error());
         ASSERT(retried->has_value());
         nudgeWindow = **retried;
-        // Step 5.a.ii / 6.a.ii: Assert bounds hold after retry. Set didExpandCalendarUnit to true.
-        ASSERT(sign != 1 || (nudgeWindow.startEpochNs <= destEpochNs && destEpochNs <= nudgeWindow.endEpochNs));
-        ASSERT(sign != -1 || (nudgeWindow.endEpochNs <= destEpochNs && destEpochNs <= nudgeWindow.startEpochNs));
+        // Step 5.a.ii / 6.a.ii: Set didExpandCalendarUnit to true. (The spec also asserts bounds
+        // hold after retry, but the assertion is violable: https://github.com/tc39/proposal-temporal/issues/3310)
         didExpandCalendarUnit = true;
     }
 
     // Steps 7-12: Extract r1, r2, startEpochNs, endEpochNs, startDuration, endDuration from nudgeWindow.
     auto& startDuration = nudgeWindow.startDuration;
     auto& endDuration = nudgeWindow.endDuration;
-    // Step 13: Assert: startEpochNs ≠ endEpochNs.
-    ASSERT(nudgeWindow.startEpochNs != nudgeWindow.endEpochNs);
+    // Step 13: Assert: startEpochNs ≠ endEpochNs. The assertion is violable when a time zone
+    // transition skips the entire calendar day (https://github.com/tc39/proposal-temporal/issues/3310).
+    // FIXME: RangeError matches the polyfill, not the spec; revisit once the issue above settles.
+    if (nudgeWindow.startEpochNs == nudgeWindow.endEpochNs)
+        return makeUnexpected(rangeError("cannot round relative to a time zone transition that skips an entire day"_s));
     // Step 14: Let progress be (destEpochNs - startEpochNs) / (endEpochNs - startEpochNs).
     Int128 progressNumerator = destEpochNs - nudgeWindow.startEpochNs;
     Int128 progressDenominator = nudgeWindow.endEpochNs - nudgeWindow.startEpochNs;


### PR DESCRIPTION
#### 170ee738c6f19a9f81f398e2fa0752b9ac234cd4
<pre>
[JSC] `Temporal.Duration` rounding divides by zero when a time zone transition skips an entire day
<a href="https://bugs.webkit.org/show_bug.cgi?id=319465">https://bugs.webkit.org/show_bug.cgi?id=319465</a>

Reviewed by Yusuke Suzuki.

When rounding a duration relative to a ZonedDateTime whose nudge window ends on a
calendar day entirely skipped by a time zone transition (Pacific/Apia skipped
2011-12-30 when it crossed the date line), both window bounds in NudgeToCalendarUnit
resolve to the same instant. Computing the progress fraction then divides by zero:
x86_64 Release crashes with SIGFPE, arm64 Release returns Infinity or self-inconsistent
values, and Debug hits the step 13 assertion. The assertion is known to be violable in
the spec itself [1]; throw a RangeError instead, matching the observable behavior of
@js-temporal/polyfill.

The bounds assertion after the ComputeNudgeWindow retry is violable the same way, even
by ordinary one-hour DST transitions; remove it and keep computing, which produces the
same result as the polyfill.

    const relativeTo = Temporal.ZonedDateTime.from(&apos;2012-01-01T12:00:00[Pacific/Apia]&apos;);
    Temporal.Duration.from({ days: -1 }).total({ unit: &apos;days&apos;, relativeTo });  // SIGFPE on x86_64

[1]: <a href="https://github.com/tc39/proposal-temporal/issues/3310">https://github.com/tc39/proposal-temporal/issues/3310</a>

* JSTests/stress/temporal-duration-round-zero-length-nudge-window.js: Added.
(shouldBe):
(shouldThrowRangeError):
(throw.new.Error):
* Source/JavaScriptCore/runtime/temporal/core/DurationArithmetic.cpp:
(JSC::TemporalCore::nudgeToCalendarUnit):

Canonical link: <a href="https://commits.webkit.org/317234@main">https://commits.webkit.org/317234@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c3639d30fcf152596910248ae066b3739e9a3e9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174734 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48667 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42448 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184316 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132602 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49959 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48350 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135971 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177692 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39407 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/156756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116449 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38048 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36420 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32792 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5265 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148471 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36248 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186739 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/35996 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/40080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144890 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48334 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144750 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39001 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49014 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39632 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/121057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/211825 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47520 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11217 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55248 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46922 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47153 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46980 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->