### PR TITLE
[check-webkit-style] Run the deprecated js-test include checker on LayoutTests

### DIFF
--- a/Tools/Scripts/webkitpy/style/checker.py
+++ b/Tools/Scripts/webkitpy/style/checker.py
@@ -48,6 +48,7 @@ from webkitpy.style.checkers.changelog import ChangeLogChecker
 from webkitpy.style.checkers.cpp import CppChecker
 from webkitpy.style.checkers.cmake import CMakeChecker
 from webkitpy.style.checkers.deprecated_js_test_includes import categories as DeprecatedJSTestIncludesCategories
+from webkitpy.style.checkers.deprecated_js_test_includes import DeprecatedJSTestIncludesChecker
 from webkitpy.style.checkers.featuredefines import FeatureDefinesChecker
 from webkitpy.style.checkers.js import JSChecker
 from webkitpy.style.checkers.jsonchecker import JSONChecker
@@ -571,6 +572,10 @@ _NEVER_SKIPPED_FILES = _NEVER_SKIPPED_JS_FILES + [
     re.compile('^' + re.escape(os.path.join('LayoutTests', 'imported', 'w3c', 'resources', 'import-expectations.json')) + r'$'),
 ]
 
+# LayoutTests is skipped wholesale (see _SKIPPED_FILES_WITHOUT_WARNING), but
+# its non-imported HTML/XHTML markup is still linted for deprecated includes.
+_DEPRECATED_JS_TEST_MARKUP_RE = re.compile(r'^LayoutTests.(?!imported).*\.(?:html|xhtml)$')
+
 # Files to skip that are less obvious.
 #
 # Some files should be skipped when checking style. For example,
@@ -883,6 +888,10 @@ class CheckerDispatcher(object):
                 return True
         return False
 
+    def _is_lintable_layout_test_markup(self, file_path):
+        """Whether the file is LayoutTests markup to lint for deprecated js-test includes."""
+        return bool(_DEPRECATED_JS_TEST_MARKUP_RE.match(file_path))
+
     def should_skip_with_warning(self, file_path):
         """Return whether the given file should be skipped with a warning."""
         for skipped_file in _SKIPPED_FILES_WITH_WARNING:
@@ -907,6 +916,9 @@ class CheckerDispatcher(object):
         for pattern in _NEVER_SKIPPED_FILES:
             if self._file_matches_pattern(file_path, pattern):
                 return False
+        # Lint LayoutTests markup despite the wholesale skip below.
+        if self._is_lintable_layout_test_markup(file_path):
+            return False
         for skipped_file in _SKIPPED_FILES_WITHOUT_WARNING:
             if self._should_skip_file_path(file_path, skipped_file):
                 return True
@@ -1039,6 +1051,8 @@ class CheckerDispatcher(object):
                 checker = TestExpectationsChecker(file_path, handle_style_error)
             elif file_path.endswith('.messages.in'):
                 checker = MessagesInChecker(file_path, handle_style_error)
+            elif self._is_lintable_layout_test_markup(file_path):
+                checker = DeprecatedJSTestIncludesChecker(handle_style_error)
             else:
                 checker = TextChecker(file_path, handle_style_error)
         elif file_type == FileType.WATCHLIST:

--- a/Tools/Scripts/webkitpy/style/checker_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checker_unittest.py
@@ -54,6 +54,7 @@ from webkitpy.style.checker import StyleProcessorConfiguration
 from webkitpy.style.checkers.basexcconfig import BaseXcconfigChecker
 from webkitpy.style.checkers.changelog import ChangeLogChecker
 from webkitpy.style.checkers.cpp import CppChecker
+from webkitpy.style.checkers.deprecated_js_test_includes import DeprecatedJSTestIncludesChecker
 from webkitpy.style.checkers.js import JSChecker
 from webkitpy.style.checkers.jsonchecker import JSONChecker
 from webkitpy.style.checkers.python import PythonChecker
@@ -348,6 +349,9 @@ class CheckerDispatcherSkipTest(unittest.TestCase):
             os.path.join('LayoutTests', 'foo.txt'),
             os.path.join('LayoutTests', 'imported', 'foo.py'),
             os.path.join('WebDriverTests', 'foo.py'),
+            # Imported markup and non-markup LayoutTests files stay skipped.
+            os.path.join('LayoutTests', 'imported', 'w3c', 'foo.html'),
+            os.path.join('LayoutTests', 'fast', 'foo.js'),
         ]
         for path in paths:
             self._assert_should_skip_without_warning(path,
@@ -362,6 +366,9 @@ class CheckerDispatcherSkipTest(unittest.TestCase):
                  os.path.join('LayoutTests', 'TestExpectations'),
                  os.path.join('WebDriverTests', 'ChangeLog'),
                  os.path.join('WebDriverTests', 'TestExpectations.json'),
+                 # LayoutTests markup is linted for deprecated js-test includes.
+                 os.path.join('LayoutTests', 'fast', 'css', 'foo.html'),
+                 os.path.join('LayoutTests', 'fast', 'forms', 'bar.xhtml'),
         ]
 
         for path in paths:
@@ -441,6 +448,10 @@ class CheckerDispatcherDispatchTest(unittest.TestCase):
     def assert_checker_text(self, file_path):
         """Assert that the dispatched checker is a TextChecker."""
         self.assert_checker(file_path, TextChecker)
+
+    def assert_checker_deprecated_js_test_includes(self, file_path):
+        """Assert that the dispatched checker is a DeprecatedJSTestIncludesChecker."""
+        self.assert_checker(file_path, DeprecatedJSTestIncludesChecker)
 
     def assert_checker_xml(self, file_path):
         """Assert that the dispatched checker is a XMLChecker."""
@@ -615,6 +626,20 @@ class CheckerDispatcherDispatchTest(unittest.TestCase):
         checker = self.dispatch(file_path)
         self.assertEqual(checker.file_path, file_path)
         self.assertEqual(checker.handle_style_error, self.mock_handle_style_error)
+
+    def test_deprecated_js_test_includes_paths(self):
+        """LayoutTests HTML/XHTML markup routes to the deprecated js-test
+        include checker; non-LayoutTests and imported markup do not."""
+        deprecated_paths = [
+            os.path.join('LayoutTests', 'fast', 'css', 'foo.html'),
+            os.path.join('LayoutTests', 'fast', 'forms', 'bar.xhtml'),
+            os.path.join('LayoutTests', 'http', 'tests', 'security', 'baz.html'),
+        ]
+        for path in deprecated_paths:
+            self.assert_checker_deprecated_js_test_includes(path)
+
+        self.assert_checker_text(os.path.join('Source', 'WebCore', 'foo.html'))
+        self.assert_checker_text(os.path.join('LayoutTests', 'imported', 'w3c', 'foo.html'))
 
     def test_xml_paths(self):
         """Test paths that should be checked as XML."""

--- a/Tools/Scripts/webkitpy/style/checkers/deprecated_js_test_includes.py
+++ b/Tools/Scripts/webkitpy/style/checkers/deprecated_js_test_includes.py
@@ -39,12 +39,10 @@ class DeprecatedJSTestIncludesChecker(object):
 
     CATEGORY = 'build/deprecated/js-test-helpers'
 
-    # Matches <script ... src="...js-test-pre.js">, the js-test-post.js
-    # counterpart, and js-test-post-async.js, with either quote style and an
-    # optional query string. Listing post-async before post in the alternation
-    # ensures it wins the longest-match for post-async filenames.
+    # (?:[^"']*/)? anchors the name to a path segment (so custom-js-test-pre.js
+    # is not flagged); post-async precedes post to win the longest match.
     _DEPRECATED_INCLUDE_RE = re.compile(
-        r'''<script\b[^>]*\bsrc\s*=\s*["'][^"']*\b(?P<filename>js-test-post-async\.js|js-test-pre\.js|js-test-post\.js)(?:\?[^"']*)?["']''',
+        r'''<script\b[^>]*\bsrc\s*=\s*["'](?:[^"']*/)?(?P<filename>js-test-post-async\.js|js-test-pre\.js|js-test-post\.js)(?:[?#][^"']*)?["']''',
         re.IGNORECASE,
     )
 

--- a/Tools/Scripts/webkitpy/style/checkers/deprecated_js_test_includes_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/deprecated_js_test_includes_unittest.py
@@ -61,6 +61,13 @@ class DeprecatedJSTestIncludesCheckerTest(unittest.TestCase):
             'js-test-pre.js',
         )
 
+    def test_flags_pre_include_deep_relative(self):
+        self.assertError(
+            ['<script src="../../../../resources/js-test-pre.js"></script>'],
+            1,
+            'js-test-pre.js',
+        )
+
     def test_flags_post_include_relative(self):
         self.assertError(
             ['<script src="../../resources/js-test-post.js"></script>'],
@@ -121,6 +128,18 @@ class DeprecatedJSTestIncludesCheckerTest(unittest.TestCase):
     def test_does_not_flag_unrelated_script(self):
         self.assertNoError(
             ['<script src="../../resources/unrelated-helper.js"></script>'],
+        )
+
+    def test_does_not_flag_similarly_named_helper(self):
+        self.assertNoError(
+            ['<script src="../../resources/custom-js-test-pre.js"></script>'],
+        )
+
+    def test_flags_with_fragment(self):
+        self.assertError(
+            ['<script src="../../resources/js-test-pre.js#frag"></script>'],
+            1,
+            'js-test-pre.js',
         )
 
     def test_does_not_flag_plain_filename_mention(self):


### PR DESCRIPTION
#### 9c88a404d6b27394838342bd15dbade0b4f9cfa8
<pre>
[check-webkit-style] Run the deprecated js-test include checker on LayoutTests
<a href="https://bugs.webkit.org/show_bug.cgi?id=319464">https://bugs.webkit.org/show_bug.cgi?id=319464</a>
<a href="https://rdar.apple.com/182275985">rdar://182275985</a>

Reviewed by Tim Nguyen.

The checker added in 313204@main never ran: every LayoutTests/ file is
skipped before a checker is dispatched, so the .html tests that carry these
includes were never linted. The unit tests passed only by calling the
checker directly.

Un-skip non-imported LayoutTests HTML/XHTML markup and route it to the
DeprecatedJSTestIncludesChecker. Also require the include to be a whole path
segment so custom-js-test-pre.js isn&apos;t flagged, and allow a trailing

* Tools/Scripts/webkitpy/style/checker.py:
(CheckerDispatcher._is_lintable_layout_test_markup):
(CheckerDispatcher.should_skip_without_warning):
(CheckerDispatcher._create_checker):
* Tools/Scripts/webkitpy/style/checker_unittest.py:
(CheckerDispatcherSkipTest.test_should_skip_without_warning__true):
(CheckerDispatcherSkipTest.test_should_skip_without_warning__false):
(CheckerDispatcherDispatchTest.assert_checker_deprecated_js_test_includes):
(CheckerDispatcherDispatchTest.test_deprecated_js_test_includes_paths):
* Tools/Scripts/webkitpy/style/checkers/deprecated_js_test_includes.py:
(DeprecatedJSTestIncludesChecker):
* Tools/Scripts/webkitpy/style/checkers/deprecated_js_test_includes_unittest.py:
(DeprecatedJSTestIncludesCheckerTest.test_flags_pre_include_deep_relative):
(DeprecatedJSTestIncludesCheckerTest.test_does_not_flag_similarly_named_helper):
(DeprecatedJSTestIncludesCheckerTest):
(DeprecatedJSTestIncludesCheckerTest.test_flags_with_fragment):

Canonical link: <a href="https://commits.webkit.org/317222@main">https://commits.webkit.org/317222@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/51f85871a4e804c3543e362068a3b665a1f4f85b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174687 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48620 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42401 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184266 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/132555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/92d0900c-ffd0-47bf-ba01-0a73e0eaaace) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176552 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49912 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48303 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135923 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/132555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c8a271fd-265e-4a5a-9200-7b6d49c0587c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177645 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39355 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/156711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116401 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/352c86d9-40f9-46e1-8570-b6a7611c96a3) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/174008 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37996 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32745 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148419 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36203 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186692 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144845 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48287 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144705 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38993 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48967 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39581 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47473 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11171 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46875 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47106 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46933 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->