### PR TITLE
[libwebrtc] Adopt Typed Memory Operations in allocator wrappers

### DIFF
--- a/Source/ThirdParty/libwebrtc/Configurations/Base.xcconfig
+++ b/Source/ThirdParty/libwebrtc/Configurations/Base.xcconfig
@@ -73,7 +73,7 @@ GCC_WARN_UNUSED_FUNCTION = YES;
 GCC_WARN_UNUSED_VARIABLE = YES;
 CLANG_WARN_SUSPICIOUS_MOVE = YES;
 PREBINDING = NO;
-WARNING_CFLAGS = $(inherited) -Wthread-safety $(WK_FIXME_WARNING_CFLAGS) -Wexit-time-destructors -Wglobal-constructors;
+WARNING_CFLAGS = $(inherited) -Wthread-safety $(WK_FIXME_WARNING_CFLAGS) -Wexit-time-destructors -Wglobal-constructors -Wallocator-wrappers;
 
 // Remove WK_FIXME_WARNING_CFLAGS once all warnings are fixed.
 // -Wno-unknown-warning-option added for -Wno-unused-but-set-parameter.

--- a/Source/ThirdParty/libwebrtc/Source/third_party/boringssl/src/crypto/err/err.cc
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/boringssl/src/crypto/err/err.cc
@@ -75,6 +75,18 @@ extern const char kOpenSSLReasonStringData[];
 
 BSSL_NAMESPACE_END
 
+#if defined(WEBRTC_WEBKIT_BUILD)
+// Use libc strdup directly (which itself wraps malloc + memcpy). The
+// upstream comment below explains why upstream avoids strdup -- MSVC
+// deprecation warnings and glibc/musl feature-macro gating -- but those
+// concerns do not apply to libwebrtc on Apple platforms, where strdup is
+// universally available. Defining strdup_libc_malloc as a function-like
+// macro lets the compiler apply Typed Memory Operations type inference at
+// each call site without needing to wrap the function in _MALLOC_TYPED
+// (which is not feasible here -- the wrapper has no size_t parameter for
+// the index anchor). See rdar://170138232.
+#define strdup_libc_malloc(str) strdup(str)
+#else
 static char *strdup_libc_malloc(const char *str) {
   // |strdup| is not in C until C23, so MSVC triggers deprecation warnings, and
   // glibc and musl gate it on a feature macro. Reimplementing it is easier.
@@ -85,6 +97,7 @@ static char *strdup_libc_malloc(const char *str) {
   }
   return ret;
 }
+#endif
 
 // err_clear clears the given queued error.
 static void err_clear(struct err_error_st *error) {

--- a/Source/ThirdParty/libwebrtc/Source/third_party/boringssl/src/crypto/mem.cc
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/boringssl/src/crypto/mem.cc
@@ -180,6 +180,15 @@ void bssl::OPENSSL_enable_malloc_failures_for_testing() {
 static int should_fail_allocation() { return 0; }
 #endif
 
+#if defined(WEBRTC_WEBKIT_BUILD)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wallocator-wrappers" // rdar://170138232
+// |OPENSSL_malloc| is taken by-address at line ~516
+// (|allocate = system_malloc ? malloc : OPENSSL_malloc;|), so |_MALLOC_TYPED|
+// cannot be applied -- the rewriter cannot rewrite calls made through a
+// runtime function pointer, and removing the untyped symbol breaks linking
+// of |OPENSSL_vasprintf_internal|.
+#endif
 void *OPENSSL_malloc(size_t size) {
   void *ptr = nullptr;
   if (should_fail_allocation()) {
@@ -215,6 +224,9 @@ err:
   OPENSSL_PUT_ERROR(CRYPTO, ERR_R_MALLOC_FAILURE);
   return nullptr;
 }
+#if defined(WEBRTC_WEBKIT_BUILD)
+#pragma clang diagnostic pop
+#endif
 
 void *OPENSSL_zalloc(size_t size) {
   void *ret = OPENSSL_malloc(size);

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libsrtp/crypto/include/alloc.h
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libsrtp/crypto/include/alloc.h
@@ -47,6 +47,10 @@
 
 #include "datatypes.h"
 
+#if defined(WEBRTC_WEBKIT_BUILD)
+#include <stdlib.h>  // For _MALLOC_TYPED and malloc_type_id_t.
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -59,7 +63,12 @@ extern "C" {
  *
  * returns pointer to memory on success or else NULL
  */
+#if defined(WEBRTC_WEBKIT_BUILD) && defined(_MALLOC_TYPE_ENABLED) && _MALLOC_TYPE_ENABLED
+void *srtp_crypto_alloc_typed(size_t size, malloc_type_id_t type_id);
+void *srtp_crypto_alloc(size_t size) _MALLOC_TYPED(srtp_crypto_alloc_typed, 1);
+#else
 void *srtp_crypto_alloc(size_t size);
+#endif
 
 /*
  * srtp_crypto_free

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libsrtp/crypto/kernel/alloc.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libsrtp/crypto/kernel/alloc.c
@@ -67,7 +67,13 @@ srtp_debug_module_t srtp_mod_alloc = {
 
 #if defined(HAVE_STDLIB_H)
 
+#if defined(WEBRTC_WEBKIT_BUILD) && defined(_MALLOC_TYPE_ENABLED) && _MALLOC_TYPE_ENABLED
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wallocator-wrappers" // rdar://170138232
+void *srtp_crypto_alloc_typed(size_t size, malloc_type_id_t type_id)
+#else
 void *srtp_crypto_alloc(size_t size)
+#endif
 {
     void *ptr;
 
@@ -75,7 +81,11 @@ void *srtp_crypto_alloc(size_t size)
         return NULL;
     }
 
+#if defined(WEBRTC_WEBKIT_BUILD) && defined(_MALLOC_TYPE_ENABLED) && _MALLOC_TYPE_ENABLED
+    ptr = malloc_type_calloc(1, size, type_id);
+#else
     ptr = calloc(1, size);
+#endif
 
     if (ptr) {
         debug_print(srtp_mod_alloc, "(location: %p) allocated", ptr);
@@ -86,6 +96,9 @@ void *srtp_crypto_alloc(size_t size)
 
     return ptr;
 }
+#if defined(WEBRTC_WEBKIT_BUILD) && defined(_MALLOC_TYPE_ENABLED) && _MALLOC_TYPE_ENABLED
+#pragma clang diagnostic pop
+#endif
 
 void srtp_crypto_free(void *ptr)
 {

--- a/Source/ThirdParty/libwebrtc/Source/third_party/opus/src/celt/os_support.h
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/opus/src/celt/os_support.h
@@ -43,27 +43,48 @@
 
 /** Opus wrapper for malloc(). To do your own dynamic allocation replace this function, opus_realloc, and opus_free */
 #ifndef OVERRIDE_OPUS_ALLOC
+#if defined(WEBRTC_WEBKIT_BUILD)
+/* Defined as a function-like macro (rather than a static inline function)
+   so the compiler can perform Typed Memory Operations type inference at
+   each call site. See rdar://170138232. */
+#define opus_alloc(size) malloc(size)
+#else
 static OPUS_INLINE void *opus_alloc (size_t size)
 {
    return malloc(size);
 }
 #endif
+#endif
 
 #ifndef OVERRIDE_OPUS_REALLOC
+#if defined(WEBRTC_WEBKIT_BUILD)
+/* Defined as a function-like macro (rather than a static inline function)
+   so the compiler can perform Typed Memory Operations type inference at
+   each call site. See rdar://170138232. */
+#define opus_realloc(ptr, size) realloc(ptr, size)
+#else
 static OPUS_INLINE void *opus_realloc (void *ptr, size_t size)
 {
    return realloc(ptr, size);
 }
 #endif
+#endif
 
 /** Used only for non-threadsafe pseudostack.
     If desired, this can always return the same area of memory rather than allocating a new one every time. */
 #ifndef OVERRIDE_OPUS_ALLOC_SCRATCH
+#if defined(WEBRTC_WEBKIT_BUILD)
+/* Defined as a function-like macro (rather than a static inline function)
+   so the compiler can perform Typed Memory Operations type inference at
+   each call site. See rdar://170138232. */
+#define opus_alloc_scratch(size) opus_alloc(size)
+#else
 static OPUS_INLINE void *opus_alloc_scratch (size_t size)
 {
    /* Scratch space doesn't need to be cleared */
    return opus_alloc(size);
 }
+#endif
 #endif
 
 /** Opus wrapper for free(). To do your own dynamic allocation replace this function, opus_realloc, and opus_free */

--- a/Source/ThirdParty/libwebrtc/Source/third_party/pffft/src/pffft.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/pffft/src/pffft.c
@@ -246,6 +246,19 @@ void validate_pffft_simd(void) {
 
 /* SSE and co like 16-bytes aligned pointers */
 #define MALLOC_V4SF_ALIGNMENT 64 // with a 64-byte alignment, we are even aligned on L2 cache lines...
+#if defined(WEBRTC_WEBKIT_BUILD)
+#if defined(_MALLOC_TYPE_ENABLED) && _MALLOC_TYPE_ENABLED
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wallocator-wrappers" // rdar://170138232
+void *pffft_aligned_malloc_typed(size_t nb_bytes, malloc_type_id_t type_id) {
+  void *p, *p0 = malloc_type_malloc(nb_bytes + MALLOC_V4SF_ALIGNMENT, type_id);
+  if (!p0) return (void *) 0;
+  p = (void *) (((size_t) p0 + MALLOC_V4SF_ALIGNMENT) & (~((size_t) (MALLOC_V4SF_ALIGNMENT-1))));
+  *((void **) p - 1) = p0;
+  return p;
+}
+#pragma clang diagnostic pop
+#else
 void *pffft_aligned_malloc(size_t nb_bytes) {
   void *p, *p0 = malloc(nb_bytes + MALLOC_V4SF_ALIGNMENT);
   if (!p0) return (void *) 0;
@@ -253,6 +266,16 @@ void *pffft_aligned_malloc(size_t nb_bytes) {
   *((void **) p - 1) = p0;
   return p;
 }
+#endif
+#else
+void *pffft_aligned_malloc(size_t nb_bytes) {
+  void *p, *p0 = malloc(nb_bytes + MALLOC_V4SF_ALIGNMENT);
+  if (!p0) return (void *) 0;
+  p = (void *) (((size_t) p0 + MALLOC_V4SF_ALIGNMENT) & (~((size_t) (MALLOC_V4SF_ALIGNMENT-1))));
+  *((void **) p - 1) = p0;
+  return p;
+}
+#endif
 
 void pffft_aligned_free(void *p) {
   if (p) free(*((void **) p - 1));

--- a/Source/ThirdParty/libwebrtc/Source/third_party/pffft/src/pffft.h
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/pffft/src/pffft.h
@@ -78,6 +78,9 @@
 #define PFFFT_H
 
 #include <stddef.h> // for size_t
+#if defined(WEBRTC_WEBKIT_BUILD)
+#include <stdlib.h> // for _MALLOC_TYPED and malloc_type_id_t
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -184,7 +187,12 @@ void pffft_zconvolve_accumulate(PFFFT_Setup* setup,
   on intel and powerpc). This function may be used to obtain such
   correctly aligned buffers.
 */
+#if defined(WEBRTC_WEBKIT_BUILD) && defined(_MALLOC_TYPE_ENABLED) && _MALLOC_TYPE_ENABLED
+void* pffft_aligned_malloc_typed(size_t nb_bytes, malloc_type_id_t type_id);
+void* pffft_aligned_malloc(size_t nb_bytes) _MALLOC_TYPED(pffft_aligned_malloc_typed, 1);
+#else
 void* pffft_aligned_malloc(size_t nb_bytes);
+#endif
 void pffft_aligned_free(void*);
 
 /* return 4 or 1 wether support SSE/Altivec instructions was enable when

--- a/Source/ThirdParty/libwebrtc/Source/third_party/yasm/libyasm/xmalloc.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/yasm/libyasm/xmalloc.c
@@ -59,6 +59,13 @@ void (*yasm_xfree) (/*@only@*/ /*@out@*/ /*@null@*/ void *p)
     /*@modifies p@*/ = def_xfree;
 
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunknown-warning-option"
+#pragma clang diagnostic ignored "-Wallocator-wrappers" // rdar://170138232
+// These three functions are only ever taken by-address to initialize the
+// global yasm_xmalloc / yasm_xcalloc / yasm_xrealloc function pointers
+// (see lines 50-56). Calls go through those function pointers at runtime,
+// so the _MALLOC_TYPED rewriter cannot rewrite them. Suppress as a group.
 static void *
 def_xmalloc(size_t size)
 {
@@ -104,6 +111,7 @@ def_xrealloc(void *oldmem, size_t size)
 
     return newmem;
 }
+#pragma clang diagnostic pop
 
 static void
 def_xfree(void *p)

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/modules/audio_processing/utility/pffft_wrapper.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/modules/audio_processing/utility/pffft_wrapper.cc
@@ -24,9 +24,16 @@ size_t GetBufferSize(size_t fft_size, Pffft::FftType fft_type) {
   return fft_size * (fft_type == Pffft::FftType::kReal ? 1 : 2);
 }
 
+#if !defined(WEBRTC_WEBKIT_BUILD)
 float* AllocatePffftBuffer(size_t size) {
   return static_cast<float*>(pffft_aligned_malloc(size * sizeof(float)));
 }
+#else
+// Defined as a function-like macro (rather than a static function) so the
+// compiler can perform Typed Memory Operations type inference at each call
+// site. See rdar://170138232.
+#define AllocatePffftBuffer(size) static_cast<float*>(pffft_aligned_malloc((size) * sizeof(float)))
+#endif
 
 }  // namespace
 

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/rtc_base/memory/aligned_malloc.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/rtc_base/memory/aligned_malloc.cc
@@ -50,6 +50,68 @@ void* GetRightAlign(const void* pointer, size_t alignment) {
   return reinterpret_cast<void*>(GetRightAlign(start_pos, alignment));
 }
 
+#if defined(WEBRTC_WEBKIT_BUILD)
+#if defined(_MALLOC_TYPE_ENABLED) && _MALLOC_TYPE_ENABLED
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wallocator-wrappers" // rdar://170138232
+void* AlignedMalloc_typed(size_t size, malloc_type_id_t type_id, size_t alignment) {
+  if (size == 0) {
+    return nullptr;
+  }
+  if (!ValidAlignment(alignment)) {
+    return nullptr;
+  }
+
+  // The memory is aligned towards the lowest address that so only
+  // alignment - 1 bytes needs to be allocated.
+  // A pointer to the start of the memory must be stored so that it can be
+  // retreived for deletion, ergo the sizeof(uintptr_t).
+  void* memory_pointer = malloc_type_malloc(size + sizeof(uintptr_t) + alignment - 1, type_id);
+  RTC_CHECK(memory_pointer) << "Couldn't allocate memory in AlignedMalloc";
+
+  // Aligning after the sizeof(uintptr_t) bytes will leave room for the header
+  // in the same memory block.
+  uintptr_t align_start_pos = reinterpret_cast<uintptr_t>(memory_pointer);
+  align_start_pos += sizeof(uintptr_t);
+  uintptr_t aligned_pos = GetRightAlign(align_start_pos, alignment);
+  void* aligned_pointer = reinterpret_cast<void*>(aligned_pos);
+
+  // Store the address to the beginning of the memory just before the aligned
+  // memory.
+  uintptr_t header_pos = aligned_pos - sizeof(uintptr_t);
+  void* header_pointer = reinterpret_cast<void*>(header_pos);
+  uintptr_t memory_start = reinterpret_cast<uintptr_t>(memory_pointer);
+  memcpy(header_pointer, &memory_start, sizeof(uintptr_t));
+
+  return aligned_pointer;
+}
+#pragma clang diagnostic pop
+#else
+void* AlignedMalloc(size_t size, size_t alignment) {
+  if (size == 0) {
+    return nullptr;
+  }
+  if (!ValidAlignment(alignment)) {
+    return nullptr;
+  }
+
+  void* memory_pointer = malloc(size + sizeof(uintptr_t) + alignment - 1);
+  RTC_CHECK(memory_pointer) << "Couldn't allocate memory in AlignedMalloc";
+
+  uintptr_t align_start_pos = reinterpret_cast<uintptr_t>(memory_pointer);
+  align_start_pos += sizeof(uintptr_t);
+  uintptr_t aligned_pos = GetRightAlign(align_start_pos, alignment);
+  void* aligned_pointer = reinterpret_cast<void*>(aligned_pos);
+
+  uintptr_t header_pos = aligned_pos - sizeof(uintptr_t);
+  void* header_pointer = reinterpret_cast<void*>(header_pos);
+  uintptr_t memory_start = reinterpret_cast<uintptr_t>(memory_pointer);
+  memcpy(header_pointer, &memory_start, sizeof(uintptr_t));
+
+  return aligned_pointer;
+}
+#endif
+#else
 void* AlignedMalloc(size_t size, size_t alignment) {
   if (size == 0) {
     return nullptr;
@@ -81,6 +143,7 @@ void* AlignedMalloc(size_t size, size_t alignment) {
 
   return aligned_pointer;
 }
+#endif
 
 void AlignedFree(void* mem_block) {
   if (mem_block == nullptr) {

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/rtc_base/memory/aligned_malloc.h
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/rtc_base/memory/aligned_malloc.h
@@ -18,6 +18,9 @@
 // Note: alignment must be a power of two. The alignment is in bytes.
 
 #include <stddef.h>
+#if defined(WEBRTC_WEBKIT_BUILD)
+#include <stdlib.h> // for _MALLOC_TYPED and malloc_type_id_t
+#endif
 
 namespace webrtc {
 
@@ -30,7 +33,12 @@ void* GetRightAlign(const void* ptr, size_t alignment);
 // Allocates memory of `size` bytes aligned on an `alignment` boundry.
 // The return value is a pointer to the memory. Note that the memory must
 // be de-allocated using AlignedFree.
+#if defined(WEBRTC_WEBKIT_BUILD) && defined(_MALLOC_TYPE_ENABLED) && _MALLOC_TYPE_ENABLED
+void* AlignedMalloc_typed(size_t size, malloc_type_id_t type_id, size_t alignment);
+void* AlignedMalloc(size_t size, size_t alignment) _MALLOC_TYPED(AlignedMalloc_typed, 1);
+#else
 void* AlignedMalloc(size_t size, size_t alignment);
+#endif
 // De-allocates memory created using the AlignedMalloc() API.
 void AlignedFree(void* mem_block);
 


### PR DESCRIPTION
#### 757068e48bcf5f86dacd0ba7211fe77ad286e64b
<pre>
[libwebrtc] Adopt Typed Memory Operations in allocator wrappers
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=319467">https://bugs.webkit.org/show_bug.cgi?id=319467</a>&gt;
&lt;<a href="https://rdar.apple.com/170007132">rdar://170007132</a>&gt;

Reviewed by Zak Ridouh.

Enable `-Wallocator-wrappers` for the libwebrtc projects and resolve
the ten resulting warnings.  The warning flags functions that directly
wrap a system allocator (`malloc`/`calloc`/`realloc`); the wrapper
hides the allocation from the compiler and prevents Typed Memory
Operations (TMO) type inference at call sites.

Resolve each wrapper using one of three strategies, picked per
wrapper based on body complexity, public-API exposure, and whether
the function is taken by-address:

- Adopt `_MALLOC_TYPED` for substantive wrappers whose `size_t`
  parameter maps directly to the underlying allocation.  The
  compiler rewrites direct calls to a typed variant that forwards
  a `malloc_type_id_t` inferred from the cast at each call site.
  Applies to `srtp_crypto_alloc`, `pffft_aligned_malloc`, and
  `webrtc::AlignedMalloc`.
- Convert trivial pass-through wrappers to function-like macros so
  the compiler sees the underlying allocator at every call site.
  Applies to `opus_alloc`, `opus_realloc`, `opus_alloc_scratch`,
  `strdup_libc_malloc`, and `webrtc::AllocatePffftBuffer`.
- Suppress `-Wallocator-wrappers` for wrappers that cannot be
  rewritten because the function is taken by-address.  yasm&apos;s
  `def_xmalloc`/`def_xcalloc`/`def_xrealloc` are only assigned to
  global function pointers; `OPENSSL_malloc` is assigned to a
  function pointer in `OPENSSL_vasprintf_internal`.  In both cases
  the rewriter cannot rewrite calls made through a function pointer
  at runtime, so the original symbol must remain defined.

Enable the warning in `Base.xcconfig`, whose `WARNING_CFLAGS` every
libwebrtc target inherits via `$(inherited)`.

All WebKit-specific divergences are wrapped in
`#if defined(WEBRTC_WEBKIT_BUILD)` so future upstream resyncs land in
the `#else` branch, per the libwebrtc fork&apos;s macro contract.  The
yasm pragma is unconditional because `yasm.xcconfig` does not define
`WEBRTC_WEBKIT_BUILD` (yasm is built as a build-time tool, not linked
into `libwebrtc.dylib`).

`strdup_libc_malloc` calls libc `strdup()` directly rather than
reimplementing it; upstream&apos;s MSVC deprecation and glibc/musl
feature-macro concerns do not apply on Apple platforms.

No new tests since this change is not directly testable.

* Source/ThirdParty/libwebrtc/Configurations/Base.xcconfig:
* Source/ThirdParty/libwebrtc/Source/third_party/boringssl/src/crypto/err/err.cc:
(strdup_libc_malloc):
* Source/ThirdParty/libwebrtc/Source/third_party/boringssl/src/crypto/mem.cc:
(OPENSSL_malloc):
* Source/ThirdParty/libwebrtc/Source/third_party/libsrtp/crypto/include/alloc.h:
* Source/ThirdParty/libwebrtc/Source/third_party/libsrtp/crypto/kernel/alloc.c:
(srtp_crypto_alloc_typed): Add.
(srtp_crypto_alloc):
* Source/ThirdParty/libwebrtc/Source/third_party/opus/src/celt/os_support.h:
* Source/ThirdParty/libwebrtc/Source/third_party/pffft/src/pffft.c:
(pffft_aligned_malloc_typed): Add.
(pffft_aligned_malloc):
* Source/ThirdParty/libwebrtc/Source/third_party/pffft/src/pffft.h:
* Source/ThirdParty/libwebrtc/Source/third_party/yasm/libyasm/xmalloc.c:
(def_xmalloc):
(def_xcalloc):
(def_xrealloc):
* Source/ThirdParty/libwebrtc/Source/webrtc/modules/audio_processing/utility/pffft_wrapper.cc:
(webrtc::AllocatePffftBuffer):
* Source/ThirdParty/libwebrtc/Source/webrtc/rtc_base/memory/aligned_malloc.cc:
(webrtc::AlignedMalloc_typed): Add.
(webrtc::AlignedMalloc):
* Source/ThirdParty/libwebrtc/Source/webrtc/rtc_base/memory/aligned_malloc.h:

Canonical link: <a href="https://commits.webkit.org/317915@main">https://commits.webkit.org/317915@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/396bbb378d11de3529dc22240e8378dde97c3316

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174767 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48700 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42481 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184347 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132675 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49992 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48383 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135993 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95992 "2 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dd331886-fcbf-4530-ac8e-a7e9b8d6b385) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177725 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39435 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156787 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116471 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/260d7053-0d86-4b18-9861-ca1258765812) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38076 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36450 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148499 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36279 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32825 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40649 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186772 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48367 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144922 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49047 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32900 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144781 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26821 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39657 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114826 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47553 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11249 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46955 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47186 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47013 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->