### PR TITLE
REGRESSION(317213@main): Broke some internal builds (various errors under UserContentControllerTests.swift)

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/UserContentControllerTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/UserContentControllerTests.swift
@@ -54,26 +54,26 @@ struct UserContentControllerTests {
 
         // The other WebKitNamespace attributes shouldn't be accessible.
 
-        let evaluateScript: Void? = try await page.callJavaScript(returning: Void?.self) {
+        let evaluateScript = try await page.callJavaScript(returning: Bool.self) {
             """
             return !!window.webkit.evaluateScript;
             """
         }
-        #expect(evaluateScript == false)
+        #expect(!evaluateScript)
 
-        let createJSHandle: Void? = try await page.callJavaScript(returning: Void?.self) {
+        let createJSHandle = try await page.callJavaScript(returning: Bool.self) {
             """
             return !!window.webkit.createJSHandle;
             """
         }
-        #expect(createJSHandle == false)
+        #expect(!createJSHandle)
 
-        let nodeSnapshotCreator: Void? = try await page.callJavaScript(returning: Void?.self) {
+        let nodeSnapshotCreator = try await page.callJavaScript(returning: Bool.self) {
             """
             return !!window.webkit.createNodeSnapshot;
             """
         }
-        #expect(cloneNode == false)
+        #expect(!nodeSnapshotCreator)
     }
 }
 


### PR DESCRIPTION
#### dc2c4a57ed42c77e26d9f5379c84e9c872d5151c
<pre>
REGRESSION(317213@main): Broke some internal builds (various errors under UserContentControllerTests.swift)
<a href="https://bugs.webkit.org/show_bug.cgi?id=319468">https://bugs.webkit.org/show_bug.cgi?id=319468</a>
<a href="https://rdar.apple.com/182277728">rdar://182277728</a>

Unreviewed build fix.

There are two build breaks post-317213@main. First, we correctly refer
to `nodeSnapshotCreator` instead of the extant `cloneNode`. Second, we
return the script results in the expected type (`Bool`, not `Void?`).

* Tools/TestWebKitAPI/Tests/WebKit/WebPage/UserContentControllerTests.swift:
(UserContentControllerTests.jsBufferInjectsWebKitNamespace):

Canonical link: <a href="https://commits.webkit.org/317221@main">https://commits.webkit.org/317221@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4879d4b75e7f110310ade09970918ded63ee61be

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174690 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48623 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/42404 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184269 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/132558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/09abc9a7-98d7-4056-86ce-a252c53d0e1c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176555 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49915 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48306 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/135925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/132558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177648 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39360 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/156717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/116403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/58e9c059-792f-4bc0-80e5-2cd26d5f950b) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/38001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32748 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/148424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/36209 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186695 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/144850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48290 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/156273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144710 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48970 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26542 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/39588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47476 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/11177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46878 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47109 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46936 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->