### PR TITLE
[AppKit Gestures] Refactor position information controlling logic out of WKAppKitGestureController

### DIFF
--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -650,6 +650,7 @@ UIProcess/mac/WindowServerConnection.mm @nonARC
 UIProcess/mac/WKFullScreenWindowController.mm @nonARC
 UIProcess/mac/WKImmediateActionController.mm @nonARC
 UIProcess/mac/WKAppKitGestureController.mm @nonARC
+UIProcess/mac/PositionInformationManager.cpp
 UIProcess/mac/WKPrintingView.mm @nonARC
 UIProcess/mac/WKQuickLookPreviewController.mm @nonARC
 UIProcess/mac/WKRevealItemPresenter.mm @nonARC

--- a/Source/WebKit/UIProcess/mac/PositionInformationManager.cpp
+++ b/Source/WebKit/UIProcess/mac/PositionInformationManager.cpp
@@ -1,0 +1,159 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "PositionInformationManager.h"
+
+#include "WebPageProxy.h"
+#include <wtf/RefPtr.h>
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PositionInformationManager);
+
+PositionInformationManager::PositionInformationManager(WebPageProxy& page)
+    : m_page(page)
+{
+}
+
+PositionInformationManager::~PositionInformationManager()
+{
+    // Guarantee every still-queued callback runs exactly once, even when the manager is torn down
+    // with requests in flight.
+    invokeAndRemovePendingHandlers([](const InteractionInformationRequest&) {
+        return true;
+    }, std::nullopt);
+}
+
+void PositionInformationManager::doAfterUpdate(const InteractionInformationRequest& request, UpdateCompletionHandler&& callback)
+{
+    if (currentIsValid(request)) {
+        callback(m_currentInformation);
+        return;
+    }
+
+    m_pendingHandlers.constructAndAppend(std::in_place, request, WTF::move(callback));
+
+    if (!hasValidOutstandingRequest(request))
+        requestUpdate(request);
+}
+
+void PositionInformationManager::didChange(const InteractionInformationAtPosition& info)
+{
+    if (m_lastOutstandingRequest && info.request.isValidForRequest(*m_lastOutstandingRequest))
+        m_lastOutstandingRequest = std::nullopt;
+
+    auto newInfo = info;
+    newInfo.mergeCompatibleOptionalInformation(m_currentInformation);
+
+    m_currentInformation = WTF::move(newInfo);
+    m_hasValidCurrentInformation = m_currentInformation.canBeValid;
+
+    // Only the callbacks whose request the newly-arrived information satisfies should resolve now.
+    invokeAndRemovePendingHandlers([&](const InteractionInformationRequest& request) {
+        return currentIsValid(request);
+    }, m_currentInformation);
+}
+
+void PositionInformationManager::invalidate()
+{
+    m_hasValidCurrentInformation = false;
+    m_currentInformation = { };
+}
+
+void PositionInformationManager::reset()
+{
+    invalidate();
+    m_lastOutstandingRequest = std::nullopt;
+    invokeAndRemovePendingHandlers([](const InteractionInformationRequest&) {
+        return true;
+    }, std::nullopt);
+}
+
+void PositionInformationManager::abandonOutstandingRequest()
+{
+    auto abandonedRequest = std::exchange(m_lastOutstandingRequest, std::nullopt);
+    if (!abandonedRequest)
+        return;
+
+    invokeAndRemovePendingHandlers([&](const InteractionInformationRequest& request) {
+        return request.isValidForRequest(*abandonedRequest);
+    }, std::nullopt);
+}
+
+void PositionInformationManager::requestUpdate(const InteractionInformationRequest& request)
+{
+    if (currentIsValid(request))
+        return;
+
+    RefPtr page = m_page.get();
+    if (!page || !page->hasRunningProcess())
+        return;
+
+    m_lastOutstandingRequest = request;
+    page->requestPositionInformation(request);
+}
+
+bool PositionInformationManager::currentIsValid(const InteractionInformationRequest& request) const
+{
+    return m_hasValidCurrentInformation && m_currentInformation.request.isValidForRequest(request);
+}
+
+bool PositionInformationManager::currentIsApproximatelyValid(const InteractionInformationRequest& request, int radius) const
+{
+    return m_hasValidCurrentInformation && m_currentInformation.request.isApproximatelyValidForRequest(request, radius);
+}
+
+bool PositionInformationManager::hasValidOutstandingRequest(const InteractionInformationRequest& request) const
+{
+    return m_lastOutstandingRequest.and_then([&request](const auto& outstandingRequest) -> std::optional<bool> {
+        return outstandingRequest.isValidForRequest(request);
+    }).value_or(false);
+}
+
+void PositionInformationManager::invokeAndRemovePendingHandlers(Function<bool(InteractionInformationRequest)>&& matches, const std::optional<InteractionInformationAtPosition>& information)
+{
+    ++m_callbackDepth;
+
+    for (auto& slot : m_pendingHandlers) {
+        if (!slot)
+            continue;
+        if (!matches(slot->request))
+            continue;
+
+        if (auto requestAndCallback = std::exchange(slot, std::nullopt); requestAndCallback->callback)
+            requestAndCallback->callback(information);
+    }
+
+    if (--m_callbackDepth)
+        return;
+
+    m_pendingHandlers.removeAllMatching([](const auto& handler) {
+        return !handler;
+    });
+}
+
+} // namespace WebKit

--- a/Source/WebKit/UIProcess/mac/PositionInformationManager.h
+++ b/Source/WebKit/UIProcess/mac/PositionInformationManager.h
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "InteractionInformationAtPosition.h"
+#include "InteractionInformationRequest.h"
+#include <optional>
+#include <utility>
+#include <wtf/CompletionHandler.h>
+#include <wtf/Platform.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/Vector.h>
+#include <wtf/WeakPtr.h>
+
+// FIXME: Share this logic with iOS.
+// FIXME: Convert this to Swift for more compile-time safety and guarantees.
+
+namespace WebKit {
+
+class WebPageProxy;
+
+// Owns the asynchronous hit-test "position information" cache and the queue of completions waiting
+// on it. A completion registered via doAfterUpdate() is guaranteed to run exactly once: either with
+// the resolved information, or with std::nullopt when the request is abandoned (the press ended
+// before the reply arrived, the page went away, or the manager is reset / destroyed).
+class PositionInformationManager {
+    WTF_MAKE_TZONE_ALLOCATED(PositionInformationManager);
+public:
+    using UpdateCompletionHandler = CompletionHandler<void(const std::optional<InteractionInformationAtPosition>&)>;
+
+    explicit PositionInformationManager(WebPageProxy&);
+    ~PositionInformationManager();
+
+    // Runs the completion handler once the cache holds information valid for the request. If the cache is already
+    // valid the callback runs synchronously; otherwise it is queued and an asynchronous update is
+    // requested (coalesced with any in-flight request that would also satisfy this one).
+    void doAfterUpdate(const InteractionInformationRequest&, UpdateCompletionHandler&&);
+
+    // Called when fresh information arrives from the web process; resolves all queued callbacks that
+    // the new information satisfies.
+    void didChange(const InteractionInformationAtPosition&);
+
+    // Drops the cached information (e.g. on a main-frame load commit). Does not touch queued callbacks.
+    void invalidate();
+
+    // Full teardown: invalidates the cache, forgets any in-flight request, and resolves every queued
+    // callback with std::nullopt.
+    void reset();
+
+    // Abandons the in-flight request (if any) and resolves the queued callbacks waiting on it with
+    // std::nullopt. Used when a deferring gesture's press ends before the reply arrives.
+    void abandonOutstandingRequest();
+
+    bool currentIsValid(const InteractionInformationRequest&) const;
+    bool currentIsApproximatelyValid(const InteractionInformationRequest&, int radius) const;
+    bool hasValidCurrentInformation() const { return m_hasValidCurrentInformation; }
+    const InteractionInformationAtPosition& currentInformation() const { return m_currentInformation; }
+
+private:
+    void requestUpdate(const InteractionInformationRequest&);
+    bool hasValidOutstandingRequest(const InteractionInformationRequest&) const;
+
+    // Invokes (exactly once) and removes every queued callback whose request satisfies `matches`,
+    // passing `information` to each. Reentrancy-safe: callbacks may re-enter and mutate the queue, so
+    // consumed slots are left as tombstones and only compacted once the outermost invocation unwinds.
+    void invokeAndRemovePendingHandlers(Function<bool(InteractionInformationRequest)>&& matches, const std::optional<InteractionInformationAtPosition>&);
+
+    struct RequestAndCallback {
+        InteractionInformationRequest request;
+        UpdateCompletionHandler callback;
+    };
+
+    WeakPtr<WebPageProxy> m_page;
+    InteractionInformationAtPosition m_currentInformation;
+    std::optional<InteractionInformationRequest> m_lastOutstandingRequest;
+    Vector<std::optional<RequestAndCallback>> m_pendingHandlers;
+    uint64_t m_callbackDepth { 0 };
+    bool m_hasValidCurrentInformation { false };
+};
+
+} // namespace WebKit

--- a/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
+++ b/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
@@ -33,6 +33,7 @@
 #import "InteractionInformationAtPosition.h"
 #import "InteractionInformationRequest.h"
 #import "NativeWebWheelEvent.h"
+#import "PositionInformationManager.h"
 #import "RemoteLayerTreeDrawingAreaProxy.h"
 #import "ScrollingAccelerationCurve.h"
 #import "ViewGestureController.h"
@@ -110,13 +111,6 @@ static WebCore::FloatSize toRawPlatformDelta(WebCore::FloatSize delta)
     return -delta;
 }
 
-using InteractionInformationCallback = Function<void(const WebKit::InteractionInformationAtPosition&)>;
-
-struct InteractionInformationRequestAndCallback {
-    WebKit::InteractionInformationRequest request;
-    InteractionInformationCallback callback;
-};
-
 static bool representsDraggableElement(const WebKit::InteractionInformationAtPosition& info)
 {
     return info.isLink || info.isImage || info.isAttachment || info.isDHTMLDraggable || info.isColorInput || info.prefersDraggingOverTextSelection;
@@ -170,11 +164,7 @@ static NSString *gestureLogDescription(NSGestureRecognizer *gesture)
     BlockPtr<void(NSDraggingSession *)> _textSelectionDragCompletionHandler;
     bool _dragGestureHasSentMouseDown;
 
-    WebKit::InteractionInformationAtPosition _positionInformation;
-    std::optional<WebKit::InteractionInformationRequest> _lastOutstandingPositionInformationRequest;
-    Vector<std::optional<InteractionInformationRequestAndCallback>> _pendingPositionInformationHandlers;
-    uint64_t _positionInformationCallbackDepth;
-    bool _hasValidPositionInformation;
+    std::unique_ptr<WebKit::PositionInformationManager> _positionInformationManager;
 }
 
 #if __has_include(<WebKitAdditions/WKAppKitGestureControllerAdditionsImpl.mm>)
@@ -190,6 +180,7 @@ static NSString *gestureLogDescription(NSGestureRecognizer *gesture)
 
     _page = page.get();
     _viewImpl = viewImpl.get();
+    _positionInformationManager = makeUnique<WebKit::PositionInformationManager>(page.get());
 
     [self setUpGestureRecognizers];
     [self addGesturesToWebView];
@@ -709,7 +700,11 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG_DEBUG(RefPtr { _page.get() }->logIdentifier(), "deferral: deferring; awaiting position info at %@", NSStringFromPoint(locationInView));
 
     WebKit::InteractionInformationRequest request { WebCore::IntPoint { locationInView } };
-    [self doAfterPositionInformationUpdate:[weakSelf = WeakObjCPtr<WKAppKitGestureController>(self), weakDeferring = WeakObjCPtr<WKDeferringGestureRecognizer>(deferringGestureRecognizer), isInScrollbar](const auto &info) {
+    _positionInformationManager->doAfterUpdate(request, [weakSelf = WeakObjCPtr<WKAppKitGestureController>(self), weakDeferring = WeakObjCPtr<WKDeferringGestureRecognizer>(deferringGestureRecognizer), isInScrollbar](const std::optional<WebKit::InteractionInformationAtPosition>& optionalInfo) {
+        if (!optionalInfo)
+            return;
+        const auto& info = *optionalInfo;
+
         RetainPtr strongSelf = weakSelf.get();
         RetainPtr strongDeferring = weakDeferring.get();
         if (!strongSelf || !strongDeferring)
@@ -746,7 +741,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
         }();
 
         [strongDeferring endDeferralShouldPreventGestures:shouldPreventGestures];
-    } forRequest:request];
+    });
 
     return YES;
 }
@@ -757,12 +752,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
         return;
 
     WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(RefPtr { _page.get() }->logIdentifier(), "deferral: press ended before position info arrived; unblocking text selection");
-    if (auto abandonedRequest = std::exchange(_lastOutstandingPositionInformationRequest, std::nullopt)) {
-        for (auto& slot : _pendingPositionInformationHandlers) {
-            if (slot && slot->request.isValidForRequest(*abandonedRequest))
-                slot.reset();
-        }
-    }
+    _positionInformationManager->abandonOutstandingRequest();
 
     [deferringGestureRecognizer endDeferralShouldPreventGestures:NO];
 }
@@ -773,100 +763,17 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
 
 #pragma mark - Position Information
 
-- (void)_invalidateCurrentPositionInformation
-{
-    _hasValidPositionInformation = false;
-    _positionInformation = { };
-}
-
 - (void)didCommitLoadForMainFrame
 {
-    [self _invalidateCurrentPositionInformation];
-}
-
-- (void)requestAsynchronousPositionInformationUpdate:(WebKit::InteractionInformationRequest)request
-{
-    if ([self _currentPositionInformationIsValidForRequest:request])
-        return;
-
-    RefPtr page = _page.get();
-    if (!page || !page->hasRunningProcess())
-        return;
-
-    _lastOutstandingPositionInformationRequest = request;
-    page->requestPositionInformation(request);
-}
-
-- (void)doAfterPositionInformationUpdate:(Function<void(const WebKit::InteractionInformationAtPosition&)>&&)handler forRequest:(WebKit::InteractionInformationRequest)request
-{
-    if ([self _currentPositionInformationIsValidForRequest:request]) {
-        handler(_positionInformation);
-        return;
-    }
-
-    _pendingPositionInformationHandlers.constructAndAppend(std::in_place, request, WTF::move(handler));
-
-    if (![self _hasValidOutstandingPositionInformationRequest:request])
-        [self requestAsynchronousPositionInformationUpdate:request];
-}
-
-- (BOOL)_currentPositionInformationIsValidForRequest:(const WebKit::InteractionInformationRequest&)request
-{
-    return _hasValidPositionInformation && _positionInformation.request.isValidForRequest(request);
-}
-
-- (BOOL)_hasValidOutstandingPositionInformationRequest:(const WebKit::InteractionInformationRequest&)request
-{
-    return _lastOutstandingPositionInformationRequest.and_then([&request](const auto& outstandingRequest) -> std::optional<bool> {
-        return outstandingRequest.isValidForRequest(request);
-    }).value_or(false);
-}
-
-- (void)_invokeAndRemovePendingHandlersValidForCurrentPositionInformation
-{
-    ASSERT(_hasValidPositionInformation);
-
-    ++_positionInformationCallbackDepth;
-    auto updatedPositionInformation = _positionInformation;
-
-    for (size_t index = 0; index < _pendingPositionInformationHandlers.size(); ++index) {
-        auto& slot = _pendingPositionInformationHandlers[index];
-        if (!slot)
-            continue;
-        if (![self _currentPositionInformationIsValidForRequest:slot->request])
-            continue;
-
-        auto requestAndHandler = std::exchange(slot, std::nullopt);
-        if (requestAndHandler->callback)
-            requestAndHandler->callback(updatedPositionInformation);
-    }
-
-    if (--_positionInformationCallbackDepth)
-        return;
-
-    for (int index = _pendingPositionInformationHandlers.size() - 1; index >= 0; --index) {
-        if (!_pendingPositionInformationHandlers[index])
-            _pendingPositionInformationHandlers.removeAt(index);
-    }
+    _positionInformationManager->invalidate();
 }
 
 - (void)positionInformationDidChange:(const WebKit::InteractionInformationAtPosition&)info
 {
-    // Handlers run in `_invokeAndRemovePendingHandlersValidForCurrentPositionInformation`
-    // can re-enter into client code (e.g. UI delegate callbacks), which may release
-    // the WKWebView and tear `self` down before this method returns.
+    // Resolving queued callbacks can re-enter into client code (e.g. UI delegate callbacks), which
+    // may release the WKWebView and tear `self` down before this method returns.
     RetainPtr protectedSelf = self;
-
-    if (_lastOutstandingPositionInformationRequest && info.request.isValidForRequest(*_lastOutstandingPositionInformationRequest))
-        _lastOutstandingPositionInformationRequest = std::nullopt;
-
-    auto newInfo = info;
-    newInfo.mergeCompatibleOptionalInformation(_positionInformation);
-
-    _positionInformation = newInfo;
-    _hasValidPositionInformation = _positionInformation.canBeValid;
-
-    [self _invokeAndRemovePendingHandlersValidForCurrentPositionInformation];
+    _positionInformationManager->didChange(info);
 }
 
 - (BOOL)_isPointInScrollbar:(NSPoint)locationInViewCoordinates
@@ -879,9 +786,9 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
 {
     WebKit::InteractionInformationRequest request { WebCore::IntPoint { locationInViewCoordinates } };
 
-    bool requestIsValid = _hasValidPositionInformation && _positionInformation.request.isValidForRequest(request);
-    bool isSelectable = _positionInformation.isSelectable();
-    bool isOverSelectableText = _positionInformation.isOverSelectableText;
+    bool requestIsValid = _positionInformationManager->currentIsValid(request);
+    bool isSelectable = _positionInformationManager->currentInformation().isSelectable();
+    bool isOverSelectableText = _positionInformationManager->currentInformation().isOverSelectableText;
 
     // The secondary click owns selectable points that are not over actual text (e.g. the page
     // background). Over a run of selectable text, the text selection manager should win so that a
@@ -889,7 +796,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     bool shouldBegin = requestIsValid && isSelectable && !isOverSelectableText;
 
     if (!requestIsValid)
-        [self _invalidateCurrentPositionInformation];
+        _positionInformationManager->invalidate();
 
     return shouldBegin;
 }
@@ -897,16 +804,18 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
 - (BOOL)_positionInformationRequestIsValidAtLocation:(NSPoint)locationInViewCoordinates withRadius:(NSInteger)radius
 {
     WebKit::InteractionInformationRequest request { WebCore::IntPoint { locationInViewCoordinates } };
-    return _hasValidPositionInformation && _positionInformation.request.isApproximatelyValidForRequest(request, radius);
+    return _positionInformationManager->currentIsApproximatelyValid(request, radius);
 }
 
 - (BOOL)_dragPressShouldBeginAtLocation:(NSPoint)locationInViewCoordinates
 {
     int radius = static_cast<int>(std::ceil([_dragPressGestureRecognizer allowableMovement]));
 
+    const auto& information = _positionInformationManager->currentInformation();
+
     // FIXME: Migrate to requestDragStart: IPC for an authoritative decision.
     // The heuristic below approximates DragController::draggableElement() by consulting the same element-type and style signals.
-    bool isDraggable = representsDraggableElement(_positionInformation);
+    bool isDraggable = representsDraggableElement(information);
     bool requestIsValid = [self _positionInformationRequestIsValidAtLocation:locationInViewCoordinates withRadius:radius];
     bool shouldDrag = requestIsValid && isDraggable;
 
@@ -914,18 +823,18 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
         RefPtr { _page.get() }->logIdentifier(),
         "Drag-press shouldBegin → %d (hasInfo=%d link=%d image=%d attachment=%d dhtml=%d color=%d prefersDrag=%d radius=%d)",
         shouldDrag,
-        _hasValidPositionInformation,
-        _positionInformation.isLink,
-        _positionInformation.isImage,
-        _positionInformation.isAttachment,
-        _positionInformation.isDHTMLDraggable,
-        _positionInformation.isColorInput,
-        _positionInformation.prefersDraggingOverTextSelection,
+        _positionInformationManager->hasValidCurrentInformation(),
+        information.isLink,
+        information.isImage,
+        information.isAttachment,
+        information.isDHTMLDraggable,
+        information.isColorInput,
+        information.prefersDraggingOverTextSelection,
         radius
     );
 
     if (!requestIsValid)
-        [self _invalidateCurrentPositionInformation];
+        _positionInformationManager->invalidate();
 
     return shouldDrag;
 }
@@ -935,15 +844,17 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     static constexpr int panPositionInformationToleranceRadius = 15;
     bool requestIsValid = [self _positionInformationRequestIsValidAtLocation:locationInViewCoordinates withRadius:panPositionInformationToleranceRadius];
 
+    const auto& information = _positionInformationManager->currentInformation();
+
     // FIXME: (rdar://181964604) Because of this logic, vertically scrolling over these elements likely will not work.
-    bool prefersInteraction = _positionInformation.isRangeInput || _positionInformation.isARIASlider;
+    bool prefersInteraction = information.isRangeInput || information.isARIASlider;
     bool yieldToContent = requestIsValid && prefersInteraction;
 
     WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(
         RefPtr { _page.get() }->logIdentifier(),
         "Pan shouldBegin → %d (hasInfo=%d valid=%d prefersInteraction=%d)",
         !yieldToContent,
-        _hasValidPositionInformation,
+        _positionInformationManager->hasValidCurrentInformation(),
         requestIsValid,
         prefersInteraction
     );
@@ -1391,9 +1302,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     _isSuppressingSingleClickGestureForTextSelection = false;
     _latestClickID.reset();
     _layerTreeTransactionIdAtLastInteractionStart.reset();
-    [self _invalidateCurrentPositionInformation];
-    _lastOutstandingPositionInformationRequest.reset();
-    _pendingPositionInformationHandlers.clear();
+    _positionInformationManager->reset();
 }
 
 #pragma mark - NSGestureRecognizerDelegate

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -5394,6 +5394,8 @@
 		335698F52B19307700C7FEE4 /* WebExtensionConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionConstants.h; sourceTree = "<group>"; };
 		336E07462EBCC1C100B4D635 /* WKAppKitGestureController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKAppKitGestureController.h; sourceTree = "<group>"; };
 		336E07472EBCC1C100B4D635 /* WKAppKitGestureController.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKAppKitGestureController.mm; sourceTree = "<group>"; };
+		33F1A0102FEFB66B00BD5D70 /* PositionInformationManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PositionInformationManager.h; sourceTree = "<group>"; };
+		33F1A0112FEFB66B00BD5D70 /* PositionInformationManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PositionInformationManager.cpp; sourceTree = "<group>"; };
 		337041FF2B5895C00077FF78 /* WebExtensionAPIWebRequestEvent.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebExtensionAPIWebRequestEvent.idl; sourceTree = "<group>"; };
 		337042002B58A0880077FF78 /* JSWebExtensionAPIWebRequestEvent.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = JSWebExtensionAPIWebRequestEvent.mm; sourceTree = "<group>"; };
 		337042012B58A0880077FF78 /* JSWebExtensionAPIWebRequestEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSWebExtensionAPIWebRequestEvent.h; sourceTree = "<group>"; };
@@ -17033,6 +17035,8 @@
 				7AFA6F682A9F57C50055322A /* DisplayLinkMac.cpp */,
 				0FCB4E5818BBE3D9000FCFC9 /* PageClientImplMac.h */,
 				0FCB4E5918BBE3D9000FCFC9 /* PageClientImplMac.mm */,
+				33F1A0112FEFB66B00BD5D70 /* PositionInformationManager.cpp */,
+				33F1A0102FEFB66B00BD5D70 /* PositionInformationManager.h */,
 				E18E6909169B563F009B6670 /* SecItemShimProxy.cpp */,
 				E18E690A169B563F009B6670 /* SecItemShimProxy.h */,
 				E18E690D169B57DF009B6670 /* SecItemShimProxy.messages.in */,


### PR DESCRIPTION
#### cb7a261712e72393e153e80f34fb5828885610e3
<pre>
[AppKit Gestures] Refactor position information controlling logic out of WKAppKitGestureController
<a href="https://bugs.webkit.org/show_bug.cgi?id=319470">https://bugs.webkit.org/show_bug.cgi?id=319470</a>
<a href="https://rdar.apple.com/182278712">rdar://182278712</a>

Reviewed by Abrar Rahman Protyasha.

This makes things a lot more organized.

* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/mac/PositionInformationManager.cpp: Added.
(WebKit::PositionInformationManager::PositionInformationManager):
(WebKit::PositionInformationManager::~PositionInformationManager):
(WebKit::PositionInformationManager::doAfterUpdate):
(WebKit::PositionInformationManager::didChange):
(WebKit::PositionInformationManager::invalidate):
(WebKit::PositionInformationManager::reset):
(WebKit::PositionInformationManager::abandonOutstandingRequest):
(WebKit::PositionInformationManager::requestUpdate):
(WebKit::PositionInformationManager::currentIsValid const):
(WebKit::PositionInformationManager::currentIsApproximatelyValid const):
(WebKit::PositionInformationManager::hasValidOutstandingRequest const):
(WebKit::PositionInformationManager::invokeAndRemovePendingHandlers):
* Source/WebKit/UIProcess/mac/PositionInformationManager.h: Added.
(WebKit::PositionInformationManager::hasValidCurrentInformation const):
(WebKit::PositionInformationManager::currentInformation const):
* Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm:
(-[WKAppKitGestureController initWithPage:viewImpl:]):
(-[WKAppKitGestureController deferringGestureRecognizer:shouldDeferGesturesForEventThatWillBeginAction:]):
(-[WKAppKitGestureController deferringGestureRecognizer:didEndActionWithEvent:]):
(-[WKAppKitGestureController didCommitLoadForMainFrame]):
(-[WKAppKitGestureController positionInformationDidChange:]):
(-[WKAppKitGestureController _secondaryClickShouldBeginAtLocation:]):
(-[WKAppKitGestureController _positionInformationRequestIsValidAtLocation:withRadius:]):
(-[WKAppKitGestureController _dragPressShouldBeginAtLocation:]):
(-[WKAppKitGestureController _panShouldBeginAtLocation:]):
(-[WKAppKitGestureController reset]):
(-[WKAppKitGestureController _invalidateCurrentPositionInformation]): Deleted.
(-[WKAppKitGestureController requestAsynchronousPositionInformationUpdate:]): Deleted.
(-[WKAppKitGestureController doAfterPositionInformationUpdate:forRequest:]): Deleted.
(-[WKAppKitGestureController _currentPositionInformationIsValidForRequest:]): Deleted.
(-[WKAppKitGestureController _hasValidOutstandingPositionInformationRequest:]): Deleted.
(-[WKAppKitGestureController _invokeAndRemovePendingHandlersValidForCurrentPositionInformation]): Deleted.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/317279@main">https://commits.webkit.org/317279@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cbf14f01a1c475aa07607e535b7a6db2450400cb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174847 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48780 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42561 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184427 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/132755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a1017424-16cc-4d31-9cbe-57c08c61ed83) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50072 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48463 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/136063 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/132755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/83c473cf-ab66-44d3-815b-8c7da43d1044) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177805 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39501 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/156854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116542 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/16675661-f65f-4aea-a9a4-507bc86c2334) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38142 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32905 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148565 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36346 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186852 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/40259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/144992 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48447 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144852 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39025 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49127 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39724 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/121213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47633 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11316 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47035 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47266 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47093 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->