### PR TITLE
[Coordinated Graphics] ScrollingTreeCoordinated: Consolidate findEventListenerRegionTypes and collectDescendantLayersAtPoint

### DIFF
--- a/Source/WebCore/page/scrolling/coordinated/ScrollingTreeCoordinated.cpp
+++ b/Source/WebCore/page/scrolling/coordinated/ScrollingTreeCoordinated.cpp
@@ -111,11 +111,9 @@ void ScrollingTreeCoordinated::didCompletePlatformRenderingUpdate()
     renderingUpdateComplete();
 }
 
-static bool collectDescendantLayersAtPoint(Vector<Ref<CoordinatedPlatformLayer>>& layersAtPoint, const Ref<CoordinatedPlatformLayer>& parent, const FloatPoint& point)
+static bool traverseDescendantLayersAtPoint(const Ref<CoordinatedPlatformLayer>& parent, const FloatPoint& point, const Function<bool(const Ref<CoordinatedPlatformLayer>&, const FloatPoint&)>& function)
 {
-    bool existsOnDescendent = false;
-    bool existsOnLayer = !!parent->scrollingNodeID() && parent->bounds().contains(point) && parent->eventRegion().contains(roundedIntPoint(point));
-    for (auto& child : parent->children()) {
+    for (auto& child : parent->children() | std::views::reverse) {
         Locker childLocker { child->lock() };
         FloatPoint transformedPoint(point);
         if (child->transform().isInvertible()) {
@@ -128,13 +126,15 @@ static bool collectDescendantLayersAtPoint(Vector<Ref<CoordinatedPlatformLayer>>
             auto pointInChildSpace = transform.projectPoint(point);
             transformedPoint.set(pointInChildSpace.x(), pointInChildSpace.y());
         }
-        existsOnDescendent |= collectDescendantLayersAtPoint(layersAtPoint, child, transformedPoint);
+        if (traverseDescendantLayersAtPoint(child, transformedPoint, function))
+            return true;
     }
 
-    if (existsOnLayer && !existsOnDescendent)
-        layersAtPoint.append(parent);
-
-    return existsOnLayer || existsOnDescendent;
+    if (parent->bounds().contains(point) && parent->eventRegion().contains(roundedIntPoint(point))) {
+        if (function(parent, point))
+            return true;
+    }
+    return false;
 }
 
 RefPtr<ScrollingTreeNode> ScrollingTreeCoordinated::scrollingNodeForPoint(FloatPoint point)
@@ -146,20 +146,19 @@ RefPtr<ScrollingTreeNode> ScrollingTreeCoordinated::scrollingNodeForPoint(FloatP
     Locker layerLocker { m_layerHitTestMutex };
 
     auto rootContentsLayer = static_cast<ScrollingTreeFrameScrollingNodeCoordinated*>(rootScrollingNode)->rootContentsLayer();
-    Vector<Ref<CoordinatedPlatformLayer>> layersAtPoint;
-    {
-        Locker rootContentsLayerLocker { rootContentsLayer->lock() };
-        collectDescendantLayersAtPoint(layersAtPoint, Ref { *rootContentsLayer }, point);
-    }
+    Locker rootContentsLayerLocker { rootContentsLayer->lock() };
 
-    for (auto& layer : layersAtPoint | std::views::reverse) {
-        Locker locker { layer->lock() };
+    RefPtr<ScrollingTreeNode> result = rootScrollingNode;
+    traverseDescendantLayersAtPoint(Ref { *rootContentsLayer }, point, [&](const Ref<CoordinatedPlatformLayer>& layer, const FloatPoint&) {
+        if (!layer->scrollingNodeID())
+            return false;
         auto* scrollingNode = nodeForID(layer->scrollingNodeID());
         if (is<ScrollingTreeScrollingNode>(scrollingNode))
-            return scrollingNode;
-    }
+            result = scrollingNode;
+        return true;
+    });
 
-    return rootScrollingNode;
+    return result;
 }
 
 #if HAVE(DISPLAY_LINK)
@@ -178,32 +177,6 @@ void ScrollingTreeCoordinated::hasNodeWithAnimatedScrollChanged(bool hasNodeWith
 #endif
 
 #if ENABLE(WHEEL_EVENT_REGIONS)
-static OptionSet<EventListenerRegionType> findEventListenerRegionTypes(const Ref<CoordinatedPlatformLayer>& parent, const FloatPoint& point)
-{
-    bool existsOnLayer = parent->bounds().contains(point) && parent->eventRegion().contains(roundedIntPoint(point));
-    for (auto& child : parent->children() | std::views::reverse) {
-        Locker childLocker { child->lock() };
-        FloatPoint transformedPoint(point);
-        if (child->transform().isInvertible()) {
-            float originX = child->anchorPoint().x() * child->size().width();
-            float originY = child->anchorPoint().y() * child->size().height();
-            auto transform = *(TransformationMatrix()
-                .translate3d(originX + child->position().x() - parent->boundsOrigin().x(), originY + child->position().y() - parent->boundsOrigin().y(), child->anchorPoint().z())
-                .multiply(child->transform())
-                .translate3d(-originX, -originY, -child->anchorPoint().z()).inverse());
-            auto pointInChildSpace = transform.projectPoint(point);
-            transformedPoint.set(pointInChildSpace.x(), pointInChildSpace.y());
-        }
-        if (auto result = findEventListenerRegionTypes(child, transformedPoint))
-            return result;
-    }
-
-    if (existsOnLayer)
-        return parent->eventRegion().eventListenerRegionTypesForPoint(roundedIntPoint(point));
-
-    return { };
-}
-
 OptionSet<EventListenerRegionType> ScrollingTreeCoordinated::eventListenerRegionTypesForPoint(FloatPoint point) const
 {
     RefPtr rootScrollingNode = rootNode();
@@ -214,7 +187,13 @@ OptionSet<EventListenerRegionType> ScrollingTreeCoordinated::eventListenerRegion
 
     Ref rootContentsLayer = *static_cast<ScrollingTreeFrameScrollingNodeCoordinated*>(rootScrollingNode.get())->rootContentsLayer();
     Locker rootContentsLayerLocker { rootContentsLayer->lock() };
-    return findEventListenerRegionTypes(rootContentsLayer, point);
+
+    OptionSet<EventListenerRegionType> result;
+    traverseDescendantLayersAtPoint(rootContentsLayer, point, [&](const Ref<CoordinatedPlatformLayer>& layer, const FloatPoint& point) {
+        result = layer->eventRegion().eventListenerRegionTypesForPoint(roundedIntPoint(point));
+        return true;
+    });
+    return result;
 }
 #endif
 


### PR DESCRIPTION
#### 0655dded5553cf5590d8d36a5965b3a771fc93e5
<pre>
[Coordinated Graphics] ScrollingTreeCoordinated: Consolidate findEventListenerRegionTypes and collectDescendantLayersAtPoint
<a href="https://bugs.webkit.org/show_bug.cgi?id=319437">https://bugs.webkit.org/show_bug.cgi?id=319437</a>

Reviewed by Carlos Garcia Campos.

315799@main added findEventListenerRegionTypes() in ScrollingTreeCoordinated.cpp
by copying collectDescendantLayersAtPoint() in the file. They can be consolidated.
Removed them, and added traverseDescendantLayersAtPoint().

* Source/WebCore/page/scrolling/coordinated/ScrollingTreeCoordinated.cpp:
(WebCore::traverseDescendantLayersAtPoint):
(WebCore::ScrollingTreeCoordinated::scrollingNodeForPoint):
(WebCore::ScrollingTreeCoordinated::eventListenerRegionTypesForPoint const):
(WebCore::collectDescendantLayersAtPoint): Deleted.
(WebCore::findEventListenerRegionTypes): Deleted.

Canonical link: <a href="https://commits.webkit.org/317533@main">https://commits.webkit.org/317533@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf2ec1f76a8207062751f295324bd636a2fc0708

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175571 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49503 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/43284 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185157 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177435 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50795 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49186 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/136711 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178528 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/40132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/157472 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117189 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/38773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37160 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/149195 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/36965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33632 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41191 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41363 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187582 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49170 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/157028 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/145680 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49850 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145518 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26682 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/40338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122043 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115846 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48357 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/11943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47759 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47989 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47816 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->