### PR TITLE
[Damage][Skia] Teach the tile and image draws to split themselves by damage rect

### DIFF
--- a/Source/WebCore/platform/Skia.cmake
+++ b/Source/WebCore/platform/Skia.cmake
@@ -21,6 +21,7 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/skia/SkiaCompositingLayerFilters.h
     platform/graphics/skia/SkiaCompositingLayerImageSetBatch.h
     platform/graphics/skia/SkiaCompositingLayerOverlapRegions.h
+    platform/graphics/skia/SkiaDamageRegion.h
     platform/graphics/skia/SkiaGPUAtlas.h
     platform/graphics/skia/SkiaHarfBuzzFont.h
     platform/graphics/skia/SkiaHarfBuzzFontCache.h

--- a/Source/WebCore/platform/graphics/skia/SkiaBackingStore.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaBackingStore.cpp
@@ -31,6 +31,7 @@
 #include "CoordinatedTileBuffer.h"
 #include "FontRenderOptions.h"
 #include "PlatformDisplay.h"
+#include "SkiaDamageRegion.h"
 #include "SkiaPaintingEngine.h"
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkColorSpace.h>
@@ -83,38 +84,62 @@ static inline bool allTileEdgesExposed(const FloatRect& totalRect, const FloatRe
     return !tileRect.x() && !tileRect.y() && tileRect.width() + tileRect.x() >= totalRect.width() && tileRect.height() + tileRect.y() >= totalRect.height();
 }
 
-void SkiaBackingStore::paintToCanvas(SkCanvas& canvas, const SkPaint& paint)
+void SkiaBackingStore::paintToCanvas(SkCanvas& canvas, const SkPaint& paint, const SkiaDamageRegion* damageRegion)
 {
     if (m_tiles.isEmpty())
         return;
 
+    // Tiles are culled against the damage region on top of the canvas clip, because quickReject() only
+    // tests the bounding box of the clip, which grows to the whole surface as soon as two damage rects
+    // are far apart.
+
     FloatRect layerRect = { { }, m_size };
 
+    const auto ctm = canvas.getLocalToDeviceAs3x3();
+    const auto sampling = SkSamplingOptions(SkFilterMode::kNearest, SkMipmapMode::kNone);
     auto tilePaint = paint;
     for (auto& tile : m_tiles.values()) {
         if (canvas.quickReject(tile.rect()))
             continue;
+
+        if (damageRegion) {
+            const auto deviceRect = ctm.mapRect(tile.rect());
+            if (!damageRegion->intersects(deviceRect))
+                continue;
+        }
 
         const auto& image = tile.image();
         if (!image)
             continue;
 
         tilePaint.setAntiAlias(paint.isAntiAlias() && allTileEdgesExposed(layerRect, tile.rect()));
-        canvas.drawImageRect(image, tile.imageSourceRect(), tile.rect(), SkSamplingOptions(SkFilterMode::kNearest, SkMipmapMode::kNone), &tilePaint, SkCanvas::kFast_SrcRectConstraint);
+        canvas.drawImageRect(image, tile.imageSourceRect(), tile.rect(), sampling, &tilePaint, SkCanvas::kFast_SrcRectConstraint);
     }
 }
 
-Vector<SkCanvas::ImageSetEntry> SkiaBackingStore::buildImageSet(SkCanvas& canvas, const SkMatrix& ctm, size_t matrixIndex, float opacity, bool enableAntialias) const
+void SkiaBackingStore::appendImageSetEntries(SkCanvas& canvas, const SkMatrix& ctm, size_t matrixIndex, float opacity, bool enableAntialias, Vector<SkCanvas::ImageSetEntry>& images, const SkiaDamageRegion* damageRegion) const
 {
     if (m_tiles.isEmpty())
-        return { };
+        return;
+
+    // Splitting a tile creates edges inside the tile, and antialiasing them would blend along those edges.
+    // This never happens: a split needs a CTM that keeps rects as rects, and the caller only antialiases
+    // when the CTM does not.
+    ASSERT(!damageRegion || !enableAntialias);
+
+    // Maps device rects back to layer coordinates. The caller only passes a damage region after establishing
+    // that the CTM keeps rects as rects, which implies it is invertible.
+    SkMatrix inverse;
+    if (damageRegion && !ctm.invert(&inverse)) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
 
     FloatRect layerRect = { { }, m_size };
 
     SkAutoCanvasRestore autoRestore(&canvas, true);
     canvas.concat(ctm);
 
-    Vector<SkCanvas::ImageSetEntry> images;
     for (auto& tile : m_tiles.values()) {
         if (canvas.quickReject(tile.rect()))
             continue;
@@ -124,10 +149,23 @@ Vector<SkCanvas::ImageSetEntry> SkiaBackingStore::buildImageSet(SkCanvas& canvas
             continue;
 
         // FIXME: implement per edge antialiasing.
-        unsigned aaFlags = enableAntialias && allTileEdgesExposed(layerRect, tile.rect()) ? SkCanvas::kAll_QuadAAFlags : SkCanvas::kNone_QuadAAFlags;
-        images.append(SkCanvas::ImageSetEntry(image, tile.imageSourceRect(), SkRect(tile.rect()), matrixIndex, opacity, aaFlags, false));
+        const unsigned aaFlags = enableAntialias && allTileEdgesExposed(layerRect, tile.rect()) ? SkCanvas::kAll_QuadAAFlags : SkCanvas::kNone_QuadAAFlags;
+        const SkRect srcRectFull = tile.imageSourceRect();
+        const SkRect dstRectFull = tile.rect();
+
+        if (!damageRegion) {
+            images.append(SkCanvas::ImageSetEntry(image, srcRectFull, dstRectFull, matrixIndex, opacity, aaFlags, false));
+            continue;
+        }
+
+        const auto deviceRect = ctm.mapRect(dstRectFull);
+        if (!damageRegion->intersects(deviceRect))
+            continue;
+
+        damageRegion->forEachDamagedSubRect(deviceRect, dstRectFull, srcRectFull, inverse, [&](const SkRect& srcSubRect, const SkRect& dstSubRect) {
+            images.append(SkCanvas::ImageSetEntry(image, srcSubRect, dstSubRect, matrixIndex, opacity, aaFlags, false));
+        });
     }
-    return images;
 }
 
 void SkiaBackingStore::drawDebugBorders(SkCanvas& canvas, const SkPaint& paint)

--- a/Source/WebCore/platform/graphics/skia/SkiaBackingStore.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaBackingStore.h
@@ -28,6 +28,8 @@
 #if USE(COORDINATED_GRAPHICS) && USE(SKIA)
 #include "CoordinatedBackingStoreProxy.h"
 #include "FloatRect.h"
+#include "IntRect.h"
+#include "SkiaDamageRegion.h"
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkCanvas.h>
 #include <skia/core/SkSurface.h>
@@ -47,12 +49,14 @@ public:
 
     float scale() const { return m_scale; }
     bool hasPendingTileUpdates() const { return m_hasPendingTileUpdates; }
+    FloatSize size() const { return m_size; }
 
     void update(const FloatSize&, float scale, CoordinatedBackingStoreProxy::Update&&);
     void processPendingTileUpdates();
 
-    void paintToCanvas(SkCanvas&, const SkPaint&);
-    Vector<SkCanvas::ImageSetEntry> buildImageSet(SkCanvas&, const SkMatrix&, size_t matrixIndex, float opacity, bool enableAntialias) const;
+    void paintToCanvas(SkCanvas&, const SkPaint&, const SkiaDamageRegion* = nullptr);
+    void appendImageSetEntries(SkCanvas&, const SkMatrix& ctm, size_t matrixIndex, float opacity, bool enableAntialias, Vector<SkCanvas::ImageSetEntry>& images, const SkiaDamageRegion* = nullptr) const;
+
     void drawDebugBorders(SkCanvas&, const SkPaint&);
 
 private:

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
@@ -486,10 +486,9 @@ void SkiaCompositingLayer::paintSelf(SkCanvas& canvas, PaintContext& context)
 
 void SkiaCompositingLayer::paintContents(SkCanvas& canvas, PaintContext& context)
 {
-    TransformationMatrix transform(context.accumulatedReplicaTransform);
-    transform.multiply(m_transforms.combined);
+    const SkM44 transform(combinedTransform(context));
 
-    auto ctm = SkM44(transform).asM33();
+    const auto ctm = transform.asM33();
     bool enableAntialias = !ctm.preservesAxisAlignment() && !ctm.preservesRightAngles();
 
     // When the layer contents are fully opaque and composited at full opacity with the default
@@ -521,11 +520,11 @@ void SkiaCompositingLayer::paintContents(SkCanvas& canvas, PaintContext& context
     };
 
     if (m_backingStore)
-        context.imageSetBatch.addImageSet(canvas, *m_backingStore, ctm, context.opacity, enableAntialias);
+        context.imageSetBatch.addImageSet(canvas, *m_backingStore, transform, context.opacity, enableAntialias, nullptr, setupPaint());
 
     if (m_contentsSolidColor.isValid() && m_contentsSolidColor.isVisible()) {
         ScopedFlush autoFlush(canvas, context.imageSetBatch, ScopedFlush::Mode::FlushBefore);
-        canvas.concat(SkM44(transform));
+        canvas.concat(transform);
         SkPaint paint = setupPaint();
         paint.setColor(SkColor(m_contentsSolidColor.colorWithAlphaMultipliedBy(context.opacity)));
         canvas.drawRect(m_contentsRect, paint);
@@ -551,7 +550,7 @@ void SkiaCompositingLayer::paintContents(SkCanvas& canvas, PaintContext& context
 
         ScopedFlush autoFlush(canvas, context.imageSetBatch, shouldPaintNow ? ScopedFlush::Mode::FlushBefore : ScopedFlush::Mode::DoNothing);
         if (shouldPaintNow) {
-            canvas.concat(SkM44(transform));
+            canvas.concat(transform);
 
             if (m_contentsClippingRect.hasNonZeroRadii() || !m_contentsClippingRect.rect().contains(m_contentsRect))
                 clipRect(canvas, m_contentsClippingRect);
@@ -591,14 +590,11 @@ void SkiaCompositingLayer::paintContents(SkCanvas& canvas, PaintContext& context
                 canvas.drawImageRect(image, SkRect::MakeSize(SkSize::Make(image->dimensions())), SkRect(m_contentsRect),
                     SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kNone), &paint, SkCanvas::kFast_SrcRectConstraint);
             } else {
-                auto clippingRect = m_contentsClippingRect.rect();
-                if (clippingRect.contains(m_contentsRect))
-                    clippingRect = { };
-
                 // The contents image composites over the backing store, so it must use SrcOver always.
                 if (forcedSrcBlendMode && m_backingStore)
                     context.imageSetBatch.updatePaintProperties(canvas, context.colorFilter, context.blendMode);
-                context.imageSetBatch.addImage(canvas, image, m_contentsRect, clippingRect, ctm, context.opacity, enableAntialias);
+
+                context.imageSetBatch.addImage(canvas, image, m_contentsRect, transform, context.opacity, enableAntialias, nullptr, setupPaint());
             }
         }
     }
@@ -610,8 +606,7 @@ void SkiaCompositingLayer::collectFrameDamage(SkCanvas& canvas, PaintContext& co
     if (!frameDamagePropagationEnabled() || !context.frameDamage)
         return;
 
-    TransformationMatrix transform(context.accumulatedReplicaTransform);
-    transform.multiply(m_transforms.combined);
+    const auto transform = combinedTransform(context);
     auto frameDamage = transform.mapRect(effectiveLayerRect());
     auto clipBounds = FloatRect(this->clipBounds(canvas, context));
     if (!clipBounds.isEmpty())
@@ -636,8 +631,7 @@ void SkiaCompositingLayer::paintDebugIndicators(SkCanvas& canvas, PaintContext& 
     if (m_size.isEmpty() || !m_visible || !m_contentsVisible || !hasVisualContent())
         return;
 
-    TransformationMatrix transform(context.accumulatedReplicaTransform);
-    transform.multiply(m_transforms.combined);
+    const auto transform = combinedTransform(context);
 
     if (m_debugBorder) {
         SkAutoCanvasRestore autoRestore(&canvas, true);
@@ -788,6 +782,13 @@ TransformationMatrix SkiaCompositingLayer::replicaTransform() const
 {
     return TransformationMatrix(m_replica->m_transforms.combined)
         .multiply(m_transforms.combined.inverse().value_or(TransformationMatrix()));
+}
+
+TransformationMatrix SkiaCompositingLayer::combinedTransform(const PaintContext& context) const
+{
+    TransformationMatrix transform(context.accumulatedReplicaTransform);
+    transform.multiply(m_transforms.combined);
+    return transform;
 }
 
 IntRect SkiaCompositingLayer::clipBounds(const SkCanvas& canvas, const PaintContext& context) const

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h
@@ -175,6 +175,7 @@ private:
     void paintBackdrop(SkCanvas&, PaintContext&);
     Vector<IntRect, 1> computeConsolidatedOverlapRegionRects(const SkCanvas&, const PaintContext&, ComputeOverlapRegionMode);
     TransformationMatrix replicaTransform() const;
+    TransformationMatrix combinedTransform(const PaintContext&) const;
     IntRect clipBounds(const SkCanvas&, const PaintContext&) const;
     sk_sp<SkImage> maskImage();
     void collect3DRenderingContextLayers(Vector<Ref<SkiaCompositingLayer>>&);

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayerImageSetBatch.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayerImageSetBatch.cpp
@@ -31,6 +31,7 @@
 #include "CoordinatedTileBuffer.h"
 #include "FloatRect.h"
 #include "SkiaBackingStore.h"
+#include "SkiaDamageRegion.h"
 
 namespace WebCore {
 
@@ -71,37 +72,76 @@ bool SkiaCompositingLayerImageSetBatch::imageRequiresLinearSampling(const SkCanv
     return !WTF::isIntegral(matrix.getTranslateX()) || !WTF::isIntegral(matrix.getTranslateY());
 }
 
-void SkiaCompositingLayerImageSetBatch::addImageSet(SkCanvas& canvas, SkiaBackingStore& backingStore, const SkMatrix& ctm, float opacity, bool enableAntialias)
+SkSamplingOptions SkiaCompositingLayerImageSetBatch::samplingOptionsForImage(const SkCanvas& canvas, const sk_sp<SkImage>& image, const FloatRect& rect, const SkMatrix& ctm) const
 {
-    updateSamplingOptions(canvas, SkSamplingOptions(SkFilterMode::kNearest, SkMipmapMode::kNone));
+    if (!imageRequiresLinearSampling(canvas, image, rect, ctm))
+        return m_samplingOptions;
 
-    if (m_preViewMatrices.isEmpty() || m_preViewMatrices.last() != ctm)
-        m_preViewMatrices.append(ctm);
-
-    auto imageSet = backingStore.buildImageSet(canvas, ctm, m_preViewMatrices.size() - 1, opacity, enableAntialias);
-    if (m_imageSet.isEmpty())
-        m_imageSet = WTF::move(imageSet);
-    else
-        m_imageSet.appendVector(WTF::move(imageSet));
+    return SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kNone);
 }
 
-void SkiaCompositingLayerImageSetBatch::addImage(SkCanvas& canvas, const sk_sp<SkImage>& image, const FloatRect& rect, const FloatRect& clip, const SkMatrix& ctm, float opacity, bool enableAntialias)
+size_t SkiaCompositingLayerImageSetBatch::matrixIndexForDraw(const SkMatrix& ctm)
 {
-    if (imageRequiresLinearSampling(canvas, image, rect, ctm))
-        updateSamplingOptions(canvas, SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kNone));
-
     if (m_preViewMatrices.isEmpty() || m_preViewMatrices.last() != ctm)
         m_preViewMatrices.append(ctm);
 
-    if (!clip.isEmpty()) {
-        auto quad = SkRect(clip).toQuad();
-        for (const auto& point : quad)
-            m_dstClips.append(point);
+    return m_preViewMatrices.size() - 1;
+}
+
+void SkiaCompositingLayerImageSetBatch::addImageSet(SkCanvas& canvas, SkiaBackingStore& backingStore, const SkM44& transform, float opacity, bool enableAntialias, const SkiaDamageRegion* damageRegion, const SkPaint& fallbackPaint)
+{
+    const auto ctm = transform.asM33();
+    const auto sampling = SkSamplingOptions(SkFilterMode::kNearest, SkMipmapMode::kNone);
+
+    if (!damageRegion) {
+        updateSamplingOptions(canvas, sampling);
+        backingStore.appendImageSetEntries(canvas, ctm, matrixIndexForDraw(ctm), opacity, enableAntialias, m_imageSet);
+        return;
     }
 
-    size_t matrixIndex = m_preViewMatrices.size() - 1;
-    unsigned aaFlags = enableAntialias ? SkCanvas::kAll_QuadAAFlags : SkCanvas::kNone_QuadAAFlags;
-    m_imageSet.append(SkCanvas::ImageSetEntry(image, SkRect::MakeWH(image->width(), image->height()), SkRect(rect), matrixIndex, opacity, aaFlags, !clip.isEmpty()));
+    // Planned once for the whole layer. appendImageSetEntries() then splits each tile by the rects that touch it.
+    const auto layerDeviceRect = ctm.mapRect(SkRect(FloatRect { { }, backingStore.size() }));
+
+    if (!planRestrictedDraw(canvas, transform, ctm, layerDeviceRect, *damageRegion, [&](SkCanvas& canvas) {
+        backingStore.paintToCanvas(canvas, fallbackPaint, damageRegion);
+    }))
+        return;
+
+    updateSamplingOptions(canvas, sampling);
+    backingStore.appendImageSetEntries(canvas, ctm, matrixIndexForDraw(ctm), opacity, enableAntialias, m_imageSet, damageRegion);
+}
+
+void SkiaCompositingLayerImageSetBatch::addImage(SkCanvas& canvas, const sk_sp<SkImage>& image, const FloatRect& rect, const SkM44& transform, float opacity, bool enableAntialias, const SkiaDamageRegion* damageRegion, const SkPaint& fallbackPaint)
+{
+    const auto ctm = transform.asM33();
+    const SkRect srcRectFull = SkRect::MakeWH(image->width(), image->height());
+    const SkRect dstRectFull = SkRect(rect);
+
+    if (!damageRegion) {
+        updateSamplingOptions(canvas, samplingOptionsForImage(canvas, image, rect, ctm));
+        const auto matrixIndex = matrixIndexForDraw(ctm);
+        const unsigned aaFlags = enableAntialias ? SkCanvas::kAll_QuadAAFlags : SkCanvas::kNone_QuadAAFlags;
+        m_imageSet.append(SkCanvas::ImageSetEntry(image, srcRectFull, dstRectFull, matrixIndex, opacity, aaFlags, false));
+        return;
+    }
+
+    const auto deviceRect = ctm.mapRect(dstRectFull);
+
+    const auto inverse = planRestrictedDraw(canvas, transform, ctm, deviceRect, *damageRegion, [&](SkCanvas& canvas) {
+        canvas.drawImageRect(image, srcRectFull, dstRectFull, SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kNone), &fallbackPaint, SkCanvas::kFast_SrcRectConstraint);
+    });
+    if (!inverse)
+        return;
+
+    // Splitting creates edges inside the image, and antialiasing them would blend along those edges. This
+    // never happens: a split needs a CTM that keeps rects as rects, which is never antialiased.
+    ASSERT(!enableAntialias);
+
+    updateSamplingOptions(canvas, samplingOptionsForImage(canvas, image, rect, ctm));
+    const auto matrixIndex = matrixIndexForDraw(ctm);
+    damageRegion->forEachDamagedSubRect(deviceRect, dstRectFull, srcRectFull, *inverse, [&](const SkRect& srcSubRect, const SkRect& dstSubRect) {
+        m_imageSet.append(SkCanvas::ImageSetEntry(image, srcSubRect, dstSubRect, matrixIndex, opacity, SkCanvas::kNone_QuadAAFlags, false));
+    });
 }
 
 void SkiaCompositingLayerImageSetBatch::flushIfNeeded(SkCanvas& canvas)
@@ -115,11 +155,11 @@ void SkiaCompositingLayerImageSetBatch::flushIfNeeded(SkCanvas& canvas)
     if (m_colorFilter)
         paint.setColorFilter(m_colorFilter);
 
-    canvas.experimental_DrawEdgeAAImageSet(m_imageSet.span().data(), m_imageSet.size(), m_dstClips.span().data(),
+    // No entry ever has a clip, so there are no clip quads to pass.
+    canvas.experimental_DrawEdgeAAImageSet(m_imageSet.span().data(), m_imageSet.size(), nullptr,
         m_preViewMatrices.span().data(), m_samplingOptions, &paint, SkCanvas::kFast_SrcRectConstraint);
 
     m_imageSet.clear();
-    m_dstClips.clear();
     m_preViewMatrices.clear();
     m_blendMode = std::nullopt;
     m_samplingOptions = { };

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayerImageSetBatch.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayerImageSetBatch.h
@@ -27,6 +27,7 @@
 
 #if USE(COORDINATED_GRAPHICS) && USE(SKIA)
 
+#include "SkiaDamageRegion.h"
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkCanvas.h>
 #include <skia/core/SkColorFilter.h>
@@ -48,8 +49,13 @@ public:
     ~SkiaCompositingLayerImageSetBatch() = default;
 
     void updatePaintProperties(SkCanvas&, const sk_sp<SkColorFilter>&, const std::optional<SkBlendMode>&);
-    void addImageSet(SkCanvas&, SkiaBackingStore&, const SkMatrix&, float opacity, bool enableAntialias);
-    void addImage(SkCanvas&, const sk_sp<SkImage>&, const FloatRect&, const FloatRect& clip, const SkMatrix&, float opacity, bool enableAntialias);
+
+    // A null damage region draws everything. Otherwise the draw is split by the rects of the region. A
+    // rotated or skewed transform cannot be split, so it is flushed and drawn under a damage clip with
+    // fallbackPaint, which is used in that case only.
+    void addImageSet(SkCanvas&, SkiaBackingStore&, const SkM44& transform, float opacity, bool enableAntialias, const SkiaDamageRegion*, const SkPaint& fallbackPaint);
+    void addImage(SkCanvas&, const sk_sp<SkImage>&, const FloatRect&, const SkM44& transform, float opacity, bool enableAntialias, const SkiaDamageRegion*, const SkPaint& fallbackPaint);
+
     void flushIfNeeded(SkCanvas&);
 
     class ScopedFlush {
@@ -71,11 +77,38 @@ public:
     };
 
 private:
+    // Decides how to limit one draw to the damage. Returns the inverse to split it with, or nothing when
+    // the draw is already handled, either because it misses the damage or because fallbackDraw() has drawn
+    // it under a damage clip, which ends the batch.
+    template<typename FallbackDrawFunction>
+    std::optional<SkMatrix> planRestrictedDraw(SkCanvas& canvas, const SkM44& transform, const SkMatrix& ctm, const SkRect& deviceRect, const SkiaDamageRegion& damageRegion, NOESCAPE const FallbackDrawFunction& fallbackDraw)
+    {
+        ASSERT(!damageRegion.isEmpty());
+
+        SkMatrix inverse;
+        switch (damageRegion.planDraw(ctm, deviceRect, inverse)) {
+        case SkiaDamageRegion::DrawDamageStrategy::Skip:
+            return std::nullopt;
+        case SkiaDamageRegion::DrawDamageStrategy::ClipToDamage: {
+            ScopedFlush autoFlush(canvas, *this, ScopedFlush::Mode::FlushBefore);
+            canvas.concat(transform);
+            damageRegion.clipCanvasInDeviceSpace(canvas);
+            fallbackDraw(canvas);
+            return std::nullopt;
+        }
+        case SkiaDamageRegion::DrawDamageStrategy::SplitByRect:
+            break;
+        }
+
+        return inverse;
+    }
+
     void updateSamplingOptions(SkCanvas&, SkSamplingOptions);
     bool imageRequiresLinearSampling(const SkCanvas&, const sk_sp<SkImage>&, const FloatRect&, const SkMatrix&) const;
+    SkSamplingOptions samplingOptionsForImage(const SkCanvas&, const sk_sp<SkImage>&, const FloatRect&, const SkMatrix&) const;
+    size_t matrixIndexForDraw(const SkMatrix& ctm);
 
     Vector<SkCanvas::ImageSetEntry> m_imageSet;
-    Vector<SkPoint> m_dstClips;
     Vector<SkMatrix> m_preViewMatrices;
     sk_sp<SkColorFilter> m_colorFilter;
     std::optional<SkBlendMode> m_blendMode;

--- a/Source/WebCore/platform/graphics/skia/SkiaDamageRegion.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaDamageRegion.h
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(COORDINATED_GRAPHICS) && USE(SKIA)
+
+#include "Damage.h"
+#include "IntRect.h"
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/core/SkCanvas.h>
+#include <skia/core/SkMatrix.h>
+#include <skia/core/SkRect.h>
+#include <skia/core/SkRegion.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
+#include <wtf/Vector.h>
+
+namespace WebCore {
+
+// The damage of a frame in device space, kept both as rects, to split draws by, and as a region, to cull
+// and clip with - built once per frame.
+class SkiaDamageRegion {
+public:
+    static SkiaDamageRegion create(const Damage& damage)
+    {
+        const auto damageRects = damage.rectsForPainting().map([](const IntRect& rect) -> SkIRect {
+            return rect;
+        });
+
+        SkiaDamageRegion damageRegion;
+        damageRegion.m_region.setRects(damageRects.span().data(), damageRects.size());
+        damageRegion.m_rects = damageRects.map([](const SkIRect& rect) -> SkRect {
+            return SkRect::Make(rect);
+        });
+
+        return damageRegion;
+    }
+
+    bool isEmpty() const { return m_rects.isEmpty(); }
+
+    // roundOut() applies floor to left/top, and ceil to right/bottom. Make sure a deviceRect touching the
+    // region along an edge triggers an intersection - this is conservative, but for sure not wrong.
+    bool intersects(const SkRect& deviceRect) const { return m_region.intersects(deviceRect.roundOut()); }
+
+    // How to limit one draw to the damage. A draw is split into as many rects as touch it, with no limit,
+    // because the parts share a paint and Skia batches them into one op. Clipping is the slow path instead:
+    // a clip of more than one rect cannot be a scissor, so it costs a stencil buffer or a mask texture.
+    enum class DrawDamageStrategy : uint8_t {
+        Skip, // Nothing touches the damage.
+        SplitByRect, // One draw per touched rect, narrowed in local coords, which narrows the image source too.
+        ClipToDamage // The CTM is rotated or skewed, so one draw under a device-space clip.
+    };
+
+    // On SplitByRect, sets inverse to the matrix that maps device rects back to local coordinates. inverse
+    // is left untouched for the other strategies.
+    DrawDamageStrategy planDraw(const SkMatrix& ctm, const SkRect& deviceRect, SkMatrix& inverse) const
+    {
+        if (!intersects(deviceRect))
+            return DrawDamageStrategy::Skip;
+
+        if (!ctm.rectStaysRect() || !ctm.invert(&inverse))
+            return DrawDamageStrategy::ClipToDamage;
+
+        return DrawDamageStrategy::SplitByRect;
+    }
+
+    // Calls emit(srcSubRect, dstSubRect) once per damage rect that touches deviceRect. deviceRect is
+    // dstRectFull mapped by the ctm, and inverseCtm maps device rects back to local coordinates.
+    template<typename EmitFunction>
+    void forEachDamagedSubRect(const SkRect& deviceRect, const SkRect& dstRectFull, const SkRect& srcRectFull, const SkMatrix& inverseCtm, NOESCAPE const EmitFunction& emit) const
+    {
+        const auto dstToSrc = SkMatrix::RectToRect(dstRectFull, srcRectFull);
+
+        for (const auto& rect : m_rects) {
+            SkRect damaged = rect;
+            if (!damaged.intersect(deviceRect))
+                continue;
+            if (damaged == deviceRect) {
+                emit(srcRectFull, dstRectFull);
+                return;
+            }
+            SkRect dstSubRect;
+            inverseCtm.mapRect(&dstSubRect, damaged);
+            emit(dstToSrc.mapRect(dstSubRect), dstSubRect);
+        }
+    }
+
+    void clipCanvasInDeviceSpace(SkCanvas& canvas) const
+    {
+        ASSERT(!isEmpty());
+        canvas.clipRegion(m_region, SkClipOp::kIntersect);
+    }
+
+private:
+    SkiaDamageRegion() = default;
+
+    Vector<SkRect> m_rects;
+    SkRegion m_region;
+};
+
+} // namespace WebCore
+
+#endif // USE(COORDINATED_GRAPHICS) && USE(SKIA)


### PR DESCRIPTION
#### 174d4885ac9e5be47c68de22fbd7987f1e6ba21e
<pre>
[Damage][Skia] Teach the tile and image draws to split themselves by damage rect
<a href="https://bugs.webkit.org/show_bug.cgi?id=319472">https://bugs.webkit.org/show_bug.cgi?id=319472</a>

Reviewed by Alejandro G. Castro.

Add SkiaDamageRegion, a frame&apos;s damage in device space, as the rects that a draw
is split by and as the same rects in a region, for the draws that have to clip and
for culling. It is built once per frame, so no draw site rebuilds the region.

Teach the tile and image draws to restrict themselves to it. planDraw() says how a
single draw is narrowed: skipped when nothing touches the damage, split into one
draw per damage rect it touches, or, when the transform is rotated or skewed and
rects cannot be narrowed, drawn under a device-space clip.

Splitting is deliberately uncapped, the sub-quads share a paint, so Skia batches
them into one op, while a clip of more than one rect cannot be a scissor and so
costs a stencil buffer or a mask texture and breaks batching. A full-viewport layer
is touched by every rect in the frame, so a cap would send exactly the biggest draws
down the expensive path - we want to avoid that.

Nothing passes a damage region yet, so every draw still paints in full.

* Source/WebCore/platform/Skia.cmake:
* Source/WebCore/platform/graphics/skia/SkiaBackingStore.cpp:
(WebCore::SkiaBackingStore::paintToCanvas):
(WebCore::SkiaBackingStore::appendImageSetEntries const):
(WebCore::SkiaBackingStore::buildImageSet const): Deleted.
* Source/WebCore/platform/graphics/skia/SkiaBackingStore.h:
(WebCore::SkiaBackingStore::size const):
* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp:
(WebCore::SkiaCompositingLayer::paintContents):
(WebCore::SkiaCompositingLayer::collectFrameDamage):
(WebCore::SkiaCompositingLayer::paintDebugIndicators):
(WebCore::SkiaCompositingLayer::combinedTransform const):
* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h:
* Source/WebCore/platform/graphics/skia/SkiaCompositingLayerImageSetBatch.cpp:
(WebCore::SkiaCompositingLayerImageSetBatch::samplingOptionsForImage const):
(WebCore::SkiaCompositingLayerImageSetBatch::matrixIndexForDraw):
(WebCore::SkiaCompositingLayerImageSetBatch::addImageSet):
(WebCore::SkiaCompositingLayerImageSetBatch::addImage):
(WebCore::SkiaCompositingLayerImageSetBatch::flushIfNeeded):
* Source/WebCore/platform/graphics/skia/SkiaCompositingLayerImageSetBatch.h:
(WebCore::SkiaCompositingLayerImageSetBatch::planRestrictedDraw):
* Source/WebCore/platform/graphics/skia/SkiaDamageRegion.h: Added.
(WebCore::SkiaDamageRegion::create):
(WebCore::SkiaDamageRegion::isEmpty const):
(WebCore::SkiaDamageRegion::intersects const):
(WebCore::SkiaDamageRegion::planDraw const):
(WebCore::SkiaDamageRegion::forEachDamagedSubRect const):
(WebCore::SkiaDamageRegion::clipCanvasInDeviceSpace const):

Canonical link: <a href="https://commits.webkit.org/317247@main">https://commits.webkit.org/317247@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5970753b21a9452bbb22f8e627ac47e56ac983f1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174788 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48721 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42502 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184368 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/132696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176653 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50013 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48404 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/136011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/132696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177746 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/39452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/156800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/116489 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/38093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32846 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/148516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36292 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186793 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/40162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/144941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48388 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144801 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49068 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26550 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39673 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/121132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47574 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11262 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46976 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47207 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47034 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->