### PR TITLE
Capture always-on scrollbars in View Transitions snapshots

### DIFF
--- a/LayoutTests/fast/scrolling/mac/view-transition-captures-composited-scrollbars-expected.html
+++ b/LayoutTests/fast/scrolling/mac/view-transition-captures-composited-scrollbars-expected.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ MockScrollbarsEnabled=false AsyncOverflowScrollingEnabled=true ] -->
+<title>view-transition snapshot includes a composited scroll container's scrollbars</title>
+<style>
+#scroller {
+    overflow: scroll;
+    width: 200px;
+    height: 200px;
+}
+#content {
+    width: 1000px;
+    height: 1000px;
+}
+</style>
+<script>
+if (window.internals)
+    internals.setUsesOverlayScrollbars(false);
+
+onload = () => {
+    scroller.scrollTop = 300;
+    scroller.scrollLeft = 300;
+};
+</script>
+<div id="scroller"><div id="content"></div></div>

--- a/LayoutTests/fast/scrolling/mac/view-transition-captures-composited-scrollbars.html
+++ b/LayoutTests/fast/scrolling/mac/view-transition-captures-composited-scrollbars.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ MockScrollbarsEnabled=false AsyncOverflowScrollingEnabled=true ] -->
+<html class="reftest-wait">
+<title>view-transition snapshot includes a composited scroll container's scrollbars</title>
+<meta name="fuzzy" content="maxDifference=0-19; totalPixels=0-152">
+<style>
+#scroller {
+    view-transition-name: target;
+    overflow: scroll;
+    width: 200px;
+    height: 200px;
+}
+#content {
+    width: 1000px;
+    height: 1000px;
+}
+
+/* Freeze the transition at frame 0 with only ::view-transition-old(target) visible, so the
+   screenshot is the captured old snapshot of the scroller (including its scrollbars). */
+html::view-transition-group(root) { animation-duration: 300s; }
+html::view-transition-old(target) { animation: unset; opacity: 1; }
+html::view-transition-new(target) { animation: unset; opacity: 0; }
+</style>
+<script>
+// Use always-on (non-overlay) scrollbars so the thumb is always visible in the
+// snapshot, independent of the machine's "Show scroll bars" setting (overlay
+// scrollbars fade out). Compositing comes from AsyncOverflowScrollingEnabled in
+// the test-runner options above; together these give the scroller composited
+// always-on scrollbars — the case this test captures.
+if (window.internals)
+    internals.setUsesOverlayScrollbars(false);
+
+function finishTest() {
+    document.documentElement.classList.remove("reftest-wait");
+}
+
+function runTest() {
+    scroller.scrollTop = 300;
+    scroller.scrollLeft = 300;
+    document.startViewTransition().ready.then(() => requestAnimationFrame(finishTest));
+}
+
+onload = () => requestAnimationFrame(() => requestAnimationFrame(runTest));
+</script>
+<div id="scroller"><div id="content"></div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/scroller-child.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/scroller-child.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://www.w3.org/TR/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="scroller-child-ref.html">
-<meta name="fuzzy" content="maxDifference=0-5; totalPixels=0-800">
+<meta name="fuzzy" content="maxDifference=0-25; totalPixels=0-800">
 <script src="/common/reftest-wait.js"></script>
 
 <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/scroller.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/scroller.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://www.w3.org/TR/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="scroller-ref.html">
-<meta name="fuzzy" content="maxDifference=0-5; totalPixels=0-10">
+<meta name="fuzzy" content="maxDifference=0-25; totalPixels=0-176">
 <script src="/common/reftest-wait.js"></script>
 
 <style>

--- a/Source/WebCore/platform/Scrollbar.h
+++ b/Source/WebCore/platform/Scrollbar.h
@@ -123,6 +123,9 @@ public:
     bool suppressInvalidation() const { return m_suppressInvalidation; }
     void setSuppressInvalidation(bool s) { m_suppressInvalidation = s; }
 
+    bool paintingIntoSnapshot() const { return m_paintingIntoSnapshot; }
+    void setPaintingIntoSnapshot(bool value) { m_paintingIntoSnapshot = value; }
+
     virtual void styleChanged() { }
 
     IntRect convertToContainingView(const IntRect&) const override;
@@ -188,6 +191,7 @@ protected:
     Timer m_scrollTimer;
 
     bool m_suppressInvalidation { false };
+    bool m_paintingIntoSnapshot { false };
 
 #if !PLATFORM(COCOA)
     float m_opacity { 1 };

--- a/Source/WebCore/platform/mac/ScrollbarThemeMac.mm
+++ b/Source/WebCore/platform/mac/ScrollbarThemeMac.mm
@@ -41,6 +41,7 @@
 #import "ScrollbarMac.h"
 #import "ScrollbarTrackCornerSystemImageMac.h"
 #import <Carbon/Carbon.h>
+#import <QuartzCore/CALayer.h>
 #import <pal/spi/cg/CoreGraphicsSPI.h>
 #import <pal/spi/mac/CoreUISPI.h>
 #import <pal/spi/mac/NSAppearanceSPI.h>
@@ -52,6 +53,58 @@
 #import <wtf/StdLibExtras.h>
 
 // FIXME: There are repainting problems due to Aqua scroll bar buttons' visual overflow.
+
+@interface NSScrollerImp (WebKitSnapshot)
+- (void)displayLayer:(CALayer *)layer;
+@end
+
+@interface WebSnapshotScrollerImpDelegate : NSObject<NSScrollerImpDelegate, CALayerDelegate>
+@property (nonatomic) BOOL useDarkAppearance;
+@property (nonatomic, weak) NSScrollerImp *scrollerImp;
+@end
+
+@implementation WebSnapshotScrollerImpDelegate
+
+- (NSRect)convertRectToBacking:(NSRect)rect
+{
+    return rect;
+}
+
+- (NSRect)convertRectFromBacking:(NSRect)rect
+{
+    return rect;
+}
+
+- (BOOL)shouldUseLayerPerPartForScrollerImp:(NSScrollerImp *)scrollerImp
+{
+    return YES;
+}
+
+- (NSAppearance *)effectiveAppearanceForScrollerImp:(NSScrollerImp *)scrollerImp
+{
+    if (auto *appearance = [NSAppearance appearanceNamed:self.useDarkAppearance ? NSAppearanceNameDarkAqua : NSAppearanceNameAqua])
+        return appearance;
+    return [NSAppearance currentDrawingAppearance];
+}
+
+- (void)displayLayer:(CALayer *)layer
+{
+    // Work around an issue where NSScrollerImp creates layers with NaN corner
+    // radii, which the window server interprets as "maximum radius given the
+    // size of the layer", but which renderInContext: does not seem to handle.
+    [self.scrollerImp displayLayer:layer];
+    if (std::isnan(static_cast<double>([layer cornerRadius]))) {
+        CGRect frame = [layer frame];
+        [layer setCornerRadius:0.5 * std::min(frame.size.width, frame.size.height)];
+    }
+}
+
+- (CALayer *)layer { return nil; }
+- (void)scrollerImp:(NSScrollerImp *)scrollerImp animateKnobAlphaTo:(CGFloat)newKnobAlpha duration:(NSTimeInterval)duration { }
+- (void)scrollerImp:(NSScrollerImp *)scrollerImp animateTrackAlphaTo:(CGFloat)newTrackAlpha duration:(NSTimeInterval)duration { }
+- (void)scrollerImp:(NSScrollerImp *)scrollerImp overlayScrollerStateChangedTo:(NSOverlayScrollerState)newOverlayScrollerState { }
+@end
+
 
 namespace WebCore {
 
@@ -511,12 +564,41 @@ void ScrollbarThemeMac::setPaintCharacteristicsForScrollbar(Scrollbar& scrollbar
     END_BLOCK_OBJC_EXCEPTIONS
 }
 
-static void paintScrollbar(Scrollbar& scrollbar, GraphicsContext& context)
+static void paintScrollbarUsingLayersForSnapshot(Scrollbar& scrollbar, GraphicsContext& context)
 {
     LocalCurrentGraphicsContext localContext { context };
 
     RetainPtr scrollerImp = ScrollbarThemeMac::scrollerImpForScrollbar(scrollbar);
-    BEGIN_BLOCK_OBJC_EXCEPTIONS
+    if (!scrollerImp)
+        return;
+
+    RetainPtr delegate = adoptNS([[WebSnapshotScrollerImpDelegate alloc] init]);
+    [delegate setUseDarkAppearance:protect(scrollbar.scrollableArea())->useDarkAppearanceForScrollbars()];
+    [delegate setScrollerImp:scrollerImp.get()];
+    [scrollerImp setDelegate:delegate.get()];
+
+    auto size = scrollbar.frameRect().size();
+
+    RetainPtr hostLayer = adoptNS([[CALayer alloc] init]);
+    [hostLayer setBounds:CGRectMake(0, 0, size.width(), size.height())];
+    [hostLayer setContentsScale:scrollbar.deviceScaleFactor()];
+    [hostLayer setGeometryFlipped:YES];
+    [scrollerImp setLayer:hostLayer.get()];
+
+    for (CALayer *sublayer in [hostLayer sublayers])
+        [sublayer setDelegate:delegate.get()];
+
+    [hostLayer renderInContext:protect(localContext.cgContext())];
+
+    [scrollerImp setLayer:nil];
+    [scrollerImp setDelegate:nil];
+}
+
+static void paintScrollbarUsingLegacyAppearance(Scrollbar& scrollbar, GraphicsContext& context)
+{
+    LocalCurrentGraphicsContext localContext { context };
+
+    RetainPtr scrollerImp = ScrollbarThemeMac::scrollerImpForScrollbar(scrollbar);
     // Use rectForPart: here; it will take the expansion transition progress into account.
     NSRect trackRect = [scrollerImp rectForPart:NSScrollerKnobSlot];
     [scrollerImp drawKnobSlotInRect:trackRect highlight:NO];
@@ -525,6 +607,15 @@ static void paintScrollbar(Scrollbar& scrollbar, GraphicsContext& context)
     // call drawKnob.
     if (scrollbar.enabled())
         [scrollerImp drawKnob];
+}
+
+static void paintScrollbar(Scrollbar& scrollbar, GraphicsContext& context)
+{
+    BEGIN_BLOCK_OBJC_EXCEPTIONS
+    if (scrollbar.paintingIntoSnapshot() && scrollbar.supportsUpdateOnSecondaryThread())
+        paintScrollbarUsingLayersForSnapshot(scrollbar, context);
+    else
+        paintScrollbarUsingLegacyAppearance(scrollbar, context);
     END_BLOCK_OBJC_EXCEPTIONS
 }
 
@@ -535,7 +626,7 @@ bool ScrollbarThemeMac::paint(Scrollbar& scrollbar, GraphicsContext& context, co
 
     setPaintCharacteristicsForScrollbar(scrollbar);
 
-    if (scrollbar.supportsUpdateOnSecondaryThread())
+    if (scrollbar.supportsUpdateOnSecondaryThread() && !scrollbar.paintingIntoSnapshot())
         return true;
 
     SetForScope isCurrentlyDrawingIntoLayer(g_isCurrentlyDrawingIntoLayer, context.isCALayerContext());

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -1484,7 +1484,12 @@ void RenderLayerScrollableArea::paintOverflowControls(GraphicsContext& context, 
             damageRect.move(-widgetPaintOffset.width(), -widgetPaintOffset.height());
         }
 
+        bool paintingIntoSnapshot = paintBehavior.contains(PaintBehavior::Snapshotting);
+        if (paintingIntoSnapshot)
+            scrollbar->setPaintingIntoSnapshot(true);
         scrollbar->paint(context, damageRect);
+        if (paintingIntoSnapshot)
+            scrollbar->setPaintingIntoSnapshot(false);
     };
 
     paintScrollBarIfNecessary(m_hBar, damageRect);


### PR DESCRIPTION
#### 34b552ef6263497a52db44d5cb38278f0b776530
<pre>
Capture always-on scrollbars in View Transitions snapshots
<a href="https://bugs.webkit.org/show_bug.cgi?id=319473">https://bugs.webkit.org/show_bug.cgi?id=319473</a>
<a href="https://rdar.apple.com/problem/182283234">rdar://problem/182283234</a>

Reviewed by Simon Fraser.

css/css-view-transitions/scroller.html and scroller-child.html fail on
wpt.fyi because the View Transitions snapshot does not include the
scrollbars of the element with scrollable overflow.

On the wpt.fyi bots, Always On Scrollbars are used, which take layout
space and render scrollbars with two rounded rectangles (one for the
track, one for the thumb). This is rendered in the UI process by getting
AppKit to create layers for the scrollbar parts. During snapshotting,
we currently skip drawing scollbars if we know that they are being
rendered by the UI process.

Also, the existing scrollbar drawing code, which uses drawKnobSlotInRect:
and drawKnob:, results in a legacy appearance that does not match the
Always On Scrollbars appearance that AppKit creates via layers.

So, we change paintScrollbar to allow painting the scrollbar during
snapshotting, even when the UI process is handling scrollbar rendering,
and add a new method to render the scrollbar via NSScrollerImp&apos;s layer-
generating path.

A custom NSScrollerImpDelegate is needed to:

1. opt in to the layer-based rendering (through
   shouldUseLayerPerPartForScrollerImp:)

2. ensure that the ScrollableArea&apos;s appearance (dark or light)
   propagates to the scrollbar

3. work around an issue where the CALayers created by the NSScrollerImp
   have corner radii set to NaN, which the window server interprets as
   &quot;maximum radius given the size of the layer&quot;, but which renderInContext:
   does not seem to handle.

(And WebScrollerImpDelegateMac, which is what the UI process uses, is tied
too closely to a ScrollerMac, so cannot be directly used here.)

The rendering of the rounded corners of the scrollbars differs a little
between the window server and renderInContext:, so the fuzz values for
the WPTs are increased.

When these WPTs are run in WebKit&apos;s CI, they use mock scrollbars and
have async overflow scrolling disabled, which causes the test to pass
despite having this issue. So we add an equivalent (almost identical) test as
a regular layout test so that we can force mock scrollbars off and async
scrolling on, which allows us to test that the Always On Scrollbar
rendering in the viewport matches UI process rendered scrollbars.

* LayoutTests/fast/scrolling/mac/view-transition-captures-composited-scrollbars-expected.html: Added.
* LayoutTests/fast/scrolling/mac/view-transition-captures-composited-scrollbars.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/scroller-child.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/scroller.html:
* Source/WebCore/platform/Scrollbar.h:
(WebCore::Scrollbar::paintingIntoSnapshot const):
(WebCore::Scrollbar::setPaintingIntoSnapshot):
* Source/WebCore/platform/mac/ScrollbarThemeMac.mm:
(-[WebSnapshotScrollerImpDelegate convertRectToBacking:]):
(-[WebSnapshotScrollerImpDelegate convertRectFromBacking:]):
(-[WebSnapshotScrollerImpDelegate shouldUseLayerPerPartForScrollerImp:]):
(-[WebSnapshotScrollerImpDelegate effectiveAppearanceForScrollerImp:]):
(-[WebSnapshotScrollerImpDelegate displayLayer:]):
(-[WebSnapshotScrollerImpDelegate scrollerImp:animateKnobAlphaTo:duration:]):
(-[WebSnapshotScrollerImpDelegate scrollerImp:animateTrackAlphaTo:duration:]):
(-[WebSnapshotScrollerImpDelegate scrollerImp:overlayScrollerStateChangedTo:]):
(WebCore::paintScrollbarUsingLayersForSnapshot):
(WebCore::paintScrollbarUsingLegacyAppearance):
(WebCore::paintScrollbar):
(WebCore::ScrollbarThemeMac::paint):
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::paintOverflowControls):

Canonical link: <a href="https://commits.webkit.org/317266@main">https://commits.webkit.org/317266@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c7a66d5338f847e07002b8a4a7c6414744b37aa8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174821 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48754 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42535 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184401 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/132729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/26679bbd-0307-4714-916f-7757238538a2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176686 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50046 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48437 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/136040 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/132729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f6f4b473-ee0a-495d-9bac-54da2c73f0ef) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177779 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/39481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/156832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116519 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9c67591f-d172-4a5e-9047-442c834f80bb) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/38122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32879 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/148545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36324 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186826 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/40211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/144971 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48421 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156388 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144830 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39016 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49101 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39702 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/121175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47607 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11294 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47009 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47240 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47067 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->