### PR TITLE
[CSS Scroll Snap] Re-snap should select the snap area aligned in both axes among multiple aligned targets

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/common-to-both-axes-supercedes-first-in-tree-order-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/common-to-both-axes-supercedes-first-in-tree-order-expected.txt
@@ -1,13 +1,13 @@
 Box 0Box 1Box 2Box 3Box 4Box 5Box 6Box 7Box 8Box 9
 
-FAIL box0 is common to both axes and is the snap target despite being last in tree order. assert_equals: scroller followed box0 in x axis after layout change expected 200 but got 100
-FAIL box1 is common to both axes and is the snap target despite being last in tree order. assert_equals: scroller followed box1 in x axis after layout change expected 200 but got 100
-FAIL box2 is common to both axes and is the snap target despite being last in tree order. assert_equals: scroller followed box2 in x axis after layout change expected 200 but got 100
-FAIL box3 is common to both axes and is the snap target despite being last in tree order. assert_equals: scroller followed box3 in x axis after layout change expected 200 but got 100
-FAIL box4 is common to both axes and is the snap target despite being last in tree order. assert_equals: scroller followed box4 in x axis after layout change expected 200 but got 100
-FAIL box5 is common to both axes and is the snap target despite being last in tree order. assert_equals: scroller followed box5 in x axis after layout change expected 200 but got 100
-FAIL box6 is common to both axes and is the snap target despite being last in tree order. assert_equals: scroller followed box6 in x axis after layout change expected 200 but got 100
-FAIL box7 is common to both axes and is the snap target despite being last in tree order. assert_equals: scroller followed box7 in x axis after layout change expected 200 but got 100
-FAIL box8 is common to both axes and is the snap target despite being last in tree order. assert_equals: scroller followed box8 in x axis after layout change expected 200 but got 100
-FAIL box9 is common to both axes and is the snap target despite being last in tree order. assert_equals: scroller followed box9 in x axis after layout change expected 200 but got 100
+PASS box0 is common to both axes and is the snap target despite being last in tree order.
+PASS box1 is common to both axes and is the snap target despite being last in tree order.
+PASS box2 is common to both axes and is the snap target despite being last in tree order.
+PASS box3 is common to both axes and is the snap target despite being last in tree order.
+PASS box4 is common to both axes and is the snap target despite being last in tree order.
+PASS box5 is common to both axes and is the snap target despite being last in tree order.
+PASS box6 is common to both axes and is the snap target despite being last in tree order.
+PASS box7 is common to both axes and is the snap target despite being last in tree order.
+PASS box8 is common to both axes and is the snap target despite being last in tree order.
+PASS box9 is common to both axes and is the snap target despite being last in tree order.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/prefer-common-to-both-axes-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/prefer-common-to-both-axes-expected.txt
@@ -1,5 +1,5 @@
 Box 1Box 2Box 3Box 4Box 5Box 6Box 7Box 8Box 9
 
-FAIL scroller prefers target aligned in both axes. assert_equals: scroller followed box1 in y axis after layout change expected 210 but got 110
-FAIL scroller follows selected snap target after layout shift, regardless of common snap area. assert_equals: scroller followed box8 in y axis after layout change expected 480 but got 380
+PASS scroller prefers target aligned in both axes.
+PASS scroller follows selected snap target after layout shift, regardless of common snap area.
 

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -1817,8 +1817,6 @@ imported/w3c/web-platform-tests/webcodecs/videoFrame-drawImage.any.worker.html [
 # Tests that use "finger" events
 imported/w3c/web-platform-tests/css/css-scroll-snap/snap-fling-in-large-area.html [ Skip ]
 
-imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/common-to-both-axes-supercedes-first-in-tree-order.html [ Pass Failure ]
-
 webkit.org/b/170629  memory/memory-pressure-simulation.html [ Pass Failure Crash ]
 
 webkit.org/b/239091 http/tests/media/modern-media-controls/macos-fullscreen-media-controls/macos-fullscreen-media-controls-live-broadcast.html [ Pass Failure ]

--- a/Source/WebCore/platform/ScrollSnapAnimatorState.cpp
+++ b/Source/WebCore/platform/ScrollSnapAnimatorState.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -167,9 +167,10 @@ void ScrollSnapAnimatorState::setActiveSnapIndexForAxis(ScrollEventAxis axis, st
 }
 
 // Selects this axis's snap target among the boxes aligned at the active offset, per
-// https://drafts.csswg.org/css-scroll-snap-1/#multiple-aligned: focused, then targeted, then
-// innermost, then first in tree order. snapTargetID is the focused/targeted representative; this
-// adds the innermost step.
+// https://drafts.csswg.org/css-scroll-snap/#multiple-aligned-snap-areas: focused, then targeted,
+// then innermost (ancestors removed), then the area aligned in both axes (the block/inline set
+// intersection), then first in tree order. snapTargetID is the focused/targeted representative; this
+// adds the innermost and common-to-both-axes steps.
 std::optional<NodeIdentifier> ScrollSnapAnimatorState::selectSnapTargetForAxis(ScrollEventAxis axis) const
 {
     auto offsets = currentlySnappedOffsetsForAxis(axis);
@@ -181,9 +182,46 @@ std::optional<NodeIdentifier> ScrollSnapAnimatorState::selectSnapTargetForAxis(S
     if ((offset.isFocused || offset.isTarget) && offset.snapTargetID)
         return *offset.snapTargetID;
 
+    const auto& areaIDs = m_snapOffsetsInfo.snapAreasIDs;
+
+    // Candidate boxes after removing any area that encloses another aligned area (its ancestors), so
+    // a nested area supersedes a co-located ancestor, including an ancestor aligned in both axes.
+    auto candidateIndices = innermostAlignedAreaIndicesForAxis(axis);
+    if (candidateIndices.isEmpty())
+        return offset.snapTargetID;
+
+    // If the block and inline candidate sets overlap, both axes snap to the box common to both.
+    // snapAreaIndices are in ascending tree order, so iterating this axis's candidates and taking the
+    // first also present in the other axis's candidates yields the first-in-tree box of the
+    // intersection, which is the same box for both axes.
+    auto otherCandidateIndices = innermostAlignedAreaIndicesForAxis(axis == ScrollEventAxis::Horizontal ? ScrollEventAxis::Vertical : ScrollEventAxis::Horizontal);
+    if (!otherCandidateIndices.isEmpty()) {
+        HashSet<NodeIdentifier> otherAxisIDs;
+        for (auto areaIndex : otherCandidateIndices)
+            otherAxisIDs.add(areaIDs[areaIndex]);
+        for (auto areaIndex : candidateIndices) {
+            if (otherAxisIDs.contains(areaIDs[areaIndex]))
+                return areaIDs[areaIndex];
+        }
+    }
+
+    // Otherwise, the first in tree order.
+    return areaIDs[candidateIndices.first()];
+}
+
+// The snap areas aligned at this axis's active offset, minus any area that encloses another aligned
+// area (an ancestor), in tree order. This is the per-axis candidate list from
+// https://drafts.csswg.org/css-scroll-snap/#multiple-aligned-snap-areas after ancestor removal.
+Vector<size_t, 1> ScrollSnapAnimatorState::innermostAlignedAreaIndicesForAxis(ScrollEventAxis axis) const
+{
+    Vector<size_t, 1> candidateIndices;
+    auto offsets = currentlySnappedOffsetsForAxis(axis);
+    if (offsets.isEmpty())
+        return candidateIndices;
+
     const auto& areas = m_snapOffsetsInfo.snapAreas;
     const auto& areaIDs = m_snapOffsetsInfo.snapAreasIDs;
-    const auto& indices = offset.snapAreaIndices;
+    const auto& indices = offsets[0].snapAreaIndices;
 
     auto enclosesAnotherArea = [&](size_t areaIndex) {
         return std::ranges::any_of(indices, [&](size_t other) {
@@ -192,15 +230,11 @@ std::optional<NodeIdentifier> ScrollSnapAnimatorState::selectSnapTargetForAxis(S
         });
     };
 
-    // The innermost box is the first in tree order (snapAreaIndices are ascending) whose area does
-    // not enclose another aligned area.
     for (auto areaIndex : indices) {
         if (areaIndex < areas.size() && areaIndex < areaIDs.size() && !enclosesAnotherArea(areaIndex))
-            return areaIDs[areaIndex];
+            candidateIndices.append(areaIndex);
     }
-    if (offset.snapTargetID)
-        return *offset.snapTargetID;
-    return std::nullopt;
+    return candidateIndices;
 }
 
 void ScrollSnapAnimatorState::updateCurrentlySnappedBoxes()
@@ -271,6 +305,16 @@ bool ScrollSnapAnimatorState::resnapAfterLayout(ScrollOffset scrollOffset, const
             snapPointChanged |= preserveCurrentTargetForAxis(ScrollEventAxis::Vertical, *targetForVerticalAxis);
 
         updateCurrentlySnappedBoxes();
+
+        // Keep the box we actually followed as this axis's recorded target. updateCurrentlySnappedBoxes()
+        // re-runs selection, which could pick a different aligned box (first-in-tree, or one that is now
+        // common to both axes) and cause the scroller to abandon its tracked target on a later layout
+        // change. The followed box is authoritative, so restore it when it is still snapped.
+        if (targetForHorizontalAxis && m_currentlySnappedBoxes.contains(*targetForHorizontalAxis))
+            m_currentSnapTargetForHorizontalAxis = *targetForHorizontalAxis;
+        if (targetForVerticalAxis && m_currentlySnappedBoxes.contains(*targetForVerticalAxis))
+            m_currentSnapTargetForVerticalAxis = *targetForVerticalAxis;
+
         LOG_WITH_STREAM(ScrollSnap, stream << "ScrollSnapAnimatorState::resnapAfterLayout() - multiple boxes snapped; chose H " << targetForHorizontalAxis << " V " << targetForVerticalAxis << " (changed " << snapPointChanged << ") m_currentlySnappedBoxes " << m_currentlySnappedBoxes);
     }
 

--- a/Source/WebCore/platform/ScrollSnapAnimatorState.h
+++ b/Source/WebCore/platform/ScrollSnapAnimatorState.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -105,9 +105,13 @@ private:
     HashSet<NodeIdentifier> currentlySnappedBoxes(const Vector<SnapOffset<LayoutUnit>>& horizontalOffsets, const Vector<SnapOffset<LayoutUnit>>& verticalOffsets) const;
 
     // This axis's snap target among the boxes aligned at the active offset, per
-    // https://drafts.csswg.org/css-scroll-snap-1/#multiple-aligned (focused, targeted, innermost,
-    // then first in tree order).
+    // https://drafts.csswg.org/css-scroll-snap/#multiple-aligned-snap-areas (focused, targeted,
+    // innermost, area aligned in both axes, then first in tree order).
     std::optional<NodeIdentifier> selectSnapTargetForAxis(ScrollEventAxis) const;
+
+    // The snap areas aligned at this axis's active offset with enclosing ancestors removed, in tree
+    // order — the per-axis candidate list after the spec's ancestor-removal step.
+    Vector<size_t, 1> innermostAlignedAreaIndicesForAxis(ScrollEventAxis) const;
 
     bool setNearestScrollSnapIndexForAxisAndOffsetInternal(ScrollEventAxis, ScrollOffset, const ScrollExtents&, float pageScale);
     void updateCurrentlySnappedBoxes();


### PR DESCRIPTION
#### 0445b6c42fa52f5d4ca8e9a2f655a2faa7a81089
<pre>
[CSS Scroll Snap] Re-snap should select the snap area aligned in both axes among multiple aligned targets
<a href="https://bugs.webkit.org/show_bug.cgi?id=319478">https://bugs.webkit.org/show_bug.cgi?id=319478</a>
<a href="https://rdar.apple.com/182285397">rdar://182285397</a>

Reviewed by Simon Fraser.

Per CSS Scroll Snap &quot;Selecting between multiple aligned snap areas&quot; [1], after
focused and targeted areas and ancestor removal (innermost wins), if the block
and inline sets of aligned areas overlap they are replaced with their
intersection before falling back to first in tree order. We stopped at first in
tree order and evaluated each axis independently, so we picked each axis&apos;s
first-in-tree box instead of the box common to both axes. Blink and Gecko both
select the common box; WebKit was the only engine that did not. We also
re-derived the target on every layout change, letting a box that became common
(or first in tree) after a layout shift steal selection from the tracked box.

Selection now intersects the two axes&apos; innermost-level candidate lists and
prefers the common box over tree order; since snap area indices are in tree
order, both axes converge on the same box. Re-snap keeps the box it actually
followed as the recorded target so a later layout shift does not abandon it.

[1] <a href="https://drafts.csswg.org/css-scroll-snap/#multiple-aligned-snap-areas">https://drafts.csswg.org/css-scroll-snap/#multiple-aligned-snap-areas</a>

* Source/WebCore/platform/ScrollSnapAnimatorState.cpp:
(WebCore::ScrollSnapAnimatorState::selectSnapTargetForAxis): Prefer a candidate
also aligned in the other axis before first in tree order.
(WebCore::ScrollSnapAnimatorState::innermostAlignedAreaIndicesForAxis): Added;
aligned areas at the axis&apos;s active offset with ancestors removed, in tree order.
(WebCore::ScrollSnapAnimatorState::resnapAfterLayout): Keep the followed target
as the recorded target across layout changes.
* Source/WebCore/platform/ScrollSnapAnimatorState.h:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/prefer-common-to-both-axes-expected.txt: Progression
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/common-to-both-axes-supercedes-first-in-tree-order-expected.txt: Ditto
* LayoutTests/platform/mac/TestExpectations: Unskip Passing test now

Canonical link: <a href="https://commits.webkit.org/317294@main">https://commits.webkit.org/317294@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d085789fe22ddef764783effc519d5cc19844e5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174838 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48771 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42552 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184418 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132746 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1ffd7f76-c664-41e8-af91-b74857204398) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176703 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50063 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48454 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136051 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b54655a2-0547-46bd-8683-29b5bfb823c8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177796 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39489 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156842 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116530 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8ae7ee62-af61-4a6e-8b8d-4981af34f794) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38130 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36512 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32896 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148553 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36334 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186843 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/40246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40712 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144981 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48438 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156398 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144841 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39039 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49118 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32955 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39715 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121200 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47624 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11304 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47026 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47257 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47084 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->