### PR TITLE
[macOS] TestWebKitAPI.WebKit.ViewScaleFactorAfterShrinkToFit is constant failure on safari-7625-branch

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ShrinkToFit.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ShrinkToFit.mm
@@ -88,15 +88,17 @@ TEST(WebKit, ViewScaleFactorAfterShrinkToFit)
     [webView loadRequest:request];
     [webView _test_waitForDidFinishNavigation];
 
-    __block bool done = false;
-    [webView evaluateJavaScript:@"document.body.clientWidth" completionHandler:^(id, NSError *) {
-        done = true;
-    }];
-    TestWebKitAPI::Util::run(&done);
+    // The WebProcess scales the view down to fit the wide document during a
+    // compositing flush and then sends ViewScaleFactorDidChange back to the
+    // UIProcess. Both steps are asynchronous with respect to navigation, so
+    // poll until the cached scale reflects the auto-scale rather than assuming
+    // it has arrived after a single round-trip.
+    bool scaledDown = TestWebKitAPI::Util::waitFor([&] {
+        return [webView _viewScale] < 1.0;
+    });
 
-    // The WebProcess scaled the view down to fit the wide document and sent
-    // ViewScaleFactorDidChange back to the UIProcess. The cached value must
-    // reflect that scale, not the default of 1.
+    // The cached value must reflect the auto-scale, not the default of 1.
+    EXPECT_TRUE(scaledDown);
     EXPECT_LT([webView _viewScale], 1.0);
     EXPECT_GT([webView _viewScale], 0.0);
 }


### PR DESCRIPTION
#### 2e0ec50936e2c9a299cc9383043d06425d61ac1a
<pre>
[macOS] TestWebKitAPI.WebKit.ViewScaleFactorAfterShrinkToFit is constant failure on safari-7625-branch
<a href="https://bugs.webkit.org/show_bug.cgi?id=319407">https://bugs.webkit.org/show_bug.cgi?id=319407</a>
<a href="https://rdar.apple.com/182233814">rdar://182233814</a>

Reviewed by Abrar Rahman Protyasha and Aditya Keerthi.

The ViewScaleFactorAfterShrinkToFit test added in 314774@main is flaky and
fails on some bots with &quot;Expected: ([webView _viewScale]) &lt; (1.0), actual:
1 vs 1&quot;, meaning the cached view scale was still the default 1.0 when
checked.

The test used a single JavaScript round-trip (document.body.clientWidth) as
an indirect signal that the WebProcess-side auto-scale had completed and
been reported to the UIProcess. However, that sequence is asynchronous with
respect to navigation and JavaScript execution: the WebProcess scales the
view during a compositing flush (DrawingArea::scaleViewToFitDocumentIfNeeded)
and only then sends ViewScaleFactorDidChange back to the UIProcess. Since the
IPC is not ordered against the JavaScript reply, on some bots [webView
_viewScale] was read before the scale factor update arrived.

Poll the actual condition under test with Util::waitFor() instead of relying
on an unrelated round-trip as a proxy for completion.

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ShrinkToFit.mm:
(TEST(WebKit, ViewScaleFactorAfterShrinkToFit)):

Canonical link: <a href="https://commits.webkit.org/317274@main">https://commits.webkit.org/317274@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46c001d5db15129e4e6fb6b6fb921d0ee7317eb7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174712 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48645 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42426 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184291 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132580 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/83d05cb3-055f-4862-aa2b-eced742f3495) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176577 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49937 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48328 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135947 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/32933d2d-8b85-4e3f-ad3c-c07f527c5aa9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177670 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39382 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156735 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116425 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4c55f881-7fcb-41e9-a8b4-73b0233192db) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38023 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36399 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32770 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148446 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36227 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186717 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40597 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144872 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48312 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144732 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39021 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48992 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32848 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114771 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39606 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47498 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11195 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46900 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47131 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46958 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->