### PR TITLE
[GLIB] Report Google Test API test results with the same name as other ports

### DIFF
--- a/Tools/glib/api_test_runner.py
+++ b/Tools/glib/api_test_runner.py
@@ -116,7 +116,7 @@ class TestRunner(object):
     def _get_tests(self, requested_test_list):
         tests = []
         for test in requested_test_list:
-            test = test.split(':', 1)[0]
+            test = self._binary_and_subtest(test)[0]
             if not os.path.exists(test):
                 test = os.path.join(self._test_programs_base_dir(), test)
             if os.path.isdir(test):
@@ -352,7 +352,7 @@ class TestRunner(object):
     def _get_test_short_name(self, test_path):
         return test_path.replace(self._test_programs_base_dir(), '', 1).lstrip('/').split(':', 1)[0]
 
-    def _get_test_name_for_upload(self, test_path):
+    def _get_test_name_for_upload(self, test_path, test_case):
         # Test binaries are built into a port-specific subdirectory
         # (TestWebKitAPI/WebKitGTK for GTK, TestWebKitAPI/WPE for WPE), so the
         # short name carries that prefix. Strip it so the same test is reported
@@ -361,21 +361,33 @@ class TestRunner(object):
         short_name = self._get_test_short_name(test_path)
         for prefix in ('WebKitGTK/', 'WPE/'):
             if short_name.startswith(prefix):
-                return short_name[len(prefix):]
-        return short_name
+                short_name = short_name[len(prefix):]
+                break
+        # Google Test cases use a dot to match other ports; GLib tests keep the colon.
+        separator = '.' if self.is_google_test(test_path) else ':'
+        return f'{short_name}{separator}{test_case}'
+
+    def _binary_and_subtest(self, test_name):
+        # Accept both the "<binary>:<subtest>" (GLib) and "<binary>.<case>"
+        # (Google Test) forms. Split the dotted form only when the bare name is
+        # not itself a program, since binary names have no dots.
+        if ':' in test_name:
+            return tuple(test_name.split(':', 1))
+        if '.' in test_name and not os.path.exists(test_name) \
+                and not os.path.exists(os.path.join(self._test_programs_base_dir(), test_name)):
+            return tuple(test_name.split('.', 1))
+        return test_name, None
 
     def _getsubtests_to_run_for_test(self, requested_test_name):
         subtests_to_run = []
         requested_test_name = self._get_test_short_name(requested_test_name)
         for test_name in self._initial_test_list:
-            subtest_name = None
-            if ':' in test_name:
-                test_name, subtest_name = test_name.split(':', 1)
+            test_name, subtest_name = self._binary_and_subtest(test_name)
             if requested_test_name == self._get_test_short_name(test_name):
                 if subtest_name:
                     subtests_to_run.append(subtest_name)
                 else:
-                    return []  # If there is any entry matching without ":subtest", return [] which means run all subtests.
+                    return []  # If there is any entry matching without a subtest, return [] which means run all subtests.
         return sorted(set(subtests_to_run))  # Remove duplicates and sort
 
     def list_tests(self):
@@ -530,7 +542,7 @@ class TestRunner(object):
             results = {}
             for test, test_cases in tests_to_upload.items():
                 for test_case in test_cases:
-                    name = "%s:%s" % (self._get_test_name_for_upload(test), test_case[0])
+                    name = self._get_test_name_for_upload(test, test_case[0])
                     results[name] = Upload.create_test_result(actual=test_case[1], expected=' '.join(test_case[2]) if test_case[2] else None)
 
             upload = Upload(


### PR DESCRIPTION
#### fc767a874967a8d29ab09dc42e7638af6e338202
<pre>
[GLIB] Report Google Test API test results with the same name as other ports
<a href="https://bugs.webkit.org/show_bug.cgi?id=319481">https://bugs.webkit.org/show_bug.cgi?id=319481</a>

Reviewed by Adrian Perez de Castro.

Google Test based API tests (TestWTF, TestWebCore, TestWebKit and
TestJavaScriptCore) were uploaded to results.webkit.org using a colon
between the binary and the test case (e.g. TestWTF:Base64.Decode), while
the other ports use a dot (TestWTF.Base64.Decode). As a result the same
test was indexed under two different names depending on the port, which
defeats cross-port analysis for the tests that are shared across all of
them.

Report Google Test cases using the dot separator so they match the name
used by the other ports. GLib tests keep the &quot;&lt;binary&gt;:&lt;subtest&gt;&quot; form,
since their subtest is a /path and they have no counterpart on the other
ports. Additionally, teach the test runner to accept the dotted form on
the command line, so a name copied from results.webkit.org can be run
directly with run-gtk-tests and run-wpe-tests.

* Tools/glib/api_test_runner.py:
(TestRunner._get_tests):
(TestRunner._get_test_name_for_upload):
(TestRunner._binary_and_subtest):
(TestRunner._getsubtests_to_run_for_test):
(TestRunner.run_tests):

Canonical link: <a href="https://commits.webkit.org/317233@main">https://commits.webkit.org/317233@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb02879efb65f3524bb189e379d057cf28613616

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174719 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48652 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42433 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184298 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132587 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176584 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49944 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48335 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135953 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177677 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39387 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/156743 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116431 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38028 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32777 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148451 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36235 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186724 "Built successfully") | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144876 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48319 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144736 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48999 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26544 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39612 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47505 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11204 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46907 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47138 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46965 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->