### PR TITLE
[JSC] Do prefetching in SlotVisitor::performIncrementOfDraining too

### DIFF
--- a/Source/JavaScriptCore/heap/MarkStack.h
+++ b/Source/JavaScriptCore/heap/MarkStack.h
@@ -39,6 +39,14 @@ public:
     size_t transferTo(MarkStackArray&, size_t limit); // Optimized for when `limit` is small.
     void donateSomeCellsTo(MarkStackArray&);
     void stealSomeCellsFrom(MarkStackArray&, size_t idleThreadCount);
+    const JSCell* popAndPrefetch();
 };
+
+inline const JSCell* MarkStackArray::popAndPrefetch()
+{
+    const JSCell* cell = removeLast();
+    __builtin_prefetch(cell);
+    return cell;
+}
 
 } // namespace JSC

--- a/Source/JavaScriptCore/heap/SlotVisitor.cpp
+++ b/Source/JavaScriptCore/heap/SlotVisitor.cpp
@@ -515,9 +515,7 @@ NEVER_INLINE void SlotVisitor::drain(MonotonicTime timeout)
                     if (!countdown || !stack.canRemoveLast())
                         return nullptr;
                     --countdown;
-                    const JSCell* cell = stack.removeLast();
-                    __builtin_prefetch(cell);
-                    return cell;
+                    return stack.popAndPrefetch();
                 };
                 for (const JSCell* next = popAndPrefetch(); next;) {
                     const JSCell* cell = next;
@@ -575,11 +573,17 @@ size_t SlotVisitor::performIncrementOfDraining(size_t bytesRequested)
                     m_isFirstVisit = (&stack == &m_collectorStack);
 
                     unsigned countdown = Options::minimumNumberOfScansBetweenRebalance();
-                    while (countdown && stack.canRemoveLast() && !isDone()) {
-                        const JSCell* cell = stack.removeLast();
+                    auto popAndPrefetch = [&] ALWAYS_INLINE_LAMBDA -> const JSCell* {
+                        if (!countdown || !stack.canRemoveLast() || isDone())
+                            return nullptr;
+                        --countdown;
+                        return stack.popAndPrefetch();
+                    };
+                    for (const JSCell* next = popAndPrefetch(); next;) {
+                        const JSCell* cell = next;
+                        next = popAndPrefetch();
                         cellBytesVisited += cell->cellSize();
                         visitChildren(cell);
-                        countdown--;
                     }
                     return IterationStatus::Done;
                 });


### PR DESCRIPTION
#### 6fddaa00b61499746a1ae20695da6841ed2c7911
<pre>
[JSC] Do prefetching in SlotVisitor::performIncrementOfDraining too
<a href="https://bugs.webkit.org/show_bug.cgi?id=319483">https://bugs.webkit.org/show_bug.cgi?id=319483</a>
<a href="https://rdar.apple.com/182289152">rdar://182289152</a>

Reviewed by Keith Miller.

We apply the same change in 316327@main to SlotVisitor::performIncrementOfDraining.
Let&apos;s perform prefetching onto the next cell. We factor the pop + software prefetch
into MarkStackArray::popAndPrefetch so both draining loops share it.

* Source/JavaScriptCore/heap/MarkStack.h:
(JSC::MarkStackArray::popAndPrefetch):
* Source/JavaScriptCore/heap/SlotVisitor.cpp:
(JSC::SlotVisitor::drain):
(JSC::SlotVisitor::performIncrementOfDraining):

Canonical link: <a href="https://commits.webkit.org/317253@main">https://commits.webkit.org/317253@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af6e30bbba13333c861b0b34c4730f30bfdec637

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174783 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48716 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42497 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184363 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/132691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/08ee87c9-bad4-4afd-a83f-8e7619a41954) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50008 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48399 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/136023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/132691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4e50b06f-2841-478c-a318-a5cd789952d7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177741 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39450 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/156804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116501 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8a4baf31-ec81-4c28-b734-5e35c7371548) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38091 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32841 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5313 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148514 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36296 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186788 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/36045 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/40149 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144938 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48383 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144798 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49063 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26555 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39682 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/121126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/211874 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47569 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11266 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55266 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46971 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47202 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47029 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->