### PR TITLE
[JSC] BBQ: strength-reduce signed div/rem by negative power-of-two constants

### DIFF
--- a/JSTests/wasm/stress/divide-rem-by-negative-constant-power-of-two.js
+++ b/JSTests/wasm/stress/divide-rem-by-negative-constant-power-of-two.js
@@ -1,0 +1,107 @@
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+// BBQ strength-reduces constant div/rem when |divisor| is a power of two.
+// Cover negative signed divisors (-2, -4, -32, …) as well as rem_s sign rules.
+let wat = `
+(module
+    (func (export "divS_i32_neg2") (param i32) (result i32)
+        local.get 0
+        i32.const -2
+        i32.div_s)
+    (func (export "remS_i32_neg2") (param i32) (result i32)
+        local.get 0
+        i32.const -2
+        i32.rem_s)
+    (func (export "divS_i32_neg4") (param i32) (result i32)
+        local.get 0
+        i32.const -4
+        i32.div_s)
+    (func (export "remS_i32_neg4") (param i32) (result i32)
+        local.get 0
+        i32.const -4
+        i32.rem_s)
+    (func (export "divS_i32_neg32") (param i32) (result i32)
+        local.get 0
+        i32.const -32
+        i32.div_s)
+    (func (export "remS_i32_neg32") (param i32) (result i32)
+        local.get 0
+        i32.const -32
+        i32.rem_s)
+    (func (export "divS_i64_neg2") (param i64) (result i64)
+        local.get 0
+        i64.const -2
+        i64.div_s)
+    (func (export "remS_i64_neg2") (param i64) (result i64)
+        local.get 0
+        i64.const -2
+        i64.rem_s)
+    (func (export "divS_i64_neg8") (param i64) (result i64)
+        local.get 0
+        i64.const -8
+        i64.div_s)
+    (func (export "remS_i64_neg8") (param i64) (result i64)
+        local.get 0
+        i64.const -8
+        i64.rem_s)
+    (func (export "divS_i32_min") (param i32) (result i32)
+        local.get 0
+        i32.const -2147483648
+        i32.div_s)
+    (func (export "remS_i32_min") (param i32) (result i32)
+        local.get 0
+        i32.const -2147483648
+        i32.rem_s)
+    (func (export "divS_i64_min") (param i64) (result i64)
+        local.get 0
+        i64.const -9223372036854775808
+        i64.div_s)
+    (func (export "remS_i64_min") (param i64) (result i64)
+        local.get 0
+        i64.const -9223372036854775808
+        i64.rem_s)
+)
+`;
+
+async function test() {
+    const instance = await instantiate(wat, {}, {});
+    const {
+        divS_i32_neg2, remS_i32_neg2,
+        divS_i32_neg4, remS_i32_neg4,
+        divS_i32_neg32, remS_i32_neg32,
+        divS_i64_neg2, remS_i64_neg2,
+        divS_i64_neg8, remS_i64_neg8,
+        divS_i32_min, remS_i32_min,
+        divS_i64_min, remS_i64_min,
+    } = instance.exports;
+
+    const i32Cases = [0, 1, 2, 3, 7, 8, 9, -1, -2, -3, -7, -8, -9, 100, -100, 0x7fffffff, -0x80000000];
+    const i64Cases = [0n, 1n, 2n, 7n, 8n, 9n, -1n, -2n, -7n, -8n, -9n, 100n, -100n, (1n << 62n), -(1n << 62n), -(1n << 63n)];
+    const i32Min = -2147483648;
+    const i64Min = -(1n << 63n);
+
+    for (let i = 0; i < wasmTestLoopCount; ++i) {
+        for (const n of i32Cases) {
+            assert.eq(divS_i32_neg2(n), (n / -2) | 0);
+            assert.eq(remS_i32_neg2(n), (n % -2) | 0);
+            assert.eq(divS_i32_neg4(n), (n / -4) | 0);
+            assert.eq(remS_i32_neg4(n), (n % -4) | 0);
+            assert.eq(divS_i32_neg32(n), (n / -32) | 0);
+            assert.eq(remS_i32_neg32(n), (n % -32) | 0);
+            assert.eq(divS_i32_min(n), (n / i32Min) | 0);
+            assert.eq(remS_i32_min(n), (n % i32Min) | 0);
+        }
+
+        for (const n of i64Cases) {
+            assert.eq(divS_i64_neg2(n), n / -2n);
+            assert.eq(remS_i64_neg2(n), n % -2n);
+            assert.eq(divS_i64_neg8(n), n / -8n);
+            assert.eq(remS_i64_neg8(n), n % -8n);
+            assert.eq(divS_i64_min(n), n / i64Min);
+            assert.eq(remS_i64_min(n), n % i64Min);
+        }
+    }
+}
+
+await assert.asyncTest(test());

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.h
@@ -345,73 +345,92 @@ void BBQJIT::emitModOrDiv(Value& lhs, Location lhsLocation, Value& rhs, Location
             }
 
             // Fall through to general case.
-        } else if (isPowerOfTwo<size_t>(divisor)) {
-            if constexpr (IsMod) {
-                if constexpr (isSigned) {
-                    // This constructs an extra operand with log2(divisor) bits equal to the sign bit of the dividend. If the dividend
-                    // is positive, this is zero and adding it achieves nothing; but if the dividend is negative, this is equal to the
-                    // divisor minus one, which is the exact amount of bias we need to get the correct result. Computing this for both
-                    // positive and negative dividends lets us elide branching, but more importantly allows us to save a register by
-                    // not needing an extra multiplySub at the end.
-                    if constexpr (is32) {
-                        m_jit.rshift32(lhsLocation.asGPR(), TrustedImm32(31), wasmScratchGPR);
-                        m_jit.urshift32(wasmScratchGPR, TrustedImm32(32 - WTF::fastLog2(static_cast<unsigned>(divisor))), wasmScratchGPR);
-                        m_jit.add32(wasmScratchGPR, lhsLocation.asGPR(), resultLocation.asGPR());
-                    } else {
-                        m_jit.rshift64(lhsLocation.asGPR(), TrustedImm32(63), wasmScratchGPR);
-                        m_jit.urshift64(wasmScratchGPR, TrustedImm32(64 - WTF::fastLog2(static_cast<uint64_t>(divisor))), wasmScratchGPR);
-                        m_jit.add64(wasmScratchGPR, lhsLocation.asGPR(), resultLocation.asGPR());
+        } else {
+            using UnsignedInt = std::make_unsigned_t<IntType>;
+            bool divisorIsNegative = isSigned && divisor < 0;
+            UnsignedInt magnitude = divisorIsNegative
+                ? static_cast<UnsignedInt>(WTF::negate(static_cast<IntType>(divisor)))
+                : static_cast<UnsignedInt>(divisor);
+
+            if (isPowerOfTwo(magnitude)) {
+                unsigned shiftAmount = WTF::fastLog2(magnitude);
+
+                if constexpr (IsMod) {
+                    if constexpr (isSigned) {
+                        // This constructs an extra operand with log2(divisor) bits equal to the sign bit of the dividend. If the dividend
+                        // is positive, this is zero and adding it achieves nothing; but if the dividend is negative, this is equal to the
+                        // divisor minus one, which is the exact amount of bias we need to get the correct result. Computing this for both
+                        // positive and negative dividends lets us elide branching, but more importantly allows us to save a register by
+                        // not needing an extra multiplySub at the end.
+                        if constexpr (is32) {
+                            m_jit.rshift32(lhsLocation.asGPR(), TrustedImm32(31), wasmScratchGPR);
+                            m_jit.urshift32(wasmScratchGPR, TrustedImm32(32 - shiftAmount), wasmScratchGPR);
+                            m_jit.add32(wasmScratchGPR, lhsLocation.asGPR(), resultLocation.asGPR());
+                        } else {
+                            m_jit.rshift64(lhsLocation.asGPR(), TrustedImm32(63), wasmScratchGPR);
+                            m_jit.urshift64(wasmScratchGPR, TrustedImm32(64 - shiftAmount), wasmScratchGPR);
+                            m_jit.add64(wasmScratchGPR, lhsLocation.asGPR(), resultLocation.asGPR());
+                        }
+
+                        lhsLocation = resultLocation;
                     }
 
-                    lhsLocation = resultLocation;
-                }
+                    if constexpr (is32)
+                        m_jit.and32(Imm32(magnitude - 1), lhsLocation.asGPR(), resultLocation.asGPR());
+                    else
+                        m_jit.and64(TrustedImm64(magnitude - 1), lhsLocation.asGPR(), resultLocation.asGPR());
 
-                if constexpr (is32)
-                    m_jit.and32(Imm32(static_cast<uint32_t>(divisor) - 1), lhsLocation.asGPR(), resultLocation.asGPR());
-                else
-                    m_jit.and64(TrustedImm64(static_cast<uint64_t>(divisor) - 1), lhsLocation.asGPR(), resultLocation.asGPR());
+                    if constexpr (isSigned) {
+                        // The extra operand we computed is still in wasmScratchGPR - now we can subtract it from the result to get the
+                        // correct answer.
+                        if constexpr (is32)
+                            m_jit.sub32(resultLocation.asGPR(), wasmScratchGPR, resultLocation.asGPR());
+                        else
+                            m_jit.sub64(resultLocation.asGPR(), wasmScratchGPR, resultLocation.asGPR());
+                    }
+                    return;
+                }
 
                 if constexpr (isSigned) {
-                    // The extra operand we computed is still in wasmScratchGPR - now we can subtract it from the result to get the
-                    // correct answer.
+                    // If we are doing signed division, we need to bias the dividend for negative numbers.
                     if constexpr (is32)
-                        m_jit.sub32(resultLocation.asGPR(), wasmScratchGPR, resultLocation.asGPR());
+                        m_jit.add32(TrustedImm32(magnitude - 1), lhsLocation.asGPR(), wasmScratchGPR);
                     else
-                        m_jit.sub64(resultLocation.asGPR(), wasmScratchGPR, resultLocation.asGPR());
+                        m_jit.add64(TrustedImm64(magnitude - 1), lhsLocation.asGPR(), wasmScratchGPR);
+
+                    // moveConditionally seems to be faster than a branch here, even if it's well predicted.
+                    if (is32)
+                        m_jit.moveConditionally32(RelationalCondition::GreaterThanOrEqual, lhsLocation.asGPR(), TrustedImm32(0), lhsLocation.asGPR(), wasmScratchGPR, wasmScratchGPR);
+                    else
+                        m_jit.moveConditionally64(RelationalCondition::GreaterThanOrEqual, lhsLocation.asGPR(), TrustedImm32(0), lhsLocation.asGPR(), wasmScratchGPR, wasmScratchGPR);
+                    lhsLocation = Location::fromGPR(wasmScratchGPR);
                 }
+
+                // Emit the actual division instruction: arithmetic shift if signed,
+                // logical shift if unsigned
+                if constexpr (isSigned) {
+                    if constexpr (is32)
+                        m_jit.rshift32(lhsLocation.asGPR(), m_jit.trustedImm32ForShift(Imm32(shiftAmount)), resultLocation.asGPR());
+                    else
+                        m_jit.rshift64(lhsLocation.asGPR(), TrustedImm32(shiftAmount), resultLocation.asGPR());
+                } else {
+                    if constexpr (is32)
+                        m_jit.urshift32(lhsLocation.asGPR(), m_jit.trustedImm32ForShift(Imm32(shiftAmount)), resultLocation.asGPR());
+                    else
+                        m_jit.urshift64(lhsLocation.asGPR(), TrustedImm32(shiftAmount), resultLocation.asGPR());
+                }
+
+                if constexpr (isSigned) {
+                    if (divisorIsNegative) {
+                        if constexpr (is32)
+                            m_jit.neg32(resultLocation.asGPR(), resultLocation.asGPR());
+                        else
+                            m_jit.neg64(resultLocation.asGPR(), resultLocation.asGPR());
+                    }
+                }
+
                 return;
             }
-
-            if constexpr (isSigned) {
-                // If we are doing signed division, we need to bias the dividend for negative numbers.
-                if constexpr (is32)
-                    m_jit.add32(TrustedImm32(static_cast<int32_t>(divisor) - 1), lhsLocation.asGPR(), wasmScratchGPR);
-                else
-                    m_jit.add64(TrustedImm64(divisor - 1), lhsLocation.asGPR(), wasmScratchGPR);
-
-                // moveConditionally seems to be faster than a branch here, even if it's well predicted.
-                if (is32)
-                    m_jit.moveConditionally32(RelationalCondition::GreaterThanOrEqual, lhsLocation.asGPR(), TrustedImm32(0), lhsLocation.asGPR(), wasmScratchGPR, wasmScratchGPR);
-                else
-                    m_jit.moveConditionally64(RelationalCondition::GreaterThanOrEqual, lhsLocation.asGPR(), TrustedImm32(0), lhsLocation.asGPR(), wasmScratchGPR, wasmScratchGPR);
-                lhsLocation = Location::fromGPR(wasmScratchGPR);
-            }
-
-            // Emit the actual division instruction: arithmetic shift if signed,
-            // logical shift if unsigned
-            if constexpr (isSigned) {
-                if constexpr (is32)
-                    m_jit.rshift32(lhsLocation.asGPR(), m_jit.trustedImm32ForShift(Imm32(WTF::fastLog2(static_cast<unsigned>(divisor)))), resultLocation.asGPR());
-                else
-                    m_jit.rshift64(lhsLocation.asGPR(), TrustedImm32(WTF::fastLog2(static_cast<uint64_t>(divisor))), resultLocation.asGPR());
-            } else {
-                if constexpr (is32)
-                    m_jit.urshift32(lhsLocation.asGPR(), m_jit.trustedImm32ForShift(Imm32(WTF::fastLog2(static_cast<unsigned>(divisor)))), resultLocation.asGPR());
-                else
-                    m_jit.urshift64(lhsLocation.asGPR(), TrustedImm32(WTF::fastLog2(static_cast<uint64_t>(divisor))), resultLocation.asGPR());
-            }
-
-            return;
         }
         // TODO: try generating integer reciprocal instead.
         checkedForNegativeOne = true;


### PR DESCRIPTION
#### bccb52eace5ba6706ce9d44c7dadd1b1a8b9055c
<pre>
[JSC] BBQ: strength-reduce signed div/rem by negative power-of-two constants
<a href="https://bugs.webkit.org/show_bug.cgi?id=269744">https://bugs.webkit.org/show_bug.cgi?id=269744</a>

Reviewed by Keith Miller.

When BBQ sees a constant divisor that is a power of two, it turns
div/rem into shifts and masks. That path only ran for positive
divisors, so values like -2 or -32 always took the slow general case.

This extends the same path to negative signed divisors by working
with the absolute value. Remainder does not depend on the sign of
the divisor, so it can reuse the positive case as-is. Division by a
negative power of two is just the positive result with the sign
flipped. Taking the magnitude of INT_MIN needs a bit of care since
it is not representable as a signed integer.

* Source/JavaScriptCore/wasm/WasmBBQJIT64.h:
(JSC::Wasm::BBQJIT::emitModOrDiv):
* JSTests/wasm/stress/divide-rem-by-negative-constant-power-of-two.js: Added.

Canonical link: <a href="https://commits.webkit.org/317309@main">https://commits.webkit.org/317309@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/949db1573ccff452b208918cb647705d8a13fd89

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174859 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48792 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42573 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184439 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132767 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50084 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48475 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136074 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177817 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39512 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156866 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116553 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38153 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36531 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32917 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5375 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148576 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36358 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186864 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/36121 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/40285 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40731 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145004 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48459 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144863 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39052 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49139 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32979 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114950 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39736 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121238 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/211951 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47645 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11328 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55284 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47047 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47278 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47105 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->