### PR TITLE
Fix threadsafe deathtest explosion

### DIFF
--- a/Tools/TestWebKitAPI/Runner/GoogleTestsController.swift
+++ b/Tools/TestWebKitAPI/Runner/GoogleTestsController.swift
@@ -22,6 +22,7 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
+
 import struct Swift.String
 
 @MainActor
@@ -70,6 +71,13 @@ extension GoogleTestsController {
 
         if let repetitions = configuration.repetitions {
             result.append("--gtest_repeat=\(repetitions)")
+        }
+
+        // Forward gtest-native flags used by the "threadsafe" death-test protocol
+        // which re-executes this binary with extra flags.
+        let gtestPassthroughPrefixes = ["--gtest_internal_run_death_test=", "--gtest_filter="]
+        for argument in CommandLine.arguments where gtestPassthroughPrefixes.contains(where: argument.hasPrefix) {
+            result.append(argument)
         }
 
         return result


### PR DESCRIPTION
#### e7dc9797f7ed88f66a2ebb94f8d920968a9d2c05
<pre>
Fix threadsafe deathtest explosion
<a href="https://bugs.webkit.org/show_bug.cgi?id=319490">https://bugs.webkit.org/show_bug.cgi?id=319490</a>
<a href="https://rdar.apple.com/182221871">rdar://182221871</a>

Reviewed by Geoffrey Garen.

Some of our tests are &quot;death tests&quot; which rely on spawning a new process to
ensure that it crashes as expected. Some of them, in turn, are &quot;threadsafe&quot;
which means that the test runner launches an entire new test executable
(instead of just using &apos;fork()&apos;).

These tests have recently become broken because of a problem passing through
arguments to those new child processes. This resulted in an infinite cascade of
new TestWTF processes, each immediately spawning another, until we got resource
exhaustion on the Mac, which removed it from the EWS pool.

This adds support for the required command-line arguments.

To reproduce this problem,
 Tools/Scripts/run-api-tests --debug TestWTF.WTF_RunLoopDeathTest.CapabilityIsCurrentFailureAssertsDeathTest
while running something like
 watch &apos;ps ax | grep -c &quot;[T]estWTF&quot;&apos;
and be ready to killall -9 TestWTF before your Mac is taken down.
Before this fix, you will see hundreds of processes being spawned within
moments.

Canonical link: <a href="https://commits.webkit.org/318480@main">https://commits.webkit.org/318480@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5f2eb53ac4e9a151e44b5b03dfdcbdafb5d27513

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174731 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48664 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42445 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184310 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132599 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a9a3a691-c14f-4783-869e-04e3066d22d7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176596 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49956 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48347 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135970 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0307f414-8c6b-4078-991a-ab0ee7bdaec8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177689 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39402 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156754 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116448 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/41a35bd2-8447-4345-86e8-d0b4cf4adf0c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38043 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36417 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148466 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36246 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32789 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40615 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186736 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48331 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144891 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39810 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49011 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32867 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144751 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39625 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114790 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47517 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11215 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46919 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47150 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46977 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->