### PR TITLE
[Tools] Add backports-asyncio-runner dependency for pytest-asyncio for python versions < 3.11

### DIFF
--- a/Tools/Scripts/libraries/webkitcorepy/setup.py
+++ b/Tools/Scripts/libraries/webkitcorepy/setup.py
@@ -30,7 +30,7 @@ def readme():
 
 setup(
     name='webkitcorepy',
-    version='1.0.2',
+    version='1.0.3',
     description='Library containing various Python support classes and functions.',
     long_description=readme(),
     long_description_content_type='text/markdown',

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py
@@ -52,7 +52,7 @@ from webkitcorepy.null_context import NullContext
 from webkitcorepy.filtered_call import filtered_call
 from webkitcorepy.partial_proxy import PartialProxy
 
-version = Version(1, 0, 2)
+version = Version(1, 0, 3)
 
 from webkitcorepy.autoinstall import Package, AutoInstall
 

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/autoinstall.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/autoinstall.py
@@ -293,6 +293,23 @@ class Package(object):
             return False
         return True
 
+    @staticmethod
+    def _merge_move(source, target):
+        # Recursively move source into target. Unlike shutil.move, existing
+        # directories at the destination are merged rather than replaced. This
+        # preserves shared namespace packages (e.g. 'backports') when multiple
+        # wheels contribute sub-packages to the same top-level directory.
+        if os.path.isdir(source) and os.path.isdir(target):
+            for entry in os.listdir(source):
+                Package._merge_move(os.path.join(source, entry), os.path.join(target, entry))
+            os.rmdir(source)
+            return
+        if os.path.isdir(target):
+            shutil.rmtree(target, ignore_errors=True)
+        elif os.path.exists(target):
+            os.remove(target)
+        shutil.move(source, target)
+
     def install(self):
         AutoInstall.register(self)
         if self.is_cached():
@@ -414,12 +431,7 @@ class Package(object):
                     ):
                         raise OSError('Cannot install {}, could not find setup.py'.format(self.name))
                     for file in to_be_moved:
-                        target = os.path.join(AutoInstall.directory, file)
-                        if os.path.isdir(target):
-                            shutil.rmtree(target, ignore_errors=True)
-                        elif os.path.exists(target):
-                            os.remove(target)
-                        shutil.move(os.path.join(temp_location, file), AutoInstall.directory)
+                        self._merge_move(os.path.join(temp_location, file), os.path.join(AutoInstall.directory, file))
 
                 self.do_post_install(temp_location)
 

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/autoinstall_unittest.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/autoinstall_unittest.py
@@ -22,6 +22,8 @@
 
 import io
 import os
+import shutil
+import tempfile
 import unittest
 from unittest.mock import patch
 from urllib.error import URLError
@@ -70,3 +72,54 @@ class ArchiveTest(unittest.TestCase):
             with self.assertRaises(URLError):
                 archive.download()
             self.assertEqual(mock_urlopen.call_count, 4)
+
+
+class MergeMoveTest(unittest.TestCase):
+    # Package._merge_move is what lets multiple distributions contribute to a
+    # shared namespace package (e.g. 'backports') without clobbering each other.
+    def setUp(self):
+        self.root = tempfile.mkdtemp()
+        self.destination = os.path.join(self.root, 'site')
+        os.makedirs(self.destination)
+
+    def tearDown(self):
+        shutil.rmtree(self.root, ignore_errors=True)
+
+    def _unpack(self, name, files):
+        # Emulate one wheel install: build an unpacked wheel and merge each of
+        # its top-level entries into the destination, as Package.install does.
+        source = os.path.join(self.root, 'unpack-{}'.format(name))
+        for relative in files:
+            path = os.path.join(source, relative)
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            with open(path, 'w') as handle:
+                handle.write(relative)
+        for top in os.listdir(source):
+            Package._merge_move(os.path.join(source, top), os.path.join(self.destination, top))
+
+    def _contents(self):
+        return sorted(
+            os.path.relpath(os.path.join(dirpath, name), self.destination).replace(os.sep, '/')
+            for dirpath, _, filenames in os.walk(self.destination)
+            for name in filenames
+        )
+
+    def test_install_order_does_not_matter(self):
+        expected = ['sample/a.py', 'sample/b/__init__.py']
+
+        self._unpack('sample-a', ['sample/a.py'])
+        self._unpack('sample-b', ['sample/b/__init__.py'])
+        self.assertEqual(self._contents(), expected)
+
+        shutil.rmtree(self.destination)
+        os.makedirs(self.destination)
+
+        self._unpack('sample-b', ['sample/b/__init__.py'])
+        self._unpack('sample-a', ['sample/a.py'])
+        self.assertEqual(self._contents(), expected)
+
+    def test_file_is_replaced_by_directory(self):
+        # A leaf that changes kind between distributions is replaced, not merged.
+        self._unpack('provides-file', ['sample/thing'])
+        self._unpack('provides-package', ['sample/thing/__init__.py'])
+        self.assertEqual(self._contents(), ['sample/thing/__init__.py'])

--- a/Tools/Scripts/webkitpy/__init__.py
+++ b/Tools/Scripts/webkitpy/__init__.py
@@ -97,12 +97,13 @@ AutoInstall.register(
             wheel=True,
             )
 )
-AutoInstall.register(Package('pytest_asyncio', Version(1, 1, 1), pypi_name='pytest-asyncio', implicit_deps=['pytest'], wheel=True))
+AutoInstall.register(Package('pytest_asyncio', Version(1, 1, 1), pypi_name='pytest-asyncio', implicit_deps=['pytest'] + (['backports.asyncio_runner'] if sys.version_info < (3, 11) else []), wheel=True))
 AutoInstall.register(Package('pytest_timeout', Version(2, 4, 0), pypi_name='pytest-timeout', implicit_deps=['pytest'], wheel=True))
 AutoInstall.register(Package('websockets', Version(12, 0), wheel=True))
 
 if sys.version_info < (3, 11):
     AutoInstall.register(Package('exceptiongroup', Version(1, 1, 0), wheel=True))
+    AutoInstall.register(Package('backports.asyncio_runner', Version(1, 2, 0), pypi_name="backports-asyncio-runner", wheel=True))
 
 AutoInstall.register(Package('importlib_metadata', Version(4, 8, 1)))
 AutoInstall.register(Package('typing_extensions', Version(4, 12, 2), wheel=True))


### PR DESCRIPTION
#### 807fb465d753ffd473a6ada02a563f9daf20e43d
<pre>
[Tools] Add backports-asyncio-runner dependency for pytest-asyncio for python versions &lt; 3.11
<a href="https://bugs.webkit.org/show_bug.cgi?id=319498">https://bugs.webkit.org/show_bug.cgi?id=319498</a>
<a href="https://rdar.apple.com/182302139">rdar://182302139</a>

Reviewed by BJ Burg and Sam Sneddon.

<a href="https://commits.webkit.org/315890@main">https://commits.webkit.org/315890@main</a> bumped `pytest-asyncio` to version 1.1.1
for python 3.14 compatibility. But under python 3.8, 3.9 and 3.10 interpreters,
that version requires `backports-asyncio-runner` as a dependency.

Drive-by fix in webkitcorepy:

The wheel-install path in AutoInstall moved each top-level directory from an
unpacked wheel into the autoinstall cache, deleting any existing directory of
the same name first. This broke PEP 420 namespace packages that are shared
across distributions: installing `backports-asyncio-runner` (which ships
`backports/asyncio/`) wiped the `backports/` directory previously populated by
`configparser` (which ships `backports/configparser/`).

Replace the destructive move with a recursive `_merge_move` helper that merges
into existing directories instead of replacing them, so co-located namespace
sub-packages survive. Bump webkitcorepy to 1.0.3.

This is the destructive-unpack problem previously described in
<a href="https://bugs.webkit.org/show_bug.cgi?id=263392">https://bugs.webkit.org/show_bug.cgi?id=263392</a> and <a href="https://bugs.webkit.org/show_bug.cgi?id=263589">https://bugs.webkit.org/show_bug.cgi?id=263589</a>
The wheel path clobbers shared directories while the legacy
dist/setuptools path merges into them. As suggested there, make the wheel path
behave like the legacy path by merging into existing directories instead of
replacing them, so co-located namespace sub-packages survive regardless of
install order.

* Tools/Scripts/webkitpy/__init__.py:
* Tools/Scripts/libraries/webkitcorepy/setup.py:
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py:
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/autoinstall.py:
(Package):
(Package._merge_move):
(Package.install):
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/autoinstall_unittest.py:
(MergeMoveTest):
(MergeMoveTest.setUp):
(MergeMoveTest.tearDown):
(MergeMoveTest._unpack):
(MergeMoveTest._contents):
(MergeMoveTest.test_install_order_does_not_matter):
(MergeMoveTest.test_file_is_replaced_by_directory):

Canonical link: <a href="https://commits.webkit.org/317620@main">https://commits.webkit.org/317620@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c0d9e3803fe593aa7a55689be442a4ab7359ef4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175846 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49779 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43563 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185439 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/26e81cad-21af-4191-80f1-61d374410091) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177709 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51071 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49461 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136929 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178802 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40392 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157707 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117408 "Passed tests") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/175169 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39034 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37412 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149453 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37199 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33909 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187860 "Built successfully") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/175249 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49446 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145924 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39250 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50126 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145764 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40559 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116171 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48633 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12179 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48035 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48267 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48092 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->