### PR TITLE
[LibWebRTC][GStreamer] Improvements in video encoder and decoder wrappers

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2835,6 +2835,7 @@ webkit.org/b/265865 imported/w3c/web-platform-tests/webrtc-stats/rtp-stats-creat
 fast/mediastream/video-rotation2.html [ Failure ]
 
 http/wpt/mediastream/webrtc-vp9-colorspace.html [ Failure ]
+webrtc/vp9.html [ Failure ]
 
 webkit.org/b/314659 webrtc/getDisplayMedia-pc-resolution.html [ Failure ]
 

--- a/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp
@@ -254,7 +254,7 @@ void CanvasCaptureMediaStreamTrack::Source::captureCanvas()
 
     gstVideoFrame.setFrameRate(frameRate);
     gstVideoFrame.setPresentationTime(fromGstClockTime(gst_clock_get_time(m_clock.get())));
-    gstVideoFrame.setMetadataAndContentHint({ metadata }, VideoFrameContentHint::Canvas);
+    gstVideoFrame.setMetadata({ metadata }, VideoFrameContentHint::Canvas, { });
 #endif
 
     videoFrameAvailable(*videoFrame, metadata);

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCIceTransportBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCIceTransportBackend.cpp
@@ -39,6 +39,7 @@ ALLOW_UNUSED_PARAMETERS_BEGIN
 ALLOW_UNUSED_PARAMETERS_END
 
 #include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -1802,133 +1802,136 @@ PlatformVideoColorSpace videoColorSpaceFromInfo(const GstVideoInfo& info)
     return colorSpace;
 }
 
-void fillVideoInfoColorimetryFromColorSpace(GstVideoInfo* info, const PlatformVideoColorSpace& colorSpace)
+GstVideoColorimetry colorimetryFromColorSpace(const PlatformVideoColorSpace& colorSpace)
 {
     ensureGStreamerInitialized();
+    GstVideoColorimetry result;
     if (colorSpace.matrix) {
         switch (*colorSpace.matrix) {
         case PlatformVideoMatrixCoefficients::Rgb:
-            GST_VIDEO_INFO_COLORIMETRY(info).matrix = GST_VIDEO_COLOR_MATRIX_RGB;
+            result.matrix = GST_VIDEO_COLOR_MATRIX_RGB;
             break;
         case PlatformVideoMatrixCoefficients::Bt709:
-            GST_VIDEO_INFO_COLORIMETRY(info).matrix = GST_VIDEO_COLOR_MATRIX_BT709;
+            result.matrix = GST_VIDEO_COLOR_MATRIX_BT709;
             break;
         case PlatformVideoMatrixCoefficients::Smpte170m:
-            GST_VIDEO_INFO_COLORIMETRY(info).matrix = GST_VIDEO_COLOR_MATRIX_BT601;
+            result.matrix = GST_VIDEO_COLOR_MATRIX_BT601;
             break;
         case PlatformVideoMatrixCoefficients::Smpte240m:
-            GST_VIDEO_INFO_COLORIMETRY(info).matrix = GST_VIDEO_COLOR_MATRIX_SMPTE240M;
+            result.matrix = GST_VIDEO_COLOR_MATRIX_SMPTE240M;
             break;
         case PlatformVideoMatrixCoefficients::Fcc:
-            GST_VIDEO_INFO_COLORIMETRY(info).matrix = GST_VIDEO_COLOR_MATRIX_FCC;
+            result.matrix = GST_VIDEO_COLOR_MATRIX_FCC;
             break;
         case PlatformVideoMatrixCoefficients::Bt2020NonconstantLuminance:
-            GST_VIDEO_INFO_COLORIMETRY(info).matrix = GST_VIDEO_COLOR_MATRIX_BT2020;
+            result.matrix = GST_VIDEO_COLOR_MATRIX_BT2020;
             break;
         case PlatformVideoMatrixCoefficients::Unspecified:
-            GST_VIDEO_INFO_COLORIMETRY(info).matrix = GST_VIDEO_COLOR_MATRIX_UNKNOWN;
+            result.matrix = GST_VIDEO_COLOR_MATRIX_UNKNOWN;
             break;
         default:
             break;
         };
-    } else
-        GST_VIDEO_INFO_COLORIMETRY(info).matrix = GST_VIDEO_COLOR_MATRIX_UNKNOWN;
+    }
 
     if (colorSpace.transfer) {
         switch (*colorSpace.transfer) {
         case PlatformVideoTransferCharacteristics::Iec6196621:
-            GST_VIDEO_INFO_COLORIMETRY(info).transfer = GST_VIDEO_TRANSFER_SRGB;
+            result.transfer = GST_VIDEO_TRANSFER_SRGB;
             break;
         case PlatformVideoTransferCharacteristics::Bt709:
-            GST_VIDEO_INFO_COLORIMETRY(info).transfer = GST_VIDEO_TRANSFER_BT709;
+            result.transfer = GST_VIDEO_TRANSFER_BT709;
             break;
         case PlatformVideoTransferCharacteristics::Smpte170m:
-            GST_VIDEO_INFO_COLORIMETRY(info).transfer = GST_VIDEO_TRANSFER_BT601;
+            result.transfer = GST_VIDEO_TRANSFER_BT601;
             break;
         case PlatformVideoTransferCharacteristics::SmpteSt2084:
-            GST_VIDEO_INFO_COLORIMETRY(info).transfer = GST_VIDEO_TRANSFER_SMPTE2084;
+            result.transfer = GST_VIDEO_TRANSFER_SMPTE2084;
             break;
         case PlatformVideoTransferCharacteristics::AribStdB67Hlg:
-            GST_VIDEO_INFO_COLORIMETRY(info).transfer = GST_VIDEO_TRANSFER_ARIB_STD_B67;
+            result.transfer = GST_VIDEO_TRANSFER_ARIB_STD_B67;
             break;
         case PlatformVideoTransferCharacteristics::Bt2020_10bit:
-            GST_VIDEO_INFO_COLORIMETRY(info).transfer = GST_VIDEO_TRANSFER_BT2020_10;
+            result.transfer = GST_VIDEO_TRANSFER_BT2020_10;
             break;
         case PlatformVideoTransferCharacteristics::Bt2020_12bit:
-            GST_VIDEO_INFO_COLORIMETRY(info).transfer = GST_VIDEO_TRANSFER_BT2020_12;
+            result.transfer = GST_VIDEO_TRANSFER_BT2020_12;
             break;
         case PlatformVideoTransferCharacteristics::Linear:
-            GST_VIDEO_INFO_COLORIMETRY(info).transfer = GST_VIDEO_TRANSFER_GAMMA10;
+            result.transfer = GST_VIDEO_TRANSFER_GAMMA10;
             break;
         case PlatformVideoTransferCharacteristics::Gamma22curve:
-            GST_VIDEO_INFO_COLORIMETRY(info).transfer = GST_VIDEO_TRANSFER_GAMMA22;
+            result.transfer = GST_VIDEO_TRANSFER_GAMMA22;
             break;
         case PlatformVideoTransferCharacteristics::Gamma28curve:
-            GST_VIDEO_INFO_COLORIMETRY(info).transfer = GST_VIDEO_TRANSFER_GAMMA28;
+            result.transfer = GST_VIDEO_TRANSFER_GAMMA28;
             break;
         case PlatformVideoTransferCharacteristics::Smpte240m:
-            GST_VIDEO_INFO_COLORIMETRY(info).transfer = GST_VIDEO_TRANSFER_SMPTE240M;
+            result.transfer = GST_VIDEO_TRANSFER_SMPTE240M;
             break;
         case PlatformVideoTransferCharacteristics::Log:
-            GST_VIDEO_INFO_COLORIMETRY(info).transfer = GST_VIDEO_TRANSFER_LOG100;
+            result.transfer = GST_VIDEO_TRANSFER_LOG100;
             break;
         case PlatformVideoTransferCharacteristics::LogSqrt:
-            GST_VIDEO_INFO_COLORIMETRY(info).transfer = GST_VIDEO_TRANSFER_LOG316;
+            result.transfer = GST_VIDEO_TRANSFER_LOG316;
             break;
         case PlatformVideoTransferCharacteristics::Unspecified:
-            GST_VIDEO_INFO_COLORIMETRY(info).transfer = GST_VIDEO_TRANSFER_UNKNOWN;
+            result.transfer = GST_VIDEO_TRANSFER_UNKNOWN;
             break;
         default:
             break;
         }
-    } else
-        GST_VIDEO_INFO_COLORIMETRY(info).transfer = GST_VIDEO_TRANSFER_UNKNOWN;
+    }
 
     if (colorSpace.primaries) {
         switch (*colorSpace.primaries) {
         case PlatformVideoColorPrimaries::Bt709:
-            GST_VIDEO_INFO_COLORIMETRY(info).primaries = GST_VIDEO_COLOR_PRIMARIES_BT709;
+            result.primaries = GST_VIDEO_COLOR_PRIMARIES_BT709;
             break;
         case PlatformVideoColorPrimaries::Bt470bg:
-            GST_VIDEO_INFO_COLORIMETRY(info).primaries = GST_VIDEO_COLOR_PRIMARIES_BT470BG;
+            result.primaries = GST_VIDEO_COLOR_PRIMARIES_BT470BG;
             break;
         case PlatformVideoColorPrimaries::Bt470m:
-            GST_VIDEO_INFO_COLORIMETRY(info).primaries = GST_VIDEO_COLOR_PRIMARIES_BT470M;
+            result.primaries = GST_VIDEO_COLOR_PRIMARIES_BT470M;
             break;
         case PlatformVideoColorPrimaries::Smpte170m:
-            GST_VIDEO_INFO_COLORIMETRY(info).primaries = GST_VIDEO_COLOR_PRIMARIES_SMPTE170M;
+            result.primaries = GST_VIDEO_COLOR_PRIMARIES_SMPTE170M;
             break;
         case PlatformVideoColorPrimaries::SmpteRp431:
-            GST_VIDEO_INFO_COLORIMETRY(info).primaries = GST_VIDEO_COLOR_PRIMARIES_SMPTERP431;
+            result.primaries = GST_VIDEO_COLOR_PRIMARIES_SMPTERP431;
             break;
         case PlatformVideoColorPrimaries::SmpteEg432:
-            GST_VIDEO_INFO_COLORIMETRY(info).primaries = GST_VIDEO_COLOR_PRIMARIES_SMPTEEG432;
+            result.primaries = GST_VIDEO_COLOR_PRIMARIES_SMPTEEG432;
             break;
         case PlatformVideoColorPrimaries::Film:
-            GST_VIDEO_INFO_COLORIMETRY(info).primaries = GST_VIDEO_COLOR_PRIMARIES_FILM;
+            result.primaries = GST_VIDEO_COLOR_PRIMARIES_FILM;
             break;
         case PlatformVideoColorPrimaries::Bt2020:
-            GST_VIDEO_INFO_COLORIMETRY(info).primaries = GST_VIDEO_COLOR_PRIMARIES_BT2020;
+            result.primaries = GST_VIDEO_COLOR_PRIMARIES_BT2020;
             break;
         case PlatformVideoColorPrimaries::Smpte240m:
-            GST_VIDEO_INFO_COLORIMETRY(info).primaries = GST_VIDEO_COLOR_PRIMARIES_SMPTE240M;
+            result.primaries = GST_VIDEO_COLOR_PRIMARIES_SMPTE240M;
             break;
         case PlatformVideoColorPrimaries::JedecP22Phosphors:
-            GST_VIDEO_INFO_COLORIMETRY(info).primaries = GST_VIDEO_COLOR_PRIMARIES_EBU3213;
+            result.primaries = GST_VIDEO_COLOR_PRIMARIES_EBU3213;
             break;
         case PlatformVideoColorPrimaries::Unspecified:
-            GST_VIDEO_INFO_COLORIMETRY(info).primaries = GST_VIDEO_COLOR_PRIMARIES_UNKNOWN;
+            result.primaries = GST_VIDEO_COLOR_PRIMARIES_UNKNOWN;
             break;
         default:
             break;
         }
-    } else
-        GST_VIDEO_INFO_COLORIMETRY(info).primaries = GST_VIDEO_COLOR_PRIMARIES_UNKNOWN;
+    }
 
     if (colorSpace.fullRange)
-        GST_VIDEO_INFO_COLORIMETRY(info).range = *colorSpace.fullRange ? GST_VIDEO_COLOR_RANGE_0_255 : GST_VIDEO_COLOR_RANGE_16_235;
-    else
-        GST_VIDEO_INFO_COLORIMETRY(info).range = GST_VIDEO_COLOR_RANGE_UNKNOWN;
+        result.range = *colorSpace.fullRange ? GST_VIDEO_COLOR_RANGE_0_255 : GST_VIDEO_COLOR_RANGE_16_235;
+    return result;
+}
+
+void fillVideoInfoColorimetryFromColorSpace(GstVideoInfo* info, const PlatformVideoColorSpace& colorSpace)
+{
+    auto colorimetry = colorimetryFromColorSpace(colorSpace);
+    GST_VIDEO_INFO_COLORIMETRY(info) = colorimetry;
 }
 
 void configureAudioDecoderForHarnessing(const GRefPtr<GstElement>& element)

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -324,6 +324,7 @@ GstClockTime webkitGstInitTime();
 PlatformVideoColorSpace videoColorSpaceFromCaps(const GstCaps*);
 PlatformVideoColorSpace videoColorSpaceFromInfo(const GstVideoInfo&);
 void fillVideoInfoColorimetryFromColorSpace(GstVideoInfo*, const PlatformVideoColorSpace&);
+GstVideoColorimetry colorimetryFromColorSpace(const PlatformVideoColorSpace&);
 
 void configureAudioDecoderForHarnessing(const GRefPtr<GstElement>&);
 void configureVideoDecoderForHarnessing(const GRefPtr<GstElement>&);

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerVideoFrameConverter.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerVideoFrameConverter.cpp
@@ -22,6 +22,7 @@
 
 #if ENABLE(VIDEO) && USE(GSTREAMER)
 
+#include "FloatSize.h"
 #include "GStreamerCommon.h"
 #include <gst/allocators/gstdmabuf.h>
 #include <gst/app/gstappsink.h>
@@ -113,6 +114,9 @@ GRefPtr<GstSample> GStreamerVideoFrameConverter::Pipeline::run(const GRefPtr<Gst
         gst_structure_remove_field(modifiedStructure, "framerate");
         gst_caps_append_structure(newCaps.get(), modifiedStructure);
     }
+
+    auto destinationSize = getVideoResolutionFromCaps(newCaps.get());
+    ASSERT_UNUSED(destinationSize, destinationSize && !destinationSize->isEmpty());
 
     GST_TRACE_OBJECT(m_pipeline.get(), "Converting sample with caps %" GST_PTR_FORMAT " to %" GST_PTR_FORMAT, gst_sample_get_caps(sample.get()), newCaps.get());
     g_object_set(m_sink.get(), "caps", newCaps.get(), nullptr);
@@ -213,12 +217,13 @@ IGNORE_WARNINGS_END
 
     auto structure = gst_caps_get_structure(destinationCaps.get(), 0);
     auto width = gstStructureGet<int>(structure, "width"_s);
+    RELEASE_ASSERT(width && *width);
     auto height = gstStructureGet<int>(structure, "height"_s);
+    RELEASE_ASSERT(height && *height);
     auto formatString = gstStructureGetString(structure, "format"_s);
-    if (width && height && !formatString.isEmpty()) {
-        auto format = gst_video_format_from_string(formatString.utf8());
-        gst_buffer_add_video_meta(writableBuffer.get(), GST_VIDEO_FRAME_FLAG_NONE, format, *width, *height);
-    }
+    RELEASE_ASSERT(!formatString.isEmpty());
+    auto format = gst_video_format_from_string(formatString.utf8());
+    gst_buffer_add_video_meta(writableBuffer.get(), GST_VIDEO_FRAME_FLAG_NONE, format, *width, *height);
     gst_sample_set_buffer(convertedSample.get(), writableBuffer.get());
 
     return convertedSample;

--- a/Source/WebCore/platform/graphics/gstreamer/GUniquePtrGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GUniquePtrGStreamer.h
@@ -48,6 +48,7 @@ WTF_DEFINE_GPTR_DELETER(GstByteReader, gst_byte_reader_free)
 WTF_DEFINE_GPTR_DELETER(GstVideoConverter, gst_video_converter_free)
 WTF_DEFINE_GPTR_DELETER(GstAudioConverter, gst_audio_converter_free)
 WTF_DEFINE_GPTR_DELETER(GstAudioInfo, gst_audio_info_free)
+WTF_DEFINE_GPTR_DELETER(GstVideoInfo, gst_video_info_free)
 WTF_DEFINE_GPTR_DELETER(GstFFTF32, gst_fft_f32_free)
 
 #if defined(BUILDING_WebCore) && USE(GSTREAMER_WEBRTC)

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -4306,10 +4306,17 @@ RefPtr<VideoFrame> MediaPlayerPrivateGStreamer::videoFrameForCurrentTime()
         return nullptr;
 
     auto frame = VideoFrameGStreamer::createWrappedSample(m_sample);
-    if (frame->contentHint() != VideoFrameContentHint::Canvas)
+    auto contentHint = frame->contentHint();
+    if (contentHint != VideoFrameContentHint::Canvas && contentHint != VideoFrameContentHint::WebRTC)
         return frame;
 
-    auto convertedSample = frame->downloadSample(GST_VIDEO_FORMAT_BGRA);
+    GRefPtr<GstSample> convertedSample;
+    if (contentHint == VideoFrameContentHint::WebRTC) {
+        auto colorSpace = frame->nativeColorSpace();
+        convertedSample = frame->convert(GST_VIDEO_FORMAT_I420, frame->presentationSize(), colorSpace);
+    } else
+        convertedSample = frame->downloadSample(GST_VIDEO_FORMAT_BGRA);
+
     if (!convertedSample)
         return nullptr;
 

--- a/Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp
@@ -152,6 +152,14 @@ Ref<VideoEncoder::EncodePromise> GStreamerVideoEncoder::encode(RawFrame&& frame,
     });
 }
 
+bool GStreamerVideoEncoder::encodeSync(RawFrame&& frame, bool shouldGenerateKeyFrame)
+{
+    auto result = m_internalEncoder->encode(WTF::move(frame), shouldGenerateKeyFrame);
+    if (result)
+        m_internalEncoder->harness()->processOutputSamples();
+    return result;
+}
+
 Ref<GenericPromise> GStreamerVideoEncoder::flush()
 {
     return invokeAsync(gstEncoderWorkQueue(), [encoder = m_internalEncoder] {

--- a/Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.h
@@ -46,6 +46,7 @@ public:
     void close() final;
     Ref<GenericPromise> setRates(uint64_t bitRate, double frameRate) final;
 
+    bool encodeSync(RawFrame&&, bool shouldGenerateKeyFrame);
     Ref<GenericPromise> setBitRateAllocation(RefPtr<WebKitVideoEncoderBitRateAllocation>&&, double frameRate);
 
 private:

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
@@ -39,6 +39,7 @@
 #include <JavaScriptCore/TypedArrayInlines.h>
 #include <skia/core/SkData.h>
 #include <skia/core/SkImage.h>
+#include <wtf/glib/GMallocString.h>
 
 #if USE(GBM)
 #include <drm_fourcc.h>
@@ -143,9 +144,10 @@ VideoFrameGStreamer::Info VideoFrameGStreamer::infoFromCaps(const GRefPtr<GstCap
     return { videoInfo, { } };
 }
 
-RefPtr<VideoFrame> VideoFrame::createFromPixelBuffer(Ref<PixelBuffer>&& pixelBuffer, PlatformVideoColorSpace&& colorSpace)
+RefPtr<VideoFrame> VideoFrame::createFromPixelBuffer(Ref<PixelBuffer>&& pixelBuffer, PlatformVideoColorSpace&&)
 {
-    return VideoFrameGStreamer::createFromPixelBuffer(WTF::move(pixelBuffer), { }, 1, { }, WTF::move(colorSpace));
+    // Setting the colorSpace on the caps leads to VP8 full-cycle webcodecs test failures, so don't do that for the time being.
+    return VideoFrameGStreamer::createFromPixelBuffer(WTF::move(pixelBuffer), { }, 1, { }, { });
 }
 
 static RefPtr<ImageGStreamer> convertSampleToImage(const GRefPtr<GstSample>& sample, const GstVideoInfo& videoInfo)
@@ -370,7 +372,7 @@ Ref<VideoFrameGStreamer> VideoFrameGStreamer::create(GRefPtr<GstSample>&& sample
 {
     CreateOptions newOptions = options;
     auto caps = gst_sample_get_caps(sample.get());
-    if (!colorSpace.primaries && doCapsHaveType(caps, GST_VIDEO_CAPS_TYPE_PREFIX))
+    if (!colorSpace.isValid() && doCapsHaveType(caps, GST_VIDEO_CAPS_TYPE_PREFIX))
         colorSpace = videoColorSpaceFromCaps(caps);
 
     if (options.presentationTime.isInvalid())
@@ -437,6 +439,14 @@ RefPtr<VideoFrameGStreamer> VideoFrameGStreamer::createFromPixelBuffer(Ref<Pixel
     if (frameRate)
         gst_caps_set_simple(caps.get(), "framerate", GST_TYPE_FRACTION, frameRateNumerator, frameRateDenominator, nullptr);
 
+    GMallocString colorimetry;
+    if (colorSpace.isValid()) {
+        auto gstColorimetry = colorimetryFromColorSpace(colorSpace);
+        colorimetry = GMallocString::unsafeAdoptFromUTF8(gst_video_colorimetry_to_string(&gstColorimetry));
+    }
+    if (!colorimetry.isEmpty())
+        gst_caps_set_simple(caps.get(), "colorimetry", G_TYPE_STRING, colorimetry.utf8(), nullptr);
+
     GRefPtr<GstSample> sample;
     Info info;
 
@@ -454,6 +464,8 @@ RefPtr<VideoFrameGStreamer> VideoFrameGStreamer::createFromPixelBuffer(Ref<Pixel
             "height", G_TYPE_INT, height, nullptr));
         if (frameRate)
             gst_caps_set_simple(outputCaps.get(), "framerate", GST_TYPE_FRACTION, frameRateNumerator, frameRateDenominator, nullptr);
+        if (!colorimetry.isEmpty())
+            gst_caps_set_simple(outputCaps.get(), "colorimetry", G_TYPE_STRING, colorimetry.utf8(), nullptr);
 
         GRefPtr inputSample = adoptGRef(gst_sample_new(buffer.get(), caps.get(), nullptr, nullptr));
         sample = GStreamerVideoFrameConverter::singleton().convert(inputSample, outputCaps);
@@ -463,7 +475,6 @@ RefPtr<VideoFrameGStreamer> VideoFrameGStreamer::createFromPixelBuffer(Ref<Pixel
         info = infoFromCaps(outputCaps);
         GRefPtr buffer = gst_sample_get_buffer(sample.get());
         auto outputBuffer = webkitGstBufferSetVideoFrameMetadata(WTF::move(buffer), options.timeMetadata, options.rotation, options.isMirrored, options.contentHint);
-        gst_buffer_add_video_meta(outputBuffer.get(), GST_VIDEO_FRAME_FLAG_NONE, format, width, height);
         setBufferFields(outputBuffer.get(), options.presentationTime, frameRate);
         sample = adoptGRef(gst_sample_make_writable(sample.leakRef()));
         gst_sample_set_buffer(sample.get(), outputBuffer.get());
@@ -496,7 +507,7 @@ VideoFrameGStreamer::VideoFrameGStreamer(GRefPtr<GstSample>&& sample, const Crea
     if (!GST_IS_BUFFER(gst_sample_get_buffer(m_sample.get())))
         return;
 
-    setMetadataAndContentHint(options.timeMetadata, options.contentHint);
+    setMetadata(options.timeMetadata, options.contentHint, options.colorSpace);
 }
 
 VideoFrameGStreamer::VideoFrameGStreamer(const GRefPtr<GstSample>& sample, const CreateOptions& options, PlatformVideoColorSpace&& colorSpace)
@@ -547,11 +558,11 @@ void VideoFrameGStreamer::setPresentationTime(const MediaTime& presentationTime)
     GST_BUFFER_PTS(buffer) = GST_BUFFER_DTS(buffer) = toGstClockTime(presentationTime);
 }
 
-void VideoFrameGStreamer::setMetadataAndContentHint(std::optional<VideoFrameTimeMetadata> metadata, VideoFrameContentHint hint)
+void VideoFrameGStreamer::setMetadata(std::optional<VideoFrameTimeMetadata> metadata, VideoFrameContentHint hint, std::optional<PlatformVideoColorSpace> colorSpace)
 {
     GRefPtr buffer = gst_sample_get_buffer(m_sample.get());
     RELEASE_ASSERT(buffer);
-    auto modifiedBuffer = webkitGstBufferSetVideoFrameMetadata(WTF::move(buffer), metadata, rotation(), isMirrored(), hint);
+    auto modifiedBuffer = webkitGstBufferSetVideoFrameMetadata(WTF::move(buffer), metadata, rotation(), isMirrored(), hint, colorSpace);
     m_sample = adoptGRef(gst_sample_make_writable(m_sample.leakRef()));
     gst_sample_set_buffer(m_sample.get(), modifiedBuffer.get());
 }
@@ -717,7 +728,7 @@ GRefPtr<GstSample> VideoFrameGStreamer::resizedSample(const IntSize& destination
     return convert(static_cast<GstVideoFormat>(pixelFormat()), destinationSize);
 }
 
-GRefPtr<GstSample> VideoFrameGStreamer::convert(GstVideoFormat format, const IntSize& destinationSize)
+GRefPtr<GstSample> VideoFrameGStreamer::convert(GstVideoFormat format, const IntSize& destinationSize, std::optional<PlatformVideoColorSpace> colorSpace)
 {
     auto* caps = gst_sample_get_caps(m_sample.get());
     const auto* structure = gst_caps_get_structure(caps, 0);
@@ -732,9 +743,15 @@ GRefPtr<GstSample> VideoFrameGStreamer::convert(GstVideoFormat format, const Int
     auto formatName = CStringView::unsafeFromUTF8(gst_video_format_to_string(format));
     GRefPtr outputCaps = adoptGRef(gst_caps_new_simple("video/x-raw", "format", G_TYPE_STRING, formatName.utf8(), "width", G_TYPE_INT, width, "height", G_TYPE_INT, height, "framerate", GST_TYPE_FRACTION, frameRateNumerator, frameRateDenominator, nullptr));
 
-    if (gst_caps_is_equal(caps, outputCaps.get()))
-        return GRefPtr<GstSample>(m_sample);
+    if (colorSpace) {
+        auto gstColorimetry = colorimetryFromColorSpace(*colorSpace);
+        auto colorimetry = GMallocString::unsafeAdoptFromUTF8(gst_video_colorimetry_to_string(&gstColorimetry));
+        if (!colorimetry.isEmpty())
+            gst_caps_set_simple(outputCaps.get(), "colorimetry", G_TYPE_STRING, colorimetry.utf8(), nullptr);
+    }
 
+    if (gst_caps_is_equal(caps, outputCaps.get()))
+        return m_sample;
     return GStreamerVideoFrameConverter::singleton().convert(m_sample, outputCaps);
 }
 
@@ -874,6 +891,11 @@ VideoFrameContentHint VideoFrameGStreamer::contentHint() const
 {
     auto buffer = gst_sample_get_buffer(m_sample.get());
     return webkitGstBufferGetContentHint(buffer);
+}
+
+PlatformVideoColorSpace VideoFrameGStreamer::nativeColorSpace() const
+{
+    return webkitGstBufferGetNativeColorSpace(gst_sample_get_buffer(m_sample.get()));
 }
 
 bool VideoFrameGStreamer::isEncoded() const

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.h
@@ -63,6 +63,7 @@ public:
         std::optional<VideoFrameTimeMetadata> timeMetadata;
         bool isMirrored { false };
         VideoFrameContentHint contentHint { VideoFrameContentHint::None };
+        std::optional<PlatformVideoColorSpace> colorSpace;
     };
 
     static Ref<VideoFrameGStreamer> create(GRefPtr<GstSample>&&, const CreateOptions&, PlatformVideoColorSpace&& = { });
@@ -75,7 +76,7 @@ public:
     void setMaxFrameRate(double);
 
     void setPresentationTime(const MediaTime&);
-    void setMetadataAndContentHint(std::optional<VideoFrameTimeMetadata>, VideoFrameContentHint);
+    void setMetadata(std::optional<VideoFrameTimeMetadata>, VideoFrameContentHint, std::optional<PlatformVideoColorSpace>);
 
     RefPtr<VideoFrameGStreamer> resizeTo(const IntSize&);
 
@@ -109,9 +110,12 @@ public:
     std::optional<DMABufFormat> dmaBufFormat() const { return m_info.dmaBufFormat; }
 
     VideoFrameContentHint contentHint() const;
+    PlatformVideoColorSpace nativeColorSpace() const;
 
     bool isEncoded() const final;
     bool hasSameEncodedFormat(const VideoFrame&) const final;
+
+    GRefPtr<GstSample> convert(GstVideoFormat, const IntSize&, std::optional<PlatformVideoColorSpace> = std::nullopt);
 
 private:
     VideoFrameGStreamer(GRefPtr<GstSample>&&, const CreateOptions&, PlatformVideoColorSpace&&);
@@ -119,8 +123,6 @@ private:
 
     bool isGStreamer() const final { return true; }
     Ref<VideoFrame> clone() final;
-
-    GRefPtr<GstSample> convert(GstVideoFormat, const IntSize&);
 
     void setMemoryTypeFromCaps();
 

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameMetadataGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameMetadataGStreamer.cpp
@@ -38,6 +38,7 @@ struct VideoFrameMetadataPrivate {
     VideoFrameContentHint contentHint { VideoFrameContentHint::None };
     Lock lock;
     HashMap<GstElement*, std::pair<GstClockTime, GstClockTime>> processingTimes WTF_GUARDED_BY_LOCK(lock);
+    PlatformVideoColorSpace nativeColorSpace;
 };
 
 WEBKIT_DEFINE_ASYNC_DATA_STRUCT(VideoFrameMetadataPrivate);
@@ -102,6 +103,7 @@ const GstMetaInfo* videoFrameMetadataGetInfo()
                 copyMeta->priv->rotation = frameMeta->priv->rotation;
                 copyMeta->priv->isMirrored = frameMeta->priv->isMirrored;
                 copyMeta->priv->contentHint = frameMeta->priv->contentHint;
+                copyMeta->priv->nativeColorSpace = frameMeta->priv->nativeColorSpace;
 
                 Locker frameMetaLocker { frameMeta->priv->lock };
                 Locker copyMetaLocker { copyMeta->priv->lock };
@@ -114,7 +116,7 @@ const GstMetaInfo* videoFrameMetadataGetInfo()
 
 // NOTE: The buffer here cannot be a const GRefPtr<>&, that would mean its refcount would be greater
 // than 1, hence it wouldn't be writable.
-void webkitGstBufferAddVideoFrameMetadata(GstBuffer* buffer, std::optional<WebCore::VideoFrameTimeMetadata> metadata, VideoFrame::Rotation rotation, bool isMirrored, VideoFrameContentHint hint)
+void webkitGstBufferAddVideoFrameMetadata(GstBuffer* buffer, std::optional<WebCore::VideoFrameTimeMetadata> metadata, VideoFrame::Rotation rotation, bool isMirrored, VideoFrameContentHint hint, std::optional<WebCore::PlatformVideoColorSpace> colorSpace)
 {
     if (!gst_buffer_is_writable(buffer)) {
         GST_ERROR("Unable to add video frame metadata on read-only buffer");
@@ -129,6 +131,8 @@ void webkitGstBufferAddVideoFrameMetadata(GstBuffer* buffer, std::optional<WebCo
         meta->priv->rotation = rotation;
         meta->priv->isMirrored = isMirrored;
         meta->priv->contentHint = hint;
+        if (colorSpace)
+            meta->priv->nativeColorSpace = *colorSpace;
         return;
     }
 
@@ -137,14 +141,16 @@ void webkitGstBufferAddVideoFrameMetadata(GstBuffer* buffer, std::optional<WebCo
     meta->priv->rotation = rotation;
     meta->priv->isMirrored = isMirrored;
     meta->priv->contentHint = hint;
+    if (colorSpace)
+        meta->priv->nativeColorSpace = *colorSpace;
 }
 
-GRefPtr<GstBuffer> webkitGstBufferSetVideoFrameMetadata(GRefPtr<GstBuffer>&& buffer, std::optional<WebCore::VideoFrameTimeMetadata> metadata, VideoFrame::Rotation rotation, bool isMirrored, VideoFrameContentHint hint)
+GRefPtr<GstBuffer> webkitGstBufferSetVideoFrameMetadata(GRefPtr<GstBuffer>&& buffer, std::optional<WebCore::VideoFrameTimeMetadata> metadata, VideoFrame::Rotation rotation, bool isMirrored, VideoFrameContentHint hint, std::optional<WebCore::PlatformVideoColorSpace> colorSpace)
 {
     IGNORE_WARNINGS_BEGIN("cast-align");
     GRefPtr modifiedBuffer = adoptGRef(gst_buffer_make_writable(buffer.leakRef()));
     IGNORE_WARNINGS_END;
-    webkitGstBufferAddVideoFrameMetadata(modifiedBuffer.get(), metadata, rotation, isMirrored, hint);
+    webkitGstBufferAddVideoFrameMetadata(modifiedBuffer.get(), metadata, rotation, isMirrored, hint, colorSpace);
     return modifiedBuffer;
 }
 
@@ -252,6 +258,17 @@ VideoFrameContentHint webkitGstBufferGetContentHint(GstBuffer* buffer)
         return meta->priv->contentHint;
 
     return VideoFrameContentHint::None;
+}
+
+PlatformVideoColorSpace webkitGstBufferGetNativeColorSpace(GstBuffer* buffer)
+{
+    if (!GST_IS_BUFFER(buffer))
+        return { };
+
+    if (auto meta = getInternalVideoFrameMetadata(buffer))
+        return meta->priv->nativeColorSpace;
+
+    return { };
 }
 
 MediaTime webkitGstBufferGetProcessingTime(GstBuffer* buffer, GstElement* element)

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameMetadataGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameMetadataGStreamer.h
@@ -22,22 +22,24 @@
 #if ENABLE(VIDEO) && USE(GSTREAMER)
 
 #include "GRefPtrGStreamer.h"
+#include "PlatformVideoColorSpace.h"
 #include "VideoFrame.h"
 #include "VideoFrameContentHint.h"
 #include "VideoFrameMetadata.h"
 #include "VideoFrameTimeMetadata.h"
 
 // Modifies the buffer in-place.
-void webkitGstBufferAddVideoFrameMetadata(GstBuffer*, std::optional<WebCore::VideoFrameTimeMetadata>, WebCore::VideoFrame::Rotation, bool isMirrored, WebCore::VideoFrameContentHint);
+void webkitGstBufferAddVideoFrameMetadata(GstBuffer*, std::optional<WebCore::VideoFrameTimeMetadata>, WebCore::VideoFrame::Rotation, bool isMirrored, WebCore::VideoFrameContentHint, std::optional<WebCore::PlatformVideoColorSpace> = std::nullopt);
 
 // Makes the buffer writable before modifying it.
-[[nodiscard]] GRefPtr<GstBuffer> webkitGstBufferSetVideoFrameMetadata(GRefPtr<GstBuffer>&&, std::optional<WebCore::VideoFrameTimeMetadata>, WebCore::VideoFrame::Rotation = WebCore::VideoFrame::Rotation::None, bool isMirrored = false, WebCore::VideoFrameContentHint = WebCore::VideoFrameContentHint::None);
+[[nodiscard]] GRefPtr<GstBuffer> webkitGstBufferSetVideoFrameMetadata(GRefPtr<GstBuffer>&&, std::optional<WebCore::VideoFrameTimeMetadata>, WebCore::VideoFrame::Rotation = WebCore::VideoFrame::Rotation::None, bool isMirrored = false, WebCore::VideoFrameContentHint = WebCore::VideoFrameContentHint::None, std::optional<WebCore::PlatformVideoColorSpace> = std::nullopt);
 
 void webkitGstTraceProcessingTimeForElement(GstElement*);
 WebCore::VideoFrameMetadata webkitGstBufferGetVideoFrameMetadata(GstBuffer*);
 std::pair<WebCore::VideoFrame::Rotation, bool> webkitGstBufferGetVideoRotation(GstBuffer*);
 
 WebCore::VideoFrameContentHint webkitGstBufferGetContentHint(GstBuffer*);
+WebCore::PlatformVideoColorSpace webkitGstBufferGetNativeColorSpace(GstBuffer*);
 
 MediaTime webkitGstBufferGetProcessingTime(GstBuffer*, GstElement*);
 

--- a/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeVideoSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeVideoSourceGStreamer.cpp
@@ -132,8 +132,14 @@ void MockRealtimeVideoSourceGStreamer::updateSampleBuffer()
     options.presentationTime = fromGstClockTime(gst_util_uint64_scale(m_frameNumber, frameRateDenominator * GST_SECOND, frameRateNumerator));
     options.rotation = videoFrameRotation();
     options.timeMetadata = WTF::move(metadata);
+    options.presentationSize = size();
 
-    auto videoFrame = VideoFrameGStreamer::createFromPixelBuffer(pixelBuffer.releaseNonNull(), m_capturer->size(), frameRate(), options);
+    PlatformVideoColorSpace colorSpace;
+    colorSpace.matrix = PlatformVideoMatrixCoefficients::Bt709;
+    colorSpace.primaries = PlatformVideoColorPrimaries::Bt709;
+    colorSpace.transfer = PlatformVideoTransferCharacteristics::Bt709;
+    colorSpace.fullRange = false;
+    auto videoFrame = VideoFrameGStreamer::createFromPixelBuffer(pixelBuffer.releaseNonNull(), m_capturer->size(), frameRate(), options, WTF::move(colorSpace));
     if (!videoFrame)
         return;
 

--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoDecoderFactory.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoDecoderFactory.cpp
@@ -28,6 +28,7 @@
 #include "GStreamerVideoCommon.h"
 #include "GStreamerVideoFrameLibWebRTC.h"
 #include "IntSize.h"
+#include "LibWebRTCUtils.h"
 #include "webrtc/modules/video_coding/codecs/vp8/libvpx_vp8_decoder.h"
 #include "webrtc/modules/video_coding/include/video_error_codes.h"
 #include <gst/app/gstappsink.h>
@@ -175,9 +176,10 @@ public:
             return WEBRTC_VIDEO_CODEC_OK;
 
         disconnectSimpleBusMessageCallback(m_pipeline.get());
-        GRefPtr bus = adoptGRef(gst_pipeline_get_bus(GST_PIPELINE(m_pipeline.get())));
-        gst_bus_disable_sync_message_emission(bus.get());
-
+        if (m_requireParse) {
+            GRefPtr bus = adoptGRef(gst_pipeline_get_bus(GST_PIPELINE(m_pipeline.get())));
+            gst_bus_disable_sync_message_emission(bus.get());
+        }
         gst_element_set_state(m_pipeline.get(), GST_STATE_NULL);
         m_src = nullptr;
         m_sink = nullptr;
@@ -395,14 +397,16 @@ private:
 
 std::unique_ptr<webrtc::VideoDecoder> GStreamerVideoDecoderFactory::Create(const webrtc::Environment& environment, const webrtc::SdpVideoFormat& format)
 {
-    if (format.name == "H264")
+    auto formatName = fromStdString(format.name);
+    // Check format ignoring ascii case, see also: webrtc/video-lowercase-media-subtype.html.
+    if (WTF::equalLettersIgnoringASCIICase(formatName, "h264"_s))
         return std::unique_ptr<webrtc::VideoDecoder>(new H264Decoder());
-    if (format == webrtc::SdpVideoFormat::VP8())
+    if (WTF::equalLettersIgnoringASCIICase(formatName, "vp8"_s))
         return VP8Decoder::Create(environment);
-    if (format.name == "VP9")
+    if (WTF::equalLettersIgnoringASCIICase(formatName, "vp9"_s))
         return VP9Decoder::Create();
 
-    GST_ERROR("Could not create decoder for %s", format.name.c_str());
+    GST_ERROR("Could not create decoder for %s", formatName.ascii().data());
     return nullptr;
 }
 

--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoEncoderFactory.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoEncoderFactory.cpp
@@ -77,12 +77,12 @@ private:
 class LibWebRTCGStreamerVideoEncoder final : public webrtc::VideoEncoder {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(LibWebRTCGStreamerVideoEncoder);
 public:
-    LibWebRTCGStreamerVideoEncoder(const webrtc::SdpVideoFormat& sdpVideoFormat)
+    LibWebRTCGStreamerVideoEncoder(const String& formatName, const webrtc::SdpVideoFormat& sdpVideoFormat)
         : m_sdpVideoFormat(sdpVideoFormat)
     {
         WebCore::VideoEncoder::Config config;
         StringBuilder builder;
-        if (m_sdpVideoFormat.IsSameCodec(webrtc::SdpVideoFormat::H264())) {
+        if (formatName == "H264"_s) {
             builder.append("avc1"_s);
             const auto profileLevelId = m_sdpVideoFormat.parameters["profile-level-id"];
             if (!profileLevelId.empty())
@@ -90,7 +90,7 @@ public:
             m_codecInfo.codecType = webrtc::kVideoCodecH264;
             m_codecInfo.codecSpecific.H264.packetization_mode = webrtc::H264PacketizationMode::NonInterleaved;
             config.useAnnexB = true;
-        } else if (m_sdpVideoFormat.IsSameCodec(webrtc::SdpVideoFormat::VP8())) {
+        } else if (formatName == "VP8"_s) {
             builder.append("vp8"_s);
             m_codecInfo.codecType = webrtc::kVideoCodecVP8;
         }
@@ -117,12 +117,11 @@ public:
         if (!m_encodedImageCallback) [[unlikely]]
             return;
 
-        auto encodedImageBuffer = GStreamerEncodedImageBuffer::create(frame.data.span());
+        if (frame.data.isEmpty())
+            return;
 
         webrtc::EncodedImage encodedImage;
-        encodedImage.SetEncodedData(encodedImageBuffer);
-        if (!encodedImage.size()) [[unlikely]]
-            return;
+        encodedImage.SetEncodedData(GStreamerEncodedImageBuffer::create(frame.data.span()));
 
         encodedImage._encodedWidth = m_size.width();
         encodedImage._encodedHeight = m_size.height();
@@ -190,8 +189,8 @@ public:
                 bitRateAllocation->setBitRate(spatialIndex, temporalIndex, bitRate);
             }
         }
-        m_frameRate = parameters.framerate_fps;
-        static_cast<GStreamerVideoEncoder&>(*m_internalEncoder).setBitRateAllocation(WTF::move(bitRateAllocation), parameters.framerate_fps);
+        m_frameRate = std::min(60.0, parameters.framerate_fps);
+        static_cast<GStreamerVideoEncoder&>(*m_internalEncoder).setBitRateAllocation(WTF::move(bitRateAllocation), *m_frameRate);
     }
 
     int32_t InitEncode(const webrtc::VideoCodec* codecSettings, const webrtc::VideoEncoder::Settings&) final
@@ -210,8 +209,6 @@ public:
 
     int32_t Release() final
     {
-        if (m_internalEncoder)
-            m_internalEncoder->close();
         return WEBRTC_VIDEO_CODEC_OK;
     }
 
@@ -246,6 +243,9 @@ public:
         auto colorSpace = colorSpaceFromLibWebRTCVideoFrame(frame);
         auto sample = convertLibWebRTCVideoFrameToGStreamerSample(frame);
 
+        if (auto size = getVideoResolutionFromCaps(gst_sample_get_caps(sample.get()))) [[likely]]
+            options.presentationSize = roundedIntSize(*size);
+
         if (m_frameRate) {
             int framerateNumerator, framerateDenominator;
             gst_util_double_to_fraction(*m_frameRate, &framerateNumerator, &framerateDenominator);
@@ -258,10 +258,16 @@ public:
         }
 
         auto gstVideoFrame = VideoFrameGStreamer::create(WTF::move(sample), options, colorSpace.value_or(PlatformVideoColorSpace { }));
+        auto previousSize = m_size;
         m_size = gstVideoFrame->presentationSize();
+        if (m_size != previousSize)
+            shouldGenerateKeyFrame = true;
         WebCore::VideoEncoder::RawFrame rawFrame { WTF::move(gstVideoFrame), frame.render_time_ms(), { } };
-        m_internalEncoder->encode(WTF::move(rawFrame), shouldGenerateKeyFrame);
-        return WEBRTC_VIDEO_CODEC_OK;
+        auto& gstEncoder = *static_cast<GStreamerVideoEncoder*>(m_internalEncoder.get());
+        if (gstEncoder.encodeSync(WTF::move(rawFrame), shouldGenerateKeyFrame))
+            return WEBRTC_VIDEO_CODEC_OK;
+
+        return WEBRTC_VIDEO_CODEC_ENCODER_FAILURE;
     }
 
 private:
@@ -288,8 +294,9 @@ std::unique_ptr<webrtc::VideoEncoder> GStreamerVideoEncoderFactory::Create(const
         return webrtc::CreateVp9Encoder(environment, { webrtc::VP9Profile::kProfile2 });
     }
 
-    if (format.IsSameCodec(webrtc::SdpVideoFormat::VP8()) || format.IsSameCodec(webrtc::SdpVideoFormat::H264()))
-        return makeUnique<LibWebRTCGStreamerVideoEncoder>(format);
+    auto formatName = fromStdString(format.name);
+    if (formatName == "VP8"_s || formatName == "H264"_s)
+        return makeUnique<LibWebRTCGStreamerVideoEncoder>(formatName, format);
 
     return nullptr;
 }

--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoFrameLibWebRTC.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoFrameLibWebRTC.cpp
@@ -21,9 +21,10 @@
 #if USE(GSTREAMER) && USE(LIBWEBRTC)
 #include "GStreamerVideoFrameLibWebRTC.h"
 
+#include "GStreamerCommon.h"
 #include "GStreamerVideoFrameConverter.h"
-#include <gst/video/video-format.h>
-#include <gst/video/video-info.h>
+#include "LibWebRTCVideoFrameUtilities.h"
+
 #include <wtf/MediaTime.h>
 #include <wtf/glib/GUniquePtr.h>
 
@@ -59,6 +60,10 @@ GRefPtr<GstSample> convertLibWebRTCVideoFrameToGStreamerSample(const webrtc::Vid
     };
     GstVideoInfo info;
     gst_video_info_set_format(&info, GST_VIDEO_FORMAT_I420, frame.width(), frame.height());
+
+    if (auto colorSpace = colorSpaceFromLibWebRTCVideoFrame(frame))
+        fillVideoInfoColorimetryFromColorSpace(&info, *colorSpace);
+
     GRefPtr buffer = adoptGRef(gst_buffer_new_wrapped_full(static_cast<GstMemoryFlags>(GST_MEMORY_FLAG_NO_SHARE | GST_MEMORY_FLAG_READONLY),
         const_cast<gpointer>(reinterpret_cast<const void*>(i420Buffer->DataY())), info.size, 0, info.size, i420Buffer, [](gpointer buffer) {
             reinterpret_cast<webrtc::I420Buffer*>(buffer)->Release();
@@ -103,14 +108,11 @@ webrtc::scoped_refptr<webrtc::I420BufferInterface> GStreamerVideoFrameLibWebRTC:
     }
 
     if (inFrame.format() != GST_VIDEO_FORMAT_I420) {
-        GstVideoInfo outInfo;
-        gst_video_info_set_format(&outInfo, GST_VIDEO_FORMAT_I420, inFrame.width(), inFrame.height());
+        GUniquePtr<GstVideoInfo> outInfo(gst_video_info_copy(inFrame.info()));
+        outInfo->finfo = gst_video_format_get_info(GST_VIDEO_FORMAT_I420);
+        GRefPtr caps = adoptGRef(gst_video_info_to_caps(outInfo.get()));
 
-        auto info = inFrame.info();
-        outInfo.fps_n = info->fps_n;
-        outInfo.fps_d = info->fps_d;
-        GRefPtr caps = adoptGRef(gst_video_info_to_caps(&outInfo));
-
+        GST_TRACE("Converting frame to I420");
         auto& converter = GStreamerVideoFrameConverter::singleton();
         auto sample = converter.convert(m_sample, caps);
         if (!sample) [[unlikely]]

--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeIncomingVideoSourceLibWebRTC.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeIncomingVideoSourceLibWebRTC.cpp
@@ -78,12 +78,14 @@ void RealtimeIncomingVideoSourceLibWebRTC::OnFrame(const webrtc::VideoFrame& fra
     GST_TRACE("Handling incoming video frame");
 #endif
 
-    auto presentationTime = MediaTime(frame.timestamp_us(), G_USEC_PER_SEC);
     auto sample = convertLibWebRTCVideoFrameToGStreamerSample(frame);
     VideoFrameGStreamer::CreateOptions options;
     options.timeMetadata = std::make_optional(metadataFromVideoFrame(frame));
-    options.presentationTime = presentationTime;
+    options.presentationTime = MediaTime(frame.timestamp_us(), G_USEC_PER_SEC);
+    options.presentationSize = { frame.width(), frame.height() };
     options.rotation = videoRotationFromLibWebRTCVideoFrame(frame);
+    options.colorSpace = colorSpaceFromLibWebRTCVideoFrame(frame);
+    options.contentHint = VideoFrameContentHint::WebRTC;
     videoFrameAvailable(VideoFrameGStreamer::create(WTF::move(sample), options), { });
 }
 

--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeOutgoingVideoSourceLibWebRTC.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeOutgoingVideoSourceLibWebRTC.cpp
@@ -74,11 +74,33 @@ void RealtimeOutgoingVideoSourceLibWebRTC::videoFrameAvailable(VideoFrame& video
         break;
     }
 
-    GST_TRACE("Sending video frame");
-    sendFrame(GStreamerVideoFrameLibWebRTC::create(GRefPtr(static_cast<VideoFrameGStreamer&>(videoFrame).sample())), videoFrame.colorSpace());
+    auto colorSpace = [&] {
+        if (auto pixelFormat = convertVideoFramePixelFormat(videoFrame.pixelFormat(), true)) {
+            if (isRGBVideoPixelFormat(*pixelFormat))
+                return PlatformVideoColorSpace { PlatformVideoColorPrimaries::Bt709, PlatformVideoTransferCharacteristics::Bt709, PlatformVideoMatrixCoefficients::Bt709, false };
+        }
+        return videoFrame.colorSpace();
+    }();
+
+    auto& gstFrame = downcast<VideoFrameGStreamer>(videoFrame);
+    auto frameSize = gstFrame.presentationSize();
+    if (frameSize.isEmpty())
+        return;
+
+    frameSize.scale(this->videoFrameScaling());
+    auto sample = gstFrame.convert(GST_VIDEO_FORMAT_I420, frameSize, colorSpace);
+    if (!sample)
+        return;
+
+    // Clear the segment otherwise a bytes segment will be pushed on the encoder, leading to
+    // potential critical warnings in videoflip which expects a time segment.
+    GRefPtr writableSample = adoptGRef(gst_sample_make_writable(sample.leakRef()));
+    gst_sample_set_segment(writableSample.get(), nullptr);
+    GST_TRACE("Sending video frame with caps %" GST_PTR_FORMAT, gst_sample_get_caps(writableSample.get()));
+    sendFrame(GStreamerVideoFrameLibWebRTC::create(WTF::move(writableSample)), colorSpace);
 }
 
-webrtc::scoped_refptr<webrtc::VideoFrameBuffer> RealtimeOutgoingVideoSourceLibWebRTC::createBlackFrame(size_t  width, size_t  height)
+webrtc::scoped_refptr<webrtc::VideoFrameBuffer> RealtimeOutgoingVideoSourceLibWebRTC::createBlackFrame(size_t width, size_t height)
 {
     GST_TRACE("Creating black video frame");
 

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.cpp
@@ -60,11 +60,7 @@ LibWebRTCProvider::LibWebRTCProvider(WebPage& webPage)
     : m_webPage(webPage)
 {
     m_useNetworkThreadWithSocketServer = false;
-#if PLATFORM(GTK) || PLATFORM(WPE)
-    m_supportsMDNS = false;
-#else
     m_supportsMDNS = true;
-#endif
 }
 
 LibWebRTCProvider::~LibWebRTCProvider() = default;


### PR DESCRIPTION
#### b3b04b37ff697c9113b5e306b3d08b84270e6eda
<pre>
[LibWebRTC][GStreamer] Improvements in video encoder and decoder wrappers
<a href="https://bugs.webkit.org/show_bug.cgi?id=319502">https://bugs.webkit.org/show_bug.cgi?id=319502</a>

Reviewed by Xabier Rodriguez-Calvar.

Several fixes were needed in the video encoder and decoder libwebrtc wrappers, notably when
determining and testing the codec mime-types. The encoder framerate is also now capped to 60 fps.

Also, as part of this patch video frames now carry the PlatforVideoColorspace information in their caps
and also potentially as metadata.

* Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp:
(WebCore::CanvasCaptureMediaStreamTrack::Source::captureCanvas):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCIceTransportBackend.cpp:
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::colorimetryFromColorSpace):
(WebCore::fillVideoInfoColorimetryFromColorSpace):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h:
* Source/WebCore/platform/graphics/gstreamer/GStreamerVideoFrameConverter.cpp:
(WebCore::GStreamerVideoFrameConverter::Pipeline::run):
(WebCore::GStreamerVideoFrameConverter::convert):
* Source/WebCore/platform/graphics/gstreamer/GUniquePtrGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::videoFrameForCurrentTime):
* Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp:
(WebCore::GStreamerVideoEncoder::encodeSync):
* Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp:
(WebCore::VideoFrame::createFromPixelBuffer):
(WebCore::VideoFrameGStreamer::create):
(WebCore::VideoFrameGStreamer::createFromPixelBuffer):
(WebCore::VideoFrameGStreamer::VideoFrameGStreamer):
(WebCore::VideoFrameGStreamer::setMetadata):
(WebCore::VideoFrameGStreamer::convert):
(WebCore::VideoFrameGStreamer::nativeColorSpace const):
(WebCore::VideoFrameGStreamer::setMetadataAndContentHint): Deleted.
* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/VideoFrameMetadataGStreamer.cpp:
(videoFrameMetadataGetInfo):
(webkitGstBufferAddVideoFrameMetadata):
(webkitGstBufferSetVideoFrameMetadata):
(webkitGstBufferGetNativeColorSpace):
* Source/WebCore/platform/graphics/gstreamer/VideoFrameMetadataGStreamer.h:
* Source/WebCore/platform/mediastream/gstreamer/MockRealtimeVideoSourceGStreamer.cpp:
(WebCore::MockRealtimeVideoSourceGStreamer::updateSampleBuffer):
* Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoDecoderFactory.cpp:
(WebCore::GStreamerVideoDecoderFactory::Create):
* Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoEncoderFactory.cpp:
(WebCore::GStreamerVideoEncoderFactory::Create):
* Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoFrameLibWebRTC.cpp:
(WebCore::convertLibWebRTCVideoFrameToGStreamerSample):
(WebCore::GStreamerVideoFrameLibWebRTC::ToI420):
* Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeIncomingVideoSourceLibWebRTC.cpp:
(WebCore::RealtimeIncomingVideoSourceLibWebRTC::OnFrame):
* Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeOutgoingVideoSourceLibWebRTC.cpp:
(WebCore::RealtimeOutgoingVideoSourceLibWebRTC::videoFrameAvailable):
(WebCore::RealtimeOutgoingVideoSourceLibWebRTC::createBlackFrame):
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.cpp:
(WebKit::LibWebRTCProvider::LibWebRTCProvider):

Canonical link: <a href="https://commits.webkit.org/317507@main">https://commits.webkit.org/317507@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/75da637db9b39b943730fba363f3c16b3a438629

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175503 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49435 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43216 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185089 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177367 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50727 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49118 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/136650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178460 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40066 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157406 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/117128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38708 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37094 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149130 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36899 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33564 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41122 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41297 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187514 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49102 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/145619 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39172 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49782 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33523 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/145456 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40272 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121975 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115730 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48289 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11875 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47691 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47921 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47748 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->