### PR TITLE
REGRESSION(316360@main):[macOS] fast/mediastream/microphone-interruption-and-audio-session.html is a constant TEXT failure

### DIFF
--- a/Source/WebCore/platform/mediastream/cocoa/BaseAudioCaptureUnit.cpp
+++ b/Source/WebCore/platform/mediastream/cocoa/BaseAudioCaptureUnit.cpp
@@ -232,8 +232,6 @@ void BaseAudioCaptureUnit::captureFailed()
         client.captureFailed();
     });
 
-    m_producingCount = 0;
-
     clearClients();
 
     stopRunning();
@@ -314,8 +312,6 @@ OSStatus BaseAudioCaptureUnit::resume()
         reconfigure();
     }
 
-    ASSERT(!m_producingCount);
-
     callOnMainThread([weakThis = WeakPtr { this }] {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis || protectedThis->m_suspended)
@@ -333,6 +329,8 @@ OSStatus BaseAudioCaptureUnit::resume()
 OSStatus BaseAudioCaptureUnit::suspend()
 {
     ASSERT(isMainThread());
+    if (m_suspended)
+        return 0;
 
     RELEASE_LOG_INFO(WebRTC, "BaseAudioCaptureUnit::suspend");
 
@@ -343,8 +341,6 @@ OSStatus BaseAudioCaptureUnit::suspend()
         client.setCanResumeAfterInterruption(client.isProducingData());
         client.setMuted(true);
     });
-
-    m_producingCount = 0;
 
     return 0;
 }


### PR DESCRIPTION
#### a450ebfaf60acf22583f90cddc23e407578f40cd
<pre>
REGRESSION(316360@main):[macOS] fast/mediastream/microphone-interruption-and-audio-session.html is a constant TEXT failure
<a href="https://rdar.apple.com/181852376">rdar://181852376</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=319003">https://bugs.webkit.org/show_bug.cgi?id=319003</a>

Reviewed by Jer Noble.

Like we are exiting early in BaseAudioCaptureUnit::resume if not suspended,we also exit early in BaseAudioCaptureUnit::suspend if already suspended.
This ensures that we would not reset the canResumeAdterInterruption flag back to false in case of two suspends
This is a speculative fix as I was not able to reproduce.

As a fly-by fix, we no longer set m_producingCount to 0 in suspend/captureFailed since m_producingCount is also updated asynchronously in BaseAudioCaptureUnit::stopProducingData, and this can trigger a DEBUG assert in BaseAudioCaptureUnit::stopProducingData. This was sometimes triggered when running LayoutTests/fast/mediastream/microphone-change-while-muted.html, which runs just before LayoutTests/fast/mediastream/microphone-interruption-and-audio-session.html.

* Source/WebCore/platform/mediastream/cocoa/BaseAudioCaptureUnit.cpp:
(WebCore::BaseAudioCaptureUnit::captureFailed):
(WebCore::BaseAudioCaptureUnit::resume):
(WebCore::BaseAudioCaptureUnit::suspend):
* Source/WebCore/platform/mediastream/cocoa/CoreAudioCaptureSource.cpp:
(WebCore::CoreAudioCaptureSource::stopProducingData):
* Source/WebCore/platform/mediastream/cocoa/CoreAudioCaptureSource.h:
(WebCore::CoreAudioCaptureSource::setCanResumeAfterInterruption):

Canonical link: <a href="https://commits.webkit.org/317299@main">https://commits.webkit.org/317299@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e22418f98e067aa1136c7ca13c9e44799de1e782

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174761 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48694 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42475 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184341 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132669 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7f31c1ce-f857-4d09-83dc-026457d62209) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176626 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49986 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48377 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135987 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177719 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39426 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156779 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116465 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3936514a-d741-412c-bd32-fad446ff7c73) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38067 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36443 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32819 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148490 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36271 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186766 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/40117 "Found 1026 new failures in b3/B3Value.h, b3/testb3_7.cpp, WebProcess/Network/WebResourceLoader.cpp, jit/OperationResult.h, UIProcess/WebProcessPool.cpp, Shared/Cocoa/WKNSArray.mm, heap/WeakSet.h, API/tests/Regress141275.mm, Shared/SessionState.cpp, NetworkProcess/NetworkResourceLoadParameters.cpp ...") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40642 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144914 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48361 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156335 "") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144773 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39042 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49041 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32892 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114820 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39649 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121205 "Found 119 new failures in b3/testb3_7.cpp, b3/B3Value.h, WebProcess/Network/WebResourceLoader.cpp, UIProcess/WebProcessPool.cpp, Shared/Cocoa/WKNSArray.mm, Shared/SessionState.cpp, NetworkProcess/NetworkResourceLoadParameters.cpp, WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm, WebProcess/WebPage/WebPage.cpp, WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm ...") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47547 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11241 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46949 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47180 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47007 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->