### PR TITLE
[GLIB] gamepad/gamepad-non-fully-active.html is flaky

### DIFF
--- a/Source/WebKit/UIProcess/API/C/WKContext.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKContext.cpp
@@ -572,11 +572,13 @@ void WKContextSetLocalhostAliases(WKContextRef, WKArrayRef localhostAliases)
         WebKit::LegacyGlobalSettings::singleton().registerHostnameAsLocal(hostname);
 }
 
-void WKContextClearMockGamepadsForTesting(WKContextRef)
+void WKContextClearMockGamepadsForTesting(WKContextRef contextRef)
 {
 #if ENABLE(GAMEPAD)
     if (WebCore::GamepadProvider::singleton().isMockGamepadProvider())
         WebCore::GamepadProvider::singleton().clearGamepadsForTesting();
+
+    protect(WebKit::toImpl(contextRef))->resetGamepadsForTesting();
 #endif
 }
 

--- a/Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.cpp
+++ b/Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.cpp
@@ -249,6 +249,11 @@ Vector<std::optional<GamepadData>> UIGamepadProvider::snapshotGamepads()
     });
 }
 
+void UIGamepadProvider::resetGamepadsForTesting()
+{
+    m_gamepads.clear();
+}
+
 #if !PLATFORM(COCOA) && !(USE(MANETTE) && OS(LINUX)) && !USE(LIBWPE) && !ENABLE(WPE_PLATFORM)
 
 void UIGamepadProvider::platformSetDefaultGamepadProvider()

--- a/Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.h
+++ b/Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.h
@@ -66,6 +66,8 @@ public:
 
     WebPageProxy* platformWebPageProxyForGamepadInput();
 
+    void resetGamepadsForTesting();
+
 private:
     friend NeverDestroyed<UIGamepadProvider>;
     UIGamepadProvider();

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -1976,6 +1976,12 @@ void WebProcessPool::gamepadDisconnected(const UIGamepad& gamepad)
         process->send(Messages::WebProcess::GamepadDisconnected(gamepad.index()), 0);
 }
 
+void WebProcessPool::resetGamepadsForTesting()
+{
+    UIGamepadProvider::singleton().resetGamepadsForTesting();
+    sendToAllProcesses(Messages::WebProcess::ResetGamepadsForTesting());
+}
+
 #endif // ENABLE(GAMEPAD)
 
 size_t WebProcessPool::numberOfConnectedGamepadsForTesting(GamepadType gamepadType)

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -461,6 +461,7 @@ public:
 #if ENABLE(GAMEPAD)
     void gamepadConnected(const UIGamepad&, WebCore::EventMakesGamepadsVisible);
     void gamepadDisconnected(const UIGamepad&);
+    void resetGamepadsForTesting();
 #endif
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/Gamepad/WebGamepadProvider.cpp
+++ b/Source/WebKit/WebProcess/Gamepad/WebGamepadProvider.cpp
@@ -143,6 +143,12 @@ void WebGamepadProvider::stopMonitoringGamepads(GamepadProviderClient& client)
     });
 }
 
+void WebGamepadProvider::resetGamepadsForTesting()
+{
+    m_gamepads.clear();
+    m_rawGamepads.clear();
+}
+
 const Vector<WeakPtr<PlatformGamepad>>& WebGamepadProvider::platformGamepads()
 {
     return m_rawGamepads;

--- a/Source/WebKit/WebProcess/Gamepad/WebGamepadProvider.h
+++ b/Source/WebKit/WebProcess/Gamepad/WebGamepadProvider.h
@@ -52,6 +52,8 @@ public:
 
     void setInitialGamepads(const Vector<std::optional<GamepadData>>&);
 
+    void resetGamepadsForTesting();
+
 private:
     friend NeverDestroyed<WebGamepadProvider>;
     WebGamepadProvider();

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -1299,6 +1299,11 @@ void WebProcess::gamepadDisconnected(unsigned index)
     WebGamepadProvider::singleton().gamepadDisconnected(index);
 }
 
+void WebProcess::resetGamepadsForTesting()
+{
+    WebGamepadProvider::singleton().resetGamepadsForTesting();
+}
+
 #endif
 
 void WebProcess::setJavaScriptGarbageCollectorTimerEnabled(bool flag)

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -634,6 +634,7 @@ private:
     void setInitialGamepads(const Vector<std::optional<GamepadData>>&);
     void gamepadConnected(const GamepadData&, WebCore::EventMakesGamepadsVisible);
     void gamepadDisconnected(unsigned index);
+    void resetGamepadsForTesting();
 #endif
 
     void establishRemoteWorkerContextConnectionToNetworkProcess(RemoteWorkerType, PageGroupIdentifier, WebPageProxyIdentifier, WebCore::PageIdentifier, const WebPreferencesStore&, WebCore::Site&&, std::optional<WebCore::ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier, RemoteWorkerInitializationData&&, WebCore::CrossOriginEmbedderPolicyValue, CompletionHandler<void()>&&);

--- a/Source/WebKit/WebProcess/WebProcess.messages.in
+++ b/Source/WebKit/WebProcess/WebProcess.messages.in
@@ -116,6 +116,7 @@ messages -> WebProcess : AuxiliaryProcess WantsAsyncDispatchMessage {
     SetInitialGamepads(Vector<std::optional<WebKit::GamepadData>> gamepadDatas)
     GamepadConnected(WebKit::GamepadData gamepadData, enum:bool WebCore::EventMakesGamepadsVisible eventVisibility)
     GamepadDisconnected(unsigned index)
+    ResetGamepadsForTesting()
 #endif
 
     EstablishRemoteWorkerContextConnectionToNetworkProcess(enum:uint8_t WebKit::RemoteWorkerType workerType, WebKit::PageGroupIdentifier pageGroupID, WebKit::WebPageProxyIdentifier webPageProxyID, WebCore::PageIdentifier pageID, struct WebKit::WebPreferencesStore store, WebCore::Site site, std::optional<WebCore::ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier, struct WebKit::RemoteWorkerInitializationData initializationData, enum:bool WebCore::CrossOriginEmbedderPolicyValue workerCrossOriginEmbedderPolicy) -> ()


### PR DESCRIPTION
#### 49b9387643b5b024544e740ad2700bf59bc15b77
<pre>
[GLIB] gamepad/gamepad-non-fully-active.html is flaky
<a href="https://bugs.webkit.org/show_bug.cgi?id=315921">https://bugs.webkit.org/show_bug.cgi?id=315921</a>

Reviewed by NOBODY (OOPS!).

Test &apos;gamepad-non-fully-active.html&apos; fails whenever it is run, 2 times or more,
in combination with &apos;gamepad-polling-access.html&apos;. The latter test grows
the WebProcess &apos;m_gamepads&apos; size value to 20, and that value leaks into
&apos;gamepad-non-fully-active.html&apos;.

Currently, there&apos;s code to reset the WebProcess &apos;m_gamepads&apos; value.
That happens at &apos;WebGamepadProvider::stopMonitoringGamepads&apos;, via an asynchronous
callback. However, if the callback doesn&apos;t execute fast enough, the
WebProcess &apos;m_gamepads&apos; size value will leak into other tests.

The solution is to add a new WebProcess message, called &apos;ResetGamepadsForTesting&apos;,
that will be used to explicitly reset &apos;m_gamepads&apos; in WebGamepadProvider.

That message is sent from &apos;WKContextClearMockGamepadsForTesting&apos;, which
already runs between every test. IPC ordering guarantees
&apos;resetGamepadsForTesting&apos; is processed before the next test&apos;s
gamepad messages.

* LayoutTests/platform/glib/TestExpectations:
* Source/WebKit/UIProcess/API/C/WKContext.cpp:
(WKContextClearMockGamepadsForTesting):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::resetGamepadsForTesting):
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/WebProcess/Gamepad/WebGamepadProvider.cpp:
(WebKit::WebGamepadProvider::resetGamepadsForTesting):
* Source/WebKit/WebProcess/Gamepad/WebGamepadProvider.h:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::resetGamepadsForTesting):
* Source/WebKit/WebProcess/WebProcess.h:
* Source/WebKit/WebProcess/WebProcess.messages.in:
</pre>
----------------------------------------------------------------------
#### 47134f3ddb39f3b1200bb5aad79bf484dbbae769
<pre>
[WPE] imported/w3c/web-platform-tests/selection/textcontrols/selectionchange.html is a text failure
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/87a60d6f280d3cae2ff462453bae87f2b5abc32c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174936 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48869 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42650 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184517 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132844 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50161 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48552 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136145 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96072 "2 flakes 2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177894 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39582 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156941 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116624 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38223 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36607 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32994 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148646 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36433 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186941 "Built successfully") | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/40425 "Found 1002 new failures in b3/B3Value.h, b3/testb3_7.cpp, WebProcess/Network/WebResourceLoader.cpp, jit/OperationResult.h, heap/WeakSet.h, API/tests/Regress141275.mm, WebProcess/WebPage/WebPage.cpp, testing/LegacyMockCDM.cpp, jsc.cpp, heap/MarkedBlock.h ...") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40809 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145074 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48536 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144932 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49216 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33054 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115028 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39806 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121341 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47722 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11406 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47124 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47355 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47182 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->