### PR TITLE
[Win] Fix build when Swift is present

### DIFF
--- a/Source/cmake/WebKitMacros.cmake
+++ b/Source/cmake/WebKitMacros.cmake
@@ -908,8 +908,16 @@ function(_webkit_generate_platform_swift_args _target _resp_path _ordering_dep)
     if (NOT EXISTS "${_empty_input}")
         file(WRITE "${_empty_input}" "")
     endif ()
-    set(_clang_cmd
-        ${CMAKE_CXX_COMPILER}
+    set(_clang_cmd ${CMAKE_CXX_COMPILER})
+    if (COMPILER_IS_CLANG_CL)
+        # clang-cl defaults to the MSVC (cl) driver, which silently ignores the
+        # GCC-style preprocess flags below (-std=, -dM, -MF, -include ...) and
+        # then treats their operands as input files, failing with "no such file
+        # or directory: cmakeconfig.h". Flip it to the GCC driver so the flags
+        # are honored. Must precede the flags it governs.
+        list(APPEND _clang_cmd --driver-mode=gcc)
+    endif ()
+    list(APPEND _clang_cmd
         -x c++ -std=c++2b
         -E -P -dM
         -MD -MF "${_depfile}" -MT "${_resp_path}"


### PR DESCRIPTION
#### 2b32d77f379c2f8a9422c8003b8cf5648975e0ec
<pre>
[Win] Fix build when Swift is present
<a href="https://bugs.webkit.org/show_bug.cgi?id=319505">https://bugs.webkit.org/show_bug.cgi?id=319505</a>

Reviewed by Adrian Taylor.

When Swift is available (as it now is in the Windows EWS Docker image),
the Swift codepath enables the &quot;Generate Swift platform args&quot; step, which
preprocesses wtf/Platform.h to record the enabled platform macros into a
.resp file passed to later Swift compilations.

_webkit_generate_platform_swift_args builds that clang preprocess command
using GCC-driver syntax (-std=c++2b -E -P -dM -MD -MF ... -include). On
Windows CMAKE_CXX_COMPILER is clang-cl, which defaults to the MSVC (cl)
driver and silently ignores those flags (-Wunknown-argument), then treats
their operands as input files, failing with:

    clang-cl: error: no such file or directory: &apos;cmakeconfig.h&apos;

Prepend --driver-mode=gcc when COMPILER_IS_CLANG_CL so clang-cl honors the
GCC-style flags. This mirrors the inverse --driver-mode=cl already used for
the include-what-you-use invocation in this file, and keeps -MD/-MF
emitting a gcc-format depfile, which the build&apos;s cmake_transform_depfile
Ninja gccdepfile step expects.

* Source/cmake/WebKitMacros.cmake:
(_webkit_generate_platform_swift_args):

Canonical link: <a href="https://commits.webkit.org/317288@main">https://commits.webkit.org/317288@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d62c255fc5e31580c118a02128bc4646d5310646

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174768 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48701 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42482 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184348 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132676 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49993 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48384 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135994 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177726 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39433 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156784 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116472 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38074 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36449 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32826 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5293 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148497 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36276 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186773 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/36030 "Built successfully and passed tests") | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40648 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144921 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48368 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144780 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39034 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49048 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32897 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114827 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39654 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/211859 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47554 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11246 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55257 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46956 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47187 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47014 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->