### PR TITLE
[run-benchmark][GTK][WPE] Add support for auto-entering container SDK when running minibrowser

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/run_benchmark.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/run_benchmark.py
@@ -11,6 +11,7 @@ from webkitpy.benchmark_runner.browser_driver.browser_driver_factory import Brow
 from webkitpy.benchmark_runner.benchmark_runner import BenchmarkRunner
 from webkitpy.benchmark_runner.webdriver_benchmark_runner import WebDriverBenchmarkRunner
 from webkitpy.benchmark_runner.webserver_benchmark_runner import WebServerBenchmarkRunner
+from webkitpy.port.linux_container_sdk_utils import maybe_enter_webkit_container_sdk
 
 
 _log = logging.getLogger(__name__)
@@ -124,6 +125,9 @@ def list_subtests(plan):
 
 
 def start(args):
+    if args.browser in ['minibrowser-gtk', 'minibrowser-wpe']:
+        # for other browsers (firefox, chrome, etc) do not auto-enter into the container SDK, as those are not available there.
+        maybe_enter_webkit_container_sdk()
     if args.json_file:
         results_json = json.load(open(args.json_file, 'r'))
         if 'debugOutput' in results_json:


### PR DESCRIPTION
#### 47787efa0f7b00c022835d1ed3f03e70b42e1f43
<pre>
[run-benchmark][GTK][WPE] Add support for auto-entering container SDK when running minibrowser
<a href="https://bugs.webkit.org/show_bug.cgi?id=319511">https://bugs.webkit.org/show_bug.cgi?id=319511</a>

Reviewed by Adrian Perez de Castro.

When executing the script run-benchmark outside of the container SDK but with
the auto-entering mechanism enabled it happens that the script first sets a
temporal random homedir and then calls run-minibrowser script. Then the script
run-minibrowser tries to auto-enter into the container, but since it has been
started with a temporal random empty home it can&apos;t find the podman image, so
it has to re-download again the huge image on a temporal dir. And it has to
do that anytime is invoked because the homedir changes from one invocation
to the next one.

To avoid this problem we can auto-enter into the container in run-benchmark
before executing the script run-minibrowser. But we should do this only when
the browser to run is minibrowser-gtk or minibrowser-wpe. Otherwise we would be
entering into the container to execute browsers like chrome or firefox which
are not available in the container SDK.

* Tools/Scripts/webkitpy/benchmark_runner/run_benchmark.py:
(start):

Canonical link: <a href="https://commits.webkit.org/317280@main">https://commits.webkit.org/317280@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf5010fff967570bbedbacc1a5b7bfbef7a70429

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174785 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48718 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42499 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184365 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132693 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176650 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50010 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48401 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136003 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177743 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39446 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156807 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116481 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/174177 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38087 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32843 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148510 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36299 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186790 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40675 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144937 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48385 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144796 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49065 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114844 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26567 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39671 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47571 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11269 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46973 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47204 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47031 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->