### PR TITLE
[GFC][Integration] Grids cannot contribute baselines currently

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-self-alignment-baseline-gfc-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-self-alignment-baseline-gfc-001-expected.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Grid: a grid with baseline self-alignment participates in its flex parent's baseline alignment (reference)</title>
+<link rel="stylesheet" href="/fonts/ahem.css">
+<style>
+  body { margin: 0; }
+  .flex { display: flex; align-items: baseline; font: 100px/1 Ahem; color: black; }
+  .reference { font-size: 100px; }
+  .item { font-size: 50px; align-self: baseline; }
+</style>
+<div class="flex">
+  <span class="reference">X</span>
+  <div class="item">X</div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-self-alignment-baseline-gfc-001-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-self-alignment-baseline-gfc-001-ref.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Grid: a grid with baseline self-alignment participates in its flex parent's baseline alignment (reference)</title>
+<link rel="stylesheet" href="/fonts/ahem.css">
+<style>
+  body { margin: 0; }
+  .flex { display: flex; align-items: baseline; font: 100px/1 Ahem; color: black; }
+  .reference { font-size: 100px; }
+  .item { font-size: 50px; align-self: baseline; }
+</style>
+<div class="flex">
+  <span class="reference">X</span>
+  <div class="item">X</div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-self-alignment-baseline-gfc-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-self-alignment-baseline-gfc-001.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Grid: a grid with baseline self-alignment participates in its flex parent's baseline alignment</title>
+<link rel="help" href="https://drafts.csswg.org/css-align/#baseline-values">
+<link rel="match" href="grid-self-alignment-baseline-gfc-001-ref.html">
+<link rel="stylesheet" href="/fonts/ahem.css">
+<meta name="assert" content="A display:grid box whose resolved align-self is baseline aligns its own baseline with the baseline of its flex parent's line.">
+<style>
+  body { margin: 0; }
+  .flex { display: flex; align-items: baseline; font: 100px/1 Ahem; }
+  .reference { font-size: 100px; }
+  .grid {
+    display: grid;
+    grid-template-rows: auto;
+    grid-template-columns: auto;
+    align-self: baseline;
+    font-size: 50px;
+  }
+  .grid > .item { grid-row: 1 / 2; }
+</style>
+<div class="flex">
+  <span class="reference">X</span>
+  <div class="grid"><div class="item">X</div></div>
+</div>

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "LayoutIntegrationGridCoverage.h"
 
+#include "BaselineAlignmentInlines.h"
 #include "Document.h"
 #include "RenderChildIterator.h"
 #include "RenderDescendantIterator.h"
@@ -285,8 +286,10 @@ static EnumSet<GridAvoidanceReason> gridLayoutAvoidanceReason(const RenderGrid& 
         ADD_REASON_AND_RETURN_IF_NEEDED(GridAvoidanceReason::GridFormattingContextIntegrationDisabled, reasons, reasonCollectionMode);
 
     CheckedRef renderGridStyle = renderGrid.style();
-
-    if (renderGridStyle->display() == Style::DisplayType::InlineGrid)
+    CheckedPtr gridParentStyle = renderGrid.parent() ? &renderGrid.parent()->style() : nullptr;
+    if (renderGridStyle->display() == Style::DisplayType::InlineGrid
+        || isBaselinePosition(renderGridStyle->justifySelf().resolve(gridParentStyle).position())
+        || isBaselinePosition(renderGridStyle->alignSelf().resolve(gridParentStyle).position()))
         ADD_REASON_AND_RETURN_IF_NEEDED(GridAvoidanceReason::GridNeedsBaseline, reasons, reasonCollectionMode);
 
     if (renderGridStyle->display() != Style::DisplayType::BlockGrid)


### PR DESCRIPTION
#### 956aa60e55335b75a3d3968936750ee20a35be8e
<pre>
[GFC][Integration] Grids cannot contribute baselines currently
<a href="https://bugs.webkit.org/show_bug.cgi?id=319512">https://bugs.webkit.org/show_bug.cgi?id=319512</a>
<a href="https://rdar.apple.com/182319810">rdar://182319810</a>

Reviewed by Alan Baradlay.

The grid formatting context integration cannot produce a baseline for a
grid yet, so grid layout coverage already bails out of GFC for
inline-grid, which needs to contribute a baseline to its parent&apos;s inline
layout.

A grid is also asked for its baseline when it is itself an item whose
resolved self-alignment is a baseline value (first or last). Extend the
coverage check to avoid GFC when the grid&apos;s resolved justify-self (inline
axis) or align-self (block axis) is a baseline position.

Canonical link: <a href="https://commits.webkit.org/317257@main">https://commits.webkit.org/317257@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a6e40bcd1f63d5b7bcaa4a27bb10d1a871606f2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174786 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48719 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42500 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184366 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/132694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b5f12cb2-9cbc-4a5d-b627-b57f6cebe668) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176651 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50011 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48402 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/136009 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/132694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4f202d9b-1d89-40bd-aaed-baaa76f005fc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177744 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39451 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/156810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116487 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a55d7074-8079-4eec-8e5a-c4846b392f03) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38092 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32844 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148515 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36302 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186791 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/40160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/144939 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48386 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156366 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144799 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39011 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49066 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39684 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/121129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47572 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11272 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46974 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47205 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47032 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->