### PR TITLE
AX: VoiceOver reads nothing for a line containing only an out-of-flow decorative image

### DIFF
--- a/LayoutTests/accessibility/mac/line-text-marker-range-for-out-of-flow-image-expected.txt
+++ b/LayoutTests/accessibility/mac/line-text-marker-range-for-out-of-flow-image-expected.txt
@@ -1,0 +1,8 @@
+This tests that an out-of-flow (position:absolute) image, which sits on no inline line box, still has a line of its own. Reading its line by text marker returns the object-replacement character so that line-by-line navigation announces the image instead of nothing. Should pass with the accessibility isolated tree both on and off.
+
+PASS: imageLineIsObjectReplacement === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/line-text-marker-range-for-out-of-flow-image.html
+++ b/LayoutTests/accessibility/mac/line-text-marker-range-for-out-of-flow-image.html
@@ -1,0 +1,39 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
+</head>
+<body>
+
+<div id="content">
+<p>Before</p>
+<div style="position: relative;">
+    <img id="image" src="resources/cake.png" aria-label="Employee Photo" style="position: absolute;">
+</div>
+<p>After</p>
+</div>
+
+<script>
+var output = "This tests that an out-of-flow (position:absolute) image, which sits on no inline line box, still has a line of its own. Reading its line by text marker returns the object-replacement character so that line-by-line navigation announces the image instead of nothing. Should pass with the accessibility isolated tree both on and off.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    setTimeout(() => {
+        const image = accessibilityController.accessibleElementById("image");
+        const range = image.textMarkerRangeForElement(image);
+        const marker = image.startTextMarkerForTextMarkerRange(range);
+        const lineString = image.stringForTextMarkerRange(image.lineTextMarkerRangeForTextMarker(marker));
+
+        window.imageLineIsObjectReplacement = lineString === String.fromCharCode(0xFFFC);
+        output += expect("imageLineIsObjectReplacement", "true");
+
+        debug(output);
+        document.getElementById("content").style.display = "none";
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -1974,8 +1974,19 @@ std::optional<SimpleRange> AccessibilityObject::rangeForCharacterRange(const Cha
 VisiblePositionRange AccessibilityObject::lineRangeForPosition(const VisiblePosition& visiblePosition) const
 {
     auto start = startOfLine(visiblePosition);
-    if (start.isNull())
+    if (start.isNull()) {
+        // An out-of-flow (floated or positioned) replaced element generates no inline line
+        // box, so startOfLine() is null and the caret has no line to read. Give it a line of
+        // its own by selecting the element's node. Select the node itself, not its contents,
+        // which are empty for a replaced element, so that reading the line emits the element's
+        // object-replacement attachment.
+        CheckedPtr renderer = this->renderer();
+        if (RefPtr node = this->node(); node && renderer && isReplacedElement()
+            && isRendererReplacedElement(renderer.get())
+            && renderer->isFloatingOrOutOfFlowPositioned())
+            return makeVisiblePositionRange(makeRangeSelectingNode(*node));
         return { };
+    }
 
     // Move from the given visiblePosition forward until it hits the start of the next line or cross over a line break.
     auto end = visiblePosition;


### PR DESCRIPTION
#### 61766a5e91da5358a559eef454ebca0f86ac4b1f
<pre>
AX: VoiceOver reads nothing for a line containing only an out-of-flow decorative image
<a href="https://bugs.webkit.org/show_bug.cgi?id=319503">https://bugs.webkit.org/show_bug.cgi?id=319503</a>
&lt;<a href="https://rdar.apple.com/problem/182309215">rdar://problem/182309215</a>&gt;

Reviewed by Dominic Mazzoni.

When VoiceOver reads by line (arrow navigation) with the accessibility
isolated tree OFF, a line whose only content is an out-of-flow
(position:absolute or floated) decorative image (e.g. &lt;img alt=&quot;&quot;&gt; whose
accessible name lives on an ancestor) is announced as nothing. With the
isolated tree ON the same line is correctly announced as &quot;image&quot;.

Root cause: the two code paths disagree about whether such an element has
a line. VoiceOver asks for the caret&apos;s line via
kAXLineTextMarkerRangeForTextMarker, which on the main thread calls
AccessibilityObject::lineRangeForPosition(). That function computes
startOfLine(visiblePosition); for a caret at an out-of-flow replaced
element startOfLine is null, because startPositionForLine() finds
RenderedPosition(c).lineBox() == null (an out-of-flow RenderReplaced /
RenderBox generates no inline line box) and its only null-line-box rescue
requires isRenderBlock(), which a RenderReplaced is not. lineRangeForPosition
therefore returns an empty range, which becomes an AXTextMarkerRange with
null boundary points, so simpleRange() is nullopt and
attributedStringForTextMarkerRange() returns nil -- VoiceOver receives no
text and speaks nothing. contentForRange() is never reached, so this is a
line-range failure, not a string-extraction one.

The isolated tree avoids this because AccessibilityRenderObject::textRuns()
emits an objectReplacementCharacter run for any isReplacedElement() and, in
its isFloatingOrOutOfFlowPositioned() branch, gives the element its own
synthetic single-object line; lineRange() over those runs then yields a
valid range that resolves to an attachment (&quot;image&quot;).

Fix: mirror that behavior on the main thread. In lineRangeForPosition(),
when startOfLine is null and the object is an out-of-flow replaced element,
fall back to a range that spans the element&apos;s own node. Use
makeRangeSelectingNode() (the {parent, index}..{parent, index+1} span), not
simpleRange()/rangeForNodeContents(): for an accessibility-ignored replaced
element rangeForNodeContents() collapses to an empty {(node,0),(node,0)}
range (it only selects the node itself when replacedNodeNeedsCharacter() is
true, which is false for an ignored image), and TextIterator over a
collapsed range short-circuits before handleReplacedElement(). A
node-selecting range makes TextIterator descend into the image and emit the
zero-length replaced stop, which contentForRange() turns into the object
wrapper attachment, so line reading announces &quot;image&quot;.

The new code runs only in the previously-dead start.isNull() branch and is
further gated on isReplacedElement() &amp;&amp; isRendererReplacedElement() &amp;&amp;
isFloatingOrOutOfFlowPositioned(), so in-flow decorative images (which sit
on a real line box and have a non-null startOfLine) are unaffected, and
there is no impact on text-offset math, selection, or editing.

The test uses a labeled out-of-flow image so it is reachable from the AX
tree in the test harness; the fix branch it exercises is gated on the
element being out-of-flow and replaced, independent of the image&apos;s name,
and the test passes with the accessibility isolated tree both on and off.

* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::lineRangeForPosition):
* LayoutTests/accessibility/mac/line-text-marker-range-for-out-of-flow-image.html: Added.
* LayoutTests/accessibility/mac/line-text-marker-range-for-out-of-flow-image-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/317341@main">https://commits.webkit.org/317341@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f155aebf1dca78944e34059d7dfc60d99ecb877

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174876 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48809 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42590 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184456 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132784 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c567250c-a660-4ae4-8eff-bca80807b143) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176741 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50101 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48492 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136089 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177834 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39532 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156883 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116568 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38173 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36549 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32934 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148596 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36375 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186881 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/40317 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40750 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145020 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48476 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156439 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144878 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39070 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49156 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32996 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114967 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39752 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121261 "Build is in progress. Recent messages:OS: Tahoe (26.3.1), Xcode: 26.2; Checked out pull request; Found 28304 issues") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47662 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11345 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47064 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47295 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47122 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->