### PR TITLE
[JSC] Match non-canonical SBFX form in B3LowerToAir

### DIFF
--- a/Source/JavaScriptCore/b3/B3LowerToAir.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerToAir.cpp
@@ -4673,40 +4673,60 @@ private:
             Value* left = m_value->child(0);
             Value* right = m_value->child(1);
 
-            // SBFX Pattern: ((src >> lsb) << amount) >> amount
-            // Where: amount = datasize - width
             auto tryAppendSBFX = [&] () -> bool {
                 Air::Opcode opcode = opcodeForType(ExtractSignedBitfield32, ExtractSignedBitfield64, m_value->type());
                 if (!isValidForm(opcode, Arg::Tmp, Arg::Imm, Arg::Imm, Arg::Tmp))
                     return false;
-                if (left->opcode() != Shl || (left->child(0)->opcode() != ZShr && left->child(0)->opcode() != SShr))
+                if (left->opcode() != Shl)
+                    return false;
+                if (!imm(right) || right->asInt() < 0)
                     return false;
 
-                Value* srcValue = left->child(0)->child(0);
-                Value* lsbValue = left->child(0)->child(1);
-                Value* amount1Value = left->child(1);
-                Value* amount2Value = right;
+                uint64_t datasize = opcode == ExtractSignedBitfield32 ? 32 : 64;
+                uint64_t amount = right->asInt();
+                if (amount >= datasize)
+                    return false;
+                uint64_t width = datasize - amount;
+                ASSERT(width);
+
+                Value* srcValue = nullptr;
+                uint64_t lsb = 0;
+
+                // SBFX Pattern: ((src >> lsb) << amount) >> amount
+                // Where: amount = datasize - width
+                if (left->child(0)->opcode() == ZShr || left->child(0)->opcode() == SShr) {
+                    Value* amount1Value = left->child(1);
+                    Value* lsbValue = left->child(0)->child(1);
+                    if (!imm(amount1Value) || !imm(lsbValue))
+                        return false;
+                    if (amount1Value->asInt() < 0 || lsbValue->asInt() < 0)
+                        return false;
+                    if (static_cast<uint64_t>(amount1Value->asInt()) != amount)
+                        return false;
+                    srcValue = left->child(0)->child(0);
+                    lsb = lsbValue->asInt();
+                } else {
+                    // SBFX Pattern (non-canonical): (src << leftAmt) >> rightAmt
+                    // Where: rightAmt > leftAmt, lsb = rightAmt - leftAmt, width = datasize - rightAmt
+                    Value* leftAmtValue = left->child(1);
+                    if (!imm(leftAmtValue) || leftAmtValue->asInt() < 0)
+                        return false;
+                    uint64_t leftAmt = leftAmtValue->asInt();
+                    if (amount <= leftAmt)
+                        return false;
+                    srcValue = left->child(0);
+                    lsb = amount - leftAmt;
+                    ASSERT(lsb);
+                }
+
                 if (m_locked.contains(srcValue))
                     return false;
-                if (!imm(lsbValue) || !imm(amount1Value) || !imm(amount2Value))
-                    return false;
-                if (lsbValue->asInt() < 0 || amount1Value->asInt() < 0 || amount2Value->asInt() < 0)
-                    return false;
 
-                uint64_t amount1 = amount1Value->asInt();
-                uint64_t amount2 = amount2Value->asInt();
-                uint64_t lsb = lsbValue->asInt();
-                uint64_t datasize = opcode == ExtractSignedBitfield32 ? 32 : 64;
-
-                if (amount1 >= datasize)
-                    return false;
-
-                uint64_t width = datasize - amount1;
                 uint64_t resultDataSize = 0;
-                if (!WTF::safeAdd(lsb, width, resultDataSize) || amount1 != amount2 || !width || resultDataSize > datasize)
+                if (!WTF::safeAdd(lsb, width, resultDataSize) || resultDataSize > datasize)
                     return false;
 
-                append(opcode, tmp(srcValue), imm(lsbValue), imm(width), tmp(m_value));
+                append(opcode, tmp(srcValue), imm(lsb), imm(width), tmp(m_value));
                 return true;
             };
 

--- a/Source/JavaScriptCore/b3/testb3.h
+++ b/Source/JavaScriptCore/b3/testb3.h
@@ -636,6 +636,8 @@ void testInsertSignedBitfieldInZero32();
 void testInsertSignedBitfieldInZero64();
 void testExtractSignedBitfield32();
 void testExtractSignedBitfield64();
+void testExtractSignedBitfieldNonCanonical32();
+void testExtractSignedBitfieldNonCanonical64();
 void testBitAndZeroShiftRightArgImmMask32();
 void testBitAndZeroShiftRightArgImmMask64();
 void testBasicSelect();

--- a/Source/JavaScriptCore/b3/testb3_2.cpp
+++ b/Source/JavaScriptCore/b3/testb3_2.cpp
@@ -7849,6 +7849,8 @@ void addBitTests(const TestConfig* config, Deque<RefPtr<SharedTask<void()>>>& ta
     RUN(testInsertSignedBitfieldInZero64());
     RUN(testExtractSignedBitfield32());
     RUN(testExtractSignedBitfield64());
+    RUN(testExtractSignedBitfieldNonCanonical32());
+    RUN(testExtractSignedBitfieldNonCanonical64());
     RUN(testAddWithLeftShift32());
     RUN(testAddWithRightShift32());
     RUN(testAddWithUnsignedRightShift32());

--- a/Source/JavaScriptCore/b3/testb3_3.cpp
+++ b/Source/JavaScriptCore/b3/testb3_3.cpp
@@ -878,6 +878,84 @@ void testExtractSignedBitfield64()
     }
 }
 
+void testExtractSignedBitfieldNonCanonical32()
+{
+    if (JSC::Options::defaultB3OptLevel() < 2)
+        return;
+
+    Vector<int32_t> srcs = {
+        0x12345678,
+        static_cast<int32_t>(0xffffffff),
+        static_cast<int32_t>(0x80000000),
+        0x00abcdef,
+    };
+    Vector<int32_t> leftAmts = { 4, 8, 16 };
+    Vector<int32_t> lsbs = { 2, 3, 4 };
+
+    for (int32_t src : srcs) {
+        for (size_t i = 0; i < leftAmts.size(); ++i) {
+            int32_t leftAmt = leftAmts.at(i);
+            int32_t lsb = lsbs.at(i);
+            int32_t rightAmt = leftAmt + lsb;
+
+            Procedure proc;
+            BasicBlock* root = proc.addBlock();
+            auto arguments = cCallArgumentValues<int32_t>(proc, root);
+
+            Value* srcValue = arguments[0];
+            Value* leftShiftValue = root->appendNew<Value>(proc, Shl, Origin(), srcValue,
+                root->appendNew<Const32Value>(proc, Origin(), leftAmt));
+            root->appendNewControlValue(proc, Return, Origin(),
+                root->appendNew<Value>(proc, SShr, Origin(), leftShiftValue,
+                    root->appendNew<Const32Value>(proc, Origin(), rightAmt)));
+
+            auto code = compileProc(proc);
+            if (isARM64())
+                checkUsesInstruction(*code, "sbfx");
+            CHECK_EQ(invoke<int32_t>(*code, src), (src << leftAmt) >> rightAmt);
+        }
+    }
+}
+
+void testExtractSignedBitfieldNonCanonical64()
+{
+    if (JSC::Options::defaultB3OptLevel() < 2)
+        return;
+
+    Vector<int64_t> srcs = {
+        0x123456789abcdef0ll,
+        static_cast<int64_t>(0xffffffffffffffffull),
+        static_cast<int64_t>(0x8000000000000000ull),
+        0x0000ffffffffffffll,
+    };
+    Vector<int32_t> leftAmts = { 4, 16, 32 };
+    Vector<int32_t> lsbs = { 2, 8, 4 };
+
+    for (int64_t src : srcs) {
+        for (size_t i = 0; i < leftAmts.size(); ++i) {
+            int32_t leftAmt = leftAmts.at(i);
+            int32_t lsb = lsbs.at(i);
+            int32_t rightAmt = leftAmt + lsb;
+
+            Procedure proc;
+            BasicBlock* root = proc.addBlock();
+            auto arguments = cCallArgumentValues<int64_t>(proc, root);
+
+            Value* srcValue = arguments[0];
+            Value* leftShiftValue = root->appendNew<Value>(proc, Shl, Origin(), srcValue,
+                root->appendNew<Const32Value>(proc, Origin(), leftAmt));
+            root->appendNewControlValue(proc, Return, Origin(),
+                root->appendNew<Value>(proc, SShr, Origin(), leftShiftValue,
+                    root->appendNew<Const32Value>(proc, Origin(), rightAmt)));
+
+            auto code = compileProc(proc);
+            if (isARM64())
+                checkUsesInstruction(*code, "sbfx");
+            CHECK_EQ(invoke<int64_t>(*code, src), (src << leftAmt) >> rightAmt);
+        }
+    }
+}
+
 void testBitOrBitOrArgImmImm32(int32_t a, int32_t b, int32_t c)
 {
     Procedure proc;


### PR DESCRIPTION
#### 41ee8b26825110c19e6aab1580e2d8ad89a2abb8
<pre>
[JSC] Match non-canonical SBFX form in B3LowerToAir
<a href="https://bugs.webkit.org/show_bug.cgi?id=271412">https://bugs.webkit.org/show_bug.cgi?id=271412</a>

Reviewed by Yijia Huang.

B3LowerToAir already selected sbfx for SShr(Shl((Z|S)Shr(src, lsb), amount), amount).
Also match SShr(Shl(src, leftAmt), rightAmt) with rightAmt &gt; leftAmt so that form
selects sbfx without expanding IR in ReduceStrength on every target.

* Source/JavaScriptCore/b3/B3LowerToAir.cpp:
(JSC::B3::LowerToAir::lower):
* Source/JavaScriptCore/b3/testb3.h:
* Source/JavaScriptCore/b3/testb3_2.cpp:
* Source/JavaScriptCore/b3/testb3_3.cpp:
(testExtractSignedBitfieldNonCanonical32):
(testExtractSignedBitfieldNonCanonical64):

Canonical link: <a href="https://commits.webkit.org/317564@main">https://commits.webkit.org/317564@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d9451e87cfb0a2daee69b23615d7cd8f409988a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175126 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49058 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42839 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184711 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/133033 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176990 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50350 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48741 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136313 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96150 "3 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178083 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39745 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157097 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116792 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/174447 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38386 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36771 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33184 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5606 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148809 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36590 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187131 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/36387 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/40781 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40974 "Found 1 new test failure: imported/w3c/web-platform-tests/pointerevents/pointerevent_pointer_boundary_events_after_removing_last_over_element.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145255 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/174526 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48725 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156653 "") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145111 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39219 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49405 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33210 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/115240 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39968 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121576 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/212217 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47911 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11563 "") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55374 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47314 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47544 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47371 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->