### PR TITLE
Support external and data: URL filter references on SVG elements

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6017,7 +6017,6 @@ imported/w3c/web-platform-tests/css/filter-effects/filter-region-calc-001.html [
 imported/w3c/web-platform-tests/css/filter-effects/filter-region-transformed-child-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/filter-effects/filter-region-units-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/filter-effects/fixed-pos-filter-clip-002.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/filter-effects/svg-external-filter-resource.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/filter-effects/svg-mutation-filter-used-by-mask.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/filter-effects/will-change-blur-filter-under-clip.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/filter-effects/svg-feimage-002.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/svg-data-uri-filter-resource-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/svg-data-uri-filter-resource-expected.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<div style="width: 100px; height: 100px; background-color: green"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/svg-data-uri-filter-resource.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/svg-data-uri-filter-resource.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<title>Filter Effects: Referencing a data: URL SVG filter from an SVG element</title>
+<link rel="help" href="https://drafts.fxtf.org/filter-effects-1/#FilterProperty">
+<link rel="help" href="https://drafts.fxtf.org/filter-effects-1/#funcdef-filter-hue-rotate">
+<link rel="match" href="reference/green-100x100.html">
+<svg>
+  <rect width="100" height="100" fill="rgb(71.79%, 28.82%, 0%)"
+        filter="url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxmaWx0ZXIgaWQ9Ik15RmlsdGVyIiBjb2xvci1pbnRlcnBvbGF0aW9uLWZpbHRlcnM9InNSR0IiPjxmZUNvbG9yTWF0cml4IHR5cGU9Imh1ZVJvdGF0ZSIgdmFsdWVzPSI5MCIvPjwvZmlsdGVyPjwvc3ZnPg==#MyFilter)"/>
+</svg>

--- a/Source/WebCore/rendering/svg/legacy/SVGResources.cpp
+++ b/Source/WebCore/rendering/svg/legacy/SVGResources.cpp
@@ -204,6 +204,26 @@ static CheckedPtr<LegacyRenderSVGResourceContainer> paintingResourceFromTreeScop
     return container;
 }
 
+// The return value is tri-state because callers need to distinguish whether the reference is external at
+// all, and if so whether it's loaded yet: nullopt = not an external/data reference (resolve locally);
+// null RefPtr = external but not loaded yet (resolve to nothing); non-null = the isolated document to
+// resolve in.
+// FIXME: The external-or-not classification could be computed once at style-build time on Style::URL.
+static std::optional<RefPtr<SVGDocument>> externalSVGResourceDocument(Document& document, const WTF::URL& url)
+{
+    if (!document.settings().svgExternalResourcesEnabled())
+        return std::nullopt;
+
+    if (!url.protocolIsData() && !SVGURIReference::isExternalURIReference(url.string(), document))
+        return std::nullopt;
+
+    auto documentURL = url;
+    documentURL.removeFragmentIdentifier();
+
+    RefPtr isolatedContext = document.svgExtensions().isolatedSVGDocumentContext(documentURL);
+    return RefPtr { isolatedContext ? isolatedContext->document() : nullptr };
+}
+
 static inline CheckedPtr<LegacyRenderSVGResourceContainer> paintingResourceFromSVGPaint(TreeScope& treeScope, const Style::SVGPaint& paint, AtomString& id, bool& hasPendingResource)
 {
     auto paintURL = paint.tryAnyURL();
@@ -212,26 +232,15 @@ static inline CheckedPtr<LegacyRenderSVGResourceContainer> paintingResourceFromS
 
     Ref document = treeScope.documentScope();
 
-    if (document->settings().svgExternalResourcesEnabled()
-        && (paintURL->resolved.protocolIsData() || SVGURIReference::isExternalURIReference(paintURL->resolved.string(), document))) {
+    if (auto externalDocument = externalSVGResourceDocument(document, paintURL->resolved)) {
         id = paintURL->resolved.fragmentIdentifier().toAtomString();
-        if (id.isEmpty())
-            return nullptr;
-
-        auto documentURL = *paintURL;
-        documentURL.resolved.removeFragmentIdentifier();
-
-        RefPtr isolatedDocument = document->svgExtensions().isolatedSVGPaintDocument(documentURL.resolved);
-        if (!isolatedDocument)
-            return nullptr;
-
-        RefPtr externalDocument = isolatedDocument->document();
-        if (!externalDocument)
+        RefPtr resolvedDocument = *externalDocument;
+        if (id.isEmpty() || !resolvedDocument)
             return nullptr;
 
         // The resource lives in the isolated document, which is realized separately and does not use
         // this document's pending-resource mechanism so no hasPendingResource.
-        return paintingResourceFromTreeScopeAndId(*externalDocument, id, nullptr);
+        return paintingResourceFromTreeScopeAndId(*resolvedDocument, id, nullptr);
     }
 
     id = SVGURIReference::fragmentIdentifierFromIRIString(*paintURL, document);
@@ -277,6 +286,13 @@ std::unique_ptr<SVGResources> SVGResources::buildCachedResources(const RenderEle
             WTF::switchOn(style.filter().first(),
                 [&](const Style::FilterReference& filterReference) {
                     auto& id = filterReference.cachedFragment;
+                    if (auto externalDocument = externalSVGResourceDocument(document, filterReference.url.resolved)) {
+                        if (RefPtr resolvedDocument = *externalDocument) {
+                            if (auto* filter = getRenderSVGResourceById<LegacyRenderSVGResourceFilter>(*resolvedDocument, id))
+                                ensureResources(foundResources).setFilter(filter);
+                        }
+                        return;
+                    }
                     if (auto* filter = getRenderSVGResourceById<LegacyRenderSVGResourceFilter>(treeScope, id))
                         ensureResources(foundResources).setFilter(filter);
                     else

--- a/Source/WebCore/style/StylePendingResources.cpp
+++ b/Source/WebCore/style/StylePendingResources.cpp
@@ -37,10 +37,13 @@
 #include "NodeInlinesLight.h"
 #include "ResourceRequest.h"
 #include "SVGDocumentExtensions.h"
+#include "SVGElement.h"
 #include "SVGURIReference.h"
 #include "Settings.h"
 #include "StyleComputedStyle+GettersInlines.h"
 #include "StyleCursor.h"
+#include "StyleFilter.h"
+#include "StyleFilterReference.h"
 #include "StyleImage.h"
 
 namespace WebCore {
@@ -77,37 +80,37 @@ static void loadPendingImage(Document& document, const Image* image, const Eleme
     const_cast<Image&>(*image).load(protect(document.cachedResourceLoader()), options);
 }
 
-static void loadPendingExternalSVGPaint(Document& document, const Style::SVGPaint& paint)
+static void loadExternalSVGResource(Document& document, const WTF::URL& url)
 {
-    auto url = paint.tryAnyURL();
-    if (!url)
+    if (url.isNull())
         return;
 
-    auto& resolved = url->resolved;
-    if (resolved.isNull())
+    if (!url.protocolIsData() && !SVGURIReference::isExternalURIReference(url.string(), document))
         return;
 
-    if (!resolved.protocolIsData() && !SVGURIReference::isExternalURIReference(resolved.string(), document))
-        return;
-
-    auto documentURL = *url;
-    documentURL.resolved.removeFragmentIdentifier();
+    auto documentURL = url;
+    documentURL.removeFragmentIdentifier();
 
     CheckedRef extensions = document.svgExtensions();
-    auto key = documentURL.resolved;
-    if (extensions->hasExternalSVGPaintResource(key))
+    if (extensions->hasExternalSVGResource(documentURL))
         return;
 
     auto options = CachedResourceLoader::defaultCachedResourceOptions();
     options.mode = FetchOptions::Mode::SameOrigin;
     options.sameOriginDataURLFlag = SameOriginDataURLFlag::Set;
 
-    CachedResourceRequest request(ResourceRequest(WTF::URL { documentURL.resolved }), options);
+    CachedResourceRequest request(ResourceRequest(WTF::URL { documentURL }), options);
     request.setInitiatorType(cachedResourceRequestInitiatorTypes().css);
     RefPtr cachedImage = protect(document.cachedResourceLoader())->requestImage(WTF::move(request)).value_or(nullptr);
     if (!cachedImage)
         return;
-    extensions->addExternalSVGPaintResource(key, *cachedImage, document);
+    extensions->addExternalSVGResource(documentURL, *cachedImage, document);
+}
+
+static void loadPendingExternalSVGPaint(Document& document, const Style::SVGPaint& paint)
+{
+    if (auto url = paint.tryAnyURL())
+        loadExternalSVGResource(document, url->resolved);
 }
 
 void loadPendingResources(Style::ComputedStyle& style, Document& document, const Element* element)
@@ -147,9 +150,21 @@ void loadPendingResources(Style::ComputedStyle& style, Document& document, const
     if (RefPtr shapeValueImage = style.shapeOutside().image())
         loadPendingImage(document, shapeValueImage.get(), element, LoadPolicy::Anonymous);
 
-    if (document.settings().svgExternalResourcesEnabled()) {
+    // External/data: SVG paint servers and filters resolve through SVGResources, which only applies
+    // to SVG elements. Restrict loading to them so CSS filter on non-SVG elements (a separate path)
+    // isn't pulled through here.
+    if (document.settings().svgExternalResourcesEnabled() && element && is<SVGElement>(*element)) {
         loadPendingExternalSVGPaint(document, style.fill());
         loadPendingExternalSVGPaint(document, style.stroke());
+
+        if (style.filter().size() == 1) {
+            WTF::switchOn(style.filter().first(),
+                [&](const Style::FilterReference& filterReference) {
+                    loadExternalSVGResource(document, filterReference.url.resolved);
+                },
+                [](const auto&) { }
+            );
+        }
     }
 
     // Are there other pseudo-elements that need resource loading?

--- a/Source/WebCore/svg/SVGDocumentExtensions.cpp
+++ b/Source/WebCore/svg/SVGDocumentExtensions.cpp
@@ -174,20 +174,20 @@ void SVGDocumentExtensions::unregisterSVGFontFaceElement(SVGFontFaceElement& ele
     m_svgFontFaceElements.remove(element);
 }
 
-bool SVGDocumentExtensions::hasExternalSVGPaintResource(const URL& url) const
+bool SVGDocumentExtensions::hasExternalSVGResource(const URL& url) const
 {
-    return m_externalSVGPaintDocuments.contains(url);
+    return m_externalSVGDocuments.contains(url);
 }
 
-void SVGDocumentExtensions::addExternalSVGPaintResource(const URL& url, CachedImage& cachedImage, Document& document)
+void SVGDocumentExtensions::addExternalSVGResource(const URL& url, CachedImage& cachedImage, Document& document)
 {
-    m_externalSVGPaintDocuments.set(url, IsolatedSVGDocumentContext::create(cachedImage, document));
+    m_externalSVGDocuments.set(url, IsolatedSVGDocumentContext::create(cachedImage, document));
 }
 
-IsolatedSVGDocumentContext* SVGDocumentExtensions::isolatedSVGPaintDocument(const URL& url) const
+IsolatedSVGDocumentContext* SVGDocumentExtensions::isolatedSVGDocumentContext(const URL& url) const
 {
-    auto it = m_externalSVGPaintDocuments.find(url);
-    return it != m_externalSVGPaintDocuments.end() ? it->value.ptr() : nullptr;
+    auto it = m_externalSVGDocuments.find(url);
+    return it != m_externalSVGDocuments.end() ? it->value.ptr() : nullptr;
 }
 
 }

--- a/Source/WebCore/svg/SVGDocumentExtensions.h
+++ b/Source/WebCore/svg/SVGDocumentExtensions.h
@@ -75,9 +75,9 @@ public:
     void registerSVGFontFaceElement(SVGFontFaceElement&);
     void unregisterSVGFontFaceElement(SVGFontFaceElement&);
 
-    bool hasExternalSVGPaintResource(const URL&) const;
-    void addExternalSVGPaintResource(const URL&, CachedImage&, Document&);
-    IsolatedSVGDocumentContext* isolatedSVGPaintDocument(const URL&) const;
+    bool hasExternalSVGResource(const URL&) const;
+    void addExternalSVGResource(const URL&, CachedImage&, Document&);
+    IsolatedSVGDocumentContext* isolatedSVGDocumentContext(const URL&) const;
 
 private:
     WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
@@ -88,7 +88,7 @@ private:
     Vector<Ref<SVGElement>> m_rebuildElements;
     bool m_areAnimationsPaused;
 
-    HashMap<URL, Ref<IsolatedSVGDocumentContext>> m_externalSVGPaintDocuments;
+    HashMap<URL, Ref<IsolatedSVGDocumentContext>> m_externalSVGDocuments;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### bc43d30fafc655c6428c87f9b96f5c50838933c9
<pre>
Support external and data: URL filter references on SVG elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=258225">https://bugs.webkit.org/show_bug.cgi?id=258225</a>
<a href="https://rdar.apple.com/114823248">rdar://114823248</a>

Reviewed by Simon Fraser.

An SVG element&apos;s filter can now reference a &lt;filter&gt; in another document —
filter=&quot;url(effects.svg#blur)&quot; or a data: URL instead of only a same-document
`#id` reference.

This covers the filter presentation attribute on SVG elements only. External references from
the CSS filter property on HTML elements are a separate follow-up.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/svg-data-uri-filter-resource-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/svg-data-uri-filter-resource.html: Added.
* Source/WebCore/rendering/svg/legacy/SVGResources.cpp:
(WebCore::externalSVGResourceDocument):
(WebCore::paintingResourceFromSVGPaint):
(WebCore::SVGResources::buildCachedResources):
* Source/WebCore/style/StylePendingResources.cpp:
(WebCore::Style::loadExternalSVGResource):
(WebCore::Style::loadPendingExternalSVGPaint):
(WebCore::Style::loadPendingResources):
* Source/WebCore/svg/SVGDocumentExtensions.cpp:
(WebCore::SVGDocumentExtensions::hasExternalSVGResource const):
(WebCore::SVGDocumentExtensions::addExternalSVGResource):
(WebCore::SVGDocumentExtensions::isolatedSVGDocumentContext const):
(WebCore::SVGDocumentExtensions::hasExternalSVGPaintResource const): Deleted.
(WebCore::SVGDocumentExtensions::addExternalSVGPaintResource): Deleted.
(WebCore::SVGDocumentExtensions::isolatedSVGPaintDocument const): Deleted.
* Source/WebCore/svg/SVGDocumentExtensions.h:

Canonical link: <a href="https://commits.webkit.org/317538@main">https://commits.webkit.org/317538@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bee717069a72c40939b317f9212178d7dbc3e541

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175574 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49506 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43287 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185160 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2b082426-7c72-4356-a911-788596e21156) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177438 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50798 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49189 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136715 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b3a8ede0-0d99-4b47-9484-a8d7068dbf9f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178531 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40139 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157473 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117193 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/28e23cb7-f632-4762-9038-b02d35c6564d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38780 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37163 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149202 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36966 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33635 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41195 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41366 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187585 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49173 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/157029 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145684 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39192 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49853 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33590 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145522 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40347 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122046 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115860 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48360 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11944 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47762 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47992 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47819 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->