### PR TITLE
[WTF] IntPairHash::equal and DefaultHash<pair<int, unsigned>> use wrong template arguments

### DIFF
--- a/Source/WTF/wtf/HashFunctions.h
+++ b/Source/WTF/wtf/HashFunctions.h
@@ -141,7 +141,7 @@ namespace WTF {
 
     template<typename T, typename U> struct IntPairHash {
         static unsigned hash(const std::pair<T, U>& p) { return pairIntHash(p.first, p.second); }
-        static bool equal(const std::pair<T, U>& a, const std::pair<T, U>& b) { return PairHash<T, T>::equal(a, b); }
+        static bool equal(const std::pair<T, U>& a, const std::pair<T, U>& b) { return PairHash<T, U>::equal(a, b); }
         static constexpr bool safeToCompareToEmptyOrDeleted = PairHash<T, U>::safeToCompareToEmptyOrDeleted;
     };
 
@@ -227,7 +227,7 @@ namespace WTF {
     template<> struct DefaultHash<std::pair<int, short>> : IntPairHash<int, short> { };
     template<> struct DefaultHash<std::pair<int, unsigned short>> : IntPairHash<int, unsigned short> { };
     template<> struct DefaultHash<std::pair<int, int>> : IntPairHash<int, int> { };
-    template<> struct DefaultHash<std::pair<int, unsigned>> : IntPairHash<unsigned, unsigned> { };
+    template<> struct DefaultHash<std::pair<int, unsigned>> : IntPairHash<int, unsigned> { };
     template<> struct DefaultHash<std::pair<unsigned, short>> : IntPairHash<unsigned, short> { };
     template<> struct DefaultHash<std::pair<unsigned, unsigned short>> : IntPairHash<unsigned, unsigned short> { };
     template<> struct DefaultHash<std::pair<unsigned, int>> : IntPairHash<unsigned, int> { };


### PR DESCRIPTION
#### c432d408c1757a45d4cdb53c2f1a7ab134ebd4c0
<pre>
[WTF] IntPairHash::equal and DefaultHash&lt;pair&lt;int, unsigned&gt;&gt; use wrong template arguments
<a href="https://bugs.webkit.org/show_bug.cgi?id=319519">https://bugs.webkit.org/show_bug.cgi?id=319519</a>

Reviewed by Chris Dumez.

Two copy/paste typos in HashFunctions.h:

- IntPairHash&lt;T, U&gt;::equal delegated to PairHash&lt;T, T&gt; instead of
  PairHash&lt;T, U&gt;, inconsistent with hash() and
  safeToCompareToEmptyOrDeleted, which both use &lt;T, U&gt;. When T != U this
  forced an implicit conversion of the pair&apos;s second element to T before
  comparing.

- DefaultHash&lt;std::pair&lt;int, unsigned&gt;&gt; specialized IntPairHash&lt;unsigned,
  unsigned&gt; rather than IntPairHash&lt;int, unsigned&gt;, the odd one out among
  the integer-pair specializations that otherwise forward the pair&apos;s own
  element types.

* Source/WTF/wtf/HashFunctions.h:
(WTF::IntPairHash::equal):

Canonical link: <a href="https://commits.webkit.org/317318@main">https://commits.webkit.org/317318@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/41206e7e9cdcb52c19ff4ae7328ea3379fd6cdf5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174813 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48746 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42527 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184393 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132721 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f7cabc9e-d89f-4891-b8c2-a0c4ff0cc095) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50038 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48429 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136041 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2b960b6c-ebfd-4211-9691-72cfb6ddf219) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177771 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39474 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156824 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116520 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/305d23bf-67ee-4e10-aa6a-1a767e7b8a3f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38115 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36491 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32871 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5333 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148538 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36316 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186818 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/36075 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/40315 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40759 "Build is in progress. Recent messages:Running configuration; Running apply-patch; Checked out pull request; Skipped layout-tests; 344 new passes 20 flakes 7 failures; Uploaded test results; Ignored 6 pre-existing failure based on results-db") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144965 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48413 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144824 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39059 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49093 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32937 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114872 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39696 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121164 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/211905 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47599 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11286 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55274 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47001 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47232 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47059 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->