### PR TITLE
AX: Make AXTextMarker::lineIndex() O(1) when start and target share a containing block

### DIFF
--- a/LayoutTests/accessibility/mac/line-index-marker-in-large-block-expected.txt
+++ b/LayoutTests/accessibility/mac/line-index-marker-in-large-block-expected.txt
@@ -1,0 +1,11 @@
+This test verifies lineIndex() returns the correct line number for markers deep inside a single large block.
+
+PASS: lineIndexForLine(0) === 0
+PASS: lineIndexForLine(1) === 1
+PASS: lineIndexForLine(20) === 20
+PASS: lineIndexForLine(39) === 39
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/line-index-marker-in-large-block.html
+++ b/LayoutTests/accessibility/mac/line-index-marker-in-large-block.html
@@ -1,0 +1,63 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<!--
+Verifies AXTextMarker::lineIndex() returns the correct line number for markers deep inside a
+single large block that wraps onto many lines (a long flat list of links separated by <br>, like
+the Apple Maps "Acknowledgements" page). This exercises the same-containing-block fast path added
+to lineIndex(): the start marker (document start) and the target marker share the block's line
+numbering, so the line index is computed directly.
+
+The content is pure text (no inline replaced elements), so the computed line index is unambiguous
+and identical on the live and isolated trees.
+-->
+
+<div id="container" style="font-family: monospace;"></div>
+
+<script>
+var output = "This test verifies lineIndex() returns the correct line number for markers deep inside a single large block.\n\n";
+
+const lineCount = 40;
+
+function buildLines() {
+    let markup = "";
+    for (let i = 0; i < lineCount; ++i)
+        markup += `<a id="line${i}" href="#">Line ${i}</a><br>`;
+    document.getElementById("container").innerHTML = markup;
+}
+
+function lineIndexForLine(i) {
+    const item = accessibilityController.accessibleElementById(`line${i}`);
+    if (!item)
+        return "no element";
+    const range = item.textMarkerRangeForElement(item);
+    const marker = item.startTextMarkerForTextMarkerRange(range);
+    return item.lineIndexForTextMarker(marker);
+}
+
+async function runTest() {
+    buildLines();
+    await waitForElementById(`line${lineCount - 1}`);
+
+    // Check a spread of lines, including ones far from the start of the block.
+    for (const i of [0, 1, 20, lineCount - 1])
+        output += expect(`lineIndexForLine(${i})`, `${i}`);
+
+    document.getElementById("container").innerHTML = "";
+
+    debug(output);
+    finishJSTest();
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+    runTest();
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXTextMarker.cpp
+++ b/Source/WebCore/accessibility/AXTextMarker.cpp
@@ -721,6 +721,26 @@ int AXTextMarker::lineIndex() const
     if (currentLineID == targetLineID)
         return 0;
 
+    // Fast path: when the start marker and this marker share a containing block, both
+    // line IDs are drawn from that block's own monotonic line numbering (the line-box
+    // index within the RenderBlock), so the number of lines between them is simply the
+    // difference of their line indices. This avoids the line-by-line walk below, which
+    // starts at the beginning of the document (or editable/text-control root) and is
+    // therefore O(lines-from-start) on every call. That is pathological on a page that
+    // is a single large block wrapping onto thousands of lines (e.g. a long flat list
+    // of links), where an assistive technology requests the line index on every caret
+    // movement, making a full traversal O(lines^2).
+    //
+    // Only out-of-flow (float / position:absolute) replaced elements and boxless line breaks
+    // store their own renderer in the lineID's containing-block slot (see
+    // AccessibilityRenderObject::textRuns); their synthetic lineIDs don't compare equal here and
+    // fall through to the walk. Everything else — including a normal in-flow inline <img>, which
+    // uses box->lineIndex() against the real containing block — compares equal and takes this
+    // fast path, which is correct because its line index is real.
+    if (currentLineID.containingBlock && currentLineID.containingBlock == targetLineID.containingBlock
+        && targetLineID.lineIndex >= currentLineID.lineIndex)
+        return static_cast<int>(targetLineID.lineIndex - currentLineID.lineIndex);
+
     auto currentMarker = WTF::move(startMarker);
     if (!currentMarker.atLineEnd()) {
         // Start from a line end, so that subsequent calls to nextLineEnd() yield a new line.


### PR DESCRIPTION
#### 1d20b393299846d0309ebc7240db4a680b18b46b
<pre>
AX: Make AXTextMarker::lineIndex() O(1) when start and target share a containing block
<a href="https://rdar.apple.com/182338926">rdar://182338926</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=319522">https://bugs.webkit.org/show_bug.cgi?id=319522</a>

Reviewed by Tyler Wilcock and Andres Gonzalez.

lineIndex() computed a marker&apos;s line number by walking the tree line-by-line from
the start of the document (or editable/text-control root) to the target line, so
it is O(lines-from-start) per call. VoiceOver requests AXLineForTextMarker on every
caret movement, so on a page that is a single large block wrapping onto thousands
of lines (e.g. a long flat list of links) character navigation degrades to O(n^2).

When the start marker and the target marker share a containing block, both line
IDs come from that block&apos;s own monotonic line numbering, so the line count between
them is just the difference of their line indices — no walk needed. Inline replaced
elements store their own renderer in the lineID&apos;s containing-block slot, so they
don&apos;t match here and correctly fall through to the existing walk.

Adds line-index-marker-in-large-block.html: pure-text (no replaced elements) so the
result is unambiguous and identical on the live and isolated trees, verifying
lineIndex() is correct for markers deep inside a single block.

* LayoutTests/accessibility/mac/line-index-marker-in-large-block-expected.txt: Added.
* LayoutTests/accessibility/mac/line-index-marker-in-large-block.html: Added.
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarker::lineIndex const):

Canonical link: <a href="https://commits.webkit.org/317438@main">https://commits.webkit.org/317438@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b71ea38c5507d9559bba5a4ffe3dd0d32a8393ca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175234 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49166 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42947 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184819 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/133441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/632db394-2468-42ac-b2ad-9575018fefa9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177098 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50458 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48849 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136402 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/133441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/34197ea1-39f2-481e-9375-f9861857be50) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178191 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39821 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157169 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116881 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3a0789ab-2cf8-4c0c-8bc5-967964775b98) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38462 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36849 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33292 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148885 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36662 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187240 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/40853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145355 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48833 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156725 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145208 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39129 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49513 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33283 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115391 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40041 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121706 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48019 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11635 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47422 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47652 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47479 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->