### PR TITLE
REGRESSION(308209@main): okaymay.be scroll-driven animation is jittery

### DIFF
--- a/Source/WebCore/animation/AnimationTimelinesController.cpp
+++ b/Source/WebCore/animation/AnimationTimelinesController.cpp
@@ -264,6 +264,20 @@ void AnimationTimelinesController::updateStaleScrollTimelines()
         scrollTimeline->updateCurrentTimeIfStale();
 }
 
+bool AnimationTimelinesController::hasProgressBasedScrollDrivenAnimation() const
+{
+    for (Ref timeline : m_timelines) {
+        if (!timeline->isProgressBased())
+            continue;
+        for (auto& animation : timeline->relevantAnimations()) {
+            RefPtr effect = animation->keyframeEffect();
+            if (effect && !effect->isCompletelyAccelerated())
+                return true;
+        }
+    }
+    return false;
+}
+
 #if ENABLE(THREADED_ANIMATIONS)
 void AnimationTimelinesController::runPostRenderingUpdateTasks()
 {

--- a/Source/WebCore/animation/AnimationTimelinesController.h
+++ b/Source/WebCore/animation/AnimationTimelinesController.h
@@ -63,6 +63,7 @@ public:
     void detachFromDocument();
     void updateAnimationsAndSendEvents(ReducedResolutionSeconds);
     void updateStaleScrollTimelines();
+    bool hasProgressBasedScrollDrivenAnimation() const;
     void addPendingAnimation(WebAnimation&);
 
     std::optional<ReducedResolutionSeconds> currentTime(UseCachedCurrentTime = UseCachedCurrentTime::Yes);

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -177,6 +177,7 @@ public:
     void customPropertyRegistrationDidChange(const AtomString&);
 
     bool canBeAccelerated() const;
+    bool isCompletelyAccelerated() const { return m_acceleratedPropertiesState == AcceleratedProperties::All; }
     bool accelerationWasPrevented() const { return m_runningAccelerated == RunningAccelerated::Prevented; }
     bool preventsAcceleration() const;
     void effectStackNoLongerPreventsAcceleration();
@@ -225,7 +226,6 @@ private:
     void didChangeTargetStyleable(const std::optional<const Styleable>&);
     ExceptionOr<void> processKeyframes(JSC::JSGlobalObject&, Document&, JSC::Strong<JSC::JSObject>&&);
     void addPendingAcceleratedAction(AcceleratedAction);
-    bool isCompletelyAccelerated() const { return m_acceleratedPropertiesState == AcceleratedProperties::All; }
     void updateAcceleratedActions();
     void setAnimatedPropertiesInStyle(Style::ComputedStyle&, const ComputedEffectTiming&) const;
     const TimingFunction* timingFunctionForKeyframeAtIndex(size_t) const;

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -10941,6 +10941,11 @@ AnimationTimelinesController& Document::ensureTimelinesController()
     return *m_timelinesController.get();
 }
 
+bool Document::hasProgressBasedScrollDrivenAnimation() const
+{
+    return m_timelinesController && m_timelinesController->hasProgressBasedScrollDrivenAnimation();
+}
+
 StyleOriginatedTimelinesController& Document::ensureStyleOriginatedTimelinesController()
 {
     if (!m_styleOriginatedTimelinesController)

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1875,6 +1875,7 @@ public:
     Vector<Ref<WebAnimation>> matchingAnimations(NOESCAPE const Function<bool(Element&)>&);
     AnimationTimelinesController* timelinesController() const { return m_timelinesController.get(); }
     WEBCORE_EXPORT AnimationTimelinesController& ensureTimelinesController();
+    WEBCORE_EXPORT bool hasProgressBasedScrollDrivenAnimation() const;
     StyleOriginatedTimelinesController* styleOriginatedTimelinesController() { return m_styleOriginatedTimelinesController.get(); }
     StyleOriginatedTimelinesController& ensureStyleOriginatedTimelinesController();
     void keyframesRuleDidChange(const String& name);

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
@@ -285,6 +285,7 @@ using WebKit::PageData::TransactionCallbackID = IPC::AsyncReplyID;
     bool viewportMetaTagWidthWasExplicit;
     bool viewportMetaTagCameFromImageDocument;
     bool isInStableState;
+    bool hasMainThreadScrollDrivenAnimations;
     WebCore::InteractiveWidget viewportMetaTagInteractiveWidget;
 
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeCommitBundle.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeCommitBundle.h
@@ -87,6 +87,7 @@ struct MainFrameData {
     bool viewportMetaTagWidthWasExplicit { false };
     bool viewportMetaTagCameFromImageDocument { false };
     bool isInStableState { false };
+    bool hasMainThreadScrollDrivenAnimations { false };
     WebCore::InteractiveWidget viewportMetaTagInteractiveWidget { WebCore::InteractiveWidget::ResizesVisual };
 
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -297,6 +297,7 @@ struct PerWebProcessState {
     BOOL viewportMetaTagWidthWasExplicit { NO };
     BOOL viewportMetaTagCameFromImageDocument { NO };
     BOOL lastTransactionWasInStableState { NO };
+    BOOL hasMainThreadScrollDrivenAnimations { NO };
 
     std::optional<WebCore::FloatSize> lastSentViewLayoutSize;
     std::optional<WebCore::IntDegrees> lastSentDeviceOrientation;

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -1194,6 +1194,7 @@ static void changeContentOffsetBoundedInValidRange(UIScrollView *scrollView, Web
         [self _trackTransactionCommit:transactionID];
 
         _perProcessState.lastTransactionID = transactionID;
+        _perProcessState.hasMainThreadScrollDrivenAnimations = mainFrameCommitData.hasMainThreadScrollDrivenAnimations;
 
 #if ENABLE(RESPONSIVE_LIVE_RESIZE_UPDATE)
         auto transactionIDForEndLiveResize = _perProcessState.transactionIDForEndLiveResize;
@@ -3259,7 +3260,10 @@ static bool scrollViewCanScroll(UIScrollView *scrollView)
         return;
     }
 
-    if (_isChangingObscuredInsetsInteractively) {
+    // If we're changing obscured insets interactively we want to throttle visible content rect updates to save power.
+    // But we must send them anyway if there are unaccelerated scroll-driven animations as they need the visible content rect
+    // updates every frame in order to avoid jitter.
+    if (_isChangingObscuredInsetsInteractively && !_perProcessState.hasMainThreadScrollDrivenAnimations) {
         auto timeSinceLastUpdate = timeNow - _timeOfLastVisibleContentRectUpdate;
         if (timeSinceLastUpdate < delayBeforeUpdatingVisibleContentRectsWhenChangingObscuredInsetsInteractively) {
             auto delay = delayBeforeUpdatingVisibleContentRectsWhenChangingObscuredInsetsInteractively - timeSinceLastUpdate;

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -2367,6 +2367,8 @@ void WebPage::willCommitMainFrameData(MainFrameData& data, const TransactionID& 
     data.viewportMetaTagCameFromImageDocument = m_viewportConfiguration.viewportArguments().type == ViewportArguments::Type::ImageDocument;
     data.avoidsUnsafeArea = m_viewportConfiguration.avoidsUnsafeArea();
     data.isInStableState = m_isInStableState;
+    if (RefPtr document = mainFrameView->frame().document())
+        data.hasMainThreadScrollDrivenAnimations = document->hasProgressBasedScrollDrivenAnimation();
     data.allowsUserScaling = allowsUserScaling();
     if (m_pendingDynamicViewportSizeUpdateID) {
         data.dynamicViewportSizeUpdateID = *m_pendingDynamicViewportSizeUpdateID;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/WKScrollViewTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/WKScrollViewTests.mm
@@ -1167,6 +1167,109 @@ TEST(WKScrollViewTests, VisibleContentRectUpdatesDuringInteractiveObscuredInsets
     EXPECT_TRUE([webView _hasPendingVisibleContentRectUpdateTimerForTesting]);
 }
 
+TEST(WKScrollViewTests, VisibleContentRectUpdatesDuringInteractiveObscuredInsetsChangeAreNotThrottledForMainThreadScrollDrivenAnimation)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 800)]);
+
+    auto insets = UIEdgeInsetsMake(50, 0, 0, 0);
+    [webView _setObscuredInsets:insets];
+
+    RetainPtr scrollView = [webView scrollView];
+    [scrollView setContentInsetAdjustmentBehavior:UIScrollViewContentInsetAdjustmentNever];
+    [scrollView setContentInset:insets];
+
+    // The fixed element runs a scroll-driven animation on 'top', a non-accelerated property, so it must be
+    // updated on the main thread for every scroll delta. Throttling visible content rect updates would make
+    // it advance in coarse steps while the page scrolls smoothly (jitter), so it must not be throttled.
+    [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html><html><head><style>"
+        "body { height: 3000px; margin: 0; }"
+        "#logo { position: fixed; top: 0; left: 0; width: 50px; height: 50px; background: red;"
+        " animation: logo-scroll linear; animation-timeline: scroll(root); }"
+        "@keyframes logo-scroll { from { top: 0; } to { top: 100px; } }"
+        "</style></head><body><div id=\"logo\"></div></body></html>"];
+    [webView waitForNextPresentationUpdate];
+
+    [scrollView setContentOffset:CGPointMake(0, 500)];
+    [webView waitForNextVisibleContentRectUpdate];
+
+    [webView _beginInteractiveObscuredInsetsChange];
+
+    // First scroll within interactive mode would normally trigger the throttle timer.
+    [scrollView setContentOffset:CGPointMake(0, 510)];
+    [webView waitForNextPresentationUpdate];
+    EXPECT_FALSE([webView _hasPendingVisibleContentRectUpdateTimerForTesting]);
+
+    // Subsequent scrolls should not be throttled either.
+    [scrollView setContentOffset:CGPointMake(0, 520)];
+    [webView waitForNextPresentationUpdate];
+    EXPECT_FALSE([webView _hasPendingVisibleContentRectUpdateTimerForTesting]);
+}
+
+TEST(WKScrollViewTests, ScrollDrivenAnimationTracksScrollDuringInteractiveObscuredInsetsChange)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 800)]);
+
+    // The fixed element runs a scroll-driven animation on 'top' (a non-accelerated property), so its position
+    // is recomputed on the main thread from the scroll offset. It moves from top:0 to top:1000 across the
+    // scroll range, so a large scroll should move it substantially.
+    [webView synchronouslyLoadHTMLString:@"<meta name='viewport' content='width=device-width, initial-scale=1'>"
+        "<style>"
+        "body { margin: 0; height: 10000px; }"
+        "#logo { position: fixed; top: 0; left: 0; width: 50px; height: 50px; background: red;"
+        " animation: logo-scroll linear; animation-timeline: scroll(root); }"
+        "@keyframes logo-scroll { from { top: 0px; } to { top: 1000px; } }"
+        "</style>"
+        "<div id='logo'></div>"];
+
+    auto insets = UIEdgeInsetsMake(50, 0, 0, 0);
+    [webView _setObscuredInsets:insets];
+    RetainPtr scrollView = [webView scrollView];
+    [scrollView setContentInsetAdjustmentBehavior:UIScrollViewContentInsetAdjustmentNever];
+    [scrollView setContentInset:insets];
+    [webView waitForNextPresentationUpdate];
+
+    // Read the animation's applied value directly. getComputedStyle gives the raw animated 'top' in px;
+    // getBoundingClientRect would be offset by the obscured insets for a fixed element.
+    auto animatedTop = ^{
+        return [[webView objectByEvaluatingJavaScript:@"parseFloat(getComputedStyle(document.getElementById('logo')).top)"] floatValue];
+    };
+
+    auto scrollAndSync = ^(CGFloat y) {
+        [scrollView setContentOffset:CGPointMake(0, y)];
+        [webView waitForNextVisibleContentRectUpdate];
+        [webView waitForNextPresentationUpdate];
+        [webView waitForNextPresentationUpdate];
+    };
+
+    // Control: with updates un-throttled, the animation advances substantially between the two scroll offsets.
+    scrollAndSync(200);
+    CGFloat controlLow = animatedTop();
+    scrollAndSync(3000);
+    CGFloat controlHigh = animatedTop();
+    EXPECT_GT(controlHigh - controlLow, 100);
+
+    // Now the interactive (throttled) path: sync back to the low offset...
+    scrollAndSync(200);
+    CGFloat baselineTop = animatedTop();
+
+    // ...then simulate the URL bar animating and scroll a large delta.
+    [webView _beginInteractiveObscuredInsetsChange];
+    [scrollView setContentOffset:CGPointMake(0, 3000)];
+
+    // Only wait for presentation updates here. Waiting for a visible content rect update would block on the
+    // throttle timer (and thereby mask the bug); presentation updates arrive every frame regardless.
+    [webView waitForNextPresentationUpdate];
+    [webView waitForNextPresentationUpdate];
+    CGFloat interactiveTop = animatedTop();
+
+    [webView _endInteractiveObscuredInsetsChange];
+
+    // With the throttle bypassed for main-thread scroll-driven animations, the animation keeps advancing with
+    // the scroll. If updates were throttled, it would stay frozen near its baseline value between the coarse
+    // (~10Hz) updates while the page scrolls smoothly, i.e. jitter.
+    EXPECT_GT(interactiveTop - baselineTop, 100);
+}
+
 TEST(WKScrollViewTests, ThrottledVisibleContentRectUpdateTimerCancelledWhenEndingInteractiveUpdates)
 {
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 800)]);


### PR DESCRIPTION
#### b07ce30ae0052f005a29fb74c470e2f63f3a1144
<pre>
REGRESSION(308209@main): okaymay.be scroll-driven animation is jittery
<a href="https://bugs.webkit.org/show_bug.cgi?id=319523">https://bugs.webkit.org/show_bug.cgi?id=319523</a>
<a href="https://rdar.apple.com/179479959">rdar://179479959</a>

Reviewed by Simon Fraser and Antoine Quint.

Unaccelerated scroll-driven animations must do layout on the main frame for every frame of scrolling. When
we are upadating obscured insets interactively, we throttle visible content rect updates and thus throttle
updates that the scroll-driven animation needs to compute the next frame of the animation. When we finally do
send an update, the animated layer jumps ahead causing a visible jitter.

To avoid this we skip the power optimization and send unthrottled visible content rect updates to the WebContent
process. The iOS power benchmark measures a neutral result so we still get the power benefit on content that does
not contain unaccelerated scroll-driven animations.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/WKScrollViewTests.mm

* Source/WebCore/animation/AnimationTimelinesController.cpp:
(WebCore::AnimationTimelinesController::hasProgressBasedScrollDrivenAnimation const):
* Source/WebCore/animation/AnimationTimelinesController.h:
* Source/WebCore/animation/KeyframeEffect.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::hasProgressBasedScrollDrivenAnimation const):
* Source/WebCore/dom/Document.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeCommitBundle.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _didCommitLayerTree:mainFrameData:pageData:transactionID:]):
(-[WKWebView _updateVisibleContentRects]):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::willCommitMainFrameData):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/WKScrollViewTests.mm:
(TestWebKitAPI::(WKScrollViewTests, VisibleContentRectUpdatesDuringInteractiveObscuredInsetsChangeAreNotThrottledForMainThreadScrollDrivenAnimation)):
(TestWebKitAPI::(WKScrollViewTests, ScrollDrivenAnimationTracksScrollDuringInteractiveObscuredInsetsChange)):

Canonical link: <a href="https://commits.webkit.org/317404@main">https://commits.webkit.org/317404@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/29c28d0c1b0a502037d8b0b85a0e9469e391d903

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175058 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48991 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42772 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184643 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132966 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9d9ddc47-5dab-443e-950e-968b67c3c44b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176923 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50283 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48674 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136259 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/94151993-3278-4b93-a7f1-0d5dafc3c0dc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178016 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39696 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157049 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116737 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/08b10a2c-de0b-4c47-8cbe-c133b14ea910) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38337 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36719 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33116 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148760 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36541 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187064 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/40613 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40922 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145201 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48658 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145057 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39116 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49338 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33162 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115162 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39915 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/121600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47844 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11514 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47247 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47477 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47304 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->