### PR TITLE
WTF::saturatingSum variadic overload truncates 3+ argument sums to uint32_t

### DIFF
--- a/Source/WTF/wtf/SaturatingArithmetic.h
+++ b/Source/WTF/wtf/SaturatingArithmetic.h
@@ -123,7 +123,7 @@ constexpr UnsignedIntegralType saturatingSum(UnsignedIntegralType a, UnsignedInt
 }
 
 template<typename IntegralType, typename... ArgumentTypes>
-constexpr uint32_t saturatingSum(IntegralType value, ArgumentTypes... arguments)
+constexpr IntegralType saturatingSum(IntegralType value, ArgumentTypes... arguments)
 {
     return saturatingSum<IntegralType>(value, saturatingSum<IntegralType>(arguments...));
 }

--- a/Tools/TestWebKitAPI/Tests/WTF/SaturatingArithmeticOperations.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/SaturatingArithmeticOperations.cpp
@@ -32,6 +32,8 @@
 #include "config.h"
 
 #include <limits.h>
+#include <limits>
+#include <type_traits>
 #include <wtf/SaturatingArithmetic.h>
 
 namespace TestWebKitAPI {
@@ -90,6 +92,17 @@ TEST(WTF, SaturatingArithmeticAddition)
     EXPECT_EQ(UINT_MAX, saturatingSum<uint32_t>(UINT_MAX / 2U + 1U, UINT_MAX / 2U + 1U));
     EXPECT_EQ(UINT_MAX, saturatingSum<uint32_t>(UINT_MAX / 3U + 1U, UINT_MAX / 3U, UINT_MAX / 3U));
     EXPECT_EQ(UINT_MAX, saturatingSum<uint32_t>(UINT_MAX / 3U + 1U, UINT_MAX / 3U + 1U, UINT_MAX / 3U + 1U));
+
+    // The variadic (3+ argument) overload must preserve the operand type in its result
+    // rather than narrowing to uint32_t, otherwise wide-type sums are silently truncated.
+    static_assert(std::same_as<decltype(saturatingSum<uint64_t>(uint64_t { 1 }, uint64_t { 1 }, uint64_t { 1 })), uint64_t>);
+
+    constexpr uint64_t big = static_cast<uint64_t>(UINT_MAX) + 1;
+    constexpr uint64_t uint64Max = std::numeric_limits<uint64_t>::max();
+    EXPECT_EQ(3 * big, saturatingSum<uint64_t>(big, big, big));
+    EXPECT_EQ(big + 3, saturatingSum<uint64_t>(big, uint64_t { 1 }, uint64_t { 2 }));
+    EXPECT_EQ(uint64Max, saturatingSum<uint64_t>(uint64Max, uint64_t { 1 }, uint64_t { 1 }));
+    EXPECT_EQ(uint64Max, saturatingSum<uint64_t>(uint64Max / 2 + 1, uint64Max / 2 + 1, uint64_t { 1 }));
 }
 
 TEST(WTF, SaturatingArithmeticSubtraction)


### PR DESCRIPTION
#### c9f0d5b44c9675990e91018b11f68d1c6f503900
<pre>
WTF::saturatingSum variadic overload truncates 3+ argument sums to uint32_t
<a href="https://bugs.webkit.org/show_bug.cgi?id=319524">https://bugs.webkit.org/show_bug.cgi?id=319524</a>
<a href="https://rdar.apple.com/182346464">rdar://182346464</a>

Reviewed by Chris Dumez.

The variadic (3+ argument) overload of saturatingSum hardcoded its return
type as uint32_t, even though it delegates to the two-argument overloads,
which correctly return the operand type. As a result, a saturating sum of
three or more arguments of a type wider than 32 bits (e.g. uint64_t) was
computed correctly and then silently narrowed to uint32_t on return.

No in-tree caller currently trips this (the only variadic call site sums
uint32_t values), so this is a latent correctness bug rather than an
active regression, but it is a trap waiting for the next wider-type caller.

Fix the return type to follow the operand type (IntegralType) instead of
the hardcoded uint32_t, and add API test coverage for the wide-type,
3+ argument case, including a static_assert pinning the deduced return
type to the operand type.

Test: Tools/TestWebKitAPI/Tests/WTF/SaturatingArithmeticOperations.cpp

* Source/WTF/wtf/SaturatingArithmetic.h:
(WTF::saturatingSum):
* Tools/TestWebKitAPI/Tests/WTF/SaturatingArithmeticOperations.cpp:
(TestWebKitAPI::TEST(WTF, SaturatingArithmeticAddition)):

Canonical link: <a href="https://commits.webkit.org/317530@main">https://commits.webkit.org/317530@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c07c5a5fecc4025f4c1f915aa07e735e2c90d0f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175539 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49471 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43252 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185125 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d8ebe855-ea39-4b93-bd6b-db927b3567ef) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177403 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50763 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49154 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136684 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1df97eda-bd65-4fd2-835b-f2bfc19b1ce8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178496 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40103 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157441 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117162 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/872c6557-8b0f-4276-b389-3770e59fb559) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38744 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37129 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5950 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149166 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36934 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33600 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/36800 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41159 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41332 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187550 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49138 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145650 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39189 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49818 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33558 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145487 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40307 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122011 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115781 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48325 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11910 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47727 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47957 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47784 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->