### PR TITLE
Digital Credentials: reject and resolve paths must queue a global task per spec

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/concurrent-requests.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/concurrent-requests.https-expected.txt
@@ -1,3 +1,5 @@
 
 PASS A second get() call while another is pending should reject with NotAllowedError.
+PASS A concurrent get() rejection is queued on the DOM manipulation task source, not settled synchronously.
+PASS Destroying the requesting document returns the coordinator to the idle interaction state.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/concurrent-requests.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/concurrent-requests.https.html
@@ -48,4 +48,68 @@
       "First request should be aborted"
     );
   }, "A second get() call while another is pending should reject with NotAllowedError.");
+
+  promise_test(async (t) => {
+    // Per "prepare credential requests" this rejection is a queued task, so a
+    // microtask queued in the same tick runs before it.
+    await test_driver.set_virtual_wallet_behavior("wait");
+    t.add_cleanup(() => test_driver.set_virtual_wallet_behavior("clear"));
+
+    const abortController = new AbortController();
+    await test_driver.bless("user activation for first request");
+    const firstRequest = navigator.credentials.get(
+      makeGetOptions({ signal: abortController.signal }),
+    );
+
+    const order = [];
+    let secondRequest;
+    await test_driver.bless("user activation for second request", () => {
+      secondRequest = navigator.credentials.get(makeGetOptions());
+      secondRequest.catch(() => order.push("rejection"));
+      Promise.resolve().then(() => order.push("microtask"));
+    });
+
+    await promise_rejects_dom(t, "NotAllowedError", secondRequest);
+    assert_array_equals(
+      order,
+      ["microtask", "rejection"],
+      "The concurrent-request rejection must be queued as a task, not settled synchronously.",
+    );
+
+    abortController.abort();
+    await promise_rejects_dom(t, "AbortError", firstRequest);
+  }, "A concurrent get() rejection is queued on the DOM manipulation task source, not settled synchronously.");
+
+  promise_test(async (t) => {
+    // A pending request whose document is destroyed must return the coordinator
+    // to the idle interaction state. If it does not, every later request on this
+    // page rejects with NotAllowedError for the lifetime of the page.
+    await test_driver.set_virtual_wallet_behavior("wait");
+    t.add_cleanup(() => test_driver.set_virtual_wallet_behavior("clear"));
+
+    const iframe = document.createElement("iframe");
+    await new Promise((resolve) => {
+      iframe.addEventListener("load", resolve, { once: true });
+      iframe.src = "about:blank";
+      document.body.appendChild(iframe);
+    });
+
+    await test_driver.bless("user activation for subframe request", null, iframe.contentWindow);
+    const subframeRequest = iframe.contentWindow.navigator.credentials.get(makeGetOptions());
+    subframeRequest.catch(() => {});
+    iframe.remove();
+
+    const responseData = "served-after-teardown";
+    await test_driver.set_virtual_wallet_behavior("respond", "org-iso-mdoc", { value: responseData });
+    await test_driver.bless("user activation for top-level request");
+    const credential = await navigator.credentials.get(
+      makeGetOptions({ protocol: "org-iso-mdoc" })
+    );
+
+    assert_equals(
+      credential.data.value,
+      responseData,
+      "A request made after the previous requester's document was destroyed must be served, not rejected as concurrent."
+    );
+  }, "Destroying the requesting document returns the coordinator to the idle interaction state.");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get-non-fully-active.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get-non-fully-active.https-expected.txt
@@ -1,5 +1,5 @@
 
 PASS non-fully active document behavior for navigator.credentials.get()
-FAIL Promise rejects with DOMException when the document becomes non-fully active promise_rejects_dom: Expect promise to reject if the document becomes non-fully active function "function() { throw e; }" threw object "TypeError: No supported document requests to present." that is not a DOMException AbortError: property "code" is equal to undefined, expected 20
+PASS Promise rejects with DOMException when the document becomes non-fully active
 PASS Aborted Digital Credentials get() requests do not leave a subsequent request stuck in an invalid state
 

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8621,7 +8621,6 @@ webkit.org/b/319761 imported/w3c/web-platform-tests/css/css-viewport/zoom/perspe
 # (the drag target is computed from glyph rects + a fixed offset). Needs a more robust target; follow-up.
 webkit.org/b/319784 editing/selection/ios/bidi-visually-contiguous-selection-multiline.html [ Failure ]
 
-webkit.org/b/317884 imported/w3c/web-platform-tests/digital-credentials/get-non-fully-active.https.html [ Skip ]
 webkit.org/b/256299 imported/w3c/web-platform-tests/digital-credentials/allow-attribute-with-get.https.html [ Pass Failure ]
 
 webkit.org/b/318157 [ Debug ] imported/w3c/web-platform-tests/IndexedDB/interleaved-cursors-small.any.sharedworker.html [ Failure ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2407,8 +2407,6 @@ webkit.org/b/317173 [ arm64 ] fast/webgpu/nocrash/fuzz-298315.html [ Pass Crash 
 
 webkit.org/b/317857 [ Debug ] http/tests/site-isolation/frame-index.html [ Skip ]
 
-webkit.org/b/317884 imported/w3c/web-platform-tests/digital-credentials/get-non-fully-active.https.html [ Failure ]
-
 webkit.org/b/318150 imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-border-shape-overflow.html [ ImageOnlyFailure ]
 webkit.org/b/318150 imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-border-shape.html [ ImageOnlyFailure ]
 

--- a/Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp
+++ b/Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp
@@ -34,7 +34,10 @@
 #include "DigitalCredentialsRequestData.h"
 #include "DigitalCredentialsRequestDataBuilder.h"
 #include "DigitalCredentialsResponseData.h"
+#include "DigitalCredentialsSession.h"
+#include "Document.h"
 #include "DocumentSecurityOrigin.h"
+#include "EventLoop.h"
 #include "ExceptionData.h"
 #include "ExceptionOr.h"
 #include "JSDOMConvertAny.h"
@@ -47,6 +50,7 @@
 #include "LocalFrame.h"
 #include "Page.h"
 #include "SecurityOriginData.h"
+#include "TaskSource.h"
 #include <JavaScriptCore/JSObject.h>
 #include <JavaScriptCore/StrongInlines.h>
 #include <Logging.h>
@@ -64,28 +68,12 @@ Ref<CredentialRequestCoordinator> CredentialRequestCoordinator::create(Ref<Crede
 }
 
 CredentialRequestCoordinator::CredentialRequestCoordinator(Ref<CredentialRequestCoordinatorClient>&& client, Page& page)
-    : ActiveDOMObject(page.localTopDocument())
-    , m_client(WTF::move(client))
+    : m_client(WTF::move(client))
     , m_page(page)
 {
 }
 
-CredentialRequestCoordinator::InteractionStateGuard::InteractionStateGuard(CredentialRequestCoordinator& coordinator)
-    : m_coordinator(coordinator)
-{
-    ASSERT(coordinator.interactionState() == InteractionState::Requesting);
-}
-
-CredentialRequestCoordinator::InteractionStateGuard::~InteractionStateGuard()
-{
-    if (!m_active)
-        return;
-
-    ASSERT(m_coordinator->interactionState() == InteractionState::Requesting
-        || m_coordinator->interactionState() == InteractionState::Aborting);
-
-    m_coordinator->setInteractionState(InteractionState::Idle);
-}
+CredentialRequestCoordinator::~CredentialRequestCoordinator() = default;
 
 CredentialRequestCoordinator::InteractionState CredentialRequestCoordinator::interactionState() const
 {
@@ -115,26 +103,43 @@ void CredentialRequestCoordinator::setInteractionState(InteractionState newState
     m_interactionState = newState;
 }
 
-void CredentialRequestCoordinator::setCurrentPromise(CredentialPromise&& promise)
+void CredentialRequestCoordinator::sessionDidFinish(const DigitalCredentialsSession& session)
 {
-    ASSERT(m_interactionState == InteractionState::Requesting);
-    ASSERT(!m_currentPromise);
-    m_currentPromise = makeUnique<CredentialPromise>(WTF::move(promise));
+    if (m_activeSession.get() != &session)
+        return;
+
+    m_activeSession = nullptr;
+    setInteractionState(InteractionState::Idle);
 }
 
-CredentialPromise* CredentialRequestCoordinator::currentPromise()
+void CredentialRequestCoordinator::dismissChooser()
 {
-    return m_currentPromise.get();
+    m_client->dismissDigitalCredentialsChooser([](bool success) {
+        if (!success)
+            LOG(DigitalCredentials, "Failed to dismiss the credential chooser.");
+    });
 }
 
 void CredentialRequestCoordinator::prepareCredentialRequests(const Document& document, CredentialPromise&& promise, Vector<UnvalidatedDigitalCredentialRequest>&& unvalidatedRequests, RefPtr<AbortSignal> signal)
 {
-    if (m_interactionState != InteractionState::Idle)
-        return promise.reject(ExceptionCode::NotAllowedError, "A credential request is already in progress."_s);
+    RefPtr context = document.scriptExecutionContext();
+    if (!context)
+        return promise.reject(Exception { ExceptionCode::AbortError, "Document has no script execution context."_s });
 
-    ASSERT(!m_currentPromise);
+    if (m_interactionState != InteractionState::Idle) {
+        // The spec queues this on the *requesting* document's global, which is not the
+        // in-flight request's, so it cannot go through the active session.
+        CheckedRef eventLoop = context->eventLoop();
+        eventLoop->queueTask(TaskSource::DOMManipulation, [promise = makeUnique<CredentialPromise>(WTF::move(promise))]() mutable {
+            promise->reject(ExceptionCode::NotAllowedError, "A credential request is already in progress."_s);
+        });
+        return;
+    }
+
+    ASSERT(!m_activeSession);
     setInteractionState(InteractionState::Requesting);
-    setCurrentPromise(WTF::move(promise));
+    Ref session = DigitalCredentialsSession::create(*context, *this, WTF::move(promise));
+    m_activeSession = session.ptr();
 
     if (!m_page)
         return rejectTheCredentialRequestWith(Exception { ExceptionCode::AbortError, "Page was destroyed."_s });
@@ -158,13 +163,13 @@ void CredentialRequestCoordinator::prepareCredentialRequests(const Document& doc
 
     if (signal) {
         ASSERT(!signal->aborted());
-        m_abortSignal = signal;
-        m_abortAlgorithmIdentifier = signal->addAlgorithm([weakThis = WeakPtr { *this }, signal = protect(signal)](JSC::JSValue reason) {
+        auto identifier = signal->addAlgorithm([weakThis = WeakPtr { *this }](JSC::JSValue reason) {
             if (!weakThis)
                 return;
             LOG(DigitalCredentials, "Credential request was aborted by AbortSignal");
             weakThis->abortTheCredentialRequest(ExceptionOr<JSC::JSValue> { WTF::move(reason) });
         });
+        session->setAbortAlgorithm(RefPtr { signal }, identifier);
     }
 
     if (signal && signal->aborted())
@@ -178,8 +183,6 @@ void CredentialRequestCoordinator::initiateTheCredentialRequest(const Document& 
     auto requestDataAndRawRequests = DigitalCredentialsRequestDataBuilder::build(validatedRequests, document, WTF::move(unvalidatedRequests));
     if (requestDataAndRawRequests.hasException())
         return rejectTheCredentialRequestWith(requestDataAndRawRequests.releaseException());
-
-    observeContext(protect(document.scriptExecutionContext()).get());
 
     auto [requestData, rawRequests] = requestDataAndRawRequests.releaseReturnValue();
 
@@ -205,43 +208,44 @@ void CredentialRequestCoordinator::processCredentialChooserResponse(Expected<Dig
         return;
     }
 
-    // A parked "wait" reply released during abort/teardown can arrive after the
-    // request already left Requesting; it is moot, so return before the guard.
     if (m_interactionState != InteractionState::Requesting) {
         LOG(DigitalCredentials, "Ignoring credential chooser response received while not in the Requesting state.");
         return;
     }
 
-    InteractionStateGuard guard(*this);
-
-    if (!m_currentPromise) {
-        LOG(DigitalCredentials, "No current promise in coordinator.");
+    RefPtr session = m_activeSession;
+    if (!session) {
+        LOG(DigitalCredentials, "No active credential request session in coordinator.");
         ASSERT_NOT_REACHED();
         return;
     }
 
-    guard.deactivate();
-
     if (!responseOrException)
-        return settleTheCredentialRequest(responseOrException.error().toException());
+        return rejectTheCredentialRequestWith(responseOrException.error().toException());
 
     auto& responseData = responseOrException.value();
 
     if (responseData.responseDataJSON.isEmpty())
-        return settleTheCredentialRequest(Exception { ExceptionCode::NotAllowedError, "The user cancelled the credential request."_s });
+        return rejectTheCredentialRequestWith(Exception { ExceptionCode::NotAllowedError, "The user cancelled the credential request."_s });
 
-    auto parsedObject = parseDigitalCredentialsResponseData(responseData.responseDataJSON);
+    session->queueSettlement([weakThis = WeakPtr { *this }, responseDataJSON = responseData.responseDataJSON, protocol = responseData.protocol](auto& promise) mutable {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis) {
+            promise.reject(Exception { ExceptionCode::AbortError, "Page was destroyed."_s });
+            return;
+        }
 
-    if (parsedObject.hasException())
-        return settleTheCredentialRequest(parsedObject.releaseException());
-
-    if (!parsedObject.returnValue())
-        return settleTheCredentialRequest(Exception { ExceptionCode::TypeError, "No parsed object."_s });
-
-    auto returnValue = parsedObject.releaseReturnValue();
-    Ref credential = DigitalCredential::create({ returnValue->vm(), returnValue }, responseData.protocol);
-
-    settleTheCredentialRequest(credential.ptr());
+        auto parsedObject = protectedThis->parseDigitalCredentialsResponseData(responseDataJSON);
+        if (parsedObject.hasException())
+            promise.reject(parsedObject.releaseException());
+        else if (!parsedObject.returnValue())
+            promise.reject(Exception { ExceptionCode::TypeError, "Parsed JSON data is not an object."_s });
+        else {
+            auto returnValue = parsedObject.releaseReturnValue();
+            Ref credential = DigitalCredential::create({ returnValue->vm(), returnValue }, protocol);
+            promise.resolve(credential.ptr());
+        }
+    });
 }
 
 ExceptionOr<JSC::JSObject*> CredentialRequestCoordinator::parseDigitalCredentialsResponseData(const String& responseDataJSON) const
@@ -284,74 +288,27 @@ ExceptionOr<JSC::JSObject*> CredentialRequestCoordinator::parseDigitalCredential
 void CredentialRequestCoordinator::rejectTheCredentialRequestWith(Exception&& exception)
 {
     ASSERT(m_interactionState != InteractionState::Idle);
-    ASSERT(m_currentPromise);
-    clearAbortAlgorithm();
-    m_currentPromise->reject(WTF::move(exception));
-    m_currentPromise.reset();
-    setInteractionState(InteractionState::Idle);
-}
 
-void CredentialRequestCoordinator::settleTheCredentialRequest(ExceptionOr<RefPtr<BasicCredential>>&& result)
-{
-    clearAbortAlgorithm();
-
-    auto promise = WTF::move(m_currentPromise);
-    m_currentPromise.reset();
-
-    ASSERT(m_interactionState == InteractionState::Requesting || m_interactionState == InteractionState::Aborting);
-
-    m_client->dismissDigitalCredentialsChooser([weakThis = WeakPtr { *this }, promise = WTF::move(promise), result = WTF::move(result)](bool success) mutable {
-        if (!success)
-            LOG(DigitalCredentials, "Failed to dismiss the credential chooser.");
-
-        if (auto* rawThis = weakThis.get())
-            rawThis->setInteractionState(InteractionState::Idle);
-
-        if (!promise)
-            return;
-
-        if (result.hasException())
-            promise->reject(result.releaseException());
-        else
-            promise->resolve(result.releaseReturnValue().get());
-    });
-}
-
-void CredentialRequestCoordinator::clearAbortAlgorithm()
-{
-    if (!m_abortAlgorithmIdentifier)
+    RefPtr session = m_activeSession;
+    if (!session)
         return;
 
-    RefPtr signal = m_abortSignal;
-    if (signal)
-        signal->removeAlgorithm(*m_abortAlgorithmIdentifier);
-
-    m_abortAlgorithmIdentifier.reset();
-    m_abortSignal = nullptr;
+    session->queueSettlement([exception = WTF::move(exception)](auto& promise) mutable {
+        promise.reject(WTF::move(exception));
+    });
 }
 
 void CredentialRequestCoordinator::abortTheCredentialRequest(ExceptionOr<JSC::JSValue>&& reason)
 {
-    clearAbortAlgorithm();
-    if (m_interactionState == InteractionState::Idle) {
-        ASSERT(!m_currentPromise);
+    RefPtr session = m_activeSession;
+    if (!session || !session->hasPromise())
         return;
-    }
 
-    if (m_interactionState == InteractionState::Aborting) {
-        ASSERT(!m_currentPromise);
+    if (m_interactionState != InteractionState::Requesting)
         return;
-    }
-
-    if (m_interactionState != InteractionState::Requesting) {
-        LOG(DigitalCredentials, "Cannot abort the credential request when it is not presenting.");
-        return;
-    }
 
     setInteractionState(InteractionState::Aborting);
-
-    auto promise = WTF::move(m_currentPromise);
-    m_currentPromise.reset();
+    dismissChooser();
 
     std::optional<Exception> abortException;
     std::optional<JSC::Strong<JSC::Unknown>> protectedReason;
@@ -371,41 +328,14 @@ void CredentialRequestCoordinator::abortTheCredentialRequest(ExceptionOr<JSC::JS
         }
     }
 
-    m_client->dismissDigitalCredentialsChooser(
-        [weakThis = WeakPtr { *this }, promise = WTF::move(promise), abortException = WTF::move(abortException), protectedReason = WTF::move(protectedReason)](bool success) mutable {
-            if (!success)
-                LOG(DigitalCredentials, "Failed to dismiss the credential chooser.");
-
-            if (auto* rawThis = weakThis.get())
-                rawThis->setInteractionState(InteractionState::Idle);
-
-            if (!promise)
-                return;
-
-            if (abortException)
-                return promise->reject(WTF::move(*abortException));
-
-            if (protectedReason)
-                return promise->rejectType<IDLAny>(protectedReason->get());
-
-            promise->reject(ExceptionCode::AbortError);
-        });
-}
-
-void CredentialRequestCoordinator::contextDestroyed()
-{
-    LOG(DigitalCredentials, "The context we were observing got destroyed");
-    abortTheCredentialRequest(Exception { ExceptionCode::AbortError, "script execution context was destroyed."_s });
-};
-
-CredentialRequestCoordinator::~CredentialRequestCoordinator()
-{
-    clearAbortAlgorithm();
-
-    if (m_currentPromise) {
-        m_currentPromise->reject(ExceptionCode::AbortError);
-        m_currentPromise.reset();
-    }
+    session->queueSettlement([abortException = WTF::move(abortException), protectedReason = WTF::move(protectedReason)](auto& promise) mutable {
+        if (abortException)
+            promise.reject(WTF::move(*abortException));
+        else if (protectedReason)
+            promise.template rejectType<IDLAny>(protectedReason->get());
+        else
+            promise.reject(Exception { ExceptionCode::AbortError, "The credential request was aborted."_s });
+    });
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/identity/CredentialRequestCoordinator.h
+++ b/Source/WebCore/Modules/identity/CredentialRequestCoordinator.h
@@ -27,15 +27,14 @@
 
 #if ENABLE(WEB_AUTHN)
 
-#include "ActiveDOMObject.h"
 #include "DigitalCredentialsProtocols.h"
 #include "ExceptionOr.h"
 #include "JSDOMPromiseDeferredForward.h"
 #include "UnvalidatedDigitalCredentialRequest.h"
 #include <JavaScriptCore/JSCJSValue.h>
 #include <optional>
-#include <wtf/CanMakeWeakPtr.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
@@ -43,6 +42,7 @@ namespace WebCore {
 class AbortSignal;
 class BasicCredential;
 class CredentialRequestCoordinatorClient;
+class DigitalCredentialsSession;
 class Document;
 class LocalFrame;
 class Page;
@@ -51,7 +51,9 @@ struct ExceptionData;
 
 using CredentialPromise = DOMPromiseDeferred<IDLNullable<IDLInterface<BasicCredential>>>;
 
-class CredentialRequestCoordinator final : public RefCounted<CredentialRequestCoordinator>, public ActiveDOMObject {
+// https://w3c-fedid.github.io/digital-credentials/#credential-request-coordinator
+// One per Page: at most one interaction is active across all of the page's frames.
+class CredentialRequestCoordinator final : public RefCountedAndCanMakeWeakPtr<CredentialRequestCoordinator> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(CredentialRequestCoordinator, WEBCORE_EXPORT);
     WTF_MAKE_NONCOPYABLE(CredentialRequestCoordinator);
 
@@ -61,32 +63,13 @@ public:
     WEBCORE_EXPORT void abortTheCredentialRequest(ExceptionOr<JSC::JSValue>&&);
     ~CredentialRequestCoordinator();
 
-    void ref() const final { RefCounted::ref(); }
-    void deref() const final { RefCounted::deref(); }
+    void sessionDidFinish(const DigitalCredentialsSession&);
+    void dismissChooser();
 
-    void contextDestroyed() final;
+    ExceptionOr<JSC::JSObject*> parseDigitalCredentialsResponseData(const String&) const;
 
 private:
-    void settleTheCredentialRequest(ExceptionOr<RefPtr<BasicCredential>>&&);
     void rejectTheCredentialRequestWith(Exception&&);
-    void clearAbortAlgorithm();
-
-    class InteractionStateGuard final {
-    public:
-        explicit InteractionStateGuard(CredentialRequestCoordinator&);
-        InteractionStateGuard(const InteractionStateGuard&) = delete;
-        InteractionStateGuard& operator=(const InteractionStateGuard&) = delete;
-        void deactivate() { m_active = false; }
-
-        InteractionStateGuard(InteractionStateGuard&&) noexcept = delete;
-        InteractionStateGuard& operator=(InteractionStateGuard&&) noexcept = delete;
-
-        ~InteractionStateGuard();
-
-    private:
-        WeakRef<CredentialRequestCoordinator> m_coordinator;
-        bool m_active { true };
-    }; // class InteractionStateGuard
 
     enum class InteractionState : uint8_t {
         Idle,
@@ -97,20 +80,14 @@ private:
     bool NODELETE canTransitionTo(InteractionState) const;
     InteractionState NODELETE interactionState() const;
     void NODELETE setInteractionState(InteractionState);
-    bool hasCurrentPromise() const { return !!m_currentPromise; }
-    void setCurrentPromise(CredentialPromise&&);
-    CredentialPromise* NODELETE currentPromise();
 
-    ExceptionOr<JSC::JSObject*> parseDigitalCredentialsResponseData(const String&) const;
     void initiateTheCredentialRequest(const Document&, Vector<ValidatedDigitalCredentialRequest>&&, Vector<UnvalidatedDigitalCredentialRequest>&&, RefPtr<AbortSignal>);
     void processCredentialChooserResponse(Expected<DigitalCredentialsResponseData, ExceptionData>&& responseOrException, RefPtr<AbortSignal>);
 
     explicit CredentialRequestCoordinator(Ref<CredentialRequestCoordinatorClient>&&, Page&);
     const Ref<CredentialRequestCoordinatorClient> m_client;
     InteractionState m_interactionState { InteractionState::Idle };
-    RefPtr<AbortSignal> m_abortSignal;
-    std::unique_ptr<CredentialPromise> m_currentPromise;
-    std::optional<uint32_t> m_abortAlgorithmIdentifier;
+    RefPtr<DigitalCredentialsSession> m_activeSession;
     WeakPtr<Page> m_page;
 };
 

--- a/Source/WebCore/Modules/identity/DigitalCredentialsSession.cpp
+++ b/Source/WebCore/Modules/identity/DigitalCredentialsSession.cpp
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "DigitalCredentialsSession.h"
+
+#if ENABLE(WEB_AUTHN)
+
+#include "AbortSignal.h"
+#include "CredentialRequestCoordinator.h"
+#include "Document.h"
+#include "JSDOMPromiseDeferred.h"
+#include "TaskSource.h"
+#include <Logging.h>
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(DigitalCredentialsSession);
+
+Ref<DigitalCredentialsSession> DigitalCredentialsSession::create(ScriptExecutionContext& context, CredentialRequestCoordinator& coordinator, CredentialPromise&& promise)
+{
+    Ref session = adoptRef(*new DigitalCredentialsSession(context, coordinator, WTF::move(promise)));
+    session->suspendIfNeeded();
+    return session;
+}
+
+DigitalCredentialsSession::DigitalCredentialsSession(ScriptExecutionContext& context, CredentialRequestCoordinator& coordinator, CredentialPromise&& promise)
+    : ActiveDOMObject(&context)
+    , m_coordinator(coordinator)
+    , m_promise(makeUnique<CredentialPromise>(WTF::move(promise)))
+{
+}
+
+DigitalCredentialsSession::~DigitalCredentialsSession()
+{
+    clearAbortAlgorithm();
+
+    if (m_promise)
+        m_promise->reject(Exception { ExceptionCode::AbortError, "The credential request was abandoned."_s });
+}
+
+void DigitalCredentialsSession::setAbortAlgorithm(RefPtr<AbortSignal>&& signal, uint32_t identifier)
+{
+    m_abortSignal = WTF::move(signal);
+    m_abortAlgorithmIdentifier = identifier;
+}
+
+void DigitalCredentialsSession::clearAbortAlgorithm()
+{
+    if (!m_abortAlgorithmIdentifier)
+        return;
+
+    if (RefPtr signal = m_abortSignal)
+        signal->removeAlgorithm(*m_abortAlgorithmIdentifier);
+
+    m_abortAlgorithmIdentifier.reset();
+    m_abortSignal = nullptr;
+}
+
+void DigitalCredentialsSession::queueSettlement(Function<void(CredentialPromise&)>&& settleFunction)
+{
+    queueTaskKeepingObjectAlive(*this, TaskSource::DOMManipulation, [settleFunction = WTF::move(settleFunction)](auto& session) mutable {
+        session.settle(WTF::move(settleFunction));
+    });
+}
+
+void DigitalCredentialsSession::settle(Function<void(CredentialPromise&)>&& settleFunction)
+{
+    if (!m_promise) {
+        abandon();
+        return;
+    }
+
+    clearAbortAlgorithm();
+    auto promise = WTF::move(m_promise);
+    settleFunction(*promise);
+    abandon();
+}
+
+void DigitalCredentialsSession::abandon()
+{
+    if (RefPtr coordinator = m_coordinator.get())
+        coordinator->sessionDidFinish(*this);
+}
+
+void DigitalCredentialsSession::stop()
+{
+    if (RefPtr coordinator = m_coordinator.get())
+        coordinator->dismissChooser();
+
+    queueSettlement([](auto& promise) {
+        promise.reject(Exception { ExceptionCode::AbortError, "The document was stopped."_s });
+    });
+
+    clearAbortAlgorithm();
+    abandon();
+}
+
+void DigitalCredentialsSession::suspend(ReasonForSuspension reason)
+{
+    if (reason != ReasonForSuspension::BackForwardCache)
+        return;
+
+    LOG(DigitalCredentials, "Credential request abandoned because its page entered the back/forward cache");
+    stop();
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(WEB_AUTHN)

--- a/Source/WebCore/Modules/identity/DigitalCredentialsSession.h
+++ b/Source/WebCore/Modules/identity/DigitalCredentialsSession.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEB_AUTHN)
+
+#include "ActiveDOMObject.h"
+#include "JSDOMPromiseDeferredForward.h"
+#include <optional>
+#include <wtf/Function.h>
+#include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/WeakPtr.h>
+
+namespace WebCore {
+
+class AbortSignal;
+class BasicCredential;
+class CredentialRequestCoordinator;
+class ScriptExecutionContext;
+
+using CredentialPromise = DOMPromiseDeferred<IDLNullable<IDLInterface<BasicCredential>>>;
+
+class DigitalCredentialsSession final : public RefCounted<DigitalCredentialsSession>, public ActiveDOMObject {
+    WTF_MAKE_TZONE_ALLOCATED(DigitalCredentialsSession);
+    WTF_MAKE_NONCOPYABLE(DigitalCredentialsSession);
+
+public:
+    static Ref<DigitalCredentialsSession> create(ScriptExecutionContext&, CredentialRequestCoordinator&, CredentialPromise&&);
+    ~DigitalCredentialsSession();
+
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
+    bool hasPromise() const { return !!m_promise; }
+
+    void setAbortAlgorithm(RefPtr<AbortSignal>&&, uint32_t identifier);
+    void clearAbortAlgorithm();
+
+    // https://w3c-fedid.github.io/digital-credentials/#dfn-reject-the-credential-request-with
+    void queueSettlement(Function<void(CredentialPromise&)>&&);
+
+private:
+    DigitalCredentialsSession(ScriptExecutionContext&, CredentialRequestCoordinator&, CredentialPromise&&);
+
+    void settle(Function<void(CredentialPromise&)>&&);
+    void abandon();
+
+    // ActiveDOMObject
+    void stop() final;
+    void suspend(ReasonForSuspension) final;
+
+    WeakPtr<CredentialRequestCoordinator> m_coordinator;
+    std::unique_ptr<CredentialPromise> m_promise;
+    RefPtr<AbortSignal> m_abortSignal;
+    std::optional<uint32_t> m_abortAlgorithmIdentifier;
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(WEB_AUTHN)

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -208,6 +208,7 @@ Modules/highlight/HighlightRegistry.cpp @cost:3
 Modules/identity/CredentialRequestCoordinator.cpp @cost:3
 Modules/identity/DigitalCredential.cpp @cost:3
 Modules/identity/DigitalCredentialsRequestDataBuilder.cpp
+Modules/identity/DigitalCredentialsSession.cpp
 Modules/identity/dummy/DummyCredentialRequestCoordinatorClient.cpp
 Modules/indexeddb/IDBCursor.cpp @cost:3
 Modules/indexeddb/IDBCursorWithValue.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -385,6 +385,7 @@
 		0D44C33E2ABA1B9F0017FB5D /* ThermalMitigationNotifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D8EF8122A9D511F000118F8 /* ThermalMitigationNotifier.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0D54CF61301D63D400DEB1E8 /* WebGPUFramePacer.h in Headers */ = {isa = PBXBuildFile; fileRef = 0D54CF5D301D5E6900DEB1E8 /* WebGPUFramePacer.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0D649B392B9EA4E500D7F335 /* CredentialRequestCoordinator.h in Headers */ = {isa = PBXBuildFile; fileRef = 0D649B382B9EA4E500D7F335 /* CredentialRequestCoordinator.h */; };
+		0D649B512B9EA4E500D7F335 /* DigitalCredentialsSession.h in Headers */ = {isa = PBXBuildFile; fileRef = 0D649B502B9EA4E500D7F335 /* DigitalCredentialsSession.h */; };
 		0D649B482B9EC50300D7F335 /* CredentialRequestCoordinatorClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 0D649B472B9EC4E200D7F335 /* CredentialRequestCoordinatorClient.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0D6D0AAB2C6ADA390073F63D /* WebGPUXRView.h in Headers */ = {isa = PBXBuildFile; fileRef = 0D6D0AAA2C6ADA390073F63D /* WebGPUXRView.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0D767CC52E450AFE00D323F7 /* XRCanvasConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 0D767CC42E450AFE00D323F7 /* XRCanvasConfiguration.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -8273,6 +8274,8 @@
 		0D5C81072B8B0FED0099BF96 /* WGSLLanguageFeatures.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WGSLLanguageFeatures.cpp; sourceTree = "<group>"; };
 		0D649B382B9EA4E500D7F335 /* CredentialRequestCoordinator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CredentialRequestCoordinator.h; sourceTree = "<group>"; };
 		0D649B3A2B9EA50A00D7F335 /* CredentialRequestCoordinator.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CredentialRequestCoordinator.cpp; sourceTree = "<group>"; };
+		0D649B502B9EA4E500D7F335 /* DigitalCredentialsSession.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DigitalCredentialsSession.h; sourceTree = "<group>"; };
+		0D649B522B9EA4E500D7F335 /* DigitalCredentialsSession.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = DigitalCredentialsSession.cpp; sourceTree = "<group>"; };
 		0D649B472B9EC4E200D7F335 /* CredentialRequestCoordinatorClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CredentialRequestCoordinatorClient.h; sourceTree = "<group>"; };
 		0D68A40F2C631A5F0062C559 /* XRGPUBinding.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = XRGPUBinding.h; sourceTree = "<group>"; };
 		0D68A4102C631A5F0062C559 /* XRGPUBinding.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = XRGPUBinding.cpp; sourceTree = "<group>"; };
@@ -25045,6 +25048,8 @@
 				48BFAF292F3137FA00E7D926 /* DigitalCredentialsRequestDataBuilder.h */,
 				0DE11A782C8AB2840003F6EE /* DigitalCredentialsResponseData.h */,
 				4828C31C2F35643E009D206E /* DigitalCredentialsSecurityOriginData.h */,
+				0D649B522B9EA4E500D7F335 /* DigitalCredentialsSession.cpp */,
+				0D649B502B9EA4E500D7F335 /* DigitalCredentialsSession.h */,
 			);
 			name = identity;
 			path = Modules/identity;
@@ -45334,6 +45339,7 @@
 				48BFAF2B2F3137FA00E7D926 /* DigitalCredentialsRequestDataBuilder.h in Headers */,
 				0DE11A792C8AB2950003F6EE /* DigitalCredentialsResponseData.h in Headers */,
 				4828C31D2F35643E009D206E /* DigitalCredentialsSecurityOriginData.h in Headers */,
+				0D649B512B9EA4E500D7F335 /* DigitalCredentialsSession.h in Headers */,
 				FDAF19991513D131008DB0C3 /* DirectConvolver.h in Headers */,
 				835D54C51F4DE53800E60671 /* DirectoryFileListCreator.h in Headers */,
 				F47A09D120A93A9700240FAE /* DisabledAdaptations.h in Headers */,

--- a/Source/WebKit/UIProcess/DigitalCredentials/WKDigitalCredentialsPicker.mm
+++ b/Source/WebKit/UIProcess/DigitalCredentials/WKDigitalCredentialsPicker.mm
@@ -428,6 +428,7 @@ static RetainPtr<NSArray<NSArray<WKIdentityDocumentPresentmentRequestAuthenticat
             WebCore::ExceptionData exceptionData = { ExceptionCode::TypeError, "Unknown protocol response from document."_s };
             [self completeWith:makeUnexpected(exceptionData)];
         }
+        return;
     }
 
     [self handleNSError:error];


### PR DESCRIPTION
#### 04257c5b705566a06a8b9877caec36eeac51588d
<pre>
Digital Credentials: reject and resolve paths must queue a global task per spec

<a href="https://bugs.webkit.org/show_bug.cgi?id=313736">https://bugs.webkit.org/show_bug.cgi?id=313736</a>
<a href="https://rdar.apple.com/182678875">rdar://182678875</a>

Reviewed by Pascoe.

A credential request&apos;s promise is now settled from a queued task, as the spec requires. It
used to settle straight away, or from inside the picker&apos;s dismissal callback. The promise,
the abort signal and the abort algorithm also move off the per-page coordinator and onto a
new DigitalCredentialsSession, which belongs to the document that asked for the credential.
The coordinator said it was an ActiveDOMObject, but it is created before the main frame has
a document, so it was never really registered as one. That meant nothing told it when a
document was stopped or suspended, which is why get-non-fully-active.https.html kept
failing (webkit.org/b/317884). Its mac-wk2 and ios expectations are removed.

When the picker returns an answer we no longer ask it to dismiss, because it dismisses
itself in the same call. The abort path still asks it to, since nothing there guarantees the
picker is gone before the promise settles. There is no test for a document that is suspended
and then destroyed. This also stops the picker reporting a good response twice.

Canonical link: <a href="https://commits.webkit.org/319421@main">https://commits.webkit.org/319421@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/622c04c5ab00950432378ef5d5de79a498c7a724

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181241 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55186 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48984 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191458 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145564 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2f87f9b9-c69e-4fec-bd03-2968842ef624) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183103 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56484 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54902 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141427 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98110 "3 flakes 13 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/43344df2-d3d2-4bdd-9866-66416668d389) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184196 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45108 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162188 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121878 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/73b1d839-4617-4450-af6b-f7ff3d9eb423) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43781 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42057 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154186 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41715 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2618 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47798 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46312 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193390 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54853 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161703 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150824 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40442 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55540 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38342 "") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150541 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45133 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127808 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123373 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54057 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16713 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53439 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53676 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53504 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->