### PR TITLE
Keep a view transition active for a frame after it begins animating.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/finished-promise-defers-cleanup-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/finished-promise-defers-cleanup-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL View transition cleanup is deferred until after the frame where `finished` promise resolves assert_equals: expected object "[object ViewTransition]" but got null
+PASS View transition cleanup is deferred until after the frame where `finished` promise resolves
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -12112,7 +12112,7 @@ void Document::performPendingViewTransitions()
     Ref activeViewTransition = *m_activeViewTransition;
     if (activeViewTransition->phase() == ViewTransitionPhase::PendingCapture)
         activeViewTransition->setupViewTransition();
-    else if (activeViewTransition->phase() == ViewTransitionPhase::Animating)
+    else if (activeViewTransition->isAnimating())
         activeViewTransition->handleTransitionFrame();
 
     if (m_activeViewTransition)

--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -800,7 +800,7 @@ void ViewTransition::activateViewTransition()
     if (RefPtr documentElement = document()->documentElement())
         documentElement->invalidateStyle();
 
-    m_phase = ViewTransitionPhase::Animating;
+    m_phase = ViewTransitionPhase::AnimatingFirstFrame;
 
     // Don't read pseudo-element styles, since that happened
     // as part of captureNewState.
@@ -846,12 +846,15 @@ void ViewTransition::handleTransitionFrame()
             || checkForActiveAnimations({ PseudoElementType::ViewTransitionOld, name });
     }
 
-    if (!hasActiveAnimations) {
+    if (!hasActiveAnimations && m_phase != ViewTransitionPhase::AnimatingFirstFrame) {
         m_phase = ViewTransitionPhase::Done;
         clearViewTransition();
         protect(m_finished.second)->resolve();
         return;
     }
+
+    if (m_phase == ViewTransitionPhase::AnimatingFirstFrame)
+        m_phase = ViewTransitionPhase::Animating;
 
     auto checkSize = checkForViewportSizeChange();
     if (checkSize.hasException()) {
@@ -1159,6 +1162,7 @@ TextStream& operator<<(TextStream& ts, ViewTransitionPhase phase)
     case ViewTransitionPhase::PendingCapture: ts << "PendingCapture"_s; break;
     case ViewTransitionPhase::CapturingOldState: ts << "CapturingOldState"_s; break;
     case ViewTransitionPhase::UpdateCallbackCalled: ts << "UpdateCallbackCalled"_s; break;
+    case ViewTransitionPhase::AnimatingFirstFrame: ts << "AnimatingFirstFrame"_s; break;
     case ViewTransitionPhase::Animating: ts << "Animating"_s; break;
     case ViewTransitionPhase::Done: ts << "Done"_s; break;
     }

--- a/Source/WebCore/dom/ViewTransition.h
+++ b/Source/WebCore/dom/ViewTransition.h
@@ -62,6 +62,7 @@ enum class ViewTransitionPhase : uint8_t {
     PendingCapture,
     CapturingOldState, // Not part of the spec.
     UpdateCallbackCalled,
+    AnimatingFirstFrame, // Not part of the spec.
     Animating,
     Done
 };
@@ -201,6 +202,7 @@ public:
     DOMPromise& NODELETE finished();
 
     ViewTransitionPhase phase() const { return m_phase; }
+    bool isAnimating() const { return m_phase == ViewTransitionPhase::AnimatingFirstFrame || m_phase == ViewTransitionPhase::Animating; }
     const OrderedNamedElementsMap& namedElements() const { return m_namedElements; };
 
     Document* NODELETE document() const;


### PR DESCRIPTION
#### a9a02a78f1520b5f172b90b6bce12d93615b7c81
<pre>
Keep a view transition active for a frame after it begins animating.
<a href="https://bugs.webkit.org/show_bug.cgi?id=315907">https://bugs.webkit.org/show_bug.cgi?id=315907</a>
<a href="https://rdar.apple.com/178317398">rdar://178317398</a>

Reviewed by NOBODY (OOPS!).

The transition must remain active for at least one rendering update after
entering the &quot;animating&quot; phase, regardless of the duration of its animations.
Without this, an animation with a 0ms duration reaches its finished state and
has its animation event dispatched (and cleared from the pending animation
event queue) during the &quot;update animations and send events&quot; step, which runs
before &quot;perform pending transition operations&quot; in the same rendering update.
It would then be observed by handleTransitionFrame() as already finished and
the transition would be cleaned up a frame early.

Introduce an AnimatingFirstFrame phase that is entered when the transition
begins animating. On this frame handleTransitionFrame() skips the check that
would clean the transition up, deferring the earliest possible cleanup to the
next rendering update. It still performs the per-frame pseudo-element style and
renderer updates, so the pseudo-elements are positioned from the live layout on
the first animating frame.

See the discussion at <a href="https://github.com/w3c/csswg-drafts/issues/7785.">https://github.com/w3c/csswg-drafts/issues/7785.</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/finished-promise-defers-cleanup-expected.txt:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::performPendingViewTransitions):
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::ViewTransition::activateViewTransition):
(WebCore::ViewTransition::handleTransitionFrame):
(WebCore::operator&lt;&lt;):
* Source/WebCore/dom/ViewTransition.h:
(WebCore::ViewTransition::isAnimating const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9a02a78f1520b5f172b90b6bce12d93615b7c81

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174867 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48800 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42581 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184447 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132775 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176732 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50092 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48483 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136081 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96042 "3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/180ef775-3580-4f66-9536-fba55fc876d4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177825 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39522 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156872 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116560 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dfaba036-23cc-4199-ba78-1afede9943b9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38163 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36542 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32925 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148586 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36364 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186872 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/40302 "Found 119 new failures in b3/B3Value.h, b3/testb3_7.cpp, WebProcess/Network/WebResourceLoader.cpp, UIProcess/WebProcessPool.cpp, Shared/Cocoa/WKNSArray.mm, Shared/SessionState.cpp, NetworkProcess/NetworkResourceLoadParameters.cpp, WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm, WebProcess/WebPage/WebPage.cpp, WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm ...") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40743 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145013 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48467 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144871 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49147 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32985 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114958 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39746 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121249 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47653 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11334 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47055 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47286 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47113 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->