### PR TITLE
[scroll-animations] View timeline sticky adjustment wrong for subject taller than the scrollport

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/sticky/view-timeline-sticky-offscreen-7-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/sticky/view-timeline-sticky-offscreen-7-expected.txt
@@ -1,4 +1,4 @@
 Subject
 
-FAIL View timeline target > viewport, bottom-sticky and top-sticky during contain. assert_approx_equals: Effect at the midpoint of the active range: contain 0% to contain 100% expected 0.5 +/- 0.001 but got 0.3
+PASS View timeline target > viewport, bottom-sticky and top-sticky during contain.
 

--- a/Source/WebCore/animation/ViewTimeline.cpp
+++ b/Source/WebCore/animation/ViewTimeline.cpp
@@ -222,6 +222,8 @@ StickinessAdjustmentData StickinessAdjustmentData::computeStickinessAdjustmentDa
         float subjectPositionInScroller = stickyBoxStuckPosition + subjectOffset - stickyBoxStaticPosition;
         if (subjectPositionInScroller > scrollContainerSize)
             return StickinessLocation::BeforeEntry;
+        if (subjectPositionInScroller < 0 && subjectPositionInScroller + subjectSize > scrollContainerSize)
+            return StickinessLocation::WhileCovering;
         if (subjectPositionInScroller + subjectSize > scrollContainerSize)
             return StickinessLocation::DuringEntry;
         if (subjectPositionInScroller + subjectSize < 0)
@@ -256,9 +258,9 @@ StickinessAdjustmentData StickinessAdjustmentData::computeStickinessAdjustmentDa
 float StickinessAdjustmentData::entryDistanceAdjustment() const
 {
     float entryDistanceAdjustment = 0;
-    if (topOrLeftAdjustmentLocation == StickinessLocation::DuringEntry)
+    if (topOrLeftAdjustmentLocation == StickinessLocation::DuringEntry || topOrLeftAdjustmentLocation == StickinessLocation::WhileCovering)
         entryDistanceAdjustment += stickyTopOrLeftAdjustment;
-    if (bottomOrRightAdjustmentLocation == StickinessLocation::DuringEntry)
+    if (bottomOrRightAdjustmentLocation == StickinessLocation::DuringEntry || bottomOrRightAdjustmentLocation == StickinessLocation::WhileCovering)
         entryDistanceAdjustment -= stickyBottomOrRightAdjustment;
     return entryDistanceAdjustment;
 }
@@ -266,9 +268,9 @@ float StickinessAdjustmentData::entryDistanceAdjustment() const
 float StickinessAdjustmentData::exitDistanceAdjustment() const
 {
     float exitDistanceAdjustment = 0;
-    if (topOrLeftAdjustmentLocation == StickinessLocation::DuringExit)
+    if (topOrLeftAdjustmentLocation == StickinessLocation::DuringExit || topOrLeftAdjustmentLocation == StickinessLocation::WhileCovering)
         exitDistanceAdjustment += stickyTopOrLeftAdjustment;
-    if (bottomOrRightAdjustmentLocation == StickinessLocation::DuringExit)
+    if (bottomOrRightAdjustmentLocation == StickinessLocation::DuringExit || bottomOrRightAdjustmentLocation == StickinessLocation::WhileCovering)
         exitDistanceAdjustment -= stickyBottomOrRightAdjustment;
     return exitDistanceAdjustment;
 }
@@ -672,6 +674,7 @@ WTF::TextStream& operator<<(WTF::TextStream& ts, const StickinessAdjustmentData:
     case StickinessAdjustmentData::StickinessLocation::BeforeEntry: ts << "BeforeEntry"_s; break;
     case StickinessAdjustmentData::StickinessLocation::DuringEntry: ts << "DuringEntry"_s; break;
     case StickinessAdjustmentData::StickinessLocation::WhileContained: ts << "WhileContained"_s; break;
+    case StickinessAdjustmentData::StickinessLocation::WhileCovering: ts << "WhileCovering"_s; break;
     case StickinessAdjustmentData::StickinessLocation::DuringExit: ts << "DuringExit"_s; break;
     case StickinessAdjustmentData::StickinessLocation::AfterExit: ts << "AfterExit"_s; break;
     }

--- a/Source/WebCore/animation/ViewTimeline.h
+++ b/Source/WebCore/animation/ViewTimeline.h
@@ -52,6 +52,7 @@ struct StickinessAdjustmentData {
         BeforeEntry,
         DuringEntry,
         WhileContained,
+        WhileCovering,
         DuringExit,
         AfterExit
     };


### PR DESCRIPTION
#### 1e9c4e439f91b540db00407136c9b9b9c30959cb
<pre>
[scroll-animations] View timeline sticky adjustment wrong for subject taller than the scrollport
<a href="https://bugs.webkit.org/show_bug.cgi?id=288913">https://bugs.webkit.org/show_bug.cgi?id=288913</a>
<a href="https://rdar.apple.com/146546693">rdar://146546693</a>

Reviewed by Antoine Quint.

A view-timeline subject taller than the scrollport is simultaneously entering
and exiting while it covers the scrollport, but computeSubjectStickinessLocation()
classified both anchors as DuringEntry (that check ran first), so
exitDistanceAdjustment() returned 0 and the contain/entry/exit-crossing ranges
were unadjusted for stickiness.

Add a WhileCovering location (checked before DuringEntry) that contributes to
both the entry and exit distance adjustments. Only an oversized subject can
satisfy it, so other cases are unaffected.

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/sticky/view-timeline-sticky-offscreen-7-expected.txt: Progression
* Source/WebCore/animation/ViewTimeline.cpp:
(WebCore::StickinessAdjustmentData::computeStickinessAdjustmentData):
(WebCore::StickinessAdjustmentData::entryDistanceAdjustment const):
(WebCore::StickinessAdjustmentData::exitDistanceAdjustment const):
(WebCore::operator&lt;&lt;):
* Source/WebCore/animation/ViewTimeline.h:

Canonical link: <a href="https://commits.webkit.org/317348@main">https://commits.webkit.org/317348@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5a09ed45fa1d8edfbaf89927e630daf29d0af5ce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175015 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48948 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42729 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184596 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/132923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/91238e95-b7b6-4961-98d6-e4269e7ec7e5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176880 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50240 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48631 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/136218 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/132923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/18fc8867-1f44-45e7-99c1-f7f42f2a505e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177973 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39650 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157011 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116697 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9baff800-7ed8-44df-b293-0525bb24bb81) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38291 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33073 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148714 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36503 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187020 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/40528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40880 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145153 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48615 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145010 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39072 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49295 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115113 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39874 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/121434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47801 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11476 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47204 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47434 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47261 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->