### PR TITLE
[JSC] for-await fast consumer must re-check the Promise species watchpoint

### DIFF
--- a/JSTests/stress/async-generator-fast-consumer-species-tamper-during.js
+++ b/JSTests/stress/async-generator-fast-consumer-species-tamper-during.js
@@ -1,0 +1,56 @@
+// for-await fast driver must still perform the observable PromiseResolve (Promise.prototype.constructor lookup)
+// when the Promise species is tampered mid-loop, after op_async_iterator_open. Async-generator variant.
+// Count verified against V8 and SpiderMonkey.
+
+function assert(cond, message) {
+    if (!cond)
+        throw new Error("Assertion failed: " + message);
+}
+
+const savedCtorDesc = Object.getOwnPropertyDescriptor(Promise.prototype, "constructor");
+function armReadCounter(counter) {
+    Object.defineProperty(Promise.prototype, "constructor", {
+        configurable: true,
+        get() { counter.n++; return Promise; },
+    });
+}
+function restoreCtor() {
+    Object.defineProperty(Promise.prototype, "constructor", savedCtorDesc);
+}
+
+async function asyncGeneratorTamperDuring(tamper) {
+    const counter = { n: 0 };
+    let armed = false;
+    async function* g() { yield 1; yield 2; yield 3; }
+    const seq = [];
+    for await (const x of g()) {
+        seq.push(x);
+        if (tamper && !armed) {
+            armed = true;
+            armReadCounter(counter);
+        }
+    }
+    if (tamper)
+        restoreCtor();
+    return counter.n + "|" + seq.join(",");
+}
+
+let done = false;
+let error = null;
+
+async function main() {
+    const N = testLoopCount;
+    for (let i = 0; i < N; i++)
+        assert((await asyncGeneratorTamperDuring(false)) === "0|1,2,3", "warm iteration " + i);
+
+    assert((await asyncGeneratorTamperDuring(true)) === "3|1,2,3", "async-gen tamper-during");
+}
+
+main().then(() => { done = true; }, (e) => { error = e; });
+
+drainMicrotasks();
+
+restoreCtor();
+if (error)
+    throw error;
+assert(done, "async main() did not complete");

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -13000,7 +13000,12 @@ void ByteCodeParser::handleAsyncIteratorOpen(const JSInstruction* currentInstruc
         // Advance symbolCall (0) -> getNext (1). m_iterator is now defined and flushed, so an OSR exit at
         // getNext lands in handleAsyncIteratorOpenCheckpoint, which reads R[m_iterator].next into m_next.
         progressToNextCheckpoint();
-        emitGetNext(/* reclassify */ true);
+        // Sentinel only while the species is primordial; the watchpoint deopts us on later tamper.
+        if (globalObject->promiseSpeciesWatchpointSet().state() == IsWatched) {
+            m_graph.watchpoints().addLazily(globalObject->promiseSpeciesWatchpointSet());
+            emitGetNext(/* reclassify */ true);
+        } else
+            emitGetNext(/* reclassify */ false);
 
         m_currentIndex = startIndex;
     }

--- a/Source/JavaScriptCore/jit/JITCall.cpp
+++ b/Source/JavaScriptCore/jit/JITCall.cpp
@@ -615,16 +615,15 @@ void JIT::emit_op_async_iterator_next(const JSInstruction* instruction)
     or32(TrustedImm32(static_cast<uint16_t>(IterationMode::FastAsyncGenerator)), regT0);
     store16ToMetadata(regT0, bytecode, OpAsyncIteratorNext::Metadata::offsetOfIterationMetadata() + IterationModeMetadata::offsetOfSeenModes());
 
-    using SlowOperation = decltype(operationEnqueueAsyncGeneratorDriver);
+    using SlowOperation = decltype(operationAsyncIteratorNextWithDriver);
     constexpr GPRReg globalObjectGPR = preferredArgumentGPR<SlowOperation, 0>();
     constexpr GPRReg iteratorGPR = preferredArgumentGPR<SlowOperation, 1>();
     constexpr GPRReg driverGPR = preferredArgumentGPR<SlowOperation, 2>();
     emitGetVirtualRegisterPayload(bytecode.m_iterator, iteratorGPR);
     emitGetVirtualRegisterPayload(bytecode.m_driver, driverGPR);
     loadGlobalObject(globalObjectGPR);
-    callOperation(operationEnqueueAsyncGeneratorDriver, globalObjectGPR, iteratorGPR, driverGPR);
-    moveTrustedValue(JSValue(vm().fastAsyncGeneratorSentinel()), resultJSR);
-    emitPutVirtualRegister(bytecode.m_dst, resultJSR);
+    callOperation(operationAsyncIteratorNextWithDriver, globalObjectGPR, iteratorGPR, driverGPR);
+    emitPutVirtualRegister(bytecode.m_dst, returnValueJSR);
     Jump doneCase = jump();
 
     genericCases.link(this);

--- a/Source/JavaScriptCore/jit/JITOperations.cpp
+++ b/Source/JavaScriptCore/jit/JITOperations.cpp
@@ -2916,6 +2916,16 @@ JSC_DEFINE_JIT_OPERATION(operationEnqueueAsyncGeneratorDriver, void, (JSGlobalOb
     OPERATION_RETURN(scope);
 }
 
+JSC_DEFINE_JIT_OPERATION(operationAsyncIteratorNextWithDriver, EncodedJSValue, (JSGlobalObject* globalObject, JSObject* iterator, JSObject* driver))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    OPERATION_RETURN(scope, JSValue::encode(asyncIteratorNextWithDriver(globalObject, iterator, driver)));
+}
+
 JSC_DEFINE_JIT_OPERATION(operationNewObject, JSCell*, (VM* vmPointer, Structure* structure))
 {
     VM& vm = *vmPointer;

--- a/Source/JavaScriptCore/jit/JITOperations.h
+++ b/Source/JavaScriptCore/jit/JITOperations.h
@@ -358,6 +358,7 @@ JSC_DECLARE_JIT_OPERATION(operationNewAsyncGeneratorFunction, EncodedJSValue, (J
 JSC_DECLARE_JIT_OPERATION(operationNewAsyncGeneratorFunctionWithInvalidatedReallocationWatchpoint, EncodedJSValue, (JSGlobalObject*, JSScope*, JSCell*));
 JSC_DECLARE_JIT_OPERATION(operationSetFunctionName, void, (JSGlobalObject*, JSCell*, EncodedJSValue));
 JSC_DECLARE_JIT_OPERATION(operationEnqueueAsyncGeneratorDriver, void, (JSGlobalObject*, JSAsyncGenerator*, JSObject*));
+JSC_DECLARE_JIT_OPERATION(operationAsyncIteratorNextWithDriver, EncodedJSValue, (JSGlobalObject*, JSObject*, JSObject*));
 JSC_DECLARE_JIT_OPERATION(operationNewObject, JSCell*, (VM*, Structure*));
 JSC_DECLARE_JIT_OPERATION(operationNewPromise, JSCell*, (VM*, Structure*));
 JSC_DECLARE_JIT_OPERATION(operationNewGenerator, JSCell*, (VM*, Structure*));

--- a/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
@@ -2023,10 +2023,10 @@ LLINT_SLOW_PATH_DECL(slow_path_async_iterator_next_with_driver)
     auto bytecode = pc->as<OpAsyncIteratorNext>();
     auto& metadata = bytecode.metadata(codeBlock);
     metadata.m_iterationMetadata.seenModes = metadata.m_iterationMetadata.seenModes | IterationMode::FastAsyncGenerator;
-    JSAsyncGenerator* iterator = uncheckedDowncast<JSAsyncGenerator>(getNonConstantOperand(callFrame, bytecode.m_iterator));
+    JSObject* iterator = asObject(getNonConstantOperand(callFrame, bytecode.m_iterator).asCell());
     auto* driver = asObject(getNonConstantOperand(callFrame, bytecode.m_driver).asCell());
-    enqueueAsyncGeneratorDriver(globalObject, iterator, driver);
-    LLINT_RETURN(vm.fastAsyncGeneratorSentinel());
+    JSValue result = asyncIteratorNextWithDriver(globalObject, iterator, driver);
+    LLINT_RETURN(result);
 }
 
 static UGPRPair handleHostCall(CallFrame* calleeFrame, JSValue callee, CodeSpecializationKind kind)

--- a/Source/JavaScriptCore/runtime/AsyncGeneratorPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/AsyncGeneratorPrototype.cpp
@@ -55,18 +55,10 @@ const ClassInfo AsyncGeneratorPrototype::s_info = { "AsyncGenerator"_s, &Base::s
 */
 
 // https://tc39.es/ecma262/#sec-asyncgenerator-prototype-next
-JSC_DEFINE_HOST_FUNCTION(asyncGeneratorPrototypeNext, (JSGlobalObject* globalObject, CallFrame* callFrame))
+JSValue asyncGeneratorNext(JSGlobalObject* globalObject, JSAsyncGenerator* generator, JSValue argument)
 {
     VM& vm = globalObject->vm();
     auto* promise = JSPromise::create(vm, globalObject->promiseStructure());
-
-    // 3. Let result be Completion(AsyncGeneratorValidate(gen, empty)).
-    // 4. IfAbruptRejectPromise(result, promiseCapability).
-    auto* generator = dynamicDowncast<JSAsyncGenerator>(callFrame->thisValue());
-    if (!generator) [[unlikely]] {
-        promise->reject(vm, createTypeError(globalObject, "|this| should be an async generator"_s));
-        return JSValue::encode(promise);
-    }
 
     // 5. Let state be gen.[[AsyncGeneratorState]].
     int32_t state = generator->state();
@@ -76,12 +68,12 @@ JSC_DEFINE_HOST_FUNCTION(asyncGeneratorPrototypeNext, (JSGlobalObject* globalObj
         // 6.b. Perform ! Call(promiseCapability.[[Resolve]], undefined, « iteratorResult »).
         auto* iteratorResult = createIteratorResultObject(globalObject, jsUndefined(), /* done */ true);
         promise->resolve(globalObject, vm, iteratorResult);
-        return JSValue::encode(promise);
+        return promise;
     }
 
     // 7. Let completion be NormalCompletion(value).
     // 8. Perform AsyncGeneratorEnqueue(gen, completion, promiseCapability).
-    generator->enqueue(vm, callFrame->argument(0), static_cast<int32_t>(JSGenerator::ResumeMode::NormalMode), promise);
+    generator->enqueue(vm, argument, static_cast<int32_t>(JSGenerator::ResumeMode::NormalMode), promise);
 
     // 9. If state is either suspended-start or suspended-yield, then
     if (state == static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorState::Init) || JSAsyncGenerator::isSuspendedYieldState(state)) {
@@ -94,7 +86,23 @@ JSC_DEFINE_HOST_FUNCTION(asyncGeneratorPrototypeNext, (JSGlobalObject* globalObj
     }
 
     // 11. Return promiseCapability.[[Promise]].
-    return JSValue::encode(promise);
+    return promise;
+}
+
+JSC_DEFINE_HOST_FUNCTION(asyncGeneratorPrototypeNext, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+
+    // 3. Let result be Completion(AsyncGeneratorValidate(gen, empty)).
+    // 4. IfAbruptRejectPromise(result, promiseCapability).
+    auto* generator = dynamicDowncast<JSAsyncGenerator>(callFrame->thisValue());
+    if (!generator) [[unlikely]] {
+        auto* promise = JSPromise::create(vm, globalObject->promiseStructure());
+        promise->reject(vm, createTypeError(globalObject, "|this| should be an async generator"_s));
+        return JSValue::encode(promise);
+    }
+
+    return JSValue::encode(asyncGeneratorNext(globalObject, generator, callFrame->argument(0)));
 }
 
 // https://tc39.es/ecma262/#sec-asyncgenerator-prototype-return

--- a/Source/JavaScriptCore/runtime/CommonSlowPaths.cpp
+++ b/Source/JavaScriptCore/runtime/CommonSlowPaths.cpp
@@ -980,8 +980,12 @@ ALWAYS_INLINE UGPRPair asyncIteratorOpenTryFastImpl(VM& vm, JSGlobalObject* glob
         RETURN_IF_EXCEPTION(throwScope, encodeResult(nullptr, reinterpret_cast<void*>(static_cast<uintptr_t>(IterationMode::Generic))));
     }
 
-    if (iterationMode != IterationMode::Generic && !canUseFastIterationMode(metadata.m_iterationMetadata.seenModes, iterationMode)) [[unlikely]]
-        iterationMode = IterationMode::Generic;
+    if (iterationMode != IterationMode::Generic) {
+        if (!canUseFastIterationMode(metadata.m_iterationMetadata.seenModes, iterationMode)) [[unlikely]]
+            iterationMode = IterationMode::Generic;
+        else if (globalObject->promiseSpeciesWatchpointSet().state() != IsWatched) [[unlikely]]
+            iterationMode = IterationMode::Generic;
+    }
 
     if (iterationMode == IterationMode::FastAsyncGenerator) {
         metadata.m_iterationMetadata.seenModes = metadata.m_iterationMetadata.seenModes | IterationMode::FastAsyncGenerator;

--- a/Source/JavaScriptCore/runtime/JSAsyncGenerator.h
+++ b/Source/JavaScriptCore/runtime/JSAsyncGenerator.h
@@ -209,4 +209,6 @@ private:
     void finishCreation(VM&);
 };
 
+JSValue asyncGeneratorNext(JSGlobalObject*, JSAsyncGenerator*, JSValue argument);
+
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSMicrotask.cpp
+++ b/Source/JavaScriptCore/runtime/JSMicrotask.cpp
@@ -627,6 +627,18 @@ void enqueueAsyncGeneratorDriver(JSGlobalObject* globalObject, JSAsyncGenerator*
         asyncGeneratorResume(globalObject, iterator);
 }
 
+JSValue asyncIteratorNextWithDriver(JSGlobalObject* globalObject, JSObject* iterator, JSObject* driver)
+{
+    VM& vm = globalObject->vm();
+    auto* generator = uncheckedDowncast<JSAsyncGenerator>(iterator);
+
+    if (globalObject->promiseSpeciesWatchpointSet().state() != IsWatched) [[unlikely]]
+        return asyncGeneratorNext(globalObject, generator, jsUndefined());
+
+    enqueueAsyncGeneratorDriver(globalObject, generator, driver);
+    return vm.fastAsyncGeneratorSentinel();
+}
+
 // https://tc39.es/ecma262/#sec-asyncgeneratoryield
 static void asyncGeneratorYield(JSGlobalObject* globalObject, JSAsyncGenerator* generator, JSValue value, MicrotaskCallCache* microtaskCallCache)
 {

--- a/Source/JavaScriptCore/runtime/JSMicrotask.h
+++ b/Source/JavaScriptCore/runtime/JSMicrotask.h
@@ -43,6 +43,8 @@ void asyncGeneratorAwaitReturn(JSGlobalObject*, JSAsyncGenerator*);
 
 void enqueueAsyncGeneratorDriver(JSGlobalObject*, JSAsyncGenerator* iterator, JSObject* driver);
 
+JSValue asyncIteratorNextWithDriver(JSGlobalObject*, JSObject* iterator, JSObject* driver);
+
 JSC_DECLARE_HOST_FUNCTION(asyncFunctionDrive);
 
 } // namespace JSC


### PR DESCRIPTION
#### 605bd7edf69445e082f71fc5b288b68b28c36045
<pre>
[JSC] for-await fast consumer must re-check the Promise species watchpoint
<a href="https://bugs.webkit.org/show_bug.cgi?id=319530">https://bugs.webkit.org/show_bug.cgi?id=319530</a>
<a href="https://rdar.apple.com/182353926">rdar://182353926</a>

Reviewed by Yijia Huang.

FastAsyncGenerator fast path should skip promise creation only when
promise watchpoint is not fired since PromiseResolve accesses promise.constructor,
so if we are setting a getter in Promise.prototype.constructor etc.,
skipping this is observable.

1. LLInt and Baseline checks this watchpoint. And going to the slow path
   when it is already fired.
2. In DFG / FTL, subscribing this watchpoint and calling a fast path. If
   this watchpoint is already fired, going to the slow path code.

Test: JSTests/stress/async-generator-fast-consumer-species-tamper-during.js

* JSTests/stress/async-generator-fast-consumer-species-tamper-during.js: Added.
(assert):
(armReadCounter):
(get restoreCtor):
(async asyncGeneratorTamperDuring.async g):
(async asyncGeneratorTamperDuring):
(async main):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleAsyncIteratorOpen):
* Source/JavaScriptCore/jit/JITCall.cpp:
(JSC::JIT::emit_op_async_iterator_next):
* Source/JavaScriptCore/jit/JITOperations.cpp:
(JSC::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/jit/JITOperations.h:
* Source/JavaScriptCore/llint/LLIntSlowPaths.cpp:
(JSC::LLInt::LLINT_SLOW_PATH_DECL):
* Source/JavaScriptCore/runtime/AsyncGeneratorPrototype.cpp:
(JSC::asyncGeneratorNext):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/CommonSlowPaths.cpp:
(JSC::asyncIteratorOpenTryFastImpl):
* Source/JavaScriptCore/runtime/JSAsyncGenerator.h:
* Source/JavaScriptCore/runtime/JSMicrotask.cpp:
(JSC::asyncIteratorNextWithDriver):
* Source/JavaScriptCore/runtime/JSMicrotask.h:

Canonical link: <a href="https://commits.webkit.org/317320@main">https://commits.webkit.org/317320@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/813180888aea5b2e569a2b6e7dfb8b06d5dd16fe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174850 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48783 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42564 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184430 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132758 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2e561434-c72e-4b7e-803b-ba7d40ad53f5) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50075 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48466 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136069 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8962f105-384e-40f1-a50b-e37dace66ab4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177808 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39503 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156858 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116548 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/18e816d8-fbf1-4ce0-bd23-51ebc61e36b2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38144 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36525 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32908 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5367 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148567 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36350 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186855 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/36112 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/40320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40725 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144997 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48450 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144856 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49130 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32971 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114941 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26576 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39727 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/121323 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/211942 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47636 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11320 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55280 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47038 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47269 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47096 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->