### PR TITLE
[JSC][Temporal] Consolidate InterpretTemporalDateTimeFields into one implementation

### DIFF
--- a/JSTests/stress/temporal-zoned-date-time-with-era-calendar.js
+++ b/JSTests/stress/temporal-zoned-date-time-with-era-calendar.js
@@ -121,3 +121,20 @@ function shouldThrow(func, errorType) {
     shouldBe(result.month, 3);
     shouldBe(result.day, 15);
 }
+
+{
+    // hebrew, year only — no month/monthCode → TypeError.
+    shouldThrow(() => Temporal.ZonedDateTime.from({
+        year: 5784, day: 1, calendar: "hebrew", timeZone: "UTC"
+    }), TypeError);
+
+    // hebrew with era+eraYear only, no month/monthCode → still TypeError.
+    shouldThrow(() => Temporal.ZonedDateTime.from({
+        era: "am", eraYear: 5784, day: 1, calendar: "hebrew", timeZone: "UTC"
+    }), TypeError);
+
+    // gregory (ISO-like) year only — same TypeError path.
+    shouldThrow(() => Temporal.ZonedDateTime.from({
+        year: 2024, day: 1, calendar: "gregory", timeZone: "UTC"
+    }), TypeError);
+}

--- a/Source/JavaScriptCore/runtime/TemporalCalendar.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalCalendar.cpp
@@ -38,6 +38,7 @@
 #include "TemporalPlainDate.h"
 #include "TemporalPlainDateTime.h"
 #include "TemporalPlainMonthDay.h"
+#include "TemporalPlainTime.h"
 #include "TemporalPlainYearMonth.h"
 #include "TemporalZonedDateTime.h"
 #include "TimeZoneICUBridge.h"
@@ -491,6 +492,39 @@ ISO8601::PlainDate isoDateFromFields(JSGlobalObject* globalObject, TemporalDateF
     }
 
     return plainDate;
+}
+
+// https://tc39.es/proposal-temporal/#sec-temporal-interprettemporaldatetimefields
+ISO8601::PlainDateTime interpretTemporalDateTimeFields(JSGlobalObject* globalObject, CalendarID calendarId,
+    const TemporalCore::CalendarFieldsIn& dateFields, const TemporalCore::TimeFieldsIn& timeFields,
+    TemporalOverflow overflow)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    // Step 1: isoDate = ? CalendarDateFromFields(calendar, fields, overflow).
+    auto dateResult = TemporalCore::dateFromFields(calendarId, dateFields, overflow);
+    if (!dateResult) [[unlikely]] {
+        if (dateResult.error().kind == TemporalErrorKind::TypeError)
+            throwTypeError(globalObject, scope, String(dateResult.error().message));
+        else
+            throwRangeError(globalObject, scope, String(dateResult.error().message));
+        return { };
+    }
+
+    // Step 2: time = ? RegulateTime(...).
+    ISO8601::Duration timeDur;
+    timeDur.setField(TemporalUnit::Hour, timeFields.hour.value_or(0));
+    timeDur.setField(TemporalUnit::Minute, timeFields.minute.value_or(0));
+    timeDur.setField(TemporalUnit::Second, timeFields.second.value_or(0));
+    timeDur.setField(TemporalUnit::Millisecond, timeFields.millisecond.value_or(0));
+    timeDur.setField(TemporalUnit::Microsecond, timeFields.microsecond.value_or(0));
+    timeDur.setField(TemporalUnit::Nanosecond, timeFields.nanosecond.value_or(0));
+    auto plainTime = TemporalPlainTime::regulateTime(globalObject, WTF::move(timeDur), overflow);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    // Step 3: Return CombineISODateAndTimeRecord(isoDate, time).
+    return ISO8601::PlainDateTime(dateResult->isoDate, plainTime);
 }
 
 ISO8601::PlainDate isoDateAdd(JSGlobalObject* globalObject, const ISO8601::PlainDate& plainDate, const ISO8601::Duration& duration, TemporalOverflow overflow)

--- a/Source/JavaScriptCore/runtime/TemporalCalendar.h
+++ b/Source/JavaScriptCore/runtime/TemporalCalendar.h
@@ -45,6 +45,8 @@ std::optional<ParsedMonthCode> parseMonthCode(JSGlobalObject*, JSValue argument)
 
 ISO8601::PlainDate isoDateFromFields(JSGlobalObject*, TemporalDateFormat, int32_t, uint32_t, uint32_t, std::optional<ParsedMonthCode>, TemporalOverflow, CalendarID = iso8601CalendarID());
 
+ISO8601::PlainDateTime interpretTemporalDateTimeFields(JSGlobalObject*, CalendarID, const TemporalCore::CalendarFieldsIn&, const TemporalCore::TimeFieldsIn&, TemporalOverflow);
+
 ISO8601::PlainDate isoDateAdd(JSGlobalObject*, const ISO8601::PlainDate&, const ISO8601::Duration&, TemporalOverflow);
 ISO8601::PlainDate calendarDateAdd(JSGlobalObject*, CalendarID, const ISO8601::PlainDate&, const ISO8601::Duration&, TemporalOverflow);
 ISO8601::Duration calendarDateUntil(CalendarID, const ISO8601::PlainDate&, const ISO8601::PlainDate&, TemporalUnit);

--- a/Source/JavaScriptCore/runtime/TemporalDuration.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalDuration.cpp
@@ -213,31 +213,6 @@ static Int128 add24HourDaysToTimeDuration(JSGlobalObject* globalObject, Int128 d
     return *result;
 }
 
-// https://tc39.es/proposal-temporal/#sec-temporal-calendardatefromfields
-static ISO8601::PlainDate resolvePlainDateFromFields(JSGlobalObject* globalObject, CalendarID calendarId,
-    bool calHasEras, const std::optional<String>& era, const std::optional<double>& eraYear,
-    bool yearAbsent, double year, double month, double day, std::optional<ParsedMonthCode> monthCode)
-{
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    if (calHasEras && era && eraYear) {
-        std::optional<StringView> eraSV = StringView(*era);
-        std::optional<int32_t> yearOpt = yearAbsent ? std::nullopt : std::optional<int32_t>(clampTo<int32_t>(year));
-        auto result = TemporalCore::calendarDateFromFields(calendarId, yearOpt,
-            clampTo<uint8_t>(month), clampTo<uint8_t>(day),
-            eraSV, std::optional<int32_t>(clampTo<int32_t>(*eraYear)), monthCode, TemporalOverflow::Constrain);
-        if (!result) [[unlikely]] {
-            throwRangeError(globalObject, scope, String(result.error().message));
-            return { };
-        }
-        return *result;
-    }
-    RELEASE_AND_RETURN(scope, isoDateFromFields(globalObject, TemporalDateFormat::Date,
-        clampTo<int32_t>(year), clampTo<uint32_t>(month), clampTo<uint32_t>(day),
-        monthCode, TemporalOverflow::Constrain));
-}
-
 // Helper: calendar-aware date addition. Uses calendarDateAdd for non-ISO, isoDateAdd for ISO.
 // https://tc39.es/proposal-temporal/#sec-temporal-calendardateadd
 static ISO8601::PlainDate calendarAwareDateAdd(JSGlobalObject* globalObject, CalendarID calendarId, const ISO8601::PlainDate& date, const ISO8601::Duration& duration, TemporalOverflow overflow)
@@ -467,6 +442,21 @@ static RelativeToRecord toRelativeTemporalObject(JSGlobalObject* globalObject, J
             }
         }
 
+        // Step 5.f: dateTimeResult = ? InterpretTemporalDateTimeFields(calendar, fields, ~constrain~).
+        TemporalCore::CalendarFieldsIn dateFields;
+        if (!yearProperty.isUndefined())
+            dateFields.year = clampTo<int32_t>(year);
+        if (!monthProperty.isUndefined())
+            dateFields.month = clampTo<uint32_t>(month);
+        if (otherMonth)
+            dateFields.monthCode = otherMonth;
+        dateFields.day = clampTo<uint8_t>(day);
+        if (era)
+            dateFields.era = *era;
+        if (eraYear)
+            dateFields.eraYear = clampTo<int32_t>(*eraYear);
+        TemporalCore::TimeFieldsIn timeFields { hour, minute, second, millisecond, microsecond, nanosecond };
+
         // Both paths (object step 5.g, string step 6.e/6.f) set timeZone before reaching here.
         if (!timeZoneValue.isUndefined()) {
             // Steps 8-9: compute offsetNs based on offsetBehaviour.
@@ -476,19 +466,10 @@ static RelativeToRecord toRelativeTemporalObject(JSGlobalObject* globalObject, J
             ASSERT(timeZoneOpt);
             TimeZone timeZone = *timeZoneOpt;
 
-            auto plainDate = resolvePlainDateFromFields(globalObject, calendarId,
-                calHasEras, era, eraYear, yearProperty.isUndefined(), year, month, day, otherMonth);
+            auto pdt = interpretTemporalDateTimeFields(globalObject, calendarId, dateFields, timeFields, TemporalOverflow::Constrain);
             RETURN_IF_EXCEPTION(scope, { });
-
-            ISO8601::Duration timeDur;
-            timeDur.setField(TemporalUnit::Hour, hour);
-            timeDur.setField(TemporalUnit::Minute, minute);
-            timeDur.setField(TemporalUnit::Second, second);
-            timeDur.setField(TemporalUnit::Millisecond, millisecond);
-            timeDur.setField(TemporalUnit::Microsecond, microsecond);
-            timeDur.setField(TemporalUnit::Nanosecond, nanosecond);
-            auto plainTime = TemporalPlainTime::regulateTime(globalObject, WTF::move(timeDur), TemporalOverflow::Constrain);
-            RETURN_IF_EXCEPTION(scope, { });
+            auto plainDate = pdt.date;
+            auto plainTime = pdt.time;
 
             // offsetBehaviour = ~option~: find the candidate whose UTC offset exactly equals givenOffsetNs
             // (offsetOption = ~reject~, matchBehaviour = ~match-exactly~ → steps 10-12).
@@ -526,11 +507,10 @@ static RelativeToRecord toRelativeTemporalObject(JSGlobalObject* globalObject, J
         }
 
         // Step 7: timeZone is ~unset~ → return { [[PlainRelativeTo]]: CreateTemporalDate(isoDate, calendar) }.
-        // Time/offset fields were read for Proxy observability but are unused in this path.
-        auto plainDate = resolvePlainDateFromFields(globalObject, calendarId,
-            calHasEras, era, eraYear, yearProperty.isUndefined(), year, month, day, otherMonth);
+        // Time fields were read for Proxy observability; we discard the regulated time here.
+        auto pdt = interpretTemporalDateTimeFields(globalObject, calendarId, dateFields, timeFields, TemporalOverflow::Constrain);
         RETURN_IF_EXCEPTION(scope, { });
-        return RelativeToRecord { nullptr, plainDate, true, calendarId };
+        return RelativeToRecord { nullptr, pdt.date, true, calendarId };
     }
 
     // Step 6: If value is not a String, throw TypeError.

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateTime.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateTime.cpp
@@ -144,8 +144,8 @@ static TemporalPlainDateTime* fromImpl(JSGlobalObject* globalObject, JSValue ite
         }
 
         // hour, microsecond, millisecond, minute (time fields interleaved before month)
-        ISO8601::Duration timeDuration { };
-        auto readTimeField = [&](JSValue val, TemporalUnit unit) {
+        TemporalCore::TimeFieldsIn timeFields;
+        auto readTimeField = [&](JSValue val, std::optional<double>& target) {
             if (val.isUndefined())
                 return;
             double d = val.toIntegerWithTruncation(globalObject);
@@ -154,27 +154,27 @@ static TemporalPlainDateTime* fromImpl(JSGlobalObject* globalObject, JSValue ite
                 throwRangeError(globalObject, scope, "Temporal time properties must be finite"_s);
                 return;
             }
-            timeDuration.setField(unit, d);
+            target = d;
         };
 
         JSValue hourProperty = item->get(globalObject, vm.propertyNames->hour);
         RETURN_IF_EXCEPTION(scope, { });
-        readTimeField(hourProperty, TemporalUnit::Hour);
+        readTimeField(hourProperty, timeFields.hour);
         RETURN_IF_EXCEPTION(scope, { });
 
         JSValue microsecondProperty = item->get(globalObject, vm.propertyNames->microsecond);
         RETURN_IF_EXCEPTION(scope, { });
-        readTimeField(microsecondProperty, TemporalUnit::Microsecond);
+        readTimeField(microsecondProperty, timeFields.microsecond);
         RETURN_IF_EXCEPTION(scope, { });
 
         JSValue millisecondProperty = item->get(globalObject, vm.propertyNames->millisecond);
         RETURN_IF_EXCEPTION(scope, { });
-        readTimeField(millisecondProperty, TemporalUnit::Millisecond);
+        readTimeField(millisecondProperty, timeFields.millisecond);
         RETURN_IF_EXCEPTION(scope, { });
 
         JSValue minuteProperty = item->get(globalObject, vm.propertyNames->minute);
         RETURN_IF_EXCEPTION(scope, { });
-        readTimeField(minuteProperty, TemporalUnit::Minute);
+        readTimeField(minuteProperty, timeFields.minute);
         RETURN_IF_EXCEPTION(scope, { });
 
         // month
@@ -184,6 +184,11 @@ static TemporalPlainDateTime* fromImpl(JSGlobalObject* globalObject, JSValue ite
         if (!monthProperty.isUndefined()) {
             month = monthProperty.toIntegerWithTruncation(globalObject);
             RETURN_IF_EXCEPTION(scope, { });
+            // Spec uses ToPositiveIntegerWithTruncation: rejects NaN/±Inf and any value ≤ 0.
+            if (!(month > 0 && std::isfinite(month))) [[unlikely]] {
+                throwRangeError(globalObject, scope, "month property must be positive and finite"_s);
+                return { };
+            }
         }
 
         // monthCode
@@ -203,13 +208,13 @@ static TemporalPlainDateTime* fromImpl(JSGlobalObject* globalObject, JSValue ite
         // nanosecond
         JSValue nanosecondProperty = item->get(globalObject, vm.propertyNames->nanosecond);
         RETURN_IF_EXCEPTION(scope, { });
-        readTimeField(nanosecondProperty, TemporalUnit::Nanosecond);
+        readTimeField(nanosecondProperty, timeFields.nanosecond);
         RETURN_IF_EXCEPTION(scope, { });
 
         // second
         JSValue secondProperty = item->get(globalObject, vm.propertyNames->second);
         RETURN_IF_EXCEPTION(scope, { });
-        readTimeField(secondProperty, TemporalUnit::Second);
+        readTimeField(secondProperty, timeFields.second);
         RETURN_IF_EXCEPTION(scope, { });
 
         // year
@@ -233,75 +238,24 @@ static TemporalPlainDateTime* fromImpl(JSGlobalObject* globalObject, JSValue ite
             RETURN_IF_EXCEPTION(scope, { });
         }
 
-        // Step 2.h: InterpretTemporalDateTimeFields(calendar, fields, overflow).
-        // Resolve month vs monthCode — done after all fields (including year) are read.
-        bool isNonISO = extractedCalendarId != iso8601CalendarID();
-        if (otherMonth) {
-            if (!isNonISO && (otherMonth->monthNumber < 1 || otherMonth->monthNumber > 12 || otherMonth->isLeapMonth)) [[unlikely]] {
-                throwRangeError(globalObject, scope, "month code is not valid for ISO 8601 calendar"_s);
-                return { };
-            }
-        }
-        if (monthProperty.isUndefined()) {
-            ASSERT(otherMonth);
-            month = otherMonth->monthNumber;
-        } else {
-            // Spec uses ToPositiveIntegerWithTruncation: rejects NaN/±Inf and any value ≤ 0.
-            if (!(month > 0 && std::isfinite(month))) [[unlikely]] {
-                throwRangeError(globalObject, scope, "month property must be positive and finite"_s);
-                return { };
-            }
-            if (otherMonth && static_cast<double>(otherMonth->monthNumber) != month) [[unlikely]] {
-                throwRangeError(globalObject, scope, "month and monthCode properties must match if both are provided"_s);
-                return { };
-            }
-        }
-
-        // Validate/clamp month and day at double level before double→unsigned cast.
-        // static_cast<unsigned> of values >= 2^32 is UB and wraps to 0 on x86.
-        if (!isNonISO) {
-            if (overflow == TemporalOverflow::Constrain) {
-                month = std::clamp(month, 1.0, 12.0);
-                day = std::clamp(day, 1.0, 31.0);
-            } else {
-                if (!(month >= 1 && month <= 12)) [[unlikely]] {
-                    throwRangeError(globalObject, scope, "month is out of range"_s);
-                    return { };
-                }
-                if (!(day >= 1 && day <= 31)) [[unlikely]] {
-                    throwRangeError(globalObject, scope, "day is out of range"_s);
-                    return { };
-                }
-            }
-        }
-
-        ISO8601::PlainDate plainDate;
-        if (calUsesEras && (extractedEra || extractedEraYear)) {
-            std::optional<StringView> era;
-            if (extractedEra)
-                era = StringView(*extractedEra);
-            // Pass nullopt when user didn't provide year (yearProperty.isUndefined()), so the
-            // year-consistency check in calendarDateFromFields correctly skips for that case.
-            std::optional<int32_t> yearOpt = yearProperty.isUndefined() ? std::nullopt : std::optional<int32_t>(clampTo<int32_t>(year));
-            auto result = TemporalCore::calendarDateFromFields(
-                extractedCalendarId, yearOpt, clampTo<uint8_t>(month),
-                clampTo<uint8_t>(day), era, extractedEraYear,
-                otherMonth, overflow);
-            if (!result) [[unlikely]] {
-                throwRangeError(globalObject, scope, String(result.error().message));
-                return { };
-            }
-            plainDate = *result;
-        } else {
-            plainDate = isoDateFromFields(globalObject, TemporalDateFormat::Date, clampTo<int32_t>(year), clampTo<uint32_t>(month), clampTo<uint32_t>(day), otherMonth, overflow, extractedCalendarId);
-            RETURN_IF_EXCEPTION(scope, { });
-        }
-
-        auto plainTime = TemporalPlainTime::regulateTime(globalObject, WTF::move(timeDuration), overflow);
+        // Step 2.h: dateTimeResult = ? InterpretTemporalDateTimeFields(calendar, fields, overflow).
+        TemporalCore::CalendarFieldsIn dateFields;
+        if (!yearProperty.isUndefined())
+            dateFields.year = clampTo<int32_t>(year);
+        if (!monthProperty.isUndefined())
+            dateFields.month = clampTo<uint32_t>(month);
+        if (otherMonth)
+            dateFields.monthCode = otherMonth;
+        dateFields.day = clampTo<uint8_t>(day);
+        if (extractedEra)
+            dateFields.era = *extractedEra;
+        if (extractedEraYear)
+            dateFields.eraYear = *extractedEraYear;
+        auto pdt = interpretTemporalDateTimeFields(globalObject, extractedCalendarId, dateFields, timeFields, overflow);
         RETURN_IF_EXCEPTION(scope, { });
 
         // Step 2.h cont.: CreateTemporalDateTime(result, calendar).
-        auto* result = TemporalPlainDateTime::tryCreateIfValid(globalObject, globalObject->plainDateTimeStructure(), WTF::move(plainDate), WTF::move(plainTime), extractedCalendarId);
+        auto* result = TemporalPlainDateTime::tryCreateIfValid(globalObject, globalObject->plainDateTimeStructure(), ISO8601::PlainDate(pdt.date), ISO8601::PlainTime(pdt.time), extractedCalendarId);
         RETURN_IF_EXCEPTION(scope, { });
         return result;
     }

--- a/Source/JavaScriptCore/runtime/TemporalZonedDateTime.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalZonedDateTime.cpp
@@ -299,95 +299,14 @@ static std::optional<ZDTEpochArgs> toEpochArgsFromPropertyBag(JSGlobalObject* gl
     }
 
     // Steps 4.j-4.k: dateTimeResult = ? InterpretTemporalDateTimeFields(calendar, fields, overflow).
-    auto& dateFields = fields.dateFields;
-    bool zdtIsNonISO = !TemporalCore::calendarIsISO(calendarID);
-    double month = dateFields.month.value_or(0);
-    double day = dateFields.day.value_or(0);
-    double year = dateFields.year.value_or(0);
-    auto& parsedMonthCode = dateFields.monthCode;
-
-    // day and year are not in PrepareCalendarFields' requiredFieldNames, but CalendarResolveFields
-    // (inside InterpretTemporalDateTimeFields) requires them — throw TypeError here to surface the
-    // right error type before CalendarDateFromFields produces a RangeError from day/year = 0.
-    if (!(day > 0)) [[unlikely]] {
-        throwTypeError(globalObject, scope, "day property must be present"_s);
-        return std::nullopt;
-    }
-    // year is required unless era+eraYear are both provided (calendar-specific substitution).
-    if (!fields.yearPresent && !(dateFields.era && dateFields.eraYear)) [[unlikely]] {
-        throwTypeError(globalObject, scope, "year property must be present"_s);
-        return std::nullopt;
-    }
-
-    if (fields.monthCodePresent) {
-        ASSERT(parsedMonthCode);
-        if (!zdtIsNonISO && (parsedMonthCode->isLeapMonth || parsedMonthCode->monthNumber < 1 || parsedMonthCode->monthNumber > 12)) [[unlikely]] {
-            throwRangeError(globalObject, scope, "month code is not valid for ISO 8601 calendar"_s);
-            return std::nullopt;
-        }
-        if (!fields.monthPresent)
-            month = parsedMonthCode->monthNumber;
-        else if (month != static_cast<double>(parsedMonthCode->monthNumber)) [[unlikely]] {
-            throwRangeError(globalObject, scope, "month and monthCode properties must match if both are provided"_s);
-            return std::nullopt;
-        }
-    } else {
-        if (!fields.monthPresent) [[unlikely]] {
-            throwTypeError(globalObject, scope, "Either month or monthCode property must be provided"_s);
-            return std::nullopt;
-        }
-        if (!(month > 0 && std::isfinite(month))) [[unlikely]] {
-            throwRangeError(globalObject, scope, "month property must be positive and finite"_s);
-            return std::nullopt;
-        }
-    }
-
-    // Step 4.j: InterpretTemporalDateTimeFields → CalendarDateFromFields → isoDate.
-    ISO8601::PlainDate plainDate;
-    if (dateFields.era || dateFields.eraYear) {
-        std::optional<StringView> era;
-        if (dateFields.era)
-            era = StringView(*dateFields.era);
-        auto result = TemporalCore::calendarDateFromFields(
-            calendarID, dateFields.year, clampTo<uint8_t>(month),
-            clampTo<uint8_t>(day), era, dateFields.eraYear, parsedMonthCode, overflow);
-        if (!result) [[unlikely]] {
-            throwRangeError(globalObject, scope, String(result.error().message));
-            return std::nullopt;
-        }
-        plainDate = *result;
-    } else {
-        if (!zdtIsNonISO) {
-            if (overflow == TemporalOverflow::Constrain) {
-                month = std::clamp(month, 1.0, 12.0);
-                day = std::clamp(day, 1.0, 31.0);
-            } else {
-                if (!(month >= 1 && month <= 12)) [[unlikely]] {
-                    throwRangeError(globalObject, scope, "month is out of range"_s);
-                    return std::nullopt;
-                }
-                if (!(day >= 1 && day <= 31)) [[unlikely]] {
-                    throwRangeError(globalObject, scope, "day is out of range"_s);
-                    return std::nullopt;
-                }
-            }
-        }
-        plainDate = isoDateFromFields(globalObject, TemporalDateFormat::Date,
-            clampTo<int32_t>(year), clampTo<uint32_t>(month), clampTo<uint32_t>(day),
-            parsedMonthCode, overflow, calendarID);
-        RETURN_IF_EXCEPTION(scope, std::nullopt);
-    }
-
-    // Step 4.l: time = result.[[Time]] → build PlainTime with overflow.
-    ISO8601::Duration timeDur;
-    timeDur.setField(TemporalUnit::Hour, fields.hour.value_or(0));
-    timeDur.setField(TemporalUnit::Minute, fields.minute.value_or(0));
-    timeDur.setField(TemporalUnit::Second, fields.second.value_or(0));
-    timeDur.setField(TemporalUnit::Millisecond, fields.millisecond.value_or(0));
-    timeDur.setField(TemporalUnit::Microsecond, fields.microsecond.value_or(0));
-    timeDur.setField(TemporalUnit::Nanosecond, fields.nanosecond.value_or(0));
-    auto plainTime = TemporalPlainTime::regulateTime(globalObject, WTF::move(timeDur), overflow);
+    TemporalCore::TimeFieldsIn timeFields {
+        fields.hour, fields.minute, fields.second,
+        fields.millisecond, fields.microsecond, fields.nanosecond,
+    };
+    auto pdt = interpretTemporalDateTimeFields(globalObject, calendarID, fields.dateFields, timeFields, overflow);
     RETURN_IF_EXCEPTION(scope, std::nullopt);
+    ISO8601::PlainDate plainDate = pdt.date;
+    ISO8601::PlainTime plainTime = pdt.time;
 
     // Steps 6-8: offsetBehaviour from offsetString (fields.[[OffsetString]]).
     // No offset string → Wall; offset string present → Option (caller's offsetOpt drives prefer/reject/use/ignore).

--- a/Source/JavaScriptCore/runtime/TemporalZonedDateTimePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalZonedDateTimePrototype.cpp
@@ -668,8 +668,8 @@ JSC_DEFINE_HOST_FUNCTION(temporalZonedDateTimePrototypeFuncWith, (JSGlobalObject
     TemporalOverflow overflow = toTemporalOverflow(globalObject, options);
     RETURN_IF_EXCEPTION(scope, { });
 
-    // Step 23: dateTimeResult = ? InterpretTemporalDateTimeFields(calendar, fields, overflow).
-    // For non-ISO calendars, fall back to calendar-coordinate current values from ISODateToFields.
+    // Step 23 fallback prep: for non-ISO calendars, absent patch fields fall back to
+    // the calendar-native values (not the raw ISO year/month/day).
     int32_t fallbackYear = curDate.year();
     uint32_t fallbackMonth = curDate.month();
     uint32_t fallbackDay = curDate.day();
@@ -687,52 +687,34 @@ JSC_DEFINE_HOST_FUNCTION(temporalZonedDateTimePrototypeFuncWith, (JSGlobalObject
 
     auto& pf = partialFields;
     auto& pDate = pf.dateFields;
-    int32_t mergedYear = pDate.year.value_or(fallbackYear);
-    uint32_t mergedMonth;
-    if (pDate.month)
-        mergedMonth = static_cast<uint32_t>(*pDate.month);
-    else if (pDate.monthCode)
-        mergedMonth = pDate.monthCode->monthNumber;
-    else
-        mergedMonth = fallbackMonth;
-    uint32_t mergedDay = pDate.day ? static_cast<uint32_t>(*pDate.day) : fallbackDay;
 
-    // For non-ISO with(), if neither month nor monthCode provided by user, use fallback monthCode.
-    std::optional<ParsedMonthCode> resolvedMonthCode = pDate.monthCode;
-    if (!pDate.month && !pDate.monthCode && fallbackMonthCode)
-        resolvedMonthCode = fallbackMonthCode;
-
-    ISO8601::PlainDate newDate;
-    if (pDate.era || pDate.eraYear) {
-        // User provided era+eraYear: route through calendarDateFromFields so ICU resolves the
-        // ISO year from era+eraYear (UCAL_ERA + UCAL_YEAR = eraYear).
-        // Pass pDate.year as optional: nullopt when absent (no consistency check),
-        // has_value when user provided it (conflict with era+eraYear throws RangeError).
-        std::optional<StringView> era;
-        if (pDate.era)
-            era = StringView(*pDate.era);
-        auto result = TemporalCore::calendarDateFromFields(
-            zdt->calendarID(), pDate.year, clampTo<uint8_t>(mergedMonth),
-            static_cast<uint8_t>(mergedDay), era, pDate.eraYear, resolvedMonthCode, overflow);
-        if (!result) [[unlikely]] {
-            throwRangeError(globalObject, scope, String(result.error().message));
-            return { };
-        }
-        newDate = *result;
-    } else {
-        newDate = isoDateFromFields(globalObject, TemporalDateFormat::Date, mergedYear, mergedMonth, mergedDay, resolvedMonthCode, overflow, zdt->calendarID());
-        RETURN_IF_EXCEPTION(scope, { });
+    // Step 23: dateTimeResult = ? InterpretTemporalDateTimeFields(calendar, fields, overflow).
+    // Merge patch onto current ZDT. Only populate month/monthCode from what the user
+    // actually provided so nonISOResolveFields' consistency check doesn't fire spuriously.
+    TemporalCore::CalendarFieldsIn merged = pDate;
+    if (!pDate.day)
+        merged.day = static_cast<uint8_t>(fallbackDay);
+    if (!pDate.year && !(pDate.era && pDate.eraYear))
+        merged.year = fallbackYear;
+    if (!pDate.month && !pDate.monthCode) {
+        // Prefer fallback monthCode (calendar-native) over numeric month for non-ISO.
+        if (fallbackMonthCode)
+            merged.monthCode = fallbackMonthCode;
+        else
+            merged.month = fallbackMonth;
     }
-
-    ISO8601::Duration timeDur { };
-    timeDur.setField(TemporalUnit::Hour, pf.hour.value_or(static_cast<double>(curTime.hour())));
-    timeDur.setField(TemporalUnit::Minute, pf.minute.value_or(static_cast<double>(curTime.minute())));
-    timeDur.setField(TemporalUnit::Second, pf.second.value_or(static_cast<double>(curTime.second())));
-    timeDur.setField(TemporalUnit::Millisecond, pf.millisecond.value_or(static_cast<double>(curTime.millisecond())));
-    timeDur.setField(TemporalUnit::Microsecond, pf.microsecond.value_or(static_cast<double>(curTime.microsecond())));
-    timeDur.setField(TemporalUnit::Nanosecond, pf.nanosecond.value_or(static_cast<double>(curTime.nanosecond())));
-    auto newTime = TemporalPlainTime::regulateTime(globalObject, WTF::move(timeDur), overflow);
+    TemporalCore::TimeFieldsIn timeFields {
+        pf.hour.value_or(static_cast<double>(curTime.hour())),
+        pf.minute.value_or(static_cast<double>(curTime.minute())),
+        pf.second.value_or(static_cast<double>(curTime.second())),
+        pf.millisecond.value_or(static_cast<double>(curTime.millisecond())),
+        pf.microsecond.value_or(static_cast<double>(curTime.microsecond())),
+        pf.nanosecond.value_or(static_cast<double>(curTime.nanosecond())),
+    };
+    auto pdt = interpretTemporalDateTimeFields(globalObject, zdt->calendarID(), merged, timeFields, overflow);
     RETURN_IF_EXCEPTION(scope, { });
+    ISO8601::PlainDate newDate = pdt.date;
+    ISO8601::PlainTime newTime = pdt.time;
 
     // Steps 24-25: InterpretISODateTimeOffset — resolve epoch nanoseconds.
     // Step 24: newOffsetNanoseconds — use provided offset OR current offset.

--- a/Source/JavaScriptCore/runtime/temporal/core/CalendarFields.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/CalendarFields.cpp
@@ -185,6 +185,8 @@ TemporalResult<ResolvedCalendarDate> dateFromFields(CalendarID calendarId, const
         return makeUnexpected(typeError("year property must be present"_s));
     if (!fields.day)
         return makeUnexpected(typeError("day property must be present"_s));
+    if (!fields.month && !fields.monthCode)
+        return makeUnexpected(typeError("month or monthCode property must be present"_s));
 
     // Resolve month from month/monthCode
     uint8_t month = 1;

--- a/Source/JavaScriptCore/runtime/temporal/core/CalendarFields.h
+++ b/Source/JavaScriptCore/runtime/temporal/core/CalendarFields.h
@@ -53,6 +53,15 @@ struct CalendarFieldsIn {
     std::optional<int32_t> eraYear;
 };
 
+struct TimeFieldsIn {
+    std::optional<double> hour;
+    std::optional<double> minute;
+    std::optional<double> second;
+    std::optional<double> millisecond;
+    std::optional<double> microsecond;
+    std::optional<double> nanosecond;
+};
+
 // Result of calendar field resolution: ISO date + calendar ID.
 struct ResolvedCalendarDate {
     ISO8601::PlainDate isoDate;


### PR DESCRIPTION
#### bc5f4aa81ce3e901e9a8314049a86b230bd5159c
<pre>
[JSC][Temporal] Consolidate InterpretTemporalDateTimeFields into one implementation
<a href="https://bugs.webkit.org/show_bug.cgi?id=319531">https://bugs.webkit.org/show_bug.cgi?id=319531</a>
<a href="https://rdar.apple.com/182355686">rdar://182355686</a>

Reviewed by Sosuke Suzuki.

Extract the spec&apos;s InterpretTemporalDateTimeFields abstract operation
into JSC::interpretTemporalDateTimeFields and route all four spec
callers through it: PlainDateTime.from, ZonedDateTime.from,
ZonedDateTime.with, and Duration.relativeTo. Prior to this patch each
caller open-coded the three steps (CalendarDateFromFields + RegulateTime
+ CombineISODateAndTimeRecord) inline.

Deletes the legacy TemporalDuration::resolvePlainDateFromFields helper
now that Duration.relativeTo routes through the shared implementation.
Introduces TemporalCore::TimeFieldsIn to mirror CalendarFieldsIn&apos;s
optional pattern.

Also restores the month-or-monthCode required-field check that the
pre-refactor callers open-coded — matches CalendarResolveFields for the
ISO branch and NonISOResolveFields for the non-ISO branch.

Tests: temporal-zoned-date-time-with-era-calendar.js
Canonical link: <a href="https://commits.webkit.org/317350@main">https://commits.webkit.org/317350@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d879d2c31215bebdd497433960b431b94cc908f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175011 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48944 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42725 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184592 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132919 "Failed to checkout and rebase branch from PR 69517") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bc514c61-258a-4ffd-9f91-1fecc58a1c62) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50236 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48627 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136208 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/132919 "Failed to checkout and rebase branch from PR 69517") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d476e17f-41a7-401b-ba9b-3b2170a59a7c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177969 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39648 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157006 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116687 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b4d79a3c-e9db-49b7-82d9-bee75b41e040) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38289 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33069 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5515 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148712 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36498 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187016 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/36273 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/40524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40875 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145149 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48611 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145006 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49291 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115109 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26595 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39878 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/121430 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/212103 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47797 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11471 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55322 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47200 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47430 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47257 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->