### PR TITLE
A dynamic view-transition-name change does not repaint the affected element.

### DIFF
--- a/LayoutTests/fast/repaint/view-transition-name-dynamic-expected.txt
+++ b/LayoutTests/fast/repaint/view-transition-name-dynamic-expected.txt
@@ -1,0 +1,6 @@
+Tests that dynamically setting view-transition-name invalidates for repaint. Setting it makes #wc a stacking context, painting the negative-z-index green child above #wc's red background. Passes if a repaint is issued for that region.
+
+(repaint rects
+  (rect 0 52 100 100)
+)
+

--- a/LayoutTests/fast/repaint/view-transition-name-dynamic.html
+++ b/LayoutTests/fast/repaint/view-transition-name-dynamic.html
@@ -1,0 +1,18 @@
+<!DOCTYPE HTML>
+<script src="resources/text-based-repaint.js"></script>
+<script>
+function repaintTest() {
+  document.getElementById('wc').style.viewTransitionName = 'something';
+}
+onload = runRepaintTest;
+</script>
+<style>
+body { margin: 0; }
+div { width: 100px; height: 100px; }
+#wc { background: red; position: relative; }
+#child { position: absolute; top: 0; left: 0; z-index: -1; background: green; }
+</style>
+<p style="height: 20px">Tests that dynamically setting view-transition-name invalidates for repaint. Setting it makes #wc a stacking context, painting the negative-z-index green child above #wc's red background. Passes if a repaint is issued for that region.</p>
+<div id="wc">
+  <div id="child"></div>
+</div>

--- a/Source/WebCore/style/StyleDifference.cpp
+++ b/Source/WebCore/style/StyleDifference.cpp
@@ -790,6 +790,9 @@ public:
         if (a.textDecorationStyle != b.textDecorationStyle || a.textDecorationColor != b.textDecorationColor || a.textDecorationThickness != b.textDecorationThickness || a.textDecorationInset != b.textDecorationInset)
             return true;
 
+        if (a.viewTransitionName != b.viewTransitionName)
+            return true;
+
         return false;
     }
 


### PR DESCRIPTION
#### f30aa1e23991cb7a6b8cd04d9954934ee51fece3
<pre>
A dynamic view-transition-name change does not repaint the affected element.
<a href="https://bugs.webkit.org/show_bug.cgi?id=315908">https://bugs.webkit.org/show_bug.cgi?id=315908</a>
<a href="https://rdar.apple.com/problem/178316558">rdar://problem/178316558</a>

Reviewed by Dan Glastonbury and Tim Nguyen.

Changing view-transition-name can change whether the element forms a
stacking context, which can reorder painting. Ensure we repaint the
element when it changes.

This fixes view-transition-name-stacking-context-dynamic.html when run
with wptrunner.

* Source/WebCore/style/StyleDifference.cpp:
(WebCore::Style::DifferenceFunctions::rareDataChangeRequiresRepaint):
* LayoutTests/fast/repaint/view-transition-name-dynamic.html: Added.
* LayoutTests/fast/repaint/view-transition-name-dynamic-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/317310@main">https://commits.webkit.org/317310@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/053a6c2da3a2a8a204994e36671a0593427aae55

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174862 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48795 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42576 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184442 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132770 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4c5e2756-da1b-408e-bea5-22adc0dd712e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176727 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50087 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48478 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136078 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c7868c2c-21bd-4c6b-b280-d346cc6ccbb2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177820 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39517 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156869 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116557 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e9c53dd5-854f-4adc-b255-5fa9023c9abf) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38158 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36537 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32920 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148581 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36361 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186867 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/40290 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40738 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145006 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48462 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156425 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144865 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39050 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49142 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32982 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114953 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39741 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121244 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47648 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11331 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47050 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47281 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47108 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->