### PR TITLE
Use C++17 `inline constexpr` variables instead of `extern const` in WebCore

### DIFF
--- a/Source/WebCore/platform/Pasteboard.h
+++ b/Source/WebCore/platform/Pasteboard.h
@@ -403,9 +403,9 @@ extern NSString *UIImagePboardType;
 #endif
 
 #if PLATFORM(MAC)
-WEBCORE_EXPORT extern const ASCIILiteral WebArchivePboardType;
-extern const ASCIILiteral WebURLNamePboardType;
-extern const ASCIILiteral WebURLsWithTitlesPboardType;
+inline constexpr ASCIILiteral WebArchivePboardType { "Apple Web Archive pasteboard type"_s };
+inline constexpr ASCIILiteral WebURLNamePboardType { "public.url-name"_s };
+inline constexpr ASCIILiteral WebURLsWithTitlesPboardType { "WebURLsWithTitlesPboardType"_s };
 #endif
 
 #if !PLATFORM(GTK) && !PLATFORM(WPE)

--- a/Source/WebCore/platform/gamepad/GamepadConstants.cpp
+++ b/Source/WebCore/platform/gamepad/GamepadConstants.cpp
@@ -33,10 +33,6 @@
 
 namespace WebCore {
 
-const GamepadButtonRole maximumGamepadButton = GamepadButtonRole::CenterClusterCenter;
-const size_t numberOfStandardGamepadButtonsWithoutHomeButton = static_cast<size_t>(maximumGamepadButton);
-const size_t numberOfStandardGamepadButtonsWithHomeButton = numberOfStandardGamepadButtonsWithoutHomeButton + 1;
-
 const String& standardGamepadMappingString()
 {
     static NeverDestroyed<String> standardGamepadMapping = "standard"_s;

--- a/Source/WebCore/platform/gamepad/GamepadConstants.h
+++ b/Source/WebCore/platform/gamepad/GamepadConstants.h
@@ -55,9 +55,9 @@ enum class GamepadButtonRole : uint8_t {
     Nonstandard2 = 18,
 };
 
-extern const size_t numberOfStandardGamepadButtonsWithoutHomeButton;
-extern const size_t numberOfStandardGamepadButtonsWithHomeButton;
-extern const GamepadButtonRole maximumGamepadButton;
+inline constexpr GamepadButtonRole maximumGamepadButton = GamepadButtonRole::CenterClusterCenter;
+inline constexpr size_t numberOfStandardGamepadButtonsWithoutHomeButton = static_cast<size_t>(maximumGamepadButton);
+inline constexpr size_t numberOfStandardGamepadButtonsWithHomeButton = numberOfStandardGamepadButtonsWithoutHomeButton + 1;
 
 const String& standardGamepadMappingString();
 #if ENABLE(WEBXR)

--- a/Source/WebCore/platform/mac/PasteboardMac.mm
+++ b/Source/WebCore/platform/mac/PasteboardMac.mm
@@ -55,10 +55,6 @@
 
 namespace WebCore {
 
-const ASCIILiteral WebArchivePboardType = "Apple Web Archive pasteboard type"_s;
-const ASCIILiteral WebURLNamePboardType = "public.url-name"_s;
-const ASCIILiteral WebURLsWithTitlesPboardType = "WebURLsWithTitlesPboardType"_s;
-
 const ASCIILiteral WebSmartPastePboardType = "NeXT smart paste pasteboard type"_s;
 const ASCIILiteral WebURLPboardType = "public.url"_s;
 

--- a/Source/WebCore/platform/network/ResourceErrorBase.cpp
+++ b/Source/WebCore/platform/network/ResourceErrorBase.cpp
@@ -35,9 +35,6 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ResourceErrorBase);
 
-const ASCIILiteral errorDomainWebKitInternal = "WebKitInternal"_s;
-const ASCIILiteral errorDomainWebKitServiceWorker = "WebKitServiceWorker"_s;
-
 inline const ResourceError& ResourceErrorBase::asResourceError() const
 {
     return *static_cast<const ResourceError*>(this);

--- a/Source/WebCore/platform/network/ResourceErrorBase.h
+++ b/Source/WebCore/platform/network/ResourceErrorBase.h
@@ -35,8 +35,8 @@ namespace WebCore {
 
 class ResourceError;
 
-WEBCORE_EXPORT extern const ASCIILiteral errorDomainWebKitInternal; // Used for errors that won't be exposed to clients.
-WEBCORE_EXPORT extern const ASCIILiteral errorDomainWebKitServiceWorker; // Used for errors that happen when loading a resource from a service worker.
+inline constexpr ASCIILiteral errorDomainWebKitInternal { "WebKitInternal"_s }; // Used for errors that won't be exposed to clients.
+inline constexpr ASCIILiteral errorDomainWebKitServiceWorker { "WebKitServiceWorker"_s }; // Used for errors that happen when loading a resource from a service worker.
 
 enum class ResourceErrorBaseType : uint8_t {
     Null,


### PR DESCRIPTION
#### fecef8215e3584312bd6957686c644d5a891b3aa
<pre>
Use C++17 `inline constexpr` variables instead of `extern const` in WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=319532">https://bugs.webkit.org/show_bug.cgi?id=319532</a>
<a href="https://rdar.apple.com/182360378">rdar://182360378</a>

Reviewed by Chris Dumez.

This lets the compiler see the constant values for better optimization.

* Source/WebCore/platform/Pasteboard.h:
* Source/WebCore/platform/gamepad/GamepadConstants.cpp:
* Source/WebCore/platform/gamepad/GamepadConstants.h:
* Source/WebCore/platform/mac/PasteboardMac.mm:
* Source/WebCore/platform/network/ResourceErrorBase.cpp:
* Source/WebCore/platform/network/ResourceErrorBase.h:

Canonical link: <a href="https://commits.webkit.org/317317@main">https://commits.webkit.org/317317@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e500266f74ad0cfc28791e5973f069f01ade7670

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174864 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48797 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42578 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184444 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132772 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176729 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50089 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48480 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136084 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177822 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39518 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156876 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116563 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38159 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36539 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32922 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148582 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36368 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186869 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/40294 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40740 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145010 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48464 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144868 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39058 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49144 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32989 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114955 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39744 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121246 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47650 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11338 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47052 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47283 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47110 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->