### PR TITLE
[WebXR] Remove check for CompositorServices support of forward-Z

### DIFF
--- a/Source/WebCore/PAL/pal/cocoa/CompositorServicesSoftLink.h
+++ b/Source/WebCore/PAL/pal/cocoa/CompositorServicesSoftLink.h
@@ -39,11 +39,8 @@ SOFT_LINK_FUNCTION_FOR_HEADER(PAL, CompositorServices, cp_drawable_get_rasteriza
 #define cp_drawable_get_rasterization_rate_map_descriptor PAL::softLink_CompositorServices_cp_drawable_get_rasterization_rate_map_descriptor
 SOFT_LINK_FUNCTION_FOR_HEADER(PAL, CompositorServices, cp_drawable_get_rasterization_rate_map, id<MTLRasterizationRateMap>, (cp_drawable_t drawable, size_t index), (drawable, index))
 #define cp_drawable_get_rasterization_rate_map PAL::softLink_CompositorServices_cp_drawable_get_rasterization_rate_map
-
-// FIXME: <rdar://134998122> Remove may fail when CC update lands.
-SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER(PAL, CompositorServices, cp_drawable_set_write_forward_depth, void, (cp_drawable_t drawable, bool is_forward_z), (drawable, is_forward_z));
+SOFT_LINK_FUNCTION_FOR_HEADER(PAL, CompositorServices, cp_drawable_set_write_forward_depth, void, (cp_drawable_t drawable, bool is_forward_z), (drawable, is_forward_z));
 #define cp_drawable_set_write_forward_depth PAL::softLink_CompositorServices_cp_drawable_set_write_forward_depth
-#define can_load_cp_drawable_set_write_forward_depth PAL::canLoad_CompositorServices_cp_drawable_set_write_forward_depth
 
 SOFT_LINK_FUNCTION_FOR_HEADER(PAL, CompositorServices, cp_frame_end_submission, void, (cp_frame_t frame), (frame))
 #define cp_frame_end_submission PAL::softLink_CompositorServices_cp_frame_end_submission

--- a/Source/WebCore/PAL/pal/cocoa/CompositorServicesSoftLink.mm
+++ b/Source/WebCore/PAL/pal/cocoa/CompositorServicesSoftLink.mm
@@ -26,9 +26,7 @@ SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, CompositorServices, cp_drawable_s
 SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, CompositorServices, cp_drawable_set_device_anchor, void, (cp_drawable_t drawable, ar_device_anchor_t device_anchor), (drawable, device_anchor), PAL_EXPORT)
 SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, CompositorServices, cp_drawable_get_rasterization_rate_map_descriptor, MTLRasterizationRateMapDescriptor*, (cp_drawable_t drawable, size_t index), (drawable, index), PAL_EXPORT)
 SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, CompositorServices, cp_drawable_get_rasterization_rate_map, id<MTLRasterizationRateMap>, (cp_drawable_t drawable, size_t index), (drawable, index), PAL_EXPORT)
-
-// FIXME: <rdar://134998122> Remove may fail when CC update lands.
-SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE_WITH_EXPORT(PAL, CompositorServices, cp_drawable_set_write_forward_depth, void, (cp_drawable_t drawable, bool is_forward_z), (drawable, is_forward_z), PAL_EXPORT)
+SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, CompositorServices, cp_drawable_set_write_forward_depth, void, (cp_drawable_t drawable, bool is_forward_z), (drawable, is_forward_z), PAL_EXPORT)
 
 SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, CompositorServices, cp_frame_end_submission, void, (cp_frame_t frame), (frame), PAL_EXPORT)
 SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, CompositorServices, cp_frame_get_frame_index, cp_layer_frame_index_t, (cp_frame_t frame), (frame), PAL_EXPORT)

--- a/Source/WebCore/platform/xr/PlatformXR.h
+++ b/Source/WebCore/platform/xr/PlatformXR.h
@@ -417,7 +417,7 @@ struct FrameData {
         std::optional<LayerSetupData> layerSetup = { std::nullopt };
         uint64_t renderingFrameIndex { 0 };
         std::optional<ExternalTextureData> textureData;
-        // FIXME: <rdar://134998122> Remove when new CC lands.
+        // FIXME: <rdar://182368025> Is this still necessary?
         bool requestDepth { false };
         bool isForTesting { false };
     };

--- a/Source/WebKit/UIProcess/XR/xros/PlatformXRCompositor.h
+++ b/Source/WebKit/UIProcess/XR/xros/PlatformXRCompositor.h
@@ -126,7 +126,6 @@ private:
 #endif // HAVE(VISIBILITY_PROPAGATION_VIEW)
     bool m_foveationEnabled { false };
     bool m_layeredModeEnabled { false };
-    bool m_forwardDepthAvailable { false };
     Vector<std::tuple<WeakObjCPtr<id<MTLTexture>>, WeakObjCPtr<id<MTLTexture>>>> m_compositorTextures;
 #if HAVE(SPATIAL_CONTROLLERS)
     RetainPtr<WKXRControllerManager> m_controllerManager;

--- a/Source/WebKit/UIProcess/XR/xros/PlatformXRCompositor.mm
+++ b/Source/WebKit/UIProcess/XR/xros/PlatformXRCompositor.mm
@@ -96,8 +96,6 @@ CompositorCoordinator::CompositorCoordinator()
     : m_sessionPage(0)
 {
     ASSERT(isCompositorServicesAvailable());
-    // FIXME: rdar://134998122
-    m_forwardDepthAvailable = can_load_cp_drawable_set_write_forward_depth();
 }
 
 void CompositorCoordinator::getPrimaryDeviceInfo(WebPageProxy& page, DeviceInfoCallback&& callback)
@@ -504,11 +502,8 @@ void CompositorCoordinator::render(cp_frame_t frame, cp_drawable_t drawable, NST
 
         frameData.inputSources = [m_xrTrackingManager collectInputSources];
 
-        // FIXME: rdar://134998122
-        if (m_forwardDepthAvailable) {
-            cp_drawable_set_write_forward_depth(drawable, m_depthRange.near < m_depthRange.far);
-            cp_drawable_set_depth_range(drawable, simd_make_float2(std::max(m_depthRange.near, m_depthRange.far), std::min(m_depthRange.near, m_depthRange.far)));
-        }
+        cp_drawable_set_write_forward_depth(drawable, m_depthRange.near < m_depthRange.far);
+        cp_drawable_set_depth_range(drawable, simd_make_float2(std::max(m_depthRange.near, m_depthRange.far), std::min(m_depthRange.near, m_depthRange.far)));
 
         size_t viewCount = cp_drawable_get_view_count(drawable);
         if (!viewCount) {
@@ -569,8 +564,7 @@ void CompositorCoordinator::render(cp_frame_t frame, cp_drawable_t drawable, NST
                 .colorTexture = colorTextureSendRight,
                 .depthStencilBuffer = depthStencilBufferSendRight,
             },
-            // FIXME: rdar://134998122
-            .requestDepth = m_forwardDepthAvailable,
+            .requestDepth = true,
         };
 
         MTLRasterizationRateMapDescriptor* desc = cp_drawable_get_rasterization_rate_map_descriptor(drawable, textureIndexLeft);


### PR DESCRIPTION
#### 2455c5c4a1f05995bab616819587931f74cdaa64
<pre>
[WebXR] Remove check for CompositorServices support of forward-Z
<a href="https://bugs.webkit.org/show_bug.cgi?id=319538">https://bugs.webkit.org/show_bug.cgi?id=319538</a>
<a href="https://rdar.apple.com/134998122">rdar://134998122</a>

Reviewed by Mike Wyrzykowski.

Removing the SPI check for cp_drawable_set_write_forward_depth since the
dependent change landed in August 2024.

No change in functionality.

* Source/WebCore/PAL/pal/cocoa/CompositorServicesSoftLink.h:
* Source/WebCore/PAL/pal/cocoa/CompositorServicesSoftLink.mm:
* Source/WebCore/platform/xr/PlatformXR.h:
* Source/WebKit/UIProcess/XR/xros/PlatformXRCompositor.h:
* Source/WebKit/UIProcess/XR/xros/PlatformXRCompositor.mm:
(WebKit::CompositorCoordinator::CompositorCoordinator):
(WebKit::CompositorCoordinator::render):

Canonical link: <a href="https://commits.webkit.org/317297@main">https://commits.webkit.org/317297@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a5410afa6e9739ff73ea3ae51835010697e8a070

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174881 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48814 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42595 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184461 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/132789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9aca6602-0bd3-44fb-ad3d-dbc4028ac5e8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176746 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50106 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48497 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136094 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/132789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177839 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39535 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156889 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116573 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d7438c5b-7524-47de-8148-9510e402b82e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38176 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32939 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148599 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36381 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186886 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/40324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145025 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48481 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144883 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39041 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49161 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39759 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/121268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47667 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11356 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47069 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47300 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47127 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->