### PR TITLE
[WebXR] Clamp minimum depth for PlatformXRCompositor

### DIFF
--- a/Source/WebKit/UIProcess/XR/xros/PlatformXRCompositor.h
+++ b/Source/WebKit/UIProcess/XR/xros/PlatformXRCompositor.h
@@ -107,6 +107,7 @@ private:
     WeakPtr<PlatformXRCoordinatorSessionEventClient> m_sessionEventClient;
     PlatformXR::Device::RequestFrameCallback m_onFrameUpdate;
     PlatformXR::DepthRange m_depthRange = { 0.1f, 1000.0f };
+    float m_minimumDepth = { -1.0f };
     std::unique_ptr<BinarySemaphore> m_renderSemaphore;
     RefPtr<Thread> m_updateThread;
     std::atomic<bool> m_terminationPending { false };

--- a/Source/WebKit/UIProcess/XR/xros/PlatformXRCompositor.mm
+++ b/Source/WebKit/UIProcess/XR/xros/PlatformXRCompositor.mm
@@ -142,7 +142,7 @@ void CompositorCoordinator::getPrimaryDeviceInfo(WebPageProxy& page, DeviceInfoC
         callback(std::nullopt);
         return;
     }
-    double minimumNearClipPlane = cp_layer_renderer_capabilities_supported_minimum_near_plane_distance(defaultRenderCapabilities.get());
+    m_minimumDepth = cp_layer_renderer_capabilities_supported_minimum_near_plane_distance(defaultRenderCapabilities.get());
 
     ASSERT(m_headsetIdentifier);
     CompositorCoordinator::getSupportedFeatures(page);
@@ -163,7 +163,7 @@ void CompositorCoordinator::getPrimaryDeviceInfo(WebPageProxy& page, DeviceInfoC
         .vrFeatures = m_supportedVRFeatures,
         .arFeatures = m_supportedARFeatures,
         .recommendedResolution = *recommendedResolution,
-        .minimumNearClipPlane = minimumNearClipPlane
+        .minimumNearClipPlane = m_minimumDepth
     };
 
     callback(WTF::move(deviceInfo));
@@ -502,8 +502,13 @@ void CompositorCoordinator::render(cp_frame_t frame, cp_drawable_t drawable, NST
 
         frameData.inputSources = [m_xrTrackingManager collectInputSources];
 
-        cp_drawable_set_write_forward_depth(drawable, m_depthRange.near < m_depthRange.far);
-        cp_drawable_set_depth_range(drawable, simd_make_float2(std::max(m_depthRange.near, m_depthRange.far), std::min(m_depthRange.near, m_depthRange.far)));
+        bool forwardZ = m_depthRange.near < m_depthRange.far;
+        cp_drawable_set_write_forward_depth(drawable, forwardZ);
+        auto depthRange = simd_make_float2(
+            std::max(m_depthRange.near, m_depthRange.far),
+            std::min(m_depthRange.near, m_depthRange.far));
+        depthRange.y = std::max(depthRange.y, m_minimumDepth);
+        cp_drawable_set_depth_range(drawable, depthRange);
 
         size_t viewCount = cp_drawable_get_view_count(drawable);
         if (!viewCount) {
@@ -511,10 +516,14 @@ void CompositorCoordinator::render(cp_frame_t frame, cp_drawable_t drawable, NST
             return;
         }
 
+        auto axisDirectionConvention = forwardZ
+            ? cp_axis_direction_convention_right_up_forward
+            : cp_axis_direction_convention_right_up_back;
+
         for (size_t i = 0; i < viewCount; ++i) {
             auto view = cp_drawable_get_view(drawable, i);
             PlatformXR::FrameData::View frameDataView;
-            auto projection = cp_drawable_compute_projection(drawable, cp_axis_direction_convention_right_up_forward, i);
+            auto projection = cp_drawable_compute_projection(drawable, axisDirectionConvention, i);
             frameDataView.projection = WebCore::TransformationMatrix(projection).toColumnMajorFloatArray();
 
             PlatformXRPose pose(cp_view_get_transform(view));


### PR DESCRIPTION
#### b006b42a19efc532b4b7392d644661af5cfe0c8d
<pre>
[WebXR] Clamp minimum depth for PlatformXRCompositor
<a href="https://bugs.webkit.org/show_bug.cgi?id=319539">https://bugs.webkit.org/show_bug.cgi?id=319539</a>
<a href="https://rdar.apple.com/181951902">rdar://181951902</a>

Reviewed by Mike Wyrzykowski.

The compositor can place a constraint on the minimum depth value that is
allowable for the page to render with. When breaking this constraint,
CompositorServices crashes with a debug message.

Query the minimum depth and clamp the requested range to the minimum.

Additionally, when a page tries to use reverse-Z for the depth range generate
the projection matrix using the correct convention.

Tested on visionPro with WonderLand engine example.

* Source/WebKit/UIProcess/XR/xros/PlatformXRCompositor.h:
* Source/WebKit/UIProcess/XR/xros/PlatformXRCompositor.mm:
(WebKit::CompositorCoordinator::getPrimaryDeviceInfo):
(WebKit::CompositorCoordinator::render):

Canonical link: <a href="https://commits.webkit.org/317502@main">https://commits.webkit.org/317502@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/529317b04f873d552bcc6ad08d160087e1bbdc11

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175099 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49032 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42813 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184684 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/133007 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50324 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48715 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136287 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96133 "3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/033c4e37-dafa-48fd-b96a-8cba7fd0aad5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178057 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39725 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157077 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116766 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38366 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36748 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33158 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148789 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36570 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187105 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc-debug-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/40683 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40951 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145230 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48699 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145086 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39169 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49379 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33190 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115213 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39945 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121543 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47885 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11542 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47288 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47518 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47345 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->