### PR TITLE
[WPT] Enable (most) picture-in-picture tests

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -427,7 +427,9 @@ compositing/geometry/frame-clipping-layer-with-top-left-inset.html [ Skip ]
 # A rounding error may cause 90deg 3d-rotated elements to count as painted
 imported/w3c/web-platform-tests/paint-timing/fcp-only/fcp-invisible-3d-rotate-descendant.html
 
-webkit.org/b/202617 imported/w3c/web-platform-tests/picture-in-picture [ Skip ]
+webkit.org/b/202617 imported/w3c/web-platform-tests/picture-in-picture/leave-picture-in-picture-disable-attribute.optional.html [ Skip ]
+webkit.org/b/202617 imported/w3c/web-platform-tests/picture-in-picture/mediastream.html [ Skip ]
+webkit.org/b/202617 imported/w3c/web-platform-tests/picture-in-picture/permissions-policy.https.sub.html [ Skip ]
 
 # PiP API tests are only relevant on mac and iPad
 media/picture-in-picture [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/META.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/META.yml
@@ -1,4 +1,4 @@
-spec: https://wicg.github.io/picture-in-picture/
+spec: https://w3c.github.io/picture-in-picture/
 suggested_reviewers:
   - beaufortfrancois
   - mounirlamouri

--- a/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: picture-in-picture
+  files: "**"

--- a/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/css-selector-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/css-selector-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Entering and leaving Picture-in-Picture toggles CSS selector
+

--- a/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/disable-picture-in-picture-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/disable-picture-in-picture-expected.txt
@@ -1,0 +1,8 @@
+
+PASS Test disablePictureInPicture IDL attribute
+FAIL Request Picture-in-Picture rejects if disablePictureInPicture is true assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL Request Picture-in-Picture rejects if disablePictureInPicture becomes true before promise resolves. assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS pictureInPictureElement is unset if disablePictureInPicture becomes true
+PASS pictureInPictureElement is unchanged if disablePictureInPicture becomes false
+PASS pictureInPictureElement is unchanged if disablePictureInPicture becomes true for another video
+

--- a/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/enter-picture-in-picture-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/enter-picture-in-picture-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Test enterpictureinpicture event
+

--- a/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/exit-picture-in-picture-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/exit-picture-in-picture-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Exit Picture-in-Picture resolves when there is a Picture-in-Picture video
+PASS Exit Picture-in-Picture rejects when there is no Picture-in-Picture video
+

--- a/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/idlharness.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/idlharness.window-expected.txt
@@ -1,0 +1,69 @@
+
+PASS idl_test setup
+PASS idl_test validation
+PASS Partial interface HTMLVideoElement: original interface defined
+PASS Partial interface HTMLVideoElement: member names are unique
+PASS Partial interface Document: original interface defined
+PASS Partial interface Document: member names are unique
+PASS Partial interface mixin DocumentOrShadowRoot: original interface mixin defined
+PASS Partial interface mixin DocumentOrShadowRoot: member names are unique
+PASS Partial interface Document[2]: member names are unique
+PASS Partial interface mixin DocumentOrShadowRoot[2]: member names are unique
+PASS Partial interface Element: member names are unique
+PASS Partial interface Document[3]: member names are unique
+PASS Document includes GlobalEventHandlers: member names are unique
+PASS HTMLElement includes GlobalEventHandlers: member names are unique
+PASS HTMLElement includes ElementContentEditable: member names are unique
+PASS HTMLElement includes HTMLOrSVGElement: member names are unique
+PASS Document includes NonElementParentNode: member names are unique
+PASS DocumentFragment includes NonElementParentNode: member names are unique
+PASS Document includes DocumentOrShadowRoot: member names are unique
+PASS ShadowRoot includes DocumentOrShadowRoot: member names are unique
+PASS Document includes ParentNode: member names are unique
+PASS DocumentFragment includes ParentNode: member names are unique
+PASS Element includes ParentNode: member names are unique
+PASS Element includes NonDocumentTypeChildNode: member names are unique
+PASS Element includes ChildNode: member names are unique
+PASS Element includes Slottable: member names are unique
+PASS Document includes XPathEvaluatorBase: member names are unique
+PASS PictureInPictureWindow interface: existence and properties of interface object
+PASS PictureInPictureWindow interface object length
+PASS PictureInPictureWindow interface object name
+PASS PictureInPictureWindow interface: existence and properties of interface prototype object
+PASS PictureInPictureWindow interface: existence and properties of interface prototype object's "constructor" property
+PASS PictureInPictureWindow interface: existence and properties of interface prototype object's @@unscopables property
+PASS PictureInPictureWindow interface: attribute width
+PASS PictureInPictureWindow interface: attribute height
+PASS PictureInPictureWindow interface: attribute onresize
+PASS PictureInPictureWindow must be primary interface of pipw
+PASS Stringification of pipw
+PASS PictureInPictureWindow interface: pipw must inherit property "width" with the proper type
+PASS PictureInPictureWindow interface: pipw must inherit property "height" with the proper type
+PASS PictureInPictureWindow interface: pipw must inherit property "onresize" with the proper type
+PASS PictureInPictureEvent interface: existence and properties of interface object
+PASS PictureInPictureEvent interface object length
+PASS PictureInPictureEvent interface object name
+PASS PictureInPictureEvent interface: existence and properties of interface prototype object
+PASS PictureInPictureEvent interface: existence and properties of interface prototype object's "constructor" property
+PASS PictureInPictureEvent interface: existence and properties of interface prototype object's @@unscopables property
+PASS PictureInPictureEvent interface: attribute pictureInPictureWindow
+PASS PictureInPictureEvent must be primary interface of new PictureInPictureEvent("type", { pictureInPictureWindow: pipw })
+PASS Stringification of new PictureInPictureEvent("type", { pictureInPictureWindow: pipw })
+PASS PictureInPictureEvent interface: new PictureInPictureEvent("type", { pictureInPictureWindow: pipw }) must inherit property "pictureInPictureWindow" with the proper type
+PASS HTMLVideoElement interface: operation requestPictureInPicture()
+PASS HTMLVideoElement interface: attribute onenterpictureinpicture
+PASS HTMLVideoElement interface: attribute onleavepictureinpicture
+PASS HTMLVideoElement interface: attribute disablePictureInPicture
+PASS HTMLVideoElement interface: video must inherit property "requestPictureInPicture()" with the proper type
+PASS HTMLVideoElement interface: video must inherit property "onenterpictureinpicture" with the proper type
+PASS HTMLVideoElement interface: video must inherit property "onleavepictureinpicture" with the proper type
+PASS HTMLVideoElement interface: video must inherit property "disablePictureInPicture" with the proper type
+PASS DocumentOrShadowRoot interface: document must inherit property "pictureInPictureElement" with the proper type
+PASS Document interface: attribute pictureInPictureEnabled
+PASS Document interface: operation exitPictureInPicture()
+PASS Document interface: attribute pictureInPictureElement
+PASS Document interface: document must inherit property "pictureInPictureEnabled" with the proper type
+PASS Document interface: document must inherit property "exitPictureInPicture()" with the proper type
+PASS Document interface: document must inherit property "pictureInPictureElement" with the proper type
+PASS ShadowRoot interface: attribute pictureInPictureElement
+

--- a/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/leave-picture-in-picture-disable-attribute.optional.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/leave-picture-in-picture-disable-attribute.optional.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>Test leavepictureinpicture event</title>
+<title>Test that leavepictureinpicture is seen when setting disablePictureInPicture=true</title>
 <meta name="timeout" content="long">
 <script src="/common/media.js"></script>
 <script src="/resources/testharness.js"></script>
@@ -23,7 +23,7 @@ promise_test(async () => {
   await requestPictureInPictureWithTrustedClick(video);
   const { pictureInPictureWindow } = await enterPipEventPromise;
 
-  await document.exitPictureInPicture();
+  video.disablePictureInPicture = true;
 
   const event = await leavePipEventPromise;
   assert_equals(pictureInPictureWindow, event.pictureInPictureWindow);
@@ -32,5 +32,5 @@ promise_test(async () => {
   assert_equals(event.cancelable, false);
   assert_equals(event.composed, false);
   assert_equals(document.pictureInPictureElement, null);
-}, 'leavepictureinpicture event is fired if document.exitPictureInPicture');
+}, 'leavepictureinpicture event is fired if video.disablePictureInPicture is set to true');
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/leave-picture-in-picture-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/leave-picture-in-picture-expected.txt
@@ -1,0 +1,3 @@
+
+PASS leavepictureinpicture event is fired if document.exitPictureInPicture
+

--- a/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/permissions-policy.https.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/permissions-policy.https.sub-expected.txt
@@ -1,0 +1,6 @@
+
+PASS picture-in-picture allowed in iframe with no allow attribute (default allowlist *)
+PASS picture-in-picture blocked in iframe with allow="picture-in-picture 'none'"
+PASS picture-in-picture denial propagates to nested iframes with no allow attribute
+PASS cross-origin iframe with allow="picture-in-picture 'none'"
+PASS cross origin picture-in-picture denial propagates to nested iframes with no allow attribute

--- a/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/permissions-policy.https.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/permissions-policy.https.sub.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<title>picture-in-picture: permissions policy via iframe allow attribute</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<body>
+<script>
+'use strict';
+
+const HELPER = '/picture-in-picture/resources/permissions-policy-helper.html';
+const NESTED  = '/picture-in-picture/resources/permissions-policy-nested-helper.html';
+
+const CROSS_HELPER = 'https://{{hosts[][]}}:{{ports[https][0]}}/picture-in-picture/resources/permissions-policy-helper.html';
+const CROSS_NESTED = 'https://{{hosts[][]}}:{{ports[https][0]}}/picture-in-picture/resources/permissions-policy-nested-helper.html';
+
+// Loads |src| in an iframe, optionally sets |allow| on it, waits for a
+// 'pip-policy-result' message from that frame, and resolves with the boolean.
+function pipAllowedInFrame(t, src, allow) {
+  return new Promise(resolve => {
+    const frame = document.createElement('iframe');
+    if (allow !== undefined) {
+      frame.allow = allow;
+    }
+
+    frame.src = src;
+
+    window.addEventListener('message', t.step_func(event => {
+      if (event.source === frame.contentWindow &&
+          event.data.type === 'pip-policy-result') {
+        document.body.removeChild(frame);
+        resolve(event.data.allowed);
+      }
+    }), { once: true });
+
+    document.body.appendChild(frame);
+  });
+}
+
+// Test 1: no allow attribute at all.
+// picture-in-picture has a default allowlist of '*', so it must be available
+// in any same-origin iframe that carries no allow attribute.
+promise_test(async t => {
+  const allowed = await pipAllowedInFrame(t, HELPER);
+  assert_true(allowed,
+    'picture-in-picture should be allowed when iframe has no allow attribute');
+}, 'picture-in-picture allowed in iframe with no allow attribute (default allowlist *)');
+
+// Test 2: Set iframe's allow to "picture-in-picture 'none'" which should block
+// picture in picture requests.
+promise_test(async t => {
+  const allowed = await pipAllowedInFrame(t, HELPER, "picture-in-picture 'none'");
+  assert_false(allowed,
+    "picture-in-picture should be blocked when allow=\"picture-in-picture 'none'\" is set");
+}, "picture-in-picture blocked in iframe with allow=\"picture-in-picture 'none'\"");
+
+// Test 3: Grand child frame, shall have it's PIP requests blocked if the child had its
+// allow set to "picture-in-picture 'none'"
+promise_test(async t => {
+  const allowed = await pipAllowedInFrame(t, NESTED, "picture-in-picture 'none'");
+  assert_false(allowed,
+    'picture-in-picture denial should propagate into nested iframes with no allow attribute');
+}, "picture-in-picture denial propagates to nested iframes with no allow attribute");
+
+// Test 4: Cross origin variant of test 2
+promise_test(async t => {
+  const allowed = await pipAllowedInFrame(t, CROSS_HELPER, "picture-in-picture 'none'");
+  assert_false(allowed,
+    "picture-in-picture should be blocked when allow=\"picture-in-picture 'none'\" is set");
+}, "cross-origin iframe with allow=\"picture-in-picture 'none'\"");
+
+// Test 5: Cross origin variant of test 3
+promise_test(async t => {
+  const allowed = await pipAllowedInFrame(t, CROSS_NESTED, "picture-in-picture 'none'");
+  assert_false(allowed,
+    'picture-in-picture denial should propagate into nested iframes with no allow attribute');
+}, "cross origin picture-in-picture denial propagates to nested iframes with no allow attribute");
+
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/picture-in-picture-element-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/picture-in-picture-element-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Test Picture-in-Picture element
+

--- a/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/picture-in-picture-window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/picture-in-picture-window-expected.txt
@@ -1,0 +1,7 @@
+
+PASS Picture-in-Picture window dimensions are set after entering Picture-in-Picture
+PASS Picture-in-Picture window dimensions are set to 0 after entering Picture-in-Picture for another video
+PASS Picture-in-Picture window is unchanged after entering Picture-in-Picture for video already in Picture-in-Picture
+PASS Picture-in-Picture window dimensions are set to 0 after exiting Picture-in-Picture
+PASS Picture-in-Picture window dimensions are set to 0 if disablePictureInPicture becomes true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/removed-from-document-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/removed-from-document-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Picture-in-Picture video does not pause when removed from document
+

--- a/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/removed-from-document.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/removed-from-document.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<title>Test Picture-in-Picture when removed from document</title>
+<script src="/common/media.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="resources/picture-in-picture-helpers.js"></script>
+<body></body>
+<script>
+promise_test(async t => {
+  const video = await loadVideo();
+  document.body.appendChild(video);
+  video.muted = true;
+  await video.play();
+  await requestPictureInPictureWithTrustedClick(video);
+
+  assert_false(video.paused);
+  document.body.offsetLeft;
+  document.body.removeChild(video);
+  await new Promise(resolve => step_timeout(resolve, 1000));
+  assert_false(video.paused);
+}, 'Picture-in-Picture video does not pause when removed from document');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/request-picture-in-picture-exits-existing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/request-picture-in-picture-exits-existing-expected.txt
@@ -1,0 +1,6 @@
+
+PASS Step 11.5.1 runs the inline exit algorithm, so leavepictureinpicture fires synchronously before enterpictureinpicture
+PASS Inline exit algorithm unsets pictureInPictureElement before firing leavepictureinpicture
+PASS Step 11.5.2 sets pictureInPictureElement to the new element before step 11.5.5 fires enterpictureinpicture
+PASS Inline exit algorithm still runs the close window algorithm on the displaced Picture-in-Picture window
+

--- a/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/request-picture-in-picture-exits-existing.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/request-picture-in-picture-exits-existing.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<title>Test request Picture-in-Picture exits existing element via inline exit algorithm (anticipated spec refactor)</title>
+<meta name="timeout" content="long">
+<script src="/common/media.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="resources/picture-in-picture-helpers.js"></script>
+<body></body>
+<script>
+
+// Test 1: When video1 enters pip followed by video2 requesting pip
+// video1 should be observed leaving first, before video2 enters.
+promise_test(async t => {
+  const video1 = await loadVideo();
+  const video2 = await loadVideo();
+
+  await requestPictureInPictureWithTrustedClick(video1);
+
+  const events = [];
+  video1.addEventListener('leavepictureinpicture',
+      () => { events.push('leave1'); });
+  video2.addEventListener('enterpictureinpicture',
+      () => { events.push('enter2'); });
+
+  await requestPictureInPictureWithTrustedClick(video2);
+
+  assert_array_equals(events, ['leave1', 'enter2'],
+      'leavepictureinpicture on the displaced element fires before ' +
+      'enterpictureinpicture on the new element, both within the same task');
+}, 'Step 11.5.1 runs the inline exit algorithm, so leavepictureinpicture ' +
+   'fires synchronously before enterpictureinpicture');
+
+// Test 2: When video1 enters pip followed by video2 requesting pip
+// in video1's leavepictureinpicture handler it should be observed that
+// document.pictureInPictureElement is null, unset by video1's exit algorithm
+// and not yet set by video2's enter algorithm.
+promise_test(async t => {
+  const video1 = await loadVideo();
+  const video2 = await loadVideo();
+
+  await requestPictureInPictureWithTrustedClick(video1);
+
+  let pipElementDuringLeave = video1;
+  video1.addEventListener('leavepictureinpicture', () => {
+    pipElementDuringLeave = document.pictureInPictureElement;
+  });
+
+  await requestPictureInPictureWithTrustedClick(video2);
+
+  assert_equals(pipElementDuringLeave, null,
+      'document.pictureInPictureElement is null inside the displaced ' +
+      'element\'s leavepictureinpicture handler (inline exit has unset ' +
+      'it, and 11.5.2 has not yet set it to the new element)');
+}, 'Inline exit algorithm unsets pictureInPictureElement before firing ' +
+   'leavepictureinpicture');
+
+// Test 3: When video1 enters pip followed by video2 requesting pip
+// video2 enterpictureinpicture handler should observe itself having been set
+// as document.pictureInPictureElement
+promise_test(async t => {
+  const video1 = await loadVideo();
+  const video2 = await loadVideo();
+
+  await requestPictureInPictureWithTrustedClick(video1);
+
+  let pipElementDuringEnter = video1;
+  video2.addEventListener('enterpictureinpicture', () => {
+    pipElementDuringEnter = document.pictureInPictureElement;
+  });
+
+  await requestPictureInPictureWithTrustedClick(video2);
+
+  assert_equals(pipElementDuringEnter, video2,
+      'document.pictureInPictureElement is the new element inside its ' +
+      'enterpictureinpicture handler');
+}, 'Step 11.5.2 sets pictureInPictureElement to the new element before ' +
+   'step 11.5.5 fires enterpictureinpicture');
+
+// Test 4: When video1 enters pip followed by video2 requesting pip
+// it's always observed that pipWindow1 has closed before video2's enterpictureinpicture
+// handler runs
+promise_test(async t => {
+  const video1 = await loadVideo();
+  const video2 = await loadVideo();
+
+  const pipWindow1 = await requestPictureInPictureWithTrustedClick(video1);
+  assert_not_equals(pipWindow1.width, 0);
+  assert_not_equals(pipWindow1.height, 0);
+  let enteredPromise = new Promise(r => {
+    video2.addEventListener('enterpictureinpicture', () => {
+      assert_equals(pipWindow1.width, 0,
+          'previous Picture-in-Picture window width is reset to 0');
+      assert_equals(pipWindow1.height, 0,
+          'previous Picture-in-Picture window height is reset to 0');
+      r();
+    });
+  });
+  await requestPictureInPictureWithTrustedClick(video2);
+  await enteredPromise;
+}, 'Inline exit algorithm still runs the close window algorithm on the ' +
+   'displaced Picture-in-Picture window');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/request-picture-in-picture-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/request-picture-in-picture-expected.txt
@@ -1,0 +1,6 @@
+
+PASS request Picture-in-Picture requires a user gesture
+PASS request Picture-in-Picture requires loaded metadata for the video element
+PASS request Picture-in-Picture requires video track for the video element
+PASS request Picture-in-Picture resolves on user click
+

--- a/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/request-picture-in-picture-twice-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/request-picture-in-picture-twice-expected.txt
@@ -1,0 +1,4 @@
+
+PASS request Picture-in-Picture consumes user gesture
+PASS request Picture-in-Picture does not require user gesture if document.pictureInPictureElement is set
+

--- a/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/resources/permissions-policy-helper.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/resources/permissions-policy-helper.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<script src=/common/media.js></script>
+<script src=/picture-in-picture/resources/picture-in-picture-helpers.js></script>
+<script>
+'use strict';
+
+// Loads a video, calls requestPictureInPicture(), and reports back whether
+// the permissions policy allows the feature. A SecurityError means the policy
+// blocked the call; a NotAllowedError means user activation was missing but
+// the policy itself allows PiP.
+window.addEventListener('load', () => {
+  const video = document.createElement('video');
+  video.src = getVideoURI('/media/movie_5');
+  video.onloadedmetadata = () => {
+    video.requestPictureInPicture()
+      .then(() => {
+        window.parent.postMessage({ type: 'pip-policy-result', allowed: true }, '*');
+      })
+      .catch(e => {
+        const allowed = e.name === 'NotAllowedError';
+        window.parent.postMessage({ type: 'pip-policy-result', allowed }, '*');
+      });
+  };
+  document.body.appendChild(video);
+}, { once: true });
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/resources/permissions-policy-nested-helper.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/resources/permissions-policy-nested-helper.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<!-- Embeds permissions-policy-helper.html in a plain <iframe> with no allow
+     attribute, then relays the result up to the parent frame. Used by the
+     permissions-policy.https.html test to verify that a PiP denial set on
+     this page's own embedding iframe is inherited by nested iframes that carry
+     no allow attribute of their own. -->
+<script>
+'use strict';
+
+window.addEventListener('load', () => {
+  const inner = document.createElement('iframe');
+  inner.src = '/picture-in-picture/resources/permissions-policy-helper.html';
+
+  window.addEventListener('message', (event) => {
+    if (event.source === inner.contentWindow &&
+        event.data.type === 'pip-policy-result') {
+      window.parent.postMessage(event.data, '*');
+    }
+  }, { once: true });
+
+  document.body.appendChild(inner);
+}, { once: true });
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/resources/unload-document-helper.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/resources/unload-document-helper.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<title>Picture-in-Picture unload-document helper</title>
+<script src="/common/media.js"></script>
+<body></body>
+<script>
+'use strict';
+
+window.video = document.createElement('video');
+window.video.src = getVideoURI('/media/movie_5');
+window.videoReady = new Promise((resolve, reject) => {
+  window.video.onloadedmetadata = () => resolve(window.video);
+  window.video.onerror = reject;
+});
+document.body.appendChild(window.video);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/resources/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/resources/w3c-import.log
@@ -10,8 +10,9 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/resources/permissions-policy-helper.html
+/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/resources/permissions-policy-nested-helper.html
 /LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/resources/picture-in-picture-helpers.js
+/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/resources/unload-document-helper.html

--- a/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/shadow-dom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/shadow-dom-expected.txt
@@ -1,0 +1,7 @@
+
+PASS Test for Picture-In-Picture and Shadow DOM
+PASS Picture-in-Picture on a video inside an open shadow root attached to a disconnected host
+PASS Picture-in-Picture on a video inside a closed shadow root attached to a disconnected host
+PASS Connecting a previously-disconnected shadow host after Picture-in-Picture starts exposes the video through shadowRoot.pictureInPictureElement
+PASS Picture-in-Picture on a video inside nested shadow roots whose outer host is disconnected
+

--- a/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/shadow-dom.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/shadow-dom.html
@@ -85,4 +85,91 @@ promise_test(async t => {
     assert_equals(getComputedStyle(ids.host2).color, 'rgb(0, 0, 254)');
   });
 });
+
+async function shadowRootTest(mode) {
+  const video = await loadVideo();
+  const host = document.createElement('div');
+  const shadow = host.attachShadow({ mode });
+  shadow.appendChild(video);
+  await requestPictureInPictureWithTrustedClick(video);
+
+  assert_equals(document.pictureInPictureElement, host,
+    'document.pictureInPictureElement is the disconnected shadow host ' +
+    '(retargeted across the shadow boundary from the unbound video)');
+
+  // Test the step 1 of the pictureInPictureElement getter algorithm:
+  // If this is a shadow root and its host is not connected,
+  // return null and abort these steps.
+  // Which looks odd, given that document.pictureInPictureElement returns non-null.
+  // See https://github.com/w3c/picture-in-picture/pull/253
+  assert_equals(shadow.pictureInPictureElement, null,
+    'shadowRoot.pictureInPictureElement is null while the shadow root\'s ' +
+    'host is not connected');
+
+  return { video, host, shadow };
+}
+
+promise_test(async t => {
+  const { shadow } = await shadowRootTest('open');
+  await document.exitPictureInPicture();
+  assert_equals(document.pictureInPictureElement, null);
+  assert_equals(shadow.pictureInPictureElement, null);
+}, 'Picture-in-Picture on a video inside an open shadow root attached to a ' +
+   'disconnected host');
+
+promise_test(async t => {
+  const { shadow } = await shadowRootTest('closed');
+  await document.exitPictureInPicture();
+  assert_equals(document.pictureInPictureElement, null);
+  assert_equals(shadow.pictureInPictureElement, null);
+}, 'Picture-in-Picture on a video inside a closed shadow root attached to a ' +
+   'disconnected host');
+
+promise_test(async t => {
+  const { video, host, shadow } = await shadowRootTest('open');
+  document.body.appendChild(host);
+
+  assert_equals(document.pictureInPictureElement, host,
+    'after connect: document.pictureInPictureElement is still the host');
+  assert_equals(shadow.pictureInPictureElement, video,
+    'after connect: shadow.pictureInPictureElement is the video, because ' +
+    'the shadow root is now in a composed document and the video is in ' +
+    'this shadow\'s tree');
+
+  await document.exitPictureInPicture();
+  assert_equals(document.pictureInPictureElement, null);
+  assert_equals(shadow.pictureInPictureElement, null);
+}, 'Connecting a previously-disconnected shadow host after Picture-in-Picture ' +
+   'starts exposes the video through shadowRoot.pictureInPictureElement');
+
+// Nested shadow roots where the outermost host is disconnected: retargeting
+// must walk all the way up to the outermost (disconnected) host, and neither
+// inner nor outer shadow root must expose the element because both are
+// outside the composed tree.
+promise_test(async t => {
+  const video = await loadVideo();
+  const outerHost = document.createElement('div');
+  const outerShadow = outerHost.attachShadow({ mode: 'open' });
+  const innerHost = document.createElement('div');
+  outerShadow.appendChild(innerHost);
+  const innerShadow = innerHost.attachShadow({ mode: 'open' });
+  innerShadow.appendChild(video);
+
+  assert_false(outerHost.isConnected);
+  assert_equals(document.pictureInPictureElement, null);
+
+  await requestPictureInPictureWithTrustedClick(video);
+
+  assert_equals(document.pictureInPictureElement, outerHost,
+    'document.pictureInPictureElement is the outermost disconnected host');
+  assert_equals(outerShadow.pictureInPictureElement, null,
+    'outerShadow.pictureInPictureElement is null while the outer host is ' +
+    'not connected');
+  assert_equals(innerShadow.pictureInPictureElement, null,
+    'innerShadow.pictureInPictureElement is null while the outer host is ' +
+    'not connected (the inner shadow is not in a composed document either)');
+
+  await document.exitPictureInPicture();
+}, 'Picture-in-Picture on a video inside nested shadow roots whose outer ' +
+   'host is disconnected');
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/unload-document-exits-picture-in-picture-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/unload-document-exits-picture-in-picture-expected.txt
@@ -1,0 +1,3 @@
+
+PASS exit Picture-in-Picture algorithm runs as part of unloading document cleanup steps
+

--- a/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/unload-document-exits-picture-in-picture.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/unload-document-exits-picture-in-picture.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<title>Exit Picture-in-Picture runs during unloading document cleanup steps</title>
+<meta name="timeout" content="long">
+<link rel="help" href="https://w3c.github.io/picture-in-picture/#exit-pip">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<body></body>
+<script>
+'use strict';
+
+const HELPER = '/picture-in-picture/resources/unload-document-helper.html';
+
+function loadIframe(src) {
+  return new Promise(resolve => {
+    const iframe = document.createElement('iframe');
+    iframe.addEventListener('load', () => resolve(iframe), { once: true });
+    iframe.src = src;
+    document.body.appendChild(iframe);
+  });
+}
+
+function navigateIframe(iframe, src) {
+  return new Promise(resolve => {
+    iframe.addEventListener('load', resolve, { once: true });
+    iframe.src = src;
+  });
+}
+
+promise_test(async t => {
+  const iframe = await loadIframe(HELPER);
+  t.add_cleanup(() => iframe.remove());
+  const video = await iframe.contentWindow.videoReady;
+
+  await test_driver.bless('enter Picture-in-Picture from iframe', null,
+                          iframe.contentWindow);
+  const pipWindow = await video.requestPictureInPicture();
+
+  assert_equals(iframe.contentDocument.pictureInPictureElement, video,
+                'pictureInPictureElement is set inside the iframe document');
+
+  assert_not_equals(pipWindow.width, 0,
+                    'pipWindow.width is non-zero before the iframe is unloaded');
+  assert_not_equals(pipWindow.height, 0,
+                    'pipWindow.height is non-zero before the iframe is unloaded');
+
+  await navigateIframe(iframe, '/common/blank.html');
+
+  assert_equals(iframe.contentDocument.pictureInPictureElement, null,
+                'the new iframe document has no pictureInPictureElement');
+  await t.step_wait(
+      () => pipWindow.width === 0 && pipWindow.height === 0,
+      'pipWindow.width and pipWindow.height become 0 after the iframe ' +
+      'document is unloaded');
+}, 'exit Picture-in-Picture algorithm runs as part of unloading document cleanup steps');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/w3c-import.log
@@ -10,20 +10,24 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/META.yml
+/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/WEB_FEATURES.yml
 /LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/css-selector.html
 /LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/disable-picture-in-picture.html
 /LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/enter-picture-in-picture.html
 /LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/exit-picture-in-picture.html
 /LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/idlharness.window.js
+/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/leave-picture-in-picture-disable-attribute.optional.html
 /LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/leave-picture-in-picture.html
 /LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/mediastream.html
+/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/permissions-policy.https.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/picture-in-picture-element.html
 /LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/picture-in-picture-window.html
+/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/removed-from-document.html
+/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/request-picture-in-picture-exits-existing.html
 /LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/request-picture-in-picture-twice.html
 /LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/request-picture-in-picture.html
 /LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/shadow-dom.html
+/LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/unload-document-exits-picture-in-picture.html

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3684,6 +3684,7 @@ webkit.org/b/202756 media/modern-media-controls/pip-placard [ Skip ]
 webkit.org/b/202756 media/modern-media-controls/pip-support [ Skip ]
 webkit.org/b/202756 media/modern-media-controls/placard-support/placard-support-pip.html [ Skip ]
 webkit.org/b/202756 media/picture-in-picture/ [ Skip ]
+webkit.org/b/202756 imported/w3c/web-platform-tests/picture-in-picture/ [ Skip ]
 webkit.org/b/211569 media/video-presentation-mode.html [ Skip ]
 webkit.org/b/206584 media/video-set-presentation-mode-to-inline.html [ Skip ]
 # Also crashing with others in webkit.org/b/198830

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -1296,6 +1296,12 @@ media/audio-playback-volume-changes-with-restrictions.html [ Skip ]
 webaudio/MediaElementAudioSource/mediaelementaudiosourcenode-volume.html [ Skip ]
 
 media/picture-in-picture/picture-in-picture-interruption.html [ Skip ]
+imported/w3c/web-platform-tests/picture-in-picture/disable-picture-in-picture.html [ Skip ]
+imported/w3c/web-platform-tests/picture-in-picture/picture-in-picture-window.html [ Skip ]
+imported/w3c/web-platform-tests/picture-in-picture/request-picture-in-picture-exits-existing.html [ Skip ]
+imported/w3c/web-platform-tests/picture-in-picture/request-picture-in-picture-twice.html [ Skip ]
+imported/w3c/web-platform-tests/picture-in-picture/request-picture-in-picture.html [ Skip ]
+
 scrollbars/scrolling-backward-by-page-accounting-bottom-fixed-elements-on-keyboard-spacebar.html [ Skip ]
 scrollbars/scrolling-backward-by-page-on-keyboard-spacebar.html [ Skip ]
 scrollbars/scrolling-by-page-accounting-oversized-fixed-elements-on-keyboard-spacebar.html [ Skip ]

--- a/LayoutTests/resources/testdriver-vendor.js
+++ b/LayoutTests/resources/testdriver-vendor.js
@@ -1,5 +1,11 @@
 const isDebug = false;
 
+// Mock video presentation mode is required so tests that enter Picture-in-Picture
+// (or otherwise transition presentation mode) do not compete for the singleton system
+// PiP window when tests run in parallel.
+if (window.internals && window.internals.setMockVideoPresentationModeEnabled)
+    window.internals.setMockVideoPresentationModeEnabled(true);
+
 function logDebug(msg) {
     if (isDebug)
         console.log(msg);
@@ -436,7 +442,7 @@ window.test_driver_internal.click = async function (element, coords)
         };
     }
 
-    if (testRunner.isIOSFamily && testRunner.isWebKit2) {
+    if (testRunner?.isIOSFamily && testRunner?.isWebKit2) {
         await new Promise((resolve) => {
             testRunner.runUIScript(`
                 uiController.singleTapAtPoint(${point.x}, ${point.y}, function() {

--- a/LayoutTests/tests-options.json
+++ b/LayoutTests/tests-options.json
@@ -5384,13 +5384,22 @@
     "imported/w3c/web-platform-tests/permissions-policy/permissions-policy-nested-header-policy-disallowed-for-all.https.sub.html": [
         "slow"
     ],
+    "imported/w3c/web-platform-tests/picture-in-picture/leave-picture-in-picture-disable-attribute.optional.html": [
+        "slow"
+    ],
     "imported/w3c/web-platform-tests/picture-in-picture/leave-picture-in-picture.html": [
         "slow"
     ],
     "imported/w3c/web-platform-tests/picture-in-picture/picture-in-picture-window.html": [
         "slow"
     ],
+    "imported/w3c/web-platform-tests/picture-in-picture/request-picture-in-picture-exits-existing.html": [
+        "slow"
+    ],
     "imported/w3c/web-platform-tests/picture-in-picture/request-picture-in-picture-twice.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/picture-in-picture/unload-document-exits-picture-in-picture.html": [
         "slow"
     ],
     "imported/w3c/web-platform-tests/pointerevents/coalesced_events_attributes_under_load.https.optional.html": [

--- a/Source/WebCore/Modules/pictureinpicture/HTMLVideoElementPictureInPicture.cpp
+++ b/Source/WebCore/Modules/pictureinpicture/HTMLVideoElementPictureInPicture.cpp
@@ -104,13 +104,19 @@ void HTMLVideoElementPictureInPicture::requestPictureInPicture(HTMLVideoElement&
         return;
     }
 
-    if (!videoElement.videoTracks() || !videoElement.videoTracks()->length()) {
+    if (!videoElement.hasVideo()) {
         promise->reject(ExceptionCode::InvalidStateError, "The video element does not have a video track or it has not detected a video track yet."_s);
         return;
     }
 
+    RefPtr window = videoElement.document().window();
+    if (!window) {
+        promise->reject(ExceptionCode::InvalidStateError, "The video element does not have a window object."_s);
+        return;
+    }
+
     bool userActivationRequired = !protect(videoElement)->document().pictureInPictureElement();
-    if (userActivationRequired && !UserGestureIndicator::processingUserGesture()) {
+    if (userActivationRequired && !window->hasTransientActivation()) {
         promise->reject(ExceptionCode::NotAllowedError, "The request is not triggered by a user activation."_s);
         return;
     }
@@ -173,19 +179,37 @@ void HTMLVideoElementPictureInPicture::didEnterPictureInPicture(const IntSize& w
         return;
 
     INFO_LOG(LOGIDENTIFIER);
-    protect(videoElement)->document().setPictureInPictureElement(videoElement.get());
+
     m_pictureInPictureWindow->setSize(windowSize);
 
-    auto initializer = PictureInPictureEvent::Init {
-        { true, false, false },
-        m_pictureInPictureWindow
-    };
-    videoElement->scheduleEvent(PictureInPictureEvent::create(eventNames().enterpictureinpictureEvent, WTF::move(initializer)));
+    // https://w3c.github.io/picture-in-picture/#dom-htmlvideoelement-requestpictureinpicture
+    // 5. Queue a global task on the media element event task source given global, to perform the following steps:
+    // 5.1. If pictureInPictureElement is not null, run the exit Picture-in-Picture algorithm.
+    //      NOTE: This step is explicitly outside the EventQueue below so that the exit steps
+    //      happen both within their own event queue task and before the steps below.
+    if (RefPtr existing = videoElement->document().pictureInPictureElement())
+        HTMLVideoElementPictureInPicture::from(*existing).didExitPictureInPicture();
 
-    if (m_enterPictureInPicturePromise) {
-        protect(m_enterPictureInPicturePromise)->resolve<IDLInterface<PictureInPictureWindow>>(m_pictureInPictureWindow);
-        m_enterPictureInPicturePromise = nullptr;
-    }
+    ActiveDOMObject::queueTaskKeepingObjectAlive(*videoElement, TaskSource::MediaElement, [enterPictureInPicturePromise = std::exchange(m_enterPictureInPicturePromise, nullptr), pictureInPictureWindow = m_pictureInPictureWindow](auto& videoElement) mutable {
+
+        // 5.2. Set doc’s Picture-in-Picture element to this.
+        videoElement.document().setPictureInPictureElement(&videoElement);
+
+        // 5.3. Append relevant settings object’s origin to initiators of active Picture-in-Picture sessions.
+        // 5.4. If this is fullscreenElement, exit fullscreen.
+        // 5.5. Fire an event named enterpictureinpicture using PictureInPictureEvent at this with its bubbles
+        //      attribute initialized to true and its pictureInPictureWindow attribute initialized to
+        //      Picture-in-Picture window.
+        auto initializer = PictureInPictureEvent::Init {
+            { true, false, false },
+            pictureInPictureWindow
+        };
+        videoElement.dispatchEvent(PictureInPictureEvent::create(eventNames().enterpictureinpictureEvent, WTF::move(initializer)));
+
+        // 6. Resolve p with pipWindow.
+        if (enterPictureInPicturePromise)
+            enterPictureInPicturePromise->resolve<IDLInterface<PictureInPictureWindow>>(pictureInPictureWindow);
+    });
 }
 
 void HTMLVideoElementPictureInPicture::didExitPictureInPicture()
@@ -196,18 +220,19 @@ void HTMLVideoElementPictureInPicture::didExitPictureInPicture()
 
     INFO_LOG(LOGIDENTIFIER);
     m_pictureInPictureWindow->close();
-    protect(videoElement)->document().setPictureInPictureElement(nullptr);
+    videoElement->document().setPictureInPictureElement(nullptr);
 
-    auto initializer = PictureInPictureEvent::Init {
-        { true, false, false },
-        m_pictureInPictureWindow
-    };
-    videoElement->scheduleEvent(PictureInPictureEvent::create(eventNames().leavepictureinpictureEvent, WTF::move(initializer)));
+    ActiveDOMObject::queueTaskKeepingObjectAlive(*videoElement, TaskSource::MediaElement, [exitPictureInPicturePromise = std::exchange(m_exitPictureInPicturePromise, nullptr), pictureInPictureWindow = m_pictureInPictureWindow](auto& videoElement) mutable {
 
-    if (m_exitPictureInPicturePromise) {
-        protect(m_exitPictureInPicturePromise)->resolve();
-        m_exitPictureInPicturePromise = nullptr;
-    }
+        auto initializer = PictureInPictureEvent::Init {
+            { true, false, false },
+            pictureInPictureWindow
+        };
+        videoElement.dispatchEvent(PictureInPictureEvent::create(eventNames().leavepictureinpictureEvent, WTF::move(initializer)));
+
+        if (exitPictureInPicturePromise)
+            exitPictureInPicturePromise->resolve();
+    });
 }
 
 void HTMLVideoElementPictureInPicture::pictureInPictureWindowResized(const IntSize& windowSize)

--- a/Source/WebCore/Modules/pictureinpicture/HTMLVideoElementPictureInPicture.h
+++ b/Source/WebCore/Modules/pictureinpicture/HTMLVideoElementPictureInPicture.h
@@ -30,6 +30,7 @@
 
 #include "PictureInPictureObserver.h"
 #include "Supplementable.h"
+#include <wtf/CancellableTask.h>
 #include <wtf/LoggerHelper.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakRef.h>
@@ -88,6 +89,8 @@ private:
     const Ref<PictureInPictureWindow> m_pictureInPictureWindow;
     RefPtr<DeferredPromise> m_enterPictureInPicturePromise;
     RefPtr<DeferredPromise> m_exitPictureInPicturePromise;
+
+    TaskCancellationGroup m_eventTaskGroup;
 
 #if !RELEASE_LOG_DISABLED
     const Ref<const Logger> m_logger;

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -444,6 +444,10 @@
 #include "LazyLoadModelObserver.h"
 #endif
 
+#if ENABLE(PICTURE_IN_PICTURE_API)
+#include "HTMLVideoElementPictureInPicture.h"
+#endif
+
 #if USE(QUICK_LOOK)
 #include "QuickLook.h"
 #endif
@@ -3742,6 +3746,11 @@ void Document::willBeRemovedFromFrame()
                 removePlaybackTargetPickerClient(*client);
         }
     }
+#endif
+
+#if ENABLE(PICTURE_IN_PICTURE_API)
+    if (RefPtr pictureInPictureElement = m_pictureInPictureElement)
+        HTMLVideoElementPictureInPicture::from(*pictureInPictureElement).didExitPictureInPicture();
 #endif
 
     protect(cachedResourceLoader())->stopUnusedPreloadsTimer();

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -823,6 +823,7 @@ protected:
 protected:
     // ActiveDOMObject
     void stop() override;
+    void suspend(ReasonForSuspension) override;
 
 private:
     friend class Internals;
@@ -842,7 +843,6 @@ private:
     void willStopBeingFullscreenElement() override;
 
     // ActiveDOMObject.
-    void suspend(ReasonForSuspension) override;
     void resume() override;
     bool virtualHasPendingActivity() const override;
 

--- a/Source/WebCore/html/HTMLVideoElement.cpp
+++ b/Source/WebCore/html/HTMLVideoElement.cpp
@@ -611,7 +611,12 @@ void HTMLVideoElement::setPresentationMode(VideoPresentationMode mode)
         return;
     }
 
-    if (!protect(mediaSession())->fullscreenPermitted() || !supportsFullscreen(videoFullscreenMode))
+#if ENABLE(PICTURE_IN_PICTURE_API)
+    bool requiresUserGesture = mode != VideoPresentationMode::PictureInPicture || !protect(document())->pictureInPictureElement();
+#else
+    bool requiresUserGesture = true;
+#endif
+    if ((requiresUserGesture && !protect(mediaSession())->fullscreenPermitted()) || !supportsFullscreen(videoFullscreenMode))
         return;
 
     if (videoFullscreenMode == VideoFullscreenModePictureInPicture)
@@ -773,6 +778,16 @@ void HTMLVideoElement::cancelVideoFrameCallback(unsigned identifier)
         if (RefPtr player = this->player())
             player->stopVideoFrameMetadataGathering();
     }
+}
+
+void HTMLVideoElement::suspend(ReasonForSuspension reason)
+{
+#if ENABLE(PICTURE_IN_PICTURE_API)
+    if (reason == ReasonForSuspension::BackForwardCache)
+        protect(HTMLVideoElementPictureInPicture::from(*this))->didExitPictureInPicture();
+#endif
+
+    HTMLMediaElement::suspend(reason);
 }
 
 void HTMLVideoElement::stop()

--- a/Source/WebCore/html/HTMLVideoElement.h
+++ b/Source/WebCore/html/HTMLVideoElement.h
@@ -149,12 +149,14 @@ public:
 #endif
 
     // ActiveDOMObject
+    void suspend(ReasonForSuspension) final;
     void stop() final;
 
     bool isIntersectingViewport() const final { return m_isIntersectingViewport; }
     void viewportIntersectionChanged(bool isIntersecting);
 
 private:
+    friend class HTMLVideoElementPictureInPicture;
     HTMLVideoElement(const QualifiedName&, Document&, bool createdByParser);
 
     void scheduleResizeEvent(const FloatSize&) final;

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
@@ -434,6 +434,7 @@ void RemoteMediaPlayerProxy::mediaPlayerReadyStateChanged()
     ALWAYS_LOG(LOGIDENTIFIER, newReadyState);
     updateCachedVideoMetrics();
     updateCachedState(true);
+    updateCachedMediaCharacteristics();
     m_cachedState.networkState = player->networkState();
     m_cachedState.duration = player->duration();
 
@@ -610,14 +611,18 @@ void RemoteMediaPlayerProxy::mediaPlayerCharacteristicChanged()
 {
     updateCachedVideoMetrics();
     updateCachedState();
+    updateCachedMediaCharacteristics();
 
+    protect(m_webProcessConnection)->send(Messages::MediaPlayerPrivateRemote::CharacteristicChanged(m_cachedState), m_id);
+}
+
+void RemoteMediaPlayerProxy::updateCachedMediaCharacteristics()
+{
     RefPtr player = m_player;
     m_cachedState.hasAudio = player->hasAudio();
     m_cachedState.hasVideo = player->hasVideo();
     m_cachedState.hasClosedCaptions = player->hasClosedCaptions();
     m_cachedState.languageOfPrimaryAudioTrack = player->languageOfPrimaryAudioTrack();
-
-    protect(m_webProcessConnection)->send(Messages::MediaPlayerPrivateRemote::CharacteristicChanged(m_cachedState), m_id);
 }
 
 bool RemoteMediaPlayerProxy::mediaPlayerRenderingCanBeAccelerated()

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
@@ -344,6 +344,8 @@ private:
     void maybeUpdateCachedVideoMetrics();
     void updateCachedVideoMetrics();
 
+    void updateCachedMediaCharacteristics();
+
     void createAudioSourceProvider();
     void setShouldEnableAudioSourceProvider(bool);
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -207,6 +207,10 @@
 #include <WebCore/HTMLMediaElement.h>
 #endif
 
+#if PLATFORM(IOS_FAMILY) && ENABLE(VIDEO_PRESENTATION_MODE)
+#include <WebCore/PictureInPictureSupport.h>
+#endif
+
 namespace WebKit {
 using namespace WebCore;
 using namespace HTMLNames;
@@ -1490,6 +1494,9 @@ bool WebChromeClient::supportsVideoFullscreenStandby()
 
 void WebChromeClient::setMockVideoPresentationModeEnabled(bool enabled)
 {
+#if PLATFORM(IOS_FAMILY) && ENABLE(VIDEO_PRESENTATION_MODE)
+    setSupportsPictureInPicture(enabled);
+#endif
     if (RefPtr page = m_page.get())
         page->send(Messages::WebPageProxy::SetMockVideoPresentationModeEnabled(enabled));
 }

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -1458,6 +1458,7 @@ void TestController::resetPreferencesToConsistentValues(const TestOptions& optio
         WKPreferencesSetProcessSwapOnNavigationEnabled(preferences, options.shouldEnableProcessSwapOnNavigation());
         WKPreferencesSetStorageBlockingPolicy(preferences, kWKAllowAllStorage); // FIXME: We should be testing the default.
         WKPreferencesSetMinimumFontSize(preferences, 0);
+        WKPreferencesSetAllowsPictureInPictureMediaPlayback(preferences, true);
 
         WKPreferencesSetBoolValueForKeyForTesting(preferences, options.allowTestOnlyIPC(), toWK("AllowTestOnlyIPC").get());
         WKPreferencesSetBoolValueForKeyForTesting(preferences, false, toWK("GlobalPrivacyControlEnabled").get());


### PR DESCRIPTION
#### 397df0f71bfd0136ef1a47a57dffe0b04eb1d814
<pre>
[WPT] Enable (most) picture-in-picture tests
<a href="https://rdar.apple.com/182373790">rdar://182373790</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=319544">https://bugs.webkit.org/show_bug.cgi?id=319544</a>

Reviewed by Eric Carlson.

Enable all existing picture-in-picture tests (except mediastream.html,
leave-picture-in-picture-disable-attribute.optional.html, and permissions-policy.https.sub.html)
by resolving all issues preventing those tests from passing:

1. Many tests were failing because the &lt;video&gt; element did not have video tracks immediately
   after &quot;loadedmetadata&quot; fired. There are two issues here:
   1.a MediaPlayerPrivateAVFoundationObjC does not create video or audio tracks until the
       AVPlayerItem is created and AVPlayerItemTracks are available, which is long after the
       ready state moves to HAVE_METADATA. Rather than requiring video tracks to be non-empty
       just check haveVideo() instead.
   1.b The RemoteMediaPlayerProxy doesn&apos;t update haveVideo when ready state changes.
2. requestPictureInPicture() was testing whether the current event was a user gesture, which
   is a much more stringent requirement than the spec requires. Check instead for a transient
   user activation.
3. Flows that don&apos;t require a user gesture (such as when another video element is already in
   PiP) were blocked by downstream code in HTMLVideoElement::setPresentationMode().
4. The promise was resolving before the &quot;enterpictureinpicture&quot; event fired, when it should have
   resolved after.
5. WebKitTestRunner did not enable the PiP setting.
6. HTMLVideoElement did not exit PiP upon entering the back-forward cache.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/css-selector-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/disable-picture-in-picture-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/enter-picture-in-picture-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/exit-picture-in-picture-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/idlharness.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/leave-picture-in-picture-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/picture-in-picture-element-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/picture-in-picture-window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/request-picture-in-picture-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/request-picture-in-picture-twice-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/shadow-dom-expected.txt: Added.
* LayoutTests/resources/testdriver-vendor.js:
(async if.await.new.Promise): Deleted.
* Source/WebCore/Modules/pictureinpicture/HTMLVideoElementPictureInPicture.cpp:
(WebCore::HTMLVideoElementPictureInPicture::requestPictureInPicture):
(WebCore::HTMLVideoElementPictureInPicture::didEnterPictureInPicture):
(WebCore::HTMLVideoElementPictureInPicture::didExitPictureInPicture):
* Source/WebCore/Modules/pictureinpicture/HTMLVideoElementPictureInPicture.h:
* Source/WebCore/html/HTMLVideoElement.cpp:
(WebCore::HTMLVideoElement::setPresentationMode):
(WebCore::HTMLVideoElement::HTMLVideoElement):
(WebCore::HTMLVideoElement::rendererIsNeeded):
(WebCore::HTMLVideoElement::supportsFullscreen const):
(WebCore::HTMLVideoElement::webkitEnterFullscreen):
(WebCore::HTMLVideoElement::suspend):
* Source/WebCore/html/HTMLVideoElement.h:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp:
(WebKit::RemoteMediaPlayerProxy::mediaPlayerReadyStateChanged):
(WebKit::RemoteMediaPlayerProxy::mediaPlayerCharacteristicChanged):
(WebKit::RemoteMediaPlayerProxy::updateCachedMediaCharacteristics):
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h:
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::resetPreferencesToConsistentValues):
* LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/META.yml:
* LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/WEB_FEATURES.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/leave-picture-in-picture-disable-attribute.optional.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/leave-picture-in-picture.html:
* LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/permissions-policy.https.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/permissions-policy.https.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/removed-from-document-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/removed-from-document.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/request-picture-in-picture-exits-existing-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/request-picture-in-picture-exits-existing.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/resources/permissions-policy-helper.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/resources/permissions-policy-nested-helper.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/resources/unload-document-helper.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/resources/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/shadow-dom.html:
* LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/unload-document-exits-picture-in-picture-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/unload-document-exits-picture-in-picture.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/picture-in-picture/w3c-import.log:
* LayoutTests/tests-options.json:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::willBeRemovedFromFrame):
* Source/WebCore/html/HTMLMediaElement.h:

Canonical link: <a href="https://commits.webkit.org/317631@main">https://commits.webkit.org/317631@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97d2531cdfe903fb6012e258c133d93a02bc7dfa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175176 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49108 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42889 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184761 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/133083 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1b607b96-775f-40f1-9f7d-f3230472a525) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177040 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50400 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48791 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136353 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96180 "2 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c78e56b0-32ee-4d2d-ba4b-d2fe8360f484) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178133 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39792 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157139 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116832 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1f9066ea-452f-45ae-abd6-d4ed419827e2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38433 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36811 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33234 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148856 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36632 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187182 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/40795 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41014 "344 new passes 12 flakes 4 failures") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145299 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48775 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156695 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145156 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39260 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49455 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33253 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115294 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40011 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121634 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47961 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11605 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47364 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47594 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47421 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->