### PR TITLE
Fetch byte stream source strands buffered data when the response goes idle

### DIFF
--- a/LayoutTests/http/wpt/fetch/fetch-byte-stream-quiet-drain-expected.txt
+++ b/LayoutTests/http/wpt/fetch/fetch-byte-stream-quiet-drain-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Fetch body delivers bytes that arrived while no read was pending, after the stream goes quiet
+

--- a/LayoutTests/http/wpt/fetch/fetch-byte-stream-quiet-drain.html
+++ b/LayoutTests/http/wpt/fetch/fetch-byte-stream-quiet-drain.html
@@ -1,0 +1,33 @@
+<!doctype html><!-- webkit-test-runner [ ReadableByteStreamFetchSourceEnabled=true ] -->
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Fetch byte stream delivers buffered bytes after the response goes quiet</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <script>
+promise_test(async (test) => {
+    const response = await fetch('resources/two-chunks-then-quiet.py');
+    const reader = response.body.getReader();
+
+    // Do not read yet. The first chunk satisfies the initial pull and fills
+    // the queue past its high-water mark, so the controller stops pulling;
+    // the second chunk arrives with no pull outstanding and gets buffered.
+    await new Promise(resolve => test.step_timeout(resolve, 2000));
+
+    let received = 0;
+    while (received < 32) {
+        const result = await Promise.race([
+            reader.read(),
+            new Promise(resolve => test.step_timeout(() => resolve('stalled'), 3000)),
+        ]);
+        assert_not_equals(result, 'stalled', 'read stalled with ' + received + ' of 32 bytes delivered and the connection idle');
+        assert_false(result.done);
+        received += result.value.byteLength;
+    }
+}, "Fetch body delivers bytes that arrived while no read was pending, after the stream goes quiet");
+    </script>
+  </body>
+</html>

--- a/LayoutTests/http/wpt/fetch/resources/two-chunks-then-quiet.py
+++ b/LayoutTests/http/wpt/fetch/resources/two-chunks-then-quiet.py
@@ -1,0 +1,12 @@
+import time
+
+
+def main(request, response):
+    response.headers.set(b"Content-Type", b"application/octet-stream")
+    response.write_status_headers()
+    response.writer.write_content(b"A" * 16)
+    # Deliver the second chunk in a separate network callback, after the
+    # controller has stopped pulling, then go quiet without closing.
+    time.sleep(0.5)
+    response.writer.write_content(b"B" * 16)
+    time.sleep(8)

--- a/Source/WebCore/Modules/fetch/FetchBodySource.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodySource.cpp
@@ -75,6 +75,12 @@ Ref<DOMPromise> FetchBodySource::pull(JSDOMGlobalObject& globalObject, ReadableB
     auto [promise, deferred] = createPromiseAndWrapper(globalObject);
     m_isPulling = true;
     m_pullPromise = WTF::move(deferred);
+
+    if (m_byteController) {
+        if (RefPtr bodyOwner = m_bodyOwner.get())
+            bodyOwner->feedStream();
+    }
+
     return promise;
 }
 


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=319542

Implements the fix suggested in the bug: drain the body consumer from
FetchBodySource::pull, matching what the non-byte source already does via
NonByteSource::doPull -> FetchBodyOwner::feedStream.

The drain is guarded on m_byteController being set. The initial pull fires
synchronously during stream creation, before FetchBodyOwner::createReadableStream
has assigned m_readableStreamSource, so calling feedStream there dereferences the
unset source and crashes the WebContent process; data that arrived before creation
is already delivered by consumeBodyAsStream when setByteController runs. The new
layout test caught this: an earlier version of this patch without the guard
crashed on it reliably.

Includes a layout test, http/wpt/fetch/fetch-byte-stream-quiet-drain.html. The
server sends 16 bytes, sleeps 500ms, sends 16 more, then goes quiet while holding
the connection open. The page waits before its first read so the first chunk fills
the queue past the highWaterMark of 1 and the second arrives with no pull
outstanding, then reads until it has all 32 bytes, racing each read against a
timeout. Verified both ways against a local release build: without the fix it
fails with "read stalled with 16 of 32 bytes delivered and the connection idle";
with the fix it passes. The only timing assumption is generous fixed waits, not a
race window.

Also verified against the repro attached to the bug, driven through MiniBrowser
(60 SSE frames 10ms apart, then the response goes idle):

  unpatched: FAIL, 7267 of 9282 bytes delivered, reader still parked in read()
  patched:   PASS, 9282 of 9282 bytes, 5/5 runs

The unpatched build reproduces at the same numbers as Safari Technology Preview,
so the before/after is measured against a meaningful control.

I have not run the full layout test suite locally; this relies on EWS for broader
regression coverage.
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/deb078389d54b51b8ec2ae90b792f6edb7ce141e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174901 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48834 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42615 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184481 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132809 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176766 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50126 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48517 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136109 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96053 "1 flakes 5 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177859 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39555 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156909 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116588 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38196 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36578 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32959 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148619 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36401 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186906 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/40404 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40780 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145040 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48501 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156465 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144898 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49181 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33022 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114992 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39781 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121303 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47687 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11374 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47089 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47320 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47147 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->