### PR TITLE
Fix two remaining failures in custom-elements/registries/Element-innerHTML.html

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/Element-innerHTML-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/Element-innerHTML-expected.txt
@@ -4,8 +4,8 @@ PASS nested descendants in innerHTML on a disconnected element should use the sc
 PASS innerHTML on a disconnected element should use the scoped registry it was created with when parsing a simple HTML
 PASS innerHTML on an inserted element should continue to use the scoped registry it was created with
 PASS nested descendants in innerHTML should use the null registry when the container element has null registry
-FAIL insertAdjacentHTML should use the element's registry even when the registry is null assert_equals: expected null but got object "[object CustomElementRegistry]"
-FAIL createContextualFragment on a range inside a template should use null registry even when the template has a scoped registry assert_equals: expected null but got object "[object CustomElementRegistry]"
+PASS insertAdjacentHTML should use the element's registry even when the registry is null
+PASS createContextualFragment on a range inside a template should use null registry even when the template has a scoped registry
 PASS innerHTML on a template with a scoped registry should use the scoped registry of the document
 PASS createContextualFragment on a range inside an element with scoped registry should use the scoped registry of the element
 PASS insertAdjacentHTML with beforebegin should use the containing scope's registry

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -6167,8 +6167,12 @@ static ExceptionOr<Ref<Element>> contextElementForInsertion(const String& where,
         return contextNodeResult.releaseException();
     CheckedRef contextNode = contextNodeResult.releaseReturnValue();
     RefPtr contextElement = dynamicDowncast<Element>(contextNode.get());
-    if (!contextElement || (contextNode->document().isHTMLDocument() && is<HTMLHtmlElement>(contextNode.get())))
-        return Ref<Element> { HTMLBodyElement::create(protect(contextNode->document())) };
+    if (!contextElement || (contextNode->document().isHTMLDocument() && is<HTMLHtmlElement>(contextNode.get()))) {
+        Ref bodyElement = HTMLBodyElement::create(protect(contextNode->document()));
+        if (contextNode->usesNullCustomElementRegistry())
+            bodyElement->setUsesNullCustomElementRegistry();
+        return Ref<Element> { WTF::move(bodyElement) };
+    }
     return contextElement.releaseNonNull();
 }
 

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -72,6 +72,7 @@
 #include "HTMLSourceElement.h"
 #include "HTMLStyleElement.h"
 #include "HTMLTableElement.h"
+#include "HTMLTemplateElement.h"
 #include "HTMLTextAreaElement.h"
 #include "HTMLTextFormControlElement.h"
 #include "LocalFrameInlines.h"
@@ -1631,7 +1632,13 @@ static void removeElementFromFragmentPreservingChildren(DocumentFragment& fragme
 
 ExceptionOr<Ref<DocumentFragment>> createContextualFragment(Element& element, const String& markup, OptionSet<ParserContentPolicy> parserContentPolicy)
 {
-    auto result = createFragmentForMarkup(element, markup, DocumentFragmentMode::New, parserContentPolicy, protect(CustomElementRegistry::registryForElement(element)), element.usesNullCustomElementRegistry() ? Element::CustomElementRegistryKind::Null : Element::CustomElementRegistryKind::Window);
+    Ref registryContainer = [&] -> Ref<Node> {
+        if (RefPtr templateElement = dynamicDowncast<HTMLTemplateElement>(element))
+            return templateElement->content();
+        return element;
+    }();
+    auto registryKind = registryContainer->usesNullCustomElementRegistry() ? Element::CustomElementRegistryKind::Null : Element::CustomElementRegistryKind::Window;
+    auto result = createFragmentForMarkup(element, markup, DocumentFragmentMode::New, parserContentPolicy, protect(CustomElementRegistry::registryForNodeOrTreeScope(registryContainer, protect(registryContainer->treeScope()))), registryKind);
     if (result.hasException())
         return result.releaseException();
 


### PR DESCRIPTION
#### e02b5154b40cd2aa151b02eba109400a6dfed69a
<pre>
Fix two remaining failures in custom-elements/registries/Element-innerHTML.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=319547">https://bugs.webkit.org/show_bug.cgi?id=319547</a>

Reviewed by Anne van Kesteren.

The failures are caused by not respecting null custom element registry flag set in context nodes:

1. insertAdjacentHTML (afterend into a null-registry shadow root): For beforebegin/afterend,
   the context node is the parent - here a shadow root created with shadowrootcustomelementregistry
   (null registry). Since a shadow root isn&apos;t an Element, contextElementForInsertion synthesizes
   an HTMLBodyElement for parsing, but that fresh body didn&apos;t carry the null-registry flag, so
   registryForElement erroneously returned the window registry.
2. createContextualFragment on a range inside a template: The context element is the template
   element itself, so registryForElement(template) returned the template&apos;s scoped registry. But
   parsing goes into the template contents owner document (which uses a null registry), so the
   fragment should use the contents&apos; registry, not the template element&apos;s.

Test: imported/w3c/web-platform-tests/custom-elements/registries/Element-innerHTML.html

* LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/Element-innerHTML-expected.txt:
* Source/WebCore/dom/Element.cpp:
(WebCore::contextElementForInsertion):
* Source/WebCore/editing/markup.cpp:
(WebCore::createContextualFragment):

Canonical link: <a href="https://commits.webkit.org/317332@main">https://commits.webkit.org/317332@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1377dbdb40e8fde9445ef530bce1e7371c75568a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174975 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48908 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42689 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184556 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/132883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3b95b902-9b6a-44f6-9705-2d70069fbe53) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176840 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50200 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48591 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136180 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/132883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e42d44ab-f33f-46d8-87b6-a3a867500777) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177933 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39615 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156972 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116659 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/00dda32d-8c2a-47d8-94a4-700448a8c161) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38256 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33033 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148679 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36464 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186980 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/40483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40842 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145114 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48575 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144970 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49255 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115072 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26584 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39837 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/121389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47761 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11437 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47164 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47394 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47221 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->