### PR TITLE
Dead if in fieldset baseline computation after subpixel-inline-layout cleanup

### DIFF
--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp
@@ -624,11 +624,8 @@ static inline void setIntegrationBaseline(const RenderBox& renderBox)
             auto marginBoxLogicalHeight = renderBox.marginBoxLogicalHeight(rootWritingMode);
             auto isWritingModeRoot = rootWritingMode.computedWritingMode() != renderBox.writingMode().computedWritingMode();
 
-            if (renderBox.isFieldset()) {
-                if (isWritingModeRoot || renderBox.shouldApplyLayoutContainment())
-                    return marginBoxLogicalHeight;
+            if (renderBox.isFieldset())
                 return marginBoxLogicalHeight;
-            }
 
             if (is<RenderButton>(renderBox)) {
                 auto contentBoxBottom = rootWritingMode.isHorizontal() ? renderBox.borderTop() + renderBox.paddingTop() + renderBox.contentBoxHeight() : renderBox.borderRight() + renderBox.paddingRight() + renderBox.contentBoxWidth();


### PR DESCRIPTION
#### 040e525dd9bdf8d0ce85934483f948b48e0cabf5
<pre>
Dead if in fieldset baseline computation after subpixel-inline-layout cleanup
<a href="https://bugs.webkit.org/show_bug.cgi?id=319550">https://bugs.webkit.org/show_bug.cgi?id=319550</a>
<a href="https://rdar.apple.com/182380648">rdar://182380648</a>

Reviewed by Alan Baradlay.

In setIntegrationBaseline(), the fieldset branch guarded a return on
isWritingModeRoot || shouldApplyLayoutContainment(), returning the raw
marginBoxLogicalHeight in that case and an integer-snapped value
otherwise. When the subpixelInlineLayoutEnabled setting was removed
(now that subpixel inline layout is always enabled), the snapToInt()
call was replaced by plain marginBoxLogicalHeight, leaving both arms of
the if identical and the guard dead.

Collapse the branch to a single return. No behavior change; the raw
subpixel value is now always the intended result.

* Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp:
(WebCore::LayoutIntegration::setIntegrationBaseline):

Canonical link: <a href="https://commits.webkit.org/317314@main">https://commits.webkit.org/317314@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a0065937795641bb7e97978c6999fe3292c79ed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174908 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48841 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42622 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184488 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132816 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1b414fc7-874e-4fbe-98b4-c857d988fbd4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176773 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50133 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48524 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136116 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5448e70e-9e96-4eb2-8979-27152de211e7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177866 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39561 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156918 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Running apply-patch; Checked out pull request; run-api-tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116595 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/26e84432-3511-4062-9167-8545d95c9fb0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38202 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36581 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32966 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148625 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36410 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186913 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/40359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40783 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145049 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48508 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144907 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39053 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49188 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33031 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114999 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39786 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121299 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47694 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11383 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47096 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47327 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47154 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->