### PR TITLE
[Site Isolation] Remove extra resize event when entering fullscreen with site isolation on

### DIFF
--- a/LayoutTests/http/tests/site-isolation/fullscreen-resize-event-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/fullscreen-resize-event-expected.txt
@@ -1,0 +1,4 @@
+
+Resize count after entering fullscreen: 1
+Resize count after exiting fullscreen: 1
+

--- a/LayoutTests/http/tests/site-isolation/fullscreen-resize-event.html
+++ b/LayoutTests/http/tests/site-isolation/fullscreen-resize-event.html
@@ -1,0 +1,14 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script>
+    if (window.testRunner) {
+        testRunner.waitUntilDone();
+        testRunner.dumpAsText()
+    }
+    addEventListener("message", (event) => {
+        document.getElementById("mylog").innerHTML += event.data + "<br>";
+        if (event.data.startsWith('Resize count after exiting fullscreen') && window.testRunner) { testRunner.notifyDone() }
+    });
+</script>
+<iframe id='frame' allowfullscreen src="http://localhost:8000/site-isolation/resources/fullscreen-resize-event.html" frameborder=0></iframe>
+<div id=mylog>
+</div>

--- a/LayoutTests/http/tests/site-isolation/resources/fullscreen-resize-event.html
+++ b/LayoutTests/http/tests/site-isolation/resources/fullscreen-resize-event.html
@@ -1,0 +1,25 @@
+<script>
+    let count = 0;
+    window.addEventListener("resize", () => { count++; });
+
+    async function enterFullScreen() {
+        await document.documentElement.requestFullscreen();
+        if (window.testRunner) { await testRunner.updatePresentation() }
+        window.parent.postMessage("Resize count after entering fullscreen: " + count, "*");
+    }
+    async function exitFullScreen() {
+        count = 0;
+        await document.exitFullscreen();
+        if (window.testRunner) { await testRunner.updatePresentation() }
+        window.parent.postMessage("Resize count after exiting fullscreen: " + count, "*");
+    }
+
+    if (window.internals) {
+        internals.withUserGesture(async () => {
+            await enterFullScreen();
+            await exitFullScreen();
+        });
+    }
+</script>
+<button onclick="enterFullScreen()">Enter</button>
+<button onclick="exitFullScreen()">Exit</button>

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -4976,6 +4976,13 @@ IntSize LocalFrameView::sizeForResizeEvent() const
     return visibleContentRectIncludingScrollbars().size();
 }
 
+void LocalFrameView::primeResizeEventBaseline(IntSize size)
+{
+    m_lastViewportSize = size;
+    if (CheckedPtr renderView = this->renderView())
+        m_lastUsedZoomFactor = renderView->style().usedZoom();
+}
+
 void LocalFrameView::scheduleResizeEventIfNeeded()
 {
     if (layoutContext().isInRenderTreeLayout() || needsLayout())

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -108,6 +108,7 @@ public:
     virtual ~LocalFrameView();
 
     WEBCORE_EXPORT void setFrameRect(const IntRect&) final;
+    WEBCORE_EXPORT void primeResizeEventBaseline(IntSize);
     Type viewType() const final { return Type::Local; }
     void writeRenderTreeAsText(TextStream&, OptionSet<RenderAsTextFlag>) override;
 

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -503,8 +503,9 @@ void WebFrame::createProvisionalFrame(ProvisionalFrameCreationParameters&& param
 
     if (parameters.layerHostingContextIdentifier)
         setLayerHostingContextIdentifier(*parameters.layerHostingContextIdentifier);
+    m_hasAppliedInitialRemoteFrameRect = false;
     if (parameters.initialRect)
-        updateLocalFrameRect(localFrame, *parameters.initialRect);
+        updateLocalFrameRect(localFrame, *parameters.initialRect, consumeIsInitialFrameRect());
 
     if (parameters.commitTiming == CommitTiming::Immediately)
         commitProvisionalFrame();
@@ -1278,7 +1279,7 @@ void WebFrame::updateFrameRectFromRemote(WebCore::IntRect newRect)
 {
     ASSERT(m_page->corePage()->settings().siteIsolationEnabled());
     if (RefPtr localFrame = coreLocalFrame())
-        updateLocalFrameRect(*localFrame, newRect);
+        updateLocalFrameRect(*localFrame, newRect, consumeIsInitialFrameRect());
     else {
         RefPtr remoteFrame = coreRemoteFrame();
         RefPtr remoteFrameView = remoteFrame->view();
@@ -1288,7 +1289,7 @@ void WebFrame::updateFrameRectFromRemote(WebCore::IntRect newRect)
     }
 }
 
-void WebFrame::updateLocalFrameRect(WebCore::LocalFrame& localFrame, WebCore::IntRect newRect)
+void WebFrame::updateLocalFrameRect(WebCore::LocalFrame& localFrame, WebCore::IntRect newRect, IsInitialFrameRect isInitialFrameRect)
 {
     RefPtr frameView = localFrame.view();
     if (!frameView)
@@ -1298,6 +1299,10 @@ void WebFrame::updateLocalFrameRect(WebCore::LocalFrame& localFrame, WebCore::In
 
     if (oldRect == newRect)
         return;
+
+    if (isInitialFrameRect == IsInitialFrameRect::Yes)
+        frameView->primeResizeEventBaseline(newRect.size());
+
     frameView->setFrameRect(newRect);
 
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.h
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.h
@@ -311,7 +311,9 @@ private:
     uint64_t messageSenderDestinationID() const final;
 
     void setLayerHostingContextIdentifier(WebCore::LayerHostingContextIdentifier identifier) { m_layerHostingContextIdentifier = identifier; }
-    void updateLocalFrameRect(WebCore::LocalFrame&, WebCore::IntRect);
+    enum class IsInitialFrameRect : bool { No, Yes };
+    void updateLocalFrameRect(WebCore::LocalFrame&, WebCore::IntRect, IsInitialFrameRect);
+    IsInitialFrameRect consumeIsInitialFrameRect() { return std::exchange(m_hasAppliedInitialRemoteFrameRect, true) ? IsInitialFrameRect::No : IsInitialFrameRect::Yes; }
 
     inline WebCore::DocumentLoader* policySourceDocumentLoader() const;
 
@@ -338,6 +340,7 @@ private:
 
     const WebCore::FrameIdentifier m_frameID;
     bool m_wasRemovedInAnotherProcess { false };
+    bool m_hasAppliedInitialRemoteFrameRect { false };
 
 #if ENABLE(TWO_PHASE_CLICKS)
     std::optional<TransactionID> m_firstLayerTreeTransactionIDAfterDidCommitLoad;

--- a/TestExpectations/apitests
+++ b/TestExpectations/apitests
@@ -218,7 +218,6 @@ webkit.org/b/305954 TestWebKitAPI.ShareableBitmap.ensureCOWBothMapsROSenderWrite
 webkit.org/b/305954 TestWebKitAPI.ShareableBitmap.ensureCOWBothMapsRWSenderWrite [ Skip ]
 webkit.org/b/305954 TestWebKitAPI.ShareableBitmap.ensureCOWBothMapsRWSenderWriteReceiverWrite [ Skip ]
 rdar://142903525 [ ios ] TestWebKitAPI.ShareSheetTests.ShareImgElementWithBase64URL [ Skip ]
-webkit.org/b/292331 TestWebKitAPI.SiteIsolation.Events [ Skip ]
 webkit.org/b/317783 [ ios ] TestWebKitAPI.SiteIsolation.FindStringSelectionSameOriginFrameBeforeWrap [ Skip ]
 webkit.org/b/316819 [ mac debug ] TestWebKitAPI.SiteIsolation.MultiProcessBFCacheSameSiteWithCrossSiteIframe [ Pass Crash ]
 webkit.org/b/310149 [ mac release ] TestWebKitAPI.SiteIsolation.PostMessageWithMessagePorts [ Skip ]

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -6715,9 +6715,7 @@ TEST(SiteIsolation, LoadWebArchiveNestedFrame)
     });
 }
 
-// FIXME: Re-enable this once the extra resize events are gone.
-// https://bugs.webkit.org/show_bug.cgi?id=292311 might do it.
-TEST(SiteIsolation, DISABLED_Events)
+TEST(SiteIsolation, Events)
 {
     auto eventListeners = "<script>"
     "addEventListener('resize', ()=>{ alert('resize') });"


### PR DESCRIPTION
#### 38e88737aa9734bff86b0807f2ef751b73900477
<pre>
[Site Isolation] Remove extra resize event when entering fullscreen with site isolation on
<a href="https://bugs.webkit.org/show_bug.cgi?id=319554">https://bugs.webkit.org/show_bug.cgi?id=319554</a>
<a href="https://rdar.apple.com/150329731">rdar://150329731</a>

Reviewed by Alex Christensen.

With site isolation, entering fullscreen from a cross-origin &lt;iframe&gt; dispatched two resize events
instead of one. The iframe&apos;s child process creates its LocalFrameView at the viewport size (its
true size isn&apos;t known yet) and records that as the resize baseline. When the real size later
arrives from the frame-owning process, setFrameRect schedules a spurious resize; fullscreen then
fires the second. A same-process iframe never sees this because its view starts at the correct
size.

Treat the first frame rect delivered from the frame-owning process as establishing the baseline
rather than a change: prime LocalFrameView&apos;s resize baseline to the incoming size before
setFrameRect, so the correction is absorbed while later size changes (fullscreen, script, layout)
still fire normally.

And this fix makes TEST(SiteIsolation, DISABLED_Events) deterministic.

* LayoutTests/http/tests/site-isolation/fullscreen-resize-event-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/fullscreen-resize-event.html: Added.
* LayoutTests/http/tests/site-isolation/resources/fullscreen-resize-event.html: Added.
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::primeResizeEventBaseline):
* Source/WebCore/page/LocalFrameView.h:
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::createProvisionalFrame):
(WebKit::WebFrame::updateFrameRectFromRemote):
(WebKit::WebFrame::updateLocalFrameRect):
* Source/WebKit/WebProcess/WebPage/WebFrame.h:
(WebKit::WebFrame::consumeIsInitialFrameRect):
* TestExpectations/apitests:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::(SiteIsolation, Events)):
(TestWebKitAPI::(SiteIsolation, DISABLED_Events)): Deleted.

Canonical link: <a href="https://commits.webkit.org/317677@main">https://commits.webkit.org/317677@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/17dd929f2c88afe5b9bdbc57151dede0e7c7ba1c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175921 "60 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49854 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43638 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185514 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f4da0813-7cac-4027-abc6-a5e1dec9096d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177784 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51146 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49536 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136998 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1f322c13-2749-4e7e-aa16-a2a4b70e335c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178877 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40465 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157777 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117477 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9c3a36bc-d5c6-438c-9798-15598c11e60f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39107 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37485 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149526 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37269 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33984 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41554 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41691 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187935 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49521 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/157328 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145996 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39292 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50201 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33894 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145835 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40627 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122397 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116264 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48708 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12250 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48110 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48342 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48167 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->