### PR TITLE
[SaferCPP] Fix uncounted call args warnings in Source/WebKit

### DIFF
--- a/Source/WebKit/Shared/WebBackForwardListFrameItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListFrameItem.h
@@ -83,7 +83,7 @@ private:
 
     WeakPtr<WebBackForwardListItem> m_backForwardListItem;
     const WebCore::BackForwardFrameItemIdentifier m_identifier;
-    Ref<FrameState> m_frameState;
+    const Ref<FrameState> m_frameState;
     WeakPtr<WebBackForwardListFrameItem> m_parent;
     Vector<Ref<WebBackForwardListFrameItem>> m_children;
 

--- a/Source/WebKit/UIProcess/FrameProcess.h
+++ b/Source/WebKit/UIProcess/FrameProcess.h
@@ -53,9 +53,9 @@ public:
 
     BrowsingContextGroup* NODELETE browsingContextGroup() const;
 
-    void incrementFrameCount() { m_frameCount++; }
-    void decrementFrameCount() { m_frameCount--; }
-    unsigned frameCount() const { return m_frameCount; }
+    SUPPRESS_NODELETE void NODELETE incrementFrameCount() { m_frameCount++; }
+    SUPPRESS_NODELETE void NODELETE decrementFrameCount() { m_frameCount--; }
+    SUPPRESS_NODELETE unsigned NODELETE frameCount() const { return m_frameCount; }
 
 private:
     friend class BrowsingContextGroup; // FrameProcess should not be created except by BrowsingContextGroup.

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -3903,7 +3903,7 @@ void WebViewImpl::contentRelativeViewsHysteresisTimerFired(PAL::HysteresisState 
     }
 
     if (m_contentRelativeViewsNeedToBeRepositioned != started && std::exchange(m_contentRelativeViewsNeedToBeRepositioned, started))
-        [inputContextForSelectionUpdates() textInputClientDidUpdateSelection];
+        [protect(inputContextForSelectionUpdates()) textInputClientDidUpdateSelection];
 }
 
 void WebViewImpl::pageScrollingHysteresisFired(PAL::HysteresisState state)


### PR DESCRIPTION
#### ff6ba6635812965622d9c3b7617b531032d3f2f7
<pre>
[SaferCPP] Fix uncounted call args warnings in Source/WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=319556">https://bugs.webkit.org/show_bug.cgi?id=319556</a>

Reviewed by NOBODY (OOPS!).

* Source/WebKit/Shared/WebBackForwardListFrameItem.h:
* Source/WebKit/UIProcess/FrameProcess.h:
(WebKit::FrameProcess::incrementFrameCount):
(WebKit::FrameProcess::decrementFrameCount):
(WebKit::FrameProcess::frameCount const):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::contentRelativeViewsHysteresisTimerFired):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff6ba6635812965622d9c3b7617b531032d3f2f7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174916 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48849 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42630 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184496 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132824 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/07be5bc8-bfdb-4853-8292-a8d2a1f908c3) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50141 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48532 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136125 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96062 "3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8b82305e-f6f1-4597-8075-6933bf3d9a79) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177874 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39564 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156919 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.CrossProcessHistoryTraversalCoalesce (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116604 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c3a80756-6a5b-409e-ab8f-16309b1992b6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38205 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36588 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32974 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148628 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36411 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186921 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/40377 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40790 "Found 1 new test failure: http/tests/websocket/tests/hybi/no-subprotocol.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145056 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48516 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144914 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49196 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33032 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115007 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39788 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121312 "Found 112 new failures in b3/B3Value.h, b3/testb3_7.cpp, WebProcess/Network/WebResourceLoader.cpp, Shared/Cocoa/WKNSArray.mm, Shared/SessionState.cpp, NetworkProcess/NetworkResourceLoadParameters.cpp, WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm, WebProcess/WebPage/WebPage.cpp, WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm, Shared/WebBackForwardListFrameItem.cpp ...") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47702 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11384 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47104 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47335 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47162 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->