### PR TITLE
[CSS Scroll Snap] Re-snap should ignore a focused snap area that is scrolled out of the snapport

### DIFF
--- a/LayoutTests/fast/scrolling/resnap-focused-offscreen-overflow-scaled-expected.txt
+++ b/LayoutTests/fast/scrolling/resnap-focused-offscreen-overflow-scaled-expected.txt
@@ -1,0 +1,8 @@
+PASS focused bottomright without scrolling to it.
+PASS scroller snapped to the shared row.
+PASS scroller followed bottomleft, not the focused offscreen bottomright.
+PASS scroller actually scrolled after the layout change.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/resnap-focused-offscreen-overflow-scaled.html
+++ b/LayoutTests/fast/scrolling/resnap-focused-offscreen-overflow-scaled.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <style>
+            .scroller {
+                overflow: scroll;
+                position: relative;
+                height: 400px;
+                width: 400px;
+                border: solid 1px black;
+                scroll-snap-type: y mandatory;
+            }
+            .no-snap { scroll-snap-align: none; }
+            .large-space {
+                height: 300vh;
+                width: 300vw;
+            }
+            .target {
+                scroll-snap-align: start;
+                position: absolute;
+                width: 100px;
+                height: 100px;
+                border: solid 1px black;
+            }
+            .top { top: 0px; }
+            .left { left: 0px; }
+            .right { left: 200px; }
+            .bottom { top: 200px; }
+        </style>
+        <script src="../../resources/js-test.js"></script>
+        <script src="../../resources/ui-helper.js"></script>
+        <script>
+        window.jsTestIsAsync = true;
+
+        var scroller;
+        var bottomleft;
+        var bottomright;
+
+        function scrollSettle()
+        {
+            return new Promise(resolve => {
+                scroller.addEventListener("scrollend", resolve, { once: true });
+            });
+        }
+
+        async function scrollToAndSettle(x, y)
+        {
+            if (scroller.scrollLeft === x && scroller.scrollTop === y)
+                return;
+            const promise = scrollSettle();
+            scroller.scrollTo(x, y);
+            await promise;
+        }
+
+        async function runTest()
+        {
+            scroller = document.getElementById("scroller");
+            bottomleft = document.getElementById("bottomleft");
+            bottomright = document.getElementById("bottomright");
+
+            // Pinch-zoom the main frame. The subscroller's own coordinate
+            // space (scroll offsets, viewport size, snap area rects) is in
+            // unscaled layout units and should be unaffected by this.
+            await testRunner.setPageScaleFactor(2, 0, 0);
+            await UIHelper.renderingUpdate();
+
+            // Move bottomright out of the snapport in the x axis, which does
+            // not snap for this scroller.
+            bottomright.style.left = "500px";
+
+            // Focus bottomright without scrolling to it.
+            bottomright.focus({ preventScroll: true });
+            if (document.activeElement === bottomright)
+                testPassed("focused bottomright without scrolling to it.");
+            else
+                testFailed("failed to focus bottomright.");
+
+            // Snap to the row shared by bottomleft and bottomright.
+            await scrollToAndSettle(0, bottomleft.offsetTop);
+            if (scroller.scrollTop === bottomleft.offsetTop)
+                testPassed("scroller snapped to the shared row.");
+            else
+                testFailed("scroller did not snap to the shared row; scrollTop is " + scroller.scrollTop);
+
+            // Shift bottomleft down. If the scroller had selected the
+            // focused-but-offscreen bottomright as its snap target, it would
+            // stay put; it should instead follow bottomleft. Reading
+            // offsetTop/scrollTop below forces the layout (and the resnap it
+            // triggers) to happen synchronously, so there is no event to wait for.
+            const initialScrollTop = scroller.scrollTop;
+            bottomleft.style.top = "400px";
+
+            if (scroller.scrollTop === bottomleft.offsetTop)
+                testPassed("scroller followed bottomleft, not the focused offscreen bottomright.");
+            else
+                testFailed("scroller did not follow bottomleft; scrollTop is " + scroller.scrollTop);
+
+            if (scroller.scrollTop !== initialScrollTop)
+                testPassed("scroller actually scrolled after the layout change.");
+            else
+                testFailed("scroller did not scroll after the layout change.");
+
+            finishJSTest();
+        }
+
+        function onLoad()
+        {
+            if (window.testRunner && window.internals)
+                runTest();
+            else {
+                var message = document.createElement("p");
+                message.innerHTML = "This test requires testRunner and internals.";
+                document.body.appendChild(message);
+                finishJSTest();
+            }
+        }
+        </script>
+    </head>
+    <body onload="onLoad();">
+        <div id="scroller" class="scroller">
+            <div class="large-space no-snap" tabindex="1" id="space"></div>
+            <div id="topleft" tabindex="1" class="top left target"></div>
+            <div id="topright" tabindex="1" class="top right target"></div>
+            <div id="bottomleft" tabindex="1" class="bottom left target"></div>
+            <div id="bottomright" tabindex="1" class="bottom right target"></div>
+        </div>
+    </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/prefer-focused-element-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/prefer-focused-element-expected.txt
@@ -1,6 +1,6 @@
 top lefttop rightbottom leftbottom right
 
 PASS scroller selects focused target from aligned choices on snap
-FAIL out-of-viewport focused element is not the selected snap target. assert_equals: scroller followed bottomleft in y axis after layout change expected 300 but got 200
+PASS out-of-viewport focused element is not the selected snap target.
 FAIL scroller follows selected snap target through layout shift,regardless of focus assert_equals: scroller followed bottomleft in y axis after layout change expected 500 but got 400
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/prefer-focused-element-scaled-ancestor-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/prefer-focused-element-scaled-ancestor-expected.txt
@@ -1,0 +1,3 @@
+
+PASS out-of-viewport focused element is not the selected snap target under a scaled ancestor.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/prefer-focused-element-scaled-ancestor.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/prefer-focused-element-scaled-ancestor.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="help" href="https://drafts.csswg.org/css-scroll-snap" />
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/dom/events/scrolling/scroll_support.js"></script>
+    <script src="resources/common.js" ></script>
+  </head>
+  <body>
+    <style>
+      /* A scaled ancestor does not change the scroller's own layout-pixel
+         coordinate space (scroll offset, viewport size, snap area rects),
+         so the focused-but-offscreen exclusion below should be unaffected
+         by it, the same way it is unaffected by a pinch-zoomed page. */
+      .scaled-ancestor {
+        transform: scale(2);
+        transform-origin: top left;
+      }
+      .scroller {
+        overflow: scroll;
+        position: relative;
+        height: 400px;
+        width: 400px;
+        border:solid 1px black;
+        scroll-snap-type: y mandatory;
+      }
+      .no-snap { scroll-snap-align: none }
+      .scroller div:focus {
+        border: solid 1px red;
+      }
+      .large-space {
+        height: 300vh;
+        width: 300vw;
+      }
+      .target {
+        scroll-snap-align: start;
+        position: absolute;
+        width: 100px;
+        height: 100px;
+        border: solid 1px black;
+      }
+      .top {
+        top: 0px;
+      }
+      .left {
+        left: 0px;
+      }
+      .right {
+        left: 200px;
+      }
+      .bottom {
+        top: 200px;
+      }
+      </style>
+    <div class="scaled-ancestor">
+      <div id="scroller" class="scroller">
+        <div class="large-space no-snap" tabindex="1" id="space"></div>
+        <div id="topleft" tabindex="1" class="top left target"></div>
+        <div id="topright" tabindex="1" class="top right target"></div>
+        <div id="bottomleft" tabindex="1" class="bottom left target"></div>
+        <div id="bottomright" tabindex="1" class="bottom right target"></div>
+      </div>
+    </div>
+    <script>
+      window.onload = () => {
+        const bottomright = document.getElementById("bottomright");
+        const bottomleft = document.getElementById("bottomleft");
+        const scroller = document.getElementById("scroller");
+
+        promise_test(async (t) => {
+          t.add_cleanup(() => {
+            bottomright.style.left = "200px";
+          })
+          await waitForCompositorCommit();
+          assert_equals(scroller.scrollTop, 0, "snapped to top row");
+
+          // Move bottomright out of the snapport.
+          bottomright.style.left = "500px";
+
+          // Set focus on bottomright without scrolling to it.
+          focusAndAssert(bottomright, true);
+          await runScrollSnapSelectionVerificationTest(t, scroller,
+                               /*aligned_elements_x=*/[],
+                               /*aligned_elements_y=*/[bottomright, bottomleft],
+                               /*axis=*/"y",
+                               /*expected_target_x=*/null,
+                               /*expected_target_y=*/bottomleft);
+        }, "out-of-viewport focused element is not the selected snap target under a scaled ancestor.");
+      }
+    </script>
+  </body>
+</html>

--- a/Source/WebCore/platform/ScrollSnapAnimatorState.cpp
+++ b/Source/WebCore/platform/ScrollSnapAnimatorState.cpp
@@ -178,11 +178,21 @@ std::optional<NodeIdentifier> ScrollSnapAnimatorState::selectSnapTargetForAxis(S
         return std::nullopt;
     const auto& offset = offsets[0];
 
-    // A focused or fragment-targeted box wins outright.
-    if ((offset.isFocused || offset.isTarget) && offset.snapTargetID)
-        return *offset.snapTargetID;
-
     const auto& areaIDs = m_snapOffsetsInfo.snapAreasIDs;
+
+    // A focused or fragment-targeted box wins outright, unless its area is scrolled out of the
+    // snapport in a non-snapping cross axis (not a valid snap position).
+    if ((offset.isFocused || offset.isTarget) && offset.snapTargetID) {
+        bool representativeAreaIsVisible = true;
+        for (auto areaIndex : offset.snapAreaIndices) {
+            if (areaIndex < areaIDs.size() && areaIDs[areaIndex] == *offset.snapTargetID) {
+                representativeAreaIsVisible = isSnapAreaVisibleInCrossAxis(areaIndex, axis);
+                break;
+            }
+        }
+        if (representativeAreaIsVisible)
+            return *offset.snapTargetID;
+    }
 
     // Candidate boxes after removing any area that encloses another aligned area (its ancestors), so
     // a nested area supersedes a co-located ancestor, including an ancestor aligned in both axes.
@@ -231,7 +241,7 @@ Vector<size_t, 1> ScrollSnapAnimatorState::innermostAlignedAreaIndicesForAxis(Sc
     };
 
     for (auto areaIndex : indices) {
-        if (areaIndex < areas.size() && areaIndex < areaIDs.size() && !enclosesAnotherArea(areaIndex))
+        if (areaIndex < areas.size() && areaIndex < areaIDs.size() && isSnapAreaVisibleInCrossAxis(areaIndex, axis) && !enclosesAnotherArea(areaIndex))
             candidateIndices.append(areaIndex);
     }
     return candidateIndices;
@@ -247,13 +257,44 @@ void ScrollSnapAnimatorState::updateCurrentlySnappedBoxes()
     m_currentSnapTargetForVerticalAxis = selectSnapTargetForAxis(ScrollEventAxis::Vertical);
 }
 
-// Returns the snapped box this axis is focused/targeted on, evaluated fresh: focus and :target can
-// change after the snap, and the re-snap algorithm evaluates them at re-snap time.
-static std::optional<NodeIdentifier> focusedOrTargetedBox(const Vector<SnapOffset<LayoutUnit>>& offsets, const HashSet<NodeIdentifier>& snappedBoxes)
+// True if the snap area is at least partly within the snapport in the (non-snapping) cross axis at
+// the last known scroll position. When the cross axis also snaps (2D case, handled by
+// closestSnapOffset) or no viewport is known yet, we don't filter. Mirrors findCompatibleSnapArea().
+bool ScrollSnapAnimatorState::isSnapAreaVisibleInCrossAxis(size_t areaIndex, ScrollEventAxis axis) const
 {
+    auto crossAxis = axis == ScrollEventAxis::Horizontal ? ScrollEventAxis::Vertical : ScrollEventAxis::Horizontal;
+    if (!snapOffsetsForAxis(crossAxis).isEmpty() || m_lastViewportSize.isEmpty())
+        return true;
+    if (areaIndex >= m_snapOffsetsInfo.snapAreas.size())
+        return true;
+
+    const auto& area = m_snapOffsetsInfo.snapAreas[areaIndex];
+    auto crossMin = crossAxis == ScrollEventAxis::Horizontal ? area.x() : area.y();
+    auto crossMax = crossAxis == ScrollEventAxis::Horizontal ? area.maxX() : area.maxY();
+    auto crossScroll = crossAxis == ScrollEventAxis::Horizontal ? m_lastLayoutScrollOffset.x() : m_lastLayoutScrollOffset.y();
+    auto crossViewport = crossAxis == ScrollEventAxis::Horizontal ? m_lastViewportSize.width() : m_lastViewportSize.height();
+    return (crossScroll + crossViewport) >= crossMin && crossScroll <= crossMax;
+}
+
+// This axis's focused/targeted snapped box, evaluated fresh (focus and :target can change after the
+// snap). A focused/targeted area scrolled out of the snapport in a non-snapping cross axis is skipped:
+// it isn't a valid snap position, so it must not win the preference.
+std::optional<NodeIdentifier> ScrollSnapAnimatorState::focusedOrTargetedBox(ScrollEventAxis axis, const HashSet<NodeIdentifier>& snappedBoxes) const
+{
+    const auto& offsets = snapOffsetsForAxis(axis);
+    const auto& areaIDs = m_snapOffsetsInfo.snapAreasIDs;
+
+    auto representativeAreaIsVisible = [&](const SnapOffset<LayoutUnit>& offset) {
+        for (auto areaIndex : offset.snapAreaIndices) {
+            if (areaIndex < areaIDs.size() && areaIDs[areaIndex] == *offset.snapTargetID)
+                return isSnapAreaVisibleInCrossAxis(areaIndex, axis);
+        }
+        return true;
+    };
+
     auto findFlagged = [&](bool SnapOffset<LayoutUnit>::*flag) -> std::optional<NodeIdentifier> {
         auto found = std::ranges::find_if(offsets, [&](const SnapOffset<LayoutUnit>& offset) {
-            return offset.snapTargetID && snappedBoxes.contains(*offset.snapTargetID) && offset.*flag;
+            return offset.snapTargetID && snappedBoxes.contains(*offset.snapTargetID) && offset.*flag && representativeAreaIsVisible(offset);
         });
         if (found != offsets.end())
             return *found->snapTargetID;
@@ -270,6 +311,8 @@ static std::optional<NodeIdentifier> focusedOrTargetedBox(const Vector<SnapOffse
 bool ScrollSnapAnimatorState::resnapAfterLayout(ScrollOffset scrollOffset, const ScrollExtents& scrollExtents, float pageScale)
 {
     bool snapPointChanged = false;
+    m_lastLayoutScrollOffset = LayoutPoint(scrollOffset.x() / pageScale, scrollOffset.y() / pageScale);
+    m_lastViewportSize = LayoutSize(scrollExtents.viewportSize);
     auto activeHorizontalIndex = activeSnapIndexForAxis(ScrollEventAxis::Horizontal);
     auto activeVerticalIndex = activeSnapIndexForAxis(ScrollEventAxis::Vertical);
     auto previouslySnappedBoxes = std::exchange(m_currentlySnappedBoxes, { });
@@ -291,7 +334,7 @@ bool ScrollSnapAnimatorState::resnapAfterLayout(ScrollOffset scrollOffset, const
     // other axis from dragging this axis off its snap position.
     if (previouslySnappedBoxes.size() > 1) {
         auto targetForAxis = [&](ScrollEventAxis axis, const Markable<NodeIdentifier>& recordedTarget) -> std::optional<NodeIdentifier> {
-            if (auto box = focusedOrTargetedBox(snapOffsetsForAxis(axis), previouslySnappedBoxes))
+            if (auto box = focusedOrTargetedBox(axis, previouslySnappedBoxes))
                 return box;
             return recordedTarget ? std::optional<NodeIdentifier> { *recordedTarget } : std::nullopt;
         };
@@ -334,6 +377,8 @@ bool ScrollSnapAnimatorState::setNearestScrollSnapIndexForAxisAndOffsetInternal(
 bool ScrollSnapAnimatorState::setNearestScrollSnapIndexForOffset(ScrollOffset scrollOffset, const ScrollExtents& scrollExtents, float pageScale)
 {
     bool snapIndexChanged = false;
+    m_lastLayoutScrollOffset = LayoutPoint(scrollOffset.x() / pageScale, scrollOffset.y() / pageScale);
+    m_lastViewportSize = LayoutSize(scrollExtents.viewportSize);
     snapIndexChanged |= setNearestScrollSnapIndexForAxisAndOffsetInternal(ScrollEventAxis::Horizontal, scrollOffset, scrollExtents, pageScale);
     snapIndexChanged |= setNearestScrollSnapIndexForAxisAndOffsetInternal(ScrollEventAxis::Vertical, scrollOffset, scrollExtents, pageScale);
 

--- a/Source/WebCore/platform/ScrollSnapAnimatorState.h
+++ b/Source/WebCore/platform/ScrollSnapAnimatorState.h
@@ -28,6 +28,7 @@
 #include <WebCore/FloatPoint.h>
 #include <WebCore/FloatSize.h>
 #include <WebCore/LayoutPoint.h>
+#include <WebCore/LayoutSize.h>
 #include <WebCore/PlatformWheelEvent.h>
 #include <WebCore/ScrollAnimationMomentum.h>
 #include <WebCore/ScrollSnapOffsetsInfo.h>
@@ -113,6 +114,14 @@ private:
     // order — the per-axis candidate list after the spec's ancestor-removal step.
     Vector<size_t, 1> innermostAlignedAreaIndicesForAxis(ScrollEventAxis) const;
 
+    // This axis's focused/targeted snapped box, skipping any whose area is off-screen in a
+    // non-snapping cross axis.
+    std::optional<NodeIdentifier> focusedOrTargetedBox(ScrollEventAxis, const HashSet<NodeIdentifier>& snappedBoxes) const;
+
+    // Whether the snap area is within the snapport in the (non-snapping) cross axis at the last known
+    // scroll position; true (no filtering) when the cross axis snaps or no viewport is known yet.
+    bool isSnapAreaVisibleInCrossAxis(size_t areaIndex, ScrollEventAxis) const;
+
     bool setNearestScrollSnapIndexForAxisAndOffsetInternal(ScrollEventAxis, ScrollOffset, const ScrollExtents&, float pageScale);
     void updateCurrentlySnappedBoxes();
 
@@ -135,6 +144,11 @@ private:
     HashSet<NodeIdentifier> m_currentlySnappedBoxes;
     Markable<NodeIdentifier> m_currentSnapTargetForHorizontalAxis;
     Markable<NodeIdentifier> m_currentSnapTargetForVerticalAxis;
+
+    // Scroll offset and viewport size from the last snap/re-snap, for cross-axis
+    // visibility checks.
+    LayoutPoint m_lastLayoutScrollOffset;
+    LayoutSize m_lastViewportSize;
 };
 
 WTF::TextStream& operator<<(WTF::TextStream&, const ScrollSnapAnimatorState&);


### PR DESCRIPTION
#### 0beb8b67a954e4e9017b8d78b319bc4667a2b587
<pre>
[CSS Scroll Snap] Re-snap should ignore a focused snap area that is scrolled out of the snapport
<a href="https://bugs.webkit.org/show_bug.cgi?id=319562">https://bugs.webkit.org/show_bug.cgi?id=319562</a>
<a href="https://rdar.apple.com/182390905">rdar://182390905</a>

Reviewed by Simon Fraser.

When multiple snap areas are aligned at a scroll position, the re-snap
algorithm prefers a focused (or fragment-targeted) area over the others.
We applied that preference unconditionally, even when the focused area&apos;s
scroll snap area is scrolled entirely outside the snapport in the axis
that is not snapping. Per css-scroll-snap &quot;Scoping Valid Snap Positions
to Visible Boxes&quot; [1], such a scroll position is not a valid snap
position, so the focused area must not win the preference; the scroll
container should snap to an aligned area that is actually visible.

The scroll path already enforces this in closestSnapOffset() via
findCompatibleSnapArea(), but the re-snap/selection path did not, so a
focused-but-offscreen area could keep the scroller pinned to an invalid
offset after a layout change.

Evaluate the same cross-axis visibility in the selection path, at the
current scroll position (recorded on each snap/re-snap), rather than at
offset-collection time (which is tied to layout timing and would make
results depend on when snap offsets were last computed). Only areas in a
container that does not snap in the cross axis are affected; a container
that snaps in both axes can bring the area into view by snapping the
other axis, so it is left to closestSnapOffset()&apos;s 2D handling.

The recorded scroll offset and viewport size are converted from client
coordinates by dividing out the page scale factor, matching the
convention used elsewhere in this file (closestSnapPointForOffset(),
adjustedScrollDestination(), targetOffsetForStartOffset()). Added two
tests: one WebKit-specific, pinch-zooming the main frame around an
overflow scroller (which always reports a page scale factor of 1) to
exercise that conversion directly; and one cross-browser WPT test using
a scaled ancestor (transform: scale()) as a portable stand-in for the
same coordinate-space concern, since page scale factor isn&apos;t scriptable
outside WebKit.

[1] <a href="https://drafts.csswg.org/css-scroll-snap/#snap-scope">https://drafts.csswg.org/css-scroll-snap/#snap-scope</a>

* Source/WebCore/platform/ScrollSnapAnimatorState.cpp:
(WebCore::ScrollSnapAnimatorState::selectSnapTargetForAxis): Ignore the
focus/target preference when the representative area is off-screen in a
non-snapping cross axis, and drop off-screen areas from the candidate list.
(WebCore::ScrollSnapAnimatorState::innermostAlignedAreaIndicesForAxis):
Skip areas that are off-screen in a non-snapping cross axis.
(WebCore::ScrollSnapAnimatorState::isSnapAreaVisibleInCrossAxis): Added.
(WebCore::ScrollSnapAnimatorState::focusedOrTargetedBox): Made a member and
made it skip areas off-screen in a non-snapping cross axis.
(WebCore::ScrollSnapAnimatorState::resnapAfterLayout): Record the scroll
offset and viewport size used by the visibility check.
(WebCore::ScrollSnapAnimatorState::setNearestScrollSnapIndexForOffset): Ditto.
(WebCore::focusedOrTargetedBox): Deleted.
* Source/WebCore/platform/ScrollSnapAnimatorState.h:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/prefer-focused-element-expected.txt:
Progression.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/prefer-focused-element-scaled-ancestor.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/prefer-focused-element-scaled-ancestor-expected.txt: Added.
* LayoutTests/fast/scrolling/resnap-focused-offscreen-overflow-scaled.html: Added.
* LayoutTests/fast/scrolling/resnap-focused-offscreen-overflow-scaled-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/317447@main">https://commits.webkit.org/317447@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/887b4a85f4d0c6d27594575911ef97f805f776e2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175386 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49318 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43099 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184972 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/db0ed4cf-7f59-41ae-93ec-7c8085273c33) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177250 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50610 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49001 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/136540 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8c2b6653-4b22-4e44-88d0-214be7def673) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178343 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39958 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/157297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117018 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ae11ab16-b78b-436b-a418-1c9a4b7294f6) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/38600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/149022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36790 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33447 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/41005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187397 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48985 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156853 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/145505 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39134 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49665 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145346 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40163 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/121858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115554 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48171 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11763 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47574 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47804 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47631 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->