### PR TITLE
Fix __has_include line continuation false positive in C++ style checker

### DIFF
--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -2342,6 +2342,10 @@ def check_spacing(file_extension, clean_lines, line_number, file_state, error):
 
     # Don't try to do spacing checks for operator methods
     line = sub(r'operator(==|!=|<|<<|<=|>=|>>|>|\+=|-=|\*=|/=|%=|&=|\|=|^=|<<=|>>=|/|\|)\(', r'operator\(', line)
+    # Don't try to do spacing checks on the include path within __has_include(<...>),
+    # since the '/' path separator is not a division operator. Such a path can appear
+    # on a preprocessor continuation line that the check below does not skip.
+    line = sub(r'(__has_include\s*\(\s*<)[^>]*(>)', r'\1\2', line)
     # Don't try to do spacing checks for #include, #import, #if, or #elif statements at
     # minimum because it messes up checks for spacing around /
     if match(r'\s*#\s*(?:include|import|if|elif)', line):

--- a/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
@@ -2511,6 +2511,21 @@ class CppStyleTest(CppStyleTestBase):
         self.assert_multi_line_lint('#if __has_include(<ApplicationServices/ApplicationServicesPriv.h>)\n', '')
         self.assert_multi_line_lint('#elif __has_include(<ApplicationServices/ApplicationServicesPriv.h>)\n', '')
         self.assert_multi_line_lint('#endif // __has_include(<ApplicationServices/ApplicationServicesPriv.h>)\n', '')
+        # The '/' in an include path within __has_include(<...>) is not a division operator,
+        # even when the __has_include lands on a preprocessor continuation line that does not
+        # itself begin with #if/#elif.
+        self.assert_multi_line_lint('#if !defined(HAVE_FOO) \\\n'
+                                    '    && __has_include(<Foo/Bar.h>)\n'
+                                    '#define HAVE_FOO 1\n'
+                                    '#endif\n', '')
+        self.assert_multi_line_lint('#if PLATFORM(FOO) \\\n'
+                                    '    || __has_include(<Foo/Bar/Baz.h>)\n'
+                                    '#endif\n', '')
+        # But genuine division on a continuation line is still flagged.
+        self.assert_multi_line_lint('#if FOO \\\n'
+                                    '    && (a/b)\n'
+                                    '#endif\n',
+                                    'Missing spaces around /  [whitespace/operators] [3]')
         self.assert_lint('Foo&& a = bar();', '')
 
     def test_operator_methods(self):


### PR DESCRIPTION
#### 451b595dfdafbc6df37f8f085a729e7fb1e3212b
<pre>
Fix __has_include line continuation false positive in C++ style checker
<a href="https://bugs.webkit.org/show_bug.cgi?id=319561">https://bugs.webkit.org/show_bug.cgi?id=319561</a>
<a href="https://rdar.apple.com/182390424">rdar://182390424</a>

Reviewed by Abrar Rahman Protyasha.

This adds a case to the style checker that prevents it from considering
the / operator within a __has_include line continuation line.

New unit tests are added that test this new behaviour.

Canonical link: <a href="https://commits.webkit.org/317369@main">https://commits.webkit.org/317369@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/958f84ceadf5a575b632b560a7ac2110e6a0fe0a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174930 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48863 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42644 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184510 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132838 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176795 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50155 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48546 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136133 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/98fc77b0-d040-4868-8bc6-87f65515e1dd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177888 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39574 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156929 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116612 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/deb63524-6088-4267-a951-465bc6c316f2) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/174252 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38215 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36601 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32988 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148638 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36421 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186935 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40803 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145068 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48530 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144926 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39094 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49210 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33042 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115022 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39800 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47716 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11394 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47118 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47349 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47176 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->