### PR TITLE
Disallow page and worker process sharing after forced BCG switch

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -10347,7 +10347,9 @@ void WebPageProxy::triggerBrowsingContextGroupSwitchForNavigation(WebCore::Navig
     Ref processForNavigation = [&]() -> Ref<WebProcessProxy> {
         if (browsingContextGroupSwitchDecision == BrowsingContextGroupSwitchDecision::NewIsolatedGroup) {
             auto enableWebAssemblyDebugger = protect(m_configuration->preferences())->webAssemblyDebuggerEnabled() ? WebProcessProxy::EnableWebAssemblyDebugger::Yes : WebProcessProxy::EnableWebAssemblyDebugger::No;
-            return protect(m_configuration->processPool())->createNewWebProcess(protect(websiteDataStore()).ptr(), lockdownMode, enhancedSecurity, enableWebAssemblyDebugger, WebProcessProxy::IsPrewarmed::No, CrossOriginMode::Isolated);
+            Ref process = protect(m_configuration->processPool())->createNewWebProcess(protect(websiteDataStore()).ptr(), lockdownMode, enhancedSecurity, enableWebAssemblyDebugger, WebProcessProxy::IsPrewarmed::No, CrossOriginMode::Isolated);
+            process->setWasCreatedForBrowsingContextGroupSwitch();
+            return process;
         }
         return protect(m_configuration->processPool())->processForSite(protect(websiteDataStore()), WebProcessProxy::IsolatedProcessType::MainFrame, responseSite, responseSite, { }, lockdownMode, enhancedSecurity, m_configuration, WebCore::ProcessSwapDisposition::COOP);
     }();

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -712,7 +712,7 @@ void WebProcessPool::establishRemoteWorkerContextConnectionToNetworkProcess(Remo
 
     // Prioritize the requesting WebProcess for running the service worker.
     if (!remoteWorkerProcessProxy && !s_useSeparateServiceWorkerProcess && requestingProcess && requestingProcess->state() != WebProcessProxy::State::Terminated) {
-        if (requestingProcess->websiteDataStore() == websiteDataStore && requestingProcess->site() == site && requestingProcess->crossOriginMode() == crossOriginMode && !requestingProcess->isInProcessCache())
+        if (requestingProcess->websiteDataStore() == websiteDataStore && requestingProcess->site() == site && requestingProcess->crossOriginMode() == crossOriginMode && !requestingProcess->isInProcessCache() && !requestingProcess->wasCreatedForBrowsingContextGroupSwitch())
             useProcessForRemoteWorkers(*requestingProcess);
     }
 
@@ -729,6 +729,11 @@ void WebProcessPool::establishRemoteWorkerContextConnectionToNetworkProcess(Remo
             if (process->crossOriginMode() != crossOriginMode)
                 continue;
             if (process->isInProcessCache())
+                continue;
+
+            // Historically, we haven't allowed main frame processes created due to a forced BCG
+            // switch to also host a service worker or shared worker.
+            if (process->wasCreatedForBrowsingContextGroupSwitch())
                 continue;
 
             useProcessForRemoteWorkers(process);
@@ -1288,8 +1293,10 @@ Ref<WebProcessProxy> WebProcessPool::processForSite(WebsiteDataStore& websiteDat
             tryPrewarmWithDomainInformation(*process, site->domain());
         ASSERT(m_processes.containsIf([&](auto& item) { return item.ptr() == process; }));
         process->setIsolatedProcessType(isolatedProcessType, mainFrameSite);
-        if (processSwapDisposition == ProcessSwapDisposition::COOP)
+        if (processSwapDisposition == ProcessSwapDisposition::COOP) {
             process->setIneligbleForWebProcessCache();
+            process->setWasCreatedForBrowsingContextGroupSwitch();
+        }
         return process.releaseNonNull();
     }
 
@@ -1315,8 +1322,10 @@ Ref<WebProcessProxy> WebProcessPool::processForSite(WebsiteDataStore& websiteDat
     auto enableWebAssemblyDebugger = protect(pageConfiguration.preferences())->webAssemblyDebuggerEnabled() ? WebProcessProxy::EnableWebAssemblyDebugger::Yes : WebProcessProxy::EnableWebAssemblyDebugger::No;
     Ref process = createNewWebProcess(&websiteDataStore, lockdownMode, enhancedSecurity, enableWebAssemblyDebugger);
     process->setIsolatedProcessType(isolatedProcessType, mainFrameSite);
-    if (processSwapDisposition == ProcessSwapDisposition::COOP)
+    if (processSwapDisposition == ProcessSwapDisposition::COOP) {
         process->setIneligbleForWebProcessCache();
+        process->setWasCreatedForBrowsingContextGroupSwitch();
+    }
     return process;
 }
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -637,6 +637,9 @@ public:
     void setIneligbleForWebProcessCache() { m_isEligibleForWebProcessCache = false; }
     bool isEligibleForWebProcessCache() const { return m_isEligibleForWebProcessCache; }
 
+    void setWasCreatedForBrowsingContextGroupSwitch() { m_wasCreatedForBrowsingContextGroupSwitch = true; }
+    bool wasCreatedForBrowsingContextGroupSwitch() const { return m_wasCreatedForBrowsingContextGroupSwitch; }
+
     void incrementFrameProcessCount() { ++m_frameProcessCount; }
     void decrementFrameProcessCount() { --m_frameProcessCount; }
     uint64_t frameProcessCount() const { return m_frameProcessCount; }
@@ -982,6 +985,7 @@ private:
 #endif
 
     bool m_isEligibleForWebProcessCache { true };
+    bool m_wasCreatedForBrowsingContextGroupSwitch { false };
 
     HashMap<String, SandboxExtension::Handle> m_fileSandboxExtensions;
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ServiceWorkerBasic.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ServiceWorkerBasic.mm
@@ -2578,6 +2578,73 @@ void testSuspendServiceWorkerProcessBasedOnClientProcesses(UseSeparateServiceWor
     }));
 }
 
+#if PLATFORM(MAC)
+
+enum class UseSiteIsolationForCOOPWorkerTest : bool { No, Yes };
+
+static void runSharedWorkerNotReusedAfterCOOPProcessSwapTest(UseSiteIsolationForCOOPWorkerTest useSiteIsolation)
+{
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    if (useSiteIsolation == UseSiteIsolationForCOOPWorkerTest::Yes) {
+        for (_WKFeature *feature in [WKPreferences _features]) {
+            if ([feature.key isEqualToString:@"SiteIsolationEnabled"])
+                [[configuration preferences] _setEnabled:YES forFeature:feature];
+        }
+    }
+
+    TestWebKitAPI::HTTPServer server({
+        { "/no-coop.html"_s, { "<body>Hello world!</body>"_s } },
+        { "/coop.html"_s, { {{ "Cross-Origin-Opener-Policy"_s, "same-origin"_s }}, "<script>const worker = new SharedWorker('sharedWorker.js'); worker.port.start();</script>"_s } },
+        { "/sharedWorker.js"_s, { {{ "Content-Type"_s, "application/javascript"_s }}, "onconnect = e => { e.ports[0].start(); };"_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Https);
+
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    [navigationDelegate allowAnyTLSCertificate];
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    // Load a first page without COOP.
+    [webView loadRequest:server.request("/no-coop.html"_s)];
+    [navigationDelegate waitForDidFinishNavigation];
+    auto sourcePID = [webView _webProcessIdentifier];
+
+    // Navigate to a COOP page. This forces the page to be loaded in to a new PID. This page also
+    // loads a shared worker.
+    [webView loadRequest:server.request("/coop.html"_s)];
+    [navigationDelegate waitForDidFinishNavigation];
+    auto coopPID = [webView _webProcessIdentifier];
+    EXPECT_NE(sourcePID, coopPID);
+
+    // This tests our historic behavior of not allowing processes created as a result of a forced
+    // BCG switch (e.g. COOP response header) to host a shared or service worker.
+    auto sharedWorkerRunsInSeparateProcess = [&]() -> bool {
+        bool foundSharedWorkerProcess = false;
+        for (_WKWebContentProcessInfo *info in [WKProcessPool _webContentProcessInfo]) {
+            if (!info.runningSharedWorkers)
+                continue;
+            if (info.pid == coopPID)
+                return false;
+            foundSharedWorkerProcess = true;
+        }
+        return foundSharedWorkerProcess;
+    };
+    EXPECT_TRUE(waitUntilEvaluatesToTrue([&] {
+        return sharedWorkerRunsInSeparateProcess();
+    }));
+}
+
+TEST(ServiceWorkers, SharedWorkerNotReusedAfterCOOPProcessSwap)
+{
+    runSharedWorkerNotReusedAfterCOOPProcessSwapTest(UseSiteIsolationForCOOPWorkerTest::No);
+}
+
+TEST(ServiceWorkers, SharedWorkerNotReusedAfterCOOPProcessSwapWithSiteIsolation)
+{
+    runSharedWorkerNotReusedAfterCOOPProcessSwapTest(UseSiteIsolationForCOOPWorkerTest::Yes);
+}
+
+#endif // PLATFORM(MAC)
+
 TEST(ServiceWorkers, SuspendServiceWorkerProcessBasedOnClientProcessesWithSeparateServiceWorkerProcess)
 {
     testSuspendServiceWorkerProcessBasedOnClientProcesses(UseSeparateServiceWorkerProcess::Yes);


### PR DESCRIPTION
#### 62abed84de6eb8a10a5c0d5e346efceb2629ca00
<pre>
Disallow page and worker process sharing after forced BCG switch
<a href="https://bugs.webkit.org/show_bug.cgi?id=319564">https://bugs.webkit.org/show_bug.cgi?id=319564</a>
<a href="https://rdar.apple.com/182280016">rdar://182280016</a>

Reviewed by NOBODY (OOPS!).

We have an existing perf optimization that tries to run service or shared workers in the same
process as the requesting process (see establishRemoteWorkerContextConnectionToNetworkProcess).
However, we have also historically disallowed this optimization if the process is a main frame
process launched as a result of a forced BCG switch (e.g. due to a COOP response header).

This behavior seems like it was more of an accident than anything. Basically, when Site Isolation is
disabled:

1. WebProcessProxy A would start the load, updating m_site in didStartProvisionalLoadForMainFrame.
2. We&apos;d process the COOP header in the navigation response, forcing a BCG switch.
3. Due to the BCG switch, WebProcessProxy B would then commit the load, and m_site was never updated
for process B. (We don&apos;t have any logic that updates m_site as the result of a commit--we only
update it as the result of a provisional load.)

However, with Site Isolation enabled, the main frame process is allowed to host the service worker,
since m_site is updated in didStartUsingProcessForSiteIsolation in that case, and the site check in
`establishRemoteWorkerContextConnectionToNetworkProcess passes.

This behavior difference happens to lead to a measurable memory regression in Membuster7 when
comparing Site Isolation off vs. on. In Membuster7, there are some pages that both use COOP response
headers and have short-lived SharedWorkers, so it turns out to be advantageous to load those workers
in to separate processes (so that their memory footprint completely goes away when the workers go
away).

So this patch makes the existing policy of not using a process that was created as as result of a
BCG switch for shared/service workers consistent across the non-SI and SI configs.

Ideally, we&apos;d just always run service/shared workers in a separate process to simplify our process
selection logic (see s_useSeparateServiceWorkerProcess). However, we aren&apos;t allowed to enable that
right now since it&apos;s a perf regression.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ServiceWorkerBasic.mm

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::triggerBrowsingContextGroupSwitchForNavigation):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::establishRemoteWorkerContextConnectionToNetworkProcess):
(WebKit::WebProcessPool::processForSite):
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ServiceWorkerBasic.mm:
((ServiceWorkers, SharedWorkerNotReusedAfterCOOPProcessSwap)):
((ServiceWorkers, SharedWorkerNotReusedAfterCOOPProcessSwapWithSiteIsolation)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/62abed84de6eb8a10a5c0d5e346efceb2629ca00

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174935 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48868 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42649 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184516 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132843 "Failed to checkout and rebase branch from PR 69544") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9522276e-c037-4188-b9f7-2afb2440a1e4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176800 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50160 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48551 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136142 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/132843 "Failed to checkout and rebase branch from PR 69544") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d1a20e90-26db-4c62-885a-707a63fac3eb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177893 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39583 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156939 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116621 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0de4d3c4-9a92-4665-8a3c-e2e8465e245c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38224 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36605 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32993 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148647 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36431 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186940 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/40421 "Failed to checkout and rebase branch from PR 69544") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40807 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145073 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48535 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144931 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49215 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33052 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115027 "Failed to checkout and rebase branch from PR 69544") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39805 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121340 "Failed to checkout and rebase branch from PR 69544") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47721 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11404 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47123 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47354 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47181 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->