### PR TITLE
[JSC][Wasm] Shrink Type to a pointer-sized payload on 64-bit

### DIFF
--- a/JSTests/wasm/stress/type-index-abstract-heap-types.js
+++ b/JSTests/wasm/stress/type-index-abstract-heap-types.js
@@ -1,0 +1,163 @@
+// https://bugs.webkit.org/show_bug.cgi?id=247454
+import * as assert from "../assert.js";
+import { compile, instantiate } from "../gc/wast-wrapper.js";
+
+function testAbstractNullsAndCasts() {
+    const m = instantiate(`
+      (module
+        (type $S (struct (field i32)))
+        (type $A (array i32))
+        (func (export "nullFuncref") (result funcref) (ref.null func))
+        (func (export "nullExternref") (result externref) (ref.null extern))
+        (func (export "nullAnyref") (result anyref) (ref.null any))
+        (func (export "nullEqref") (result eqref) (ref.null eq))
+        (func (export "nullI31ref") (result i31ref) (ref.null i31))
+        (func (export "nullStructref") (result structref) (ref.null struct))
+        (func (export "nullArrayref") (result arrayref) (ref.null array))
+        (func (export "nullNone") (result nullref) (ref.null none))
+        (func (export "nullNofunc") (result nullfuncref) (ref.null nofunc))
+        (func (export "nullNoextern") (result nullexternref) (ref.null noextern))
+
+        (func (export "castI31ToAny") (param i32) (result anyref)
+          (ref.cast anyref (ref.i31 (local.get 0))))
+        (func (export "testI31IsEq") (param i32) (result i32)
+          (ref.test eqref (ref.i31 (local.get 0))))
+        (func (export "testStructIsAny") (result i32)
+          (ref.test anyref (struct.new $S (i32.const 1))))
+        (func (export "testArrayIsStruct") (result i32)
+          (ref.test structref (array.new_default $A (i32.const 1))))
+        (func (export "castStructToStructref") (result structref)
+          (ref.cast structref (struct.new $S (i32.const 7))))
+        (func (export "castArrayToArrayref") (result arrayref)
+          (ref.cast arrayref (array.new_default $A (i32.const 2))))
+        (func (export "castFailAnyToStruct") (param anyref) (result (ref null $S))
+          (ref.cast (ref null $S) (local.get 0)))
+      )
+    `).exports;
+
+    assert.eq(m.nullFuncref(), null);
+    assert.eq(m.nullExternref(), null);
+    assert.eq(m.nullAnyref(), null);
+    assert.eq(m.nullEqref(), null);
+    assert.eq(m.nullI31ref(), null);
+    assert.eq(m.nullStructref(), null);
+    assert.eq(m.nullArrayref(), null);
+    assert.eq(m.nullNone(), null);
+    assert.eq(m.nullNofunc(), null);
+    assert.eq(m.nullNoextern(), null);
+
+    assert.eq(m.testI31IsEq(42), 1);
+    assert.eq(m.testStructIsAny(), 1);
+    assert.eq(m.testArrayIsStruct(), 0);
+    m.castI31ToAny(99);
+    m.castStructToStructref();
+    m.castArrayToArrayref();
+
+    assert.throws(
+        () => m.castFailAnyToStruct(42),
+        WebAssembly.RuntimeError,
+        "cast"
+    );
+}
+
+function testSubtypeValidation() {
+    compile(`
+      (module
+        (type $S (struct))
+        (func (param (ref null $S)) (result)
+          (drop (local.get 0)))
+        (func (param anyref) (result)
+          (call 0 (ref.cast (ref null $S) (local.get 0)))))
+    `);
+
+    assert.throws(
+        () => compile(`
+          (module
+            (func (param funcref) (result)
+              (drop (ref.cast externref (local.get 0)))))
+        `),
+        WebAssembly.CompileError,
+        "ref.cast"
+    );
+
+    assert.throws(
+        () => compile(`
+          (module
+            (func (param externref) (result anyref)
+              (ref.cast anyref (local.get 0))))
+        `),
+        WebAssembly.CompileError,
+        "ref.cast"
+    );
+
+    compile(`
+      (module
+        (func (param i31ref) (result anyref)
+          (ref.cast anyref (local.get 0))))
+    `);
+
+    compile(`
+      (module
+        (func (param structref) (result eqref)
+          (ref.cast eqref (local.get 0))))
+    `);
+}
+
+function testGlobalsAndTables() {
+    const m = instantiate(`
+      (module
+        (global $g (mut anyref) (ref.null any))
+        (global $gf (export "gf") funcref (ref.null func))
+        (table $t 2 anyref)
+        (func (export "setGlobal") (param anyref)
+          (global.set $g (local.get 0)))
+        (func (export "getGlobal") (result anyref)
+          (global.get $g))
+        (func (export "setTable") (param i32 anyref)
+          (table.set $t (local.get 0) (local.get 1)))
+        (func (export "getTable") (param i32) (result anyref)
+          (table.get $t (local.get 0)))
+        (func (export "nullInTable") (result i32)
+          (table.set $t (i32.const 0) (ref.null none))
+          (ref.is_null (table.get $t (i32.const 0))))
+      )
+    `).exports;
+
+    assert.eq(m.gf.value, null);
+    m.setGlobal(null);
+    assert.eq(m.getGlobal(), null);
+    m.setTable(1, "hello");
+    assert.eq(m.getTable(1), "hello");
+    assert.eq(m.nullInTable(), 1);
+}
+
+function testConcreteVsAbstract() {
+    const m = instantiate(`
+      (module
+        (type $S (sub (struct (field i32))))
+        (type $T (sub $S (struct (field i32) (field i64))))
+        (func (export "asAny") (result anyref)
+          (struct.new $T (i32.const 1) (i64.const 2)))
+        (func (export "asStruct") (result structref)
+          (struct.new $S (i32.const 3)))
+        (func (export "castToS") (param anyref) (result (ref null $S))
+          (ref.cast (ref null $S) (local.get 0)))
+        (func (export "testIsS") (param anyref) (result i32)
+          (ref.test (ref null $S) (local.get 0)))
+      )
+    `).exports;
+
+    const v = m.asAny();
+    assert.eq(m.testIsS(v), 1);
+    m.castToS(v);
+    m.castToS(m.asStruct());
+    assert.eq(m.testIsS(null), 1);
+    assert.eq(m.testIsS(42), 0);
+}
+
+for (let i = 0; i < wasmTestLoopCount; ++i) {
+    testAbstractNullsAndCasts();
+    testSubtypeValidation();
+    testGlobalsAndTables();
+    testConcreteVsAbstract();
+}

--- a/Source/JavaScriptCore/b3/B3LowerMacros.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerMacros.cpp
@@ -689,7 +689,7 @@ private:
                     ASSERT(fieldType.is<Wasm::Type>());
                     auto unpacked = fieldType.unpacked();
                     Type b3Type;
-                    switch (unpacked.kind) {
+                    switch (unpacked.kind()) {
                     case Wasm::TypeKind::I32:
                         b3Type = Int32;
                         break;
@@ -848,7 +848,7 @@ private:
                     ASSERT(elementType.is<Wasm::Type>());
                     auto unpacked = elementType.unpacked();
                     Type b3Type;
-                    switch (unpacked.kind) {
+                    switch (unpacked.kind()) {
                     case Wasm::TypeKind::I32:
                         b3Type = Int32;
                         break;
@@ -1373,7 +1373,7 @@ private:
             if (allowNull)
                 return std::nullopt;
 
-            if (Wasm::typeIndexIsType(static_cast<Wasm::TypeIndex>(toHeapType)))
+            if (!Wasm::isTypeIndexHeapType(toHeapType))
                 return std::nullopt;
 
             if (targetRTT->kind() == Wasm::RTTKind::Function)
@@ -1465,7 +1465,7 @@ private:
             currentBlock = nonNullCase;
         }
 
-        if (Wasm::typeIndexIsType(static_cast<Wasm::TypeIndex>(toHeapType))) {
+        if (!Wasm::isTypeIndexHeapType(toHeapType)) {
             switch (static_cast<Wasm::TypeKind>(toHeapType)) {
             case Wasm::TypeKind::Funcref:
             case Wasm::TypeKind::Externref:

--- a/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
+++ b/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
@@ -4171,7 +4171,7 @@ private:
                 auto rtt = structNew->rtt();
                 int32_t toHeapType = cast->targetHeapType();
                 RefPtr targetRTT = cast->targetRTT();
-                if (!Wasm::typeIndexIsType(static_cast<Wasm::TypeIndex>(toHeapType))) {
+                if (Wasm::isTypeIndexHeapType(toHeapType)) {
                     if (rtt->isSubRTT(*targetRTT)) {
                         // shouldNegate can only be set on WasmRefTest.
                         ASSERT(!cast->shouldNegate());
@@ -4243,7 +4243,7 @@ private:
                 auto rtt = structNew->rtt();
                 int32_t toHeapType = cast->targetHeapType();
                 RefPtr targetRTT = cast->targetRTT();
-                if (!Wasm::typeIndexIsType(static_cast<Wasm::TypeIndex>(toHeapType))) {
+                if (Wasm::isTypeIndexHeapType(toHeapType)) {
                     const bool isSubtype = rtt->isSubRTT(*targetRTT);
                     replaceWithNewValue(m_proc.addIntConstant(m_value, cast->shouldNegate() ? !isSubtype : isSubtype));
                     break;

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -5705,7 +5705,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
 
         ASSERT(signature->returnCount() == 1);
         auto type = signature->returnType(0);
-        switch (type.kind) {
+        switch (type.kind()) {
         case Wasm::TypeKind::I32: {
             setNonCellTypeForNode(node, SpecInt32Only);
             break;

--- a/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
@@ -1854,7 +1854,7 @@ private:
                 for (unsigned index = 0; index < signature->argumentCount(); ++index) {
                     auto type = signature->argumentType(index);
                     Edge argument = m_graph.varArgChild(m_node, 2 + index);
-                    switch (type.kind) {
+                    switch (type.kind()) {
                     case Wasm::TypeKind::I32: {
                         if (!argument->shouldSpeculateInt32())
                             success = false;
@@ -1890,7 +1890,7 @@ private:
                 if (!signature->returnsVoid()) {
                     ASSERT(signature->returnCount() == 1);
                     auto type = signature->returnType(0);
-                    switch (type.kind) {
+                    switch (type.kind()) {
                     case Wasm::TypeKind::I32:
                     case Wasm::TypeKind::I64:
                     case Wasm::TypeKind::Ref:
@@ -1934,7 +1934,7 @@ private:
                     auto type = signature->argumentType(index);
                     Edge argument = m_graph.varArgChild(m_node, 2 + index);
                     Node* argumentNode = argument.node();
-                    switch (type.kind) {
+                    switch (type.kind()) {
                     case Wasm::TypeKind::I32: {
                         m_insertionSet.insertCheck(checkIndex, m_node->origin, Edge(argumentNode, Int32Use));
                         m_graph.varArgChild(m_node, 2 + index) = Edge(argumentNode, KnownInt32Use);
@@ -1972,7 +1972,7 @@ private:
 
                 if (!signature->returnsVoid()) {
                     auto type = signature->returnType(0);
-                    switch (type.kind) {
+                    switch (type.kind()) {
                     case Wasm::TypeKind::I32: {
                         m_node->setResult(NodeResultInt32);
                         break;

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -14949,7 +14949,7 @@ IGNORE_CLANG_WARNINGS_END
         for (unsigned i = signature->argumentCount(); i--;) {
             bool isStack = wasmCallInfo.params[i].location.isStackArgument();
             auto type = signature->argumentType(i);
-            switch (type.kind) {
+            switch (type.kind()) {
             case Wasm::TypeKind::I32:
                 if (isStack)
                     arguments.append(ConstrainedValue(lowInt32(m_graph.varArgChild(node, 2 + i)), ValueRep::stackArgument(safeCast<int32_t>(wasmCallInfo.params[i].location.offsetFromSP()))));
@@ -15024,7 +15024,7 @@ IGNORE_CLANG_WARNINGS_END
         if (signature->returnsVoid())
             patchpoint = m_out.patchpoint(Void);
         else {
-            switch (signature->returnType(0).kind) {
+            switch (signature->returnType(0).kind()) {
             case Wasm::TypeKind::I32: {
                 patchpoint = m_out.patchpoint(Int32);
                 patchpoint->resultConstraints = { ValueRep::reg(wasmCallInfo.results[0].location.jsr().payloadGPR()) };
@@ -15123,7 +15123,7 @@ IGNORE_CLANG_WARNINGS_END
         if (signature->returnsVoid())
             setJSValue(m_out.constInt64(JSValue::encode(jsUndefined())));
         else {
-            switch (signature->returnType(0).kind) {
+            switch (signature->returnType(0).kind()) {
             case Wasm::TypeKind::I32: {
                 setInt32(patchpoint);
                 break;

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -465,9 +465,9 @@ ControlData::ControlData(BBQJIT& generator, BlockType blockType, BlockSignature&
         // For TopLevel, use the function's calling convention
         CallInformation wasmCallInfo = wasmCallingConvention().callInformationFor(generator.m_functionSignature.get(), CallRole::Callee);
         for (unsigned i = 0; i < m_signature.argumentCount(); ++i)
-            m_argumentLocations.append(Location::fromArgumentLocation(wasmCallInfo.params[i], m_signature.argumentType(i).kind));
+            m_argumentLocations.append(Location::fromArgumentLocation(wasmCallInfo.params[i], m_signature.argumentType(i).kind()));
         for (unsigned i = 0; i < m_signature.returnCount(); ++i)
-            m_resultLocations.append(Location::fromArgumentLocation(wasmCallInfo.results[i], m_signature.returnType(i).kind));
+            m_resultLocations.append(Location::fromArgumentLocation(wasmCallInfo.results[i], m_signature.returnType(i).kind()));
         return;
     }
 
@@ -478,13 +478,13 @@ ControlData::ControlData(BBQJIT& generator, BlockType blockType, BlockSignature&
         liveScratchFPRs.forEach([&] (auto r) { fprSetCopy.remove(r); });
 
         for (unsigned i = 0; i < m_signature.argumentCount(); ++i)
-            m_argumentLocations.append(allocateArgumentOrResult(generator, m_signature.argumentType(i).kind, i, gprSetCopy, fprSetCopy));
+            m_argumentLocations.append(allocateArgumentOrResult(generator, m_signature.argumentType(i).kind(), i, gprSetCopy, fprSetCopy));
     }
 
     auto gprSetCopy = generator.validGPRs();
     auto fprSetCopy = generator.validFPRs();
     for (unsigned i = 0; i < m_signature.returnCount(); ++i)
-        m_resultLocations.append(allocateArgumentOrResult(generator, m_signature.returnType(i).kind, i, gprSetCopy, fprSetCopy));
+        m_resultLocations.append(allocateArgumentOrResult(generator, m_signature.returnType(i).kind(), i, gprSetCopy, fprSetCopy));
 }
 
 // This function is intentionally not using implicitSlots since arguments and results should not include implicit slot.
@@ -730,12 +730,12 @@ BBQJIT::BBQJIT(CompilationContext& compilationContext, const RTT& signature, Mod
     ASSERT(callInfo.params.size() == m_functionSignature->argumentCount());
     for (unsigned i = 0; i < m_functionSignature->argumentCount(); i ++) {
         const Type& type = m_functionSignature->argumentType(i);
-        m_localSlots.append(allocateStack(Value::fromLocal(type.kind, i)));
+        m_localSlots.append(allocateStack(Value::fromLocal(type.kind(), i)));
         m_locals.append(Location::none());
-        m_localTypes.append(type.kind);
+        m_localTypes.append(type.kind());
 
-        Value parameter = Value::fromLocal(type.kind, i);
-        bind(parameter, Location::fromArgumentLocation(callInfo.params[i], type.kind));
+        Value parameter = Value::fromLocal(type.kind(), i);
+        bind(parameter, Location::fromArgumentLocation(callInfo.params[i], type.kind()));
         m_arguments.append(i);
     }
     m_localAndCalleeSaveStorage = m_frameSizeForValidation; // All stack slots allocated so far are locals.
@@ -781,7 +781,7 @@ bool BBQJIT::addArguments(const RTT& signature)
 Value BBQJIT::addConstant(Type type, uint64_t value)
 {
     Value result;
-    switch (type.kind) {
+    switch (type.kind()) {
     case TypeKind::I32:
         result = Value::fromI32(value);
         LOG_INSTRUCTION("I32Const", RESULT(result));
@@ -813,8 +813,8 @@ Value BBQJIT::addConstant(Type type, uint64_t value)
     case TypeKind::Noneref:
     case TypeKind::Nofuncref:
     case TypeKind::Noexternref:
-        result = Value::fromRef(type.kind, static_cast<EncodedJSValue>(value));
-        LOG_INSTRUCTION("RefConst", makeString(type.kind), RESULT(result));
+        result = Value::fromRef(type.kind(), static_cast<EncodedJSValue>(value));
+        LOG_INSTRUCTION("RefConst", makeString(type.kind()), RESULT(result));
         break;
     default:
         RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("Unimplemented constant type.\n");
@@ -822,7 +822,7 @@ Value BBQJIT::addConstant(Type type, uint64_t value)
     }
 
     if (Options::disableBBQConsts()) [[unlikely]] {
-        Value stackResult = topValue(type.kind);
+        Value stackResult = topValue(type.kind());
         emitStoreConst(result, canonicalSlot(stackResult));
         result = stackResult;
     }
@@ -841,10 +841,10 @@ PartialResult BBQJIT::addLocal(Type type, uint32_t numberOfLocals)
 {
     for (uint32_t i = 0; i < numberOfLocals; i ++) {
         uint32_t localIndex = m_locals.size();
-        m_localSlots.append(allocateStack(Value::fromLocal(type.kind, localIndex)));
+        m_localSlots.append(allocateStack(Value::fromLocal(type.kind(), localIndex)));
         m_localAndCalleeSaveStorage = m_frameSizeForValidation;
         m_locals.append(m_localSlots.last());
-        m_localTypes.append(type.kind);
+        m_localTypes.append(type.kind());
     }
     return { };
 }
@@ -1000,9 +1000,9 @@ PartialResult BBQJIT::addLocal(Type type, uint32_t numberOfLocals)
     // This is probably not ideal, we have infrastructure to support binding locals to registers, but
     // we currently can't track local versioning (meaning we can get SSA-style issues where assigning
     // to a local also updates all previous uses).
-    result = topValue(m_parser->typeOfLocal(localIndex).kind);
+    result = topValue(m_parser->typeOfLocal(localIndex).kind());
     Location resultLocation = allocate(result);
-    emitLoad(Value::fromLocal(m_parser->typeOfLocal(localIndex).kind, localIndex), resultLocation);
+    emitLoad(Value::fromLocal(m_parser->typeOfLocal(localIndex).kind(), localIndex), resultLocation);
     LOG_INSTRUCTION("GetLocal", localIndex, RESULT(result));
     return { };
 }
@@ -1011,7 +1011,7 @@ PartialResult BBQJIT::addLocal(Type type, uint32_t numberOfLocals)
 {
     if (!value.isConst())
         loadIfNecessary(value);
-    Value local = Value::fromLocal(m_parser->typeOfLocal(localIndex).kind, localIndex);
+    Value local = Value::fromLocal(m_parser->typeOfLocal(localIndex).kind(), localIndex);
     Location localLocation = locationOf(local);
     emitStore(value, localLocation);
     consume(value);
@@ -1022,12 +1022,12 @@ PartialResult BBQJIT::addLocal(Type type, uint32_t numberOfLocals)
 [[nodiscard]] PartialResult BBQJIT::teeLocal(uint32_t localIndex, Value value, Value& result)
 {
     auto type = m_parser->typeOfLocal(localIndex);
-    Value local = Value::fromLocal(type.kind, localIndex);
+    Value local = Value::fromLocal(type.kind(), localIndex);
     if (value.isConst()) {
         Location localLocation = locationOf(local);
         emitStore(value, localLocation);
         consume(value);
-        result = topValue(type.kind);
+        result = topValue(type.kind());
         Location resultLocation = allocate(result);
         emitMoveConst(value, resultLocation);
     } else {
@@ -1035,9 +1035,9 @@ PartialResult BBQJIT::addLocal(Type type, uint32_t numberOfLocals)
         Location localLocation = locationOf(local);
         emitStore(value, localLocation);
         consume(value);
-        result = topValue(type.kind);
+        result = topValue(type.kind());
         Location resultLocation = allocate(result);
-        emitMove(type.kind, srcLocation, resultLocation);
+        emitMove(type.kind(), srcLocation, resultLocation);
     }
     LOG_INSTRUCTION("TeeLocal", localIndex, value, RESULT(result));
     return { };
@@ -1509,7 +1509,7 @@ FloatingPointRange BBQJIT::lookupTruncationRange(TruncationKind truncationKind)
 
     consume(operand); // Allow temp operand location to be reused
 
-    result = topValue(returnType.kind);
+    result = topValue(returnType.kind());
     Location resultLocation = allocate(result);
     TruncationKind kind = truncationKind(truncationOp);
     auto range = lookupTruncationRange(kind);
@@ -1558,7 +1558,7 @@ FloatingPointRange BBQJIT::lookupTruncationRange(TruncationKind truncationKind)
 
         consume(operand);
 
-        result = topValue(returnType.kind);
+        result = topValue(returnType.kind());
         Location resultLocation = allocate(result);
 
         LOG_INSTRUCTION("TruncSaturated", operand, operandLocation, RESULT(result));
@@ -1616,7 +1616,7 @@ FloatingPointRange BBQJIT::lookupTruncationRange(TruncationKind truncationKind)
 
     consume(operand); // Allow temp operand location to be reused
 
-    result = topValue(returnType.kind);
+    result = topValue(returnType.kind());
     Location resultLocation = allocate(result);
 
     LOG_INSTRUCTION("TruncSaturated", operand, operandLocation, RESULT(result));
@@ -3296,7 +3296,7 @@ void BBQJIT::emitEntryTierUpCheck()
 
     LocalOrTempIndex i = 0;
     for (; i < m_arguments.size(); ++i)
-        flushValue(Value::fromLocal(m_parser->typeOfLocal(i).kind, i));
+        flushValue(Value::fromLocal(m_parser->typeOfLocal(i).kind(), i));
 
     // Zero all locals that aren't initialized by arguments.
     enum class ClearMode { Zero, JSNull };
@@ -3367,7 +3367,7 @@ void BBQJIT::emitEntryTierUpCheck()
 
     JIT_COMMENT(m_jit, "initialize locals");
     for (; i < m_locals.size(); ++i) {
-        TypeKind type = m_parser->typeOfLocal(i).kind;
+        TypeKind type = m_parser->typeOfLocal(i).kind();
         switch (type) {
         case TypeKind::I32:
         case TypeKind::I31ref:
@@ -3572,13 +3572,13 @@ StackMap BBQJIT::makeStackMap(const ControlData& data, std::span<const TypedExpr
 
     for (size_t i = 0; i < m_parser->controlStack().size(); ++i) {
         for (const TypedExpression& expr : m_parser->enclosedSliceOf(i))
-            stackMap[stackMapIndex++] = OSREntryValue(toB3Rep(locationOf(expr.value())), toB3Type(expr.type().kind));
+            stackMap[stackMapIndex++] = OSREntryValue(toB3Rep(locationOf(expr.value())), toB3Type(expr.type().kind()));
     }
 
     for (const TypedExpression& expr : enclosingStack)
-        stackMap[stackMapIndex++] = OSREntryValue(toB3Rep(locationOf(expr.value())), toB3Type(expr.type().kind));
+        stackMap[stackMapIndex++] = OSREntryValue(toB3Rep(locationOf(expr.value())), toB3Type(expr.type().kind()));
     for (unsigned i = 0; i < data.argumentLocations().size(); i++)
-        stackMap[stackMapIndex++] = OSREntryValue(toB3Rep(data.argumentLocations()[i]), toB3Type(data.argumentType(i).kind));
+        stackMap[stackMapIndex++] = OSREntryValue(toB3Rep(data.argumentLocations()[i]), toB3Type(data.argumentType(i).kind()));
 
     RELEASE_ASSERT(stackMapIndex == numElements);
     m_osrEntryScratchBufferSize = std::max(m_osrEntryScratchBufferSize, BBQCallee::extraOSRValuesForLoopIndex + numElements);
@@ -3697,7 +3697,7 @@ void BBQJIT::emitLoopTierUpCheckAndOSREntryData(const ControlData& data, std::sp
     const auto& blockSignature = data.signature();
     while (expressionStack.size() < blockSignature.argumentCount()) {
         Type type = blockSignature.argumentType(expressionStack.size());
-        expressionStack.constructAndAppend(type, Value::fromTemp(type.kind, dataElse.enclosedHeight() + dataElse.implicitSlots() + expressionStack.size()));
+        expressionStack.constructAndAppend(type, Value::fromTemp(type.kind(), dataElse.enclosedHeight() + dataElse.implicitSlots() + expressionStack.size()));
     }
 
     dataElse.startBlock(*this, expressionStack);
@@ -3725,7 +3725,7 @@ void BBQJIT::emitLoopTierUpCheckAndOSREntryData(const ControlData& data, std::sp
     Stack expressionStack;
     const auto& functionSignature = dataElse.signature();
     for (unsigned i = 0; i < functionSignature.argumentCount(); i ++)
-        expressionStack.constructAndAppend(functionSignature.argumentType(i), Value::fromTemp(functionSignature.argumentType(i).kind, dataElse.enclosedHeight() + dataElse.implicitSlots() + i));
+        expressionStack.constructAndAppend(functionSignature.argumentType(i), Value::fromTemp(functionSignature.argumentType(i).kind(), dataElse.enclosedHeight() + dataElse.implicitSlots() + i));
     dataElse.startBlock(*this, expressionStack);
     data = dataElse;
     return { };
@@ -3940,7 +3940,7 @@ void BBQJIT::prepareForExceptions()
         Vector<Location, 8> returnLocationsForShuffle;
         for (unsigned i = 0; i < wasmCallInfo.results.size(); ++i) {
             returnValuesForShuffle.append(returnValues[offset + i]);
-            returnLocationsForShuffle.append(Location::fromArgumentLocation(wasmCallInfo.results[i], returnValues[offset + i].type().kind));
+            returnLocationsForShuffle.append(Location::fromArgumentLocation(wasmCallInfo.results[i], returnValues[offset + i].type().kind()));
         }
         emitShuffle(returnValuesForShuffle, returnLocationsForShuffle);
         LOG_INSTRUCTION("Return", returnLocationsForShuffle);
@@ -4112,7 +4112,7 @@ void BBQJIT::prepareForExceptions()
         unsigned offset = enclosedStack.size() - returnCount;
         for (unsigned i = 0; i < returnCount; ++i) {
             Type type = blockSignature.returnType(i);
-            enclosedStack[offset + i] = TypedExpression(type, Value::fromTemp(type.kind, entryData.enclosedHeight() + entryData.implicitSlots() + i));
+            enclosedStack[offset + i] = TypedExpression(type, Value::fromTemp(type.kind(), entryData.enclosedHeight() + entryData.implicitSlots() + i));
         }
         unbindAllRegisters();
     }
@@ -4356,7 +4356,7 @@ void BBQJIT::saveValuesAcrossCallAndPassArguments(const Args& arguments, const C
     // careful.
     for (size_t i = 0; i < callInfo.params.size(); ++i) {
         auto type = signature.argumentType(i);
-        Location paramLocation = Location::fromArgumentLocation(callInfo.params[i], type.kind);
+        Location paramLocation = Location::fromArgumentLocation(callInfo.params[i], type.kind());
         if (paramLocation.isRegister()) {
             RegisterBinding binding;
             if (paramLocation.isGPR())
@@ -4375,7 +4375,7 @@ void BBQJIT::saveValuesAcrossCallAndPassArguments(const Args& arguments, const C
     parameterLocations.reserveInitialCapacity(callInfo.params.size());
     for (unsigned i = 0; i < callInfo.params.size(); i++) {
         auto type = signature.argumentType(i);
-        auto parameterLocation = Location::fromArgumentLocation(callInfo.params[i], type.kind);
+        auto parameterLocation = Location::fromArgumentLocation(callInfo.params[i], type.kind());
         parameterLocations.append(parameterLocation);
     }
 
@@ -4393,7 +4393,7 @@ template<size_t N>
 void BBQJIT::returnValuesFromCall(Vector<Value, N>& results, const RTT& functionType, const CallInformation& callInfo)
 {
     for (size_t i = 0; i < callInfo.results.size(); i ++) {
-        Value result = topValue(functionType.returnType(i).kind, i);
+        Value result = topValue(functionType.returnType(i).kind(), i);
         Location returnLocation = Location::fromArgumentLocation(callInfo.results[i], result.type());
         if (returnLocation.isRegister()) {
             RegisterBinding currentBinding;
@@ -4496,7 +4496,7 @@ void BBQJIT::emitTailCall(FunctionSpaceIndex functionIndexSpace, const RTT& sign
         case ValueLocation::Kind::GPRRegister:
         case ValueLocation::Kind::FPRRegister: {
             auto type = signature.argumentType(i);
-            parameterLocations.append(Location::fromArgumentLocation(param, type.kind));
+            parameterLocations.append(Location::fromArgumentLocation(param, type.kind()));
             break;
         }
         case ValueLocation::Kind::StackArgument:
@@ -4777,7 +4777,7 @@ void BBQJIT::emitIndirectTailCall(const char* opcode, const Value& callee, GPRRe
         case ValueLocation::Kind::GPRRegister:
         case ValueLocation::Kind::FPRRegister: {
             auto type = signature.argumentType(i);
-            parameterLocations.append(Location::fromArgumentLocation(param, type.kind));
+            parameterLocations.append(Location::fromArgumentLocation(param, type.kind()));
             break;
         }
         case ValueLocation::Kind::StackArgument:

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.h
@@ -834,7 +834,7 @@ public:
             for (unsigned i = 0; i < predecessor.resultLocations().size(); ++i) {
                 unsigned offset = expressionStack.size() - predecessor.resultLocations().size();
                 // Intentionally not using implicitSlots since results should not include implicit slot.
-                expressionStack[i + offset].value() = Value::fromTemp(expressionStack[i + offset].type().kind, predecessor.enclosedHeight() + i);
+                expressionStack[i + offset].value() = Value::fromTemp(expressionStack[i + offset].type().kind(), predecessor.enclosedHeight() + i);
                 generator.bind(expressionStack[i + offset].value(), predecessor.resultLocations()[i]);
             }
         }

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
@@ -163,7 +163,7 @@ Value BBQJIT::instanceValue()
 {
     // FIXME: Emit this inline <https://bugs.webkit.org/show_bug.cgi?id=198506>.
     ASSERT(index.type() == TypeKind::I32);
-    TypeKind returnType = m_info.tables[tableIndex].wasmType().kind;
+    TypeKind returnType = m_info.tables[tableIndex].wasmType().kind();
     ASSERT(typeKindSizeInBytes(returnType) == 8);
 
     Vector<Value, 8> arguments = {
@@ -187,19 +187,19 @@ Value BBQJIT::instanceValue()
     Type type = global.type;
 
     int32_t offset = JSWebAssemblyInstance::offsetOfGlobal(m_info, index);
-    Value globalValue = Value::pinned(type.kind, Location::fromGlobal(offset));
+    Value globalValue = Value::pinned(type.kind(), Location::fromGlobal(offset));
 
     switch (global.bindingMode) {
     case Wasm::GlobalInformation::BindingMode::EmbeddedInInstance:
-        result = topValue(type.kind);
+        result = topValue(type.kind());
         emitLoad(globalValue, loadIfNecessary(result));
         break;
     case Wasm::GlobalInformation::BindingMode::Portable:
         ASSERT(global.mutability == Wasm::Mutability::Mutable);
         m_jit.loadPtr(Address(GPRInfo::wasmContextInstancePointer, offset), wasmScratchGPR);
-        result = topValue(type.kind);
+        result = topValue(type.kind());
         Location resultLocation = allocate(result);
-        switch (type.kind) {
+        switch (type.kind()) {
         case TypeKind::I32:
             m_jit.load32(Address(wasmScratchGPR), resultLocation.asGPR());
             break;
@@ -282,7 +282,7 @@ Value BBQJIT::instanceValue()
         ASSERT(valueLocation.isRegister());
         consume(value);
 
-        switch (type.kind) {
+        switch (type.kind()) {
         case TypeKind::I32:
             m_jit.store32(valueLocation.asGPR(), Address(wasmScratchGPR));
             break;
@@ -649,7 +649,7 @@ void BBQJIT::emitAtomicOpGeneric(ExtAtomicOpType op, Address address, GPRReg old
     if (accessWidth(loadOp) != Width8)
         recordJumpToThrowException(ExceptionType::UnalignedMemoryAccess, m_jit.branchTest64(ResultCondition::NonZero, pointer.asGPR(), TrustedImm64(sizeOfAtomicOpMemoryAccess(loadOp) - 1)));
 
-    Value result = topValue(valueType.kind);
+    Value result = topValue(valueType.kind());
     Location resultLocation = allocate(result);
 
     if (!(isARM64_LSE() || isX86_64())) {
@@ -657,7 +657,7 @@ void BBQJIT::emitAtomicOpGeneric(ExtAtomicOpType op, Address address, GPRReg old
         emitAtomicOpGeneric(loadOp, address, resultLocation.asGPR(), scratches.gpr(0), [&](GPRReg oldGPR, GPRReg newGPR) {
             emitSanitizeAtomicResult(loadOp, canonicalWidth(accessWidth(loadOp)) == Width64 ? TypeKind::I64 : TypeKind::I32, oldGPR, newGPR);
         });
-        emitSanitizeAtomicResult(loadOp, valueType.kind, resultLocation.asGPR());
+        emitSanitizeAtomicResult(loadOp, valueType.kind(), resultLocation.asGPR());
         return result;
     }
 
@@ -724,7 +724,7 @@ void BBQJIT::emitAtomicOpGeneric(ExtAtomicOpType op, Address address, GPRReg old
         break;
     }
 
-    emitSanitizeAtomicResult(loadOp, valueType.kind, resultLocation.asGPR());
+    emitSanitizeAtomicResult(loadOp, valueType.kind(), resultLocation.asGPR());
 
     return result;
 }
@@ -842,7 +842,7 @@ Value BBQJIT::emitAtomicBinaryRMWOp(ExtAtomicOpType op, Type valueType, Location
     if (accessWidth(op) != Width8)
         recordJumpToThrowException(ExceptionType::UnalignedMemoryAccess, m_jit.branchTest64(ResultCondition::NonZero, pointer.asGPR(), TrustedImm64(sizeOfAtomicOpMemoryAccess(op) - 1)));
 
-    Value result = topValue(valueType.kind);
+    Value result = topValue(valueType.kind());
     Location resultLocation = allocate(result);
 
     GPRReg scratchGPR = InvalidGPRReg;
@@ -906,7 +906,7 @@ Value BBQJIT::emitAtomicBinaryRMWOp(ExtAtomicOpType op, Type valueType, Location
                 RELEASE_ASSERT_NOT_REACHED();
                 break;
             }
-            emitSanitizeAtomicResult(op, valueType.kind, resultLocation.asGPR());
+            emitSanitizeAtomicResult(op, valueType.kind(), resultLocation.asGPR());
             return result;
         }
         break;
@@ -961,7 +961,7 @@ Value BBQJIT::emitAtomicBinaryRMWOp(ExtAtomicOpType op, Type valueType, Location
                 RELEASE_ASSERT_NOT_REACHED();
                 break;
             }
-            emitSanitizeAtomicResult(op, valueType.kind, resultLocation.asGPR());
+            emitSanitizeAtomicResult(op, valueType.kind(), resultLocation.asGPR());
             return result;
         }
         break;
@@ -997,7 +997,7 @@ Value BBQJIT::emitAtomicBinaryRMWOp(ExtAtomicOpType op, Type valueType, Location
                 RELEASE_ASSERT_NOT_REACHED();
                 break;
             }
-            emitSanitizeAtomicResult(op, valueType.kind, resultLocation.asGPR());
+            emitSanitizeAtomicResult(op, valueType.kind(), resultLocation.asGPR());
             return result;
         }
 #endif
@@ -1028,7 +1028,7 @@ Value BBQJIT::emitAtomicBinaryRMWOp(ExtAtomicOpType op, Type valueType, Location
                 RELEASE_ASSERT_NOT_REACHED();
                 break;
             }
-            emitSanitizeAtomicResult(op, valueType.kind, resultLocation.asGPR());
+            emitSanitizeAtomicResult(op, valueType.kind(), resultLocation.asGPR());
             return result;
         }
 #endif
@@ -1059,7 +1059,7 @@ Value BBQJIT::emitAtomicBinaryRMWOp(ExtAtomicOpType op, Type valueType, Location
                 RELEASE_ASSERT_NOT_REACHED();
                 break;
             }
-            emitSanitizeAtomicResult(op, valueType.kind, resultLocation.asGPR());
+            emitSanitizeAtomicResult(op, valueType.kind(), resultLocation.asGPR());
             return result;
         }
 #endif
@@ -1109,7 +1109,7 @@ Value BBQJIT::emitAtomicBinaryRMWOp(ExtAtomicOpType op, Type valueType, Location
                 RELEASE_ASSERT_NOT_REACHED();
                 break;
             }
-            emitSanitizeAtomicResult(op, valueType.kind, resultLocation.asGPR());
+            emitSanitizeAtomicResult(op, valueType.kind(), resultLocation.asGPR());
             return result;
         }
         break;
@@ -1182,14 +1182,14 @@ Value BBQJIT::emitAtomicBinaryRMWOp(ExtAtomicOpType op, Type valueType, Location
         case ExtAtomicOpType::I64AtomicRmw16XchgU:
         case ExtAtomicOpType::I64AtomicRmw32XchgU:
         case ExtAtomicOpType::I64AtomicRmwXchg:
-            emitSanitizeAtomicResult(op, valueType.kind, valueLocation.asGPR(), newGPR);
+            emitSanitizeAtomicResult(op, valueType.kind(), valueLocation.asGPR(), newGPR);
             break;
         default:
             RELEASE_ASSERT_NOT_REACHED();
             break;
         }
     });
-    emitSanitizeAtomicResult(op, valueType.kind, resultLocation.asGPR());
+    emitSanitizeAtomicResult(op, valueType.kind(), resultLocation.asGPR());
     return result;
 }
 
@@ -1657,7 +1657,7 @@ void BBQJIT::emitAllocateGCArrayUninitialized(GPRReg resultGPR, TypeSignatureInd
         ASSERT(arrayref.asI64() == JSValue::encode(jsNull()));
         consume(index);
         emitThrowException(ExceptionType::NullAccess);
-        result = topValue(resultType.kind);
+        result = topValue(resultType.kind());
         return { };
     }
 
@@ -1680,7 +1680,7 @@ void BBQJIT::emitAllocateGCArrayUninitialized(GPRReg resultGPR, TypeSignatureInd
     emitArrayGetPayload(elementType, arrayLocation.asGPR(), wasmScratchGPR);
 
     consume(arrayref);
-    result = topValue(resultType.kind);
+    result = topValue(resultType.kind());
     Location resultLocation = allocate(result);
 
     if (index.isConst()) {
@@ -1769,7 +1769,7 @@ void BBQJIT::emitAllocateGCArrayUninitialized(GPRReg resultGPR, TypeSignatureInd
             LOG_INSTRUCTION("ArrayGetU", typeIndex, arrayref, index, RESULT(result));
             return { };
         case ExtGCOpType::ArrayGetS: {
-            ASSERT(resultType.kind == TypeKind::I32);
+            ASSERT(resultType.kind() == TypeKind::I32);
             uint8_t bitShift = (sizeof(uint32_t) - elementType.elementSize()) * 8;
 
             m_jit.lshift32(TrustedImm32(bitShift), resultLocation.asGPR());
@@ -2055,7 +2055,7 @@ void BBQJIT::emitAllocateGCStructUninitialized(GPRReg resultGPR, TypeSignatureIn
         auto* structPtr = context.gpr<JSWebAssemblyStruct*>(resultGPR);
         for (unsigned i = 0; i < debugStructType->fieldCount(); ++i) {
             auto type = debugStructType->field(i).type.unpacked();
-            if (type.kind != TypeKind::V128)
+            if (type.kind() != TypeKind::V128)
                 validateWasmValue(structPtr->get(i), type);
         }
     });
@@ -2095,7 +2095,7 @@ void BBQJIT::emitAllocateGCStructUninitialized(GPRReg resultGPR, TypeSignatureIn
         auto* structPtr = context.gpr<JSWebAssemblyStruct*>(resultGPR);
         for (unsigned i = 0; i < debugStructType->fieldCount(); ++i) {
             auto type = debugStructType->field(i).type.unpacked();
-            if (type.kind != TypeKind::V128)
+            if (type.kind() != TypeKind::V128)
                 validateWasmValue(structPtr->get(i), type);
         }
     });
@@ -2109,7 +2109,7 @@ void BBQJIT::emitAllocateGCStructUninitialized(GPRReg resultGPR, TypeSignatureIn
 [[nodiscard]] PartialResult BBQJIT::addStructGet(ExtGCOpType structGetKind, TypedExpression typedStruct, const RTT& structType, uint32_t fieldIndex, Value& result)
 {
     auto structValue = typedStruct.value();
-    TypeKind resultKind = structType.field(fieldIndex).type.unpacked().kind;
+    TypeKind resultKind = structType.field(fieldIndex).type.unpacked().kind();
     if (structValue.isConst()) {
         // This is the only constant struct currently possible.
         ASSERT(JSValue::decode(structValue.asRef()).isNull());
@@ -2233,7 +2233,7 @@ void BBQJIT::emitRefTestOrCast(CastKind castKind, const TypedExpression& typedVa
         if (allowNull)
             return std::nullopt;
 
-        if (typeIndexIsType(static_cast<Wasm::TypeIndex>(toHeapType)))
+        if (!isTypeIndexHeapType(toHeapType))
             return std::nullopt;
 
         Ref targetRTT = m_info.rtt(ModuleInformation::typeSignatureIndexFromHeapType(toHeapType));
@@ -2260,7 +2260,7 @@ void BBQJIT::emitRefTestOrCast(CastKind castKind, const TypedExpression& typedVa
         }
     }
 
-    if (typeIndexIsType(static_cast<Wasm::TypeIndex>(toHeapType))) {
+    if (!isTypeIndexHeapType(toHeapType)) {
         switch (static_cast<TypeKind>(toHeapType)) {
         case Wasm::TypeKind::Funcref:
         case Wasm::TypeKind::Externref:
@@ -3213,9 +3213,9 @@ void BBQJIT::emitCatchImpl(ControlData& dataCatch, const RTT& exceptionSignature
         unsigned offset = 0;
         for (unsigned i = 0; i < exceptionSignature.argumentCount(); ++i) {
             Type type = exceptionSignature.argumentType(i);
-            Value result = Value::fromTemp(type.kind, dataCatch.enclosedHeight() + dataCatch.implicitSlots() + i);
+            Value result = Value::fromTemp(type.kind(), dataCatch.enclosedHeight() + dataCatch.implicitSlots() + i);
             Location slot = canonicalSlot(result);
-            switch (type.kind) {
+            switch (type.kind()) {
             case TypeKind::I32:
                 m_jit.transfer32(Address(wasmScratchGPR, JSWebAssemblyException::Payload::Storage::offsetOfData() + offset * sizeof(uint64_t)), slot.asAddress());
                 break;
@@ -3257,7 +3257,7 @@ void BBQJIT::emitCatchImpl(ControlData& dataCatch, const RTT& exceptionSignature
             }
             bind(result, slot);
             results.append(result);
-            offset += type.kind == TypeKind::V128 ? 2 : 1;
+            offset += type.kind() == TypeKind::V128 ? 2 : 1;
         }
     }
 }
@@ -3301,7 +3301,7 @@ void BBQJIT::emitCatchTableImpl(ControlData& entryData, ControlType::TryTableTar
             for (unsigned i = 0; i < signature->argumentCount(); ++i) {
                 Type type = signature->argumentType(i);
                 Location slot = targetControl.targetLocations()[i];
-                switch (type.kind) {
+                switch (type.kind()) {
                 case TypeKind::I32:
                     if (slot.isGPR())
                         m_jit.load32(Address(wasmScratchGPR, JSWebAssemblyException::Payload::Storage::offsetOfData() + offset * sizeof(uint64_t)), slot.asGPR());
@@ -3356,7 +3356,7 @@ void BBQJIT::emitCatchTableImpl(ControlData& entryData, ControlType::TryTableTar
                     RELEASE_ASSERT_NOT_REACHED();
                     break;
                 }
-                offset += type.kind == TypeKind::V128 ? 2 : 1;
+                offset += type.kind() == TypeKind::V128 ? 2 : 1;
             }
         }
     }
@@ -3481,7 +3481,9 @@ void BBQJIT::emitCatchTableImpl(ControlData& entryData, ControlType::TryTableTar
         if (refValue.isNull())
             condition = Value::fromI32(static_cast<uint32_t>(shouldNegate ? !allowNull : allowNull));
         else {
-            bool matches = isSubtype(Type { TypeKind::Ref, static_cast<TypeIndex>(TypeKind::I31ref) }, Type { TypeKind::Ref, static_cast<TypeIndex>(heapType) });
+            // Const i31 only folds cleanly against abstract heap types.
+            bool matches = !isTypeIndexHeapType(heapType)
+                && isSubtype(Type { TypeKind::Ref, typeIndexFromTypeKind(TypeKind::I31ref) }, Type { TypeKind::Ref, typeIndexFromTypeKind(static_cast<TypeKind>(heapType)) });
             condition = Value::fromI32(shouldNegate ? !matches : matches);
         }
     } else {
@@ -4059,7 +4061,7 @@ void BBQJIT::materializeVectorConstant(v128_t value, Location result)
     Location valueLocation = loadIfNecessary(value);
     consume(value);
 
-    result = topValue(simdScalarType(info.lane).kind);
+    result = topValue(simdScalarType(info.lane).kind());
     Location resultLocation = allocate(result);
     LOG_INSTRUCTION("VectorExtractLane", info.lane, lane, value, valueLocation, RESULT(result));
 

--- a/Source/JavaScriptCore/wasm/WasmCallingConvention.h
+++ b/Source/JavaScriptCore/wasm/WasmCallingConvention.h
@@ -168,7 +168,7 @@ private:
     {
         ASSERT(isValueType(valueType));
         unsigned valueSize = bytesForWidth(valueType.width());
-        switch (valueType.kind) {
+        switch (valueType.kind()) {
         case TypeKind::I32:
         case TypeKind::I64:
         case TypeKind::Funcref:
@@ -254,7 +254,7 @@ private:
     ArgumentLocation marshallLocation(CallRole role, Type valueType, size_t& gpArgumentCount, size_t& fpArgumentCount, size_t& stackOffset) const
     {
         ASSERT(isValueType(valueType));
-        switch (valueType.kind) {
+        switch (valueType.kind()) {
         case TypeKind::I32:
         case TypeKind::I64:
         case TypeKind::Funcref:
@@ -359,7 +359,7 @@ private:
     {
         ASSERT(isValueType(valueType));
         unsigned alignedWidth = bytesForWidth(valueType.width());
-        switch (valueType.kind) {
+        switch (valueType.kind()) {
         case TypeKind::I64:
         case TypeKind::Funcref:
         case TypeKind::Exnref:
@@ -387,7 +387,7 @@ public:
         uint32_t fprIndex = 0;
         uint32_t stackCount = 0;
         for (uint32_t i = 0; i < signature.returnCount(); i++) {
-            switch (signature.returnType(i).kind) {
+            switch (signature.returnType(i).kind()) {
             case TypeKind::I64:
             case TypeKind::Funcref:
             case TypeKind::Exnref:
@@ -428,7 +428,7 @@ public:
         uint32_t fprIndex = 0;
         uint32_t stackCount = 0;
         for (uint32_t i = 0; i < signature.argumentCount(); i++) {
-            switch (signature.argumentType(i).kind) {
+            switch (signature.argumentType(i).kind()) {
             case TypeKind::I64:
             case TypeKind::Funcref:
             case TypeKind::Exnref:

--- a/Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp
@@ -220,7 +220,7 @@ public:
 
     ExpressionType NODELETE addConstant(Type type, uint64_t value)
     {
-        switch (type.kind) {
+        switch (type.kind()) {
         case TypeKind::I32:
         case TypeKind::I64:
         case TypeKind::F32:
@@ -268,7 +268,7 @@ public:
         WASM_COMPILE_FAIL_IF(m_info.globals[index].mutability != Mutability::Immutable, "get_global import kind index ", index, " is mutable ");
 
         if (m_mode == Mode::Evaluate) {
-            if (m_info.globals[index].type.kind == TypeKind::V128)
+            if (m_info.globals[index].type.kind() == TypeKind::V128)
                 result = ConstExprValue(m_instance->loadV128Global(index));
             else
                 result = ConstExprValue(m_instance->loadI64Global(index));

--- a/Source/JavaScriptCore/wasm/WasmFormat.cpp
+++ b/Source/JavaScriptCore/wasm/WasmFormat.cpp
@@ -87,7 +87,7 @@ void validateWasmValue(uint64_t wasmValue, Type expectedType)
             ASSERT(is<JSWebAssemblyArray>(value));
 
         if (isRefWithTypeIndex(expectedType)) {
-            auto expectedRTT = Wasm::TypeInformation::getCanonicalRTT(expectedType.index);
+            auto expectedRTT = Wasm::TypeInformation::getCanonicalRTT(expectedType.index());
             if (expectedRTT->kind() == RTTKind::Function) {
                 ASSERT(is<JSFunction>(value));
                 return;
@@ -106,7 +106,7 @@ void BlockSignature::dump(PrintStream& out) const
         out.print("("_s);
         CommaPrinter comma;
         for (FunctionArgCount arg = 0; arg < argumentCount(); ++arg)
-            out.print(comma, makeString(argumentType(arg).kind));
+            out.print(comma, makeString(argumentType(arg).kind()));
         out.print(")"_s);
     }
 
@@ -114,7 +114,7 @@ void BlockSignature::dump(PrintStream& out) const
         CommaPrinter comma;
         out.print(" -> ["_s);
         for (FunctionArgCount ret = 0; ret < returnCount(); ++ret)
-            out.print(comma, makeString(returnType(ret).kind));
+            out.print(comma, makeString(returnType(ret).kind()));
         out.print("]"_s);
     }
 }

--- a/Source/JavaScriptCore/wasm/WasmFormat.h
+++ b/Source/JavaScriptCore/wasm/WasmFormat.h
@@ -174,7 +174,7 @@ constexpr int32_t minI31ref = -1073741824;
 
 inline bool isValueType(Type type)
 {
-    switch (type.kind) {
+    switch (type.kind()) {
     case TypeKind::I32:
     case TypeKind::I64:
     case TypeKind::F32:
@@ -186,7 +186,7 @@ inline bool isValueType(Type type)
         return false;
     case TypeKind::Ref:
     case TypeKind::RefNull:
-        return type.index != invalidTypeIndex;
+        return type.index() != invalidTypeIndex;
     case TypeKind::V128:
         return Options::useWasmSIMD();
     default:
@@ -226,50 +226,50 @@ inline bool isRefType(StorageType type)
 
 inline bool isExternref(Type type)
 {
-    return isRefType(type) && type.index == static_cast<TypeIndex>(TypeKind::Externref);
+    return isRefType(type) && type.index() == typeIndexFromTypeKind(TypeKind::Externref);
 }
 
 inline bool isFuncref(Type type)
 {
-    return isRefType(type) && type.index == static_cast<TypeIndex>(TypeKind::Funcref);
+    return isRefType(type) && type.index() == typeIndexFromTypeKind(TypeKind::Funcref);
 }
 
 inline bool isEqref(Type type)
 {
-    return isRefType(type) && type.index == static_cast<TypeIndex>(TypeKind::Eqref);
+    return isRefType(type) && type.index() == typeIndexFromTypeKind(TypeKind::Eqref);
 }
 
 inline bool isAnyref(Type type)
 {
-    return isRefType(type) && type.index == static_cast<TypeIndex>(TypeKind::Anyref);
+    return isRefType(type) && type.index() == typeIndexFromTypeKind(TypeKind::Anyref);
 }
 
 inline bool isNoexnref(Type type)
 {
-    return isRefType(type) && type.index == static_cast<TypeIndex>(TypeKind::Noexnref);
+    return isRefType(type) && type.index() == typeIndexFromTypeKind(TypeKind::Noexnref);
 }
 
 inline bool isNoneref(Type type)
 {
-    return isRefType(type) && type.index == static_cast<TypeIndex>(TypeKind::Noneref);
+    return isRefType(type) && type.index() == typeIndexFromTypeKind(TypeKind::Noneref);
 }
 
 inline bool isNofuncref(Type type)
 {
-    return isRefType(type) && type.index == static_cast<TypeIndex>(TypeKind::Nofuncref);
+    return isRefType(type) && type.index() == typeIndexFromTypeKind(TypeKind::Nofuncref);
 }
 
 inline bool isNoexternref(Type type)
 {
-    return isRefType(type) && type.index == static_cast<TypeIndex>(TypeKind::Noexternref);
+    return isRefType(type) && type.index() == typeIndexFromTypeKind(TypeKind::Noexternref);
 }
 
 inline bool isInternalref(Type type)
 {
     if (!isRefType(type))
         return false;
-    if (typeIndexIsType(type.index)) {
-        switch (static_cast<TypeKind>(type.index)) {
+    if (isAbstractTypeIndex(type.index())) {
+        switch (typeIndexAsTypeKind(type.index())) {
         case TypeKind::I31ref:
         case TypeKind::Arrayref:
         case TypeKind::Structref:
@@ -281,32 +281,32 @@ inline bool isInternalref(Type type)
             return false;
         }
     }
-    return TypeInformation::getCanonicalRTT(type.index)->kind() != RTTKind::Function;
+    return TypeInformation::getCanonicalRTT(type.index())->kind() != RTTKind::Function;
 }
 
 inline bool isI31ref(Type type)
 {
-    return isRefType(type) && type.index == static_cast<TypeIndex>(TypeKind::I31ref);
+    return isRefType(type) && type.index() == typeIndexFromTypeKind(TypeKind::I31ref);
 }
 
 inline bool isArrayref(Type type)
 {
-    return isRefType(type) && type.index == static_cast<TypeIndex>(TypeKind::Arrayref);
+    return isRefType(type) && type.index() == typeIndexFromTypeKind(TypeKind::Arrayref);
 }
 
 inline bool isStructref(Type type)
 {
-    return isRefType(type) && type.index == static_cast<TypeIndex>(TypeKind::Structref);
+    return isRefType(type) && type.index() == typeIndexFromTypeKind(TypeKind::Structref);
 }
 
 inline bool isExnref(Type type)
 {
-    return isRefType(type) && type.index == static_cast<TypeIndex>(TypeKind::Exnref);
+    return isRefType(type) && type.index() == typeIndexFromTypeKind(TypeKind::Exnref);
 }
 
 inline JSString* typeToJSAPIString(VM& vm, Type type)
 {
-    switch (type.kind) {
+    switch (type.kind()) {
     case TypeKind::I32:
         return jsNontrivialString(vm, "i32"_s);
     case TypeKind::I64:
@@ -331,44 +331,44 @@ inline JSString* typeToJSAPIString(VM& vm, Type type)
 
 inline Type nonNullFuncrefType()
 {
-    return Wasm::Type { Wasm::TypeKind::Ref, static_cast<Wasm::TypeIndex>(Wasm::TypeKind::Funcref) };
+    return Wasm::Type { Wasm::TypeKind::Ref, typeIndexFromTypeKind(Wasm::TypeKind::Funcref) };
 }
 
 inline Type funcrefType()
 {
-    return Wasm::Type { Wasm::TypeKind::RefNull, static_cast<Wasm::TypeIndex>(Wasm::TypeKind::Funcref) };
+    return Wasm::Type { Wasm::TypeKind::RefNull, typeIndexFromTypeKind(Wasm::TypeKind::Funcref) };
 }
 
 inline Type externrefType(bool isNullable = true)
 {
-    return Wasm::Type { isNullable ? Wasm::TypeKind::RefNull : Wasm::TypeKind::Ref, static_cast<Wasm::TypeIndex>(Wasm::TypeKind::Externref) };
+    return Wasm::Type { isNullable ? Wasm::TypeKind::RefNull : Wasm::TypeKind::Ref, typeIndexFromTypeKind(Wasm::TypeKind::Externref) };
 }
 
 inline Type eqrefType()
 {
-    return Wasm::Type { Wasm::TypeKind::RefNull, static_cast<Wasm::TypeIndex>(Wasm::TypeKind::Eqref) };
+    return Wasm::Type { Wasm::TypeKind::RefNull, typeIndexFromTypeKind(Wasm::TypeKind::Eqref) };
 }
 
 inline Type anyrefType(bool isNullable = true)
 {
-    return Wasm::Type { isNullable ? Wasm::TypeKind::RefNull : Wasm::TypeKind::Ref, static_cast<Wasm::TypeIndex>(Wasm::TypeKind::Anyref) };
+    return Wasm::Type { isNullable ? Wasm::TypeKind::RefNull : Wasm::TypeKind::Ref, typeIndexFromTypeKind(Wasm::TypeKind::Anyref) };
 }
 
 inline Type arrayrefType(bool isNullable = true)
 {
     // Returns a non-null ref type, since this is used for the return types of array operations
     // that are guaranteed to return a non-null array reference
-    return Wasm::Type { isNullable ? Wasm::TypeKind::RefNull : Wasm::TypeKind::Ref, static_cast<Wasm::TypeIndex>(Wasm::TypeKind::Arrayref) };
+    return Wasm::Type { isNullable ? Wasm::TypeKind::RefNull : Wasm::TypeKind::Ref, typeIndexFromTypeKind(Wasm::TypeKind::Arrayref) };
 }
 
 inline Type exnrefType()
 {
-    return Wasm::Type { Wasm::TypeKind::RefNull, static_cast<Wasm::TypeIndex>(Wasm::TypeKind::Exnref) };
+    return Wasm::Type { Wasm::TypeKind::RefNull, typeIndexFromTypeKind(Wasm::TypeKind::Exnref) };
 }
 
 inline bool isRefWithTypeIndex(Type type)
 {
-    return isRefType(type) && !typeIndexIsType(type.index);
+    return isRefType(type) && !isAbstractTypeIndex(type.index());
 }
 
 inline bool isTypeIndexHeapType(int32_t heapType)
@@ -396,9 +396,9 @@ inline bool isSubtypeSlow(Type sub, Type parent)
 
     if (isRefWithTypeIndex(sub)) {
         if (isRefWithTypeIndex(parent))
-            return isSubtypeIndex(sub.index, parent.index);
+            return isSubtypeIndex(sub.index(), parent.index());
 
-        Ref<const RTT> subRTT = TypeInformation::getCanonicalRTT(sub.index);
+        Ref<const RTT> subRTT = TypeInformation::getCanonicalRTT(sub.index());
 
         if ((isAnyref(parent) || isEqref(parent)))
             return subRTT->kind() != RTTKind::Function;
@@ -432,7 +432,7 @@ inline bool isSubtypeSlow(Type sub, Type parent)
         return true;
 
     if (sub.isRef() && parent.isRefNull())
-        return sub.index == parent.index;
+        return sub.index() == parent.index();
 
     return false;
 }

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -381,11 +381,11 @@ private:
             out.print("(ref "_s);
             if (type.isNullable())
                 out.print("null "_s);
-            if (typeIndexIsType(type.index))
-                out.print(heapTypeKindAsString(static_cast<TypeKind>(type.index)));
+            if (isAbstractTypeIndex(type.index()))
+                out.print(heapTypeKindAsString(typeIndexAsTypeKind(type.index())));
             // FIXME: use name section if it exists to provide a nicer name.
             else {
-                RefPtr rtt = TypeInformation::tryGetRTT(type.index);
+                RefPtr rtt = TypeInformation::tryGetRTT(type.index());
                 if (rtt && rtt->kind() == RTTKind::Function)
                     out.print("<func:"_s);
                 else if (rtt && rtt->kind() == RTTKind::Array)
@@ -396,7 +396,7 @@ private:
                 }
                 // Print the type section index by searching for the matching type definition.
                 for (uint32_t i = 0; i < m_info.typeCount(); ++i) {
-                    if (m_info.rtt(TypeSignatureIndex(i)).asTypeIndex() == type.index) {
+                    if (m_info.rtt(TypeSignatureIndex(i)).asTypeIndex() == type.index()) {
                         out.print(i);
                         break;
                     }
@@ -771,7 +771,7 @@ auto FunctionParser<Context>::load(Type memoryType) -> PartialResult
 
     WASM_TRY_POP_EXPRESSION_STACK_INTO(pointer, "load pointer"_s);
 
-    WASM_VALIDATOR_FAIL_IF(pointer.type().kind != m_info.memory(memoryIndex).addressType().asWasmTypeKind(), m_currentOpcode, " pointer type mismatch"_s);
+    WASM_VALIDATOR_FAIL_IF(pointer.type().kind() != m_info.memory(memoryIndex).addressType().asWasmTypeKind(), m_currentOpcode, " pointer type mismatch"_s);
     ExpressionType result;
     WASM_TRY_ADD_TO_CONTEXT(load(static_cast<LoadOpType>(m_currentOpcode), pointer, result, offset, memoryIndex));
     m_expressionStack.constructAndAppend(memoryType, result);
@@ -804,7 +804,7 @@ auto FunctionParser<Context>::store(Type memoryType) -> PartialResult
     WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "store value"_s);
     WASM_TRY_POP_EXPRESSION_STACK_INTO(pointer, "store pointer"_s);
 
-    WASM_VALIDATOR_FAIL_IF(pointer.type().kind != m_info.memory(memoryIndex).addressType().asWasmTypeKind(), m_currentOpcode, " pointer type mismatch"_s);
+    WASM_VALIDATOR_FAIL_IF(pointer.type().kind() != m_info.memory(memoryIndex).addressType().asWasmTypeKind(), m_currentOpcode, " pointer type mismatch"_s);
 
     WASM_VALIDATOR_FAIL_IF(value.type() != memoryType, m_currentOpcode, " value type mismatch"_s);
 
@@ -848,7 +848,7 @@ auto FunctionParser<Context>::atomicLoad(ExtAtomicOpType op, Type memoryType) ->
     }
     WASM_TRY_POP_EXPRESSION_STACK_INTO(pointer, "load pointer"_s);
 
-    WASM_VALIDATOR_FAIL_IF(pointer.type().kind != m_info.memory(memoryIndex).addressType().asWasmTypeKind(), static_cast<unsigned>(op), " pointer type mismatch"_s);
+    WASM_VALIDATOR_FAIL_IF(pointer.type().kind() != m_info.memory(memoryIndex).addressType().asWasmTypeKind(), static_cast<unsigned>(op), " pointer type mismatch"_s);
 
     ExpressionType result;
     WASM_TRY_ADD_TO_CONTEXT(atomicLoad(op, memoryType, pointer, result, offset, memoryIndex));
@@ -880,7 +880,7 @@ auto FunctionParser<Context>::atomicStore(ExtAtomicOpType op, Type memoryType) -
     WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "store value"_s);
     WASM_TRY_POP_EXPRESSION_STACK_INTO(pointer, "store pointer"_s);
 
-    WASM_VALIDATOR_FAIL_IF(pointer.type().kind != m_info.memory(memoryIndex).addressType().asWasmTypeKind(), m_currentOpcode, " pointer type mismatch"_s);
+    WASM_VALIDATOR_FAIL_IF(pointer.type().kind() != m_info.memory(memoryIndex).addressType().asWasmTypeKind(), m_currentOpcode, " pointer type mismatch"_s);
     WASM_VALIDATOR_FAIL_IF(value.type() != memoryType, m_currentOpcode, " value type mismatch"_s);
 
     WASM_TRY_ADD_TO_CONTEXT(atomicStore(op, memoryType, pointer, value, offset, memoryIndex));
@@ -910,7 +910,7 @@ auto FunctionParser<Context>::atomicBinaryRMW(ExtAtomicOpType op, Type memoryTyp
     WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "value"_s);
     WASM_TRY_POP_EXPRESSION_STACK_INTO(pointer, "pointer"_s);
 
-    WASM_VALIDATOR_FAIL_IF(pointer.type().kind != m_info.memory(memoryIndex).addressType().asWasmTypeKind(), static_cast<unsigned>(op), " pointer type mismatch"_s);
+    WASM_VALIDATOR_FAIL_IF(pointer.type().kind() != m_info.memory(memoryIndex).addressType().asWasmTypeKind(), static_cast<unsigned>(op), " pointer type mismatch"_s);
     WASM_VALIDATOR_FAIL_IF(value.type() != memoryType, static_cast<unsigned>(op), " value type mismatch"_s);
 
     ExpressionType result;
@@ -944,7 +944,7 @@ auto FunctionParser<Context>::atomicCompareExchange(ExtAtomicOpType op, Type mem
     WASM_TRY_POP_EXPRESSION_STACK_INTO(expected, "expected"_s);
     WASM_TRY_POP_EXPRESSION_STACK_INTO(pointer, "pointer"_s);
 
-    WASM_VALIDATOR_FAIL_IF(pointer.type().kind != m_info.memory(memoryIndex).addressType().asWasmTypeKind(), static_cast<unsigned>(op), " pointer type mismatch"_s);
+    WASM_VALIDATOR_FAIL_IF(pointer.type().kind() != m_info.memory(memoryIndex).addressType().asWasmTypeKind(), static_cast<unsigned>(op), " pointer type mismatch"_s);
     WASM_VALIDATOR_FAIL_IF(expected.type() != memoryType, static_cast<unsigned>(op), " expected type mismatch"_s);
     WASM_VALIDATOR_FAIL_IF(value.type() != memoryType, static_cast<unsigned>(op), " value type mismatch"_s);
 
@@ -979,7 +979,7 @@ auto FunctionParser<Context>::atomicWait(ExtAtomicOpType op, Type memoryType) ->
     WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "value"_s);
     WASM_TRY_POP_EXPRESSION_STACK_INTO(pointer, "pointer"_s);
 
-    WASM_VALIDATOR_FAIL_IF(pointer.type().kind != m_info.memory(memoryIndex).addressType().asWasmTypeKind(), static_cast<unsigned>(op), " pointer type mismatch"_s);
+    WASM_VALIDATOR_FAIL_IF(pointer.type().kind() != m_info.memory(memoryIndex).addressType().asWasmTypeKind(), static_cast<unsigned>(op), " pointer type mismatch"_s);
     WASM_VALIDATOR_FAIL_IF(value.type() != memoryType, static_cast<unsigned>(op), " value type mismatch"_s);
     WASM_VALIDATOR_FAIL_IF(!timeout.type().isI64(), static_cast<unsigned>(op), " timeout type mismatch"_s);
 
@@ -1012,7 +1012,7 @@ auto FunctionParser<Context>::atomicNotify(ExtAtomicOpType op) -> PartialResult
     WASM_TRY_POP_EXPRESSION_STACK_INTO(count, "count"_s);
     WASM_TRY_POP_EXPRESSION_STACK_INTO(pointer, "pointer"_s);
 
-    WASM_VALIDATOR_FAIL_IF(pointer.type().kind != m_info.memory(memoryIndex).addressType().asWasmTypeKind(), static_cast<unsigned>(op), " pointer type mismatch"_s);
+    WASM_VALIDATOR_FAIL_IF(pointer.type().kind() != m_info.memory(memoryIndex).addressType().asWasmTypeKind(), static_cast<unsigned>(op), " pointer type mismatch"_s);
     WASM_VALIDATOR_FAIL_IF(!count.type().isI32(), static_cast<unsigned>(op), " count type mismatch"_s); // The spec's definition is saying i64, but all implementations (including tests) are using i32. So looks like the spec is wrong.
 
     ExpressionType result;
@@ -2038,7 +2038,7 @@ ALWAYS_INLINE auto FunctionParser<Context>::parseBlockSignature(const ModuleInfo
             return parseReftypeSignature(info, result);
 
         Type type = { typeKind, invalidTypeIndex };
-        WASM_PARSER_FAIL_IF(!(isValueType(type) || type.isVoid()), "result type of block: "_s, makeString(type.kind), " is not a value type or Void"_s);
+        WASM_PARSER_FAIL_IF(!(isValueType(type) || type.isVoid()), "result type of block: "_s, makeString(type.kind()), " is not a value type or Void"_s);
 
         result = BlockSignature { type };
         m_offset++;
@@ -2185,7 +2185,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         TypedExpression index;
         WASM_TRY_POP_EXPRESSION_STACK_INTO(index, "table.get"_s);
         Wasm::TypeKind tableAddressType = m_info.tables[tableIndex].addressType().asWasmTypeKind();
-        WASM_VALIDATOR_FAIL_IF(tableAddressType != index.type().kind, "table.get index to type "_s, index.type(), " expected "_s, tableAddressType);
+        WASM_VALIDATOR_FAIL_IF(tableAddressType != index.type().kind(), "table.get index to type "_s, index.type(), " expected "_s, tableAddressType);
 
         ExpressionType result;
         WASM_TRY_ADD_TO_CONTEXT(addTableGet(tableIndex, index, result));
@@ -2202,7 +2202,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "table.set"_s);
         WASM_TRY_POP_EXPRESSION_STACK_INTO(index, "table.set"_s);
         Wasm::TypeKind tableAddressType = m_info.tables[tableIndex].addressType().asWasmTypeKind();
-        WASM_VALIDATOR_FAIL_IF(tableAddressType != index.type().kind, "table.set index to type "_s, index.type(), " expected "_s, tableAddressType);
+        WASM_VALIDATOR_FAIL_IF(tableAddressType != index.type().kind(), "table.set index to type "_s, index.type(), " expected "_s, tableAddressType);
         Type type = m_info.tables[tableIndex].wasmType();
         WASM_VALIDATOR_FAIL_IF(!isSubtype(value.type(), type), "table.set value to type "_s, value.type(), " expected "_s, type);
         RELEASE_ASSERT(m_info.tables[tableIndex].type() == TableElementType::Externref || m_info.tables[tableIndex].type() == TableElementType::Funcref);
@@ -2230,9 +2230,9 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             WASM_TRY_POP_EXPRESSION_STACK_INTO(dstOffset, "table.init"_s);
 
             Wasm::TypeKind tableAddressType = m_info.tables[immediates.tableIndex].addressType().asWasmTypeKind();
-            WASM_VALIDATOR_FAIL_IF(dstOffset.type().kind != tableAddressType, "table.init dst_offset to type "_s, dstOffset.type(), " expected "_s, tableAddressType);
-            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != srcOffset.type().kind, "table.init src_offset to type "_s, srcOffset.type(), " expected "_s, TypeKind::I32);
-            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != length.type().kind, "table.init length to type "_s, length.type(), " expected "_s, TypeKind::I32);
+            WASM_VALIDATOR_FAIL_IF(dstOffset.type().kind() != tableAddressType, "table.init dst_offset to type "_s, dstOffset.type(), " expected "_s, tableAddressType);
+            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != srcOffset.type().kind(), "table.init src_offset to type "_s, srcOffset.type(), " expected "_s, TypeKind::I32);
+            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != length.type().kind(), "table.init length to type "_s, length.type(), " expected "_s, TypeKind::I32);
 
             WASM_TRY_ADD_TO_CONTEXT(addTableInit(immediates.elementIndex, immediates.tableIndex, dstOffset, srcOffset, length));
             break;
@@ -2267,7 +2267,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             Type tableType = m_info.tables[tableIndex].wasmType();
             WASM_VALIDATOR_FAIL_IF(!isSubtype(fill.type(), tableType), "table.grow expects fill value of type "_s, tableType, " got "_s, fill.type());
             AddressType addressType = m_info.table(tableIndex).addressType();
-            WASM_VALIDATOR_FAIL_IF(delta.type().kind != addressType.asWasmTypeKind(), "table.grow expects an "_s, addressType.is64Bit() ? "i64"_s : "i32"_s, " delta value, got "_s, delta.type());
+            WASM_VALIDATOR_FAIL_IF(delta.type().kind() != addressType.asWasmTypeKind(), "table.grow expects an "_s, addressType.is64Bit() ? "i64"_s : "i32"_s, " delta value, got "_s, delta.type());
 
             ExpressionType result;
             WASM_TRY_ADD_TO_CONTEXT(addTableGrow(tableIndex, fill, delta, result));
@@ -2289,8 +2289,8 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             auto tableType = table.wasmType();
             auto addressTypeKind = table.addressType().asWasmTypeKind();
             WASM_VALIDATOR_FAIL_IF(!isSubtype(fill.type(), tableType), "table.fill expects fill value of type "_s, tableType, " got "_s, fill.type());
-            WASM_VALIDATOR_FAIL_IF(offset.type().kind != addressTypeKind, "table.fill expects an "_s, addressTypeKind, " offset value, got "_s, offset.type());
-            WASM_VALIDATOR_FAIL_IF(count.type().kind != addressTypeKind, "table.fill expects an "_s, addressTypeKind, " count value, got "_s, count.type());
+            WASM_VALIDATOR_FAIL_IF(offset.type().kind() != addressTypeKind, "table.fill expects an "_s, addressTypeKind, " offset value, got "_s, offset.type());
+            WASM_VALIDATOR_FAIL_IF(count.type().kind() != addressTypeKind, "table.fill expects an "_s, addressTypeKind, " count value, got "_s, count.type());
 
             WASM_TRY_ADD_TO_CONTEXT(addTableFill(tableIndex, offset, fill, count));
             break;
@@ -2312,13 +2312,13 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
 
             auto dstTableAddressType = m_info.tables[immediates.dstTableIndex].addressType();
             auto srcTableAddressType = m_info.tables[immediates.srcTableIndex].addressType();
-            WASM_VALIDATOR_FAIL_IF(dstOffset.type().kind != dstTableAddressType.asWasmTypeKind(), "table.copy dst_offset to type "_s, dstOffset.type(), " expected "_s, dstTableAddressType.asWasmTypeKind());
-            WASM_VALIDATOR_FAIL_IF(srcOffset.type().kind != srcTableAddressType.asWasmTypeKind(), "table.copy src_offset to type "_s, srcOffset.type(), " expected "_s, srcTableAddressType.asWasmTypeKind());
+            WASM_VALIDATOR_FAIL_IF(dstOffset.type().kind() != dstTableAddressType.asWasmTypeKind(), "table.copy dst_offset to type "_s, dstOffset.type(), " expected "_s, dstTableAddressType.asWasmTypeKind());
+            WASM_VALIDATOR_FAIL_IF(srcOffset.type().kind() != srcTableAddressType.asWasmTypeKind(), "table.copy src_offset to type "_s, srcOffset.type(), " expected "_s, srcTableAddressType.asWasmTypeKind());
 
             if (dstTableAddressType.is64Bit() && srcTableAddressType.is64Bit())
-                WASM_VALIDATOR_FAIL_IF(length.type().kind != TypeKind::I64, "table.copy length to type "_s, length.type(), " expected "_s, TypeKind::I64);
+                WASM_VALIDATOR_FAIL_IF(length.type().kind() != TypeKind::I64, "table.copy length to type "_s, length.type(), " expected "_s, TypeKind::I64);
             else
-                WASM_VALIDATOR_FAIL_IF(length.type().kind != TypeKind::I32, "table.copy length to type "_s, length.type(), " expected "_s, TypeKind::I32);
+                WASM_VALIDATOR_FAIL_IF(length.type().kind() != TypeKind::I32, "table.copy length to type "_s, length.type(), " expected "_s, TypeKind::I32);
 
             WASM_TRY_ADD_TO_CONTEXT(addTableCopy(immediates.dstTableIndex, immediates.srcTableIndex, dstOffset, srcOffset, length));
             break;
@@ -2338,13 +2338,13 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             WASM_TRY_POP_EXPRESSION_STACK_INTO(dstAddress, "memory.fill");
 
             if (m_info.memory(memoryIndex).isMemory64()) {
-                WASM_VALIDATOR_FAIL_IF(TypeKind::I64 != dstAddress.type().kind, "memory.fill dstAddress to type ", dstAddress.type(), " expected ", TypeKind::I64);
-                WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != targetValue.type().kind, "memory.fill targetValue to type ", targetValue.type(), " expected ", TypeKind::I32);
-                WASM_VALIDATOR_FAIL_IF(TypeKind::I64 != count.type().kind, "memory.fill size to type ", count.type(), " expected ", TypeKind::I64);
+                WASM_VALIDATOR_FAIL_IF(TypeKind::I64 != dstAddress.type().kind(), "memory.fill dstAddress to type ", dstAddress.type(), " expected ", TypeKind::I64);
+                WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != targetValue.type().kind(), "memory.fill targetValue to type ", targetValue.type(), " expected ", TypeKind::I32);
+                WASM_VALIDATOR_FAIL_IF(TypeKind::I64 != count.type().kind(), "memory.fill size to type ", count.type(), " expected ", TypeKind::I64);
             } else {
-                WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != dstAddress.type().kind, "memory.fill dstAddress to type ", dstAddress.type(), " expected ", TypeKind::I32);
-                WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != targetValue.type().kind, "memory.fill targetValue to type ", targetValue.type(), " expected ", TypeKind::I32);
-                WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != count.type().kind, "memory.fill size to type ", count.type(), " expected ", TypeKind::I32);
+                WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != dstAddress.type().kind(), "memory.fill dstAddress to type ", dstAddress.type(), " expected ", TypeKind::I32);
+                WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != targetValue.type().kind(), "memory.fill targetValue to type ", targetValue.type(), " expected ", TypeKind::I32);
+                WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != count.type().kind(), "memory.fill size to type ", count.type(), " expected ", TypeKind::I32);
             }
 
             WASM_TRY_ADD_TO_CONTEXT(addMemoryFill(dstAddress, targetValue, count, memoryIndex));
@@ -2365,19 +2365,19 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             WASM_TRY_POP_EXPRESSION_STACK_INTO(dstAddress, "memory.copy");
 
             if (m_info.memory(dstMemoryIndex).isMemory64())
-                WASM_VALIDATOR_FAIL_IF(TypeKind::I64 != dstAddress.type().kind, "memory.copy dstAddress to type ", dstAddress.type(), " expected ", TypeKind::I64);
+                WASM_VALIDATOR_FAIL_IF(TypeKind::I64 != dstAddress.type().kind(), "memory.copy dstAddress to type ", dstAddress.type(), " expected ", TypeKind::I64);
             else
-                WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != dstAddress.type().kind, "memory.copy dstAddress to type ", dstAddress.type(), " expected ", TypeKind::I32);
+                WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != dstAddress.type().kind(), "memory.copy dstAddress to type ", dstAddress.type(), " expected ", TypeKind::I32);
 
             if (m_info.memory(srcMemoryIndex).isMemory64())
-                WASM_VALIDATOR_FAIL_IF(TypeKind::I64 != srcAddress.type().kind, "memory.copy targetValue to type ", srcAddress.type(), " expected ", TypeKind::I64);
+                WASM_VALIDATOR_FAIL_IF(TypeKind::I64 != srcAddress.type().kind(), "memory.copy targetValue to type ", srcAddress.type(), " expected ", TypeKind::I64);
             else
-                WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != srcAddress.type().kind, "memory.copy targetValue to type ", srcAddress.type(), " expected ", TypeKind::I32);
+                WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != srcAddress.type().kind(), "memory.copy targetValue to type ", srcAddress.type(), " expected ", TypeKind::I32);
 
             if (m_info.memory(dstMemoryIndex).isMemory64() && m_info.memory(srcMemoryIndex).isMemory64())
-                WASM_VALIDATOR_FAIL_IF(TypeKind::I64 != count.type().kind, "memory.copy size to type ", count.type(), " expected ", TypeKind::I64);
+                WASM_VALIDATOR_FAIL_IF(TypeKind::I64 != count.type().kind(), "memory.copy size to type ", count.type(), " expected ", TypeKind::I64);
             else
-                WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != count.type().kind, "memory.copy size to type ", count.type(), " expected ", TypeKind::I32);
+                WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != count.type().kind(), "memory.copy size to type ", count.type(), " expected ", TypeKind::I32);
 
             WASM_TRY_ADD_TO_CONTEXT(addMemoryCopy(dstAddress, srcAddress, count, dstMemoryIndex, srcMemoryIndex));
             break;
@@ -2396,12 +2396,12 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             WASM_TRY_POP_EXPRESSION_STACK_INTO(dstAddress, "memory.init");
 
             if (m_info.memory(immediates.memoryIndex).isMemory64())
-                WASM_VALIDATOR_FAIL_IF(TypeKind::I64 != dstAddress.type().kind, "memory.init dst address to type ", dstAddress.type(), " expected ", TypeKind::I64);
+                WASM_VALIDATOR_FAIL_IF(TypeKind::I64 != dstAddress.type().kind(), "memory.init dst address to type ", dstAddress.type(), " expected ", TypeKind::I64);
             else
-                WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != dstAddress.type().kind, "memory.init dst address to type ", dstAddress.type(), " expected ", TypeKind::I32);
+                WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != dstAddress.type().kind(), "memory.init dst address to type ", dstAddress.type(), " expected ", TypeKind::I32);
 
-            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != srcAddress.type().kind, "memory.init src address to type ", srcAddress.type(), " expected ", TypeKind::I32);
-            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != length.type().kind, "memory.init length to type ", length.type(), " expected ", TypeKind::I32);
+            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != srcAddress.type().kind(), "memory.init src address to type ", srcAddress.type(), " expected ", TypeKind::I32);
+            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != length.type().kind(), "memory.init length to type ", length.type(), " expected ", TypeKind::I32);
 
             WASM_TRY_ADD_TO_CONTEXT(addMemoryInit(immediates.dataSegmentIndex, dstAddress, srcAddress, length, immediates.memoryIndex));
             break;
@@ -2430,10 +2430,10 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             WASM_TRY_POP_EXPRESSION_STACK_INTO(rhsLo, "i64.add128/sub128"_s);
             WASM_TRY_POP_EXPRESSION_STACK_INTO(lhsHi, "i64.add128/sub128"_s);
             WASM_TRY_POP_EXPRESSION_STACK_INTO(lhsLo, "i64.add128/sub128"_s);
-            WASM_VALIDATOR_FAIL_IF(TypeKind::I64 != lhsLo.type().kind, "i64.add128/sub128 lhs_lo to type "_s, lhsLo.type(), " expected "_s, TypeKind::I64);
-            WASM_VALIDATOR_FAIL_IF(TypeKind::I64 != lhsHi.type().kind, "i64.add128/sub128 lhs_hi to type "_s, lhsHi.type(), " expected "_s, TypeKind::I64);
-            WASM_VALIDATOR_FAIL_IF(TypeKind::I64 != rhsLo.type().kind, "i64.add128/sub128 rhs_lo to type "_s, rhsLo.type(), " expected "_s, TypeKind::I64);
-            WASM_VALIDATOR_FAIL_IF(TypeKind::I64 != rhsHi.type().kind, "i64.add128/sub128 rhs_hi to type "_s, rhsHi.type(), " expected "_s, TypeKind::I64);
+            WASM_VALIDATOR_FAIL_IF(TypeKind::I64 != lhsLo.type().kind(), "i64.add128/sub128 lhs_lo to type "_s, lhsLo.type(), " expected "_s, TypeKind::I64);
+            WASM_VALIDATOR_FAIL_IF(TypeKind::I64 != lhsHi.type().kind(), "i64.add128/sub128 lhs_hi to type "_s, lhsHi.type(), " expected "_s, TypeKind::I64);
+            WASM_VALIDATOR_FAIL_IF(TypeKind::I64 != rhsLo.type().kind(), "i64.add128/sub128 rhs_lo to type "_s, rhsLo.type(), " expected "_s, TypeKind::I64);
+            WASM_VALIDATOR_FAIL_IF(TypeKind::I64 != rhsHi.type().kind(), "i64.add128/sub128 rhs_hi to type "_s, rhsHi.type(), " expected "_s, TypeKind::I64);
 
             ExpressionType resultLo;
             ExpressionType resultHi;
@@ -2454,8 +2454,8 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             TypedExpression lhs;
             WASM_TRY_POP_EXPRESSION_STACK_INTO(rhs, "i64.mul_wide"_s);
             WASM_TRY_POP_EXPRESSION_STACK_INTO(lhs, "i64.mul_wide"_s);
-            WASM_VALIDATOR_FAIL_IF(TypeKind::I64 != lhs.type().kind, "i64.mul_wide lhs to type "_s, lhs.type(), " expected "_s, TypeKind::I64);
-            WASM_VALIDATOR_FAIL_IF(TypeKind::I64 != rhs.type().kind, "i64.mul_wide rhs to type "_s, rhs.type(), " expected "_s, TypeKind::I64);
+            WASM_VALIDATOR_FAIL_IF(TypeKind::I64 != lhs.type().kind(), "i64.mul_wide lhs to type "_s, lhs.type(), " expected "_s, TypeKind::I64);
+            WASM_VALIDATOR_FAIL_IF(TypeKind::I64 != rhs.type().kind(), "i64.mul_wide rhs to type "_s, rhs.type(), " expected "_s, TypeKind::I64);
 
             ExpressionType resultLo;
             ExpressionType resultHi;
@@ -2489,7 +2489,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             ExpressionType result;
             WASM_TRY_ADD_TO_CONTEXT(addRefI31(value, result));
 
-            m_expressionStack.constructAndAppend(Type { TypeKind::Ref, static_cast<TypeIndex>(TypeKind::I31ref) }, result);
+            m_expressionStack.constructAndAppend(Type { TypeKind::Ref, typeIndexFromTypeKind(TypeKind::I31ref) }, result);
             break;
         }
         case ExtGCOpType::I31GetS: {
@@ -2525,7 +2525,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             WASM_TRY_POP_EXPRESSION_STACK_INTO(size, "array.new");
             WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "array.new");
             WASM_VALIDATOR_FAIL_IF(!isSubtype(value.type(), unpackedElementType), "array.new value to type ", value.type(), " expected ", unpackedElementType);
-            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != size.type().kind, "array.new index to type ", size.type(), " expected ", TypeKind::I32);
+            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != size.type().kind(), "array.new index to type ", size.type(), " expected ", TypeKind::I32);
 
             if (unpackedElementType.isV128())
                 m_context.notifyFunctionUsesSIMD();
@@ -2546,7 +2546,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
 
             TypedExpression size;
             WASM_TRY_POP_EXPRESSION_STACK_INTO(size, "array.new_default");
-            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != size.type().kind, "array.new_default index to type ", size.type(), " expected ", TypeKind::I32);
+            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != size.type().kind(), "array.new_default index to type ", size.type(), " expected ", TypeKind::I32);
 
             ExpressionType result;
             WASM_TRY_ADD_TO_CONTEXT(addArrayNewDefault(typeIndex, size, result));
@@ -2614,12 +2614,12 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             // Get the array size
             TypedExpression size;
             WASM_TRY_POP_EXPRESSION_STACK_INTO(size, "array.new_data");
-            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != size.type().kind, "array.new_data: size has type ", size.type().kind, " expected ", TypeKind::I32);
+            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != size.type().kind(), "array.new_data: size has type ", size.type().kind(), " expected ", TypeKind::I32);
 
             // Get the offset into the data segment
             TypedExpression offset;
             WASM_TRY_POP_EXPRESSION_STACK_INTO(offset, "array.new_data");
-            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != offset.type().kind, "array.new_data: offset has type ", offset.type().kind, " expected ", TypeKind::I32);
+            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != offset.type().kind(), "array.new_data: offset has type ", offset.type().kind(), " expected ", TypeKind::I32);
 
             ExpressionType result;
             WASM_TRY_ADD_TO_CONTEXT(addArrayNewData(typeIndex, dataIndex, size, offset, result));
@@ -2652,12 +2652,12 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             // Get the array size
             TypedExpression size;
             WASM_TRY_POP_EXPRESSION_STACK_INTO(size, "array.new_elem");
-            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != size.type().kind, "array.new_elem: size has type ", size.type().kind, " expected ", TypeKind::I32);
+            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != size.type().kind(), "array.new_elem: size has type ", size.type().kind(), " expected ", TypeKind::I32);
 
             // Get the offset into the data segment
             TypedExpression offset;
             WASM_TRY_POP_EXPRESSION_STACK_INTO(offset, "array.new_elem");
-            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != offset.type().kind, "array.new_elem: offset has type ", offset.type().kind, " expected ", TypeKind::I32);
+            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != offset.type().kind(), "array.new_elem: offset has type ", offset.type().kind(), " expected ", TypeKind::I32);
 
             ExpressionType result;
             WASM_TRY_ADD_TO_CONTEXT(addArrayNewElem(typeIndex, elemSegmentIndex, size, offset, result));
@@ -2677,7 +2677,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
 
             // array.get_s and array.get_u are only valid for packed arrays
             if (op == ExtGCOpType::ArrayGetS || op == ExtGCOpType::ArrayGetU)
-                WASM_PARSER_FAIL_IF(!elementType.is<PackedType>(), opName, " applied to wrong type of array -- expected: i8 or i16, found "_s, elementType.as<Type>().kind);
+                WASM_PARSER_FAIL_IF(!elementType.is<PackedType>(), opName, " applied to wrong type of array -- expected: i8 or i16, found "_s, elementType.as<Type>().kind());
 
             // array.get is not valid for packed arrays
             if (op == ExtGCOpType::ArrayGet)
@@ -2689,7 +2689,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             WASM_TRY_POP_EXPRESSION_STACK_INTO(index, "array.get"_s);
             WASM_TRY_POP_EXPRESSION_STACK_INTO(arrayref, "array.get"_s);
             WASM_VALIDATOR_FAIL_IF(!isSubtype(arrayref.type(), arrayRefType), opName, " arrayref to type ", arrayref.type(), " expected ", arrayRefType);
-            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != index.type().kind, "array.get index to type ", index.type(), " expected ", TypeKind::I32);
+            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != index.type().kind(), "array.get index to type ", index.type(), " expected ", TypeKind::I32);
 
             if (resultType.isV128())
                 m_context.notifyFunctionUsesSIMD();
@@ -2716,7 +2716,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             WASM_TRY_POP_EXPRESSION_STACK_INTO(index, "array.set"_s);
             WASM_TRY_POP_EXPRESSION_STACK_INTO(arrayref, "array.set"_s);
             WASM_VALIDATOR_FAIL_IF(!isSubtype(arrayref.type(), arrayRefType), "array.set arrayref to type ", arrayref.type(), " expected ", arrayRefType);
-            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != index.type().kind, "array.set index to type ", index.type(), " expected ", TypeKind::I32);
+            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != index.type().kind(), "array.set index to type ", index.type(), " expected ", TypeKind::I32);
             WASM_VALIDATOR_FAIL_IF(!isSubtype(value.type(), unpackedElementType), "array.set value to type ", value.type(), " expected ", unpackedElementType);
 
             if (unpackedElementType.isV128())
@@ -2729,7 +2729,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         case ExtGCOpType::ArrayLen: {
             TypedExpression arrayref;
             WASM_TRY_POP_EXPRESSION_STACK_INTO(arrayref, "array.len"_s);
-            WASM_VALIDATOR_FAIL_IF(!isSubtype(arrayref.type(), Type { TypeKind::RefNull, static_cast<TypeIndex>(TypeKind::Arrayref) }), "array.len value to type ", arrayref.type(), " expected arrayref");
+            WASM_VALIDATOR_FAIL_IF(!isSubtype(arrayref.type(), Type { TypeKind::RefNull, typeIndexFromTypeKind(TypeKind::Arrayref) }), "array.len value to type ", arrayref.type(), " expected arrayref");
 
             ExpressionType result;
             WASM_TRY_ADD_TO_CONTEXT(addArrayLen(arrayref, result));
@@ -2752,9 +2752,9 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             WASM_TRY_POP_EXPRESSION_STACK_INTO(offset, "array.fill"_s);
             WASM_TRY_POP_EXPRESSION_STACK_INTO(arrayref, "array.fill"_s);
             WASM_VALIDATOR_FAIL_IF(!isSubtype(arrayref.type(), arrayRefType), "array.fill arrayref to type ", arrayref.type(), " expected ", arrayRefType);
-            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != offset.type().kind, "array.fill offset to type ", offset.type(), " expected ", TypeKind::I32);
+            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != offset.type().kind(), "array.fill offset to type ", offset.type(), " expected ", TypeKind::I32);
             WASM_VALIDATOR_FAIL_IF(!isSubtype(value.type(), unpackedElementType), "array.fill value to type ", value.type(), " expected ", unpackedElementType);
-            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != size.type().kind, "array.fill size to type ", size.type(), " expected ", TypeKind::I32);
+            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != size.type().kind(), "array.fill size to type ", size.type(), " expected ", TypeKind::I32);
 
             if (unpackedElementType.isV128())
                 m_context.notifyFunctionUsesSIMD();
@@ -2782,10 +2782,10 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             WASM_TRY_POP_EXPRESSION_STACK_INTO(dstOffset, "array.copy"_s);
             WASM_TRY_POP_EXPRESSION_STACK_INTO(dst, "array.copy"_s);
             WASM_VALIDATOR_FAIL_IF(!isSubtype(dst.type(), dstArrayRefType), "array.copy dst to type ", dst.type(), " expected ", dstArrayRefType);
-            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != dstOffset.type().kind, "array.copy dstOffset to type ", dstOffset.type(), " expected ", TypeKind::I32);
+            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != dstOffset.type().kind(), "array.copy dstOffset to type ", dstOffset.type(), " expected ", TypeKind::I32);
             WASM_VALIDATOR_FAIL_IF(!isSubtype(src.type(), srcArrayRefType), "array.copy src to type ", src.type(), " expected ", srcArrayRefType);
-            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != srcOffset.type().kind, "array.copy srcOffset to type ", srcOffset.type(), " expected ", TypeKind::I32);
-            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != size.type().kind, "array.copy size to type ", size.type(), " expected ", TypeKind::I32);
+            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != srcOffset.type().kind(), "array.copy srcOffset to type ", srcOffset.type(), " expected ", TypeKind::I32);
+            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != size.type().kind(), "array.copy size to type ", size.type(), " expected ", TypeKind::I32);
 
             WASM_TRY_ADD_TO_CONTEXT(addArrayCopy(dstTypeIndex, dst, dstOffset, srcTypeIndex, src, srcOffset, size));
             break;
@@ -2813,9 +2813,9 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             WASM_TRY_POP_EXPRESSION_STACK_INTO(dstOffset, "array.init_elem"_s);
             WASM_TRY_POP_EXPRESSION_STACK_INTO(dst, "array.init_elem"_s);
             WASM_VALIDATOR_FAIL_IF(!isSubtype(dst.type(), dstArrayRefType), "array.init_elem dst to type ", dst.type(), " expected ", dstArrayRefType);
-            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != dstOffset.type().kind, "array.init_elem dstOffset to type ", dstOffset.type(), " expected ", TypeKind::I32);
-            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != srcOffset.type().kind, "array.init_elem srcOffset to type ", srcOffset.type(), " expected ", TypeKind::I32);
-            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != size.type().kind, "array.init_elem size to type ", size.type(), " expected ", TypeKind::I32);
+            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != dstOffset.type().kind(), "array.init_elem dstOffset to type ", dstOffset.type(), " expected ", TypeKind::I32);
+            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != srcOffset.type().kind(), "array.init_elem srcOffset to type ", srcOffset.type(), " expected ", TypeKind::I32);
+            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != size.type().kind(), "array.init_elem size to type ", size.type(), " expected ", TypeKind::I32);
 
             WASM_TRY_ADD_TO_CONTEXT(addArrayInitElem(dstTypeIndex, dst, dstOffset, elemSegmentIndex, srcOffset, size));
             break;
@@ -2838,9 +2838,9 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             WASM_TRY_POP_EXPRESSION_STACK_INTO(dstOffset, "array.init_data"_s);
             WASM_TRY_POP_EXPRESSION_STACK_INTO(dst, "array.init_data"_s);
             WASM_VALIDATOR_FAIL_IF(!isSubtype(dst.type(), dstArrayRefType), "array.init_data dst to type "_s, dst.type(), " expected "_s, dstArrayRefType);
-            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != dstOffset.type().kind, "array.init_data dstOffset to type "_s, dstOffset.type(), " expected "_s, TypeKind::I32);
-            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != srcOffset.type().kind, "array.init_data srcOffset to type "_s, srcOffset.type(), " expected "_s, TypeKind::I32);
-            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != size.type().kind, "array.init_data size to type "_s, size.type(), " expected "_s, TypeKind::I32);
+            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != dstOffset.type().kind(), "array.init_data dstOffset to type "_s, dstOffset.type(), " expected "_s, TypeKind::I32);
+            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != srcOffset.type().kind(), "array.init_data srcOffset to type "_s, srcOffset.type(), " expected "_s, TypeKind::I32);
+            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != size.type().kind(), "array.init_data size to type "_s, size.type(), " expected "_s, TypeKind::I32);
 
             WASM_TRY_ADD_TO_CONTEXT(addArrayInitData(dstTypeIndex, dst, dstOffset, dataSegmentIndex, srcOffset, size));
             break;
@@ -2901,7 +2901,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             WASM_FAIL_IF_HELPER_FAILS(parseStructFieldManipulation(structGetInput, opName));
 
             if (op == ExtGCOpType::StructGetS || op == ExtGCOpType::StructGetU)
-                WASM_PARSER_FAIL_IF(!structGetInput.field.type.template is<PackedType>(), opName, " applied to wrong type of struct -- expected: i8 or i16, found "_s, structGetInput.field.type.template as<Type>().kind);
+                WASM_PARSER_FAIL_IF(!structGetInput.field.type.template is<PackedType>(), opName, " applied to wrong type of struct -- expected: i8 or i16, found "_s, structGetInput.field.type.template as<Type>().kind());
 
             if (op == ExtGCOpType::StructGet)
                 WASM_PARSER_FAIL_IF(structGetInput.field.type.template is<PackedType>(), opName, " applied to packed array of "_s, structGetInput.field.type.template as<PackedType>(), " -- use struct.get_s or struct.get_u"_s);
@@ -2946,8 +2946,9 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             WASM_TRY_POP_EXPRESSION_STACK_INTO(ref, opName);
             WASM_VALIDATOR_FAIL_IF(!isRefType(ref.type()), opName, " to type "_s, ref.type(), " expected a reference type"_s);
 
-            TypeIndex resultTypeIndex = static_cast<TypeIndex>(heapType);
-            if (typeIndexIsType(resultTypeIndex)) {
+            TypeIndex resultTypeIndex;
+            if (!isTypeIndexHeapType(heapType)) {
+                resultTypeIndex = typeIndexFromTypeKind(static_cast<TypeKind>(heapType));
                 switch (static_cast<TypeKind>(heapType)) {
                 case TypeKind::Funcref:
                 case TypeKind::Nofuncref:
@@ -3014,12 +3015,12 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             if (isTypeIndexHeapType(heapType1))
                 typeIndex1 = m_info.rtt(ModuleInformation::typeSignatureIndexFromHeapType(heapType1)).asTypeIndex();
             else
-                typeIndex1 = static_cast<TypeIndex>(heapType1);
+                typeIndex1 = typeIndexFromTypeKind(static_cast<TypeKind>(heapType1));
 
             if (isTypeIndexHeapType(heapType2))
                 typeIndex2 = m_info.rtt(ModuleInformation::typeSignatureIndexFromHeapType(heapType2)).asTypeIndex();
             else
-                typeIndex2 = static_cast<TypeIndex>(heapType2);
+                typeIndex2 = typeIndexFromTypeKind(static_cast<TypeKind>(heapType2));
 
             // Manually pop the stack in order to avoid decreasing the stack size, as we will immediately put it back.
             TypedExpression ref;
@@ -3132,7 +3133,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             TypeIndex typeIndex = m_info.rtt(ModuleInformation::typeSignatureIndexFromHeapType(heapType)).asTypeIndex();
             typeOfNull = Type { TypeKind::RefNull, typeIndex };
         } else
-            typeOfNull = Type { TypeKind::RefNull, static_cast<TypeIndex>(heapType) };
+            typeOfNull = Type { TypeKind::RefNull, typeIndexFromTypeKind(static_cast<TypeKind>(heapType)) };
         m_expressionStack.constructAndAppend(typeOfNull, m_context.addConstant(typeOfNull, JSValue::encode(jsNull())));
         return { };
     }
@@ -3170,7 +3171,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         ExpressionType result;
         WASM_TRY_ADD_TO_CONTEXT(addRefAsNonNull(ref, result));
 
-        m_expressionStack.constructAndAppend(Type { TypeKind::Ref, ref.type().index }, result);
+        m_expressionStack.constructAndAppend(Type { TypeKind::Ref, ref.type().index() }, result);
         return { };
     }
 
@@ -3188,7 +3189,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
 
         ExpressionType result;
         WASM_TRY_ADD_TO_CONTEXT(addBranchNull(data, ref, expressionStack(), false, result));
-        m_expressionStack.constructAndAppend(Type { TypeKind::Ref, ref.type().index }, result);
+        m_expressionStack.constructAndAppend(Type { TypeKind::Ref, ref.type().index() }, result);
 
         return { };
     }
@@ -3201,7 +3202,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         // Pop the stack manually to avoid changing the stack size, because the branch needs the value with a different type.
         WASM_PARSER_FAIL_IF(m_expressionStack.size() == m_currentStackBegin, "can't pop empty stack in br_on_non_null"_s);
         ref = m_expressionStack.takeLast();
-        m_expressionStack.constructAndAppend(Type { TypeKind::Ref, ref.type().index }, ref.value());
+        m_expressionStack.constructAndAppend(Type { TypeKind::Ref, ref.type().index() }, ref.value());
         WASM_VALIDATOR_FAIL_IF(!isRefType(ref.type()), "br_on_non_null ref to type "_s, ref.type(), " expected a reference type"_s);
 
         ControlType& data = m_controlStack[m_controlStack.size() - 1 - target].controlData;
@@ -3224,8 +3225,8 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         TypedExpression ref1;
         WASM_TRY_POP_EXPRESSION_STACK_INTO(ref0, "ref.eq"_s);
         WASM_TRY_POP_EXPRESSION_STACK_INTO(ref1, "ref.eq"_s);
-        WASM_VALIDATOR_FAIL_IF(!isSubtype(ref0.type(), eqrefType()), "ref.eq ref0 to type "_s, ref0.type().kind, " expected "_s, TypeKind::Eqref);
-        WASM_VALIDATOR_FAIL_IF(!isSubtype(ref1.type(), eqrefType()), "ref.eq ref1 to type "_s, ref1.type().kind, " expected "_s, TypeKind::Eqref);
+        WASM_VALIDATOR_FAIL_IF(!isSubtype(ref0.type(), eqrefType()), "ref.eq ref0 to type "_s, ref0.type().kind(), " expected "_s, TypeKind::Eqref);
+        WASM_VALIDATOR_FAIL_IF(!isSubtype(ref1.type(), eqrefType()), "ref.eq ref1 to type "_s, ref1.type().kind(), " expected "_s, TypeKind::Eqref);
 
         ExpressionType result;
         WASM_TRY_ADD_TO_CONTEXT(addRefEq(ref0, ref1, result));
@@ -3301,7 +3302,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         Type globalType = m_info.globals[index].type;
         ASSERT(isValueType(globalType));
 
-        WASM_VALIDATOR_FAIL_IF(!isSubtype(value.type(), globalType), "set_global "_s, index, " with type "_s, globalType.kind, " with a variable of type "_s, value.type().kind);
+        WASM_VALIDATOR_FAIL_IF(!isSubtype(value.type(), globalType), "set_global "_s, index, " with type "_s, globalType.kind(), " with a variable of type "_s, value.type().kind());
 
         if (globalType.isV128())
             m_context.notifyFunctionUsesSIMD();
@@ -3385,7 +3386,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         WASM_PARSER_FAIL_IF(argumentCount > m_expressionStack.size() - m_currentStackBegin, "call_indirect expects "_s, argumentCount, " arguments, but the expression stack currently holds "_s, m_expressionStack.size() - m_currentStackBegin, " values"_s);
 
         Wasm::Type tableAddressType = m_info.table(tableIndex).addressType().asWasmType();
-        WASM_VALIDATOR_FAIL_IF(tableAddressType!= m_expressionStack.last().type(), "call_indirect index to type "_s, m_expressionStack.last().type().kind, " expected "_s, tableAddressType.kind);
+        WASM_VALIDATOR_FAIL_IF(tableAddressType!= m_expressionStack.last().type(), "call_indirect index to type "_s, m_expressionStack.last().type().kind(), " expected "_s, tableAddressType.kind());
 
         ArgumentList args;
         WASM_ALLOCATOR_FAIL_IF(!args.tryReserveInitialCapacity(argumentCount), "can't allocate enough memory for "_s, argumentCount, " call_indirect arguments"_s);
@@ -3723,7 +3724,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             }
             if (catchTarget.type == CatchKind::CatchRef || catchTarget.type == CatchKind::CatchAllRef) {
                 ExpressionType exp;
-                results.constructAndAppend(Type { TypeKind::Ref, static_cast<TypeIndex>(TypeKind::Exnref) }, exp);
+                results.constructAndAppend(Type { TypeKind::Ref, typeIndexFromTypeKind(TypeKind::Exnref) }, exp);
             }
 
             WASM_VALIDATOR_FAIL_IF(results.size() != target.branchTargetArity());
@@ -4536,12 +4537,12 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
             if (isTypeIndexHeapType(heapType1))
                 typeIndex1 = m_info.rtt(ModuleInformation::typeSignatureIndexFromHeapType(heapType1)).asTypeIndex();
             else
-                typeIndex1 = static_cast<TypeIndex>(heapType1);
+                typeIndex1 = typeIndexFromTypeKind(static_cast<TypeKind>(heapType1));
 
             if (isTypeIndexHeapType(heapType2))
                 typeIndex2 = m_info.rtt(ModuleInformation::typeSignatureIndexFromHeapType(heapType2)).asTypeIndex();
             else
-                typeIndex2 = static_cast<TypeIndex>(heapType2);
+                typeIndex2 = typeIndexFromTypeKind(static_cast<TypeKind>(heapType2));
 
             WASM_VALIDATOR_FAIL_IF(!isSubtype(Type { hasNull2 ? TypeKind::RefNull : TypeKind::Ref, typeIndex2 }, Type { hasNull1 ? TypeKind::RefNull : TypeKind::Ref, typeIndex1 }), "target heaptype was not a subtype of source heaptype for "_s, opName);
             return { };

--- a/Source/JavaScriptCore/wasm/WasmGlobal.cpp
+++ b/Source/JavaScriptCore/wasm/WasmGlobal.cpp
@@ -45,7 +45,7 @@ JSValue Global::get(JSGlobalObject* globalObject) const
     VM& vm = globalObject->vm();
     auto throwScope = DECLARE_THROW_SCOPE(vm);
 
-    switch (m_type.kind) {
+    switch (m_type.kind()) {
     case TypeKind::I32:
         return jsNumber(std::bit_cast<int32_t>(static_cast<uint32_t>(m_value.m_primitive)));
     case TypeKind::I64:
@@ -78,7 +78,7 @@ void Global::set(JSGlobalObject* globalObject, JSValue argument)
     VM& vm = globalObject->vm();
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     ASSERT(m_mutability != Wasm::Immutable);
-    switch (m_type.kind) {
+    switch (m_type.kind()) {
     case TypeKind::I32: {
         int32_t value = argument.toInt32(globalObject);
         RETURN_IF_EXCEPTION(throwScope, void());
@@ -118,7 +118,7 @@ void Global::set(JSGlobalObject* globalObject, JSValue argument)
                 return;
             }
             m_value.m_externref.set(m_owner->vm(), m_owner, argument);
-        } else if (isFuncref(m_type) || (isRefWithTypeIndex(m_type) && TypeInformation::tryGetRTT(m_type.index) && TypeInformation::tryGetRTT(m_type.index)->kind() == RTTKind::Function)) {
+        } else if (isFuncref(m_type) || (isRefWithTypeIndex(m_type) && TypeInformation::tryGetRTT(m_type.index()) && TypeInformation::tryGetRTT(m_type.index())->kind() == RTTKind::Function)) {
             RELEASE_ASSERT(m_owner);
             WebAssemblyFunction* wasmFunction = nullptr;
             WebAssemblyWrapperFunction* wasmWrapperFunction = nullptr;
@@ -128,7 +128,7 @@ void Global::set(JSGlobalObject* globalObject, JSValue argument)
             }
 
             if (isRefWithTypeIndex(m_type) && !argument.isNull()) {
-                Wasm::TypeIndex paramIndex = m_type.index;
+                Wasm::TypeIndex paramIndex = m_type.index();
                 Wasm::TypeIndex argIndex = (wasmFunction ? wasmFunction->rtt() : wasmWrapperFunction->rtt())->asTypeIndex();
                 if (paramIndex != argIndex) {
                     throwTypeError(globalObject, throwScope, "Argument value did not match the reference type"_s);
@@ -141,7 +141,7 @@ void Global::set(JSGlobalObject* globalObject, JSValue argument)
             return;
         } else {
             JSValue internref = Wasm::internalizeExternref(argument);
-            if (!Wasm::TypeInformation::isReferenceValueAssignable(internref, m_type.isNullable(), m_type.index)) {
+            if (!Wasm::TypeInformation::isReferenceValueAssignable(internref, m_type.isNullable(), m_type.index())) {
                 // FIXME: provide a better error message here
                 // https://bugs.webkit.org/show_bug.cgi?id=247746
                 throwTypeError(globalObject, throwScope, "Argument value did not match the reference type"_s);

--- a/Source/JavaScriptCore/wasm/WasmGlobal.h
+++ b/Source/JavaScriptCore/wasm/WasmGlobal.h
@@ -104,7 +104,7 @@ public:
 private:
     Global(Wasm::Type type, Wasm::Mutability mutability, uint64_t initialValue)
         : m_type(type)
-        , m_typeRTT(TypeInformation::tryGetRTT(type.index))
+        , m_typeRTT(TypeInformation::tryGetRTT(type.index()))
         , m_mutability(mutability)
     {
         ASSERT(m_type != Types::V128);
@@ -113,7 +113,7 @@ private:
 
     Global(Wasm::Type type, Wasm::Mutability mutability, v128_t initialValue)
         : m_type(type)
-        , m_typeRTT(TypeInformation::tryGetRTT(type.index))
+        , m_typeRTT(TypeInformation::tryGetRTT(type.index()))
         , m_mutability(mutability)
     {
         ASSERT(m_type == Types::V128);

--- a/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
@@ -2535,7 +2535,7 @@ void IPIntGenerator::convertTryToCatch(ControlType& tryBlock, CatchKind catchKin
     const auto& signature = m_info.rtt(m_info.typeSignatureIndexFromExceptionIndexSpace(exceptionIndex));
     unsigned offset = 0;
     for (unsigned i = 0; i < signature.argumentCount(); ++i)
-        offset += signature.argumentType(i).kind == TypeKind::V128 ? 2 : 1;
+        offset += signature.argumentType(i).kind() == TypeKind::V128 ? 2 : 1;
     unsigned throwCalleeStackSize = WTF::roundUpToMultipleOf<stackAlignmentBytes()>(offset * sizeof(uint64_t));
     m_metadata->m_maxCalleeStackSize = std::max(throwCalleeStackSize, m_metadata->m_maxCalleeStackSize);
 

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
@@ -1081,8 +1081,8 @@ WASM_IPINT_EXTERN_CPP_DECL(any_convert_extern, EncodedJSValue value)
 
 WASM_IPINT_EXTERN_CPP_DECL(ref_test, int32_t heapType, bool allowNull, EncodedJSValue value)
 {
-    if (Wasm::typeIndexIsType(static_cast<Wasm::TypeIndex>(heapType))) {
-        bool result = Wasm::refCast(value, allowNull, static_cast<Wasm::TypeIndex>(heapType));
+    if (!Wasm::isTypeIndexHeapType(heapType)) {
+        bool result = Wasm::refCast(value, allowNull, Wasm::typeIndexFromTypeKind(static_cast<Wasm::TypeKind>(heapType)));
         IPINT_RETURN(static_cast<uint64_t>(result));
     }
 
@@ -1093,8 +1093,8 @@ WASM_IPINT_EXTERN_CPP_DECL(ref_test, int32_t heapType, bool allowNull, EncodedJS
 
 WASM_IPINT_EXTERN_CPP_DECL(ref_cast, int32_t heapType, bool allowNull, EncodedJSValue value)
 {
-    if (Wasm::typeIndexIsType(static_cast<Wasm::TypeIndex>(heapType))) {
-        if (!Wasm::refCast(value, allowNull, static_cast<Wasm::TypeIndex>(heapType))) [[unlikely]]
+    if (!Wasm::isTypeIndexHeapType(heapType)) {
+        if (!Wasm::refCast(value, allowNull, Wasm::typeIndexFromTypeKind(static_cast<Wasm::TypeKind>(heapType)))) [[unlikely]]
             IPINT_THROW(Wasm::ExceptionType::CastFailure);
         IPINT_RETURN(value);
     }

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -985,7 +985,7 @@ private:
             }
         } else {
             auto unpacked = elementType.unpacked();
-            switch (unpacked.kind) {
+            switch (unpacked.kind()) {
             case Wasm::TypeKind::I32:
                 heap = &m_heaps.JSWebAssemblyArray_i32;
                 break;
@@ -2345,7 +2345,7 @@ auto OMGIRGenerator::getGlobal(uint32_t index, ExpressionType& result) -> Partia
     switch (global.bindingMode) {
     case Wasm::GlobalInformation::BindingMode::EmbeddedInInstance: {
         auto* value = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, toB3Type(global.type), origin(), instanceValue(), safeCast<int32_t>(JSWebAssemblyInstance::offsetOfGlobal(m_info, index)));
-        switch (global.type.kind) {
+        switch (global.type.kind()) {
         case TypeKind::I32:
             m_heaps.decorateMemory(&m_heaps.JSWebAssemblyInstance_embeddedGlobals_i32[index], value);
             break;
@@ -2400,7 +2400,7 @@ auto OMGIRGenerator::setGlobal(uint32_t index, ExpressionType value) -> PartialR
     switch (global.bindingMode) {
     case Wasm::GlobalInformation::BindingMode::EmbeddedInInstance: {
         auto* store = m_currentBlock->appendNew<MemoryValue>(m_proc, Store, origin(), get(value), instanceValue(), safeCast<int32_t>(JSWebAssemblyInstance::offsetOfGlobal(m_info, index)));
-        switch (global.type.kind) {
+        switch (global.type.kind()) {
         case TypeKind::I32:
             m_heaps.decorateMemory(&m_heaps.JSWebAssemblyInstance_embeddedGlobals_i32[index], store);
             break;
@@ -2874,7 +2874,7 @@ inline Value* OMGIRGenerator::sanitizeAtomicResult(ExtAtomicOpType op, Type valu
         }
     };
 
-    switch (valueType.kind) {
+    switch (valueType.kind()) {
     case TypeKind::I64: {
         if (accessWidth(op) == Width64)
             return result;
@@ -2942,7 +2942,7 @@ auto OMGIRGenerator::atomicLoad(ExtAtomicOpType op, Type valueType, ExpressionTy
             this->emitExceptionCheck(jit, origin, ExceptionType::OutOfBoundsMemoryAccess);
         });
 
-        switch (valueType.kind) {
+        switch (valueType.kind()) {
         case TypeKind::I32:
             result = push(constant(Int32, 0));
             break;
@@ -3082,7 +3082,7 @@ auto OMGIRGenerator::atomicBinaryRMW(ExtAtomicOpType op, Type valueType, Express
             this->emitExceptionCheck(jit, origin, ExceptionType::OutOfBoundsMemoryAccess);
         });
 
-        switch (valueType.kind) {
+        switch (valueType.kind()) {
         case TypeKind::I32:
             result = push(constant(Int32, 0));
             break;
@@ -3114,7 +3114,7 @@ Value* OMGIRGenerator::emitAtomicCompareExchange(ExtAtomicOpType op, Type valueT
     }
 
     Value* maximum = nullptr;
-    switch (valueType.kind) {
+    switch (valueType.kind()) {
     case TypeKind::I64: {
         switch (accessWidth) {
         case Width8:
@@ -3199,7 +3199,7 @@ auto OMGIRGenerator::atomicCompareExchange(ExtAtomicOpType op, Type valueType, E
             this->emitExceptionCheck(jit, origin, ExceptionType::OutOfBoundsMemoryAccess);
         });
 
-        switch (valueType.kind) {
+        switch (valueType.kind()) {
         case TypeKind::I32:
             result = push(constant(Int32, 0));
             break;
@@ -4156,10 +4156,10 @@ void OMGIRGenerator::emitRefTestOrCast(CastKind castKind, TypedExpression refere
 
     RefPtr<const Wasm::RTT> targetRTT;
     int32_t originalTypeIndex = toHeapType;
-    if (!typeIndexIsType(static_cast<Wasm::TypeIndex>(toHeapType))) {
+    if (isTypeIndexHeapType(toHeapType)) {
         targetRTT = &m_info.rtt(ModuleInformation::typeSignatureIndexFromHeapType(toHeapType));
         toHeapType = 0;
-        ASSERT(!typeIndexIsType(static_cast<Wasm::TypeIndex>(toHeapType)));
+        ASSERT(isTypeIndexHeapType(toHeapType));
     }
 
     OptionSet<B3::WasmRefTypeCheckFlag> flags;
@@ -4905,7 +4905,7 @@ auto OMGIRGenerator::addCatchToUnreachable(unsigned exceptionIndex, const RTT& s
         Type type = signature.argumentType(i);
         Value* value = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, toB3Type(type), origin(), payload, safeCast<int32_t>(offset * sizeof(uint64_t)));
         results.append(push(value));
-        offset += type.kind == TypeKind::V128 ? 2 : 1;
+        offset += type.kind() == TypeKind::V128 ? 2 : 1;
     }
     TRACE_CF("CATCH");
     return { };
@@ -4995,13 +4995,13 @@ auto OMGIRGenerator::emitCatchTableImpl(ControlData& data, const ControlData::Tr
             Type type = signature->argumentType(i);
             Value* value = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, toB3Type(type), origin(), buffer, safeCast<int32_t>(offset * sizeof(uint64_t)));
             resultStack.constructAndAppend(type, value);
-            offset += type.kind == TypeKind::V128 ? 2 : 1;
+            offset += type.kind() == TypeKind::V128 ? 2 : 1;
         }
     }
 
     if (target.type == CatchKind::CatchRef || target.type == CatchKind::CatchAllRef) {
         exception = wasmRefOfCell(exception);
-        resultStack.constructAndAppend(Type { TypeKind::RefNull, static_cast<TypeIndex>(TypeKind::Exnref) }, exception);
+        resultStack.constructAndAppend(Type { TypeKind::RefNull, typeIndexFromTypeKind(TypeKind::Exnref) }, exception);
     }
 
     auto& targetControl = m_parser->resolveControlRef(target.target).controlData;

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -198,7 +198,7 @@ JSC_DEFINE_JIT_OPERATION(operationJSToWasmEntryWrapperBuildReturnFrame, EncodedJ
     IndexingType indexingType = ArrayWithUndecided;
     for (unsigned i = 0; i < signature.returnCount(); ++i) {
         Type type = signature.returnType(i);
-        switch (type.kind) {
+        switch (type.kind()) {
         case TypeKind::I32:
             indexingType = leastUpperBoundOfIndexingTypes(indexingType, ArrayWithInt32);
             break;
@@ -230,7 +230,7 @@ JSC_DEFINE_JIT_OPERATION(operationJSToWasmEntryWrapperBuildReturnFrame, EncodedJ
         Type type = signature.returnType(i);
         JSValue result;
         if (loc.isGPR() || loc.isFPR()) {
-            switch (type.kind) {
+            switch (type.kind()) {
             case TypeKind::I32:
                 result = jsNumber(*access.operator()<int32_t>(registerSpace, GPRInfo::toArgumentIndex(loc.jsr().payloadGPR()) * sizeof(UCPURegister)));
                 break;
@@ -249,7 +249,7 @@ JSC_DEFINE_JIT_OPERATION(operationJSToWasmEntryWrapperBuildReturnFrame, EncodedJ
                 break;
             }
         } else {
-            switch (type.kind) {
+            switch (type.kind()) {
             case TypeKind::I32:
                 result = jsNumber(*access.operator()<int32_t>(callFrame, calleeSPOffsetFromFP + loc.offsetFromSP()));
                 break;
@@ -333,7 +333,7 @@ JSC_DEFINE_JIT_OPERATION(operationWasmToJSExitMarshalArguments, void, (void* sp,
         auto wasmParam = wasmCC.params[argNum].location;
         auto dst = jsCC.params[argNum].location.offsetFromFP();
 
-        switch (argType.kind) {
+        switch (argType.kind()) {
         case TypeKind::Void:
         case TypeKind::Func:
         case TypeKind::Struct:
@@ -488,7 +488,7 @@ JSC_DEFINE_JIT_OPERATION(operationWasmToJSExitMarshalReturnValues, void, (void* 
 
     if (signature.returnCount() == 1) {
         const auto& returnType = signature.returnType(0);
-        switch (returnType.kind) {
+        switch (returnType.kind()) {
         case TypeKind::I32: {
             if (!returned.isNumber() || !returned.isInt32()) {
                 // slow path
@@ -573,7 +573,7 @@ JSC_DEFINE_JIT_OPERATION(operationWasmToJSExitMarshalReturnValues, void, (void* 
                     }
 
                     if (isRefWithTypeIndex(returnType) && !value.isNull()) {
-                        Wasm::TypeIndex paramIndex = returnType.index;
+                        Wasm::TypeIndex paramIndex = returnType.index();
                         Wasm::TypeIndex argIndex = (wasmFunction ? wasmFunction->rtt() : wasmWrapperFunction->rtt())->asTypeIndex();
                         if (paramIndex != argIndex) {
                             throwVMTypeError(globalObject, scope, "Argument function did not match the reference type"_s);
@@ -584,7 +584,7 @@ JSC_DEFINE_JIT_OPERATION(operationWasmToJSExitMarshalReturnValues, void, (void* 
                 } else {
                     // operationConvertToAnyref
                     value = Wasm::internalizeExternref(value);
-                    if (!Wasm::TypeInformation::isReferenceValueAssignable(value, returnType.isNullable(), returnType.index)) [[unlikely]] {
+                    if (!Wasm::TypeInformation::isReferenceValueAssignable(value, returnType.isNullable(), returnType.index())) [[unlikely]] {
                         throwTypeError(globalObject, scope, "Argument value did not match the reference type"_s);
                         OPERATION_RETURN(scope);
                     }
@@ -626,7 +626,7 @@ JSC_DEFINE_JIT_OPERATION(operationWasmToJSExitMarshalReturnValues, void, (void* 
 
         uint64_t unboxedValue = 0;
         const auto& returnType = signature.returnType(index);
-        switch (returnType.kind) {
+        switch (returnType.kind()) {
         case TypeKind::I32:
             unboxedValue = static_cast<uint32_t>(value.toInt32(globalObject));
             OPERATION_RETURN_IF_EXCEPTION(scope);
@@ -660,7 +660,7 @@ JSC_DEFINE_JIT_OPERATION(operationWasmToJSExitMarshalReturnValues, void, (void* 
                         OPERATION_RETURN(scope);
                     }
                     if (Wasm::isRefWithTypeIndex(returnType) && !value.isNull()) {
-                        Wasm::TypeIndex paramIndex = returnType.index;
+                        Wasm::TypeIndex paramIndex = returnType.index();
                         Wasm::TypeIndex argIndex = (wasmFunction ? wasmFunction->rtt() : wasmWrapperFunction->rtt())->asTypeIndex();
                         if (paramIndex != argIndex) {
                             throwTypeError(globalObject, scope, "Argument value did not match the reference type"_s);
@@ -669,7 +669,7 @@ JSC_DEFINE_JIT_OPERATION(operationWasmToJSExitMarshalReturnValues, void, (void* 
                     }
                 } else {
                     value = Wasm::internalizeExternref(value);
-                    if (!Wasm::TypeInformation::isReferenceValueAssignable(value, returnType.isNullable(), returnType.index)) [[unlikely]] {
+                    if (!Wasm::TypeInformation::isReferenceValueAssignable(value, returnType.isNullable(), returnType.index())) [[unlikely]] {
                         throwTypeError(globalObject, scope, "Argument value did not match the reference type"_s);
                         OPERATION_RETURN(scope);
                     }
@@ -1324,7 +1324,7 @@ JSC_DEFINE_JIT_OPERATION(operationConvertToFuncref, EncodedJSValue, (JSWebAssemb
     Type resultType = signature->returnType(0);
 
     if (isRefWithTypeIndex(resultType) && !value.isNull()) {
-        Wasm::TypeIndex paramIndex = resultType.index;
+        Wasm::TypeIndex paramIndex = resultType.index();
         Wasm::TypeIndex argIndex = (wasmFunction ? wasmFunction->rtt() : wasmWrapperFunction->rtt())->asTypeIndex();
         if (paramIndex != argIndex)
             OPERATION_RETURN(scope, throwVMTypeError(globalObject, scope, "Argument value did not match the reference type"_s));
@@ -1347,7 +1347,7 @@ JSC_DEFINE_JIT_OPERATION(operationConvertToAnyref, EncodedJSValue, (JSWebAssembl
 
     JSValue value = JSValue::decode(v);
     value = Wasm::internalizeExternref(value);
-    if (!Wasm::TypeInformation::isReferenceValueAssignable(value, resultType.isNullable(), resultType.index)) [[unlikely]]
+    if (!Wasm::TypeInformation::isReferenceValueAssignable(value, resultType.isNullable(), resultType.index())) [[unlikely]]
         OPERATION_RETURN(scope, throwVMTypeError(globalObject, scope, "Argument value did not match the reference type"_s));
 
     OPERATION_RETURN(scope, JSValue::encode(value));
@@ -1406,7 +1406,7 @@ JSC_DEFINE_JIT_OPERATION(operationIterateResults, void, (JSWebAssemblyInstance* 
 
         uint64_t unboxedValue = 0;
         const auto& returnType = signature->returnType(index);
-        switch (returnType.kind) {
+        switch (returnType.kind()) {
         case TypeKind::I32:
             unboxedValue = static_cast<uint32_t>(value.toInt32(globalObject));
             break;
@@ -1436,7 +1436,7 @@ JSC_DEFINE_JIT_OPERATION(operationIterateResults, void, (JSWebAssemblyInstance* 
                         OPERATION_RETURN(scope);
                     }
                     if (Wasm::isRefWithTypeIndex(returnType) && !value.isNull()) {
-                        Wasm::TypeIndex paramIndex = returnType.index;
+                        Wasm::TypeIndex paramIndex = returnType.index();
                         Wasm::TypeIndex argIndex = (wasmFunction ? wasmFunction->rtt() : wasmWrapperFunction->rtt())->asTypeIndex();
                         if (paramIndex != argIndex) {
                             throwTypeError(globalObject, scope, "Argument value did not match the reference type"_s);
@@ -1445,7 +1445,7 @@ JSC_DEFINE_JIT_OPERATION(operationIterateResults, void, (JSWebAssemblyInstance* 
                     }
                 } else {
                     value = Wasm::internalizeExternref(value);
-                    if (!Wasm::TypeInformation::isReferenceValueAssignable(value, returnType.isNullable(), returnType.index)) [[unlikely]] {
+                    if (!Wasm::TypeInformation::isReferenceValueAssignable(value, returnType.isNullable(), returnType.index())) [[unlikely]] {
                         throwTypeError(globalObject, scope, "Argument value did not match the reference type"_s);
                         OPERATION_RETURN(scope);
                     }
@@ -1865,8 +1865,8 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmRefTest, UCPUStrictInt32, (JSWebA
     int32_t truth = shouldNegate ? 0 : 1;
     int32_t falsity = shouldNegate ? 1 : 0;
 
-    if (Wasm::typeIndexIsType(static_cast<Wasm::TypeIndex>(heapType))) {
-        bool result = Wasm::refCast(reference, static_cast<bool>(allowNull), static_cast<Wasm::TypeIndex>(heapType));
+    if (!Wasm::isTypeIndexHeapType(heapType)) {
+        bool result = Wasm::refCast(reference, static_cast<bool>(allowNull), Wasm::typeIndexFromTypeKind(static_cast<Wasm::TypeKind>(heapType)));
         return toUCPUStrictInt32(result ? truth : falsity);
     }
 
@@ -1877,8 +1877,8 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmRefTest, UCPUStrictInt32, (JSWebA
 
 JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmRefCast, EncodedJSValue, (JSWebAssemblyInstance* instance, EncodedJSValue reference, uint32_t allowNull, int32_t heapType))
 {
-    if (Wasm::typeIndexIsType(static_cast<Wasm::TypeIndex>(heapType))) {
-        if (!Wasm::refCast(reference, static_cast<bool>(allowNull), static_cast<Wasm::TypeIndex>(heapType))) [[unlikely]]
+    if (!Wasm::isTypeIndexHeapType(heapType)) {
+        if (!Wasm::refCast(reference, static_cast<bool>(allowNull), Wasm::typeIndexFromTypeKind(static_cast<Wasm::TypeKind>(heapType)))) [[unlikely]]
             return encodedJSValue();
         return reference;
     }

--- a/Source/JavaScriptCore/wasm/WasmOperationsInlines.h
+++ b/Source/JavaScriptCore/wasm/WasmOperationsInlines.h
@@ -237,7 +237,7 @@ inline EncodedJSValue arrayNewData(JSWebAssemblyInstance* instance, uint32_t typ
             break;
         }
     } else {
-        switch (fieldType.type.as<Type>().kind) {
+        switch (fieldType.type.as<Type>().kind()) {
         case Wasm::TypeKind::I32:
         case Wasm::TypeKind::F32: {
             return createArrayFromDataSegment<uint32_t>(instance, structure, arraySize, dataSegmentIndex, offset);

--- a/Source/JavaScriptCore/wasm/WasmParser.h
+++ b/Source/JavaScriptCore/wasm/WasmParser.h
@@ -325,14 +325,14 @@ ALWAYS_INLINE bool ParserBase::parseValueType(const ModuleInformation& info, Typ
     TypeKind typeKind = static_cast<TypeKind>(kind);
     TypeIndex typeIndex = 0;
     if (isValidHeapTypeKind(kind)) {
-        typeIndex = static_cast<TypeIndex>(typeKind);
+        typeIndex = typeIndexFromTypeKind(typeKind);
         typeKind = TypeKind::RefNull;
     } else if (typeKind == TypeKind::Ref || typeKind == TypeKind::RefNull) {
         int32_t heapType;
         if (!parseHeapType(info, heapType))
             return false;
         if (heapType < 0)
-            typeIndex = static_cast<TypeIndex>(heapType);
+            typeIndex = typeIndexFromTypeKind(static_cast<TypeKind>(heapType));
         else {
             // For recursive references inside recursion groups, we construct a
             // placeholder projection with an invalid group index. These should

--- a/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
@@ -354,7 +354,7 @@ auto SectionParser::parseTableHelper(bool isImport) -> PartialResult
         bool isExtendedConstantExpression;
         v128_t unusedVector { };
         WASM_FAIL_IF_HELPER_FAILS(parseInitExpr(initOpcode, isExtendedConstantExpression, initialBitsOrImportNumber, unusedVector, type, typeForInitOpcode));
-        WASM_PARSER_FAIL_IF(!isSubtype(typeForInitOpcode, type), "Table init_expr opcode of type "_s, typeForInitOpcode.kind, " doesn't match table's type "_s, type.kind);
+        WASM_PARSER_FAIL_IF(!isSubtype(typeForInitOpcode, type), "Table init_expr opcode of type "_s, typeForInitOpcode.kind(), " doesn't match table's type "_s, type.kind());
 
         if (isExtendedConstantExpression)
             tableInitType = TableInformation::FromExtendedExpression;
@@ -485,7 +485,7 @@ auto SectionParser::parseGlobal() -> PartialResult
             global.initializationType = GlobalInformation::FromRefFunc;
         else
             global.initializationType = GlobalInformation::FromExpression;
-        WASM_PARSER_FAIL_IF(!isSubtype(typeForInitOpcode, global.type), "Global init_expr opcode of type "_s, typeForInitOpcode.kind, " doesn't match global's type "_s, global.type.kind);
+        WASM_PARSER_FAIL_IF(!isSubtype(typeForInitOpcode, global.type), "Global init_expr opcode of type "_s, typeForInitOpcode.kind(), " doesn't match global's type "_s, global.type.kind());
 
         if (initOpcode == RefFunc) {
             ASSERT(global.initializationType != GlobalInformation::FromVector);
@@ -829,7 +829,7 @@ auto SectionParser::parseInitExpr(uint8_t& opcode, bool& isExtendedConstantExpre
             TypeIndex typeIndex = m_info->rtt(ModuleInformation::typeSignatureIndexFromHeapType(heapType)).asTypeIndex();
             typeOfNull = Type { TypeKind::RefNull, typeIndex };
         } else
-            typeOfNull = Type { TypeKind::RefNull, static_cast<TypeIndex>(heapType) };
+            typeOfNull = Type { TypeKind::RefNull, typeIndexFromTypeKind(static_cast<TypeKind>(heapType)) };
         resultType = typeOfNull;
         bitsOrImportNumber = JSValue::encode(jsNull());
         break;
@@ -1290,7 +1290,7 @@ auto SectionParser::parseElementSegmentVectorOfExpressions(Type elementType, Vec
         bool isExtendedConstantExpression;
         v128_t unusedVector { };
         WASM_FAIL_IF_HELPER_FAILS(parseInitExpr(initOpcode, isExtendedConstantExpression, initialBitsOrIndex, unusedVector, elementType, typeForInitOpcode));
-        WASM_PARSER_FAIL_IF(!isSubtype(typeForInitOpcode, elementType), "Element section's "_s, elementNum, "th element's init_expr opcode of type "_s, typeForInitOpcode.kind, " doesn't match element's type "_s, elementType.kind);
+        WASM_PARSER_FAIL_IF(!isSubtype(typeForInitOpcode, elementType), "Element section's "_s, elementNum, "th element's init_expr opcode of type "_s, typeForInitOpcode.kind(), " doesn't match element's type "_s, elementType.kind());
 
         if (isExtendedConstantExpression)
             initType = Element::InitializationType::FromExtendedExpression;

--- a/Source/JavaScriptCore/wasm/WasmTable.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTable.cpp
@@ -86,7 +86,7 @@ Table::Table(uint32_t initial, std::optional<uint64_t> maximum, Type wasmType, W
     : m_maximum(maximum)
     , m_type(type)
     , m_wasmType(wasmType)
-    , m_wasmTypeRTT(TypeInformation::tryGetRTT(wasmType.index))
+    , m_wasmTypeRTT(TypeInformation::tryGetRTT(wasmType.index()))
     , m_isFixedSized(maximum && maximum.value() == initial)
     , m_addressType(addressType)
     , m_owner(nullptr)

--- a/Source/JavaScriptCore/wasm/WasmTag.h
+++ b/Source/JavaScriptCore/wasm/WasmTag.h
@@ -44,7 +44,7 @@ public:
     {
         size_t result = 0;
         for (size_t i = 0; i < parameterCount(); i ++)
-            result += m_rtt->argumentType(i).kind == TypeKind::V128 ? 2 : 1;
+            result += m_rtt->argumentType(i).kind() == TypeKind::V128 ? 2 : 1;
         return result;
     }
 

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp
@@ -55,7 +55,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(TypeInformation);
 void StorageType::dump(PrintStream& out) const
 {
     if (is<Type>())
-        out.print(makeString(as<Type>().kind));
+        out.print(makeString(as<Type>().kind()));
     else {
         ASSERT(is<PackedType>());
         out.print(makeString(as<PackedType>()));
@@ -173,16 +173,16 @@ void RTT::rewriteInternalRefs(TypeSectionState* state, std::span<const Ref<const
         Type t = slot.type;
         if (!isRefWithTypeIndex(t))
             return;
-        if (t.index == invalidTypeIndex)
+        if (t.index() == invalidTypeIndex)
             return;
         // Placeholder-tagged Projection pointers are emitted by the parser
         // (createPlaceholderProjection in WasmParser.h / WasmSectionParser.cpp)
         // for intra-rec-group refs. Untagged indices are bare RTT* (already
         // canonical) and don't need rewriting.
-        if (!isPlaceholderRef(t.index))
+        if (!isPlaceholderRef(t.index()))
             return;
         ASSERT(!slot.rttAnchor);
-        const Projection* projection = untagProjection(t.index);
+        const Projection* projection = untagProjection(t.index());
         RefPtr<const RTT> canonical = nullptr;
         if (projection->recursionGroup() == recursionGroup) {
             ProjectionIndex pi = projection->projectionIndex();
@@ -199,7 +199,7 @@ void RTT::rewriteInternalRefs(TypeSectionState* state, std::span<const Ref<const
             canonical = projection->rtt();
             RELEASE_ASSERT(canonical);
         }
-        slot.type = Type { t.kind, canonical->asTypeIndex() };
+        slot.type = Type { t.kind(), canonical->asTypeIndex() };
         slot.rttAnchor = WTF::move(canonical);
     });
 }
@@ -239,14 +239,14 @@ void RTT::dump(PrintStream& out) const
         {
             CommaPrinter comma;
             for (FunctionArgCount arg = 0; arg < argumentCount(); ++arg)
-                out.print(comma, makeString(argumentType(arg).kind));
+                out.print(comma, makeString(argumentType(arg).kind()));
         }
         out.print(")"_s);
         out.print(" -> ["_s);
         {
             CommaPrinter comma;
             for (FunctionArgCount ret = 0; ret < returnCount(); ++ret)
-                out.print(comma, makeString(returnType(ret).kind));
+                out.print(comma, makeString(returnType(ret).kind()));
         }
         out.print("]"_s);
         return;
@@ -290,14 +290,14 @@ RefPtr<const RTT> TypeInformation::extractExternalRTT(Type type)
 {
     if (!isRefWithTypeIndex(type))
         return nullptr;
-    if (type.index == invalidTypeIndex)
+    if (type.index() == invalidTypeIndex)
         return nullptr;
     // Placeholder Projection refs are intra-recgroup; they get rewritten to
     // canonical RTT pointers later (rewriteInternalRefs), at which point we
     // anchor them. Skip here.
-    if (isPlaceholderRef(type.index))
+    if (isPlaceholderRef(type.index()))
         return nullptr;
-    return std::bit_cast<const RTT*>(type.index);
+    return std::bit_cast<const RTT*>(type.index());
 }
 
 // Returns a Variant<ProjectionIndex, const RTT*>: the first alternative for
@@ -323,7 +323,7 @@ template<typename IntraLookup>
 inline EncodedRef encodeRef(Type type, IntraLookup&& intra)
 {
     ASSERT(isRefWithTypeIndex(type));
-    return encodeRef(std::bit_cast<const RTT*>(type.index), intra);
+    return encodeRef(std::bit_cast<const RTT*>(type.index()), intra);
 }
 
 // High bit on the ProjectionIndex hash keeps the internal and external hash
@@ -339,25 +339,30 @@ inline unsigned hashEncodedRef(EncodedRef r)
 template<typename IntraLookup>
 inline unsigned hashType(Type type, IntraLookup&& intra)
 {
-    unsigned h = WTF::IntHash<uint8_t>::hash(static_cast<uint8_t>(type.kind));
+    unsigned h = WTF::IntHash<uint8_t>::hash(static_cast<uint8_t>(type.kind()));
     if (isRefWithTypeIndex(type))
         h = WTF::pairIntHash(h, hashEncodedRef(encodeRef(type, intra)));
-    else if (type.index)
-        h = WTF::pairIntHash(h, static_cast<unsigned>(type.index));
+    else if (TypeIndex typeIndex = type.index()) {
+        // Abstract indices put the tag only in high bits; low 32 bits are 0.
+        if (isAbstractTypeIndex(typeIndex))
+            h = WTF::pairIntHash(h, static_cast<unsigned>(static_cast<uint8_t>(static_cast<int8_t>(typeIndexAsTypeKind(typeIndex)))));
+        else
+            h = WTF::pairIntHash(h, static_cast<unsigned>(typeIndex));
+    }
     return h;
 }
 
 template<typename IntraLookupA, typename IntraLookupB>
 inline bool equalTypes(Type a, IntraLookupA&& aIntra, Type b, IntraLookupB&& bIntra)
 {
-    if (a.kind != b.kind)
+    if (a.kind() != b.kind())
         return false;
     if (isRefWithTypeIndex(a)) {
         if (!isRefWithTypeIndex(b))
             return false;
         return encodeRef(a, aIntra) == encodeRef(b, bIntra);
     }
-    return a.index == b.index;
+    return a.index() == b.index();
 }
 
 template<typename IntraLookup>
@@ -622,7 +627,7 @@ bool TypeInformation::isRefWithRecursiveReference(Type type)
     // External (canonical) Type::index values are RTT pointers; they never
     // name a placeholder. Parser-internal placeholder Projections are wrapped
     // in TypeIndex via placeholderRefIndex().
-    return isRefWithTypeIndex(type) && isPlaceholderRef(type.index);
+    return isRefWithTypeIndex(type) && isPlaceholderRef(type.index());
 }
 
 bool TypeInformation::isRefWithRecursiveReference(StorageType storageType)
@@ -654,11 +659,11 @@ Ref<const RTT> TypeInformation::getCanonicalRTT(TypeIndex type)
 // CanonicalHashing/CanonicalEquality).
 //
 // A Type ref inside a member's payload is "internal" iff
-// TypeInformation::get(type.index) is a Projection whose recursionGroup ==
+// TypeInformation::get(type.index()) is a Projection whose recursionGroup ==
 // the candidate's recursionGroup. In that case the ref is hashed/
 // compared by the relative projection index. Otherwise the ref is "external"
 // and is hashed/compared by the canonical RTT pointer obtained from
-// TypeInformation::get(type.index).rtt(). This way, modules that have
+// TypeInformation::get(type.index()).rtt(). This way, modules that have
 // already canonicalized their external dependencies (true once we walk
 // recgroups in their declared order) produce the same key.
 // =====================================================================
@@ -806,8 +811,8 @@ bool TypeInformation::isReferenceValueAssignable(JSValue refValue, bool allowNul
     if (refValue.isNull())
         return allowNull;
 
-    if (typeIndexIsType(typeIndex)) {
-        switch (static_cast<TypeKind>(typeIndex)) {
+    if (isAbstractTypeIndex(typeIndex)) {
+        switch (typeIndexAsTypeKind(typeIndex)) {
         case TypeKind::Externref:
         case TypeKind::Anyref:
             // Casts to these types cannot fail as any value can be an externref/hostref.
@@ -1019,8 +1024,9 @@ bool NODELETE Type::definitelyIsCellOrNull() const
     if (!isRefType(*this))
         return false;
 
-    if (typeIndexIsType(index)) {
-        switch (static_cast<TypeKind>(index)) {
+    TypeIndex typeIndex = index();
+    if (isAbstractTypeIndex(typeIndex)) {
+        switch (typeIndexAsTypeKind(typeIndex)) {
         case TypeKind::Funcref:
         case TypeKind::Arrayref:
         case TypeKind::Structref:
@@ -1038,8 +1044,9 @@ bool Type::definitelyIsWasmGCObjectOrNull() const
     if (!isRefType(*this))
         return false;
 
-    if (typeIndexIsType(index)) {
-        switch (static_cast<TypeKind>(index)) {
+    TypeIndex typeIndex = index();
+    if (isAbstractTypeIndex(typeIndex)) {
+        switch (typeIndexAsTypeKind(typeIndex)) {
         case TypeKind::Arrayref:
         case TypeKind::Structref:
             return true;
@@ -1048,7 +1055,7 @@ bool Type::definitelyIsWasmGCObjectOrNull() const
         }
     }
 
-    if (RefPtr rtt = TypeInformation::tryGetRTT(index))
+    if (RefPtr rtt = TypeInformation::tryGetRTT(typeIndex))
         return rtt->kind() == RTTKind::Struct || rtt->kind() == RTTKind::Array;
 
     return false;
@@ -1056,16 +1063,16 @@ bool Type::definitelyIsWasmGCObjectOrNull() const
 
 void Type::dump(PrintStream& out) const
 {
-    TypeKind kindToPrint = kind;
-    if (index != invalidTypeIndex) {
-        if (typeIndexIsType(index)) {
-            // If the index is negative, it represents a TypeKind.
-            kindToPrint = static_cast<TypeKind>(index);
-        } else if (index & projectionTagBit) {
-            out.print(*untagProjection(index));
+    TypeKind kindToPrint = kind();
+    TypeIndex typeIndex = index();
+    if (typeIndex != invalidTypeIndex) {
+        if (isAbstractTypeIndex(typeIndex)) {
+            kindToPrint = typeIndexAsTypeKind(typeIndex);
+        } else if (typeIndex & projectionTagBit) {
+            out.print(*untagProjection(typeIndex));
             return;
         } else {
-            out.print(*reinterpret_cast<const RTT*>(index));
+            out.print(*reinterpret_cast<const RTT*>(typeIndex));
             return;
         }
     }

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
@@ -288,7 +288,7 @@ using SupertypeCount = uint32_t;
 
 ALWAYS_INLINE Width Type::width() const
 {
-    switch (kind) {
+    switch (kind()) {
 #define CREATE_CASE(name, id, b3type, inc, wasmName, width, ...) case TypeKind::name: return widthForBytes(width / 8);
     FOR_EACH_WASM_TYPE(CREATE_CASE)
 #undef CREATE_CASE
@@ -300,7 +300,7 @@ ALWAYS_INLINE Width Type::width() const
 #define CREATE_CASE(name, id, b3type, ...) case TypeKind::name: return b3type;
 inline B3::Type toB3Type(Type type)
 {
-    switch (type.kind) {
+    switch (type.kind()) {
     FOR_EACH_WASM_TYPE(CREATE_CASE)
     }
     RELEASE_ASSERT_NOT_REACHED();
@@ -396,7 +396,7 @@ public:
     size_t elementSize() const
     {
         if (is<Type>()) {
-            switch (as<Type>().kind) {
+            switch (as<Type>().kind()) {
             case Wasm::TypeKind::I32:
             case Wasm::TypeKind::F32:
                 return sizeof(uint32_t);
@@ -432,14 +432,14 @@ public:
     int8_t typeCode() const
     {
         if (is<Type>())
-            return static_cast<int8_t>(as<Type>().kind);
+            return static_cast<int8_t>(as<Type>().kind());
         return static_cast<int8_t>(as<PackedType>());
     }
 
     TypeIndex index() const
     {
         if (is<Type>())
-            return as<Type>().index;
+            return as<Type>().index();
         return 0;
     }
     void dump(WTF::PrintStream& out) const;
@@ -450,7 +450,7 @@ private:
 
 inline ASCIILiteral makeString(const StorageType& storageType)
 {
-    return(storageType.is<Type>() ? makeString(storageType.as<Type>().kind) :
+    return(storageType.is<Type>() ? makeString(storageType.as<Type>().kind()) :
         makeString(storageType.as<PackedType>()));
 }
 
@@ -466,7 +466,7 @@ inline size_t typeSizeInBytes(const StorageType& storageType)
         }
         }
     }
-    return typeKindSizeInBytes(storageType.as<Type>().kind);
+    return typeKindSizeInBytes(storageType.as<Type>().kind());
 }
 
 inline size_t typeAlignmentInBytes(const StorageType& storageType)

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinitionInlines.h
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinitionInlines.h
@@ -48,7 +48,7 @@ inline TypeInformation& TypeInformation::singleton()
 
 inline RefPtr<const RTT> TypeInformation::tryGetRTT(TypeIndex typeIndex)
 {
-    if (typeIndexIsType(typeIndex) || typeIndex == invalidTypeIndex)
+    if (isAbstractTypeIndex(typeIndex) || typeIndex == invalidTypeIndex)
         return nullptr;
     return std::bit_cast<const RTT*>(typeIndex);
 }

--- a/Source/JavaScriptCore/wasm/WasmTypeSectionState.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTypeSectionState.cpp
@@ -201,8 +201,8 @@ const Projection* TypeSectionState::createPlaceholderProjection(ProjectionIndex 
 
 Type TypeSectionState::substitute(Type type, const RecursionGroup* projectee)
 {
-    if (isRefWithTypeIndex(type) && isPlaceholderRef(type.index)) {
-        const Projection* projection = untagProjection(type.index);
+    if (isRefWithTypeIndex(type) && isPlaceholderRef(type.index())) {
+        const Projection* projection = untagProjection(type.index());
         if (projection->isPlaceholder()) {
             auto* newProjection = createProjection(projectee, projection->projectionIndex());
             TypeKind kind = type.isNullable() ? TypeKind::RefNull : TypeKind::Ref;

--- a/Source/JavaScriptCore/wasm/WasmTypeSectionState.h
+++ b/Source/JavaScriptCore/wasm/WasmTypeSectionState.h
@@ -39,19 +39,13 @@ namespace JSC { namespace Wasm {
 // Subtype/RecursionGroup/Projection are parser-internal classes.
 //
 // TypeIndex (uintptr_t) is overloaded to carry one of:
-//   - Abstract heap type (small negative number representing a TypeKind).
-//   - Bare RTT pointer (untagged, low bits all zero).
-//   - Bare Subtype pointer (tag bit subtypeTagBit set, used in
-//     RecursionGroup::types() to discriminate Subtype members from concrete
-//     RTT members).
-//   - Bare Projection pointer (tag bit projectionTagBit set). Two contexts
-//     use this tag with the same bit: (a) Subtype::superTypes() entries for
-//     intra-rec-group supertype refs, and (b) Type::index values carrying a
-//     placeholder ref during parsing, before rewriteInternalRefs replaces
-//     them with bare canonical RTT*.
+//   - Abstract heap type (64-bit: EnumTaggingTraits on null; 32-bit: negative TypeKind)
+//   - Bare RTT pointer (untagged)
+//   - Bare Subtype pointer (subtypeTagBit), for RecursionGroup::types()
+//   - Bare Projection pointer (projectionTagBit): Subtype::superTypes() intra-group
+//     refs, or Type::index placeholders until rewriteInternalRefs
 //
-// projectionTagBit and subtypeTagBit are independent (different positions);
-// each context knows which (if any) tag may be set on the indices it sees.
+// projectionTagBit / subtypeTagBit are low bits; 64-bit abstract tags use high bits.
 class Subtype;
 class Projection;
 

--- a/Source/JavaScriptCore/wasm/debugger/WasmDebugServerUtilities.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmDebugServerUtilities.cpp
@@ -67,7 +67,7 @@ void logWasmLocalValue(size_t index, const JSC::IPInt::IPIntLocal& local, const 
 {
     dataLog("  Local[", index, "] (", localType, "): ");
 
-    switch (localType.kind) {
+    switch (localType.kind()) {
     case TypeKind::I32:
         dataLogLn("i32=", local.i32, " [index ", index, "]");
         break;

--- a/Source/JavaScriptCore/wasm/debugger/WasmQueryHandler.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmQueryHandler.cpp
@@ -399,7 +399,7 @@ void QueryHandler::handleWasmLocal(StringView packet)
     logWasmLocalValue(localIndex, local, localType);
 
     String response;
-    uint32_t width = typeKindToWidth(localType.kind);
+    uint32_t width = typeKindToWidth(localType.kind());
     switch (width) {
     case 32: {
         response = toNativeEndianHex(local.i32);
@@ -410,12 +410,12 @@ void QueryHandler::handleWasmLocal(StringView packet)
         break;
     }
     case 128: {
-        RELEASE_ASSERT(localType.kind == TypeKind::V128, "Expected V128 for 128-bit type");
+        RELEASE_ASSERT(localType.kind() == TypeKind::V128, "Expected V128 for 128-bit type");
         response = toNativeEndianHex(local.v128);
         break;
     }
     default:
-        RELEASE_ASSERT(false, "Unsupported TypeKind bit size: ", width, " for TypeKind: ", localType.kind);
+        RELEASE_ASSERT(false, "Unsupported TypeKind bit size: ", width, " for TypeKind: ", localType.kind());
         break;
     }
     m_debugServer.sendReply(response);
@@ -467,7 +467,7 @@ void QueryHandler::handleWasmGlobal(StringView packet)
     }
 
     Type globalType = moduleInfo.global(globalIndex).type;
-    uint32_t width = typeKindToWidth(globalType.kind);
+    uint32_t width = typeKindToWidth(globalType.kind());
 
     String response;
     switch (width) {

--- a/Source/JavaScriptCore/wasm/generateWasmOpsHeader.py
+++ b/Source/JavaScriptCore/wasm/generateWasmOpsHeader.py
@@ -236,7 +236,9 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #if ENABLE(WEBASSEMBLY)
 
 #include <cstdint>
+#include <wtf/CompactPointerTuple.h>
 #include <wtf/PrintStream.h>
+#include <wtf/TaggedPtr.h>
 #include <wtf/text/ASCIILiteral.h>
 
 namespace JSC {
@@ -266,24 +268,198 @@ enum class PackedType: int8_t {
 
 using TypeIndex = uintptr_t;
 
-inline bool typeIndexIsType(TypeIndex index)
+#define FOR_EACH_WASM_ABSTRACT_HEAP_TYPE_INDEX_TAG(macro) \\
+    macro(Noexnref) \\
+    macro(Nofuncref) \\
+    macro(Noexternref) \\
+    macro(Noneref) \\
+    macro(Funcref) \\
+    macro(Externref) \\
+    macro(Anyref) \\
+    macro(Eqref) \\
+    macro(I31ref) \\
+    macro(Structref) \\
+    macro(Arrayref) \\
+    macro(Exnref)
+
+enum class TypeIndexTag : uint8_t {
+    Concrete = 0,
+#define CREATE_TYPE_INDEX_TAG(name) name,
+    FOR_EACH_WASM_ABSTRACT_HEAP_TYPE_INDEX_TAG(CREATE_TYPE_INDEX_TAG)
+#undef CREATE_TYPE_INDEX_TAG
+    NumberOfTags,
+};
+
+// EnumTaggingTraits uses 4 high bits on ADDRESS64.
+static_assert(static_cast<unsigned>(TypeIndexTag::NumberOfTags) <= 16);
+
+// Stand-in for EnumTaggingTraits (needs complete type + alignof). alignas(16) matches RTT.
+// Also used as CompactPointerTuple's pointer type for Type's payload (needs allowCompactPointers).
+struct alignas(16) TypeIndexTagStorage {
+    WTF_ALLOW_STRUCT_COMPACT_POINTERS;
+};
+using TypeIndexTaggingTraits = EnumTaggingTraits<TypeIndexTagStorage, TypeIndexTag, TypeIndexTag::Concrete>;
+
+inline TypeIndexTag typeKindToTypeIndexTag(TypeKind kind)
 {
-    auto signedIndex = static_cast<std::make_signed<TypeIndex>::type>(index);
-    return (signedIndex < 0) && (signedIndex > minTypeValue);
+    switch (kind) {
+#define CREATE_CASE(name) case TypeKind::name: return TypeIndexTag::name;
+    FOR_EACH_WASM_ABSTRACT_HEAP_TYPE_INDEX_TAG(CREATE_CASE)
+#undef CREATE_CASE
+    default:
+        RELEASE_ASSERT_NOT_REACHED();
+        return TypeIndexTag::Concrete;
+    }
 }
 
-struct Type {
-    TypeKind kind;
-    TypeIndex index;
-
-    bool operator==(const Type& other) const
-    {
-        return other.kind == kind && other.index == index;
+inline TypeKind typeIndexTagToTypeKind(TypeIndexTag tag)
+{
+    switch (tag) {
+#define CREATE_CASE(name) case TypeIndexTag::name: return TypeKind::name;
+    FOR_EACH_WASM_ABSTRACT_HEAP_TYPE_INDEX_TAG(CREATE_CASE)
+#undef CREATE_CASE
+    case TypeIndexTag::Concrete:
+    case TypeIndexTag::NumberOfTags:
+        RELEASE_ASSERT_NOT_REACHED();
+        return TypeKind::Void;
     }
+    RELEASE_ASSERT_NOT_REACHED();
+    return TypeKind::Void;
+}
+
+inline bool isAbstractHeapTypeKind(TypeKind kind)
+{
+    switch (kind) {
+#define CREATE_CASE(name) case TypeKind::name: return true;
+    FOR_EACH_WASM_ABSTRACT_HEAP_TYPE_INDEX_TAG(CREATE_CASE)
+#undef CREATE_CASE
+    default:
+        return false;
+    }
+}
+
+inline TypeIndex typeIndexFromTypeKind(TypeKind kind)
+{
+    RELEASE_ASSERT(isAbstractHeapTypeKind(kind));
+#if CPU(ADDRESS64)
+    return TypeIndexTaggingTraits::wrap(nullptr, typeKindToTypeIndexTag(kind));
+#else
+    return static_cast<TypeIndex>(kind);
+#endif
+}
+
+inline bool isAbstractTypeIndex(TypeIndex index)
+{
+#if CPU(ADDRESS64)
+    return TypeIndexTaggingTraits::unwrapTag(index) != TypeIndexTag::Concrete;
+#else
+    auto signedIndex = static_cast<std::make_signed_t<TypeIndex>>(index);
+    return (signedIndex < 0) && (signedIndex > minTypeValue);
+#endif
+}
+
+inline TypeKind typeIndexAsTypeKind(TypeIndex index)
+{
+    ASSERT(isAbstractTypeIndex(index));
+#if CPU(ADDRESS64)
+    return typeIndexTagToTypeKind(TypeIndexTaggingTraits::unwrapTag(index));
+#else
+    return static_cast<TypeKind>(index);
+#endif
+}
+
+// CompactPointerTuple packs pointer + uint8 kind bits on ADDRESS64 (one word);
+// on 32-bit it is a real { pointer, type } pair (same API).
+// TypeKind is a signed int8_t enum, so the tag is the uint8_t bit pattern.
+//   Bare kinds — pointer null, tag = TypeKind bits
+//   Concrete ref/ref_null — pointer = TypeIndex (RTT* / parse-time tagged ptr), tag = Ref/RefNull
+//   Abstract ref/ref_null — pointer holds TypeIndexTag (1..NumberOfTags-1), tag = Ref/RefNull
+// Abstract TypeIndex may use EnumTaggingTraits high tags on ADDRESS64 and cannot live in the
+// pointer half as a full tagged index, so abstract heaps store only TypeIndexTag and rebuild
+// in index().
+struct Type {
+    using Payload = CompactPointerTuple<TypeIndexTagStorage*, uint8_t>;
+
+    constexpr Type()
+        : m_data(nullptr, encodeKind(TypeKind::Void))
+    {
+    }
+
+    Type(TypeKind typeKind, TypeIndex typeIndex = 0)
+    {
+        set(typeKind, typeIndex);
+    }
+
+    static constexpr Type fromBareKind(TypeKind typeKind)
+    {
+        return Type { Payload { nullptr, encodeKind(typeKind) } };
+    }
+
+    void set(TypeKind typeKind, TypeIndex typeIndex)
+    {
+        if (typeKind == TypeKind::Ref || typeKind == TypeKind::RefNull) {
+            if (isAbstractTypeIndex(typeIndex)) {
+                auto tag = typeKindToTypeIndexTag(typeIndexAsTypeKind(typeIndex));
+                ASSERT(static_cast<unsigned>(tag) > static_cast<unsigned>(TypeIndexTag::Concrete));
+                ASSERT(static_cast<unsigned>(tag) < static_cast<unsigned>(TypeIndexTag::NumberOfTags));
+                m_data = Payload { std::bit_cast<TypeIndexTagStorage*>(static_cast<uintptr_t>(tag)), encodeKind(typeKind) };
+                return;
+            }
+            m_data = Payload { std::bit_cast<TypeIndexTagStorage*>(typeIndex), encodeKind(typeKind) };
+            return;
+        }
+        ASSERT(!typeIndex);
+        m_data = Payload { nullptr, encodeKind(typeKind) };
+    }
+
+    constexpr TypeKind kind() const { return decodeKind(m_data.type()); }
+
+    constexpr TypeIndex index() const
+    {
+        TypeKind typeKind = kind();
+        if (typeKind != TypeKind::Ref && typeKind != TypeKind::RefNull)
+            return 0;
+
+        // ADDRESS64: data()+mask avoids bit_cast to/from pointers in constexpr.
+        // 32-bit CompactPointerTuple has no packed data(); pointer() is fine.
+#if CPU(ADDRESS64)
+        uintptr_t payload = static_cast<uintptr_t>(m_data.data() & Payload::pointerMask);
+#else
+        uintptr_t payload = std::bit_cast<uintptr_t>(m_data.pointer());
+#endif
+        if (payload && payload < static_cast<uintptr_t>(TypeIndexTag::NumberOfTags))
+            return typeIndexFromTypeKind(typeIndexTagToTypeKind(static_cast<TypeIndexTag>(payload)));
+        return static_cast<TypeIndex>(payload);
+    }
+
+    constexpr bool operator==(const Type& other) const { return m_data == other.m_data; }
+
+private:
+    explicit constexpr Type(Payload data)
+        : m_data(data)
+    {
+    }
+
+    static constexpr uint8_t encodeKind(TypeKind typeKind)
+    {
+        return static_cast<uint8_t>(static_cast<int8_t>(typeKind));
+    }
+
+    static constexpr TypeKind decodeKind(uint8_t bits)
+    {
+        return static_cast<TypeKind>(static_cast<int8_t>(bits));
+    }
+
+    Payload m_data;
+#if CPU(ADDRESS64)
+    static_assert(sizeof(Payload) == sizeof(void*));
+#endif
+public:
 
     bool isNullable() const
     {
-        return kind == TypeKind::RefNull || kind == TypeKind::Externref || kind == TypeKind::Funcref;
+        TypeKind typeKind = kind();
+        return typeKind == TypeKind::RefNull || typeKind == TypeKind::Externref || typeKind == TypeKind::Funcref;
     }
 
     // Saying conservatively.
@@ -295,13 +471,13 @@ struct Type {
 
     // Use Wasm::isFuncref and Wasm::isExternref instead because they check against all kinds of representations of function references and external references.
 
-    #define CREATE_PREDICATE(name, ...) bool is ## name() const { return kind == TypeKind::name; }
+#define CREATE_PREDICATE(name, ...) bool is ## name() const { return kind() == TypeKind::name; }
     FOR_EACH_WASM_TYPE_EXCEPT_FUNCREF_AND_EXTERNREF(CREATE_PREDICATE)
-    #undef CREATE_PREDICATE
+#undef CREATE_PREDICATE
 
     bool isGP64() const
     {
-        switch(kind) {
+        switch (kind()) {
         case TypeKind::I64:
         case TypeKind::Funcref:
         case TypeKind::Exnref:
@@ -315,9 +491,13 @@ struct Type {
     }
 };
 
+#if CPU(ADDRESS64)
+static_assert(sizeof(Type) == sizeof(void*));
+#endif
+
 namespace Types
 {
-#define CREATE_CONSTANT(name, id, ...) constexpr Type name = Type{TypeKind::name, 0u};
+#define CREATE_CONSTANT(name, id, ...) constexpr Type name = Type::fromBareKind(TypeKind::name);
 FOR_EACH_WASM_TYPE(CREATE_CONSTANT)
 #undef CREATE_CONSTANT
 #if USE(JSVALUE64)
@@ -326,6 +506,15 @@ constexpr Type IPtr = I64;
 constexpr Type IPtr = I32;
 #endif
 } // namespace Types
+
+static_assert(Types::I32.kind() == TypeKind::I32);
+static_assert(Types::I32.index() == 0);
+static_assert(Types::Funcref.kind() == TypeKind::Funcref);
+static_assert(Types::Funcref.index() == 0);
+static_assert(Type::fromBareKind(TypeKind::Ref).kind() == TypeKind::Ref);
+static_assert(Type::fromBareKind(TypeKind::Ref).index() == 0);
+static_assert(Type::fromBareKind(TypeKind::RefNull).kind() == TypeKind::RefNull);
+static_assert(Types::Funcref != Type::fromBareKind(TypeKind::RefNull));
 
 #define CREATE_CASE(name, id, ...) case id: return true;
 template <typename Int>

--- a/Source/JavaScriptCore/wasm/js/JSToWasm.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSToWasm.cpp
@@ -47,7 +47,7 @@ static void marshallJSResult(CCallHelpers& jit, const RTT& signature, const Call
 {
     auto boxNativeCalleeResult = [](CCallHelpers& jit, Type type, ValueLocation src, JSValueRegs dst) {
         JIT_COMMENT(jit, "boxNativeCalleeResult ", type);
-        switch (type.kind) {
+        switch (type.kind()) {
         case TypeKind::Void:
             jit.moveTrustedValue(jsUndefined(), dst);
             break;
@@ -125,7 +125,7 @@ static void marshallJSResult(CCallHelpers& jit, const RTT& signature, const Call
                 ASSERT(!loc.isGPR() || savedResultRegisters.find(loc.jsr().payloadGPR())->offset() + 4 == savedResultRegisters.find(loc.jsr().tagGPR())->offset());
 #endif
                 auto address = CCallHelpers::Address(CCallHelpers::stackPointerRegister, wasmFrameConvention.headerAndArgumentStackSizeInBytes);
-                switch (type.kind) {
+                switch (type.kind()) {
                 case TypeKind::F32:
                 case TypeKind::F64:
                     boxNativeCalleeResult(jit, type, loc, scratchJSR);
@@ -144,7 +144,7 @@ static void marshallJSResult(CCallHelpers& jit, const RTT& signature, const Call
                     auto readLocation = CCallHelpers::Address(CCallHelpers::stackPointerRegister, loc.offsetFromSP() + stackResultReadOffset);
                     auto writeLocation = CCallHelpers::Address(CCallHelpers::stackPointerRegister, loc.offsetFromSP());
                     ValueLocation tmp;
-                    switch (type.kind) {
+                    switch (type.kind()) {
                     case TypeKind::F32:
                         tmp = ValueLocation { fprScratch };
                         jit.loadFloat(readLocation, fprScratch);
@@ -167,7 +167,7 @@ static void marshallJSResult(CCallHelpers& jit, const RTT& signature, const Call
                 }
             }
 
-            switch (type.kind) {
+            switch (type.kind()) {
             case TypeKind::I32:
                 indexingType = leastUpperBoundOfIndexingTypes(indexingType, ArrayWithInt32);
                 break;
@@ -637,7 +637,7 @@ CodePtr<JSEntryPtrTag> RTT::jsToWasmICEntrypoint() const
 
         auto type = argumentType(i);
         JIT_COMMENT(jit, "Arg ", i, " : ", type);
-        switch (type.kind) {
+        switch (type.kind()) {
         case Wasm::TypeKind::I32: {
             materializeTagRegistersIfNeeded();
             jit.loadValue(jsParam, scratchJSR);
@@ -684,7 +684,7 @@ CodePtr<JSEntryPtrTag> RTT::jsToWasmICEntrypoint() const
         case Wasm::TypeKind::RefNull:
         case Wasm::TypeKind::Funcref:
         case Wasm::TypeKind::Externref: {
-            if (Wasm::isFuncref(type) || (Wasm::isRefWithTypeIndex(type) && Wasm::TypeInformation::tryGetRTT(type.index) && Wasm::TypeInformation::tryGetRTT(type.index)->kind() == Wasm::RTTKind::Function)) {
+            if (Wasm::isFuncref(type) || (Wasm::isRefWithTypeIndex(type) && Wasm::TypeInformation::tryGetRTT(type.index()) && Wasm::TypeInformation::tryGetRTT(type.index())->kind() == Wasm::RTTKind::Function)) {
                 // Ensure we have a WASM exported function.
                 jit.loadValue(jsParam, scratchJSR);
                 auto isNull = jit.branchIfNull(scratchJSR);
@@ -703,7 +703,7 @@ CodePtr<JSEntryPtrTag> RTT::jsToWasmICEntrypoint() const
 
                 isWasmFunction.link(&jit);
                 if (Wasm::isRefWithTypeIndex(type)) {
-                    auto targetRTT = TypeInformation::getCanonicalRTT(type.index);
+                    auto targetRTT = TypeInformation::getCanonicalRTT(type.index());
                     jit.loadPtr(jsParam, scratchJSR.payloadGPR());
                     jit.loadPtr(CCallHelpers::Address(scratchJSR.payloadGPR(), WebAssemblyFunctionBase::offsetOfRTT()), scratchJSR.payloadGPR());
                     slowPath.append(jit.branchPtr(CCallHelpers::NotEqual, scratchJSR.payloadGPR(), CCallHelpers::TrustedImmPtr(targetRTT.ptr())));

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyArrayInlines.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyArrayInlines.h
@@ -89,7 +89,7 @@ auto JSWebAssemblyArray::visitSpan(auto functor)
 
     // m_element_type must be a type, so we can get its kind
     ASSERT(type.is<Wasm::Type>());
-    switch (type.as<Wasm::Type>().kind) {
+    switch (type.as<Wasm::Type>().kind()) {
     case Wasm::TypeKind::I32:
     case Wasm::TypeKind::F32:
         return functor(span<uint32_t>());
@@ -118,7 +118,7 @@ auto JSWebAssemblyArray::visitSpanNonVector(auto functor)
 
     // m_element_type must be a type, so we can get its kind
     ASSERT(type.is<Wasm::Type>());
-    switch (type.as<Wasm::Type>().kind) {
+    switch (type.as<Wasm::Type>().kind()) {
     case Wasm::TypeKind::I32:
     case Wasm::TypeKind::F32:
         return functor(span<uint32_t>());
@@ -153,7 +153,7 @@ void JSWebAssemblyArray::set(VM& vm, uint32_t index, uint64_t value)
 
 void JSWebAssemblyArray::set(VM&, uint32_t index, v128_t value)
 {
-    ASSERT(elementType().type.as<Wasm::Type>().kind == Wasm::TypeKind::V128);
+    ASSERT(elementType().type.as<Wasm::Type>().kind() == Wasm::TypeKind::V128);
     span<v128_t>()[index] = value;
 }
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyException.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyException.cpp
@@ -73,7 +73,7 @@ void JSWebAssemblyException::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     for (unsigned i = 0; i < tagType.argumentCount(); ++i) {
         if (isRefType(tagType.argumentType(i)))
             visitor.append(std::bit_cast<WriteBarrier<Unknown>>(exception->payload()[offset]));
-        offset += tagType.argumentType(i).kind == Wasm::TypeKind::V128 ? 2 : 1;
+        offset += tagType.argumentType(i).kind() == Wasm::TypeKind::V128 ? 2 : 1;
     }
     visitor.reportExtraMemoryVisited(exception->payload().size());
 }
@@ -93,7 +93,7 @@ JSValue JSWebAssemblyException::getArg(JSGlobalObject* globalObject, unsigned i)
     SUPPRESS_UNCOUNTED_LOCAL const auto& tagType = tag().type();
     ASSERT(i < tagType.argumentCount());
 
-    auto argTypeKind = tagType.argumentType(i).kind;
+    auto argTypeKind = tagType.argumentType(i).kind();
     if (argTypeKind == Wasm::TypeKind::V128 || argTypeKind == Wasm::TypeKind::Exnref) {
         throwTypeError(globalObject, scope, "argument type cannot be a V128 or exnref");
         return { };
@@ -101,7 +101,7 @@ JSValue JSWebAssemblyException::getArg(JSGlobalObject* globalObject, unsigned i)
 
     unsigned offset = 0;
     for (unsigned j = 0; j < i; ++j)
-        offset += tagType.argumentType(j).kind == Wasm::TypeKind::V128 ? 2 : 1;
+        offset += tagType.argumentType(j).kind() == Wasm::TypeKind::V128 ? 2 : 1;
     RELEASE_AND_RETURN(scope, toJSValue(globalObject, tagType.argumentType(i), payload()[offset]));
 }
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyHelpers.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyHelpers.h
@@ -200,7 +200,7 @@ ALWAYS_INLINE JSValue defaultValueForReferenceType(const Wasm::Type type)
 
 ALWAYS_INLINE JSValue toJSValue(JSGlobalObject* globalObject, const Wasm::Type type, uint64_t bits)
 {
-    switch (type.kind) {
+    switch (type.kind()) {
     case Wasm::TypeKind::Void:
         return jsUndefined();
     case Wasm::TypeKind::I32:
@@ -228,7 +228,7 @@ ALWAYS_INLINE uint64_t toWebAssemblyValue(JSGlobalObject* globalObject, const Wa
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    switch (type.kind) {
+    switch (type.kind()) {
     case Wasm::TypeKind::I32:
         RELEASE_AND_RETURN(scope, value.toInt32(globalObject));
     case Wasm::TypeKind::I64:
@@ -260,7 +260,7 @@ ALWAYS_INLINE uint64_t toWebAssemblyValue(JSGlobalObject* globalObject, const Wa
             RELEASE_ASSERT_NOT_REACHED();
         else {
             value = Wasm::internalizeExternref(value);
-            if (!Wasm::TypeInformation::isReferenceValueAssignable(value, type.isNullable(), type.index)) {
+            if (!Wasm::TypeInformation::isReferenceValueAssignable(value, type.isNullable(), type.index())) {
                 // FIXME: provide a better error message here
                 // https://bugs.webkit.org/show_bug.cgi?id=247746
                 return throwVMTypeError(globalObject, scope, "Argument value did not match the reference type"_s);

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp
@@ -83,7 +83,7 @@ uint64_t JSWebAssemblyStruct::get(uint32_t fieldIndex) const
     }
     ASSERT(fieldType(fieldIndex).type.is<Wasm::Type>());
 
-    switch (fieldType(fieldIndex).type.as<Wasm::Type>().kind) {
+    switch (fieldType(fieldIndex).type.as<Wasm::Type>().kind()) {
     case TypeKind::I32:
     case TypeKind::F32:
         return *std::bit_cast<uint32_t*>(targetPointer);
@@ -130,7 +130,7 @@ void JSWebAssemblyStruct::set(uint32_t fieldIndex, uint64_t argument)
     }
     ASSERT(fieldType(fieldIndex).type.is<Wasm::Type>());
 
-    switch (fieldType(fieldIndex).type.as<Wasm::Type>().kind) {
+    switch (fieldType(fieldIndex).type.as<Wasm::Type>().kind()) {
     case TypeKind::I32:
     case TypeKind::F32: {
         *std::bit_cast<uint32_t*>(targetPointer) = static_cast<uint32_t>(argument);
@@ -177,7 +177,7 @@ void JSWebAssemblyStruct::set(uint32_t fieldIndex, v128_t argument)
 {
     uint8_t* targetPointer = fieldPointer(fieldIndex);
     ASSERT(fieldType(fieldIndex).type.is<Wasm::Type>());
-    ASSERT(fieldType(fieldIndex).type.as<Wasm::Type>().kind == Wasm::TypeKind::V128);
+    ASSERT(fieldType(fieldIndex).type.as<Wasm::Type>().kind() == Wasm::TypeKind::V128);
     *std::bit_cast<v128_t*>(targetPointer) = argument;
 }
 

--- a/Source/JavaScriptCore/wasm/js/WasmToJS.cpp
+++ b/Source/JavaScriptCore/wasm/js/WasmToJS.cpp
@@ -144,7 +144,7 @@ Expected<MacroAssemblerCodeRef<WasmEntryPtrTag>, BindingFailure> wasmToJS(const 
         unsigned frOffset = CallFrameSlot::firstArgument * static_cast<int>(sizeof(Register));
         for (unsigned argNum = 0; argNum < argCount; ++argNum) {
             Type argType = signature.argumentType(argNum);
-            switch (argType.kind) {
+            switch (argType.kind()) {
             case TypeKind::Void:
             case TypeKind::Func:
             case TypeKind::Struct:
@@ -240,7 +240,7 @@ Expected<MacroAssemblerCodeRef<WasmEntryPtrTag>, BindingFailure> wasmToJS(const 
 
         for (unsigned argNum = 0; argNum < argCount; ++argNum) {
             Type argType = signature.argumentType(argNum);
-            switch (argType.kind) {
+            switch (argType.kind()) {
             case TypeKind::Void:
             case TypeKind::Func:
             case TypeKind::Struct:
@@ -350,7 +350,7 @@ Expected<MacroAssemblerCodeRef<WasmEntryPtrTag>, BindingFailure> wasmToJS(const 
 
     if (signature.returnCount() == 1) {
         const auto& returnType = signature.returnType(0);
-        switch (returnType.kind) {
+        switch (returnType.kind()) {
         case TypeKind::I64: {
             // FIXME: Optimize I64 extraction from BigInt.
             // https://bugs.webkit.org/show_bug.cgi?id=220053

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyBuiltin.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyBuiltin.cpp
@@ -159,7 +159,7 @@ bool WebAssemblyArrayMutI16TypeExpectation::isValid(const Wasm::Type& type) cons
 {
     if (!type.isRefNull())
         return false;
-    RefPtr referentRTT = Wasm::TypeInformation::tryGetRTT(type.index);
+    RefPtr referentRTT = Wasm::TypeInformation::tryGetRTT(type.index());
     if (!referentRTT || referentRTT->kind() != Wasm::RTTKind::Array)
         return false;
     Wasm::FieldType elementType = referentRTT->elementType();

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyExceptionConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyExceptionConstructor.cpp
@@ -74,7 +74,7 @@ JSC_DEFINE_HOST_FUNCTION(constructJSWebAssemblyException, (JSGlobalObject* globa
     FixedVector<uint64_t> payload(values.size());
     for (unsigned i = 0; i < values.size(); ++i) {
         auto type = tagFunctionType.argumentType(i);
-        if (type.kind == Wasm::TypeKind::V128 || isExnref(type)) [[unlikely]]
+        if (type.kind() == Wasm::TypeKind::V128 || isExnref(type)) [[unlikely]]
             return throwVMTypeError(globalObject, scope, "WebAssembly.Exception constructor expects payload includes neither v128 nor exnref."_s);
         payload[i] = toWebAssemblyValue(globalObject, type, values.at(i));
         RETURN_IF_EXCEPTION(scope, { });

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyGlobalConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyGlobalConstructor.cpp
@@ -97,7 +97,7 @@ JSC_DEFINE_HOST_FUNCTION(constructJSWebAssemblyGlobal, (JSGlobalObject* globalOb
 
     uint64_t initialValue = 0;
     JSValue argument = callFrame->argument(1);
-    switch (type.kind) {
+    switch (type.kind()) {
     case Wasm::TypeKind::I32: {
         if (!argument.isUndefined()) {
             int32_t value = argument.toInt32(globalObject);

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
@@ -308,7 +308,7 @@ void WebAssemblyModuleRecord::initializeImports(JSGlobalObject* globalObject, JS
                     if (globalValue->global()->mutability() != Wasm::Immutable)
                         return exception(createJSWebAssemblyLinkError(globalObject, vm, importFailMessage(import, "imported global"_s, "must be a same mutability"_s)));
                     const auto& declaredGlobalType = moduleInformation.globals[import.kindIndex].type;
-                    switch (declaredGlobalType.kind) {
+                    switch (declaredGlobalType.kind()) {
                     case Wasm::TypeKind::I32:
                     case Wasm::TypeKind::I64:
                     case Wasm::TypeKind::F32:
@@ -336,7 +336,7 @@ void WebAssemblyModuleRecord::initializeImports(JSGlobalObject* globalObject, JS
                             }
 
                             if (Wasm::isRefWithTypeIndex(declaredGlobalType) && !value.isNull()) {
-                                Wasm::TypeIndex paramIndex = global.type.index;
+                                Wasm::TypeIndex paramIndex = global.type.index();
                                 Wasm::TypeIndex argIndex = (wasmFunction ? wasmFunction->rtt() : wasmWrapperFunction->rtt())->asTypeIndex();
                                 if (paramIndex != argIndex)
                                     return exception(createJSWebAssemblyLinkError(globalObject, vm, importFailMessage(import, "imported global"_s, "Argument value did not match the reference type"_s)));
@@ -349,7 +349,7 @@ void WebAssemblyModuleRecord::initializeImports(JSGlobalObject* globalObject, JS
                             auto global = globalValue->global()->get(globalObject);
                             RETURN_IF_EXCEPTION(scope, void());
                             value = Wasm::internalizeExternref(global);
-                            if (!Wasm::TypeInformation::isReferenceValueAssignable(value, declaredGlobalType.isNullable(), declaredGlobalType.index))
+                            if (!Wasm::TypeInformation::isReferenceValueAssignable(value, declaredGlobalType.isNullable(), declaredGlobalType.index()))
                                 return exception(createJSWebAssemblyLinkError(globalObject, vm, importFailMessage(import, "imported global"_s, "Argument value did not match the reference type"_s)));
                             m_instance->setGlobal(import.kindIndex, value);
                         }
@@ -368,7 +368,7 @@ void WebAssemblyModuleRecord::initializeImports(JSGlobalObject* globalObject, JS
                     }
 
                     // iii. Append ToWebAssemblyValue(v) to imports.
-                    switch (globalType.kind) {
+                    switch (globalType.kind()) {
                     case Wasm::TypeKind::I32:
                         m_instance->setGlobal(import.kindIndex, value.toInt32(globalObject));
                         break;
@@ -401,7 +401,7 @@ void WebAssemblyModuleRecord::initializeImports(JSGlobalObject* globalObject, JS
                             }
 
                             if (Wasm::isRefWithTypeIndex(globalType) && !value.isNull()) {
-                                Wasm::TypeIndex paramIndex = global.type.index;
+                                Wasm::TypeIndex paramIndex = global.type.index();
                                 Wasm::TypeIndex argIndex = (wasmFunction ? wasmFunction->rtt() : wasmWrapperFunction->rtt())->asTypeIndex();
                                 if (paramIndex != argIndex)
                                     return exception(createJSWebAssemblyLinkError(globalObject, vm, importFailMessage(import, "imported global"_s, "Argument value did not match the reference type"_s)));
@@ -412,7 +412,7 @@ void WebAssemblyModuleRecord::initializeImports(JSGlobalObject* globalObject, JS
                             return exception(createJSWebAssemblyLinkError(globalObject, vm, importFailMessage(import, "imported global"_s, "cannot be exnref"_s)));
                         else {
                             value = Wasm::internalizeExternref(value);
-                            if (!Wasm::TypeInformation::isReferenceValueAssignable(value, global.type.isNullable(), global.type.index))
+                            if (!Wasm::TypeInformation::isReferenceValueAssignable(value, global.type.isNullable(), global.type.index()))
                                 return exception(createJSWebAssemblyLinkError(globalObject, vm, importFailMessage(import, "imported global"_s, "Argument value did not match the reference type"_s)));
                             m_instance->setGlobal(import.kindIndex, value);
                         }
@@ -710,7 +710,7 @@ void WebAssemblyModuleRecord::initializeExports(JSGlobalObject* globalObject)
         }
         case Wasm::ExternalKind::Global: {
             const Wasm::GlobalInformation& global = moduleInformation.globals[exp.kindIndex];
-            switch (global.type.kind) {
+            switch (global.type.kind()) {
             case Wasm::TypeKind::Externref:
             case Wasm::TypeKind::Funcref:
             case Wasm::TypeKind::Ref:
@@ -724,7 +724,7 @@ void WebAssemblyModuleRecord::initializeExports(JSGlobalObject* globalObject)
                 // But we need to create a binding just to export it. This binding is not actually connected. But this is OK since it is immutable.
                 if (global.bindingMode == Wasm::GlobalInformation::BindingMode::EmbeddedInInstance) {
                     RefPtr<Wasm::Global> globalRef;
-                    if (global.type.kind == Wasm::TypeKind::V128) {
+                    if (global.type.kind() == Wasm::TypeKind::V128) {
                         v128_t initialValue = m_instance->loadV128Global(exp.kindIndex);
                         globalRef = Wasm::Global::create(global.type, global.mutability, initialValue);
                     } else {

--- a/Source/WTF/wtf/CompactPointerTuple.h
+++ b/Source/WTF/wtf/CompactPointerTuple.h
@@ -70,7 +70,7 @@ public:
 
     static constexpr uint64_t pointerMask = (1ULL << maxNumberOfBitsInPointer) - 1;
 
-    CompactPointerTuple(PointerType pointer, Type type)
+    constexpr CompactPointerTuple(PointerType pointer, Type type)
         : m_data(encode(pointer, type))
     {
         ASSERT(this->type() == type);
@@ -84,21 +84,29 @@ public:
     {
     }
 
-    PointerType pointer() const { return std::bit_cast<PointerType>(m_data & pointerMask); }
+    constexpr PointerType pointer() const
+    {
+        // bit_cast to a pointer type is not allowed in constant expressions.
+        if (std::is_constant_evaluated()) {
+            ASSERT_UNDER_CONSTEXPR_CONTEXT(!(m_data & pointerMask));
+            return nullptr;
+        }
+        return std::bit_cast<PointerType>(m_data & pointerMask);
+    }
     void setPointer(PointerType pointer)
     {
         m_data = encode(pointer, type());
         ASSERT(this->pointer() == pointer);
     }
 
-    Type type() const { return decodeType(m_data); }
+    constexpr Type type() const { return decodeType(m_data); }
     void setType(Type type)
     {
         m_data = encode(pointer(), type);
         ASSERT(this->type() == type);
     }
 
-    uint64_t data() const { return m_data; }
+    constexpr uint64_t data() const { return m_data; }
 
     void swap(CompactPointerTuple& other)
     {
@@ -115,15 +123,21 @@ private:
         return static_cast<Type>(static_cast<UnsignedType>(value >> maxNumberOfBitsInPointer));
     }
 
-    static uint64_t encode(PointerType pointer, Type type)
+    static constexpr uint64_t encode(PointerType pointer, Type type)
     {
+        // bit_cast from a pointer type is not allowed in constant expressions.
+        // Constexpr construction is limited to a null pointer (pointer bits 0).
+        if (std::is_constant_evaluated()) {
+            ASSERT_UNDER_CONSTEXPR_CONTEXT(!pointer);
+            return encodeType(type);
+        }
         return std::bit_cast<uint64_t>(pointer) | encodeType(type);
     }
 
     uint64_t m_data { 0 };
 #else
 public:
-    CompactPointerTuple(PointerType pointer, Type type)
+    constexpr CompactPointerTuple(PointerType pointer, Type type)
         : m_pointer(pointer)
         , m_type(type)
     {
@@ -137,9 +151,9 @@ public:
     {
     }
 
-    PointerType pointer() const { return m_pointer; }
+    constexpr PointerType pointer() const { return m_pointer; }
     void setPointer(PointerType pointer) { m_pointer = pointer; }
-    Type type() const { return m_type; }
+    constexpr Type type() const { return m_type; }
     void setType(Type type) { m_type = type; }
 
     void swap(CompactPointerTuple& other)


### PR DESCRIPTION
#### f66c3804ee6c2efbaf23130a1a282fa345f299cd
<pre>
[JSC][Wasm] Shrink Type to a pointer-sized payload on 64-bit
<a href="https://bugs.webkit.org/show_bug.cgi?id=247454">https://bugs.webkit.org/show_bug.cgi?id=247454</a>

Reviewed by Yusuke Suzuki.

On ADDRESS64, store Wasm::Type in one pointer-sized word with
CompactPointerTuple (pointer half + TypeKind bits as the tag). Use the same
Type API on 32-bit where CompactPointerTuple is a real pointer+tag pair.
Bare kinds use a null pointer; concrete ref/ref_null store a TypeIndex;
abstract heap types store a small TypeIndexTag and rebuild the TypeIndex
in index().

EnumTaggingTraits remains for standalone abstract TypeIndex tags on
ADDRESS64. CompactPointerTuple constexpr paths assert a null pointer so
they cannot silently drop a non-null payload.

Access via kind() / index() / set(). Call sites that used .kind / .index
fields are updated to methods.

* Source/WTF/wtf/CompactPointerTuple.h:
* Source/JavaScriptCore/wasm/generateWasmOpsHeader.py:
* Source/JavaScriptCore/wasm/WasmFormat.h:
* Source/JavaScriptCore/wasm/WasmFormat.cpp:
* Source/JavaScriptCore/wasm/WasmTypeDefinition.h:
* Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp:
* Source/JavaScriptCore/wasm/WasmTypeDefinitionInlines.h:
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
* Source/JavaScriptCore/wasm/WasmSectionParser.cpp:
* Source/JavaScriptCore/wasm/WasmParser.h:
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
* Source/JavaScriptCore/wasm/WasmBBQJIT.h:
* Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp:
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
* Source/JavaScriptCore/wasm/WasmOperationsInlines.h:
* Source/JavaScriptCore/wasm/WasmCallingConvention.h:
* Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp:
* Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp:
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp:
* Source/JavaScriptCore/wasm/WasmGlobal.cpp:
* Source/JavaScriptCore/wasm/WasmGlobal.h:
* Source/JavaScriptCore/wasm/WasmTable.cpp:
* Source/JavaScriptCore/wasm/WasmTag.h:
* Source/JavaScriptCore/wasm/WasmTypeSectionState.cpp:
* Source/JavaScriptCore/wasm/WasmTypeSectionState.h:
* Source/JavaScriptCore/wasm/debugger/WasmDebugServerUtilities.cpp:
* Source/JavaScriptCore/wasm/debugger/WasmQueryHandler.cpp:
* Source/JavaScriptCore/wasm/js/JSToWasm.cpp:
* Source/JavaScriptCore/wasm/js/WasmToJS.cpp:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyArrayInlines.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyException.cpp:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyHelpers.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp:
* Source/JavaScriptCore/wasm/js/WebAssemblyBuiltin.cpp:
* Source/JavaScriptCore/wasm/js/WebAssemblyExceptionConstructor.cpp:
* Source/JavaScriptCore/wasm/js/WebAssemblyGlobalConstructor.cpp:
* Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp:
* Source/JavaScriptCore/b3/B3LowerMacros.cpp:
* Source/JavaScriptCore/b3/B3ReduceStrength.cpp:
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
* Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
* JSTests/wasm/stress/type-index-abstract-heap-types.js: Added.

Canonical link: <a href="https://commits.webkit.org/317748@main">https://commits.webkit.org/317748@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/279f7d26c9e137023c04641a013c45bc66bd5c1c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176053 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49986 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43770 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185667 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51278 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49668 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137134 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179009 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40589 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157890 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117609 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39238 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37604 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/6399 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149654 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37389 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34116 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/37317 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41705 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41815 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188069 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49653 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146128 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50334 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34005 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145951 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26768 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40733 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122542 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/116445 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48840 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12357 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48242 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48474 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48299 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->