### PR TITLE
Cherry-pick 315752@main (cffe1bb49663). https://bugs.webkit.org/show_bug.cgi?id=317618

### DIFF
--- a/JSTests/stress/array-prototype-flat-reentrant-mutation.js
+++ b/JSTests/stress/array-prototype-flat-reentrant-mutation.js
@@ -1,0 +1,16 @@
+//@ skip if $addressBits <= 32
+//@ runDefault
+//@ memoryHog!
+
+try {
+    let iterations = 0;
+    const array = [-1, undefined, undefined];
+    array[Symbol.iterator] = function* () {
+        for (const _ of Array.prototype[Symbol.iterator].call(this)) {
+            if (++iterations > 28)
+                return;
+            this.push(Array.prototype.flat.call(array, 1 << 30));
+        }
+    };
+    [...array];
+} catch (e) { }

--- a/LayoutTests/fast/dom/MutationObserver/no-document-leak-expected.txt
+++ b/LayoutTests/fast/dom/MutationObserver/no-document-leak-expected.txt
@@ -1,0 +1,10 @@
+Tests that a MutationObserver with a pending mutation record does not leak its document when the document is stopped (e.g. its frame is removed).
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Document did not leak
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/dom/MutationObserver/no-document-leak.html
+++ b/LayoutTests/fast/dom/MutationObserver/no-document-leak.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/gc.js"></script>
+<script>
+description("Tests that a MutationObserver with a pending mutation record does not leak its document when the document is stopped (e.g. its frame is removed).");
+
+if (window.internals) {
+    jsTestIsAsync = true;
+
+    window.onload = function () {
+        testDocumentIsNotLeaked(
+            async function initAndRemove(frameCount)
+            {
+                let frames = await new Promise((resolve, reject) => {
+                    let frames = [];
+                    let counter = 0;
+                    function onLoad() {
+                        counter++;
+                        if (counter == frameCount)
+                            resolve(frames);
+                    }
+                    for (let i = 0; i < frameCount; ++i) {
+                        let frame = document.createElement('iframe');
+                        frame.src = "resources/no-document-leak-frame.html";
+                        frame.onload = onLoad;
+                        document.body.appendChild(frame);
+                        frames.push(frame);
+                    }
+                });
+                let frameIdentifiers = [];
+                for (let i = 0; i < frameCount; ++i) {
+                    let frame = frames[i];
+                    frameIdentifiers.push(internals.documentIdentifier(frame.contentDocument));
+                    let frameTarget = frame.contentDocument.getElementById("target");
+                    frameTarget.setAttribute("data-x", String(i));
+                    frame.remove();
+                }
+                nukeArray(frames);
+                frames = null;
+                return frameIdentifiers;
+            },
+            {
+                documentCount: 100
+            }
+        ).then(
+            () => testPassed("Document did not leak"),
+            (error) => testFailed(error.message)
+        ).finally(finishJSTest);
+    };
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/dom/MutationObserver/resources/no-document-leak-frame.html
+++ b/LayoutTests/fast/dom/MutationObserver/resources/no-document-leak-frame.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<div id="target"></div>
+
+<script>
+var target = document.getElementById("target");
+var observer = new MutationObserver(function() { });
+observer.observe(target, { attributes: true, childList: true, characterData: true, subtree: true });
+</script>

--- a/LayoutTests/http/wpt/webcodecs/frame-clone-and-convert-expected.txt
+++ b/LayoutTests/http/wpt/webcodecs/frame-clone-and-convert-expected.txt
@@ -1,0 +1,3 @@
+
+PASS frame-clone-and-convert
+

--- a/LayoutTests/http/wpt/webcodecs/frame-clone-and-convert.html
+++ b/LayoutTests/http/wpt/webcodecs/frame-clone-and-convert.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+const WIDTH = 320, HEIGHT = 240;
+const MAX_ITERATIONS = 3000;
+
+async function getVP8Keyframe(w, h) {
+    return new Promise((resolve, reject) => {
+        const chunks = [];
+        const enc = new VideoEncoder({
+            output: (chunk) => chunks.push(chunk),
+            error: reject
+        });
+        enc.configure({
+            codec: 'vp8',
+            width: w,
+            height: h,
+            bitrate: 500000,
+            framerate: 30
+        });
+
+        const canvas = new OffscreenCanvas(w, h);
+        const ctx = canvas.getContext('2d');
+        // Draw some content so it's a real frame
+        ctx.fillStyle = '#336699';
+        ctx.fillRect(0, 0, w, h);
+        ctx.fillStyle = '#FF0000';
+        ctx.fillRect(10, 10, 50, 50);
+        const bitmap = canvas.transferToImageBitmap();
+        const vf = new VideoFrame(bitmap, { timestamp: 0 });
+        enc.encode(vf, { keyFrame: true });
+        vf.close();
+        bitmap.close();
+
+        enc.flush().then(() => {
+            enc.close();
+            if (!chunks.length) { reject(new Error('No encoded chunks')); return; }
+            const buf = new ArrayBuffer(chunks[0].byteLength);
+            chunks[0].copyTo(buf);
+            resolve(buf);
+        }).catch(reject);
+    });
+}
+
+async function getVideoFrame(test)
+{
+    const vp8Data = await getVP8Keyframe(WIDTH, HEIGHT);
+    let resolveCallback;
+    const promise = new Promise((resolve, reject)  => {
+        resolveCallback = resolve;
+        test.step_timeout(() => reject("decoding timed out"), 5000);
+    });
+    const raceDecoder = new VideoDecoder({
+        output: frame => resolveCallback(frame),
+        error: (e) => {}
+    });
+    raceDecoder.configure({ codec: 'vp8' });
+    raceDecoder.decode(new EncodedVideoChunk({
+        type: 'key',
+        timestamp: 0,
+        data: vp8Data
+    }));
+
+    return promise;
+}
+
+promise_test(async t => {
+    let shouldDelay = false;
+    for (let i = 0; i < 10; ++i) {
+        const frame = await getVideoFrame(t);
+        t.add_cleanup(() => frame.close());
+
+        const raceEncoder = new VideoEncoder({
+            output: () => {},
+            error: (e) => {}
+        });
+        raceEncoder.configure({
+            codec: 'vp8',
+            width: WIDTH,
+            height: HEIGHT,
+            bitrate: 500000,
+            framerate: 30
+        });
+
+        const encodeCloneEncoder = new VideoEncoder({
+            output: () => {},
+            error: (e) => {}
+        });
+        encodeCloneEncoder.configure({
+            codec: 'vp8',
+            width: WIDTH,
+            height: HEIGHT,
+            bitrate: 500000,
+            framerate: 30
+        });
+
+        raceEncoder.encode(frame, { keyFrame: true });
+        if (shouldDelay)
+            await new Promise(resolve => t.step_timeout(resolve, 1));
+        shouldDelay = !shouldDelay;
+
+        const frameClone = new VideoFrame(frame, { timestamp: 1000 });
+        t.add_cleanup(() => frameClone.close());
+
+        encodeCloneEncoder.encode(frameClone, { keyFrame: true });
+    }
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/multiline-last-baseline-item-count-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/multiline-last-baseline-item-count-expected.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Flexbox Reference: last baseline of a multi-line flex container comes from its last line</title>
+<link rel="author" title="Ahmad Saleem" href="mailto:ahmad.saleem792@gmail.com">
+<style>
+body { margin: 0; }
+.outer {
+    display: flex;
+    align-items: last baseline;
+    font: 16px/30px monospace;
+}
+.flex {
+    display: flex;
+    flex-wrap: wrap;
+    width: 100px;
+}
+.flex > div {
+    width: 45px;
+    height: 30px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if "Ref" shares a baseline with "C" (the bottom row), not "B".</p>
+<div class="outer">
+    <div class="flex">
+        <div>A</div>
+        <div>B</div>
+        <div>C</div>
+    </div>
+    <div>Ref</div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/multiline-last-baseline-item-count-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/multiline-last-baseline-item-count-ref.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Flexbox Reference: last baseline of a multi-line flex container comes from its last line</title>
+<link rel="author" title="Ahmad Saleem" href="mailto:ahmad.saleem792@gmail.com">
+<style>
+body { margin: 0; }
+.outer {
+    display: flex;
+    align-items: last baseline;
+    font: 16px/30px monospace;
+}
+.flex {
+    display: flex;
+    flex-wrap: wrap;
+    width: 100px;
+}
+.flex > div {
+    width: 45px;
+    height: 30px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if "Ref" shares a baseline with "C" (the bottom row), not "B".</p>
+<div class="outer">
+    <div class="flex">
+        <div>A</div>
+        <div>B</div>
+        <div>C</div>
+    </div>
+    <div>Ref</div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/multiline-last-baseline-item-count.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/multiline-last-baseline-item-count.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Flexbox: last baseline of a multi-line flex container comes from its last line</title>
+<link rel="author" title="Ahmad Saleem" href="mailto:ahmad.saleem792@gmail.com">
+<link rel="help" href="https://www.w3.org/TR/css-flexbox-1/#flex-baselines">
+<link rel="help" href="https://www.w3.org/TR/css-align-3/#baseline-values">
+<link rel="match" href="multiline-last-baseline-item-count-ref.html">
+<meta name="assert" content="When the first and last lines of a wrapping flex container have a different number of items, the container's last baseline is taken from an item on the last line, even if an earlier line has a baseline-aligned item.">
+<style>
+body { margin: 0; }
+.outer {
+    display: flex;
+    align-items: last baseline;
+    font: 16px/30px monospace;
+}
+.flex {
+    display: flex;
+    flex-wrap: wrap;
+    width: 100px;
+}
+.flex > div {
+    width: 45px;
+    height: 30px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if "Ref" shares a baseline with "C" (the bottom row), not "B".</p>
+<div class="outer">
+    <div class="flex">
+        <div>A</div>
+        <div style="align-self: baseline">B</div>
+        <div>C</div>
+    </div>
+    <div>Ref</div>
+</div>
+</body>
+</html>

--- a/Source/JavaScriptCore/runtime/JSArray.cpp
+++ b/Source/JavaScriptCore/runtime/JSArray.cpp
@@ -2413,6 +2413,8 @@ JSArray* JSArray::fastFlat(JSGlobalObject* globalObject, uint64_t depth, uint64_
         RETURN_IF_EXCEPTION(scope, nullptr);
         if (flattenedLength == std::numeric_limits<uint64_t>::max()) [[unlikely]]
             return nullptr;
+        if (flattenedLength > MAX_STORAGE_VECTOR_LENGTH) [[unlikely]]
+            return nullptr;
 
         Structure* resultStructure = globalObject->arrayStructureForIndexingTypeDuringAllocation(sourceType);
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -3839,6 +3839,9 @@ void Document::stopActiveDOMObjects()
     ScriptExecutionContext::stopActiveDOMObjects();
     platformSuspendOrStopActiveDOMObjects();
 
+    if (RefPtr eventLoop = m_eventLoop)
+        eventLoop->removeMutationObserversForContext(*this);
+
     // https://www.w3.org/TR/screen-wake-lock/#handling-document-loss-of-full-activity
     if (m_wakeLockManager)
         m_wakeLockManager->releaseAllLocks(WakeLockType::Screen);

--- a/Source/WebCore/dom/WindowEventLoop.cpp
+++ b/Source/WebCore/dom/WindowEventLoop.cpp
@@ -27,12 +27,15 @@
 #include "WindowEventLoop.h"
 
 #include "CommonVM.h"
+#include "ContextDestructionObserverInlines.h"
 #include "CustomElementReactionQueue.h"
 #include "DocumentPage.h"
 #include "HTMLSlotElement.h"
 #include "IdleCallbackController.h"
 #include "Microtasks.h"
+#include "MutationCallback.h"
 #include "MutationObserver.h"
+#include "NodeDocument.h"
 #include "OpportunisticTaskScheduler.h"
 #include "SecurityOrigin.h"
 #include "ThreadGlobalData.h"
@@ -259,6 +262,31 @@ void WindowEventLoop::queueMutationObserverCompoundMicrotask()
         protectedThis->m_deliveringMutationRecords = true;
         MutationObserver::notifyMutationObservers(*protectedThis);
         protectedThis->m_deliveringMutationRecords = false;
+    });
+}
+
+void WindowEventLoop::removeMutationObserversForContext(ScriptExecutionContext& context)
+{
+    if (m_activeObservers.isEmpty() && m_suspendedObservers.isEmpty() && m_signalSlotList.isEmpty())
+        return;
+
+    auto disconnectMatching = [&](HashSet<Ref<MutationObserver>>& observers) {
+        observers.removeIf([&](auto& observer) {
+            auto* observerContext = observer->callback().scriptExecutionContext();
+            if (observerContext && observerContext != &context)
+                return false;
+            observer->disconnect();
+            return true;
+        });
+    };
+    disconnectMatching(m_activeObservers);
+    disconnectMatching(m_suspendedObservers);
+
+    m_signalSlotList.removeAllMatching([&](auto& slot) {
+        if (&slot->document() != &context)
+            return false;
+        slot->didRemoveFromSignalSlotList();
+        return true;
     });
 }
 

--- a/Source/WebCore/dom/WindowEventLoop.h
+++ b/Source/WebCore/dom/WindowEventLoop.h
@@ -41,6 +41,7 @@ class Document;
 class HTMLSlotElement;
 class MutationObserver;
 class Page;
+class ScriptExecutionContext;
 class SecurityOrigin;
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#window-event-loop
@@ -57,6 +58,7 @@ public:
     Vector<GCReachableRef<Element>>& shadowRootAttachedElements() { return m_shadowRootAttachedElementList; }
     HashSet<Ref<MutationObserver>>& activeMutationObservers() { return m_activeObservers; }
     HashSet<Ref<MutationObserver>>& suspendedMutationObservers() { return m_suspendedObservers; }
+    void removeMutationObserversForContext(ScriptExecutionContext&);
 
     CustomElementQueue& backupElementQueue();
 

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -3388,10 +3388,9 @@ void LocalFrameView::textFragmentIndicatorTimerFired()
     if (!m_pendingTextFragmentIndicatorRange)
         return;
     
-    if (m_pendingTextFragmentIndicatorText != plainText(m_pendingTextFragmentIndicatorRange.value()))
-        return;
-    
     auto range = m_pendingTextFragmentIndicatorRange.value();
+    if (m_pendingTextFragmentIndicatorText != plainText(range))
+        return;
 
     // FIXME: <http://webkit.org/b/245262> (Scroll To Text Fragment should use DelegateMainFrameScroll)
     auto selectionChange = revealRangeWithTemporarySelection(range);

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -570,6 +570,9 @@ ExceptionOr<void> Navigation::updateCurrentEntry(UpdateCurrentEntryOptions&& opt
 bool Navigation::hasEntriesAndEventsDisabled() const
 {
     RefPtr window = this->window();
+    if (!window)
+        return true;
+
     RefPtr document = window->document();
     if (!document || !document->isFullyActive())
         return true;

--- a/Source/WebCore/page/ResourceUsageThread.cpp
+++ b/Source/WebCore/page/ResourceUsageThread.cpp
@@ -105,10 +105,12 @@ void ResourceUsageThread::notifyObservers(ResourceUsageData&& data)
 
 void ResourceUsageThread::recomputeCollectionMode()
 {
-    m_collectionMode = None;
+    ResourceUsageCollectionMode mode = None;
 
     for (auto& pair : m_observers.values())
-        m_collectionMode = static_cast<ResourceUsageCollectionMode>(m_collectionMode | pair.first);
+        mode = static_cast<ResourceUsageCollectionMode>(mode | pair.first);
+
+    m_collectionMode = mode;
 }
 
 void ResourceUsageThread::createThreadIfNeeded()
@@ -134,7 +136,11 @@ void ResourceUsageThread::createThreadIfNeeded()
         auto start = WallTime::now();
 
         ResourceUsageData data;
-        ResourceUsageCollectionMode mode = m_collectionMode;
+        ResourceUsageCollectionMode mode;
+        {
+            Locker locker { m_observersLock };
+            mode = m_collectionMode;
+        }
         if (mode & CPU)
             platformCollectCPUData(m_vm, data);
         if (mode & Memory)

--- a/Source/WebCore/page/ResourceUsageThread.h
+++ b/Source/WebCore/page/ResourceUsageThread.h
@@ -82,7 +82,7 @@ private:
     Lock m_observersLock;
     Condition m_condition;
     HashMap<void*, std::pair<ResourceUsageCollectionMode, std::function<void(const ResourceUsageData&)>>> m_observers WTF_GUARDED_BY_LOCK(m_observersLock);
-    ResourceUsageCollectionMode m_collectionMode { None };
+    ResourceUsageCollectionMode m_collectionMode WTF_GUARDED_BY_LOCK(m_observersLock) { None };
 
     // Platforms may need to access some data from the common VM.
     // They should ensure their use of the VM is thread safe.

--- a/Source/WebCore/platform/graphics/FontCascadeCache.h
+++ b/Source/WebCore/platform/graphics/FontCascadeCache.h
@@ -221,8 +221,8 @@ bool operator==(const FontFamilyName&, const FontFamilyName&);
 struct FontCascadeCacheKey {
     FontDescriptionKey fontDescriptionKey; // Shared with the lower level FontCache (caching Font objects)
     Vector<FontFamilyName, 3> families;
-    unsigned fontSelectorId;
-    unsigned fontSelectorVersion;
+    unsigned fontSelectorId { 0 };
+    unsigned fontSelectorVersion { 0 };
     bool hasComplexFontSelector { true };
 
 

--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -636,7 +636,8 @@ std::optional<DynamicContentScalingDisplayList> ImageBuffer::dynamicContentScali
 
 void ImageBuffer::transferToNewContext(const ImageBufferCreationContext& context)
 {
-    backend()->transferToNewContext(context);
+    if (auto* backend = ensureBackend())
+        backend->transferToNewContext(context);
 }
 
 String ImageBuffer::debugDescription() const

--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -161,7 +161,7 @@ public:
     WEBCORE_EXPORT IntSize backendSize() const;
 
     virtual void ensureBackendCreated() const { ensureBackend(); }
-    bool hasBackend() { return !!backend(); }
+    bool hasBackend() const { return !!backend(); }
 
     WEBCORE_EXPORT void transferToNewContext(const ImageBufferCreationContext&);
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
@@ -579,7 +579,10 @@ static void webKitMediaSrcLoop(void* userData)
                 GST_DEBUG_OBJECT(pad, "Pushing new CAPS event: %" GST_PTR_FORMAT, gst_sample_get_caps(sample.get()));
                 [[maybe_unused]] bool result = gst_pad_push_event(stream->pad.get(), gst_event_new_caps(gst_sample_get_caps(sample.get())));
                 GST_DEBUG_OBJECT(pad, "CAPS event pushed, result = %s.", boolForPrinting(result));
-                ASSERT(result);
+                // result can be false when we started flushing from another thread just before
+                // pushing the caps event...
+                if (!result && !GST_PAD_IS_FLUSHING(pad))
+                    GST_WARNING_OBJECT(pad, "CAPS event was not handled downstream");
             });
             if (streamingMembers->isFlushing) {
                 gst_pad_pause_task(pad);

--- a/Source/WebCore/platform/mediastream/libwebrtc/VideoFrameLibWebRTC.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/VideoFrameLibWebRTC.cpp
@@ -84,7 +84,13 @@ CVPixelBufferRef VideoFrameLibWebRTC::pixelBuffer() const
 
 Ref<VideoFrame> VideoFrameLibWebRTC::clone()
 {
-    return adoptRef(*new VideoFrameLibWebRTC(presentationTime(), isMirrored(), rotation(), PlatformVideoColorSpace { colorSpace() }, m_buffer.get(), ConversionCallback { m_conversionCallback }));
+    Locker locker { m_pixelBufferLock };
+    Ref clone = adoptRef(*new VideoFrameLibWebRTC(presentationTime(), isMirrored(), rotation(), PlatformVideoColorSpace { colorSpace() }, m_buffer.get(), ConversionCallback { m_conversionCallback }));
+
+    Locker cloneLocker { clone->m_pixelBufferLock };
+    clone->m_pixelBuffer = m_pixelBuffer;
+
+    return clone;
 }
 
 }

--- a/Source/WebCore/platform/mediastream/libwebrtc/VideoFrameLibWebRTC.h
+++ b/Source/WebCore/platform/mediastream/libwebrtc/VideoFrameLibWebRTC.h
@@ -66,7 +66,7 @@ private:
     IntSize m_size;
     uint32_t m_videoPixelFormat { 0 };
 
-    mutable ConversionCallback m_conversionCallback;
+    mutable ConversionCallback m_conversionCallback WTF_GUARDED_BY_LOCK(m_pixelBufferLock);
     mutable RetainPtr<CVPixelBufferRef> m_pixelBuffer WTF_GUARDED_BY_LOCK(m_pixelBufferLock);
     mutable Lock m_pixelBufferLock;
 };

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -1471,7 +1471,7 @@ void RenderFlexibleBox::performFlexLayout(RelayoutChildren relayoutChildren)
     if (!lineStates.isEmpty()) {
         auto isWrapReverse = this->isWrapReverse();
         auto firstLineItemsCountInOriginalOrder = lineStates.first().flexLayoutItems.size();
-        auto lastLineItemsCountInOriginalOrder = lineStates.first().flexLayoutItems.size();
+        auto lastLineItemsCountInOriginalOrder = lineStates.last().flexLayoutItems.size();
 
         m_numberOfFlexItemsOnFirstLine = !isWrapReverse ? firstLineItemsCountInOriginalOrder : lastLineItemsCountInOriginalOrder;
         m_numberOfFlexItemsOnLastLine = !isWrapReverse ? lastLineItemsCountInOriginalOrder : firstLineItemsCountInOriginalOrder;


### PR DESCRIPTION
#### bce8040a062cf5d1ab6671eff036ac3e7f833d06
<pre>
Cherry-pick 315752@main (cffe1bb49663). <a href="https://bugs.webkit.org/show_bug.cgi?id=317618">https://bugs.webkit.org/show_bug.cgi?id=317618</a>

    Document leak in MutationObserver
    <a href="https://bugs.webkit.org/show_bug.cgi?id=317618">https://bugs.webkit.org/show_bug.cgi?id=317618</a>
    <a href="https://rdar.apple.com/178665935">rdar://178665935</a>

    Reviewed by Chris Dumez.

    Previously, stopping a document didn&apos;t remove its MutationObservers from
    the shared WindowEventLoop&apos;s observer sets, so an observer left parked there
    with a pending mutation record keeps its target nodes, and therefore the
    whole document, alive forever.

    This is resolved by draining a stopped context&apos;s MutationObservers from those
    sets in Document::stopActiveDOMObjects().

    Test: fast/dom/MutationObserver/no-document-leak.html

    * LayoutTests/fast/dom/MutationObserver/no-document-leak-expected.txt: Added.
    * LayoutTests/fast/dom/MutationObserver/no-document-leak.html: Added.
    * LayoutTests/fast/dom/MutationObserver/resources/no-document-leak-frame.html: Added.
    * Source/WebCore/dom/Document.cpp:
    (WebCore::Document::stopActiveDOMObjects):
    * Source/WebCore/dom/WindowEventLoop.cpp:
    (WebCore::WindowEventLoop::removeMutationObserversForContext):
    * Source/WebCore/dom/WindowEventLoop.h:

    Canonical link: <a href="https://commits.webkit.org/315752@main">https://commits.webkit.org/315752@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.1000@webkitglib/2.52">https://commits.webkit.org/305877.1000@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### b22fc77eb6521f20452c5624e9c8714a091b4e88
<pre>
Cherry-pick 315760@main (77c66694dfbc). <a href="https://bugs.webkit.org/show_bug.cgi?id=317695">https://bugs.webkit.org/show_bug.cgi?id=317695</a>

    Check if JSArray::fastFlat exceeds maximum legal length
    <a href="https://bugs.webkit.org/show_bug.cgi?id=317695">https://bugs.webkit.org/show_bug.cgi?id=317695</a>
    <a href="https://rdar.apple.com/178997662">rdar://178997662</a>

    Reviewed by Sosuke Suzuki and Yusuke Suzuki.

    JSC::JSArray::fastFlat crashes if the flattened array exceeds the
    maximum length of the vector holding it. This patch changes it to return
    null and bail out to the slow path in JSC::arrayProtoFuncFlat instead of
    crashing.

    Test: JSTests/stress/array-prototype-flat-reentrant-mutation.js

    * JSTests/stress/array-prototype-flat-reentrant-mutation.js: Added.
    (try.array.Symbol.iterator):
    (catch):
    * Source/JavaScriptCore/runtime/JSArray.cpp:
    (JSC::JSArray::fastFlat):

    Canonical link: <a href="https://commits.webkit.org/315760@main">https://commits.webkit.org/315760@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.999@webkitglib/2.52">https://commits.webkit.org/305877.999@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 9e3bb9c3cd58dec94a4e1db35e0b18faffad65eb
<pre>
Cherry-pick 315855@main (e505d4781740). <a href="https://bugs.webkit.org/show_bug.cgi?id=317805">https://bugs.webkit.org/show_bug.cgi?id=317805</a>

    Null-check window in Navigation::hasEntriesAndEventsDisabled()
    <a href="https://bugs.webkit.org/show_bug.cgi?id=317805">https://bugs.webkit.org/show_bug.cgi?id=317805</a>
    <a href="https://rdar.apple.com/180575315">rdar://180575315</a>

    Reviewed by Basuke Suzuki.

    There is a possibility that this-&gt;window() could be null when
    Navigation::hasEntriesAndEventsDisabled(). Add a null-check.

    No new tests needed.

    * Source/WebCore/page/Navigation.cpp:
    (WebCore::Navigation::hasEntriesAndEventsDisabled const):

    Canonical link: <a href="https://commits.webkit.org/315855@main">https://commits.webkit.org/315855@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.998@webkitglib/2.52">https://commits.webkit.org/305877.998@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### ce741651319d46f201b9413796a451842efe180a
<pre>
Cherry-pick 315876@main (3ca64a2480fa). <a href="https://bugs.webkit.org/show_bug.cgi?id=317908">https://bugs.webkit.org/show_bug.cgi?id=317908</a>

    Rare null derefs under LocalFrameView::textFragmentIndicatorTimerFired()
    <a href="https://bugs.webkit.org/show_bug.cgi?id=317908">https://bugs.webkit.org/show_bug.cgi?id=317908</a>
    <a href="https://rdar.apple.com/180240279">rdar://180240279</a>

    Reviewed by Abrar Rahman Protyasha.

    * Source/WebCore/page/LocalFrameView.cpp:
    (WebCore::LocalFrameView::textFragmentIndicatorTimerFired):
    Keep a local copy of m_pendingTextFragmentIndicatorRange when calling into
    plainText(), because plainText() does layout, which can in turn result in
    m_pendingTextFragmentIndicatorRange being reset, subsequently causing a null deref.

    Canonical link: <a href="https://commits.webkit.org/315876@main">https://commits.webkit.org/315876@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.997@webkitglib/2.52">https://commits.webkit.org/305877.997@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 15f1bb526e04a337a0be8c6ca18fa5ee24414319
<pre>
Cherry-pick 315980@main (0a98e10bf354). <a href="https://bugs.webkit.org/show_bug.cgi?id=317998">https://bugs.webkit.org/show_bug.cgi?id=317998</a>

    ImageBuffer::hasBackend() should be const
    <a href="https://bugs.webkit.org/show_bug.cgi?id=317998">https://bugs.webkit.org/show_bug.cgi?id=317998</a>
    <a href="https://rdar.apple.com/180785695">rdar://180785695</a>

    Reviewed by Kimmo Kinnunen.

    ImageBuffer::hasBackend() only calls backend(), which is already a const
    member function, so the method can be const itself. Mark it const for
    const-correctness.

    * Source/WebCore/platform/graphics/ImageBuffer.h:
    (WebCore::ImageBuffer::hasBackend const):
    (WebCore::ImageBuffer::hasBackend): Deleted.

    Canonical link: <a href="https://commits.webkit.org/315980@main">https://commits.webkit.org/315980@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.996@webkitglib/2.52">https://commits.webkit.org/305877.996@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### cb03aede6c74e6011d875d2882c9ccb77fe8d571
<pre>
Cherry-pick 315982@main (9ca4025a7330). <a href="https://bugs.webkit.org/show_bug.cgi?id=318049">https://bugs.webkit.org/show_bug.cgi?id=318049</a>

    ImageBuffer::transferToNewContext() can null-deref backend()
    <a href="https://bugs.webkit.org/show_bug.cgi?id=318049">https://bugs.webkit.org/show_bug.cgi?id=318049</a>
    <a href="https://rdar.apple.com/180836227">rdar://180836227</a>

    Reviewed by Kimmo Kinnunen.

    ImageBuffer::transferToNewContext() was the only method in ImageBuffer
    that dereferenced backend() raw, while every sibling method guards with
    `if (auto* backend = ensureBackend())`. Its sole caller,
    RemoteRenderingBackend::moveToImageBuffer(), operates on a serialized
    ImageBuffer taken from the resource cache. Backend allocation can
    legitimately fail (size limits / OOM), leaving a live ImageBuffer whose
    m_backend is null, so transferToNewContext() would null-deref.

    Guard the access with ensureBackend(), matching the established pattern
    used throughout ImageBuffer. When there is no backend there is nothing
    to transfer, so skipping the call is correct.

    * Source/WebCore/platform/graphics/ImageBuffer.cpp:
    (WebCore::ImageBuffer::transferToNewContext):

    Canonical link: <a href="https://commits.webkit.org/315982@main">https://commits.webkit.org/315982@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.995@webkitglib/2.52">https://commits.webkit.org/305877.995@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 3da834c0f1e96095f3d002977217467d139177ef
<pre>
Cherry-pick 316027@main (bcc89c676083). <a href="https://bugs.webkit.org/show_bug.cgi?id=318069">https://bugs.webkit.org/show_bug.cgi?id=318069</a>

    Fix typo in RenderFlexibleBox::performFlexLayout(): last-line item count read from first line
    <a href="https://bugs.webkit.org/show_bug.cgi?id=318069">https://bugs.webkit.org/show_bug.cgi?id=318069</a>
    <a href="https://rdar.apple.com/180869111">rdar://180869111</a>

    Reviewed by Alan Baradlay.

    lastLineItemsCountInOriginalOrder was initialized from lineStates.first()
    instead of lineStates.last() — a copy/paste typo from the line above. This
    patch fixes it.

    When the first and last lines of a wrapping flex container have a different
    number of items, the count used to locate the container&apos;s last baseline was
    wrong, so the baseline was taken from a baseline-aligned item on the first
    line instead of an item on the last line. Added a reftest covering this case
    (first line: two items, last line: one item); it failed before this change
    and matches Chrome and Firefox now.

    * Source/WebCore/rendering/RenderFlexibleBox.cpp:
    (WebCore::RenderFlexibleBox::performFlexLayout):
    * LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/multiline-last-baseline-item-count-expected.html: Added.
    * LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/multiline-last-baseline-item-count-ref.html: Added.
    * LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/multiline-last-baseline-item-count.html: Added.

    Canonical link: <a href="https://commits.webkit.org/316027@main">https://commits.webkit.org/316027@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.994@webkitglib/2.52">https://commits.webkit.org/305877.994@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 0df5dc7316e2c527a873f6d1301e3af55f587bab
<pre>
Cherry-pick 316090@main (ccf04bde4757). <a href="https://bugs.webkit.org/show_bug.cgi?id=318087">https://bugs.webkit.org/show_bug.cgi?id=318087</a>

    ResourceUsageThread reads m_collectionMode off-thread without holding its lock
    <a href="https://bugs.webkit.org/show_bug.cgi?id=318087">https://bugs.webkit.org/show_bug.cgi?id=318087</a>

    Reviewed by Darin Adler.

    m_collectionMode is written by recomputeCollectionMode() while holding m_observersLock
    (from addObserver()/removeObserver() on the main thread), but the dedicated resource-usage
    sampling thread read it in threadBody() without acquiring the lock. waitUntilObservers()
    releases the lock before threadBody() reaches the read, so the locked main-thread write and
    the unlocked background-thread read could run concurrently on a non-atomic variable, which is
    a data race / undefined behavior. The field was also not annotated, so Clang&apos;s thread-safety
    analysis could not catch the unguarded access.

    Synchronize m_collectionMode with the same lock that already guards the m_observers set it is
    derived from: annotate it WTF_GUARDED_BY_LOCK(m_observersLock) so unguarded accesses become a
    build error, and read it under a short Locker scope in threadBody() (without holding the lock
    across the platformCollect* calls). recomputeCollectionMode() now accumulates into a local and
    performs a single store, which it already does under the lock.

    * Source/WebCore/page/ResourceUsageThread.cpp:
    (WebCore::ResourceUsageThread::recomputeCollectionMode):
    (WebCore::ResourceUsageThread::threadBody):
    * Source/WebCore/page/ResourceUsageThread.h:
    (WebCore::ResourceUsageThread::WTF_GUARDED_BY_LOCK):

    Canonical link: <a href="https://commits.webkit.org/316090@main">https://commits.webkit.org/316090@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.993@webkitglib/2.52">https://commits.webkit.org/305877.993@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 599adacf7ce052864ad665a05e3a8a2c440eb907
<pre>
Cherry-pick 316102@main (97d2c63b0b2b). <a href="https://bugs.webkit.org/show_bug.cgi?id=318056">https://bugs.webkit.org/show_bug.cgi?id=318056</a>

    FontCascadeCacheKey has uninitialized fontSelectorId and fontSelectorVersion members
    <a href="https://bugs.webkit.org/show_bug.cgi?id=318056">https://bugs.webkit.org/show_bug.cgi?id=318056</a>
    <a href="https://rdar.apple.com/180838174">rdar://180838174</a>

    Reviewed by Dan Glastonbury.

    Add { 0 } initializers to both members to match the rest of the struct and
    guarantee defined values for all default-constructed keys.

    * Source/WebCore/platform/graphics/FontCascadeCache.h:

    Canonical link: <a href="https://commits.webkit.org/316102@main">https://commits.webkit.org/316102@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.992@webkitglib/2.52">https://commits.webkit.org/305877.992@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 9ae58bc021e6f1accb635634cc2b706d698b100d
<pre>
Cherry-pick 316053@main (abc2312528f8). <a href="https://bugs.webkit.org/show_bug.cgi?id=317971">https://bugs.webkit.org/show_bug.cgi?id=317971</a>

    [WPE] media/media-source/media-source-real-play-after-eos.html is crashing
    <a href="https://bugs.webkit.org/show_bug.cgi?id=317971">https://bugs.webkit.org/show_bug.cgi?id=317971</a>

    Reviewed by Alicia Boya Garcia and Xabier Rodriguez-Calvar.

    Remove the assert on caps event push result otherwise we can get racy crashes on post-commit bots
    when a flush-start event is pushed downstream from another thread just before a caps change has to
    be notified.

    * LayoutTests/platform/glib/TestExpectations:
    * LayoutTests/platform/wpe/TestExpectations:
    * Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp:
    (webKitMediaSrcLoop):

    Canonical link: <a href="https://commits.webkit.org/316053@main">https://commits.webkit.org/316053@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.991@webkitglib/2.52">https://commits.webkit.org/305877.991@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 9750e8274bd1b8565a9b94b3ad5125b67ee0ed40
<pre>
Cherry-pick 316112@main (e7f7480061c3). <a href="https://bugs.webkit.org/show_bug.cgi?id=313917">https://bugs.webkit.org/show_bug.cgi?id=313917</a>

    [WebCore] Data race on VideoFrameLibWebRTC::m_conversionCallback between clone and pixelBuffer causes use-after-free
    <a href="https://rdar.apple.com/175482151">rdar://175482151</a>

    Reviewed by Jean-Yves Avenard.

    We add a thread annotation to make sure the conversion callback cannot be modified without the pixel buffer lock.
    We update VideoFrameLibWebRTC::clone so that it holds the pixel buffer lock to ensure it gets a correct conversion callback.
    We also copy the pixel buffer with a lock, as it could be null on the cloned video frame if the conversion callback has already been called.

    Covered by LayoutTests/http/wpt/webcodecs/frame-clone-and-convert.html, which does the following:
    1. Create a LibWebRTC VideoFrame.
    2. Encode it using VP8 so that the VideoFrame pixelBuffer method is executed in a background queue.
    3. In parallel, clone the VideoFrame to exercice the racy code path and encode the cloned frame.

    * LayoutTests/http/wpt/webcodecs/frame-clone-and-convert-expected.txt: Added.
    * LayoutTests/http/wpt/webcodecs/frame-clone-and-convert.html: Added.
    * Source/WebCore/platform/mediastream/libwebrtc/VideoFrameLibWebRTC.cpp:
    (WebCore::VideoFrameLibWebRTC::clone):
    * Source/WebCore/platform/mediastream/libwebrtc/VideoFrameLibWebRTC.h:

    Originally-landed-as: 305413.760@safari-7624-branch (f4c62c374952). <a href="https://rdar.apple.com/180436627">rdar://180436627</a>
    Canonical link: <a href="https://commits.webkit.org/316112@main">https://commits.webkit.org/316112@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.990@webkitglib/2.52">https://commits.webkit.org/305877.990@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d64d15c0a0717a5ec48b46b2883384bde8a324f2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174948 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/48881 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/42662 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184529 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/132856 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176813 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/50173 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/48564 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136153 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/132856 "The change is no longer eligible for processing.") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177906 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Running apply-patch; Checked out pull request; Passed webkitperl tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/50173 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/42662 "The change is no longer eligible for processing.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116632 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Running checkout-pull-request; run-api-tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/50173 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/48564 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33006 "Built successfully") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/42662 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/50173 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/42662 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186953 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/36210 "The change is no longer eligible for processing.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/40445 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/48564 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145089 "Passed tests") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/48548 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/42662 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144947 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/49228 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/42662 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/115040 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26589 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/49228 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/121355 "The change is no longer eligible for processing.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/212040 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/47734 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/42662 "The change is no longer eligible for processing.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55303 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/47136 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/47367 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/47194 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->