### PR TITLE
[JSC] Iterator#includes should propagate a thrown error in |IteratorClose| abstract operation on matching the target value

### DIFF
--- a/JSTests/stress/iterator-prototype-includes.js
+++ b/JSTests/stress/iterator-prototype-includes.js
@@ -211,6 +211,96 @@ class TestIterator extends Iterator {
     sameValue(iter.isClosed, false, `${TEST_NAME}: iterator should not be closed`);
 }
 
+{
+    const TEST_NAME = 'calling .includes() should raise a thrown error in |IteratorClose| in step 10-d: return is method'
+
+    class ExpectedError extends Error {
+        constructor(...args) {
+            super(...args);
+            this.name = new.target.name;
+        }
+    }
+
+    class ThisTestIterator extends TestIterator {
+        constructor() {
+            super(5);
+        }
+
+        return() {
+            throw new ExpectedError('this error should be propagated to the caller'); 
+        }
+    }
+
+    const iter = new ThisTestIterator();
+    shouldThrow(TEST_NAME, () => {
+        callTestTargetFunction(iter, 2);
+    }, ExpectedError, 'this error should be propagated to the caller');
+}
+
+{
+    const TEST_NAME = 'calling .includes() should raise a thrown error in |IteratorClose| in step 10-d: return is getter'
+
+    class ExpectedError extends Error {
+        constructor(...args) {
+            super(...args);
+            this.name = new.target.name;
+        }
+    }
+
+    class ThisTestIterator extends TestIterator {
+        constructor() {
+            super(5);
+        }
+
+        get return() {
+            throw new ExpectedError('this error should be propagated to the caller'); 
+        }
+    }
+
+    const iter = new ThisTestIterator();
+    shouldThrow(TEST_NAME, () => {
+        callTestTargetFunction(iter, 2);
+    }, ExpectedError, 'this error should be propagated to the caller');
+}
+
+{
+    const TEST_NAME = 'calling .includes() should raise a thrown error in |IteratorClose| in step 10-d: return is not a function'
+
+    class ThisTestIterator extends TestIterator {
+        constructor() {
+            super(5);
+        }
+
+        return = 'return';
+    }
+
+    const iter = new ThisTestIterator();
+    shouldThrow(TEST_NAME, () => {
+        callTestTargetFunction(iter, 2);
+    }, TypeError, 'Type error');
+}
+
+{
+    const TEST_NAME = 'calling .includes() should raise a thrown error in |IteratorClose| in step 10-d: the returned value of .return() is invalid'
+
+    class ThisTestIterator extends TestIterator {
+        constructor() {
+            super(5);
+        }
+
+        return() {
+            // |IteratorClose| would throw a TypeError in the step 7 if the returned value is not an object.
+            // https://tc39.es/ecma262/2026/#sec-iteratorclose
+            return true;
+        }
+    }
+
+    const iter = new ThisTestIterator();
+    shouldThrow(TEST_NAME, () => {
+        callTestTargetFunction(iter, 2);
+    }, TypeError, `Iterator result interface is not an object.`);
+}
+
 // with second argument
 
 {
@@ -508,6 +598,96 @@ class TestIterator extends Iterator {
         sameValue(iter.isDone, false, `${testName}: iterator should be done`);
         sameValue(iter.isClosed, true, `${testName}: iterator should not be closed`);
     }
+}
+
+{
+    const TEST_NAME = 'call with 2nd arg: calling .includes() should raise a thrown error in |IteratorClose| in step 10-d: return is method'
+
+    class ExpectedError extends Error {
+        constructor(...args) {
+            super(...args);
+            this.name = new.target.name;
+        }
+    }
+
+    class ThisTestIterator extends TestIterator {
+        constructor() {
+            super(5);
+        }
+
+        return() {
+            throw new ExpectedError('this error should be propagated to the caller'); 
+        }
+    }
+
+    const iter = new ThisTestIterator();
+    shouldThrow(TEST_NAME, () => {
+        callTestTargetFunction(iter, 2, 1);
+    }, ExpectedError, 'this error should be propagated to the caller');
+}
+
+{
+    const TEST_NAME = 'call with 2nd arg: calling .includes() should raise a thrown error in |IteratorClose| in step 10-d: return is not a function'
+
+    class ThisTestIterator extends TestIterator {
+        constructor() {
+            super(5);
+        }
+
+        return = 'return';
+    }
+
+    const iter = new ThisTestIterator();
+    shouldThrow(TEST_NAME, () => {
+        callTestTargetFunction(iter, 2, 1);
+    }, TypeError, 'Type error');
+}
+
+{
+    const TEST_NAME = 'call with 2nd arg: calling .includes() should raise a thrown error in |IteratorClose| in step 10-d: return is getter'
+
+    class ExpectedError extends Error {
+        constructor(...args) {
+            super(...args);
+            this.name = new.target.name;
+        }
+    }
+
+    class ThisTestIterator extends TestIterator {
+        constructor() {
+            super(5);
+        }
+
+        get return() {
+            throw new ExpectedError('this error should be propagated to the caller'); 
+        }
+    }
+
+    const iter = new ThisTestIterator();
+    shouldThrow(TEST_NAME, () => {
+        callTestTargetFunction(iter, 2, 1);
+    }, ExpectedError, 'this error should be propagated to the caller');
+}
+
+{
+    const TEST_NAME = 'call with 2nd arg: calling .includes() should raise a thrown error in |IteratorClose| in step 10-d: the returned value of .return() is invalid'
+
+    class ThisTestIterator extends TestIterator {
+        constructor() {
+            super(5);
+        }
+
+        return() {
+            // |IteratorClose| would throw a TypeError in the step 7 if the returned value is not an object.
+            // https://tc39.es/ecma262/2026/#sec-iteratorclose
+            return true;
+        }
+    }
+
+    const iter = new ThisTestIterator();
+    shouldThrow(TEST_NAME, () => {
+        callTestTargetFunction(iter, 2, 1);
+    }, TypeError, `Iterator result interface is not an object.`);
 }
 
 // invalid

--- a/Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp
@@ -310,7 +310,7 @@ JSC_DEFINE_HOST_FUNCTION(iteratorProtoFuncIncludes, (JSGlobalObject* globalObjec
 
         if (isEqual) {
             iteratorClose(globalObject, iterationRecord.iterator);
-            TRY_CLEAR_EXCEPTION(scope, { });
+            RETURN_IF_EXCEPTION(scope, { });
             return JSValue::encode(jsBoolean(true));
         }
     }


### PR DESCRIPTION
#### 0a0c75c029a02ac511abaf491e38178e66c931e5
<pre>
[JSC] Iterator#includes should propagate a thrown error in |IteratorClose| abstract operation on matching the target value
<a href="https://bugs.webkit.org/show_bug.cgi?id=319569">https://bugs.webkit.org/show_bug.cgi?id=319569</a>

Reviewed by Keith Miller.

This is a bug by the wrong implementation in bug 309883.

According to [the spec](<a href="https://tc39.es/proposal-iterator-includes/)">https://tc39.es/proposal-iterator-includes/)</a>,
in the step 10-d, we should propagate an error happening in `IteratorClose` abstract operation.

* JSTests/stress/iterator-prototype-includes.js:
    This adds some cases that `IteratorClose` throw an error.
* Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp:

Canonical link: <a href="https://commits.webkit.org/317622@main">https://commits.webkit.org/317622@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c8521d66210e9274ca8f16426649c7dc45ae5ab1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175192 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49124 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42905 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184777 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/133272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50416 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48807 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136365 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/133272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178149 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39793 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157146 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116844 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38434 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36819 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33250 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5655 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148857 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36639 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187198 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/36453 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/40811 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41022 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145312 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48791 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145169 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39254 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49471 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33260 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/115325 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40016 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121654 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/212283 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47977 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11612 "") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55396 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47380 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47610 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47437 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->