### PR TITLE
[JSC][Wasm] Force BoundsChecking for Memory64 accesses in BBQ

### DIFF
--- a/JSTests/wasm/stress/memory64-bbq-bounds-checking.js
+++ b/JSTests/wasm/stress/memory64-bbq-bounds-checking.js
@@ -1,0 +1,39 @@
+//@ skip if $addressBits <= 32
+//@ requireOptions("--useWasmMemory64=1")
+//@ runDefaultWasm("-m", "--useWasmMemory64=1", "--useOMGJIT=0", "--thresholdForBBQOptimizeAfterWarmUp=0")
+// https://bugs.webkit.org/show_bug.cgi?id=308683
+// Memory64 cannot use signaling memory; BBQ must emit explicit bounds checks.
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+const { exports } = await instantiate(`
+(module
+  (memory i64 1)
+  (func (export "load") (param i64) (result i32)
+    (i32.load (local.get 0)))
+  (func (export "store") (param i64)
+    (i32.store (local.get 0) (i32.const 7)))
+  (func (export "constLoad") (result i32)
+    (i32.load (i64.const -1)))
+  (func (export "largeOffsetLoad") (result i32)
+    (i32.load offset=0xffffffff (i64.const 0)))
+)
+`, {}, { memory64: true });
+
+function test() {
+    assert.throws(() => exports.load(0xffffffffffffffffn), WebAssembly.RuntimeError, "Out of bounds");
+    assert.throws(() => exports.load(0xfffffffffffffffen), WebAssembly.RuntimeError, "Out of bounds");
+    assert.throws(() => exports.store(0xffffffffffffffffn), WebAssembly.RuntimeError, "Out of bounds");
+    assert.throws(() => exports.constLoad(), WebAssembly.RuntimeError, "Out of bounds");
+    assert.throws(() => exports.largeOffsetLoad(), WebAssembly.RuntimeError, "Out of bounds");
+    // One page = 65536 bytes; i32 load needs 4 bytes.
+    assert.throws(() => exports.load(65536n), WebAssembly.RuntimeError, "Out of bounds");
+    assert.throws(() => exports.load(65535n), WebAssembly.RuntimeError, "Out of bounds");
+    assert.throws(() => exports.load(65533n), WebAssembly.RuntimeError, "Out of bounds");
+    assert.eq(exports.load(65532n), 0);
+    exports.store(0n);
+    assert.eq(exports.load(0n), 7);
+}
+
+for (let i = 0; i < wasmTestLoopCount; ++i)
+    test();

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.h
@@ -1180,8 +1180,7 @@ public:
             pointerLocation = loadIfNecessary(pointer);
         ASSERT(pointerLocation.isGPR());
 
-        // conservatively force bounds checking if memoryIndex != 0
-        switch (memoryIndex ? MemoryMode::BoundsChecking : m_mode) {
+        switch (m_info.memoryModeForAccess(memoryIndex, m_mode)) {
         case MemoryMode::BoundsChecking: {
             // We're not using signal handling only when the memory is not shared.
             // Regardless of signaling, we must check that no memory access exceeds the current memory size.
@@ -1204,7 +1203,7 @@ public:
         }
 
         case MemoryMode::Signaling: {
-            RELEASE_ASSERT(!m_info.memory(memoryIndex).isMemory64());
+            RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!m_info.memory(memoryIndex).isMemory64());
             // We've virtually mapped 4GiB+redzone for this memory. Only the user-allocated pages are addressable, contiguously in range [0, current],
             // and everything above is mapped PROT_NONE. We don't need to perform any explicit bounds check in the 4GiB range because WebAssembly register
             // memory accesses are 32-bit. However WebAssembly register + offset accesses perform the addition in 64-bit which can push an access above

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.h
@@ -81,7 +81,7 @@ auto BBQJIT::emitCheckAndPrepareAndMaterializePointerApply(Value pointer, uint64
         else {
             uint64_t finalOffset = constantPointer + uoffset;
             if (finalOffset <= static_cast<uint64_t>(std::numeric_limits<int32_t>::max()) && B3::Air::Arg::isValidAddrForm(B3::Air::Move, static_cast<int32_t>(finalOffset), Width::Width128)) {
-                switch (memoryIndex ? MemoryMode::BoundsChecking : m_mode) {
+                switch (m_info.memoryModeForAccess(memoryIndex, m_mode)) {
                 case MemoryMode::BoundsChecking: {
                     m_jit.move(TrustedImmPtr(constantPointer + boundary), wasmScratchGPR);
                     recordJumpToThrowException(ExceptionType::OutOfBoundsMemoryAccess, m_jit.branchPtr(RelationalCondition::AboveOrEqual, wasmScratchGPR, boundsCheckingSizeRegister));
@@ -107,8 +107,7 @@ auto BBQJIT::emitCheckAndPrepareAndMaterializePointerApply(Value pointer, uint64
     ASSERT(pointerLocation.isGPR());
 
     // FIXME: for clarity we should probably rename m_mode to m_memory0Mode or something similar
-    // conservatively force bounds checking for nonzero memories
-    switch (memoryIndex ? MemoryMode::BoundsChecking : m_mode) {
+    switch (m_info.memoryModeForAccess(memoryIndex, m_mode)) {
     case MemoryMode::BoundsChecking: {
         // We're not using signal handling only when the memory is not shared.
         // Regardless of signaling, we must check that no memory access exceeds the current memory size.
@@ -129,7 +128,7 @@ auto BBQJIT::emitCheckAndPrepareAndMaterializePointerApply(Value pointer, uint64
         break;
     }
     case MemoryMode::Signaling: {
-        RELEASE_ASSERT(!m_info.memory(memoryIndex).isMemory64());
+        RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!m_info.memory(memoryIndex).isMemory64());
         // We've virtually mapped 4GiB+redzone for this memory. Only the user-allocated pages are addressable, contiguously in range [0, current],
         // and everything above is mapped PROT_NONE. We don't need to perform any explicit bounds check in the 4GiB range because WebAssembly register
         // memory accesses are 32-bit. However WebAssembly register + offset accesses perform the addition in 64-bit which can push an access above
@@ -141,7 +140,7 @@ auto BBQJIT::emitCheckAndPrepareAndMaterializePointerApply(Value pointer, uint64
         // than the declared 'maximum' will trap, so we can compare against that number. If there was no declared 'maximum' then we still know that
         // any access equal to or greater than 4GiB will trap, no need to add the redzone.
         if (uoffset >= Memory::fastMappedRedzoneBytes()) {
-            RELEASE_ASSERT(!m_info.memory(memoryIndex).isMemory64());
+            RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!m_info.memory(memoryIndex).isMemory64());
             uint64_t maximum = m_info.memory(memoryIndex).maximum() ? m_info.memory(memoryIndex).maximum().bytes() : std::numeric_limits<uint32_t>::max();
             m_jit.zeroExtend32ToWord(pointerLocation.asGPR(), wasmScratchGPR);
             if (boundary)

--- a/Source/JavaScriptCore/wasm/WasmModuleInformation.h
+++ b/Source/JavaScriptCore/wasm/WasmModuleInformation.h
@@ -29,6 +29,7 @@
 
 #if ENABLE(WEBASSEMBLY)
 
+#include <JavaScriptCore/MemoryMode.h>
 #include <JavaScriptCore/WasmBranchHints.h>
 #include <JavaScriptCore/WasmFormat.h>
 #include <JavaScriptCore/WasmModuleDebugInfo.h>
@@ -118,6 +119,15 @@ struct ModuleInformation final : public ThreadSafeRefCounted<ModuleInformation> 
     const MemoryInformation& memory(unsigned index) const { return memories[index]; }
     const TableInformation& table(unsigned index) const { return tables[index]; }
     const GlobalInformation& global(unsigned index) const { return globals[index]; }
+
+    // Signaling relies on 32-bit addresses + PROT_NONE redzone. Memory64 and non-zero
+    // multi-memories must always use explicit bounds checks.
+    MemoryMode memoryModeForAccess(unsigned memoryIndex, MemoryMode memory0Mode) const
+    {
+        if (memoryIndex || memory(memoryIndex).isMemory64())
+            return MemoryMode::BoundsChecking;
+        return memory0Mode;
+    }
 
     bool isDeclaredFunction(FunctionSpaceIndex index) const { return m_declaredFunctions.contains(index); }
     void addDeclaredFunction(FunctionSpaceIndex index) { m_declaredFunctions.set(index); }

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -2497,7 +2497,7 @@ inline Value* OMGIRGenerator::emitCheckAndPreparePointer(Value* pointer, uint64_
 
     if (!memoryIndex) {
         // m_mode is the mode used for memory 0
-        switch (m_mode) {
+        switch (m_info.memoryModeForAccess(memoryIndex, m_mode)) {
         case MemoryMode::BoundsChecking: {
             // We're not using signal handling only when the memory is not shared.
             // Regardless of signaling, we must check that no memory access exceeds the current memory size.
@@ -2516,7 +2516,7 @@ inline Value* OMGIRGenerator::emitCheckAndPreparePointer(Value* pointer, uint64_
         }
 
         case MemoryMode::Signaling: {
-            RELEASE_ASSERT(!m_info.memory(memoryIndex).isMemory64());
+            RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!m_info.memory(memoryIndex).isMemory64());
             // We've virtually mapped 4GiB+redzone for this memory. Only the user-allocated pages are addressable, contiguously in range [0, current],
             // and everything above is mapped PROT_NONE. We don't need to perform any explicit bounds check in the 4GiB range because WebAssembly register
             // memory accesses are 32-bit. However WebAssembly register + offset accesses perform the addition in 64-bit which can push an access above


### PR DESCRIPTION
#### d6d09268899bff2ceb25fac7da00a0bc0cbb77eb
<pre>
[JSC][Wasm] Force BoundsChecking for Memory64 accesses in BBQ
<a href="https://bugs.webkit.org/show_bug.cgi?id=308683">https://bugs.webkit.org/show_bug.cgi?id=308683</a>

Reviewed by Cole Carley and Keith Miller.

Signaling memory mode relies on 32-bit addresses and a PROT_NONE redzone.
Memory64 cannot use that scheme, so compilers must always emit explicit
bounds checks for Memory64 (and for non-zero multi-memories). Put that
policy on ModuleInformation::memoryModeForAccess and use it from BBQ and
OMG. Keep RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!isMemory64()) on
Signaling paths so a wrong mode selection still hard-fails.

* Source/JavaScriptCore/wasm/WasmModuleInformation.h:
* Source/JavaScriptCore/wasm/WasmBBQJIT.h:
* Source/JavaScriptCore/wasm/WasmBBQJIT64.h:
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
* JSTests/wasm/stress/memory64-bbq-bounds-checking.js: Added.

Canonical link: <a href="https://commits.webkit.org/318602@main">https://commits.webkit.org/318602@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c223db3f9a3d68daa515a7ee6913a2dd895fedb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178387 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52325 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46120 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188002 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141635 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53619 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52035 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139066 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181344 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42630 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159828 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119521 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41296 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39647 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1490 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/8316 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151696 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39327 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36458 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39660 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44925 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43889 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190430 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51994 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148224 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39886 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52675 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35950 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147998 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42711 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124940 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/119559 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51193 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14302 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50578 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50818 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50640 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->