### PR TITLE
[cleanup] Have RenderFlexibleBox lay out a flex item after main sizing instead of FlexLayout

### DIFF
--- a/Source/WebCore/rendering/RenderFlexLayout.cpp
+++ b/Source/WebCore/rendering/RenderFlexLayout.cpp
@@ -206,17 +206,6 @@ static LayoutUnit constrainSizeByMinMax(LayoutUnit size, std::pair<LayoutUnit, L
     return std::max(minMaxSizes.first, std::min(size, minMaxSizes.second));
 }
 
-static void updateFlexItemDirtyBitsBeforeLayout(bool relayoutFlexItem, RenderBox& flexItem)
-{
-    if (flexItem.isOutOfFlowPositioned())
-        return;
-
-    // FIXME: Technically percentage height objects only need a relayout if their percentage isn't going to be turned into
-    // an auto value. Add a method to determine this, so that we can avoid the relayout.
-    if (relayoutFlexItem || flexItem.hasRelativeLogicalHeight())
-        flexItem.setChildNeedsLayout(MarkingBehavior::MarkOnlyThis);
-}
-
 FlexLayout::FlexLines FlexLayout::computeFlexLines(FlexLayoutItems& flexItems, std::span<const FlexBaseAndHypotheticalMainSize> sizingList)
 {
     // 9.3. (#5) Collect flex items into flex lines: a single-line container collects all items into one line; a
@@ -460,50 +449,9 @@ void FlexLayout::trimCrossAxisMarginsForFlexItems(FlexLayoutItems& flexItems, co
 void FlexLayout::layoutFlexItems(std::span<FlexLayoutItem> flexLayoutItems, std::span<const LayoutUnit> mainSizes, RelayoutChildren relayoutChildren)
 {
     for (size_t index = 0; index < flexLayoutItems.size(); ++index)
-        layoutFlexItemAfterMainSizing(flexLayoutItems[index], mainSizes[index], relayoutChildren);
+        m_flexBox.layoutFlexItemAfterMainSizing(flexLayoutItems[index], mainSizes[index], relayoutChildren);
 }
 
-void FlexLayout::layoutFlexItemAfterMainSizing(FlexLayoutItem& flexLayoutItem, LayoutUnit mainSize, RelayoutChildren relayoutChildren)
-{
-    auto& flexItem = flexLayoutItem.renderer.get();
-
-    setOverridingMainSizeForFlexItem(flexItem, mainSize);
-    // The flexed content size and the override size include the scrollbar
-    // width, so we need to compare to the size including the scrollbar.
-    // FIXME: Should it include the scrollbar?
-    if (mainSize != flexLayoutUtils().mainAxisContentExtentForFlexItemIncludingScrollbar(flexItem))
-        flexItem.setChildNeedsLayout(MarkingBehavior::MarkOnlyThis);
-    else {
-        // To avoid double applying margin changes in
-        // updateAutoMarginsInCrossAxis, we reset the margins here.
-        resetAutoMarginsAndLogicalTopInCrossAxis(flexItem);
-    }
-    // We may have already forced relayout for orthogonal flowing children in
-    // computeInnerFlexBaseSizeForFlexItem.
-    bool forceFlexItemRelayout = relayoutChildren == RelayoutChildren::Yes && !m_flexBox.hasFlexItemCompletedLayout(flexItem);
-    if (!forceFlexItemRelayout && flexItemHasPercentHeightDescendants(flexItem)) {
-        // Have to force another relayout even though the child is sized
-        // correctly, because its descendants are not sized correctly yet. Our
-        // previous layout of the child was done without an override height set.
-        // So, redo it here.
-        forceFlexItemRelayout = true;
-    }
-    updateFlexItemDirtyBitsBeforeLayout(forceFlexItemRelayout, flexItem);
-    if (!flexItem.needsLayout())
-        flexItem.markForPaginationRelayoutIfNeeded();
-    if (flexItem.needsLayout())
-        m_flexBox.markFlexItemLayoutComplete(flexItem);
-
-    {
-        auto flexLayoutScope = m_flexBox.scopedAfterMainAxisItemSizing();
-        flexItem.layoutIfNeeded();
-    }
-
-    if (!flexLayoutItem.everHadLayout && flexItem.checkForRepaintDuringLayout()) {
-        flexItem.repaint();
-        flexItem.repaintOverhangingFloats(true);
-    }
-}
 
 Vector<LayoutUnit> FlexLayout::hypotheticalCrossSizeForFlexItems(const FlexLayoutItems& flexItems)
 {
@@ -1474,7 +1422,7 @@ LayoutUnit FlexLayout::applyStretchAlignmentToFlexItem(const FlexLayoutItem& fle
 
         // FIXME: Can avoid laying out here in some cases. See https://webkit.org/b/87905.
         bool flexItemNeedsRelayout = desiredLogicalHeight != flexItem.logicalHeight();
-        if (!flexItemNeedsRelayout && m_flexBox.hasFlexItemCompletedLayout(flexItem) && flexItemHasPercentHeightDescendants(flexItem)) {
+        if (!flexItemNeedsRelayout && m_flexBox.hasFlexItemCompletedLayout(flexItem) && m_flexBox.flexItemHasPercentHeightDescendants(flexItem)) {
             // Have to force another relayout even though the child is sized
             // correctly, because its descendants are not sized correctly yet. Our
             // previous layout of the child was done without an override height set.
@@ -1556,32 +1504,6 @@ LayoutUnit FlexLayout::applyStretchMinMaxCrossSize(const FlexLayoutItem& flexLay
     return newSize;
 }
 
-void FlexLayout::setOverridingMainSizeForFlexItem(RenderBox& flexItem, LayoutUnit preferredSize)
-{
-    if (flexLayoutUtils().mainAxisIsFlexItemInlineAxis(flexItem))
-        flexItem.setOverridingBorderBoxLogicalWidth(preferredSize + flexItem.borderAndPaddingLogicalWidth());
-    else
-        flexItem.setOverridingBorderBoxLogicalHeight(preferredSize + flexItem.borderAndPaddingLogicalHeight());
-}
-
-void FlexLayout::resetAutoMarginsAndLogicalTopInCrossAxis(RenderBox& flexItem)
-{
-    if (flexLayoutUtils().hasAutoMarginsInCrossAxis(flexItem)) {
-        flexItem.updateLogicalHeight();
-        if (m_constraints.isHorizontalFlow) {
-            if (flexItem.style().marginTop().isAuto())
-                flexItem.setMarginTop(0_lu);
-            if (flexItem.style().marginBottom().isAuto())
-                flexItem.setMarginBottom(0_lu);
-        } else {
-            if (flexItem.style().marginLeft().isAuto())
-                flexItem.setMarginLeft(0_lu);
-            if (flexItem.style().marginRight().isAuto())
-                flexItem.setMarginRight(0_lu);
-        }
-    }
-}
-
 void FlexLayout::setFlowAwareLocationForFlexItem(RenderBox& flexItem, const LayoutPoint& location)
 {
     if (m_constraints.isHorizontalFlow)
@@ -1595,44 +1517,5 @@ void FlexLayout::setFlexItemGeometry(FlexLayoutItem& flexLayoutItem, const Layou
     setFlowAwareLocationForFlexItem(flexLayoutItem.renderer, location);
 }
 
-bool FlexLayout::flexItemHasPercentHeightDescendants(const RenderBox& renderer) const
-{
-    // FIXME: This function can be removed soon after webkit.org/b/204318 is fixed. Evaluate whether the
-    // skipContainingBlockForPercentHeightCalculation() check below should be moved to the caller in that case.
-    CheckedPtr renderBlock = dynamicDowncast<RenderBlock>(renderer);
-    if (!renderBlock)
-        return false;
-
-    // FlexibleBoxImpl's like RenderButton might wrap their children in anonymous blocks. Those anonymous blocks are
-    // skipped for percentage height calculations in RenderBox::computePercentageLogicalHeight() and thus
-    // addPercentHeightDescendant() is never called for them. This means that this method would always wrongly
-    // return false for a child of a <button> with a percentage height.
-    if (m_flexBox.hasPercentHeightDescendants()) {
-        for (auto& descendant : *m_flexBox.percentHeightDescendants()) {
-            if (renderBlock->isContainingBlockAncestorFor(descendant))
-                return true;
-        }
-    }
-
-    if (!renderBlock->hasPercentHeightDescendants())
-        return false;
-
-    auto* percentHeightDescendants = renderBlock->percentHeightDescendants();
-    if (!percentHeightDescendants)
-        return false;
-
-    for (auto& descendant : *percentHeightDescendants) {
-        bool hasOutOfFlowAncestor = false;
-        for (auto* ancestor = descendant.containingBlock(); ancestor && ancestor != renderBlock.get(); ancestor = ancestor->containingBlock()) {
-            if (ancestor->isOutOfFlowPositioned()) {
-                hasOutOfFlowAncestor = true;
-                break;
-            }
-        }
-        if (!hasOutOfFlowAncestor)
-            return true;
-    }
-    return false;
-}
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderFlexLayout.h
+++ b/Source/WebCore/rendering/RenderFlexLayout.h
@@ -154,7 +154,6 @@ private:
     void trimCrossAxisMarginsForFlexItems(FlexLayoutItems& flexItems, const FlexLines&);
     // Lays out each flex item at its resolved main size.
     void layoutFlexItems(std::span<FlexLayoutItem>, std::span<const LayoutUnit> mainSizes, RelayoutChildren);
-    void layoutFlexItemAfterMainSizing(FlexLayoutItem&, LayoutUnit mainSize, RelayoutChildren);
     Vector<LayoutUnit> hypotheticalCrossSizeForFlexItems(const FlexLayoutItems&);
     Vector<LayoutUnit> crossSizeForFlexLines(const FlexLines&, const FlexLayoutItems&, const Vector<LayoutUnit>& hypotheticalCrossSizeList);
     Vector<LayoutPoint> handleMainAxisAlignment(const FlexLines&, FlexLayoutItems&, const Vector<LayoutUnit>& mainSizeList, const Vector<LayoutUnit>& lineCrossOffsetList, LayoutUnit gapBetweenItems);
@@ -199,13 +198,9 @@ private:
     bool NODELETE updateAutoMarginsInCrossAxis(FlexLayoutItem&, LayoutUnit& crossOffset, LayoutUnit availableAlignmentSpace);
     LayoutUnit applyStretchAlignmentToFlexItem(const FlexLayoutItem&, LayoutUnit lineCrossAxisExtent);
     LayoutUnit applyStretchMinMaxCrossSize(const FlexLayoutItem&, LayoutUnit lineCrossAxisExtent, LogicalBoxAxis);
-    void setOverridingMainSizeForFlexItem(RenderBox&, LayoutUnit);
 
-    void resetAutoMarginsAndLogicalTopInCrossAxis(RenderBox& flexItem);
     void NODELETE setFlowAwareLocationForFlexItem(RenderBox& flexItem, const LayoutPoint&);
     void setFlexItemGeometry(FlexLayoutItem&, const LayoutPoint& location);
-
-    bool flexItemHasPercentHeightDescendants(const RenderBox&) const;
 
     const FlexLayoutUtils& flexLayoutUtils() const;
 

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -75,6 +75,17 @@ static bool canSetFlexItemContentLogicalHeight(const RenderBox& flexItem)
     return !flexItem.isFloatingOrOutOfFlowPositioned() && !flexItem.shouldComputeLogicalHeightFromAspectRatio() && !is<RenderReplaced>(flexItem);
 }
 
+static void updateFlexItemDirtyBitsBeforeLayout(bool relayoutFlexItem, RenderBox& flexItem)
+{
+    if (flexItem.isOutOfFlowPositioned())
+        return;
+
+    // FIXME: Technically percentage height objects only need a relayout if their percentage isn't going to be turned into
+    // an auto value. Add a method to determine this, so that we can avoid the relayout.
+    if (relayoutFlexItem || flexItem.hasRelativeLogicalHeight())
+        flexItem.setChildNeedsLayout(MarkingBehavior::MarkOnlyThis);
+}
+
 #define SET_OR_CLEAR_OVERRIDING_SIZE(box, SizeType, size)       \
     {                                                           \
         if (size)                                               \
@@ -682,6 +693,114 @@ void RenderFlexibleBox::dirtyPercentHeightDescendantsWithinFlexItem(RenderBox& f
         if (flexItemBlockFlow->isContainingBlockAncestorFor(descendant))
             flexItemBlockFlow->dirtyForLayoutFromPercentageHeightDescendant(descendant);
     }
+}
+
+void RenderFlexibleBox::layoutFlexItemAfterMainSizing(FlexLayoutItem& flexLayoutItem, LayoutUnit mainSize, RelayoutChildren relayoutChildren)
+{
+    auto& flexItem = flexLayoutItem.renderer.get();
+
+    setOverridingMainSizeForFlexItem(flexItem, mainSize);
+    // The flexed content size and the override size include the scrollbar
+    // width, so we need to compare to the size including the scrollbar.
+    // FIXME: Should it include the scrollbar?
+    if (mainSize != flexLayoutUtils().mainAxisContentExtentForFlexItemIncludingScrollbar(flexItem))
+        flexItem.setChildNeedsLayout(MarkingBehavior::MarkOnlyThis);
+    else {
+        // To avoid double applying margin changes in
+        // updateAutoMarginsInCrossAxis, we reset the margins here.
+        resetAutoMarginsAndLogicalTopInCrossAxis(flexItem);
+    }
+    // We may have already forced relayout for orthogonal flowing children in
+    // computeInnerFlexBaseSizeForFlexItem.
+    bool forceFlexItemRelayout = relayoutChildren == RelayoutChildren::Yes && !hasFlexItemCompletedLayout(flexItem);
+    if (!forceFlexItemRelayout && flexItemHasPercentHeightDescendants(flexItem)) {
+        // Have to force another relayout even though the child is sized
+        // correctly, because its descendants are not sized correctly yet. Our
+        // previous layout of the child was done without an override height set.
+        // So, redo it here.
+        forceFlexItemRelayout = true;
+    }
+    updateFlexItemDirtyBitsBeforeLayout(forceFlexItemRelayout, flexItem);
+    if (!flexItem.needsLayout())
+        flexItem.markForPaginationRelayoutIfNeeded();
+    if (flexItem.needsLayout())
+        markFlexItemLayoutComplete(flexItem);
+
+    {
+        auto flexLayoutScope = scopedAfterMainAxisItemSizing();
+        flexItem.layoutIfNeeded();
+    }
+
+    if (!flexLayoutItem.everHadLayout && flexItem.checkForRepaintDuringLayout()) {
+        flexItem.repaint();
+        flexItem.repaintOverhangingFloats(true);
+    }
+}
+
+void RenderFlexibleBox::setOverridingMainSizeForFlexItem(RenderBox& flexItem, LayoutUnit preferredSize)
+{
+    if (flexLayoutUtils().mainAxisIsFlexItemInlineAxis(flexItem))
+        flexItem.setOverridingBorderBoxLogicalWidth(preferredSize + flexItem.borderAndPaddingLogicalWidth());
+    else
+        flexItem.setOverridingBorderBoxLogicalHeight(preferredSize + flexItem.borderAndPaddingLogicalHeight());
+}
+
+void RenderFlexibleBox::resetAutoMarginsAndLogicalTopInCrossAxis(RenderBox& flexItem)
+{
+    if (flexLayoutUtils().hasAutoMarginsInCrossAxis(flexItem)) {
+        flexItem.updateLogicalHeight();
+        if (flexLayoutUtils().isHorizontalFlow()) {
+            if (flexItem.style().marginTop().isAuto())
+                flexItem.setMarginTop(0_lu);
+            if (flexItem.style().marginBottom().isAuto())
+                flexItem.setMarginBottom(0_lu);
+        } else {
+            if (flexItem.style().marginLeft().isAuto())
+                flexItem.setMarginLeft(0_lu);
+            if (flexItem.style().marginRight().isAuto())
+                flexItem.setMarginRight(0_lu);
+        }
+    }
+}
+
+bool RenderFlexibleBox::flexItemHasPercentHeightDescendants(const RenderBox& renderer) const
+{
+    // FIXME: This function can be removed soon after webkit.org/b/204318 is fixed. Evaluate whether the
+    // skipContainingBlockForPercentHeightCalculation() check below should be moved to the caller in that case.
+    CheckedPtr renderBlock = dynamicDowncast<RenderBlock>(renderer);
+    if (!renderBlock)
+        return false;
+
+    // FlexibleBoxImpl's like RenderButton might wrap their children in anonymous blocks. Those anonymous blocks are
+    // skipped for percentage height calculations in RenderBox::computePercentageLogicalHeight() and thus
+    // addPercentHeightDescendant() is never called for them. This means that this method would always wrongly
+    // return false for a child of a <button> with a percentage height.
+    if (hasPercentHeightDescendants()) {
+        for (auto& descendant : *percentHeightDescendants()) {
+            if (renderBlock->isContainingBlockAncestorFor(descendant))
+                return true;
+        }
+    }
+
+    if (!renderBlock->hasPercentHeightDescendants())
+        return false;
+
+    auto* percentHeightDescendants = renderBlock->percentHeightDescendants();
+    if (!percentHeightDescendants)
+        return false;
+
+    for (auto& descendant : *percentHeightDescendants) {
+        bool hasOutOfFlowAncestor = false;
+        for (auto* ancestor = descendant.containingBlock(); ancestor && ancestor != renderBlock.get(); ancestor = ancestor->containingBlock()) {
+            if (ancestor->isOutOfFlowPositioned()) {
+                hasOutOfFlowAncestor = true;
+                break;
+            }
+        }
+        if (!hasOutOfFlowAncestor)
+            return true;
+    }
+    return false;
 }
 
 LayoutUnit RenderFlexibleBox::staticMainAxisPositionForPositionedFlexItem(const RenderBox& flexItem)

--- a/Source/WebCore/rendering/RenderFlexibleBox.h
+++ b/Source/WebCore/rendering/RenderFlexibleBox.h
@@ -187,6 +187,10 @@ private:
     void stretchFlexItemLogicalHeight(RenderBox& flexItem, LayoutUnit desiredLogicalHeight, bool needsRelayout);
     void relayoutFlexItemForStretchedCrossSize(RenderBox& flexItem, LayoutUnit crossSize, LogicalBoxAxis crossAxis);
     void dirtyPercentHeightDescendantsWithinFlexItem(RenderBox& flexItem);
+    void layoutFlexItemAfterMainSizing(FlexLayoutItem&, LayoutUnit mainSize, RelayoutChildren);
+    void setOverridingMainSizeForFlexItem(RenderBox& flexItem, LayoutUnit mainSize);
+    void resetAutoMarginsAndLogicalTopInCrossAxis(RenderBox& flexItem);
+    bool flexItemHasPercentHeightDescendants(const RenderBox&) const;
     void markFlexItemLayoutComplete(const RenderBox& flexItem) { m_flexItemsWithCompletedLayout.add(flexItem); }
     bool hasFlexItemCompletedLayout(const RenderBox& flexItem) const { return m_flexItemsWithCompletedLayout.contains(flexItem); }
     void addItemAtFlexLineStart(const RenderBox& flexItem) { m_marginTrimItems.m_itemsAtFlexLineStart.add(flexItem); }


### PR DESCRIPTION
#### c8b6308aaa691fa0dd3f84bdcbf2d15a2f97b01e
<pre>
[cleanup] Have RenderFlexibleBox lay out a flex item after main sizing instead of FlexLayout
<a href="https://bugs.webkit.org/show_bug.cgi?id=318614">https://bugs.webkit.org/show_bug.cgi?id=318614</a>
&lt;<a href="https://rdar.apple.com/problem/182019677">rdar://problem/182019677</a>&gt;

Reviewed by Antti Koivisto.

FlexLayout::layoutFlexItemAfterMainSizing laid each flex item out once its flexed main size was
resolved: it applied that main size, decided whether the item needed a relayout, and called
layoutIfNeeded (plus the pagination and repaint bookkeeping). Laying a flex item out is render-tree
work that belongs to the container, not the item-layout algorithm.

Move it and its exclusively-used helpers (setOverridingMainSizeForFlexItem,
resetAutoMarginsAndLogicalTopInCrossAxis, and the updateFlexItemDirtyBitsBeforeLayout file-static)
into RenderFlexibleBox. flexItemHasPercentHeightDescendants moves too, since the stretch relayout
decision also reads it. FlexLayout::layoutFlexItems now calls
m_flexBox.layoutFlexItemAfterMainSizing per item; resetAutoMarginsAndLogicalTopInCrossAxis reads
its flow direction from flexLayoutUtils() rather than the constraints it no longer has.

With this, FlexLayout no longer lays out any flex item directly: it computes the sizes and
positions and decides whether a relayout is needed, and RenderFlexibleBox performs every layout
(the block-axis measure, the main-axis layout here, and the stretch relayouts).

No change in behavior: the moved bodies are unchanged, run under the same conditions, and in the
same order.

* Source/WebCore/rendering/RenderFlexLayout.cpp:
* Source/WebCore/rendering/RenderFlexLayout.h:
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
* Source/WebCore/rendering/RenderFlexibleBox.h:

Canonical link: <a href="https://commits.webkit.org/317311@main">https://commits.webkit.org/317311@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/34d37235f137e00021c165219f6a8cc5a538fb2f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174954 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48887 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42668 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184535 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/132862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3dde94fd-22cf-48a1-abb0-58c8b5c0ff2b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176819 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50179 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48570 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136155 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/132862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1e5347fc-966e-4cee-860a-5abab4c7178a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177912 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39597 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156953 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116634 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3abc4b40-98bc-40e0-9fc2-d3c0fbfbb055) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38238 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33012 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148661 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36445 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186959 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/40451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145093 "Found 1 new test failure: compositing/color-matching/image-color-matching.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48554 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144951 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39051 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49234 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115046 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39818 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/121362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47740 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11418 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47142 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47373 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47200 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->