### PR TITLE
[scroll-animations] use the last matching timeline when `animation-timeline` matches multiple timelines

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-deferred-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-deferred-expected.txt
@@ -1,5 +1,5 @@
 
 PASS Animation.timeline returns attached timeline
 FAIL Animation.timeline returns null for an inactive deferred timeline assert_equals: expected null but got object "[object ScrollTimeline]"
-FAIL Animation.timeline naming conflict resolves to last in tree order promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'timeline.source.id')"
+PASS Animation.timeline naming conflict resolves to last in tree order
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope-expected.txt
@@ -4,7 +4,7 @@ PASS Deferred timeline with no attachments
 PASS Inner timeline does not interfere with outer timeline
 PASS Deferred timeline with two attachments
 PASS Dynamically re-attaching
-FAIL Dynamically detaching assert_equals: expected "50px" but got "0px"
+PASS Dynamically detaching
 PASS Removing/inserting element with attaching timeline
 PASS Ancestor attached element becoming display:none/block
 PASS A deferred timeline appearing dynamically in the ancestor chain

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-dynamic-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Dynamically changing view-timeline attachment assert_equals: div25 expected "25" but got "-1"
+PASS Dynamically changing view-timeline attachment
 PASS Dynamically changing view-timeline-axis
 PASS Dynamically changing view-timeline-inset
 PASS Element with scoped view-timeline becoming display:none

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-lookup-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-lookup-expected.txt
@@ -3,7 +3,7 @@ PASS view-timeline on self
 PASS timeline-scope on preceding sibling
 PASS view-timeline on ancestor
 PASS timeline-scope on ancestor sibling
-FAIL timeline-scope on ancestor sibling, resolve to last match in tree order assert_equals: expected "50" but got "auto"
+PASS timeline-scope on ancestor sibling, resolve to last match in tree order
 FAIL ancestor search stops at timeline-scope assert_equals: expected "auto" but got "0"
 PASS view-timeline on ancestor sibling, scroll-timeline wins on same element
 

--- a/Source/WebCore/animation/StyleOriginatedTimelinesController.cpp
+++ b/Source/WebCore/animation/StyleOriginatedTimelinesController.cpp
@@ -108,15 +108,13 @@ ScrollTimeline* StyleOriginatedTimelinesController::determineTreeOrder(const Vec
         }
         if (!matchedTimelines.isEmpty()) {
             if (containsElement(timelineScopeElements, element.get())) {
-                if (matchedTimelines.size() == 1)
-                    return matchedTimelines.first().unsafePtr();
                 // Naming conflict due to timeline-scope, see if the element declares a non-deferred timeline.
                 for (auto& matchedTimeline : matchedTimelines) {
                     if (element == originatingElement(matchedTimeline).element().get())
                         return matchedTimeline.unsafePtr();
                 }
-                // If we only have deferred timelines, then the timeline is the inactive timeline.
-                return &inactiveNamedTimeline(matchedTimelines.first()->name());
+                // Otherwise return the last of the matching timelines per https://github.com/w3c/csswg-drafts/issues/12581.
+                return matchedTimelines.last().unsafePtr();
             }
             ASSERT(matchedTimelines.size() <= 2);
             // Favor scroll timelines in case of conflict


### PR DESCRIPTION
#### 925fa1f8d9b9d79b212008d83065b99c2c7a9def
<pre>
[scroll-animations] use the last matching timeline when `animation-timeline` matches multiple timelines
<a href="https://bugs.webkit.org/show_bug.cgi?id=319575">https://bugs.webkit.org/show_bug.cgi?id=319575</a>
<a href="https://rdar.apple.com/182405676">rdar://182405676</a>

Reviewed by Sam Weinig and Anne van Kesteren.

The CSS WG resolved [0] to &quot;change timeline clash resolution to use last in tree order&quot;.

[0] <a href="https://github.com/w3c/csswg-drafts/issues/12581">https://github.com/w3c/csswg-drafts/issues/12581</a>

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-deferred-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-dynamic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-lookup-expected.txt:
* Source/WebCore/animation/StyleOriginatedTimelinesController.cpp:
(WebCore::StyleOriginatedTimelinesController::determineTreeOrder):

Canonical link: <a href="https://commits.webkit.org/317330@main">https://commits.webkit.org/317330@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33021c85d29ea180f64e3b72bc08c8ec6f84819a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174960 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48893 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42674 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184541 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/132868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bc364e67-921d-4b2e-a692-909fa507cc0f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176825 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50185 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48576 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136161 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/132868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3f735b21-e906-4a3a-ac7d-e4e82364ab9a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177918 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39602 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156961 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116640 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/72f20087-ec39-460b-8b8a-a04453ab6396) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38243 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33018 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148666 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36453 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186965 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/40460 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40827 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145099 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48560 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144956 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49240 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115052 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26583 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request; Reviewed by Sam Weinig and Anne van Kesteren; Canonicalized commit; Pushed commit to WebKit repository") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39825 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/121369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47746 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11426 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47150 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47379 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47206 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->