### PR TITLE
Don't cache HTTP/network errors in the module map

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/repeated-imports.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/repeated-imports.any-expected.txt
@@ -3,8 +3,8 @@ PASS Importing a specifier that previously failed due to an incorrect type attri
 PASS Importing a specifier that previously succeeded with the correct type attribute should fail if the incorrect attribute is later given
 PASS Two modules of different type with the same specifier can load if the server changes its responses
 FAIL An import should succeed even if the same specifier/module type pair previously failed due to a MIME type mismatch assert_unreached: Should have rejected: Dynamic import of JSON with a JS type content should fail Reached unreachable code
-FAIL An import should succeed even if the same specifier/module type pair previously failed due to a HTTP error promise_test: Unhandled rejection with value: object "TypeError: Importing a module script failed."
-FAIL An import should succeed even if the same specifier/module type pair previously failed due to a network error promise_test: Unhandled rejection with value: object "TypeError: Importing a module script failed."
+PASS An import should succeed even if the same specifier/module type pair previously failed due to a HTTP error
+PASS An import should succeed even if the same specifier/module type pair previously failed due to a network error
 PASS If an import previously succeeded for a given specifier/module type attribute pair, future uses of that pair should yield the same result
 PASS Multiple import calls with the same specifier should be joined into a single fetch
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/repeated-imports.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/repeated-imports.any.sharedworker-expected.txt
@@ -3,8 +3,8 @@ PASS Importing a specifier that previously failed due to an incorrect type attri
 PASS Importing a specifier that previously succeeded with the correct type attribute should fail if the incorrect attribute is later given
 PASS Two modules of different type with the same specifier can load if the server changes its responses
 FAIL An import should succeed even if the same specifier/module type pair previously failed due to a MIME type mismatch assert_unreached: Should have rejected: Dynamic import of JSON with a JS type content should fail Reached unreachable code
-FAIL An import should succeed even if the same specifier/module type pair previously failed due to a HTTP error promise_test: Unhandled rejection with value: object "TypeError: Importing a module script failed."
-FAIL An import should succeed even if the same specifier/module type pair previously failed due to a network error promise_test: Unhandled rejection with value: object "TypeError: Importing a module script failed."
+PASS An import should succeed even if the same specifier/module type pair previously failed due to a HTTP error
+PASS An import should succeed even if the same specifier/module type pair previously failed due to a network error
 PASS If an import previously succeeded for a given specifier/module type attribute pair, future uses of that pair should yield the same result
 PASS Multiple import calls with the same specifier should be joined into a single fetch
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/repeated-imports.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/repeated-imports.any.worker-expected.txt
@@ -3,8 +3,8 @@ PASS Importing a specifier that previously failed due to an incorrect type attri
 PASS Importing a specifier that previously succeeded with the correct type attribute should fail if the incorrect attribute is later given
 PASS Two modules of different type with the same specifier can load if the server changes its responses
 FAIL An import should succeed even if the same specifier/module type pair previously failed due to a MIME type mismatch assert_unreached: Should have rejected: Dynamic import of JSON with a JS type content should fail Reached unreachable code
-FAIL An import should succeed even if the same specifier/module type pair previously failed due to a HTTP error promise_test: Unhandled rejection with value: object "TypeError: Importing a module script failed."
-FAIL An import should succeed even if the same specifier/module type pair previously failed due to a network error promise_test: Unhandled rejection with value: object "TypeError: Importing a module script failed."
+PASS An import should succeed even if the same specifier/module type pair previously failed due to a HTTP error
+PASS An import should succeed even if the same specifier/module type pair previously failed due to a network error
 PASS If an import previously succeeded for a given specifier/module type attribute pair, future uses of that pair should yield the same result
 PASS Multiple import calls with the same specifier should be joined into a single fetch
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/concurrent-failed-imports-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/concurrent-failed-imports-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Multiple concurrent <script type=module> loads of a failing module should all fail but only fetch once
-FAIL A joined <script type=module> load is notified with its own fetch result even if a sibling's error handler re-inserts a script for the same specifier assert_equals: script #3 should perform a fresh fetch and load, since the failed fetch was not cached expected "load" but got "error"
+PASS A joined <script type=module> load is notified with its own fetch result even if a sibling's error handler re-inserts a script for the same specifier
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/dynamic-import/concurrent-failed-imports.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/dynamic-import/concurrent-failed-imports.any-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Multiple concurrent imports of a failing module should all reject but only fetch once
-FAIL A joined import is notified with its own fetch result even if a sibling's rejection handler re-imports the same specifier promise_test: Unhandled rejection with value: object "TypeError: Importing a module script failed."
+PASS A joined import is notified with its own fetch result even if a sibling's rejection handler re-imports the same specifier
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/dynamic-import/concurrent-failed-imports.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/dynamic-import/concurrent-failed-imports.any.sharedworker-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Multiple concurrent imports of a failing module should all reject but only fetch once
-FAIL A joined import is notified with its own fetch result even if a sibling's rejection handler re-imports the same specifier promise_test: Unhandled rejection with value: object "TypeError: Importing a module script failed."
+PASS A joined import is notified with its own fetch result even if a sibling's rejection handler re-imports the same specifier
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/dynamic-import/concurrent-failed-imports.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/dynamic-import/concurrent-failed-imports.any.worker-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Multiple concurrent imports of a failing module should all reject but only fetch once
-FAIL A joined import is notified with its own fetch result even if a sibling's rejection handler re-imports the same specifier promise_test: Unhandled rejection with value: object "TypeError: Importing a module script failed."
+PASS A joined import is notified with its own fetch result even if a sibling's rejection handler re-imports the same specifier
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/dynamic-import/repeated-imports.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/dynamic-import/repeated-imports.any-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL An import should succeed even if the same specifier/type attribute pair previously failed due to a MIME type mismatch assert_equals: expected "2" but got "1"
-FAIL An import should succeed even if the same specifier/type pair previously failed due to a network error (e.g. 404) assert_equals: expected "1" but got "0"
+PASS An import should succeed even if the same specifier/type attribute pair previously failed due to a MIME type mismatch
+PASS An import should succeed even if the same specifier/type pair previously failed due to a network error (e.g. 404)
 PASS Multiple imports in sequence with the same specifier/type pair should only fetch the module once
 PASS Multiple concurrent imports with the same specifier/type pair should only fetch the module once
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/dynamic-import/repeated-imports.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/dynamic-import/repeated-imports.any.sharedworker-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL An import should succeed even if the same specifier/type attribute pair previously failed due to a MIME type mismatch assert_equals: expected "2" but got "1"
-FAIL An import should succeed even if the same specifier/type pair previously failed due to a network error (e.g. 404) assert_equals: expected "1" but got "0"
+PASS An import should succeed even if the same specifier/type attribute pair previously failed due to a MIME type mismatch
+PASS An import should succeed even if the same specifier/type pair previously failed due to a network error (e.g. 404)
 PASS Multiple imports in sequence with the same specifier/type pair should only fetch the module once
 PASS Multiple concurrent imports with the same specifier/type pair should only fetch the module once
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/dynamic-import/repeated-imports.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/dynamic-import/repeated-imports.any.worker-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL An import should succeed even if the same specifier/type attribute pair previously failed due to a MIME type mismatch assert_equals: expected "2" but got "1"
-FAIL An import should succeed even if the same specifier/type pair previously failed due to a network error (e.g. 404) assert_equals: expected "1" but got "0"
+PASS An import should succeed even if the same specifier/type attribute pair previously failed due to a MIME type mismatch
+PASS An import should succeed even if the same specifier/type pair previously failed due to a network error (e.g. 404)
 PASS Multiple imports in sequence with the same specifier/type pair should only fetch the module once
 PASS Multiple concurrent imports with the same specifier/type pair should only fetch the module once
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/instantiation-error-8-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/instantiation-error-8-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Instantiate attempt on a tree w/ previously instantiate-failed tree as a sub-tree shouldn't crash.
+

--- a/Source/JavaScriptCore/runtime/JSMicrotask.cpp
+++ b/Source/JavaScriptCore/runtime/JSMicrotask.cpp
@@ -1184,24 +1184,25 @@ static void moduleLoadTopSettled(JSGlobalObject* globalObject, VM& vm, ThrowScop
         // onFetchRejected logic
         const Identifier& specifier = context->moduleRequest().m_specifier;
         auto type = context->moduleRequest().type();
-        ModuleRegistryEntry* entry = globalObject->moduleLoader()->ensureRegistered(globalObject, specifier, type);
-        if (scope.exception()) {
-            intermediatePromise->rejectWithCaughtException(vm, scope);
-            return;
-        }
         JSValue errorValue = arguments[1];
         if (auto* error = dynamicDowncast<ErrorInstance>(errorValue)) {
             auto failure = JSModuleLoader::getErrorInfo(globalObject, error);
-            if (failure.isEvaluationError(specifier, type))
+            // https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-single-module-script step 13.1
+            // Don't register the module unless it's an evaluation error.
+            if (failure.isEvaluationError(specifier, type)) {
+                ModuleRegistryEntry* entry = globalObject->moduleLoader()->ensureRegistered(globalObject, specifier, type);
+                if (scope.exception()) {
+                    intermediatePromise->rejectWithCaughtException(vm, scope);
+                    return;
+                }
                 entry->setEvaluationError(globalObject, error);
-            else
-                entry->setFetchError(globalObject, error);
+            }
         }
         intermediatePromise->reject(vm, errorValue);
     }
 }
 
-static void moduleLoadTopRejected(JSGlobalObject* globalObject, VM& vm, ThrowScope& scope, std::span<const JSValue, maxMicrotaskArguments> arguments, uint8_t payload)
+static void moduleLoadTopRejected(JSGlobalObject* globalObject, VM& vm, std::span<const JSValue, maxMicrotaskArguments> arguments, uint8_t payload)
 {
     // loadModule first overload: onLoadRejected
     // arguments[0] = pre-created resultPromise
@@ -1215,26 +1216,11 @@ static void moduleLoadTopRejected(JSGlobalObject* globalObject, VM& vm, ThrowSco
     else {
         const Identifier& specifier = context->moduleRequest().m_specifier;
         auto type = context->moduleRequest().type();
-        ModuleRegistryEntry* entry = globalObject->moduleLoader()->ensureRegistered(globalObject, specifier, type);
-        if (scope.exception()) {
-            resultPromise->rejectWithCaughtException(vm, scope);
-            return;
-        }
-        if (JSValue fetchErrorValue = entry->fetchError()) {
-            if (ErrorInstance* fetchError = dynamicDowncast<ErrorInstance>(fetchErrorValue)) {
-                ErrorInstance* fetchErrorCopy = JSModuleLoader::maybeDuplicateFetchError(globalObject, fetchError);
-                if (scope.exception()) {
-                    resultPromise->rejectWithCaughtException(vm, scope);
-                    return;
-                }
-                resultPromise->reject(vm, fetchErrorCopy);
-            } else
-                resultPromise->reject(vm, fetchErrorValue);
-            return;
-        }
-        JSValue error = arguments[1];
-        entry->setEvaluationError(globalObject, error);
-        resultPromise->reject(vm, error);
+        // https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-single-module-script step 13.1
+        // Only set an error if the entry already exists.
+        if (ModuleRegistryEntry* entry = globalObject->moduleLoader()->getRegisteredMayBeNull(specifier, type))
+            entry->setEvaluationError(globalObject, arguments[1]);
+        resultPromise->reject(vm, arguments[1]);
     }
 }
 
@@ -1373,7 +1359,7 @@ static void moduleLoadReturnRecord(JSGlobalObject*, VM& vm, ThrowScope& scope, s
         resultPromise->reject(vm, arguments[1]);
 }
 
-static void moduleLoadStoreError(JSGlobalObject* globalObject, ThrowScope& scope, std::span<const JSValue, maxMicrotaskArguments> arguments, uint8_t payload)
+static void moduleLoadStoreError(JSGlobalObject* globalObject, std::span<const JSValue, maxMicrotaskArguments> arguments, uint8_t payload)
 {
     // loadModule second overload: fire-and-forget error categorization
     // arguments[0] = unused
@@ -1385,8 +1371,11 @@ static void moduleLoadStoreError(JSGlobalObject* globalObject, ThrowScope& scope
         JSValue errorValue = arguments[1];
         const Identifier& specifier = context->moduleRequest().m_specifier;
         auto type = context->moduleRequest().type();
-        ModuleRegistryEntry* entry = globalObject->moduleLoader()->ensureRegistered(globalObject, specifier, type);
-        RETURN_IF_EXCEPTION(scope, void());
+        // https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-single-module-script step 13.1
+        // Only set an error if the entry already exists.
+        ModuleRegistryEntry* entry = globalObject->moduleLoader()->getRegisteredMayBeNull(specifier, type);
+        if (!entry)
+            return;
         if (auto* error = dynamicDowncast<ErrorInstance>(errorValue)) {
             auto failure = JSModuleLoader::getErrorInfo(globalObject, error);
             if (failure.isEvaluationError(specifier, type))
@@ -2017,7 +2006,7 @@ void runInternalMicrotask(JSGlobalObject* globalObject, VM& vm, InternalMicrotas
     }
 
     case InternalMicrotask::ModuleLoadTopRejected: {
-        moduleLoadTopRejected(globalObject, vm, scope, arguments, payload);
+        moduleLoadTopRejected(globalObject, vm, arguments, payload);
         return;
     }
 
@@ -2062,7 +2051,7 @@ void runInternalMicrotask(JSGlobalObject* globalObject, VM& vm, InternalMicrotas
     }
 
     case InternalMicrotask::ModuleLoadStoreError: {
-        moduleLoadStoreError(globalObject, scope, arguments, payload);
+        moduleLoadStoreError(globalObject, arguments, payload);
         return;
     }
 

--- a/Source/JavaScriptCore/runtime/JSModuleLoader.cpp
+++ b/Source/JavaScriptCore/runtime/JSModuleLoader.cpp
@@ -355,13 +355,17 @@ JSPromise* JSModuleLoader::loadModule(JSGlobalObject* globalObject, const Identi
     ScriptFetchParameters::Type type = parameters ? parameters->type() : ScriptFetchParameters::Type::JavaScript;
 
     if (ModuleRegistryEntry* entry = getRegisteredMayBeNull(specifier, type)) {
-        JSValue error = entry->error(globalObject);
-        RETURN_IF_EXCEPTION(scope, nullptr);
-        if (error)
-            return JSPromise::rejectedPromise(globalObject, error);
+        if (entry->fetchError())
+            removeFailedFetchEntry(entry);
+        else {
+            JSValue error = entry->error(globalObject);
+            RETURN_IF_EXCEPTION(scope, nullptr);
+            if (error)
+                return JSPromise::rejectedPromise(globalObject, error);
 
-        if (entry->status() != ModuleRegistryEntry::Status::New)
-            promise = entry->ensureFetchPromise(globalObject);
+            if (entry->status() != ModuleRegistryEntry::Status::New)
+                promise = entry->ensureFetchPromise(globalObject);
+        }
     }
 
     if (!promise) {
@@ -976,6 +980,18 @@ ModuleRegistryEntry* JSModuleLoader::getRegisteredMayBeNull(const Identifier& ke
     if (auto iter = m_moduleMap.find({ key.impl(), type }); iter != m_moduleMap.end())
         return iter->value.get();
     return nullptr;
+}
+
+void JSModuleLoader::removeFailedFetchEntry(ModuleRegistryEntry* entry)
+{
+    // https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-single-module-script step 13.1.2.
+    ASSERT(entry->status() == ModuleRegistryEntry::Status::FetchFailed);
+    ModuleMapKey moduleMapKey { entry->key().impl(), entry->moduleType() };
+    auto iter = m_moduleMap.find(moduleMapKey);
+    if (iter == m_moduleMap.end() || iter->value.get() != entry)
+        return;
+    Locker locker { cellLock() };
+    m_moduleMap.remove(iter);
 }
 
 void JSModuleLoader::addResolutionFailure(VM& vm, const ResolutionMapKey& key, JSValue error)

--- a/Source/JavaScriptCore/runtime/JSModuleLoader.h
+++ b/Source/JavaScriptCore/runtime/JSModuleLoader.h
@@ -174,11 +174,14 @@ public:
 
     ModuleRegistryEntry* ensureRegistered(JSGlobalObject*, const Identifier& key, ScriptFetchParameters::Type);
 
+    // https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-single-module-script step 13.1.2.
+    void removeFailedFetchEntry(ModuleRegistryEntry*);
+
+    ModuleRegistryEntry* getRegisteredMayBeNull(const Identifier& key, ScriptFetchParameters::Type);
+
 private:
     JSModuleLoader(VM&, Structure*);
     void finishCreation(JSGlobalObject*, VM&);
-
-    ModuleRegistryEntry* getRegisteredMayBeNull(const Identifier& key, ScriptFetchParameters::Type);
 
     void addResolutionFailure(VM&, const ResolutionMapKey&, JSValue error);
 


### PR DESCRIPTION
#### f324cca020c0e50244783167f30a433f24758888
<pre>
Don&apos;t cache HTTP/network errors in the module map
<a href="https://bugs.webkit.org/show_bug.cgi?id=319492">https://bugs.webkit.org/show_bug.cgi?id=319492</a>

Reviewed by Keith Miller.

This implements the spec changes from <a href="https://github.com/whatwg/html/pull/10327">https://github.com/whatwg/html/pull/10327</a> to avoid caching HTTP or network module import failures.

No new tests, but lots of progressions.

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/repeated-imports.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/repeated-imports.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/repeated-imports.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/concurrent-failed-imports-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/dynamic-import/concurrent-failed-imports.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/dynamic-import/concurrent-failed-imports.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/dynamic-import/concurrent-failed-imports.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/dynamic-import/repeated-imports.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/dynamic-import/repeated-imports.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/dynamic-import/repeated-imports.any.worker-expected.txt:
* Source/JavaScriptCore/runtime/JSMicrotask.cpp:
(JSC::moduleLoadTopRejected): Avoid registering failed module loads.
(JSC::moduleLoadStoreError): Avoid registering failed module loads.
(JSC::runInternalMicrotask): Avoid registering failed module loads.
(JSC::moduleLoadTopSettled): Avoid registering failed module loads.
* Source/JavaScriptCore/runtime/JSModuleLoader.cpp:
(JSC::JSModuleLoader::loadModule): Remove failed modules.
(JSC::JSModuleLoader::removeFailedFetchEntry):
* Source/JavaScriptCore/runtime/JSModuleLoader.h:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/instantiation-error-8-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/319474@main">https://commits.webkit.org/319474@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db1b8576f6c09d9181da3ee895e9003b8260deac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174965 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48898 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42679 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184546 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132873 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50190 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48581 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136169 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96080 "4 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177923 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39605 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156966 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116648 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38246 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36631 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5475 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148669 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36458 "Passed tests") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/36227 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/40564 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40833 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186970 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48565 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145105 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40474 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49245 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33079 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144961 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39829 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121376 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115057 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47751 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11431 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47154 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47384 "Built successfully") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47211 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | | | 
<!--EWS-Status-Bubble-End-->