### PR TITLE
[Debug] media/media-source/media-source-evict-invalid-time-crash.html is a permanent crash

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -258,7 +258,6 @@ fast/shapes/shape-outside-floats/shape-outside-imagedata-overflow.html [ Skip ]
 [ Debug ] fast/files/blob-stream-chunks.html [ Skip ]
 [ Debug ] security/decode-buffer-size.html [ Skip ]
 [ Debug ] security/text-decode-long-strings.html [ Skip ]
-[ Debug ] media/media-source/media-source-evict-invalid-time-crash.html [ Skip ]
 
 # Only iOS supports QuickLook
 quicklook [ Skip ]

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
@@ -631,7 +631,7 @@ void SourceBufferPrivate::computeEvictionData(ComputeEvictionDataRule rule)
                 });
             }
 
-            PlatformTimeRanges buffered { MediaTime::zeroTime(), MediaTime::positiveInfiniteTime() };
+            PlatformTimeRanges buffered { currentTime, MediaTime::positiveInfiniteTime() };
             iterateTrackBuffers([&](const TrackBuffer& trackBuffer) {
                 buffered.intersectWith(trackBuffer.buffered());
             });
@@ -1795,12 +1795,15 @@ bool SourceBufferPrivate::evictFrames(uint64_t newDataSize, const MediaTime& cur
         const auto minimumRangeStartAfterCurrentTime = currentTime + timeChunk;
 
         do {
-            PlatformTimeRanges buffered { MediaTime::zeroTime(), MediaTime::positiveInfiniteTime() };
+            PlatformTimeRanges buffered { currentTime, MediaTime::positiveInfiniteTime() };
             iterateTrackBuffers([&](const TrackBuffer& trackBuffer) {
                 buffered.intersectWith(trackBuffer.buffered());
             });
 
             auto rangeEndAfterCurrentTime = buffered.maximumBufferedTime();
+            if (!buffered.length())
+                break;
+
             if (!rangeEndAfterCurrentTime.isValid()) {
                 ASSERT_NOT_REACHED();
                 break;


### PR DESCRIPTION
#### 281431c36b192d11bd39f636fcbe01988ddabde1
<pre>
[Debug] media/media-source/media-source-evict-invalid-time-crash.html is a permanent crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=319576">https://bugs.webkit.org/show_bug.cgi?id=319576</a>
<a href="https://rdar.apple.com/182407431">rdar://182407431</a>

Reviewed by Youenn Fablet.

315066@main made an incorrect assumption and skip on why removeCodedFramesInternal
can be called with an invalid end time.
The test added was skipped on debug when it shouldn&apos;t have been.

It is possible for the SourceBuffer&apos;s tracks to not overlap, as such the
buffered range after currentTime could be empty. This would have caused
buffered.maximumBufferedTime(); to return MediaTime::invalidTime and would
have caused the problem 315066@main attempted to fix.

We avoid the condition altogether by exiting the loop early if the buffered
intersection is empty, this was likely the primary root cause for 315066@main.

Additionally, we optimised the loop by calculating the intersected range
from the currentTime, so there&apos;s no need to skip unnecessarily the segments
prior currentTime later.

Covered by existing tests.

* LayoutTests/TestExpectations:
* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::evictFrames):

Canonical link: <a href="https://commits.webkit.org/317389@main">https://commits.webkit.org/317389@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6bef0891601260de1fb73958c5a9213c53f638ac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175021 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48954 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42735 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184602 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132929 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3bdccc54-182e-4115-9ff4-63869b8bcecf) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176886 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50246 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48637 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136214 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8abcd30a-e586-47ad-af92-0cf0cfabd47b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177979 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39656 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157009 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116693 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/53c9dd2c-4845-4816-b79d-34763ff38b8e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38297 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36681 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33079 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148720 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36501 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187050 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/40539 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40883 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145184 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48621 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145040 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39106 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49301 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33122 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115119 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39877 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121491 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47807 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11474 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47210 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47440 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47267 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->