### PR TITLE
[GTK] Implement touch event synthesis in WebKitTestRunner

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -4624,7 +4624,6 @@ webkit.org/b/278719 fast/events/touch/multi-touch-some-without-handlers.html [ T
 webkit.org/b/278719 fast/events/touch/ontouchstart-active-selector.html [ Failure ]
 webkit.org/b/278719 fast/events/touch/page-scaled-touch-gesture-click.html [ Timeout ]
 webkit.org/b/278719 fast/events/touch/scroll-without-mouse-lacks-mousemove-events.html [ Failure ]
-webkit.org/b/278719 fast/events/touch/send-oncancel-event.html [ Timeout ]
 webkit.org/b/278719 fast/events/touch/touch-constructor.html [ Failure ]
 webkit.org/b/278719 fast/events/touch/touch-input-element-change-documents.html [ Failure ]
 webkit.org/b/278719 fast/events/touch/touch-scaled-scrolled.html [ Failure ]

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -1092,37 +1092,13 @@ imported/w3c/web-platform-tests/css/css-view-transitions/window-resize-aborts-tr
 
 imported/w3c/web-platform-tests/css/css-overflow/overflow-auto-scrolling-with-margin-and-transform.html [ Skip ]
 
-webkit.org/b/278719 fast/events/touch/basic-multi-touch-events.html [ Failure ]
-webkit.org/b/278719 fast/events/touch/basic-multi-touch-events-limited.html [ Failure ]
-webkit.org/b/278719 fast/events/touch/touch-target.html [ Failure ]
-webkit.org/b/278719 fast/events/touch/touch-target-limited.html [ Timeout ]
-
-webkit.org/b/278719 fast/events/touch/basic-single-touch-events.html [ Timeout ]
 webkit.org/b/278719 fast/events/touch/emulate-touch-events.html [ Failure ]
-webkit.org/b/278719 fast/events/touch/input-touch-target.html [ Failure ]
-webkit.org/b/278719 fast/events/touch/inserted-fragment-touch-target.html [ Timeout ]
-webkit.org/b/278719 fast/events/touch/moved-touch-target.html [ Timeout ]
-webkit.org/b/278719 fast/events/touch/multi-touch-grouped-targets.html [ Skip ]
-webkit.org/b/278719 fast/events/touch/multi-touch-inside-iframes.html [ Timeout ]
-webkit.org/b/278719 fast/events/touch/multi-touch-inside-nested-iframes.html [ Skip ]
-webkit.org/b/278719 fast/events/touch/removed-fragment-touch-target.html [ Timeout ]
-webkit.org/b/278719 fast/events/touch/removed-touch-target.html [ Timeout ]
-webkit.org/b/278719 fast/events/touch/tap-highlight-color.html [ Timeout ]
-webkit.org/b/278719 fast/events/touch/textarea-touch-target.html [ Failure ]
-webkit.org/b/278719 fast/events/touch/text-node-touch-target.html [ Failure ]
-webkit.org/b/278719 fast/events/touch/touch-active-state.html [ Timeout ]
-webkit.org/b/278719 fast/events/touch/touch-coords-in-zoom-and-scroll.html [ Failure ]
-webkit.org/b/278719 fast/events/touch/touch-event-frames.html [ Timeout ]
-webkit.org/b/278719 fast/events/touch/touch-event-pageXY.html [ Skip ]
+webkit.org/b/278719 fast/events/touch/touch-event-frames.html [ Failure ]
+webkit.org/b/278719 fast/events/touch/touch-event-pageXY.html [ Failure ]
 webkit.org/b/278719 fast/events/touch/touch-handler-count.html [ Failure ]
-webkit.org/b/278719 fast/events/touch/touch-inside-iframe.html [ Timeout ]
-webkit.org/b/278719 fast/events/touch/touch-inside-iframe-scrolled.html [ Timeout ]
-webkit.org/b/278719 fast/events/touch/touch-slider.html [ Crash Failure ]
 webkit.org/b/278719 fast/events/touch/touch-stale-node-crash.html [ Timeout ]
 webkit.org/b/278719 imported/w3c/web-platform-tests/touch-events/idlharness.window.html [ Failure ]
 webkit.org/b/278719 imported/w3c/web-platform-tests/touch-events/touch-globaleventhandler-interface.html [ Failure ]
-
-webkit.org/b/208984 fast/events/touch/touch-slider-no-js-touch-listener.html [ Failure ]
 
 webkit.org/b/213782 svg/custom/object-sizing-explicit-width.xhtml [ Failure Pass ]
 
@@ -1238,7 +1214,6 @@ webkit.org/b/315994 [ Debug ] imported/w3c/web-platform-tests/css/css-fonts/vari
 webkit.org/b/315994 imported/w3c/web-platform-tests/css/css-view-transitions/new-content-inline-with-offset-from-containing-block-clipped.html [ ImageOnlyFailure Pass ]
 webkit.org/b/315994 imported/w3c/web-platform-tests/css/css-view-transitions/old-content-inline-with-offset-from-containing-block-clipped.html [ ImageOnlyFailure Pass ]
 
-webkit.org/b/278719 fast/events/touch/touch-scaled-scrolled.html [ Failure Timeout ]
 webkit.org/b/317009 [ Release ] fast/events/mouse-events-on-textarea-resize.html [ Pass Failure ]
 
 webkit.org/b/316547 imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/pushstate.https.html [ Failure ]

--- a/LayoutTests/platform/gtk/fast/events/touch/basic-single-touch-events-expected.txt
+++ b/LayoutTests/platform/gtk/fast/events/touch/basic-single-touch-events-expected.txt
@@ -1,0 +1,85 @@
+This tests basic single touch event support.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS lastEvent.type is "touchstart"
+PASS lastEvent.touches.length is 1
+PASS lastEvent.changedTouches.length is 1
+PASS lastEvent.targetTouches.length is 1
+PASS lastEvent.pageX is 0
+PASS lastEvent.pageY is 0
+PASS lastEvent.shiftKey is false
+PASS lastEvent.touches[0].target.id is "touchtarget"
+PASS lastEvent.touches[0].pageX is 10
+PASS lastEvent.touches[0].pageY is 10
+PASS lastEvent.touches[0].clientX is 10
+PASS lastEvent.touches[0].clientY is 10
+PASS lastEvent.touches[0].identifier is 0
+FAIL lastEvent.touches[0].webkitRadiusX should be 10. Was 0.
+FAIL lastEvent.touches[0].webkitRadiusY should be 10. Was 0.
+PASS lastEvent.changedTouches[0].pageX is 10
+PASS lastEvent.changedTouches[0].pageY is 10
+PASS lastEvent.changedTouches[0].clientX is 10
+PASS lastEvent.changedTouches[0].clientY is 10
+PASS lastEvent.changedTouches[0].identifier is 0
+FAIL lastEvent.changedTouches[0].webkitRadiusX should be 10. Was 0.
+FAIL lastEvent.changedTouches[0].webkitRadiusY should be 10. Was 0.
+PASS lastEvent.targetTouches[0].pageX is 10
+PASS lastEvent.targetTouches[0].pageY is 10
+PASS lastEvent.targetTouches[0].clientX is 10
+PASS lastEvent.targetTouches[0].clientY is 10
+PASS lastEvent.targetTouches[0].identifier is 0
+FAIL lastEvent.targetTouches[0].webkitRadiusX should be 10. Was 0.
+FAIL lastEvent.targetTouches[0].webkitRadiusY should be 10. Was 0.
+PASS lastEvent.type is "touchmove"
+PASS lastEvent.touches.length is 1
+PASS lastEvent.changedTouches.length is 1
+PASS lastEvent.targetTouches.length is 1
+PASS lastEvent.pageX is 0
+PASS lastEvent.pageY is 0
+PASS lastEvent.touches[0].pageX is 50
+PASS lastEvent.touches[0].pageY is 50
+PASS lastEvent.touches[0].clientX is 50
+PASS lastEvent.touches[0].clientY is 50
+PASS lastEvent.touches[0].identifier is 0
+FAIL lastEvent.touches[0].webkitRadiusX should be 12. Was 0.
+FAIL lastEvent.touches[0].webkitRadiusY should be 12. Was 0.
+PASS lastEvent.shiftKey is true
+PASS lastEvent.altKey is true
+PASS lastEvent.ctrlKey is false
+PASS lastEvent.metaKey is false
+PASS lastEvent.type is "touchend"
+PASS lastEvent.touches.length is 0
+PASS lastEvent.changedTouches.length is 1
+PASS lastEvent.targetTouches.length is 0
+PASS lastEvent.pageX is 0
+PASS lastEvent.pageY is 0
+PASS lastEvent.changedTouches[0].pageX is 50
+PASS lastEvent.changedTouches[0].pageY is 50
+PASS lastEvent.changedTouches[0].clientX is 50
+PASS lastEvent.changedTouches[0].clientY is 50
+PASS lastEvent.changedTouches[0].identifier is 0
+FAIL lastEvent.changedTouches[0].webkitRadiusX should be 12. Was 0.
+FAIL lastEvent.changedTouches[0].webkitRadiusY should be 12. Was 0.
+PASS lastEvent.shiftKey is false
+PASS lastEvent.altKey is false
+PASS lastEvent.type is "touchstart"
+PASS lastEvent.touches.length is 1
+PASS lastEvent.changedTouches.length is 1
+PASS lastEvent.targetTouches.length is 1
+PASS lastEvent.pageX is 0
+PASS lastEvent.pageY is 0
+PASS lastEvent.targetTouches[0].target.tagName is "DIV"
+PASS lastEvent.type is "touchmove"
+PASS lastEvent.touches.length is 1
+PASS lastEvent.changedTouches.length is 1
+PASS lastEvent.targetTouches.length is 1
+PASS lastEvent.pageX is 0
+PASS lastEvent.pageY is 0
+PASS lastEvent.touches[0].target.tagName is "DIV"
+PASS successfullyParsed is true
+Some tests failed.
+
+TEST COMPLETE
+

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -880,7 +880,6 @@ fast/events/mouse-cursor-pseudo-elements.html [ Failure Pass ]
 webkit.org/b/278719 fast/events/touch/touch-event-frames.html [ Failure ]
 webkit.org/b/278719 fast/events/touch/frame-hover-update.html [ Failure ]
 webkit.org/b/278719 fast/events/touch/ontouchstart-active-selector.html [ Failure  ]
-webkit.org/b/278719 fast/events/touch/send-oncancel-event.html [ Pass ]
 webkit.org/b/278719 fast/events/touch/touch-event-pageXY.html [ Failure ]
 
 # The assertion failure occurs to WPE only.

--- a/Source/WebKit/Shared/NativeWebTouchEvent.h
+++ b/Source/WebKit/Shared/NativeWebTouchEvent.h
@@ -63,6 +63,7 @@ public:
 #endif
 #elif PLATFORM(GTK)
     NativeWebTouchEvent(GdkEvent*, Vector<WebPlatformTouchPoint>&&);
+    NativeWebTouchEvent(WebEventType, OptionSet<WebEventModifier>, Vector<WebPlatformTouchPoint>&&);
     NativeWebTouchEvent(const NativeWebTouchEvent&);
     const GdkEvent* nativeEvent() const { return m_nativeEvent.get(); }
 #elif PLATFORM(WPE)

--- a/Source/WebKit/Shared/gtk/NativeWebTouchEventGtk.cpp
+++ b/Source/WebKit/Shared/gtk/NativeWebTouchEventGtk.cpp
@@ -30,6 +30,7 @@
 
 #include "GtkVersioning.h"
 #include "WebEventFactory.h"
+#include <wtf/MonotonicTime.h>
 
 namespace WebKit {
 
@@ -42,6 +43,11 @@ namespace WebKit {
 NativeWebTouchEvent::NativeWebTouchEvent(GdkEvent* event, Vector<WebPlatformTouchPoint>&& touchPoints)
     : WebTouchEvent(WebEventFactory::createWebTouchEvent(event, WTF::move(touchPoints)))
     , m_nativeEvent(constructNativeEvent(event))
+{
+}
+
+NativeWebTouchEvent::NativeWebTouchEvent(WebEventType type, OptionSet<WebEventModifier> modifiers, Vector<WebPlatformTouchPoint>&& touchPoints)
+    : WebTouchEvent({ type, modifiers, MonotonicTime::now() }, WTF::move(touchPoints), { }, { })
 {
 }
 

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
@@ -3419,6 +3419,55 @@ void webkitWebViewBaseSynthesizeWheelEvent(WebKitWebViewBase* webViewBase, const
         delta, wheelTicks, toWebKitWheelEventPhase(phase), toWebKitWheelEventPhase(momentumPhase), true));
 }
 
+#if ENABLE(TOUCH_EVENTS)
+static WebPlatformTouchPoint::State toWebPlatformTouchPointState(SyntheticTouchPoint::State state)
+{
+    switch (state) {
+    case SyntheticTouchPoint::State::Stationary:
+        return WebPlatformTouchPoint::State::Stationary;
+    case SyntheticTouchPoint::State::Pressed:
+        return WebPlatformTouchPoint::State::Pressed;
+    case SyntheticTouchPoint::State::Moved:
+        return WebPlatformTouchPoint::State::Moved;
+    case SyntheticTouchPoint::State::Released:
+        return WebPlatformTouchPoint::State::Released;
+    case SyntheticTouchPoint::State::Cancelled:
+        return WebPlatformTouchPoint::State::Cancelled;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+void webkitWebViewBaseSynthesizeTouchEvent(WebKitWebViewBase* webViewBase, TouchEventType type, Vector<SyntheticTouchPoint>&& points, unsigned modifiers)
+{
+    WebKitWebViewBasePrivate* priv = webViewBase->priv;
+    if (priv->dialog)
+        return;
+
+    WebEventType webEventType;
+    switch (type) {
+    case TouchEventType::Start:
+        webEventType = WebEventType::TouchStart;
+        break;
+    case TouchEventType::Move:
+        webEventType = WebEventType::TouchMove;
+        break;
+    case TouchEventType::End:
+        webEventType = WebEventType::TouchEnd;
+        break;
+    case TouchEventType::Cancel:
+        webEventType = WebEventType::TouchCancel;
+        break;
+    }
+
+    auto touchPoints = points.map([widget = GTK_WIDGET(webViewBase)](const SyntheticTouchPoint& point) -> WebPlatformTouchPoint {
+        auto rootCoords = widgetRootCoords(widget, point.x, point.y);
+        return WebPlatformTouchPoint(point.id, toWebPlatformTouchPointState(point.state), DoublePoint(rootCoords.x(), rootCoords.y()), DoublePoint(point.x, point.y));
+    });
+
+    priv->pageProxy->handleTouchEvent(nullptr, NativeWebTouchEvent(webEventType, toWebKitModifiers(modifiers), WTF::move(touchPoints)));
+}
+#endif // ENABLE(TOUCH_EVENTS)
+
 void webkitWebViewBaseMakeBlank(WebKitWebViewBase* webViewBase, bool makeBlank)
 {
     WebKitWebViewBasePrivate* priv = webViewBase->priv;

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBaseInternal.h
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBaseInternal.h
@@ -27,6 +27,7 @@
 
 #include <WebKit/WKBase.h>
 #include <WebCore/PlatformMouseEvent.h>
+#include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
 class SkImage;
@@ -48,6 +49,18 @@ WK_EXPORT void webkitWebViewBaseSynthesizeKeyEvent(WebKitWebViewBase*, KeyEventT
 
 enum class WheelEventPhase { NoPhase, Began, Changed, Ended, Cancelled, MayBegin };
 WK_EXPORT void webkitWebViewBaseSynthesizeWheelEvent(WebKitWebViewBase*, double deltaX, double deltaY, int x, int y, WheelEventPhase, WheelEventPhase momentumPhase, bool);
+
+#if ENABLE(TOUCH_EVENTS)
+enum class TouchEventType { Start, Move, End, Cancel };
+struct SyntheticTouchPoint {
+    enum class State : uint8_t { Stationary, Pressed, Moved, Released, Cancelled };
+    unsigned id { 0 };
+    State state { State::Stationary };
+    int x { 0 };
+    int y { 0 };
+};
+WK_EXPORT void webkitWebViewBaseSynthesizeTouchEvent(WebKitWebViewBase*, TouchEventType, Vector<SyntheticTouchPoint>&&, unsigned modifiers);
+#endif
 
 WK_EXPORT SkImage* webkitWebViewBaseSnapshotForTesting(WebKitWebViewBase*);
 

--- a/Tools/WebKitTestRunner/EventSenderProxy.h
+++ b/Tools/WebKitTestRunner/EventSenderProxy.h
@@ -133,6 +133,16 @@ public:
     void clearTouchPoints();
     void releaseTouchPoint(int index);
     void cancelTouchPoint(int index);
+
+#if PLATFORM(GTK)
+    struct TouchPoint {
+        enum class State : uint8_t { Stationary, Pressed, Moved, Released, Cancelled };
+        unsigned id { 0 };
+        State state { State::Stationary };
+        int x { 0 };
+        int y { 0 };
+    };
+#endif
 #endif
 
     // Double two-finger tap on trackpad.
@@ -180,6 +190,10 @@ private:
 #endif
 #if PLATFORM(GTK)
     bool m_hasPreciseDeltas { false };
+#if ENABLE(TOUCH_EVENTS)
+    Vector<TouchPoint> m_touchPoints;
+    unsigned m_touchModifiers { 0 };
+#endif
 #endif
 #if USE(LIBWPE) || ENABLE(WPE_PLATFORM)
     std::unique_ptr<EventSenderProxyClient> m_client;

--- a/Tools/WebKitTestRunner/gtk/EventSenderProxyGtk.cpp
+++ b/Tools/WebKitTestRunner/gtk/EventSenderProxyGtk.cpp
@@ -406,56 +406,121 @@ void EventSenderProxy::leapForward(int milliseconds)
 }
 
 #if ENABLE(TOUCH_EVENTS)
-void EventSenderProxy::addTouchPoint(int, int)
+static SyntheticTouchPoint::State toSyntheticTouchPointState(EventSenderProxy::TouchPoint::State state)
 {
+    switch (state) {
+    case EventSenderProxy::TouchPoint::State::Stationary:
+        return SyntheticTouchPoint::State::Stationary;
+    case EventSenderProxy::TouchPoint::State::Pressed:
+        return SyntheticTouchPoint::State::Pressed;
+    case EventSenderProxy::TouchPoint::State::Moved:
+        return SyntheticTouchPoint::State::Moved;
+    case EventSenderProxy::TouchPoint::State::Released:
+        return SyntheticTouchPoint::State::Released;
+    case EventSenderProxy::TouchPoint::State::Cancelled:
+        return SyntheticTouchPoint::State::Cancelled;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
 }
 
-void EventSenderProxy::updateTouchPoint(int, int, int)
+void EventSenderProxy::addTouchPoint(int x, int y)
 {
+    unsigned id = 0;
+    for (const auto& point : m_touchPoints) {
+        if (point.id >= id)
+            id = point.id + 1;
+    }
+    m_touchPoints.append({ id, TouchPoint::State::Pressed, x, y });
+}
+
+void EventSenderProxy::updateTouchPoint(int index, int x, int y)
+{
+    ASSERT(index >= 0);
+    ASSERT(static_cast<size_t>(index) < m_touchPoints.size());
+    auto& point = m_touchPoints[index];
+    point.x = x;
+    point.y = y;
+    point.state = TouchPoint::State::Moved;
+}
+
+static void sendTouchEvent(TestController* testController, const Vector<EventSenderProxy::TouchPoint>& touchPoints, TouchEventType type, unsigned modifiers, CompletionHandler<void()>&& completionHandler)
+{
+    auto points = touchPoints.map([](const auto& point) {
+        return SyntheticTouchPoint { point.id, toSyntheticTouchPointState(point.state), point.x, point.y };
+    });
+
+    webkitWebViewBaseSynthesizeTouchEvent(toWebKitGLibAPI(testController->mainWebView()->platformView()),
+        type, WTF::move(points), modifiers);
+
+    if (completionHandler)
+        testController->doAfterProcessingAllPendingTouchAndWheelEvents(WTF::move(completionHandler));
+}
+
+static void markAllTouchPointsStationary(Vector<EventSenderProxy::TouchPoint>& touchPoints)
+{
+    for (auto& point : touchPoints)
+        point.state = EventSenderProxy::TouchPoint::State::Stationary;
 }
 
 void EventSenderProxy::touchStart(CompletionHandler<void()>&& completionHandler)
 {
-    if (completionHandler)
-        completionHandler();
+    sendTouchEvent(m_testController, m_touchPoints, TouchEventType::Start, webkitModifiersToGDKModifiers(m_touchModifiers), WTF::move(completionHandler));
+    markAllTouchPointsStationary(m_touchPoints);
 }
 
 void EventSenderProxy::touchMove(CompletionHandler<void()>&& completionHandler)
 {
-    if (completionHandler)
-        completionHandler();
+    sendTouchEvent(m_testController, m_touchPoints, TouchEventType::Move, webkitModifiersToGDKModifiers(m_touchModifiers), WTF::move(completionHandler));
+    markAllTouchPointsStationary(m_touchPoints);
 }
 
 void EventSenderProxy::touchEnd(CompletionHandler<void()>&& completionHandler)
 {
-    if (completionHandler)
-        completionHandler();
+    sendTouchEvent(m_testController, m_touchPoints, TouchEventType::End, 0, WTF::move(completionHandler));
+    m_touchPoints.removeAllMatching([](const auto& point) {
+        return point.state == TouchPoint::State::Released;
+    });
+    markAllTouchPointsStationary(m_touchPoints);
 }
 
 void EventSenderProxy::touchCancel(CompletionHandler<void()>&& completionHandler)
 {
-    if (completionHandler)
-        completionHandler();
+    sendTouchEvent(m_testController, m_touchPoints, TouchEventType::Cancel, 0, WTF::move(completionHandler));
+    m_touchPoints.removeAllMatching([](const auto& point) {
+        return point.state == TouchPoint::State::Cancelled;
+    });
+    markAllTouchPointsStationary(m_touchPoints);
 }
 
 void EventSenderProxy::clearTouchPoints()
 {
+    m_touchPoints.clear();
 }
 
-void EventSenderProxy::releaseTouchPoint(int)
+void EventSenderProxy::releaseTouchPoint(int index)
 {
+    ASSERT(index >= 0);
+    ASSERT(static_cast<size_t>(index) < m_touchPoints.size());
+    m_touchPoints[index].state = TouchPoint::State::Released;
 }
 
-void EventSenderProxy::cancelTouchPoint(int)
+void EventSenderProxy::cancelTouchPoint(int index)
 {
+    ASSERT(index >= 0);
+    ASSERT(static_cast<size_t>(index) < m_touchPoints.size());
+    m_touchPoints[index].state = TouchPoint::State::Cancelled;
 }
 
 void EventSenderProxy::setTouchPointRadius(int, int)
 {
 }
 
-void EventSenderProxy::setTouchModifier(WKEventModifiers, bool)
+void EventSenderProxy::setTouchModifier(WKEventModifiers modifier, bool enable)
 {
+    if (enable)
+        m_touchModifiers |= modifier;
+    else
+        m_touchModifiers &= ~modifier;
 }
 #endif // ENABLE(TOUCH_EVENTS)
 


### PR DESCRIPTION
#### c4264e1b1836110efffc4cabc2ed5d7f0de9fc79
<pre>
[GTK] Implement touch event synthesis in WebKitTestRunner
<a href="https://bugs.webkit.org/show_bug.cgi?id=319580">https://bugs.webkit.org/show_bug.cgi?id=319580</a>

Reviewed by Nikolas Zimmermann and Carlos Garcia Campos.

The GTK EventSenderProxy touch methods were empty stubs, so
eventSender.addTouchPoint(), touchStart() and friends dispatched nothing
and the fast/events/touch tests timed out. Unlike mouse, key and wheel
events, WebKitWebViewBase had no touch synthesis entry point, and the
existing touch path is built around GdkEvent, which cannot be constructed
by application code under GTK4. Add webkitWebViewBaseSynthesizeTouchEvent(),
which builds the WebPlatformTouchPoint list and dispatches a
NativeWebTouchEvent directly, the same way the mouse path already bypasses
GdkEvent; the GTK EventSenderProxy keeps the touch point state and maps it
onto that entry point.

Update the touch event test expectations for the tests that now pass, were
unskipped, or changed to a deterministic failure, and add a GTK baseline
for basic-single-touch-events.html (touch point radius is unsupported, as
on WPE, but the touch modifiers are applied).

Covered by fast/events/touch tests.

* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/gtk/TestExpectations:
* LayoutTests/platform/gtk/fast/events/touch/basic-single-touch-events-expected.txt: Added.
* LayoutTests/platform/wpe/TestExpectations:
* Source/WebKit/Shared/NativeWebTouchEvent.h:
* Source/WebKit/Shared/gtk/NativeWebTouchEventGtk.cpp:
(WebKit::NativeWebTouchEvent::NativeWebTouchEvent):
(WebKit::m_nativeEvent):
* Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp:
(toWebPlatformTouchPointState):
(webkitWebViewBaseSynthesizeTouchEvent):
* Source/WebKit/UIProcess/API/gtk/WebKitWebViewBaseInternal.h:
* Tools/WebKitTestRunner/EventSenderProxy.h:
* Tools/WebKitTestRunner/gtk/EventSenderProxyGtk.cpp:
(WTR::toSyntheticTouchPointState):
(WTR::EventSenderProxy::addTouchPoint):
(WTR::EventSenderProxy::updateTouchPoint):
(WTR::sendTouchEvent):
(WTR::markAllTouchPointsStationary):
(WTR::EventSenderProxy::touchStart):
(WTR::EventSenderProxy::touchMove):
(WTR::EventSenderProxy::touchEnd):
(WTR::EventSenderProxy::touchCancel):
(WTR::EventSenderProxy::clearTouchPoints):
(WTR::EventSenderProxy::releaseTouchPoint):
(WTR::EventSenderProxy::cancelTouchPoint):
(WTR::EventSenderProxy::setTouchModifier):

Canonical link: <a href="https://commits.webkit.org/319450@main">https://commits.webkit.org/319450@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f87dbc0639413e031d3b517acb24c70c6584645e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181502 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55449 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49251 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191725 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145828 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183364 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56755 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55170 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141659 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184457 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45344 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/162410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122099 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/44022 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/42293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/154423 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41936 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2886 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48075 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46549 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193653 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55118 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151064 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55805 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150772 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27564 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45349 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128088 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123723 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54321 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16934 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53703 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53941 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53768 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->