### PR TITLE
[Damage] Track each swap-chain target's damage since it was last current

### DIFF
--- a/Source/WebCore/platform/graphics/skia/SkiaDamageRegion.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaDamageRegion.h
@@ -32,6 +32,7 @@
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkCanvas.h>
 #include <skia/core/SkMatrix.h>
+#include <skia/core/SkPaint.h>
 #include <skia/core/SkRect.h>
 #include <skia/core/SkRegion.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
@@ -105,6 +106,15 @@ public:
             inverseCtm.mapRect(&dstSubRect, damaged);
             emit(dstToSrc.mapRect(dstSubRect), dstSubRect);
         }
+    }
+
+    void fillCanvasInDeviceSpace(SkCanvas& canvas, const SkPaint& paint) const
+    {
+        // Unlike clipRegion(), drawRegion() maps the region by the CTM, so the canvas must carry none
+        // for the region to land in device space.
+        ASSERT(!isEmpty());
+        ASSERT(canvas.getLocalToDeviceAs3x3().isIdentity());
+        canvas.drawRegion(m_region, paint);
     }
 
     void clipCanvasInDeviceSpace(SkCanvas& canvas) const

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp
@@ -38,6 +38,7 @@
 #include <WebCore/Region.h>
 #include <WebCore/Settings.h>
 #include <WebCore/ShareableBitmap.h>
+#include <WebCore/SkiaDamageRegion.h>
 #include <array>
 #include <fcntl.h>
 #include <unistd.h>
@@ -126,7 +127,7 @@ AcceleratedSurface::AcceleratedSurface(WebPage& webPage, Function<void()>&& fram
     , m_isVisible(webPage.activityState().contains(ActivityState::IsVisible))
     , m_useExplicitSync(usesGL() && useExplicitSync())
 #if ENABLE(DAMAGE_TRACKING)
-    , m_damageTracker(m_swapChain)
+    , m_damageTracker(m_swapChain, !usesGL())
 #endif
 {
 }
@@ -149,19 +150,6 @@ AcceleratedSurface::RenderTarget::RenderTarget(AcceleratedSurface& surface, cons
 }
 
 AcceleratedSurface::RenderTarget::~RenderTarget() = default;
-
-#if ENABLE(DAMAGE_TRACKING)
-void AcceleratedSurface::RenderTarget::addDamage(const std::optional<Damage>& damage)
-{
-    if (!m_damage)
-        return;
-
-    if (damage)
-        m_damage->add(*damage);
-    else
-        m_damage = std::nullopt;
-}
-#endif
 
 void AcceleratedSurface::RenderTarget::createSkiaSurfaceForFramebuffer(unsigned fbo)
 {
@@ -885,20 +873,49 @@ uint64_t AcceleratedSurface::SwapChain::window()
 #endif
 
 #if ENABLE(DAMAGE_TRACKING)
+void AcceleratedSurface::SwapChainDamageTracker::recordFrameDamage(Damage&& damage, AccumulateIntoSwapChain accumulate)
+{
+    m_frameDamage = WTF::move(damage);
+
+    // Add this frame's damage to every target, so each one repaints what changed since it was last
+    // rendered. This must happen on record rather than on read, since a frame that never reads its
+    // damage still has to contribute to the other targets.
+    if (accumulate == AccumulateIntoSwapChain::Yes) {
+        m_swapChain.forEachTarget([&](RenderTarget& target) {
+            target.addDamage(*m_frameDamage);
+        });
+    }
+}
+
 Vector<IntRect, 1> AcceleratedSurface::SwapChainDamageTracker::takeFrameDamageRects()
 {
     if (!m_frameDamage)
         return { };
 
-    return std::exchange(m_frameDamage, std::nullopt)->rects();
+    const auto frameDamage = *std::exchange(m_frameDamage, std::nullopt);
+    if (frameDamage.mode() != Damage::Mode::Rectangles || m_swapChain.size().isEmpty())
+        return frameDamage.rects();
+
+    // The frame damage is fine-grained, because the compositing restriction needs it that way, but the
+    // platform only wants a bounded number of rects. Merge it down to the threshold here, which is the
+    // only thing the threshold bounds.
+    Damage platformDamage(m_swapChain.size(), Damage::Mode::Rectangles, m_rectangleThreshold);
+    platformDamage.add(frameDamage);
+    return platformDamage.rects();
 }
 
-const std::optional<Damage>& AcceleratedSurface::SwapChainDamageTracker::damageForTarget(RenderTarget& target)
+void AcceleratedSurface::SwapChainDamageTracker::didPresent(RenderTarget& target, TargetContents targetContents)
 {
-    m_swapChain.forEachTarget([&](RenderTarget& candidate) {
-        candidate.addDamage(m_frameDamage);
-    });
-    return target.damage();
+    if (targetContents == TargetContents::Invalid) {
+        // Nothing was drawn, so drop the record and let the target's next use repaint it fully.
+        target.setDamage(std::nullopt);
+        return;
+    }
+
+    // The target is now current, so start a fresh, empty record. NoMaxRectangles keeps the grid as
+    // fine as the mode allows, since on a wide, short surface the threshold would collapse it into a
+    // few full-height cells.
+    target.setDamage(Damage(m_swapChain.size(), m_needsFineGrainedDamage ? Damage::Mode::Rectangles : Damage::Mode::BoundingBox, Damage::NoMaxRectangles));
 }
 #endif
 
@@ -1051,7 +1068,20 @@ void AcceleratedSurface::willRenderFrame(const IntSize& size)
         glViewport(0, 0, size.width(), size.height());
 }
 
-void AcceleratedSurface::clear(const OptionSet<WebCore::CompositionReason>& reasons)
+static void clearCanvas(SkCanvas& canvas, SkColor color, const SkiaDamageRegion* damageRegion)
+{
+    if (!damageRegion) {
+        canvas.clear(color);
+        return;
+    }
+
+    SkPaint paint;
+    paint.setColor(color);
+    paint.setBlendMode(SkBlendMode::kSrc);
+    damageRegion->fillCanvasInDeviceSpace(canvas, paint);
+}
+
+void AcceleratedSurface::clear(const OptionSet<WebCore::CompositionReason>& reasons, const SkiaDamageRegion* damageRegion)
 {
     std::optional<Color> backgroundColor;
     {
@@ -1062,9 +1092,9 @@ void AcceleratedSurface::clear(const OptionSet<WebCore::CompositionReason>& reas
     if (m_useSkia) {
         if (auto* canvas = this->canvas()) {
             if (backgroundColor && !backgroundColor->isOpaque())
-                canvas->clear(SK_ColorTRANSPARENT);
+                clearCanvas(*canvas, SK_ColorTRANSPARENT, damageRegion);
             else if (reasons.contains(CompositionReason::AsyncScrolling))
-                canvas->clear(backgroundColor ? SkColor(*backgroundColor) : SK_ColorWHITE);
+                clearCanvas(*canvas, backgroundColor ? SkColor(*backgroundColor) : SK_ColorWHITE, damageRegion);
         }
         return;
     }
@@ -1085,7 +1115,7 @@ void AcceleratedSurface::clear(const OptionSet<WebCore::CompositionReason>& reas
     }
 }
 
-void AcceleratedSurface::didRenderFrame()
+void AcceleratedSurface::didRenderFrame(TargetContents targetContents)
 {
 #if PLATFORM(GTK) || PLATFORM(WPE)
     TraceScope traceScope(WaitForCompositionCompletionStart, WaitForCompositionCompletionEnd);
@@ -1099,12 +1129,10 @@ void AcceleratedSurface::didRenderFrame()
 
     Vector<IntRect, 1> damageRects;
 #if ENABLE(DAMAGE_TRACKING)
-    // For GL targets we use bounding box damage for render target damage, as its only 2 consumers so far
-    // (CoordinatedBackingStore & ThreadedCompositor) only fetch bounds. Thus having damage with
-    // better resolution is pointless as the bounds are the same in such case.
-    // FIXME: If we start to consume fine-grained damage in the Skia compositor, we will need to relax the usesGL condition.
-    m_target->setDamage(Damage(m_swapChain.size(), usesGL() ? Damage::Mode::BoundingBox : Damage::Mode::Rectangles, m_damageTracker.rectangleThreshold()));
+    m_damageTracker.didPresent(*m_target, targetContents);
     damageRects = m_damageTracker.takeFrameDamageRects();
+#else
+    UNUSED_PARAM(targetContents);
 #endif
 
     m_target->didRenderFrame();
@@ -1125,7 +1153,7 @@ void AcceleratedSurface::sendFrame()
 const std::optional<Damage>& AcceleratedSurface::renderTargetDamage()
 {
     static std::optional<Damage> nulloptDamage;
-    return m_target ? m_damageTracker.damageForTarget(*m_target) : nulloptDamage;
+    return m_target ? m_damageTracker.damageSinceTargetWasLastCurrent(*m_target) : nulloptDamage;
 }
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h
@@ -76,6 +76,7 @@ class BitmapTexture;
 class GLFence;
 class ShareableBitmap;
 class ShareableBitmapHandle;
+class SkiaDamageRegion;
 }
 
 namespace WebKit {
@@ -131,12 +132,21 @@ public:
 
     void willDestroyGLContext();
     void willRenderFrame(const WebCore::IntSize&);
-    void didRenderFrame();
+
+    enum class TargetContents : bool {
+        // The next use of this target must repaint it in full, because either nothing was drawn or what
+        // was drawn contains pixels the layer tree will not reproduce, like a debug overlay.
+        Invalid,
+        Valid
+    };
+    void didRenderFrame(TargetContents = TargetContents::Valid);
     void sendFrame();
-    void clear(const OptionSet<WebCore::CompositionReason>&);
+    void clear(const OptionSet<WebCore::CompositionReason>&, const WebCore::SkiaDamageRegion* = nullptr);
 
 #if ENABLE(DAMAGE_TRACKING)
-    void setFrameDamage(WebCore::Damage&& damage) { m_damageTracker.recordFrameDamage(WTF::move(damage)); }
+    void setFrameDamage(WebCore::Damage&& damage) { m_damageTracker.recordFrameDamage(WTF::move(damage), SwapChainDamageTracker::AccumulateIntoSwapChain::Yes); }
+
+    void setFrameDamageForPlatformOnly(WebCore::Damage&& damage) { m_damageTracker.recordFrameDamage(WTF::move(damage), SwapChainDamageTracker::AccumulateIntoSwapChain::No); }
     void setFrameDamageRectangleThreshold(unsigned threshold) { m_damageTracker.setRectangleThreshold(threshold); }
     const std::optional<WebCore::Damage>& frameDamage() const LIFETIME_BOUND { return m_damageTracker.frameDamage(); }
     const std::optional<WebCore::Damage>& renderTargetDamage();
@@ -171,6 +181,10 @@ private:
     void frameDone();
     void releaseUnusedBuffersTimerFired();
 
+#if ENABLE(DAMAGE_TRACKING)
+    class SwapChainDamageTracker;
+#endif
+
     class RenderTarget {
         WTF_MAKE_TZONE_ALLOCATED(RenderTarget);
     public:
@@ -187,10 +201,21 @@ private:
 
         SkSurface* skiaSurface() const { return m_skiaSurface.get(); }
 
+    private:
 #if ENABLE(DAMAGE_TRACKING)
-        void setDamage(WebCore::Damage&& damage) { m_damage = WTF::move(damage); }
+        // The damage record is maintained by SwapChainDamageTracker alone, which is what keeps it meaning
+        // everything that changed since this target was last current.
+        friend class SwapChainDamageTracker;
+
+        void setDamage(std::optional<WebCore::Damage>&& damage) { m_damage = WTF::move(damage); }
         const std::optional<WebCore::Damage>& damage() LIFETIME_BOUND { return m_damage; }
-        void addDamage(const std::optional<WebCore::Damage>&);
+        void addDamage(const WebCore::Damage& damage)
+        {
+            if (m_damage)
+                m_damage->add(damage);
+        }
+
+        std::optional<WebCore::Damage> m_damage;
 #endif
 
     protected:
@@ -202,9 +227,6 @@ private:
         const CheckedRef<AcceleratedSurface> m_surface;
         WebCore::IntSize m_size;
         sk_sp<SkSurface> m_skiaSurface;
-#if ENABLE(DAMAGE_TRACKING)
-        std::optional<WebCore::Damage> m_damage;
-#endif
     };
 
 #if PLATFORM(GTK) || ENABLE(WPE_PLATFORM)
@@ -412,28 +434,43 @@ private:
     class SwapChainDamageTracker {
         WTF_MAKE_NONCOPYABLE(SwapChainDamageTracker);
     public:
-        explicit SwapChainDamageTracker(SwapChain& swapChain)
+        // needsFineGrainedDamage tells whether the records need individual rects, which is only worth
+        // building when someone iterates them, and no GL consumer does, reading nothing but the bounds.
+        SwapChainDamageTracker(SwapChain& swapChain, bool needsFineGrainedDamage)
             : m_swapChain(swapChain)
+            , m_needsFineGrainedDamage(needsFineGrainedDamage)
         {
         }
 
         void setRectangleThreshold(unsigned threshold) { m_rectangleThreshold = threshold; }
-        unsigned rectangleThreshold() const { return m_rectangleThreshold; }
 
-        // This frame's content change vs the last presented frame - propagated to the platform.
-        void recordFrameDamage(WebCore::Damage&& damage) { m_frameDamage = WTF::move(damage); }
+        enum class AccumulateIntoSwapChain : bool { No, Yes };
+
+        void recordFrameDamage(WebCore::Damage&&, AccumulateIntoSwapChain);
         const std::optional<WebCore::Damage>& frameDamage() const LIFETIME_BOUND { return m_frameDamage; }
         Vector<WebCore::IntRect, 1> takeFrameDamageRects();
 
-        // Propagates this frame's damage into every buffer and returns the given buffer's accumulated damage.
-        const std::optional<WebCore::Damage>& damageForTarget(RenderTarget&);
+        void didPresent(RenderTarget&, TargetContents);
+        const std::optional<WebCore::Damage>& damageSinceTargetWasLastCurrent(RenderTarget& target LIFETIME_BOUND) { return target.damage(); }
 
-        // Discards the pending frame damage, e.g. when the swap chain is resized.
-        void reset() { m_frameDamage = std::nullopt; }
+        // Discards the pending frame damage and every target's record, e.g. when the swap chain is
+        // resized, which leaves the targets holding contents no record can describe.
+        void reset()
+        {
+            m_frameDamage = std::nullopt;
+            m_swapChain.forEachTarget([](RenderTarget& target) {
+                target.setDamage(std::nullopt);
+            });
+        }
 
     private:
         SwapChain& m_swapChain;
+        const bool m_needsFineGrainedDamage;
         std::optional<WebCore::Damage> m_frameDamage;
+        // The most rects takeFrameDamageRects() will return. Once the frame damage holds more than
+        // this many rects, they all collapse into their single bounding box, trading precision for a
+        // smaller message to the platform. Only takeFrameDamageRects() is affected, so the per-target
+        // damage used for compositing stays fine-grained no matter how many rects the frame has.
         unsigned m_rectangleThreshold { 4 };
     };
 #endif


### PR DESCRIPTION
#### 98318f4fd93d26c39dd554961608fe1852bb4264
<pre>
[Damage] Track each swap-chain target&apos;s damage since it was last current
<a href="https://bugs.webkit.org/show_bug.cgi?id=319581">https://bugs.webkit.org/show_bug.cgi?id=319581</a>

Reviewed by Alejandro G. Castro.

A compositor that repaints only what changed this frame is only correct if it draws
into the target that holds the previous frame. That is rarely the case: the swap chain
hands back whichever target is free, and that one is a frame or more behind. So every
target needs its own record of what changed since it was last current.

The old code built that record on read. damageForTarget() added the pending frame
damage to every target and returned the one asked for, so a record only grew if someone
read it that frame. The optional it took meant two things at once, because a nullopt
dropped every record. Together with setFrameDamage() skipping empty damage, reading the
damage on a frame that changed nothing wiped the whole chain. The target being drawn got
a fresh record when it was presented, so the others paid the price and repainted in full
on their next use. The rectangle threshold went to the record instead of to the rects
handed to the platform, which did nothing on the composited path: the record is a
bounding box, and the frame damage the platform got was built without a threshold.

The new code keeps those steps apart. recordFrameDamage() adds the frame&apos;s damage to
every target right when it is recorded, unless the damage is only meant for the
platform, so every frame counts even if nobody reads it. didPresent() clears the record
of the target that just became current, and takes a TargetContents telling whether the
target really holds what it should, dropping the record when it does not. Reads are now
a plain lookup, and SwapChainDamageTracker is the only writer, which turns &quot;everything
that changed since this target was last current&quot; into a real invariant.

A record now uses Damage&apos;s default grid instead of the threshold&apos;s, which on a wide,
short surface would collapse into a few full-height cells. The threshold now applies in
takeFrameDamageRects(), bounding the rects handed to the platform. How much detail a
record keeps is up to its consumer: no GL consumer walks the rects, they only read the
bounds, so those records stay bounding boxes.

Clearing can take the damage rects too, drawn as a region rather than clipped, because a
region of more than one rect cannot be a scissor and Skia would build a clip mask for it.

* Source/WebCore/platform/graphics/skia/SkiaDamageRegion.h:
(WebCore::SkiaDamageRegion::fillCanvasInDeviceSpace const):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp:
(WebKit::AcceleratedSurface::AcceleratedSurface):
(WebKit::AcceleratedSurface::SwapChainDamageTracker::recordFrameDamage):
(WebKit::AcceleratedSurface::SwapChainDamageTracker::takeFrameDamageRects):
(WebKit::AcceleratedSurface::SwapChainDamageTracker::didPresent):
(WebKit::clearCanvas):
(WebKit::AcceleratedSurface::clear):
(WebKit::AcceleratedSurface::didRenderFrame):
(WebKit::AcceleratedSurface::renderTargetDamage):
(WebKit::AcceleratedSurface::RenderTarget::addDamage): Deleted.
(WebKit::AcceleratedSurface::SwapChainDamageTracker::damageForTarget): Deleted.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h:

Canonical link: <a href="https://commits.webkit.org/317342@main">https://commits.webkit.org/317342@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1dfae455b7efc3d8195906370a655a83334dcf2d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174996 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48929 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42710 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184577 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/132904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176861 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50221 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48612 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/136244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/132904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177954 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39637 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156993 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116676 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38278 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33054 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148701 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36485 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187001 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/40507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40862 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145135 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48596 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144991 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49276 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115094 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26590 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39861 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/121412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47782 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11458 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47185 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47415 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47242 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->