### PR TITLE
[JSC] `AsyncFromSyncIterator` should not close the sync iterator for a rejected value when done is true

### DIFF
--- a/JSTests/stress/async-from-sync-iterator-done-rejected-no-close.js
+++ b/JSTests/stress/async-from-sync-iterator-done-rejected-no-close.js
@@ -1,0 +1,52 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${String(actual)}, expected: ${String(expected)}`);
+}
+
+var error = new Error("rejected");
+
+function makeIterable(done) {
+    var record = { returnCount: 0 };
+    record.iterable = {
+        [Symbol.iterator]() {
+            return {
+                next() {
+                    return { value: Promise.reject(error), done };
+                },
+                return() {
+                    record.returnCount++;
+                    return {};
+                }
+            };
+        }
+    };
+    return record;
+}
+
+async function test() {
+    var record = makeIterable(true);
+    try {
+        for await (var v of record.iterable) { }
+        throw new Error("should not reach");
+    } catch (e) {
+        shouldBe(e, error);
+    }
+    shouldBe(record.returnCount, 0);
+
+    record = makeIterable(false);
+    try {
+        for await (var v of record.iterable) { }
+        throw new Error("should not reach");
+    } catch (e) {
+        shouldBe(e, error);
+    }
+    shouldBe(record.returnCount, 1);
+}
+
+var finished = false;
+var failure;
+test().then(() => { finished = true; }, (e) => { failure = e; });
+drainMicrotasks();
+if (failure)
+    throw failure;
+shouldBe(finished, true);

--- a/Source/JavaScriptCore/runtime/JSMicrotask.cpp
+++ b/Source/JavaScriptCore/runtime/JSMicrotask.cpp
@@ -303,7 +303,7 @@ static void asyncFromSyncIteratorContinueOrDone(JSGlobalObject* globalObject, VM
     }
     case JSPromise::Status::Rejected: {
         JSValue syncIterator = contextObject->getDirect(vm, vm.propertyNames->builtinNames().syncIteratorPrivateName());
-        if (syncIterator.isObject()) {
+        if (!done && syncIterator.isObject()) {
             auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
             JSValue returnMethod = asObject(syncIterator)->get(globalObject, vm.propertyNames->returnKeyword);
             if (!catchScope.exception() && returnMethod.isCallable())


### PR DESCRIPTION
#### a6ca226ff9c3f9f4eb4d621a915aaa075ac2d221
<pre>
[JSC] `AsyncFromSyncIterator` should not close the sync iterator for a rejected value when done is true
<a href="https://bugs.webkit.org/show_bug.cgi?id=319585">https://bugs.webkit.org/show_bug.cgi?id=319585</a>

Reviewed by Yusuke Suzuki.

317012@main made asyncFromSyncIteratorContinueOrDone close the sync iterator
when the awaited &quot;value&quot; of an iterator result is a rejected promise, but it
did so regardless of `done`. AsyncFromSyncIteratorContinuation[1] step 12 sets
onRejected to undefined when done is true, since a finished iterator has
nothing to close, so JSC ran `return` in a case where the spec (and V8) do not.

    let returnCount = 0;
    const it = { [Symbol.iterator]: () =&gt; ({
        next: () =&gt; ({ value: Promise.reject(new Error), done: true }),
        return() { returnCount++; return {}; }
    }) };
    (async () =&gt; { try { for await (const _ of it) {} } catch {} })();
    // JSC: returnCount === 1, expected 0

Only close the iterator on the rejected path when the microtask carries a
done: false result. closeOnRejection === false (%AsyncFromSyncIteratorPrototype%.return)
is already handled by the builtin passing @undefined as the sync iterator.

[1]: <a href="https://tc39.es/ecma262/#sec-asyncfromsynciteratorcontinuation">https://tc39.es/ecma262/#sec-asyncfromsynciteratorcontinuation</a>

Test: JSTests/stress/async-from-sync-iterator-done-rejected-no-close.js

* JSTests/stress/async-from-sync-iterator-done-rejected-no-close.js: Added.
(shouldBe):
(makeIterable):
(async test):
(test.then):
* Source/JavaScriptCore/runtime/JSMicrotask.cpp:
(JSC::asyncFromSyncIteratorContinueOrDone):

Canonical link: <a href="https://commits.webkit.org/317371@main">https://commits.webkit.org/317371@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5125e1e6b058063e0539de7f1e414147f7921d4c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174977 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48910 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42691 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184558 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132885 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50202 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48593 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136181 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177935 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39618 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156980 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116660 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38259 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36643 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33035 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5489 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148682 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36472 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186982 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/36239 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/40485 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40845 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145117 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48577 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144973 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39097 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49257 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33093 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115074 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39840 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Ignored 2 pre-existing failure based on results-db; Uploaded test results") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121391 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/212069 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47763 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11445 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55315 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47166 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47396 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47223 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->