### PR TITLE
[scroll-animations] only match `animation-timeline` to a timeline within the nearest `timeline-scope` element for that name

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-lookup-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-lookup-expected.txt
@@ -4,6 +4,6 @@ PASS timeline-scope on preceding sibling
 PASS view-timeline on ancestor
 PASS timeline-scope on ancestor sibling
 PASS timeline-scope on ancestor sibling, resolve to last match in tree order
-FAIL ancestor search stops at timeline-scope assert_equals: expected "auto" but got "0"
+PASS ancestor search stops at timeline-scope
 PASS view-timeline on ancestor sibling, scroll-timeline wins on same element
 

--- a/Source/WebCore/animation/StyleOriginatedTimelinesController.cpp
+++ b/Source/WebCore/animation/StyleOriginatedTimelinesController.cpp
@@ -90,14 +90,7 @@ ScrollTimeline& StyleOriginatedTimelinesController::inactiveNamedTimeline(const 
     return timelines.last();
 }
 
-static bool containsElement(const Vector<WeakStyleable>& timelineScopeElements, Element* matchElement)
-{
-    return timelineScopeElements.containsIf([matchElement] (const WeakStyleable& entry ) {
-        return entry.element() == matchElement;
-    });
-}
-
-ScrollTimeline* StyleOriginatedTimelinesController::determineTreeOrder(const Vector<Ref<ScrollTimeline>>& ancestorTimelines, const Styleable& styleable, const Vector<WeakStyleable>& timelineScopeElements)
+ScrollTimeline* StyleOriginatedTimelinesController::determineTreeOrder(const Vector<Ref<ScrollTimeline>>& ancestorTimelines, const Styleable& styleable, const Element* timelineScopeElement)
 {
     RefPtr element = styleable.element;
     while (element) {
@@ -107,7 +100,7 @@ ScrollTimeline* StyleOriginatedTimelinesController::determineTreeOrder(const Vec
                 matchedTimelines.append(timeline);
         }
         if (!matchedTimelines.isEmpty()) {
-            if (containsElement(timelineScopeElements, element.get())) {
+            if (timelineScopeElement == element.get()) {
                 // Naming conflict due to timeline-scope, see if the element declares a non-deferred timeline.
                 for (auto& matchedTimeline : matchedTimelines) {
                     if (element == originatingElement(matchedTimeline).element().get())
@@ -123,7 +116,7 @@ ScrollTimeline* StyleOriginatedTimelinesController::determineTreeOrder(const Vec
             return matchedTimelines.last().unsafePtr();
         }
         // Has blocking timeline scope element
-        if (containsElement(timelineScopeElements, element.get()))
+        if (timelineScopeElement == element.get())
             return nullptr;
         element = element->parentElementInComposedTree();
     }
@@ -132,7 +125,7 @@ ScrollTimeline* StyleOriginatedTimelinesController::determineTreeOrder(const Vec
     return nullptr;
 }
 
-ScrollTimeline* StyleOriginatedTimelinesController::determineTimelineForElement(const Vector<Ref<ScrollTimeline>>& timelines, const Styleable& styleable, const Vector<WeakStyleable>& timelineScopeElements)
+ScrollTimeline* StyleOriginatedTimelinesController::determineTimelineForElement(const Vector<Ref<ScrollTimeline>>& timelines, const Styleable& styleable, const Element* timelineScopeElement)
 {
     // https://drafts.csswg.org/scroll-animations-1/#timeline-scoping
     // A named scroll progress timeline or view progress timeline is referenceable by:
@@ -152,7 +145,7 @@ ScrollTimeline* StyleOriginatedTimelinesController::determineTimelineForElement(
     }
     if (matchedTimelines.isEmpty())
         return nullptr;
-    return determineTreeOrder(matchedTimelines, styleable, timelineScopeElements);
+    return determineTreeOrder(matchedTimelines, styleable, timelineScopeElement);
 }
 
 Vector<Ref<ScrollTimeline>>& StyleOriginatedTimelinesController::timelinesForName(const AtomString& name)
@@ -349,8 +342,25 @@ void StyleOriginatedTimelinesController::attachAnimation(CSSAnimation& animation
 
     LOG_WITH_STREAM(Animations, stream << "StyleOriginatedTimelinesController::attachAnimation: " << timelineName->value << " target: " << *target);
 
+    auto relevantTimelineScopeElement = [&] -> RefPtr<Element> {
+        auto timelineScopeElements = relatedTimelineScopeElements(*timelineName);
+        if (timelineScopeElements.isEmpty())
+            return nullptr;
+        // Find the nearest parent within timelineScopeElements.
+        for (RefPtr currentParent = target->element.parentElementInComposedTree(); currentParent; currentParent = currentParent->parentElementInComposedTree()) {
+            for (auto timelineScopeElement : timelineScopeElements) {
+                if (currentParent == &timelineScopeElement.styleable()->element)
+                    return currentParent;
+            }
+        }
+        return nullptr;
+    }();
+
     auto it = m_nameToTimelineMap.find(timelineName->value);
-    auto hasNamedTimeline = it != m_nameToTimelineMap.end() && it->value.containsIf([](auto& timeline) {
+    auto hasNamedTimeline = it != m_nameToTimelineMap.end() && it->value.containsIf([&](auto& timeline) {
+        auto timelineScope = timeline->timelineScopeDeclaredElement();
+        if (timelineScope && timelineScope.get() != relevantTimelineScopeElement.get())
+            return false;
         return !timeline->isInactiveStyleOriginatedTimeline();
     });
 
@@ -362,34 +372,20 @@ void StyleOriginatedTimelinesController::attachAnimation(CSSAnimation& animation
         return;
     }
 
-    auto timelineScopeElements = relatedTimelineScopeElements(*timelineName);
-
     if (!hasNamedTimeline) {
-        // First, determine whether the name is within scope, ie. whether a parent element
-        // has a `timeline-scope` property that contains this timeline name.
-        auto nameIsWithinScope = [&] {
-            for (auto timelineScopeElement : timelineScopeElements) {
-                ASSERT(timelineScopeElement.element());
-                Ref protectedTimelineScopeElement { *timelineScopeElement.element() };
-                if (*target == timelineScopeElement.styleable() || target->element.isComposedTreeDescendantOf(protectedTimelineScopeElement.get()))
-                    return true;
-            }
-            return false;
-        }();
-
         ASSERT(allowsDeferral == AllowsDeferral::No);
         // We don't have an active named timeline and yet we must set a timeline since
-        // we've already dealt with the defferal case before. There are two cases:
+        // we've already dealt with the deferral case before. There are two cases:
         //     1. the name is within scope and we should create a placeholder inactive
         //        scroll timeline, or,
         //     2. the name is not within scope and the timeline is null.
-        if (nameIsWithinScope)
+        if (relevantTimelineScopeElement)
             protectedAnimation->setTimeline(&inactiveNamedTimeline(timelineName->value));
         else
             protectedAnimation->setTimeline(nullptr);
     } else {
         auto& timelines = it->value;
-        RefPtr timeline = determineTimelineForElement(timelines, *target, timelineScopeElements);
+        RefPtr timeline = determineTimelineForElement(timelines, *target, relevantTimelineScopeElement.get());
         LOG_WITH_STREAM(Animations, stream << "StyleOriginatedTimelinesController::attachAnimation: " << timelineName->value << " styleable: " << *target << " attaching to timeline of element: " << originatingElement(*timeline));
         // A deferred inactive timeline means there was a conflict with multiple timelines existing within
         // a parent element with a "timeline-scope" property. In that case, we must reconsider timeline attachment

--- a/Source/WebCore/animation/StyleOriginatedTimelinesController.h
+++ b/Source/WebCore/animation/StyleOriginatedTimelinesController.h
@@ -83,8 +83,8 @@ private:
 
     enum class AllowsDeferral : bool { No, Yes };
     void attachAnimation(CSSAnimation&, AllowsDeferral);
-    ScrollTimeline* determineTimelineForElement(const Vector<Ref<ScrollTimeline>>&, const Styleable&, const Vector<WeakStyleable>&);
-    ScrollTimeline* determineTreeOrder(const Vector<Ref<ScrollTimeline>>&, const Styleable&, const Vector<WeakStyleable>&);
+    ScrollTimeline* determineTimelineForElement(const Vector<Ref<ScrollTimeline>>&, const Styleable&, const Element*);
+    ScrollTimeline* determineTreeOrder(const Vector<Ref<ScrollTimeline>>&, const Styleable&, const Element*);
     ScrollTimeline& inactiveNamedTimeline(const AtomString&);
 
     Vector<Ref<CSSAnimation>> m_cssAnimationsPendingAttachment;


### PR DESCRIPTION
#### 6819cd6b87a62c56a0f1ead43d286515aae65602
<pre>
[scroll-animations] only match `animation-timeline` to a timeline within the nearest `timeline-scope` element for that name
<a href="https://bugs.webkit.org/show_bug.cgi?id=319589">https://bugs.webkit.org/show_bug.cgi?id=319589</a>
<a href="https://rdar.apple.com/182417407">rdar://182417407</a>

Reviewed by Cameron McCormack.

Only the nearest parent with a `timeline-scope` [0] value matching the `animation-timeline`
should be considered as establishing a valid scope [1]. As such, we look for such an element
in `StyleOriginatedTimelinesController::attachAnimation()` and pass it down to `determineTimelineForElement()`
and `determineTreeOrder()` to determine what the matching timeline, if any, is.

[0] <a href="https://drafts.csswg.org/scroll-animations-1/#timeline-scope">https://drafts.csswg.org/scroll-animations-1/#timeline-scope</a>
[1] <a href="https://drafts.csswg.org/scroll-animations-1/#timeline-scoping">https://drafts.csswg.org/scroll-animations-1/#timeline-scoping</a>

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-lookup-expected.txt:
* Source/WebCore/animation/StyleOriginatedTimelinesController.cpp:
(WebCore::StyleOriginatedTimelinesController::determineTreeOrder):
(WebCore::StyleOriginatedTimelinesController::determineTimelineForElement):
(WebCore::StyleOriginatedTimelinesController::attachAnimation):
(WebCore::containsElement): Deleted.
* Source/WebCore/animation/StyleOriginatedTimelinesController.h:

Canonical link: <a href="https://commits.webkit.org/317376@main">https://commits.webkit.org/317376@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fbc18257e4949755091644c459c7a545286e229d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/175212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/49144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/42925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184797 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/133261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/177076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/50436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/48827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136384 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/133261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/178169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/50436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/42925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116863 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/50436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/48827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33270 "Built successfully") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/42925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/50436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/42925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187218 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/40831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/48827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145330 "Passed tests") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/48811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/42925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145187 "Passed tests") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/49491 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/42925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115362 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26623 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/49491 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/121679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/47997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/42925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/47400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/47630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/47457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->