### PR TITLE
Digital Credentials get() should skip unsupported-protocol requests before serializing their data

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get.https-expected.txt
@@ -15,9 +15,9 @@ PASS navigator.credentials.get() promise is rejected if abort controller is abor
 PASS Mediation is implicitly required and hence ignored. Request is aborted regardless.
 PASS Throws TypeError when request data is not JSON stringifiable.
 PASS `requests` field is required in the options object.
-FAIL navigator.credentials.get() with one unknown protocol with malformed data and one known protocol with proper data should skip the unknown one and not fail. promise_rejects_dom: function "function() { throw e; }" threw object "TypeError: Type error" that is not a DOMException AbortError: property "code" is equal to undefined, expected 20
+PASS navigator.credentials.get() with one unknown protocol with malformed data and one known protocol with proper data should skip the unknown one and not fail.
 PASS navigator.credentials.get() with only bogus requests should reject with TypeError.
-FAIL navigator.credentials.get() with good requests at the start and end should skip the bogus ones and not fail. promise_rejects_dom: function "function() { throw e; }" threw object "TypeError: Type error" that is not a DOMException AbortError: property "code" is equal to undefined, expected 20
-FAIL navigator.credentials.get() with bogus requests at both ends should skip them and not fail. promise_rejects_dom: function "function() { throw e; }" threw object "TypeError: Type error" that is not a DOMException AbortError: property "code" is equal to undefined, expected 20
+PASS navigator.credentials.get() with good requests at the start and end should skip the bogus ones and not fail.
+PASS navigator.credentials.get() with bogus requests at both ends should skip them and not fail.
 PASS navigator.credentials.get() returns coordinator to idle after mid-flight abort.
 

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/digital-credentials/get.https-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/digital-credentials/get.https-expected.txt
@@ -15,9 +15,9 @@ PASS navigator.credentials.get() promise is rejected if abort controller is abor
 PASS Mediation is implicitly required and hence ignored. Request is aborted regardless.
 PASS Throws TypeError when request data is not JSON stringifiable.
 PASS `requests` field is required in the options object.
-FAIL navigator.credentials.get() with one unknown protocol with malformed data and one known protocol with proper data should skip the unknown one and not fail. promise_rejects_dom: function "function() { throw e; }" threw object "TypeError: JSON.stringify cannot serialize BigInt." that is not a DOMException AbortError: property "code" is equal to undefined, expected 20
+PASS navigator.credentials.get() with one unknown protocol with malformed data and one known protocol with proper data should skip the unknown one and not fail.
 PASS navigator.credentials.get() with only bogus requests should reject with TypeError.
-FAIL navigator.credentials.get() with good requests at the start and end should skip the bogus ones and not fail. promise_rejects_dom: function "function() { throw e; }" threw object "TypeError: JSON.stringify cannot serialize BigInt." that is not a DOMException AbortError: property "code" is equal to undefined, expected 20
-FAIL navigator.credentials.get() with bogus requests at both ends should skip them and not fail. promise_rejects_dom: function "function() { throw e; }" threw object "TypeError: JSON.stringify cannot serialize BigInt." that is not a DOMException AbortError: property "code" is equal to undefined, expected 20
+PASS navigator.credentials.get() with good requests at the start and end should skip the bogus ones and not fail.
+PASS navigator.credentials.get() with bogus requests at both ends should skip them and not fail.
 PASS navigator.credentials.get() returns coordinator to idle after mid-flight abort.
 

--- a/Source/WebCore/Modules/identity/DigitalCredential.cpp
+++ b/Source/WebCore/Modules/identity/DigitalCredential.cpp
@@ -79,6 +79,10 @@ static std::optional<DigitalCredentialPresentationProtocol> convertProtocolStrin
 
 static ExceptionOr<std::optional<UnvalidatedDigitalCredentialRequest>> jsToCredentialRequest(const Document& document, const DigitalCredentialGetRequest& request)
 {
+    auto protocol = convertProtocolString(request.protocol);
+    if (!protocol)
+        return std::optional<UnvalidatedDigitalCredentialRequest> { std::nullopt }; // Skip requests with an unsupported protocol.
+
     auto scope = DECLARE_THROW_SCOPE(document.globalObject()->vm());
     auto* globalObject = document.globalObject();
 
@@ -86,10 +90,6 @@ static ExceptionOr<std::optional<UnvalidatedDigitalCredentialRequest>> jsToCrede
     JSC::JSONStringify(globalObject, request.data.get(), 0);
     if (scope.exception()) [[unlikely]]
         return Exception { ExceptionCode::ExistingExceptionError };
-
-    auto protocol = convertProtocolString(request.protocol);
-    if (!protocol)
-        return std::optional<UnvalidatedDigitalCredentialRequest> { std::nullopt }; // Return empty optional for unknown protocols
 
     switch (*protocol) {
     case DigitalCredentialPresentationProtocol::OrgIsoMdoc: {


### PR DESCRIPTION
#### 4867cdb405b802990af7c2e86f647b4984fc3ebb
<pre>
Digital Credentials get() should skip unsupported-protocol requests before serializing their data

<a href="https://bugs.webkit.org/show_bug.cgi?id=319582">https://bugs.webkit.org/show_bug.cgi?id=319582</a>
<a href="https://rdar.apple.com/problem/182412976">rdar://problem/182412976</a>

Reviewed by Abrar Rahman Protyasha.

A request carrying non-serializable data (for example a BigInt) on an
unsupported protocol threw a TypeError instead of being skipped, because the
JSON-serializability check ran before the protocol-support check. Per the
Digital Credentials specification&apos;s validate credential requests steps, a
request with an unsupported protocol is skipped before its data is serialized;
a request with a supported protocol whose data is not serializable still
throws. Move the protocol check ahead of the serializability check to match.

Canonical link: <a href="https://commits.webkit.org/317592@main">https://commits.webkit.org/317592@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6661f3500c9dc545a98e793956fcdfa4ced1f4a7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175553 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49485 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43266 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185139 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/704966b1-c7ef-4e69-9309-b26f9e3034ef) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177417 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50777 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49168 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136692 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3d8872d7-c001-4f07-ab98-9a7e9976ae86) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178510 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40115 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157454 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117170 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/261d0f16-35f2-4c61-bf44-65b28c34b594) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38756 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37143 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149178 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36947 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33614 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41173 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41346 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187564 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49152 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145662 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39236 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49832 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33571 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145499 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40320 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122025 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115810 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48339 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11923 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47741 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47971 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47798 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->