### PR TITLE
[WPE] fast/dom/timer-throttling-hidden-page.html is timing out

### DIFF
--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -600,10 +600,6 @@ webkit.org/b/168164 fast/picture/viewport-resize.html [ Timeout ]
 
 webkit.org/b/142292 fast/images/animated-gif-window-resizing.html [ Timeout ]
 
-# webkit.org/b/188506 fast/dom/timer-throttling-hidden-page.html [ Failure ]
-webkit.org/b/212350 fast/dom/timer-throttling-hidden-page.html [ Timeout ]
-webkit.org/b/212350 fast/dom/timer-throttling-hidden-page-2.html [ Timeout ]
-
 #////////////////////////////////////////////////////////////////////////////////////////
 # 8. TESTS FAILING
 #////////////////////////////////////////////////////////////////////////////////////////

--- a/Tools/WebKitTestRunner/wpe/TestControllerWPE.cpp
+++ b/Tools/WebKitTestRunner/wpe/TestControllerWPE.cpp
@@ -35,6 +35,15 @@
 #include <wtf/text/Base64.h>
 #include <wtf/text/MakeString.h>
 
+#if ENABLE(WPE_PLATFORM)
+#include <wpe/wpe-platform.h>
+#endif
+
+#if USE(LIBWPE)
+#include "PlatformWebViewClientLibWPE.h"
+#include <WPEToolingBackends/HeadlessViewBackend.h>
+#endif
+
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkData.h>
 #include <skia/encode/SkPngEncoder.h>
@@ -46,8 +55,25 @@ void TestController::notifyDone()
 {
 }
 
-void TestController::setHidden(bool)
+void TestController::setHidden(bool hidden)
 {
+    auto* view = mainWebView();
+    if (!view)
+        return;
+
+#if ENABLE(WPE_PLATFORM)
+    if (!useWPELegacyAPI()) {
+        wpe_view_set_visible(WKViewGetView(view->platformView()), !hidden);
+        return;
+    }
+#endif
+#if USE(LIBWPE)
+    auto* client = static_cast<PlatformWebViewClientLibWPE*>(view->platformWindow());
+    if (hidden)
+        client->backend()->removeActivityState(wpe_view_activity_state_visible);
+    else
+        client->backend()->addActivityState(wpe_view_activity_state_visible);
+#endif
 }
 
 void TestController::platformInitialize(const Options&)


### PR DESCRIPTION
#### 21c00b801db96dc00e0d2f060d871c6c559af53b
<pre>
[WPE] fast/dom/timer-throttling-hidden-page.html is timing out
<a href="https://bugs.webkit.org/show_bug.cgi?id=212350">https://bugs.webkit.org/show_bug.cgi?id=212350</a>

Reviewed by Carlos Garcia Campos and Claudio Saavedra.

Add implementation of method &apos;setHidden&apos; in &apos;TestControllerWPE.cpp&apos;.

The missing implementation prevented the test from toggling visibility,
which eventually caused the test to hang.

* LayoutTests/platform/wpe/TestExpectations:
* Tools/WebKitTestRunner/wpe/TestControllerWPE.cpp:
(WTR::TestController::setHidden):

Canonical link: <a href="https://commits.webkit.org/317615@main">https://commits.webkit.org/317615@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a89f2790df20b12887cc996cd71b3b660564f91

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175201 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49133 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42914 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184786 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/133243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177065 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50425 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48816 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136376 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/133243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178158 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39797 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157148 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116855 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38438 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36825 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33259 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148861 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36641 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187207 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41028 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145322 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48800 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145179 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49480 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33262 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115348 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26714 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40020 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47986 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11614 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47389 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47619 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47446 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->