### PR TITLE
[JSC] Handle `DataView` BigInt64 accessors in DFG / FTL

### DIFF
--- a/JSTests/microbenchmarks/data-view-bigint64-byte-swap.js
+++ b/JSTests/microbenchmarks/data-view-bigint64-byte-swap.js
@@ -1,0 +1,18 @@
+function byteSwap64(dv, byteLength) {
+    for (let i = 0; i < byteLength; i += 8)
+        dv.setBigUint64(i, dv.getBigUint64(i, false), true);
+}
+noInline(byteSwap64);
+
+const size = 16 * 1024;
+let dv = new DataView(new ArrayBuffer(size));
+for (let i = 0; i < size; ++i)
+    dv.setUint8(i, (i * 37 + 11) & 255);
+
+for (let i = 0; i < 4e3; ++i)
+    byteSwap64(dv, size);
+
+for (let i = 0; i < size; ++i) {
+    if (dv.getUint8(i) !== ((i * 37 + 11) & 255))
+        throw new Error("bad result");
+}

--- a/JSTests/microbenchmarks/data-view-get-bigint64.js
+++ b/JSTests/microbenchmarks/data-view-get-bigint64.js
@@ -1,0 +1,28 @@
+function getInt64(dv, byteLength) {
+    let last = 0n;
+    for (let i = 0; i < byteLength; i += 8)
+        last = dv.getBigInt64(i, true);
+    return last;
+}
+noInline(getInt64);
+
+function getUint64(dv, byteLength) {
+    let last = 0n;
+    for (let i = 0; i < byteLength; i += 8)
+        last = dv.getBigUint64(i, false);
+    return last;
+}
+noInline(getUint64);
+
+const size = 16 * 1024;
+let dv = new DataView(new ArrayBuffer(size));
+for (let i = 0; i < size; i += 4)
+    dv.setUint32(i, i * 2654435761, true);
+
+let acc = 0n;
+for (let i = 0; i < 4e3; ++i) {
+    acc = getInt64(dv, size);
+    acc = getUint64(dv, size);
+}
+if (typeof acc !== "bigint")
+    throw new Error("bad result");

--- a/JSTests/microbenchmarks/data-view-set-bigint64.js
+++ b/JSTests/microbenchmarks/data-view-set-bigint64.js
@@ -1,0 +1,22 @@
+function setInt64(dv, byteLength, values) {
+    for (let i = 0; i < byteLength; i += 8)
+        dv.setBigInt64(i, values[(i >> 3) & 3], true);
+}
+noInline(setInt64);
+
+function setUint64(dv, byteLength, values) {
+    for (let i = 0; i < byteLength; i += 8)
+        dv.setBigUint64(i, values[(i >> 3) & 3], false);
+}
+noInline(setUint64);
+
+const size = 16 * 1024;
+let dv = new DataView(new ArrayBuffer(size));
+let values = [0x0102030405060708n, -0x7fedcba987654321n, (1n << 64n) + 5n, -1n];
+
+for (let i = 0; i < 4e3; ++i) {
+    setInt64(dv, size, values);
+    setUint64(dv, size, values);
+}
+if (dv.getBigUint64(0, false) !== 0x0102030405060708n)
+    throw new Error("bad result");

--- a/JSTests/stress/dataview-jit-bigint64-byte-offset.js
+++ b/JSTests/stress/dataview-jit-bigint64-byte-offset.js
@@ -1,0 +1,40 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("bad value: " + actual + " expected: " + expected);
+}
+
+function shouldThrow(func, errorType) {
+    let error = null;
+    try {
+        func();
+    } catch (e) {
+        error = e;
+    }
+    if (!(error instanceof errorType))
+        throw new Error("bad error: " + error);
+}
+
+function get(dv, offset) { return dv.getBigUint64(offset, true); }
+function set(dv, offset, value) { dv.setBigUint64(offset, value, true); }
+noInline(get);
+noInline(set);
+
+const buffer = new ArrayBuffer(32);
+const bytes = new Uint8Array(buffer);
+const dv = new DataView(buffer, 8, 16);
+
+for (let i = 0; i < testLoopCount; i++) {
+    set(dv, 0, 0x0807060504030201n);
+    for (let j = 0; j < 8; j++)
+        shouldBe(bytes[8 + j], j + 1);
+    shouldBe(get(dv, 0), 0x0807060504030201n);
+
+    set(dv, 8, BigInt(i));
+    shouldBe(get(dv, 8), BigInt(i));
+    for (let j = 0; j < 8; j++)
+        shouldBe(bytes[16 + j], Number((BigInt(i) >> BigInt(8 * j)) & 0xffn));
+}
+
+shouldThrow(() => get(dv, 9), RangeError);
+shouldThrow(() => set(dv, 16, 1n), RangeError);
+shouldThrow(() => get(dv, -1), RangeError);

--- a/JSTests/stress/dataview-jit-bigint64-cse-and-aliasing.js
+++ b/JSTests/stress/dataview-jit-bigint64-cse-and-aliasing.js
@@ -1,0 +1,50 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("bad value: " + actual + " expected: " + expected);
+}
+
+function getSetGet(dv, offset, value) {
+    let before = dv.getBigInt64(offset, true);
+    dv.setBigInt64(offset, value, true);
+    let after = dv.getBigInt64(offset, true);
+    return [before, after];
+}
+noInline(getSetGet);
+
+function getTwice(dv, offset) {
+    let a = dv.getBigUint64(offset, false);
+    let b = dv.getBigUint64(offset, false);
+    return [a, b];
+}
+noInline(getTwice);
+
+function getArrayStoreGet(dv, array, index, value) {
+    let before = dv.getBigUint64(index * 8, true);
+    array[index] = value;
+    let after = dv.getBigUint64(index * 8, true);
+    return [before, after];
+}
+noInline(getArrayStoreGet);
+
+const dv = new DataView(new ArrayBuffer(64));
+for (let i = 0; i < testLoopCount; i++) {
+    dv.setBigInt64(8, BigInt(i), true);
+    let [before, after] = getSetGet(dv, 8, BigInt(-i) - 1n);
+    shouldBe(before, BigInt(i));
+    shouldBe(after, BigInt(-i) - 1n);
+
+    dv.setBigUint64(16, BigInt(i) * 3n, false);
+    let [a, b] = getTwice(dv, 16);
+    shouldBe(a, BigInt(i) * 3n);
+    shouldBe(b, BigInt(i) * 3n);
+}
+
+const buffer = new ArrayBuffer(64);
+const aliasedView = new DataView(buffer);
+const array = new BigUint64Array(buffer);
+for (let i = 0; i < testLoopCount; i++) {
+    array[2] = BigInt(i);
+    let [before, after] = getArrayStoreGet(aliasedView, array, 2, BigInt(i) + (1n << 40n));
+    shouldBe(before, BigInt(i));
+    shouldBe(after, BigInt(i) + (1n << 40n));
+}

--- a/JSTests/stress/dataview-jit-bigint64-type-check-failures.js
+++ b/JSTests/stress/dataview-jit-bigint64-type-check-failures.js
@@ -1,0 +1,50 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("bad value: " + actual + " expected: " + expected);
+}
+
+function shouldThrow(func, errorType) {
+    let error = null;
+    try {
+        func();
+    } catch (e) {
+        error = e;
+    }
+    if (!(error instanceof errorType))
+        throw new Error("bad error: " + error);
+}
+
+function get(dv, offset, littleEndian) { return dv.getBigUint64(offset, littleEndian); }
+function set(dv, offset, value, littleEndian) { dv.setBigUint64(offset, value, littleEndian); }
+noInline(get);
+noInline(set);
+
+const dv = new DataView(new ArrayBuffer(64));
+for (let i = 0; i < testLoopCount; i++) {
+    set(dv, 8, 0x0102030405060708n, true);
+    shouldBe(get(dv, 8, true), 0x0102030405060708n);
+}
+
+shouldBe(get(dv, 8.9, true), 0x0102030405060708n);
+shouldBe(get(dv, "8", true), 0x0102030405060708n);
+shouldBe(get(dv, [8], true), 0x0102030405060708n);
+shouldThrow(() => get(dv, 8n, true), TypeError);
+shouldThrow(() => get(dv, Symbol("8"), true), TypeError);
+shouldBe(get(dv, NaN, true), 0n);
+
+set(dv, 16.7, 0xa1a2a3a4a5a6a7a8n, true);
+shouldBe(get(dv, 16, true), 0xa1a2a3a4a5a6a7a8n);
+shouldThrow(() => set(dv, 8n, 1n, true), TypeError);
+
+shouldBe(get(dv, 8, 1), 0x0102030405060708n);
+shouldBe(get(dv, 8, "yes"), 0x0102030405060708n);
+shouldBe(get(dv, 8, undefined), 0x0807060504030201n);
+shouldBe(get(dv, 8, null), 0x0807060504030201n);
+shouldBe(get(dv, 8, {}), 0x0102030405060708n);
+set(dv, 24, 0x1112131415161718n, 0);
+shouldBe(get(dv, 24, false), 0x1112131415161718n);
+
+shouldThrow(() => get({}, 0, true), TypeError);
+shouldThrow(() => get(new Uint8Array(64), 0, true), TypeError);
+shouldThrow(() => set(null, 0, 1n, true), TypeError);
+shouldThrow(() => get.call(undefined, DataView.prototype, 0, true), TypeError);

--- a/JSTests/stress/dataview-jit-bigint64.js
+++ b/JSTests/stress/dataview-jit-bigint64.js
@@ -1,0 +1,171 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("bad value: " + actual + " expected: " + expected);
+}
+
+function shouldThrow(func, errorType) {
+    let error = null;
+    try {
+        func();
+    } catch (e) {
+        error = e;
+    }
+    if (!(error instanceof errorType))
+        throw new Error("bad error: " + error);
+}
+
+function toUint64(v) {
+    return BigInt.asUintN(64, v);
+}
+
+function toInt64(v) {
+    return BigInt.asIntN(64, v);
+}
+
+function refSetBigUint64(bytes, offset, value, littleEndian) {
+    let v = toUint64(value);
+    for (let i = 0; i < 8; i++)
+        bytes[offset + i] = Number((v >> BigInt(8 * (littleEndian ? i : 7 - i))) & 0xffn);
+}
+
+function getLE(view, offset) { return [view.getBigInt64(offset, true), view.getBigUint64(offset, true)]; }
+function getBE(view, offset) { return [view.getBigInt64(offset, false), view.getBigUint64(offset, false)]; }
+function getDefault(view, offset) { return [view.getBigInt64(offset), view.getBigUint64(offset)]; }
+function getVar(view, offset, le) { return [view.getBigInt64(offset, le), view.getBigUint64(offset, le)]; }
+noInline(getLE);
+noInline(getBE);
+noInline(getDefault);
+noInline(getVar);
+
+function setLE(view, offset, v) { view.setBigInt64(offset, v, true); view.setBigUint64(offset + 8, v, true); }
+function setBE(view, offset, v) { view.setBigInt64(offset, v, false); view.setBigUint64(offset + 8, v, false); }
+function setDefault(view, offset, v) { view.setBigInt64(offset, v); view.setBigUint64(offset + 8, v); }
+function setVar(view, offset, v, le) { view.setBigInt64(offset, v, le); view.setBigUint64(offset + 8, v, le); }
+noInline(setLE);
+noInline(setBE);
+noInline(setDefault);
+noInline(setVar);
+
+const size = 64;
+const bytes = new Uint8Array(size);
+const view = new DataView(bytes.buffer);
+
+const values = [
+    0n, 1n, -1n, 255n, 256n, 0x7fffffffn, 0x80000000n, 0xffffffffn, 0x100000000n,
+    (1n << 63n) - 1n, 1n << 63n, (1n << 64n) - 1n, -(1n << 63n), -(1n << 63n) + 1n,
+    0x0102030405060708n, 0xf1f2f3f4f5f6f7f8n,
+    (1n << 64n) + 5n, (1n << 128n) + 7n, -((1n << 64n) + 5n), -((1n << 100n) + 123n), 1n << 64n, -(1n << 64n),
+];
+
+for (let i = 0; i < testLoopCount; i++) {
+    const value = values[i % values.length];
+    const offset = (i * 3) % (size - 16);
+
+    for (const le of [true, false]) {
+        setVar(view, offset, value, le);
+        const expected = new Uint8Array(16);
+        refSetBigUint64(expected, 0, value, le);
+        refSetBigUint64(expected, 8, value, le);
+        for (let j = 0; j < 16; j++)
+            shouldBe(bytes[offset + j], expected[j]);
+
+        const [i64, u64] = getVar(view, offset, le);
+        shouldBe(i64, toInt64(value));
+        shouldBe(u64, toUint64(value));
+    }
+
+    setLE(view, offset, value);
+    let [a, b] = getLE(view, offset);
+    shouldBe(a, toInt64(value));
+    shouldBe(b, toUint64(value));
+
+    setBE(view, offset, value);
+    [a, b] = getBE(view, offset);
+    shouldBe(a, toInt64(value));
+    shouldBe(b, toUint64(value));
+
+    setDefault(view, offset, value);
+    [a, b] = getDefault(view, offset);
+    shouldBe(a, toInt64(value));
+    shouldBe(b, toUint64(value));
+    shouldBe(view.getBigUint64(offset, false), toUint64(value));
+}
+
+function oobGet(view, offset) { return view.getBigUint64(offset, true); }
+function oobSet(view, offset) { view.setBigUint64(offset, 1n, true); }
+noInline(oobGet);
+noInline(oobSet);
+for (let i = 0; i < testLoopCount; i++) {
+    oobGet(view, 0);
+    oobSet(view, 0);
+}
+for (const badOffset of [size - 7, size, -1, 0x7fffffff]) {
+    shouldThrow(() => oobGet(view, badOffset), RangeError);
+    shouldThrow(() => oobSet(view, badOffset), RangeError);
+}
+
+function setAny(view, offset, v) { view.setBigUint64(offset, v, true); }
+noInline(setAny);
+for (let i = 0; i < testLoopCount; i++)
+    setAny(view, 0, 42n);
+for (const bad of [42, 1.5, null, undefined, Symbol("x")])
+    shouldThrow(() => setAny(view, 0, bad), TypeError);
+shouldThrow(() => setAny(view, 0, {}), SyntaxError);
+setAny(view, 0, "42");
+shouldBe(view.getBigUint64(0, true), 42n);
+setAny(view, 0, true);
+shouldBe(view.getBigUint64(0, true), 1n);
+setAny(view, 0, 7n);
+shouldBe(view.getBigUint64(0, true), 7n);
+
+{
+    const buffer = new ArrayBuffer(16);
+    const detachedView = new DataView(buffer);
+    detachedView.setBigUint64(0, 0x1122334455667788n, true);
+    transferArrayBuffer(buffer);
+    shouldThrow(() => oobGet(detachedView, 0), TypeError);
+    shouldThrow(() => oobSet(detachedView, 0), TypeError);
+}
+
+{
+    const rab = new ArrayBuffer(32, { maxByteLength: 64 });
+    const resizableView = new DataView(rab);
+    function rget(view, offset) { return view.getBigUint64(offset, true); }
+    function rset(view, offset, value) { view.setBigUint64(offset, value, true); }
+    noInline(rget);
+    noInline(rset);
+    for (let i = 0; i < testLoopCount; i++) {
+        rset(resizableView, 16, BigInt(i));
+        shouldBe(rget(resizableView, 16), BigInt(i));
+    }
+    rab.resize(16);
+    shouldThrow(() => rget(resizableView, 16), RangeError);
+    rab.resize(64);
+    rset(resizableView, 48, 99n);
+    shouldBe(rget(resizableView, 48), 99n);
+}
+
+function gcGet(view, offset) { return view.getBigUint64(offset, true); }
+noInline(gcGet);
+view.setBigUint64(0, 0xdeadbeefcafebaben, true);
+{
+    const keep = [];
+    for (let i = 0; i < 5 * testLoopCount; i++) {
+        keep.push(gcGet(view, 0));
+        if (keep.length > 64)
+            keep.shift();
+    }
+    fullGC();
+    for (const k of keep)
+        shouldBe(k, 0xdeadbeefcafebaben);
+}
+
+function setZero(view) { view.setBigUint64(0, 0n, true); view.setBigInt64(8, 0n, true); }
+noInline(setZero);
+for (let i = 0; i < testLoopCount; i++) {
+    view.setBigUint64(0, 0xffffffffffffffffn, true);
+    view.setBigInt64(8, -1n, true);
+    setZero(view);
+    shouldBe(view.getBigUint64(0, true), 0n);
+    shouldBe(view.getBigInt64(8, true), 0n);
+}

--- a/JSTests/stress/dataview-jit-bounds-checks.js
+++ b/JSTests/stress/dataview-jit-bounds-checks.js
@@ -14,6 +14,8 @@ let getOps = {
     getInt32: 4,
     getFloat32: 4,
     getFloat64: 8,
+    getBigInt64: 8,
+    getBigUint64: 8,
 };
 
 let setOps = {
@@ -25,6 +27,8 @@ let setOps = {
     setInt32: 4,
     setFloat32: 4,
     setFloat64: 8,
+    setBigInt64: 8,
+    setBigUint64: 8,
 };
 
 let getFuncs = [];
@@ -55,6 +59,10 @@ for (let p of Object.keys(setOps)) {
     setFuncs.push(func);
 }
 
+function valueFor(name) {
+    return name.indexOf("Big") !== -1 ? 10n : 10;
+}
+
 function assertThrowsRangeError(f) {
     let e = null;
     try {
@@ -75,7 +83,7 @@ function test(warmup) {
         }
 
         for (let f of setFuncs) {
-            f(dv, 0, 10);
+            f(dv, 0, valueFor(f.name));
         }
     }
 
@@ -97,15 +105,15 @@ function test(warmup) {
     for (let f of setFuncs) {
         assertThrowsRangeError(() => {
             let index = size - setOps[f.name] + 1;
-            f(dv, index, 10);
+            f(dv, index, valueFor(f.name));
         });
         assertThrowsRangeError(() => {
             let index = -1;
-            f(dv, index, 10);
+            f(dv, index, valueFor(f.name));
         });
         assertThrowsRangeError(() => {
             let index = -2147483648;
-            f(dv, index, 10);
+            f(dv, index, valueFor(f.name));
         });
     }
 }

--- a/JSTests/stress/dataview-jit-unaligned-accesses.js
+++ b/JSTests/stress/dataview-jit-unaligned-accesses.js
@@ -14,6 +14,8 @@ let getOps = {
     getInt32: 4,
     getFloat32: 4,
     getFloat64: 8,
+    getBigInt64: 8,
+    getBigUint64: 8,
 };
 
 let setOps = {
@@ -25,6 +27,8 @@ let setOps = {
     setInt32: 4,
     setFloat32: 4,
     setFloat64: 8,
+    setBigInt64: 8,
+    setBigUint64: 8,
 };
 
 let getFuncs = [];
@@ -67,7 +71,7 @@ function test() {
         }
 
         for (let f of setFuncs) {
-            f(dv, index, 10);
+            f(dv, index, f.name.indexOf("Big") !== -1 ? 10n : 10);
         }
     }
 

--- a/Source/JavaScriptCore/b3/B3AbstractHeapRepository.h
+++ b/Source/JavaScriptCore/b3/B3AbstractHeapRepository.h
@@ -93,6 +93,7 @@ namespace JSC::B3 {
     macro(JSArrayBufferView_mode, JSArrayBufferView::offsetOfMode(), Mutability::Mutable) \
     macro(JSArrayBufferView_vector, JSArrayBufferView::offsetOfVector(), Mutability::Mutable) \
     macro(JSBigInt_length, JSBigInt::offsetOfLength(), Mutability::Immutable) \
+    macro(JSBigInt_data, JSBigInt::offsetOfData(), Mutability::Immutable) \
     macro(JSBoundFunction_targetFunction, JSBoundFunction::offsetOfTargetFunction(), Mutability::Mutable) \
     macro(JSBoundFunction_boundThis, JSBoundFunction::offsetOfBoundThis(), Mutability::Mutable) \
     macro(JSBoundFunction_boundArg0, JSBoundFunction::offsetOfBoundArgs() + sizeof(WriteBarrier<Unknown>) * 0, Mutability::Mutable) \

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -5891,12 +5891,14 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         DataViewData data = node->dataViewData();
         if (data.byteSize < 4)
             setNonCellTypeForNode(node, SpecInt32Only);
-        else {
-            ASSERT(data.byteSize == 4);
+        else if (data.byteSize == 4) {
             if (data.isSigned)
                 setNonCellTypeForNode(node, SpecInt32Only);
             else
                 setNonCellTypeForNode(node, SpecInt52Any);
+        } else {
+            ASSERT(data.byteSize == 8);
+            setTypeForNode(node, SpecHeapBigInt);
         }
         break;
     }

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -4869,7 +4869,9 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
         case DataViewGetUint32:
         case DataViewGetFloat16:
         case DataViewGetFloat32:
-        case DataViewGetFloat64: {
+        case DataViewGetFloat64:
+        case DataViewGetBigInt64:
+        case DataViewGetBigUint64: {
             if (!is64Bit())
                 return CallOptimizationResult::DidNothing;
 
@@ -4925,6 +4927,13 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
                 byteSize = 8;
                 op = DataViewGetFloat;
                 break;
+
+            case DataViewGetBigInt64:
+                isSigned = true;
+                [[fallthrough]];
+            case DataViewGetBigUint64:
+                byteSize = 8;
+                break;
             default:
                 RELEASE_ASSERT_NOT_REACHED();
             }
@@ -4972,7 +4981,9 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
         case DataViewSetUint32:
         case DataViewSetFloat16:
         case DataViewSetFloat32:
-        case DataViewSetFloat64: {
+        case DataViewSetFloat64:
+        case DataViewSetBigInt64:
+        case DataViewSetBigUint64: {
             if (!is64Bit())
                 return CallOptimizationResult::DidNothing;
 
@@ -5023,6 +5034,13 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
                 break;
             case DataViewSetFloat64:
                 isFloatingPoint = true;
+                byteSize = 8;
+                break;
+
+            case DataViewSetBigInt64:
+                isSigned = true;
+                [[fallthrough]];
+            case DataViewSetBigUint64:
                 byteSize = 8;
                 break;
             default:

--- a/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
@@ -264,7 +264,6 @@ bool doesGC(Graph& graph, Node* node)
     case FilterSetPrivateBrandStatus:
     case DateGetInt32OrNaN:
     case DateGetTime:
-    case DataViewGetInt:
     case DataViewGetFloat:
     case DataViewSet:
     case PutByOffset:
@@ -535,6 +534,9 @@ bool doesGC(Graph& graph, Node* node)
     case GlobalIsFinite:
     case GlobalIsNaN:
         return node->child1().useKind() == UntypedUse;
+
+    case DataViewGetInt:
+        return node->dataViewData().byteSize == 8;
 
     case CallNumberConstructor:
         switch (node->child1().useKind()) {

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -3697,6 +3697,9 @@ private:
                     else
                         node->setResult(NodeResultInt52);
                     break;
+                case 8:
+                    node->setResult(NodeResultJS);
+                    break;
                 default:
                     RELEASE_ASSERT_NOT_REACHED();
                 }
@@ -3725,6 +3728,9 @@ private:
                         fixEdge<Int32Use>(valueToStore);
                     else
                         fixEdge<Int52RepUse>(valueToStore);
+                    break;
+                case 8:
+                    fixEdge<HeapBigIntUse>(valueToStore);
                     break;
                 }
             }

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -6472,6 +6472,15 @@ JSC_DEFINE_JIT_OPERATION(operationInt64ToBigInt, EncodedJSValue, (JSGlobalObject
     OPERATION_RETURN(scope, JSValue::encode(JSBigInt::makeHeapBigIntOrBigInt32(globalObject, value)));
 }
 
+JSC_DEFINE_JIT_OPERATION(operationUInt64ToBigInt, EncodedJSValue, (JSGlobalObject* globalObject, uint64_t value))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    OPERATION_RETURN(scope, JSValue::encode(JSBigInt::makeHeapBigIntOrBigInt32(globalObject, value)));
+}
+
 JSC_DEFINE_JIT_OPERATION(operationThrowDFG, void, (JSGlobalObject* globalObject, EncodedJSValue valueToThrow))
 {
     VM& vm = globalObject->vm();

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -500,6 +500,7 @@ JSC_DECLARE_JIT_OPERATION(operationDateGetTimezoneOffset, EncodedJSValue, (VM*, 
 JSC_DECLARE_JIT_OPERATION(operationDateGetYear, EncodedJSValue, (VM*, DateInstance*));
 
 JSC_DECLARE_JIT_OPERATION(operationInt64ToBigInt, EncodedJSValue, (JSGlobalObject*, int64_t));
+JSC_DECLARE_JIT_OPERATION(operationUInt64ToBigInt, EncodedJSValue, (JSGlobalObject*, uint64_t));
 
 JSC_DECLARE_JIT_OPERATION(operationProcessTypeProfilerLogDFG, void, (VM*));
 

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -6440,6 +6440,29 @@ void SpeculativeJIT::compile(Node* node)
                     strictInt52Result(t2, node);
                 break;
             }
+            case 8: {
+                load64(baseIndex, t2);
+
+                if (data.isLittleEndian == TriState::False)
+                    byteSwap64(t2);
+                else if (data.isLittleEndian == TriState::Indeterminate) {
+                    RELEASE_ASSERT(isLittleEndianGPR != InvalidGPRReg);
+                    auto isLittleEndian = branchTest32(NonZero, isLittleEndianGPR, TrustedImm32(1));
+                    byteSwap64(t2);
+                    isLittleEndian.link(this);
+                }
+
+                flushRegisters();
+                GPRFlushedCallResult result(this);
+                GPRReg resultGPR = result.gpr();
+                if (data.isSigned)
+                    callOperation(operationInt64ToBigInt, resultGPR, LinkableConstant::globalObject(*this, node), t2);
+                else
+                    callOperation(operationUInt64ToBigInt, resultGPR, LinkableConstant::globalObject(*this, node), t2);
+                exceptionCheck();
+                jsValueResult(resultGPR, node);
+                break;
+            }
             default:
                 RELEASE_ASSERT_NOT_REACHED();
             }
@@ -6567,6 +6590,7 @@ void SpeculativeJIT::compile(Node* node)
         std::optional<SpeculateStrictInt52Operand> int52Value;
         std::optional<SpeculateDoubleOperand> doubleValue;
         std::optional<SpeculateInt32Operand> int32Value;
+        std::optional<SpeculateCellOperand> bigIntValue;
         std::optional<FPRTemporary> fprTemporary;
         GPRReg valueGPR = InvalidGPRReg;
         FPRReg valueFPR = InvalidFPRReg;
@@ -6591,6 +6615,11 @@ void SpeculativeJIT::compile(Node* node)
         case Int52RepUse:
             int52Value.emplace(this, valueEdge);
             valueGPR = int52Value->gpr();
+            break;
+        case HeapBigIntUse:
+            bigIntValue.emplace(this, valueEdge);
+            valueGPR = bigIntValue->gpr();
+            speculateHeapBigInt(valueEdge, valueGPR);
             break;
         default:
             RELEASE_ASSERT_NOT_REACHED();
@@ -6779,6 +6808,24 @@ void SpeculativeJIT::compile(Node* node)
                     emitBigEndianCode();
                     done.link(this);
                 }
+
+                break;
+            }
+            case 8: {
+                RELEASE_ASSERT(valueEdge.useKind() == HeapBigIntUse);
+                RELEASE_ASSERT(valueGPR != InvalidGPRReg);
+
+                toBigInt64(valueGPR, t3);
+
+                if (data.isLittleEndian == TriState::False)
+                    byteSwap64(t3);
+                else if (data.isLittleEndian == TriState::Indeterminate) {
+                    RELEASE_ASSERT(isLittleEndianGPR != InvalidGPRReg);
+                    auto isLittleEndian = branchTest32(NonZero, isLittleEndianGPR, TrustedImm32(1));
+                    byteSwap64(t3);
+                    isLittleEndian.link(this);
+                }
+                store64(t3, baseIndex);
 
                 break;
             }

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -21516,6 +21516,29 @@ IGNORE_CLANG_WARNINGS_END
 
                 break;
             }
+            case 8: {
+                LValue loadedValue = m_out.load64(pointer);
+
+                if (data.isLittleEndian == TriState::False)
+                    loadedValue = byteSwap64(loadedValue);
+                else if (data.isLittleEndian == TriState::Indeterminate) {
+                    auto emitLittleEndianCode = [&] {
+                        return loadedValue;
+                    };
+                    auto emitBigEndianCode = [&] {
+                        return byteSwap64(loadedValue);
+                    };
+
+                    loadedValue = emitCodeBasedOnEndiannessBranch(isLittleEndian, emitLittleEndianCode, emitBigEndianCode);
+                }
+
+                JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
+                if (data.isSigned)
+                    setJSValue(vmCall(Int64, operationInt64ToBigInt, weakPointer(globalObject), loadedValue));
+                else
+                    setJSValue(vmCall(Int64, operationUInt64ToBigInt, weakPointer(globalObject), loadedValue));
+                break;
+            }
             default:
                 RELEASE_ASSERT_NOT_REACHED();
             }
@@ -21636,6 +21659,9 @@ IGNORE_CLANG_WARNINGS_END
             break;
         case Int52RepUse:
             valueToStore = lowStrictInt52(valueEdge);
+            break;
+        case HeapBigIntUse:
+            valueToStore = lowHeapBigInt(valueEdge);
             break;
         default:
             RELEASE_ASSERT_NOT_REACHED();
@@ -21770,6 +21796,29 @@ IGNORE_CLANG_WARNINGS_END
                 };
                 auto emitBigEndianCode = [&] () -> LValue {
                     m_out.store32(byteSwap32(valueToStore), pointer);
+                    return nullptr;
+                };
+
+                if (data.isLittleEndian == TriState::False)
+                    emitBigEndianCode();
+                else if (data.isLittleEndian == TriState::True)
+                    emitLittleEndianCode();
+                else
+                    emitCodeBasedOnEndiannessBranch(isLittleEndian, emitLittleEndianCode, emitBigEndianCode);
+
+                break;
+            }
+            case 8: {
+                RELEASE_ASSERT(valueEdge.useKind() == HeapBigIntUse);
+
+                LValue int64Value = toBigInt64(valueToStore);
+
+                auto emitLittleEndianCode = [&] () -> LValue {
+                    m_out.store64(int64Value, pointer);
+                    return nullptr;
+                };
+                auto emitBigEndianCode = [&] () -> LValue {
+                    m_out.store64(byteSwap64(int64Value), pointer);
                     return nullptr;
                 };
 
@@ -24761,6 +24810,25 @@ IGNORE_CLANG_WARNINGS_END
         LValue result = lowCell(edge, mode);
         speculateHeapBigInt(edge, result);
         return result;
+    }
+
+    LValue toBigInt64(LValue bigInt)
+    {
+        LBasicBlock nonZeroLength = m_out.newBlock();
+        LBasicBlock continuation = m_out.newBlock();
+
+        LValue length = m_out.load32NonNegative(bigInt, m_heaps.JSBigInt_length);
+        ValueFromBlock zeroValue = m_out.anchor(m_out.int64Zero);
+        m_out.branch(m_out.isZero32(length), unsure(continuation), unsure(nonZeroLength));
+
+        LBasicBlock lastNext = m_out.appendTo(nonZeroLength, continuation);
+        LValue digit = m_out.load64(bigInt, m_heaps.JSBigInt_data);
+        LValue isNegative = m_out.testNonZero32(m_out.load8ZeroExt32(bigInt, m_heaps.JSCell_typeInfoFlags), m_out.constInt32(TypeInfoPerCellBit));
+        ValueFromBlock nonZeroValue = m_out.anchor(m_out.select(isNegative, m_out.neg(digit), digit));
+        m_out.jump(continuation);
+
+        m_out.appendTo(continuation, lastNext);
+        return m_out.phi(Int64, zeroValue, nonZeroValue);
     }
 
 #if USE(BIGINT32)

--- a/Source/JavaScriptCore/runtime/Intrinsic.h
+++ b/Source/JavaScriptCore/runtime/Intrinsic.h
@@ -279,6 +279,8 @@ namespace JSC {
     macro(DataViewGetFloat16) \
     macro(DataViewGetFloat32) \
     macro(DataViewGetFloat64) \
+    macro(DataViewGetBigInt64) \
+    macro(DataViewGetBigUint64) \
     macro(DataViewSetInt8) \
     macro(DataViewSetUint8) \
     macro(DataViewSetInt16) \
@@ -288,6 +290,8 @@ namespace JSC {
     macro(DataViewSetFloat16) \
     macro(DataViewSetFloat32) \
     macro(DataViewSetFloat64) \
+    macro(DataViewSetBigInt64) \
+    macro(DataViewSetBigUint64) \
     \
     macro(WasmFunctionIntrinsic) \
 

--- a/Source/JavaScriptCore/runtime/JSDataViewPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSDataViewPrototype.cpp
@@ -48,8 +48,8 @@ namespace JSC {
   getFloat16            dataViewProtoFuncGetFloat16          DontEnum|Function       1  DataViewGetFloat16
   getFloat32            dataViewProtoFuncGetFloat32          DontEnum|Function       1  DataViewGetFloat32
   getFloat64            dataViewProtoFuncGetFloat64          DontEnum|Function       1  DataViewGetFloat64
-  getBigInt64           dataViewProtoFuncGetBigInt64         DontEnum|Function       1
-  getBigUint64          dataViewProtoFuncGetBigUint64        DontEnum|Function       1
+  getBigInt64           dataViewProtoFuncGetBigInt64         DontEnum|Function       1  DataViewGetBigInt64
+  getBigUint64          dataViewProtoFuncGetBigUint64        DontEnum|Function       1  DataViewGetBigUint64
   setInt8               dataViewProtoFuncSetInt8             DontEnum|Function       2  DataViewSetInt8
   setUint8              dataViewProtoFuncSetUint8            DontEnum|Function       2  DataViewSetUint8
   setInt16              dataViewProtoFuncSetInt16            DontEnum|Function       2  DataViewSetInt16
@@ -59,8 +59,8 @@ namespace JSC {
   setFloat16            dataViewProtoFuncSetFloat16          DontEnum|Function       2  DataViewSetFloat16
   setFloat32            dataViewProtoFuncSetFloat32          DontEnum|Function       2  DataViewSetFloat32
   setFloat64            dataViewProtoFuncSetFloat64          DontEnum|Function       2  DataViewSetFloat64
-  setBigInt64           dataViewProtoFuncSetBigInt64         DontEnum|Function       2
-  setBigUint64          dataViewProtoFuncSetBigUint64        DontEnum|Function       2
+  setBigInt64           dataViewProtoFuncSetBigInt64         DontEnum|Function       2  DataViewSetBigInt64
+  setBigUint64          dataViewProtoFuncSetBigUint64        DontEnum|Function       2  DataViewSetBigUint64
   buffer                dataViewProtoGetterBuffer            DontEnum|ReadOnly|CustomAccessor
   byteOffset            dataViewProtoGetterByteOffset        DontEnum|ReadOnly|CustomAccessor
 @end


### PR DESCRIPTION
#### e164bce2e8884f242389930d9c0551d4b1f4ebb4
<pre>
[JSC] Handle `DataView` BigInt64 accessors in DFG / FTL
<a href="https://bugs.webkit.org/show_bug.cgi?id=319594">https://bugs.webkit.org/show_bug.cgi?id=319594</a>

Reviewed by Yusuke Suzuki.

DataView.prototype.getBigInt64 / getBigUint64 / setBigInt64 / setBigUint64
were the only DataView accessors without JIT intrinsics, so every call was
a C++ host call.

This handles them as the byteSize == 8 integer case of the existing
DataViewGetInt / DataViewSet nodes. Gets do the 64-bit load and byte swap
inline and box the result via operationInt64ToBigInt / newly added
operationUInt64ToBigInt. Sets speculate the value as HeapBigInt and store its
low 64 bits (toBigInt64), which is exactly the ToBigInt64 / ToBigUint64
wrapping the spec requires.

                                       Baseline                  Patched

data-view-bigint64-byte-swap      146.5305+-4.5918     ^     30.7756+-0.1811        ^ definitely 4.7613x faster
data-view-set-bigint64            127.1115+-1.1375     ^     15.5786+-1.0692        ^ definitely 8.1593x faster
data-view-get-bigint64            135.3561+-0.8063     ^     56.3917+-0.4440        ^ definitely 2.4003x faster

Tests: JSTests/microbenchmarks/data-view-bigint64-byte-swap.js
       JSTests/microbenchmarks/data-view-get-bigint64.js
       JSTests/microbenchmarks/data-view-set-bigint64.js
       JSTests/stress/dataview-jit-bigint64-byte-offset.js
       JSTests/stress/dataview-jit-bigint64-cse-and-aliasing.js
       JSTests/stress/dataview-jit-bigint64-type-check-failures.js
       JSTests/stress/dataview-jit-bigint64.js

* JSTests/microbenchmarks/data-view-bigint64-byte-swap.js: Added.
(byteSwap64):
* JSTests/microbenchmarks/data-view-get-bigint64.js: Added.
(getInt64):
(getUint64):
* JSTests/microbenchmarks/data-view-set-bigint64.js: Added.
(setInt64):
(setUint64):
* JSTests/stress/dataview-jit-bigint64-byte-offset.js: Added.
(shouldBe):
(shouldThrow):
(get dv):
(set dv):
* JSTests/stress/dataview-jit-bigint64-cse-and-aliasing.js: Added.
(shouldBe):
(getSetGet):
(getTwice):
(getArrayStoreGet):
* JSTests/stress/dataview-jit-bigint64-type-check-failures.js: Added.
(shouldBe):
(shouldThrow):
(get dv):
(set dv):
(shouldBe.get dv):
* JSTests/stress/dataview-jit-bigint64.js: Added.
(shouldBe):
(shouldThrow):
(toUint64):
(toInt64):
(refSetBigUint64):
(getBE):
(getDefault):
(getVar):
(setLE):
(setBE):
(setDefault):
(setVar):
(oobGet):
(oobSet):
(setAny):
(shouldBe.view.getBigUint64):
(shouldThrow.rget):
(shouldThrow.rset):
(gcGet):
(view.setBigUint64):
(setZero):
* Source/JavaScriptCore/b3/B3AbstractHeapRepository.h:
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):
* Source/JavaScriptCore/dfg/DFGDoesGC.cpp:
(JSC::DFG::doesGC):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/runtime/Intrinsic.h:
* Source/JavaScriptCore/runtime/JSDataViewPrototype.cpp:

Canonical link: <a href="https://commits.webkit.org/317392@main">https://commits.webkit.org/317392@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a5a4023f07192910e4e192c48cdb6e320a1aef40

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174998 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48931 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42712 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184579 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132906 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50223 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48614 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136212 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96090 "2 flakes 4 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177956 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39635 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156994 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116691 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38276 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36663 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33056 "Built successfully") | 
| [❌ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5503 "Found 1 new JSC stress test failure: stress/async-generator-fast-consumer-species-tamper-during.js.ftl-eager-no-cjit (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148699 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36486 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187003 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/36260 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/40534 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40865 "Found 1 new test failure: http/wpt/background-fetch/change-documents-in-progress-event.window.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145137 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48598 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144993 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39107 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49278 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33107 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115096 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39868 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121414 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/212090 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47784 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11459 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55319 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47187 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47417 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47244 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->