### PR TITLE
[GTK][WPE]  The scrolling thread shouldn't block the compositor thread to flush compositing state

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
@@ -1019,6 +1019,40 @@ void CoordinatedPlatformLayer::flushPendingState()
         notifyCompositionRequired();
 }
 
+void CoordinatedPlatformLayer::flushPositionChanges(const OptionSet<CompositionReason>& reasons, bool useSkiaTarget)
+{
+    ASSERT(!isMainThread());
+    if (!reasons.containsAny({ CompositionReason::RenderingUpdate, CompositionReason::AsyncScrolling }))
+        return;
+
+    Locker locker { m_lock };
+    if (!m_pendingChanges.containsAny({ Change::Position, Change::BoundsOrigin }))
+        return;
+
+    auto applyPositionChanges = [this](auto& layer) {
+        if (m_pendingChanges.contains(Change::Position)) {
+            layer.setPosition(m_position);
+            m_pendingChanges.remove(Change::Position);
+        }
+
+        if (m_pendingChanges.contains(Change::BoundsOrigin)) {
+            layer.setBoundsOrigin(m_boundsOrigin);
+            m_pendingChanges.remove(Change::BoundsOrigin);
+        }
+    };
+
+#if USE(SKIA)
+    if (useSkiaTarget) {
+        applyPositionChanges(ensureSkiaTarget());
+        return;
+    }
+#else
+    UNUSED_PARAM(useSkiaTarget);
+#endif
+
+    applyPositionChanges(ensureTarget());
+}
+
 void CoordinatedPlatformLayer::flushCompositingState(const OptionSet<CompositionReason>& reasons, bool useSkiaTarget)
 {
     ASSERT(!isMainThread());
@@ -1041,16 +1075,6 @@ void CoordinatedPlatformLayer::flushCompositingState(const OptionSet<Composition
 void CoordinatedPlatformLayer::flushCompositingStateOnTarget(const OptionSet<CompositionReason>& reasons, TextureMapperLayer& layer)
 {
     if (reasons.containsAny({ CompositionReason::RenderingUpdate, CompositionReason::AsyncScrolling })) {
-        if (m_pendingChanges.contains(Change::Position)) {
-            layer.setPosition(m_position);
-            m_pendingChanges.remove(Change::Position);
-        }
-
-        if (m_pendingChanges.contains(Change::BoundsOrigin)) {
-            layer.setBoundsOrigin(m_boundsOrigin);
-            m_pendingChanges.remove(Change::BoundsOrigin);
-        }
-
         if (m_pendingChanges.contains(Change::ContentsRect)) {
             layer.setContentsRect(m_contentsRect);
             m_pendingChanges.remove(Change::ContentsRect);
@@ -1238,16 +1262,6 @@ void CoordinatedPlatformLayer::flushCompositingStateOnTarget(const OptionSet<Com
 void CoordinatedPlatformLayer::flushCompositingStateOnSkiaTarget(const OptionSet<CompositionReason>& reasons, SkiaCompositingLayer& layer)
 {
     if (reasons.containsAny({ CompositionReason::RenderingUpdate, CompositionReason::AsyncScrolling })) {
-        if (m_pendingChanges.contains(Change::Position)) {
-            layer.setPosition(m_position);
-            m_pendingChanges.remove(Change::Position);
-        }
-
-        if (m_pendingChanges.contains(Change::BoundsOrigin)) {
-            layer.setBoundsOrigin(m_boundsOrigin);
-            m_pendingChanges.remove(Change::BoundsOrigin);
-        }
-
         if (m_pendingChanges.contains(Change::ContentsRect)) {
             layer.setContentsRect(m_contentsRect);
             m_pendingChanges.remove(Change::ContentsRect);

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
@@ -196,6 +196,7 @@ public:
     void updateBackingStore();
 
     void flushPendingState();
+    void flushPositionChanges(const OptionSet<CompositionReason>&, bool = false);
     void flushCompositingState(const OptionSet<CompositionReason>&, bool = false);
 
     bool hasPendingTilesCreation() const { return m_pendingTilesCreation; }

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedSceneState.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedSceneState.cpp
@@ -129,16 +129,19 @@ void CoordinatedSceneState::flushCompositingState(const OptionSet<CompositionRea
 {
     commitPendingLayers();
 
-    // We update the tiles after flushing to release the state lock as early as possible.
-    Vector<Ref<CoordinatedPlatformLayer>, 16> layersWithPendingTileUpdates;
     {
         Locker stateLock { m_stateLock };
-        m_rootLayer->flushCompositingState(reasons, useSkia);
-        for (auto& layer : m_committedLayers) {
-            layer->flushCompositingState(reasons, useSkia);
-            if (layer->hasPendingBackingStoreTileUpdates())
-                layersWithPendingTileUpdates.append(Ref { layer });
-        }
+        m_rootLayer->flushPositionChanges(reasons, useSkia);
+        for (auto& layer : m_committedLayers)
+            layer->flushPositionChanges(reasons, useSkia);
+    }
+
+    Vector<Ref<CoordinatedPlatformLayer>, 16> layersWithPendingTileUpdates;
+    m_rootLayer->flushCompositingState(reasons, useSkia);
+    for (auto& layer : m_committedLayers) {
+        layer->flushCompositingState(reasons, useSkia);
+        if (layer->hasPendingBackingStoreTileUpdates())
+            layersWithPendingTileUpdates.append(Ref { layer });
     }
 
     for (auto& layer : layersWithPendingTileUpdates)


### PR DESCRIPTION
#### a73186252db3bc5c0877e3ecb1764556efdb6dc9
<pre>
[GTK][WPE]  The scrolling thread shouldn&apos;t block the compositor thread to flush compositing state
<a href="https://bugs.webkit.org/show_bug.cgi?id=319596">https://bugs.webkit.org/show_bug.cgi?id=319596</a>

Reviewed by Fujii Hironori.

The scene state lock currently covers the compositor&apos;s entire per-layer flush
(positions, transforms, animations, backing store and tile bookkeeping), so the
scrolling thread&apos;s end-of-walk commit in flushPendingState() can wait for up to
a whole flush, milliseconds on layer-heavy pages, adding input latency.

Split the compositor&apos;s flush in two passes. The first pass, under the scene
state lock, applies only Change::Position and Change::BoundsOrigin to the
targets: positions are the only state committed by the scrolling thread, and
applying them for the whole tree under a single lock hold is what keeps the
compositor from observing a half-committed set (bug 315185). The second pass
everything else, runs without the scene state lock.

* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp:
(WebCore::CoordinatedPlatformLayer::flushPositionChanges):
(WebCore::CoordinatedPlatformLayer::flushCompositingStateOnTarget):
(WebCore::CoordinatedPlatformLayer::flushCompositingStateOnSkiaTarget):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedSceneState.cpp:
(WebKit::CoordinatedSceneState::flushCompositingState):

Canonical link: <a href="https://commits.webkit.org/317379@main">https://commits.webkit.org/317379@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23d5c4899ed04a39ffd0e79844071d0f0f9d34e6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175004 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48937 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42718 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184585 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132912 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176869 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50229 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48620 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136206 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177962 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39642 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157001 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116685 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38283 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36669 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33062 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148706 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36493 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187009 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/40517 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40871 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145159 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48604 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144999 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39102 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49284 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33114 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115102 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39864 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121446 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47790 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11466 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47193 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47423 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47250 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->