### PR TITLE
REGRESSION(313224@main): inspector/animation/lifecycle-css-animation.html fails on Apple ports

### DIFF
--- a/LayoutTests/inspector/animation/lifecycle-css-animation-expected.txt
+++ b/LayoutTests/inspector/animation/lifecycle-css-animation-expected.txt
@@ -17,17 +17,17 @@ keyframes:
   {
     "offset": 0,
     "easing": "cubic-bezier(0.1, 0.2, 0.3, 0.4)",
-    "style": "opacity: 0;\ncolor: rgb(255, 0, 0);"
+    "style": "color: rgb(255, 0, 0);\nopacity: 0;"
   },
   {
     "offset": 0.5,
     "easing": "cubic-bezier(0.1, 0.2, 0.3, 0.4)",
-    "style": "opacity: 0.5;\ncolor: rgb(0, 128, 0);"
+    "style": "color: rgb(0, 128, 0);\nopacity: 0.5;"
   },
   {
     "offset": 1,
     "easing": "cubic-bezier(0.1, 0.2, 0.3, 0.4)",
-    "style": "opacity: 1;\ncolor: rgb(0, 0, 255);"
+    "style": "color: rgb(0, 0, 255);\nopacity: 1;"
   }
 ]
 
@@ -51,17 +51,17 @@ keyframes:
   {
     "offset": 0,
     "easing": "cubic-bezier(0.1, 0.2, 0.3, 0.4)",
-    "style": "opacity: 0;\ncolor: rgb(255, 0, 0);"
+    "style": "color: rgb(255, 0, 0);\nopacity: 0;"
   },
   {
     "offset": 0.5,
     "easing": "cubic-bezier(0.1, 0.2, 0.3, 0.4)",
-    "style": "opacity: 0.5;\ncolor: rgb(0, 128, 0);"
+    "style": "color: rgb(0, 128, 0);\nopacity: 0.5;"
   },
   {
     "offset": 1,
     "easing": "cubic-bezier(0.1, 0.2, 0.3, 0.4)",
-    "style": "opacity: 1;\ncolor: rgb(0, 0, 255);"
+    "style": "color: rgb(0, 0, 255);\nopacity: 1;"
   }
 ]
 

--- a/LayoutTests/inspector/animation/lifecycle-web-animation-expected.txt
+++ b/LayoutTests/inspector/animation/lifecycle-web-animation-expected.txt
@@ -37,12 +37,10 @@ keyframes:
 ]
 
 
--- Running test case: Animation.Lifecycle.WebAnimation.CustomProperty
+-- Running test case: Animation.Lifecycle.CSSAnimation.CustomProperty
 Adding named animation to body.
 PASS: Animation created 'customKeyframes'.
-FAIL: Animation type should be Web Animation.
-    Expected: "web-animation"
-    Actual: "css-animation"
+PASS: Animation type should be CSS Animation.
 iterationCount: Infinity
 iterationDuration: 1000
 timingFunction: "linear"

--- a/LayoutTests/inspector/animation/lifecycle-web-animation.html
+++ b/LayoutTests/inspector/animation/lifecycle-web-animation.html
@@ -57,12 +57,12 @@ function test()
     });
 
     suite.addTestCase({
-        name: "Animation.Lifecycle.WebAnimation.CustomProperty",
-        description: "Check that Web Inspector is notified whenever web animations with custom properties are created/destroyed.",
+        name: "Animation.Lifecycle.CSSAnimation.CustomProperty",
+        description: "Check that Web Inspector is notified whenever CSS animations with custom properties are created/destroyed.",
         async test() {
             InspectorTest.log("Adding named animation to body.");
             let creationResults = await Promise.all([
-                InspectorTest.AnimationLifecycleUtilities.awaitAnimationCreated(WI.Animation.Type.WebAnimation),
+                InspectorTest.AnimationLifecycleUtilities.awaitAnimationCreated(WI.Animation.Type.CSSAnimation),
                 InspectorTest.evaluateInPage(`addNamedAnimationToBody()`),
             ]);
 

--- a/LayoutTests/inspector/animation/resources/lifecycle-utilities.js
+++ b/LayoutTests/inspector/animation/resources/lifecycle-utilities.js
@@ -68,10 +68,10 @@ TestPage.registerInitializer(() => {
                 let traceText = `  ${i}: `;
                 traceText += callFrame.functionName || "(anonymous function)";
 
-                if (callFrame.nativeCode)
-                    traceText += " - [native code]";
-                else if (callFrame.programCode)
+                if (callFrame.programCode)
                     traceText += " - [program code]";
+                else if (callFrame.nativeCode)
+                    traceText += " - [native code]";
                 else if (callFrame.sourceCodeLocation) {
                     let location = callFrame.sourceCodeLocation;
                     traceText += " - " + sanitizeURL(location.sourceCode.url) + `:${location.lineNumber}:${location.columnNumber}`;

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -1486,8 +1486,6 @@ webkit.org/b/207142 requestidlecallback/requestidlecallback-is-called.html [ Pas
 
 webkit.org/b/207226 http/tests/misc/image-blocked-src-change.html [ Pass Failure ]
 
-webkit.org/b/207306 inspector/animation/lifecycle-css-animation.html [ Pass Failure ]
-
 webkit.org/b/112939 fast/performance/performance-now-timestamps.html [ Pass Failure ]
 
 webkit.org/b/207363 inspector/css/pseudo-creation.html [ Pass Failure ]

--- a/Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp
@@ -60,10 +60,12 @@
 #include "TimingFunction.h"
 #include "WebAnimation.h"
 #include "WebAnimationTypes.h"
+#include "WebAnimationUtilities.h"
 #include <JavaScriptCore/IdentifiersFactory.h>
 #include <JavaScriptCore/InjectedScriptManager.h>
 #include <JavaScriptCore/InspectorEnvironment.h>
 #include <JavaScriptCore/ScriptCallStackFactory.h>
+#include <ranges>
 #include <wtf/HashMap.h>
 #include <wtf/Seconds.h>
 #include <wtf/Stopwatch.h>
@@ -159,7 +161,8 @@ static Ref<JSON::ArrayOf<Inspector::Protocol::Animation::Keyframe>> buildObjectF
                 keyframePayload->setEasing(timingFunction->cssText());
 
             StringBuilder stylePayloadBuilder;
-            auto& properties = blendingKeyframe.properties();
+            auto properties = copyToVector(blendingKeyframe.properties());
+            std::ranges::sort(properties, codePointCompareLessThan, animatablePropertyAsString);
             size_t count = properties.size();
             for (auto property : properties) {
                 --count;


### PR DESCRIPTION
#### b98102852edf39cd8651956ac89d7855f808b458
<pre>
REGRESSION(313224@main): inspector/animation/lifecycle-css-animation.html fails on Apple ports
<a href="https://bugs.webkit.org/show_bug.cgi?id=207306">https://bugs.webkit.org/show_bug.cgi?id=207306</a>
&lt;<a href="https://rdar.apple.com/problem/59205827">rdar://problem/59205827</a>&gt;

Reviewed by Antoine Quint.

* Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp:
(WebCore::buildObjectForKeyframes):
* LayoutTests/inspector/animation/lifecycle-css-animation-expected.txt:
Sort properties by name before serializing style-originated keyframes so they&apos;re consistent.

* LayoutTests/inspector/animation/lifecycle-web-animation.html:
* LayoutTests/inspector/animation/lifecycle-web-animation-expected.txt:
Drive-by: animations created via `@keyframes` are CSS Animations not Web Animations.

* LayoutTests/inspector/animation/resources/lifecycle-utilities.js:
(InspectorTest.AnimationLifecycleUtilities.awaitAnimationCreated):
Drive-by: a call frame can be both `programCode` and `nativeCode` when its source cannot be resolved so match the UI by preferring `programCode` when logging its type.

* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/317334@main">https://commits.webkit.org/317334@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ee111b4ff3b8b960cc9df760de07caf4240c595

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175006 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48939 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42720 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184587 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132914 "Failed to checkout and rebase branch from PR 69575") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176871 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50231 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48622 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/136204 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/132914 "Failed to checkout and rebase branch from PR 69575") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177964 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39645 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/157002 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116683 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38286 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33064 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/148709 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36494 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187011 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/40519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/145144 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48606 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156558 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145000 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39068 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49286 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33115 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115104 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39867 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/121425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47792 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11467 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47195 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47425 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47252 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->